### PR TITLE
Separated ContentHandler::delete() into deleteContent() and deleteVersion()

### DIFF
--- a/eZ/Publish/Core/Persistence/InMemory/LocationHandler.php
+++ b/eZ/Publish/Core/Persistence/InMemory/LocationHandler.php
@@ -378,7 +378,7 @@ class LocationHandler implements LocationHandlerInterface
         {
             try
             {
-                $this->handler->contentHandler()->delete( $location->contentId );
+                $this->handler->contentHandler()->deleteContent( $location->contentId );
             }
             // Ignoring a NotFound exception since the content handler also takes care of removing itself and locations
             catch ( NotFound $e )

--- a/eZ/Publish/Core/Persistence/InMemory/Tests/ContentHandlerRelationTest.php
+++ b/eZ/Publish/Core/Persistence/InMemory/Tests/ContentHandlerRelationTest.php
@@ -115,7 +115,7 @@ class ContentHandlerRelationTest extends HandlerTest
             // Removing default objects as well as those created by tests
             foreach ( $this->contentToDelete as $content )
             {
-                $contentHandler->delete( $content->contentInfo->contentId );
+                $contentHandler->deleteContent( $content->contentInfo->contentId );
             }
         }
         catch ( NotFound $e )

--- a/eZ/Publish/Core/Persistence/InMemory/Tests/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/InMemory/Tests/ContentHandlerTest.php
@@ -86,14 +86,14 @@ class ContentHandlerTest extends HandlerTest
             // Removing default objects as well as those created by tests
             foreach ( $this->contentToDelete as $content )
             {
-                $contentHandler->delete( $content->contentInfo->contentId );
+                $contentHandler->deleteContent( $content->contentInfo->contentId );
             }
         }
         catch ( NotFound $e )
         {
         }
         unset( $this->contentId );
-        //$contentHandler->delete( 2 );
+        //$contentHandler->deleteContent( 2 );
         parent::tearDown();
     }
 
