### PR TITLE
Fix InMemory TrashHandler::recover not throwing NotFoundException

### DIFF
--- a/eZ/Publish/Core/Persistence/InMemory/TrashHandler.php
+++ b/eZ/Publish/Core/Persistence/InMemory/TrashHandler.php
@@ -105,14 +105,7 @@ class TrashHandler implements TrashHandlerInterface
     public function recover( $trashedId, $newParentId )
     {
         $trashedLocation = $this->loadTrashItem( $trashedId );
-        try
-        {
-            $newParent = $this->handler->locationHandler()->load( $newParentId );
-        }
-        catch ( NotFound $e )
-        {
-            throw new ParentNotFound( $trashedLocation->id, $newParentId, $e );
-        }
+        $newParent = $this->handler->locationHandler()->load( $newParentId );
 
         // Restore location under $newParent
         $struct = new CreateStruct;
@@ -124,7 +117,7 @@ class TrashHandler implements TrashHandlerInterface
             }
         }
 
-        $struct->parentId = $newParentId;
+        $struct->parentId = $newParent->id;
         return $this->handler->locationHandler()->create( $struct )->id;
     }
 


### PR DESCRIPTION
With this, exception bubbles from below

The purpose of the pull request is so InMemory trash handler is compatible with Legacy
