### PR TITLE
Removed: usage of LocationService::loadMainLocation() in MVC

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/View/ContentViewProvider/Configured/Matcher/Depth.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ContentViewProvider/Configured/Matcher/Depth.php
@@ -34,7 +34,7 @@ class Depth extends MultipleValued
      */
     public function matchContentInfo( ContentInfo $contentInfo )
     {
-        $location = $this->repository->getLocationService()->loadMainLocation( $contentInfo );
+        $location = $this->repository->getLocationService()->loadLocation( $contentInfo->mainLocationId );
         return isset( $this->values[$location->depth] );
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/View/ContentViewProvider/Configured/Matcher/Id/ParentContentType.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ContentViewProvider/Configured/Matcher/Id/ParentContentType.php
@@ -37,7 +37,7 @@ class ParentContentType extends MultipleValued
     public function matchContentInfo( ContentInfo $contentInfo )
     {
         return $this->matchLocation(
-            $this->repository->getLocationService()->loadMainLocation( $contentInfo )
+            $this->repository->getLocationService()->loadLocation( $contentInfo->mainLocationId )
         );
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/View/ContentViewProvider/Configured/Matcher/Id/ParentLocation.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ContentViewProvider/Configured/Matcher/Id/ParentLocation.php
@@ -34,7 +34,7 @@ class ParentLocation extends MultipleValued
      */
     public function matchContentInfo( ContentInfo $contentInfo )
     {
-        $location = $this->repository->getLocationService()->loadMainLocation( $contentInfo );
+        $location = $this->repository->getLocationService()->loadLocation( $contentInfo->mainLocationId );
         return isset( $this->values[$location->parentLocationId] );
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/View/ContentViewProvider/Configured/Matcher/Identifier/ParentContentType.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ContentViewProvider/Configured/Matcher/Identifier/ParentContentType.php
@@ -37,7 +37,7 @@ class ParentContentType extends MultipleValued
     public function matchContentInfo( ContentInfo $contentInfo )
     {
         return $this->matchLocation(
-            $this->repository->getLocationService()->loadMainLocation( $contentInfo )
+            $this->repository->getLocationService()->loadLocation( $contentInfo->mainLocationId )
         );
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/ContentViewProvider/Configured/Matcher/DepthTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/ContentViewProvider/Configured/Matcher/DepthTest.php
@@ -96,7 +96,7 @@ class ParentLocationTest extends BaseTest
         $this->matcher->setMatchingConfig( $matchingConfig );
         $this->assertSame(
             $expectedResult,
-            $this->matcher->matchContentInfo( $this->getContentInfoMock() )
+            $this->matcher->matchContentInfo( $this->getContentInfoMock( array( "mainLocationId" => 42 ) ) )
         );
     }
 
@@ -140,8 +140,8 @@ class ParentLocationTest extends BaseTest
             ->getMock()
         ;
         $locationServiceMock->expects( $this->once() )
-            ->method( 'loadMainLocation' )
-            ->with( $this->isInstanceOf( 'eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo' ) )
+            ->method( 'loadLocation' )
+            ->with( 42 )
             ->will(
                 $this->returnValue(
                     $this->getLocationMock( array( 'depth' => $depth ) )

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/ContentViewProvider/Configured/Matcher/Id/ParentContentTypeTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/ContentViewProvider/Configured/Matcher/Id/ParentContentTypeTest.php
@@ -63,7 +63,7 @@ class ParentContentTypeTest extends BaseTest
             ->disableOriginalConstructor()
             ->getMock()
         ;
-        $locationServiceMock->expects( $this->once() )
+        $locationServiceMock->expects( $this->atLeastOnce() )
             ->method( 'loadLocation' )
             ->will(
                 $this->returnValue( $parentLocation )
@@ -71,7 +71,7 @@ class ParentContentTypeTest extends BaseTest
         ;
         // The following is used in the case of a match by contentInfo
         $locationServiceMock->expects( $this->any() )
-            ->method( 'loadMainLocation' )
+            ->method( 'loadLocation' )
             ->will(
                 $this->returnValue( $this->getLocationMock() )
             )

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/ContentViewProvider/Configured/Matcher/Id/ParentLocationTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/ContentViewProvider/Configured/Matcher/Id/ParentLocationTest.php
@@ -86,7 +86,7 @@ class ParentLocationTest extends BaseTest
         $this->matcher->setMatchingConfig( $matchingConfig );
         $this->assertSame(
             $expectedResult,
-            $this->matcher->matchContentInfo( $this->getContentInfoMock() )
+            $this->matcher->matchContentInfo( $this->getContentInfoMock( array( "mainLocationId" => 42 ) ) )
         );
     }
 
@@ -130,8 +130,8 @@ class ParentLocationTest extends BaseTest
             ->getMock()
         ;
         $locationServiceMock->expects( $this->once() )
-            ->method( 'loadMainLocation' )
-            ->with( $this->isInstanceOf( 'eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo' ) )
+            ->method( 'loadLocation' )
+            ->with( 42 )
             ->will(
                 $this->returnValue(
                     $this->getLocationMock( array( 'parentLocationId' => $parentLocationId ) )

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/ContentViewProvider/Configured/Matcher/Identifier/ParentContentTypeTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/ContentViewProvider/Configured/Matcher/Identifier/ParentContentTypeTest.php
@@ -63,7 +63,7 @@ class ParentContentTypeTest extends BaseTest
             ->disableOriginalConstructor()
             ->getMock()
         ;
-        $locationServiceMock->expects( $this->once() )
+        $locationServiceMock->expects( $this->atLeastOnce() )
             ->method( 'loadLocation' )
             ->will(
                 $this->returnValue( $parentLocation )
@@ -71,7 +71,7 @@ class ParentContentTypeTest extends BaseTest
         ;
         // The following is used in the case of a match by contentInfo
         $locationServiceMock->expects( $this->any() )
-            ->method( 'loadMainLocation' )
+            ->method( 'loadLocation' )
             ->will(
                 $this->returnValue( $this->getLocationMock() )
             )


### PR DESCRIPTION
This PR removes usage of LocationService::loadMainLocation() from MVC
