### PR TITLE
Fixed: field property language changed to languageCode

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/EzcDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/EzcDatabase.php
@@ -174,10 +174,10 @@ class EzcDatabase extends Gateway
         $languages = array();
         foreach ( $fields as $field )
         {
-            if ( isset( $languages[$field->language] ) )
+            if ( isset( $languages[$field->languageCode] ) )
                 continue;
 
-            $languages[$field->language] = true;
+            $languages[$field->languageCode] = true;
         }
 
         if ( $alwaysAvailable )


### PR DESCRIPTION
This is a leftover from SPI Field "language" to "languageCode" change
