### PR TITLE
Throw BadStateException when creating a user if user with provided login already exists

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Stubs/UserServiceStub.php
+++ b/eZ/Publish/API/Repository/Tests/Stubs/UserServiceStub.php
@@ -20,7 +20,6 @@ use \eZ\Publish\API\Repository\Values\User\UserGroupUpdateStruct;
 use \eZ\Publish\API\Repository\Tests\Stubs\Exceptions\InvalidArgumentExceptionStub;
 use \eZ\Publish\API\Repository\Tests\Stubs\Exceptions\NotFoundExceptionStub;
 use \eZ\Publish\API\Repository\Tests\Stubs\Exceptions\UnauthorizedExceptionStub;
-use \eZ\Publish\API\Repository\Tests\Stubs\Exceptions\BadStateExceptionStub;
 use \eZ\Publish\API\Repository\Tests\Stubs\Values\User\UserStub;
 use \eZ\Publish\API\Repository\Tests\Stubs\Values\User\UserCreateStructStub;
 use \eZ\Publish\API\Repository\Tests\Stubs\Values\User\UserGroupStub;
@@ -316,7 +315,7 @@ class UserServiceStub implements UserService
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user group was not found
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException if a field in the $userCreateStruct is not valid
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException if a required field is missing
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if a user with provided login already exists
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if a user with provided login already exists
      */
     public function createUser( UserCreateStruct $userCreateStruct, array $parentGroups )
     {
@@ -329,7 +328,7 @@ class UserServiceStub implements UserService
         {
             if ( $user->login == $userCreateStruct->login )
             {
-                throw new BadStateExceptionStub( 'What error code should be used?' );
+                throw new InvalidArgumentExceptionStub( 'What error code should be used?' );
             }
         }
 

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -961,10 +961,10 @@ class UserServiceTest extends BaseTest
      *
      * @return void
      * @see \eZ\Publish\API\Repository\UserService::createUser()
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      * @depends eZ\Publish\API\Repository\Tests\UserServiceTest::testCreateUser
      */
-    public function testCreateUserThrowsBadStateException()
+    public function testCreateUserThrowsInvalidArgumentException()
     {
         $repository = $this->getRepository();
 
@@ -990,7 +990,7 @@ class UserServiceTest extends BaseTest
         // Load parent group for the user
         $group = $userService->loadUserGroup( $editorsGroupId );
 
-        // This call will fail with a "BadStateException", because the
+        // This call will fail with a "InvalidArgumentException", because the
         // user with "admin" login already exists.
         $userService->createUser( $userCreate, array( $group ) );
         /* END: Use Case */

--- a/eZ/Publish/API/Repository/UserService.php
+++ b/eZ/Publish/API/Repository/UserService.php
@@ -119,7 +119,7 @@ interface UserService
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException if a field in the $userCreateStruct is not valid
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException if a required field is missing or set  to an empty value
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if a field value is not accepted by the field type
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if a user with provided login already exists
+     *                                                                        if a user with provided login already exists
      */
     public function createUser( UserCreateStruct $userCreateStruct, array $parentGroups );
 

--- a/eZ/Publish/Core/REST/Client/UserService.php
+++ b/eZ/Publish/Core/REST/Client/UserService.php
@@ -189,7 +189,7 @@ class UserService implements \eZ\Publish\API\Repository\UserService, Sessionable
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user group was not found
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException if a field in the $userCreateStruct is not valid
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException if a required field is missing
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if a user with provided login already exists
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if a user with provided login already exists
      */
     public function createUser( UserCreateStruct $userCreateStruct, array $parentGroups )
     {

--- a/eZ/Publish/Core/REST/Server/Controller/User.php
+++ b/eZ/Publish/Core/REST/Server/Controller/User.php
@@ -27,7 +27,6 @@ use eZ\Publish\API\Repository\Values\User\UserGroupRoleAssignment;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
-use eZ\Publish\API\Repository\Exceptions\BadStateException;
 
 use eZ\Publish\Core\REST\Common\Exceptions\InvalidArgumentException AS RestInvalidArgumentException;
 use eZ\Publish\Core\REST\Server\Exceptions\ForbiddenException;
@@ -246,7 +245,7 @@ class User extends RestController
         {
             $createdUser = $this->userService->createUser( $userCreateStruct, array( $userGroup ) );
         }
-        catch ( BadStateException $e )
+        catch ( InvalidArgumentException $e )
         {
             throw new ForbiddenException( $e->getMessage() );
         }

--- a/eZ/Publish/Core/Repository/Tests/Service/UserBase.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/UserBase.php
@@ -507,11 +507,11 @@ abstract class UserBase extends BaseServiceTest
     }
 
     /**
-     * Test creating a user throwing BadStateException
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * Test creating a user throwing InvalidArgumentException
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      * @covers \eZ\Publish\API\Repository\UserService::createUser
      */
-    public function testCreateUserThrowsBadStateException()
+    public function testCreateUserThrowsInvalidArgumentException()
     {
         $userService = $this->repository->getUserService();
 

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -400,7 +400,7 @@ class UserService implements UserServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to move the user group
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException if a field in the $userCreateStruct is not valid
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException if a required field is missing or set to an empty value
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if a user with provided login already exists
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if a user with provided login already exists
      */
     public function createUser( APIUserCreateStruct $userCreateStruct, array $parentGroups )
     {
@@ -425,7 +425,7 @@ class UserService implements UserServiceInterface
         try
         {
             $this->userHandler->loadByLogin( $userCreateStruct->login );
-            throw new BadStateException( "userCreateStruct", "User with provided login already exists" );
+            throw new InvalidArgumentException( "userCreateStruct", "User with provided login already exists" );
         }
         catch ( NotFoundException $e )
         {

--- a/eZ/Publish/Core/SignalSlot/UserService.php
+++ b/eZ/Publish/Core/SignalSlot/UserService.php
@@ -183,7 +183,7 @@ class UserService implements UserServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException if a field in the $userCreateStruct is not valid
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException if a required field is missing or set  to an empty value
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if a field value is not accepted by the field type
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if a user with provided login already exists
+     *                                                                        if a user with provided login already exists
      */
     public function createUser( \eZ\Publish\API\Repository\Values\User\UserCreateStruct $userCreateStruct, array $parentGroups )
     {


### PR DESCRIPTION
_DO NOT MERGE!_

Currently, it's possible to create a user with duplicated login. This PR takes care of it by adding additional exception for UserService::createUser method.

Needs review from @docb22 and @tobyS before merging because of API changes and changes in InMemory stubs and API integration tests.