@@ -148,13 +148,13 @@ class ContentHandlerTest extends HandlerTest
     /**
      * Test delete function
      *
-     * @covers \eZ\Publish\Core\Persistence\InMemory\ContentHandler::delete
+     * @covers \eZ\Publish\Core\Persistence\InMemory\ContentHandler::deleteContent
      * @group contentHandler
      */
     public function testDelete()
     {
         $contentHandler = $this->persistenceHandler->contentHandler();
-        $contentHandler->delete( $this->content->contentInfo->contentId );
+        $contentHandler->deleteContent( $this->content->contentInfo->contentId );
 
         try
         {
@@ -181,10 +181,10 @@ class ContentHandlerTest extends HandlerTest
      * @covers \eZ\Publish\Core\Persistence\InMemory\ContentHandler::delete
      * @group contentHandler
      */
-    public function testDeleteWithSecondArgument()
+    public function testDeleteVersion()
     {
         $contentHandler = $this->persistenceHandler->contentHandler();
-        $contentHandler->delete( 1, 2 );
+        $contentHandler->deleteVersion( 1, 2 );
 
         $versionInfo = $contentHandler->loadVersionInfo( 1, 2 );
         if ( !empty( $versionInfo ) )

--- a/eZ/Publish/Core/Persistence/InMemory/Tests/LocationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/InMemory/Tests/LocationHandlerTest.php
@@ -149,7 +149,7 @@ class LocationHandlerTest extends HandlerTest
         {
             try
             {
-                $contentHandler->delete( $content->contentInfo->contentId );
+                $contentHandler->deleteContent( $content->contentInfo->contentId );
             }
             catch ( NotFound $e )
             {

--- a/eZ/Publish/Core/Persistence/InMemory/Tests/SearchHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/InMemory/Tests/SearchHandlerTest.php
@@ -78,7 +78,7 @@ class SearchHandlerTest extends HandlerTest
             // Removing default objects as well as those created by tests
             foreach ( $this->contentToDelete as $content )
             {
-                $contentHandler->delete( $content->contentInfo->contentId );
+                $contentHandler->deleteContent( $content->contentInfo->contentId );
             }
         }
         catch ( NotFound $e )

--- a/eZ/Publish/Core/Persistence/InMemory/Tests/TrashHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/InMemory/Tests/TrashHandlerTest.php
@@ -157,7 +157,7 @@ class TrashHandlerTest extends HandlerTest
         {
             try
             {
-                $contentHandler->delete( $content->contentInfo->contentId );
+                $contentHandler->deleteContent( $content->contentInfo->contentId );
             }
             catch ( NotFound $e )
             {

--- a/eZ/Publish/Core/Persistence/InMemory/TrashHandler.php
+++ b/eZ/Publish/Core/Persistence/InMemory/TrashHandler.php
@@ -156,7 +156,7 @@ class TrashHandler implements TrashHandlerInterface
             // Remove associated content for trashed locations
             foreach ( $contentIds as $contentId )
             {
-                $this->handler->contentHandler()->delete( $contentId );
+                $this->handler->contentHandler()->deleteContent( $contentId );
             }
 
             // Remove trashed locations
@@ -170,7 +170,7 @@ class TrashHandler implements TrashHandlerInterface
     public function deleteTrashItem( $trashedId )
     {
         $vo = $this->loadTrashItem( $trashedId );
-        $this->handler->contentHandler()->delete( $vo->contentId );
+        $this->handler->contentHandler()->deleteContent( $vo->contentId );
         $this->backend->delete( 'Content\\Location\\Trashed', $trashedId );
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -367,33 +367,42 @@ class Handler implements BaseContentHandler
     }
 
     /**
-     * If $versionNo is not set, deletes all versions and fields, all locations (subtree), and all relations.
-     * When $versionNo is set, deletes given version, its fields, node assignment, relations and names.
+     * Deletes all versions and fields, all locations (subtree), and all relations.
      *
-     * Removes the relations, but not the related objects. When $versionNo is not set,
-     * all subtrees of the assigned nodes of this content objects are removed (recursively).
+     * Removes the relations, but not the related objects. All subtrees of the
+     * assigned nodes of this content objects are removed (recursively).
      *
      * @param int $contentId
-     * @param int|null $versionNo
+     * @return boolean
+     */
+    public function deleteContent( $contentId )
+    {
+        $locationIds = $this->contentGateway->getAllLocationIds( $contentId );
+        foreach ( $locationIds as $locationId )
+        {
+            $this->locationGateway->removeSubtree( $locationId );
+        }
+        $this->fieldHandler->deleteFields( $contentId );
+
+        $this->contentGateway->deleteRelations( $contentId );
+        $this->contentGateway->deleteVersions( $contentId );
+        $this->contentGateway->deleteNames( $contentId );
+        $this->contentGateway->deleteContent( $contentId );
+    }
+
+    /**
+     * Deletes given version, its fields, node assignment, relations and names.
+     *
+     * Removes the relations, but not the related objects.
+     *
+     * @param int $contentId
+     * @param int $versionNo
      *
      * @return boolean
      */
-    public function delete( $contentId, $versionNo = null )
+    public function deleteVersion( $contentId, $versionNo )
     {
-        if ( isset( $versionNo ) )
-        {
-            $this->locationGateway->deleteNodeAssignment( $contentId, $versionNo );
-        }
-        else
-        {
-            $locationIds = $this->contentGateway->getAllLocationIds( $contentId );
-            foreach ( $locationIds as $locationId )
-            {
-                $this->locationGateway->removeSubtree( $locationId );
-            }
-            $this->contentGateway->deleteContent( $contentId );
-        }
-
+        $this->locationGateway->deleteNodeAssignment( $contentId, $versionNo );
         $this->fieldHandler->deleteFields( $contentId, $versionNo );
         $this->contentGateway->deleteRelations( $contentId, $versionNo );
         $this->contentGateway->deleteVersions( $contentId, $versionNo );

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Trash/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Trash/Handler.php
@@ -180,7 +180,7 @@ class Handler implements BaseTrashHandler
         $this->locationGateway->removeElementFromTrash( $trashItem->id );
 
         if ( $this->locationGateway->countLocationsByContentId( $trashItem->contentId ) < 1 )
-            $this->contentHandler->delete( $trashItem->contentId );
+            $this->contentHandler->deleteContent( $trashItem->contentId );
     }
 }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
@@ -557,9 +557,9 @@ class ContentHandlerTest extends TestCase
 
     /**
      * @return void
-     * @covers eZ\Publish\Core\Persistence\Legacy\Content\Handler::delete
+     * @covers eZ\Publish\Core\Persistence\Legacy\Content\Handler::deleteContent
      */
-    public function testDelete()
+    public function testDeleteContent()
     {
         $handler = $this->getContentHandler();
 
@@ -579,7 +579,6 @@ class ContentHandlerTest extends TestCase
                 $this->equalTo( 24 )
             )
         );
-        $locationHandlerMock->expects( $this->never() )->method( 'deleteNodeAssignment' );
 
         $fieldHandlerMock->expects( $this->once() )
             ->method( 'deleteFields' )
@@ -597,14 +596,14 @@ class ContentHandlerTest extends TestCase
             ->method( 'deleteContent' )
             ->with( $this->equalTo( 23 ) );
 
-        $handler->delete( 23 );
+        $handler->deleteContent( 23 );
     }
 
     /**
      * @return void
-     * @covers eZ\Publish\Core\Persistence\Legacy\Content\Handler::delete
+     * @covers eZ\Publish\Core\Persistence\Legacy\Content\Handler::deleteVersion
      */
-    public function testDeleteWithSecondArgument()
+    public function testDeleteVersion()
     {
         $handler = $this->getContentHandler();
 
@@ -612,8 +611,6 @@ class ContentHandlerTest extends TestCase
         $locationHandlerMock = $this->getLocationGatewayMock();
         $fieldHandlerMock  = $this->getFieldHandlerMock();
 
-        $gatewayMock->expects( $this->never() )->method( 'getAllLocationIds' );
-        $locationHandlerMock->expects( $this->never() )->method( 'removeSubtree' );
         $locationHandlerMock->expects( $this->once() )
             ->method( 'deleteNodeAssignment' )
             ->with(
@@ -645,9 +642,8 @@ class ContentHandlerTest extends TestCase
                 $this->equalTo( 225 ),
                 $this->equalTo( 2 )
             );
-        $gatewayMock->expects( $this->never() )->method( 'deleteContent' );
 
-        $handler->delete( 225, 2 );
+        $handler->deleteVersion( 225, 2 );
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/TrashHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/TrashHandlerTest.php
@@ -210,7 +210,7 @@ class TrashHandlerTest extends TestCase
 
             $this->contentHandler
                 ->expects( $this->at( $iContent++ ) )
-                ->method( 'delete' )
+                ->method( 'deleteContent' )
                 ->with( $trashedElement['contentobject_id'] );
         }
 
@@ -266,7 +266,7 @@ class TrashHandlerTest extends TestCase
 
         $this->contentHandler
             ->expects( $this->once() )
-            ->method( 'delete' )
+            ->method( 'deleteContent' )
             ->with( 67 );
 
         $handler->deleteTrashItem( 69 );
@@ -321,7 +321,7 @@ class TrashHandlerTest extends TestCase
 
         $this->contentHandler
             ->expects( $this->never() )
-            ->method( 'delete' );
+            ->method( 'deleteContent' );
 
         $handler->deleteTrashItem( 69 );
     }

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -671,7 +671,7 @@ class ContentService implements ContentServiceInterface
      */
     public function deleteContent( APIContentInfo $contentInfo )
     {
-        $this->persistenceHandler->contentHandler()->delete( $contentInfo->contentId );
+        $this->persistenceHandler->contentHandler()->deleteContent( $contentInfo->contentId );
     }
 
     /**

--- a/eZ/Publish/SPI/Persistence/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Handler.php
@@ -156,18 +156,27 @@ interface Handler
     public function updateContent( $contentId, $versionNo, UpdateStruct $content );
 
     /**
-     * If $versionNo is not set, deletes all versions and fields, all locations (subtree), and all relations.
-     * When $versionNo is set, deletes given version, its fields, node assignment, relations and names.
+     * Deletes all versions and fields, all locations (subtree), and all relations.
      *
-     * Removes the relations, but not the related objects. When locations are being deleted,
-     * all subtrees of the assigned nodes of this content object are removed (recursively).
+     * Removes the relations, but not the related objects. All subtrees of the
+     * assigned nodes of this content objects are removed (recursively).
      *
      * @param int $contentId
-     * @param int|null $versionNo
+     * @return boolean
+     */
+    public function deleteContent( $contentId );
+
+    /**
+     * Deletes given version, its fields, node assignment, relations and names.
+     *
+     * Removes the relations, but not the related objects.
+     *
+     * @param int $contentId
+     * @param int $versionNo
      *
      * @return boolean
      */
-    public function delete( $contentId, $versionNo = null );
+    public function deleteVersion( $contentId, $versionNo );
 
     /**
      * Return the versions for $contentId


### PR DESCRIPTION
ContentHandler::delete() calls and mock checks renamed to deleteContent.
