### PR TITLE
Fixed EZP-19830: ezmultiupload is broken if used through the Symfony stack

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/SessionInitByPostListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/SessionInitByPostListener.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * File containing the SessionInitByPostListener class.
+ *
+ * @copyright Copyright (C) 1999-2012 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\EventListener;
+
+use eZ\Publish\Core\MVC\Symfony\MVCEvents,
+    eZ\Publish\Core\MVC\Symfony\Event\PostSiteAccessMatchEvent,
+    Symfony\Component\EventDispatcher\EventSubscriberInterface,
+    Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Initializes the session id by looking at a POST variable named like the
+ * session. Mainly used by Flash (for instance ezmultiupload LS).
+ */
+class SessionInitByPostListener implements EventSubscriberInterface
+{
+    /**
+     * @var \Symfony\Component\DependencyInjection\ContainerInterface
+     */
+    private $container;
+
+    public function __construct( ContainerInterface $container )
+    {
+        $this->container = $container;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            MVCEvents::SITEACCESS => array( 'onSiteAccessMatch', 249 )
+        );
+    }
+
+    public function onSiteAccessMatch( PostSiteAccessMatchEvent $event )
+    {
+        if ( !$this->container->has( 'session' ) || !$this->container->has( 'request' ) )
+        {
+            return;
+        }
+        $session = $this->container->get( 'session' );
+        $sessionName = $session->getName();
+        $request = $this->container->get( 'request' );
+
+        if (
+            !$session->isStarted()
+            && !$request->hasPreviousSession()
+            && $request->request->has( $sessionName )
+        )
+        {
+            $session->setId( $request->request->get( $sessionName ) );
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/session.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/session.yml
@@ -1,10 +1,17 @@
 parameters:
     ezpublish.session_set_dynamic_name_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\SessionSetDynamicNameListener
+    ezpublish.session_init_by_post_listener.class:  eZ\Bundle\EzPublishCoreBundle\EventListener\SessionInitByPostListener
     ezpublish.session.attribute_bag.storage_key: "_ezpublish"
 
 services:
     ezpublish.session_set_dynamic_name_listener:
         class: %ezpublish.session_set_dynamic_name_listener.class%
+        arguments: [@service_container]
+        tags:
+            - { name: kernel.event_subscriber }
+
+    ezpublish.session_init_by_post_listener:
+        class: %ezpublish.session_init_by_post_listener.class%
         arguments: [@service_container]
         tags:
             - { name: kernel.event_subscriber }


### PR DESCRIPTION
# Description

Bug: https://jira.ez.no/browse/EZP-19830

Depending on the used browser, ezmultiupload LS might fail to create any object. This comes from the fact that in some browsers the Flash player is not able send the Cookie header containing the current session id. To handle this case, eZ Publish legacy is able to [initialize the session id by looking at a POST variable](https://github.com/ezsystems/ezpublish/blob/master/lib/ezsession/classes/ezsession.php#L293). The Symfony stack hasn't this feature, this patch adds it.

This patch against the legacy also needs to be applied: https://github.com/ezsystems/ezpublish/compare/ezp-19830_ezmultiupload_session
# Tests

Manual tests (uploading with ezmultiupload LS, login on different siteaccess with and without session cookies, ...)
