### PR TITLE
Fixed EZP-114: eZScript breaks REST test server

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -38,7 +38,10 @@ if ( $classLoader instanceof Composer\Autoload\ClassLoader )
 // Bootstrap eZ Publish legacy kernel if configured
 if ( !empty( $settings['service']['parameters']['legacy_dir'] ) )
 {
-    $legacyKernel = new LegacyKernel( new LegacyKernelCLI, $settings['service']['parameters']['legacy_dir'], getcwd() );
+    // Define $legacyKernelHandler to whatever you need before loading this bootstrap file.
+    // CLI handler is used by defaut, but you must use \ezpKernelWeb if not in CLI context (i.e. REST server)
+    $legacyKernelHandler = isset( $legacyKernelHandler ) ? $legacyKernelHandler : new LegacyKernelCLI;
+    $legacyKernel = new LegacyKernel( $legacyKernelHandler, $settings['service']['parameters']['legacy_dir'], getcwd() );
     set_exception_handler( null );
     // Avoid "Fatal error" text from legacy kernel if not called
     $legacyKernel->runCallback(

--- a/eZ/Publish/Core/REST/Server/index.php
+++ b/eZ/Publish/Core/REST/Server/index.php
@@ -37,6 +37,8 @@ if ( !isset( $_ENV['DATABASE'] ) )
     exit( 1 );
 }
 
+// Exposing $legacyKernelHandler to be a web handler (to be used in bootstrap.php)
+$legacyKernelHandler = new \ezpKernelWeb;
 require_once __DIR__ . '/../../../../../bootstrap.php';
 
 /*


### PR DESCRIPTION
It was broken because wrong kernel handler was used (CLI instead of web).
This PR should do the trick.

@tobyS @bdunogier @emodric @andrerom Can you please confirm ?
Thanks
