### PR TITLE
Fix bug in create method in legacy content handler due to mixup with variable names

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
@@ -236,14 +236,14 @@ class Handler implements BaseLocationHandler
     /**
      * Creates a new location rooted at $location->parentId.
      *
-     * @param \eZ\Publish\SPI\Persistence\Content\Location\CreateStruct $locationStruct
+     * @param \eZ\Publish\SPI\Persistence\Content\Location\CreateStruct $createStruct
      * @return \eZ\Publish\SPI\Persistence\Content\Location
      */
-    public function create( CreateStruct $locationStruct )
+    public function create( CreateStruct $createStruct )
     {
-        $parentNodeData = $this->locationGateway->getBasicNodeData( $locationStruct->parentId );
-        $locationStruct = $this->locationGateway->create( $locationStruct, $parentNodeData );
-        $this->locationGateway->createNodeAssignment( $locationStruct, $parentNodeData['node_id'], LocationGateway::NODE_ASSIGNMENT_OP_CODE_CREATE_NOP );
+        $parentNodeData = $this->locationGateway->getBasicNodeData( $createStruct->parentId );
+        $locationStruct = $this->locationGateway->create( $createStruct, $parentNodeData );
+        $this->locationGateway->createNodeAssignment( $createStruct, $parentNodeData['node_id'], LocationGateway::NODE_ASSIGNMENT_OP_CODE_CREATE_NOP );
 
         return $locationStruct;
     }


### PR DESCRIPTION
createNodeAssignment method accepts CreateStruct object, but the variable is overwritten by previous line ($this->locationGateway->create) which returns Location object.
