### PR TITLE
Fix InMemory UserHandler::loadByLogin not throwing NotFoundException if no users are found

### DIFF
--- a/eZ/Publish/Core/Persistence/InMemory/UserHandler.php
+++ b/eZ/Publish/Core/Persistence/InMemory/UserHandler.php
@@ -91,7 +91,7 @@ class UserHandler implements UserHandlerInterface
         $users = $this->backend->find( 'User', array( 'login' => $login ) );
         if ( !$alsoMatchEmail )
         {
-            if ( empty ( $users ) )
+            if ( empty( $users ) )
                 throw new NotFound( 'User', $login );
 
             return $users;
@@ -107,7 +107,7 @@ class UserHandler implements UserHandlerInterface
             $users[] = $emailUser;
         }
 
-        if ( empty ( $users ) )
+        if ( empty( $users ) )
             throw new NotFound( 'User', $login );
 
         return $users;


### PR DESCRIPTION
This is so InMemory handler would be in sync with Legacy handler
