### PR TITLE
EZP-19865 - Allow to share session between some siteaccesses (frontend)

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
@@ -60,6 +60,10 @@ class Common extends AbstractParser
                 ->info( 'Whether to use UrlAliasRouter or not. If false, will let the legacy kernel handle url aliases.' )
                 ->defaultValue( true )
             ->end()
+            ->scalarNode( 'session_name' )
+                ->info( 'The session name. If you want a session name per siteaccess, use "{siteaccess_hash}" token. Will override default session name from framework.session.name' )
+                ->example( array( 'session_name' => 'eZSESSID{siteaccess_hash}' ) )
+            ->end()
         ;
     }
 
@@ -103,6 +107,8 @@ class Common extends AbstractParser
                 $container->setParameter( "ezsettings.$sa.storage_dir", $settings['storage_dir'] );
             if ( isset( $settings['binary_dir'] ) )
                 $container->setParameter( "ezsettings.$sa.binary_dir", $settings['binary_dir'] );
+            if ( isset( $settings['session_name'] ) )
+                $container->setParameter( "ezsettings.$sa.session_name", $settings['session_name'] );
         }
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/SessionSetDynamicNameListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/SessionSetDynamicNameListener.php
@@ -12,7 +12,8 @@ namespace eZ\Bundle\EzPublishCoreBundle\EventListener;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents,
     eZ\Publish\Core\MVC\Symfony\Event\PostSiteAccessMatchEvent,
     Symfony\Component\EventDispatcher\EventSubscriberInterface,
-    Symfony\Component\DependencyInjection\ContainerInterface;
+    Symfony\Component\DependencyInjection\ContainerInterface,
+    Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
  * SiteAccess match listener.
@@ -47,11 +48,14 @@ class SessionSetDynamicNameListener implements EventSubscriberInterface
 
     public function onSiteAccessMatch( PostSiteAccessMatchEvent $event )
     {
-        $session = $event->getRequest()->getSession();
-        if ( !$session )
+        if ( !$this->container->has( 'session' ) )
         {
             return;
         }
+
+        // Getting from the container and not from the request because the session object is assigned to the request only when session has started.
+        $session = $this->container->get( 'session' );
+
 
         /** @var $configResolver \eZ\Publish\Core\MVC\ConfigResolverInterface */
         $configResolver = $this->container->get( 'ezpublish.config.resolver' );
@@ -63,6 +67,10 @@ class SessionSetDynamicNameListener implements EventSubscriberInterface
                     self::MARKER, md5( $event->getSiteAccess()->name ), $sessionName
                 )
             );
+        }
+        else
+        {
+            $session->setName( $sessionName );
         }
     }
 }


### PR DESCRIPTION
Ref https://jira.ez.no/browse/EZP-19865

With this PR, you can have a session name set in your siteaccess configuration, that will override the one set in `framework.session.name` (defaults to _PHPSESSID_).

The default behavior is to have a different session name per siteaccess (session name will be `eZSESSID{siteaccess_hash}`, where `{siteaccess_hash}` will be replaced by a real hash).

Consider following config in `ezpublish.yml`:

``` yaml
ezpublish:
    siteaccess:
        # Available siteaccesses
        list:
            - ezdemo_site
            - fre
            - ezdemo_site_admin
        # Siteaccess groups. Use them to group common settings.
        groups:
            ezdemo_group: [ezdemo_site, fre, ezdemo_site_admin]
            front_group: [ezdemo_site, fre]
        default_siteaccess: ezdemo_site
        match:
            Map\URI:
                ezdemo_site: ezdemo_site
                fre: fre
                ezdemo_site_admin: ezdemo_site_admin

    # System settings, grouped by siteaccess and/or siteaccess group
    system:
        ezdemo_group:
            database:
                type: mysql
                user: root
                password: root
                server: localhost
                database_name: ezdemo
            languages: [eng-GB, fre-FR]
            var_dir: var/ezdemo_site
        front_group:
            session_name: TotoAimeLeVelo
        ezdemo_site_admin:
            # Bypass UrlAliasRouter to use the admin interface since everything needs to run via the legacy kernel
            url_alias_router: false
```

In this example, both `ezdemo_site` and `fre` (members of **front_group** will have _TotoAimeLeVelo_ as session name and will thus be able to share it, while `ezdemo_site_admin` will have `eZSESSID{siteaccess_hash}` (which is the default value).
## Note

If a session name has been set under **framework.session.name** like the following, it will be ignored:

``` yaml
framework:
    session:
        name: SomeSessionName # Will be automatically overridden by eZ Publish configuration
```
