### PR TITLE
Fix copying objects in InMemory content handler by setting missing fields

### DIFF
--- a/eZ/Publish/Core/Persistence/InMemory/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/InMemory/ContentHandler.php
@@ -178,6 +178,8 @@ class ContentHandler implements ContentHandlerInterface
         if ( !$content )
             throw new NotFound( "Content", "contentId: $contentId" );
 
+        $time = time();
+
         $currentVersionNo = $versionNo === false ? $content->currentVersionNo : $versionNo;
         $contentObj = $this->backend->create(
             "Content", array(
@@ -186,10 +188,12 @@ class ContentHandler implements ContentHandlerInterface
                 "ownerId" => $content->ownerId,
                 "status" => $content->status,
                 "currentVersionNo" => $currentVersionNo,
+                "initialLanguageId" => $content->initialLanguageId,
+                "modified" => $time,
+                "published" => $time
             )
         );
 
-        $time = time();
         // Copy version(s)
         foreach (
             $this->backend->find(


### PR DESCRIPTION
Objects are copied without valid initial language id and modified/published dates which makes my tests fail.

P.S. May be the case in other places, didn't search for it.
