### PR TITLE
Added: dump feature as a var_dump() replacement

### DIFF
--- a/ezp/Base/Collection/ReadOnly.php
+++ b/ezp/Base/Collection/ReadOnly.php
@@ -10,13 +10,15 @@
 namespace ezp\Base\Collection;
 use ezp\Base\Collection,
     ezp\Base\Exception\ReadOnly as ReadOnlyException,
-    ArrayObject;
+    ezp\Base\Dumpable,
+    ArrayObject,
+    SplObjectStorage;
 
 /**
  * Read Only Collection class
  *
  */
-class ReadOnly extends ArrayObject implements Collection
+class ReadOnly extends ArrayObject implements Collection, Dumpable
 {
     /**
      * Returns the first index at which a given element can be found in the array, or false if it is not present.
@@ -78,6 +80,62 @@ class ReadOnly extends ArrayObject implements Collection
     public function exchangeArray( $input )
     {
         throw new ReadOnlyException( 'Collection' );
+    }
+
+    /**
+     * Dump an object in a similar way to var_dump()
+     *
+     * @param int $maxDepth Maximum depth
+     * @param int $currentLevel Current level
+     * @param \SplObjectStorage Set of objects already printed (to avoid recursion)
+     */
+    public function dump( $maxDepth = Dumpable::DEFAULT_DEPTH, $currentLevel = 0, SplObjectStorage $objectSet = null )
+    {
+        $spaces = str_repeat( " ", 2 * $currentLevel );
+
+        if ( $maxDepth === $currentLevel )
+        {
+            echo $spaces, "...\n";
+            return;
+        }
+
+        if ( $objectSet === null )
+        {
+            $objectSet = new SplObjectStorage ();
+        }
+        else if ( $objectSet->contains( $this ) )
+        {
+            echo $spaces, "**RECURSION**\n";
+            return;
+        }
+
+        $objectSet->attach( $this );
+
+        echo
+            $spaces, "object(", get_class( $this ), ") {\n",
+            $spaces, "elements array(", count( $this ), "):\n";
+
+        foreach ( $this as $key => $value )
+        {
+            echo $spaces, "  [$key] =>\n";
+            if ( $value instanceof Dumpable  )
+            {
+                // Artificially increasing the currentLevel for rendering purpose
+                $value->dump( $maxDepth + 1, $currentLevel + 2, $objectSet );
+            }
+            else if ( $value !== null )
+            {
+                echo get_class( $value ), "\n";
+            }
+            else
+            {
+                echo "NULL\n";
+            }
+        }
+
+        $objectSet->detach( $this );
+
+        echo $spaces, "}\n";
     }
 }
 

--- a/ezp/Base/Dumpable.php
+++ b/ezp/Base/Dumpable.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * File containing the ezp\Base\Dumpable interface
+ *
+ * @copyright Copyright (C) 1999-2011 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace ezp\Base;
+use SplObjectStorage;
+
+/**
+ * Interface for content that can be rendered using the dump method.
+ */
+interface Dumpable
+{
+    /**
+     * Default dump depth
+     *
+     * @var int
+     */
+    const DEFAULT_DEPTH = 5;
+
+    /**
+     * Dump an object in a similar way to var_dump()
+     *
+     * @param int $maxDepth Maximum depth
+     * @param int $currentLevel Current level
+     * @param \SplObjectStorage Set of objects already printed (to avoid recursion)
+     */
+    public function dump( $maxDepth = self::DEFAULT_DEPTH, $currentLevel = 0, SplObjectStorage $objectSet = null );
+}

--- a/ezp/Base/Proxy.php
+++ b/ezp/Base/Proxy.php
@@ -8,12 +8,14 @@
  */
 
 namespace ezp\Base;
+use ezp\Base\Dumpable,
+    SplObjectStorage;
 
 /**
  * Proxy class for model objects
  *
  */
-abstract class Proxy
+abstract class Proxy implements Dumpable
 {
     /**
      * Service used to load the object the proxy represents.
@@ -96,5 +98,31 @@ abstract class Proxy
     {
         $this->lazyLoad();
         return isset( $this->proxiedObject->$property );
+    }
+
+    /**
+     * Dump an object in a similar way to var_dump()
+     *
+     * @param int $maxDepth Maximum depth
+     * @param int $currentLevel Current level
+     * @param \SplObjectStorage Set of objects already printed (to avoid recursion)
+     */
+    public function dump( $maxDepth = Dumpable::DEFAULT_DEPTH, $currentLevel = 0, SplObjectStorage $objectSet = null )
+    {
+        $spaces = str_repeat( " ", 2 * $currentLevel );
+
+        if ( $maxDepth === $currentLevel )
+        {
+            echo $spaces, "...\n";
+            return;
+        }
+
+        echo
+            $spaces, "object(", get_class( $this ), ") {\n",
+            $spaces, "id:";
+
+        var_dump( $this->id );
+
+        echo $spaces, "}\n";
     }
 }


### PR DESCRIPTION
Calling the dump() method on an ezp\Content\Concrete object with a depth = 2 would display something like:

```
object(ezp\Content\Concrete) {
id: '108'
currentVersionNo: 1
status: NULL
ownerId: '14'
alwaysAvailable: false
remoteId: '17e526d5a6eed6da1053f784c6fc91d9'
sectionId: 1
typeId: 1
modified: 1324552107
published: 1324552107
initialLanguageId: 2
mainLocation: NULL
section:
  object(ezp\Content\Section\Proxy) {
  id:int(1)
  }
owner:
  object(ezp\User\Proxy) {
  id:string(2) "14"
  }
fields:
  object(ezp\Content\Field\StaticCollection) {
  type:string(17) "ezp\Content\Field"
  elements array(5):
    [name] =>
      ...
    [short_description] =>
      ...
    [short_name] =>
      ...
    [description] =>
      ...
    [show_children] =>
      ...
  }
contentType:
  object(ezp\Content\Type\Proxy) {
  id:int(1)
  }
versions:
  object(ezp\Content\Version\LazyCollection) {
  type:string(19) "ezp\Content\Version"
  elements array(1):
    [1] =>
      ...
  }
locations:
  object(ezp\Base\Collection\Type) {
  type:string(20) "ezp\Content\Location"
  elements array(0):
  }
relations:
  object(ezp\Base\Collection\Type) {
  type:string(20) "ezp\Content\Relation"
  elements array(0):
  }
reverseRelations:
  object(ezp\Base\Collection\Type) {
  type:string(20) "ezp\Content\Relation"
  elements array(0):
  }
currentVersion:
  object(ezp\Content\Version\Concrete) {
  id: '609'
  name: NULL
  versionNo: 1
  creatorId: '14'
  created: 1324552107
  modified: 1324552107
  status: 0
  contentId: '108'
  initialLanguageId: 2
  fields:
    ...
  content:
    ...
  ownerId: '14'
  alwaysAvailable: false
  remoteId: '17e526d5a6eed6da1053f784c6fc91d9'
  sectionId: 1
  typeId: 1
  contentStatus: NULL
  mainLocation: NULL
  section:
    ...
  owner:
    ...
  contentType:
    ...
  locations:
    ...
  relations:
    ...
  reverseRelations:
    ...
  initialLanguage: NULL
  }
initialLanguage: NULL
}
```
