### PR TITLE
Add missing read only properties to role structs

### DIFF
--- a/eZ/Publish/API/Repository/Values/User/PolicyCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/PolicyCreateStruct.php
@@ -31,7 +31,7 @@ abstract class PolicyCreateStruct extends ValueObject
      *
      * @return \eZ\Publish\API\Repository\Values\User\Limitation[]
      */
-    public abstract function getLimitations();
+    abstract public function getLimitations();
 
     /**
      *

--- a/eZ/Publish/API/Repository/Values/User/PolicyUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/PolicyUpdateStruct.php
@@ -14,7 +14,7 @@ abstract class PolicyUpdateStruct extends ValueObject
      *
      * @return \eZ\Publish\API\Repository\Values\User\Limitation[]
      */
-    public abstract function getLimitations();
+    abstract public function getLimitations();
 
     /**
      *

--- a/eZ/Publish/API/Repository/Values/User/RoleCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleCreateStruct.php
@@ -29,7 +29,7 @@ abstract class RoleCreateStruct extends ValueObject
      *
      * @return \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct[]
      */
-    public abstract function getPolicies();
+    abstract public function getPolicies();
 
     /**
      * Adds a policy to this role


### PR DESCRIPTION
These should be readable. As far as I can see, there's no way to access limitations and policies once added to structs, there's no abstract methods to implement like, for example, eZ\Publish\API\Repository\Values\User\Role::getPolicies
