### PR TITLE
Fix bug in InMemory search handler for Status criterion

### DIFF
--- a/eZ/Publish/Core/Persistence/InMemory/SearchHandler.php
+++ b/eZ/Publish/Core/Persistence/InMemory/SearchHandler.php
@@ -193,7 +193,6 @@ class SearchHandler extends SearchHandlerInterface
                         throw new Exception( "Unsuported StatusCriterion->value[0]: " . $criterion->value[0] );
 
                 }
-                $match['status'] = $criterion->value[0];
             }
             else if ( $criterion instanceof ParentLocationId && !isset( $match['locations']['parentId'] ) )
             {


### PR DESCRIPTION
This is an obvious bug, Status criterion sets the value to be matched even when processed by switch statement, which is a problem becaue Status consts are not the same as Content consts.
