### PR TITLE
Fixed: make possible to render a view outside of the complete pagelayout

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -6,6 +6,8 @@ parameters:
 
     ezpublish.view_manager.class: eZ\Publish\Core\MVC\Symfony\View\Manager
     ezpublish.content_view_provider.configured.class: eZ\Bundle\EzPublishCoreBundle\View\ContentViewProvider\Configured
+    ezpublish.content_view.viewbase_layout: "EzPublishCoreBundle::viewbase_layout.html.twig"
+    ezpublish.content_view.content_block_name: "content"
 
 services:
     # Redefining twig loader to use the chain loader instead of only the file system loader.
@@ -37,7 +39,7 @@ services:
 
     ezpublish.view_manager:
         class: %ezpublish.view_manager.class%
-        arguments: [@templating, @event_dispatcher, @?logger]
+        arguments: [@templating, @event_dispatcher, %ezpublish.content_view.viewbase_layout%, @?logger]
 
     ezpublish.content_view_provider.configured:
         class: %ezpublish.content_view_provider.configured.class%

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/viewbase_layout.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/viewbase_layout.html.twig
@@ -1,0 +1,4 @@
+{# this is the layout used when we want to render a block with any decoration
+ # ie with using the complete pagelayout.
+ #}
+{% block content %}{% endblock %}

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/view.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/view.yml
@@ -3,7 +3,8 @@ parameters:
     ezpublish_legacy.content_view_decorator.twig.class: eZ\Publish\Core\MVC\Legacy\View\TwigContentViewLayoutDecorator
     ezpublish_legacy.content_view_decorator.options:
         layout: %ezpublish_legacy.view.default_layout%
-        contentBlockName: %ezpublish_legacy.view.content_block_name%
+        viewbaseLayout: %ezpublish.content_view.viewbase_layout%
+        contentBlockName: %ezpublish.content_view.content_block_name%
 
 services:
     ezpublish_legacy.content_view_provider:

--- a/eZ/Publish/Core/MVC/Legacy/View/TwigContentViewLayoutDecorator.php
+++ b/eZ/Publish/Core/MVC/Legacy/View/TwigContentViewLayoutDecorator.php
@@ -76,8 +76,13 @@ class TwigContentViewLayoutDecorator implements ContentViewInterface
         return function ( array $params ) use ( $options, $contentView, $twig )
         {
             $contentViewClosure = $contentView->getTemplateIdentifier();
+            $layout = $options['layout'];
+            if ( isset( $params['noLayout'] ) && $params['noLayout'] )
+            {
+                $layout = $options['viewbaseLayout'];
+            }
             $twigContentTemplate = <<<EOT
-{% extends "{$options['layout']}" %}
+{% extends "{$layout}" %}
 
 {% block {$options['contentBlockName']} %}
 {$contentViewClosure( $params )}

--- a/eZ/Publish/Core/MVC/Symfony/View/Manager.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Manager.php
@@ -49,10 +49,19 @@ class Manager
      */
     protected $eventDispatcher;
 
-    public function __construct( EngineInterface $templateEngine, EventDispatcherInterface $eventDispatcher, LoggerInterface $logger = null )
+    /**
+     * The base layout template to use when the view is requested to be generated
+     * outside of the pagelayout.
+     *
+     * @var string
+     */
+    protected $viewBaseLayout;
+
+    public function __construct( EngineInterface $templateEngine, EventDispatcherInterface $eventDispatcher, $viewBaseLayout, LoggerInterface $logger = null )
     {
         $this->templateEngine = $templateEngine;
         $this->eventDispatcher = $eventDispatcher;
+        $this->viewBaseLayout = $viewBaseLayout;
         $this->logger = $logger;
     }
 
@@ -170,6 +179,7 @@ class Manager
      */
     public function renderContentView( ContentViewInterface $view, array $defaultParams = array() )
     {
+        $defaultParams['viewbaseLayout'] = $this->viewBaseLayout;
         $view->addParameters( $defaultParams );
         $this->eventDispatcher->dispatch(
             MVCEvents::PRE_CONTENT_VIEW,

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/ViewManagerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/ViewManagerTest.php
@@ -32,6 +32,8 @@ class ViewManagerTest extends \PHPUnit_Framework_TestCase
      */
     private $eventDispatcherMock;
 
+    private $viewBaseLayout = 'EzPublishCoreBundle::viewbase.html.twig';
+
     protected  function setUp()
     {
         parent::setUp();
@@ -39,7 +41,8 @@ class ViewManagerTest extends \PHPUnit_Framework_TestCase
         $this->eventDispatcherMock = $this->getMock( 'Symfony\\Component\\EventDispatcher\\EventDispatcherInterface' );
         $this->viewManager = new Manager(
             $this->templateEngineMock,
-            $this->eventDispatcherMock
+            $this->eventDispatcherMock,
+            $this->viewBaseLayout
         );
     }
 
@@ -115,7 +118,7 @@ class ViewManagerTest extends \PHPUnit_Framework_TestCase
         $this->templateEngineMock
             ->expects( $this->once() )
             ->method( 'render' )
-            ->with( $templateIdentifier, $params + array( 'content' => $content ) )
+            ->with( $templateIdentifier, $params + array( 'content' => $content, 'viewbaseLayout' => $this->viewBaseLayout ) )
             ->will( $this->returnValue( $expectedTemplateResult ) )
         ;
 
@@ -164,7 +167,7 @@ class ViewManagerTest extends \PHPUnit_Framework_TestCase
         ;
 
         // Configuring template engine behaviour
-        $params += array( 'content' => $content );
+        $params += array( 'content' => $content, 'viewbaseLayout' => $this->viewBaseLayout );
         $expectedTemplateResult = serialize( array_keys( $params ) );
         $this->templateEngineMock
             ->expects( $this->never() )
@@ -205,7 +208,7 @@ class ViewManagerTest extends \PHPUnit_Framework_TestCase
         $this->templateEngineMock
             ->expects( $this->once() )
             ->method( 'render' )
-            ->with( $templateIdentifier, $params + array( 'location' => $location, 'content' => $content ) )
+            ->with( $templateIdentifier, $params + array( 'location' => $location, 'content' => $content, 'viewbaseLayout' => $this->viewBaseLayout ) )
             ->will( $this->returnValue( $expectedTemplateResult ) )
         ;
 
@@ -242,7 +245,7 @@ class ViewManagerTest extends \PHPUnit_Framework_TestCase
         ;
 
         // Configuring template engine behaviour
-        $params += array( 'location' => $location, 'content' => $content );
+        $params += array( 'location' => $location, 'content' => $content, 'viewbaseLayout' => $this->viewBaseLayout );
         $expectedTemplateResult = serialize( array_keys( $params ) );
         $this->templateEngineMock
             ->expects( $this->never() )


### PR DESCRIPTION
With this patch, it's now possible to execute a view without using the complete pagelayout if the view template is correctly written.
see https://github.com/ezsystems/ezpublish5/blob/2d78fcfbe02ba39d7c92a7e0fe4b225a9be9a0ef/src/EzSystems/DemoBundle/Resources/views/full/small_folder.html.twig for an example.
