### PR TITLE
Add doc for throwing IllegalArgumentException in UserService::loadUserByCredentials

### DIFF
--- a/eZ/Publish/API/Repository/UserService.php
+++ b/eZ/Publish/API/Repository/UserService.php
@@ -138,6 +138,7 @@ interface UserService
      * @return \eZ\Publish\API\Repository\Values\User\User
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user with the given credentials was not found
+     * @throws \eZ\Publish\API\Repository\Exceptions\IllegalArgumentException if multiple users with same login were found
      */
     public function loadUserByCredentials( $login, $password );
 


### PR DESCRIPTION
Since persistence method to load user by login/email is designed to return more than one user, this is to make sure that we only have one user when using login/password combination in user service.
