### PR TITLE
Completely removed loadMainLocation()

### DIFF
--- a/eZ/Publish/API/Repository/LocationService.php
+++ b/eZ/Publish/API/Repository/LocationService.php
@@ -67,21 +67,6 @@ interface LocationService
     public function loadLocationByRemoteId( $remoteId );
 
     /**
-     * loads the main location of a content object
-     *
-     * @deprecated
-     * @todo This method will be removed, use ContentInfo::mainLocationId
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user user is not allowed to read this location
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if there is no published version yet
-     *
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\Location|null Null if no location exists
-     */
-    public function loadMainLocation( ContentInfo $contentInfo );
-
-    /**
      * Loads the locations for the given content object.
      *
      * If a $rootLocation is given, only locations that belong to this location are returned.

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -4009,8 +4009,8 @@ class ContentServiceTest extends BaseContentServiceTest
         $liveContent = $contentService->publishVersion( $draft->getVersionInfo() );
         /* END: Use Case */
 
-        $location = $locationService->loadMainLocation(
-            $liveContent->getVersionInfo()->getContentInfo()
+        $location = $locationService->loadLocation(
+            $liveContent->getVersionInfo()->getContentInfo()->mainLocationId
         );
 
         $aliases = $urlAliasService->listLocationAliases( $location );
@@ -4050,8 +4050,8 @@ class ContentServiceTest extends BaseContentServiceTest
         $liveContent = $contentService->publishVersion( $draft->getVersionInfo() );
         /* END: Use Case */
 
-        $location = $locationService->loadMainLocation(
-            $liveContent->getVersionInfo()->getContentInfo()
+        $location = $locationService->loadLocation(
+            $liveContent->getVersionInfo()->getContentInfo()->mainLocationId
         );
 
         $aliases = $urlAliasService->listLocationAliases( $location, false );
@@ -4098,7 +4098,9 @@ class ContentServiceTest extends BaseContentServiceTest
 
         // Create a custom URL alias
         $urlAliasService->createUrlAlias(
-            $locationService->loadMainLocation( $content->getVersionInfo()->getContentInfo() ),
+            $locationService->loadLocation(
+                $content->getVersionInfo()->getContentInfo()->mainLocationId
+            ),
             '/my/fancy/story-about-ez-publish',
             'eng-US'
         );
@@ -4119,8 +4121,8 @@ class ContentServiceTest extends BaseContentServiceTest
         $liveContent = $contentService->publishVersion( $draftVersion2->getVersionInfo() );
         /* END: Use Case */
 
-        $location = $locationService->loadMainLocation(
-            $liveContent->getVersionInfo()->getContentInfo()
+        $location = $locationService->loadLocation(
+            $liveContent->getVersionInfo()->getContentInfo()->mainLocationId
         );
 
         $aliases = $urlAliasService->listLocationAliases( $location );

--- a/eZ/Publish/API/Repository/Tests/LocationServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceAuthorizationTest.php
@@ -156,36 +156,6 @@ class LocationServiceAuthorizationTest extends BaseTest
     }
 
     /**
-     * Test for the loadMainLocation() method.
-     *
-     * @return void
-     * @see \eZ\Publish\API\Repository\LocationService::loadMainLocation()
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     * @depends eZ\Publish\API\Repository\Tests\LocationServiceTest::testLoadMainLocation
-     */
-    public function testLoadMainLocationThrowsUnauthorizedException()
-    {
-        $repository = $this->getRepository();
-
-        $editorsGroupId = $this->generateId( 'group', 13 );
-
-        /* BEGIN: Use Case */;
-        $user = $this->createUserVersion1();
-
-        $contentService = $repository->getContentService();
-        $locationService = $repository->getLocationService();
-
-        $contentInfo = $contentService->loadContentInfo( $editorsGroupId );
-
-        // Set current user to newly created user
-        $repository->setCurrentUser( $user );
-
-        // This call will fail with an "UnauthorizedException"
-        $locationService->loadMainLocation( $contentInfo );
-        /* END: Use Case */
-    }
-
-    /**
      * Test for the swapLocation() method.
      *
      * @return void

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -468,68 +468,6 @@ class LocationServiceTest extends BaseTest
     }
 
     /**
-     * Test for the loadMainLocation() method.
-     *
-     * @return void
-     * @see \eZ\Publish\API\Repository\LocationService::loadMainLocation()
-     * @depends eZ\Publish\API\Repository\Tests\LocationServiceTest::testLoadLocation
-     */
-    public function testLoadMainLocation()
-    {
-        $repository = $this->getRepository();
-
-        $contentId = $this->generateId( 'object', 4 );
-        /* BEGIN: Use Case */
-        // $contentId is the ID of an existing content object
-        $contentService = $repository->getContentService();
-        $locationService = $repository->getLocationService();
-
-        $contentInfo = $contentService->loadContentInfo( $contentId );
-
-        $location = $locationService->loadMainLocation(
-            $contentInfo
-        );
-        /* END: Use Case */
-
-        $this->assertEquals(
-            $locationService->loadLocation( $this->generateId( 'location', 5 ) ),
-            $location
-        );
-    }
-
-    /**
-     * Test for the loadMainLocation() method.
-     *
-     * @return void
-     * @see \eZ\Publish\API\Repository\LocationService::loadMainLocation()
-     * @depends eZ\Publish\API\Repository\Tests\LocationServiceTest::testLoadMainLocation
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\BadStateException
-     */
-    public function testLoadMainLocationThrowsBadStateException()
-    {
-        $repository = $this->getRepository();
-
-        /* BEGIN: Use Case */;
-        $contentTypeService = $repository->getContentTypeService();
-        $contentService = $repository->getContentService();
-        $locationService = $repository->getLocationService();
-
-        // Create new content, which is not published
-        $folderType = $contentTypeService->loadContentTypeByIdentifier( 'folder' );
-        $contentCreate = $contentService->newContentCreateStruct(
-            $folderType, 'eng-US'
-        );
-        $contentCreate->setField( 'name', 'New Folder' );
-        $content = $contentService->createContent( $contentCreate );
-
-        // Throws Exception, since $content has no published version, yet
-        $location = $locationService->loadMainLocation(
-            $content->contentInfo
-        );
-        /* END: Use Case */
-    }
-
-    /**
      * Test for the loadLocations() method.
      *
      * @return void

--- a/eZ/Publish/API/Repository/Tests/Stubs/LocationServiceStub.php
+++ b/eZ/Publish/API/Repository/Tests/Stubs/LocationServiceStub.php
@@ -341,25 +341,6 @@ class LocationServiceStub implements LocationService
     }
 
     /**
-     * loads the main location of a content object
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user user is not allowed to read this location
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if there is no published version yet
-     *
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\Location|null Null if no location exists
-     */
-    public function loadMainLocation( ContentInfo $contentInfo )
-    {
-        if ( $contentInfo->published === false )
-        {
-            throw new Exceptions\BadStateExceptionStub;
-        }
-        return $this->loadLocation( $contentInfo->mainLocationId );
-    }
-
-    /**
      * Loads the locations for the given content object.
      *
      * If a $rootLocation is given, only locations that belong to this location are returned.

--- a/eZ/Publish/Core/REST/Client/LocationService.php
+++ b/eZ/Publish/Core/REST/Client/LocationService.php
@@ -205,21 +205,6 @@ class LocationService implements \eZ\Publish\API\Repository\LocationService, Ses
     }
 
     /**
-     * loads the main location of a content object
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user user is not allowed to read this location
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if there is no published version yet
-     *
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\Location|null Null if no location exists
-     */
-    public function loadMainLocation( ContentInfo $contentInfo )
-    {
-        throw new \Exception( "@TODO: Implement." );
-    }
-
-    /**
      * Loads the locations for the given content object.
      *
      * If a $rootLocation is given, only locations that belong to this location are returned.

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -209,57 +209,6 @@ class LocationService implements LocationServiceInterface
     }
 
     /**
-     * loads the main location of a content object
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user user is not allowed to read this location
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if there is no published version yet
-     *
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\Location|null Null if no location exists
-     */
-    public function loadMainLocation( APIContentInfo $contentInfo )
-    {
-        if ( !is_numeric( $contentInfo->id ) )
-            throw new InvalidArgumentValue( "id", $contentInfo->id, "ContentInfo" );
-
-        $query = new Query(
-            array(
-                'criterion' => new CriterionLogicalAnd(
-                    array(
-                        new CriterionContentId( $contentInfo->id ),
-                        new CriterionStatus( CriterionStatus::STATUS_PUBLISHED ),
-                    )
-                )
-            )
-        );
-
-        $searchResult = $this->persistenceHandler->searchHandler()->findContent( $query );
-        if ( $searchResult->totalCount == 0 )
-            throw new BadStateException( "contentInfo", 'content info has no published versions yet' );
-        if ( $searchResult->totalCount > 1 )
-            throw new BadStateException( "contentInfo", 'several content info exists for id:' . $contentInfo->id );
-
-        $spiLocations = $searchResult->searchHits[0]->valueObject->locations;
-        if ( empty( $spiLocations ) || !is_array( $spiLocations ) )
-            return null;
-
-        foreach ( $spiLocations as $spiLocation )
-        {
-            if ( $spiLocation->id == $spiLocation->mainLocationId )
-            {
-                $location = $this->buildDomainLocationObject( $spiLocation );
-                if ( !$this->repository->canUser( 'content', 'read', $location->getContentInfo(), $location ) )
-                    throw new UnauthorizedException( 'content', 'read' );
-
-                return $location;
-            }
-        }
-
-        return null;
-    }
-
-    /**
      * Loads the locations for the given content object.
      *
      * If a $rootLocation is given, only locations that belong to this location are returned.


### PR DESCRIPTION
This PR completely removes LocationService::loadMainLocation() for reasons mentioned before:
- it uses search handler which will cease to work for this purpose when locations are removed from SPI Content
- ContentInfo contains main location id and loadLocation( $contentInfo->mainLocationId ) can be used instead
