### PR TITLE
Object state service exceptions on existing identifiers

### DIFF
--- a/eZ/Publish/API/Repository/ObjectStateService.php
+++ b/eZ/Publish/API/Repository/ObjectStateService.php
@@ -31,6 +31,7 @@ interface ObjectStateService
      * Creates a new object state group
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to create an object state group
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the object state group with provided identifier already exists
      *
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroupCreateStruct $objectStateGroupCreateStruct
      *
@@ -72,6 +73,7 @@ interface ObjectStateService
      * Updates an object state group
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to update an object state group
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the object state group with provided identifier already exists
      *
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup $objectStateGroup
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroupUpdateStruct $objectStateGroupUpdateStruct
@@ -96,6 +98,7 @@ interface ObjectStateService
      * set to this state.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to create an object state
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the object state with provided identifier already exists in the same group
      *
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup $objectStateGroup
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateCreateStruct $objectStateCreateStruct
@@ -119,6 +122,7 @@ interface ObjectStateService
      * Updates an object state
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to update an object state
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the object state with provided identifier already exists in the same group
      *
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectState $objectState
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateUpdateStruct $objectStateUpdateStruct

--- a/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
@@ -757,6 +757,49 @@ class ObjectStateServiceTest extends BaseTest
     }
 
     /**
+     * Test for the createObjectState() method.
+     *
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @return void
+     * @see \eZ\Publish\API\Repository\ObjectStateService::createObjectState()
+     * @depends testLoadObjectStateGroup
+     * @depends testCreateObjectState
+     */
+    public function testCreateObjectStateThrowsInvalidArgumentException()
+    {
+        $repository = $this->getRepository();
+
+        $objectStateGroupId = $this->generateId( 'objectstategroup', 2 );
+        // $objectStateGroupId contains the ID of the standard object state
+        // group ez_lock.
+        $objectStateService = $repository->getObjectStateService();
+
+        $loadedObjectStateGroup = $objectStateService->loadObjectStateGroup(
+            $objectStateGroupId
+        );
+
+        $objectStateCreateStruct = $objectStateService->newObjectStateCreateStruct(
+            // 'not_locked' is the identifier of already existing state
+            'not_locked'
+        );
+        $objectStateCreateStruct->priority = 23;
+        $objectStateCreateStruct->defaultLanguageCode = 'eng-US';
+        $objectStateCreateStruct->names = array(
+            'eng-US' => 'Locked and Unlocked',
+        );
+        $objectStateCreateStruct->descriptions = array(
+            'eng-US' => 'A state between locked and unlocked.',
+        );
+
+        // This call will fail because object state with
+        // 'not_locked' identifier already exists
+        $objectStateService->createObjectState(
+            $loadedObjectStateGroup,
+            $objectStateCreateStruct
+        );
+    }
+
+    /**
      * testCreateObjectStateStructValues
      *
      * @param array $testData
@@ -912,6 +955,47 @@ class ObjectStateServiceTest extends BaseTest
             $loadedObjectState,
             $updateStateStruct,
             $updatedObjectState
+        );
+    }
+
+    /**
+     * Test for the updateObjectState() method.
+     *
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @return void
+     * @see \eZ\Publish\API\Repository\ObjectStateService::updateObjectState()
+     * @depends testUpdateObjectState
+     */
+    public function testUpdateObjectStateThrowsInvalidArgumentException()
+    {
+        $repository = $this->getRepository();
+
+        $objectStateId = $this->generateId( 'objectstate', 2 );
+        // $objectStateId contains the ID of the "locked" state
+        $objectStateService = $repository->getObjectStateService();
+
+        $loadedObjectState = $objectStateService->loadObjectState(
+            $objectStateId
+        );
+
+        $updateStateStruct = $objectStateService->newObjectStateUpdateStruct();
+        // 'not_locked' is the identifier of already existing state
+        $updateStateStruct->identifier = 'not_locked';
+        $updateStateStruct->defaultLanguageCode = 'ger-DE';
+        $updateStateStruct->names = array(
+            'eng-US' => 'Somehow locked',
+            'ger-DE' => 'Irgendwie gelockt',
+        );
+        $updateStateStruct->descriptions = array(
+            'eng-US' => 'The object is somehow locked',
+            'ger-DE' => 'Sindelfingen',
+        );
+
+        // This call will fail because state with
+        // 'not_locked' identifier already exists
+        $objectStateService->updateObjectState(
+            $loadedObjectState,
+            $updateStateStruct
         );
     }
 

--- a/eZ/Publish/API/Repository/Tests/Stubs/ObjectStateServiceStub.php
+++ b/eZ/Publish/API/Repository/Tests/Stubs/ObjectStateServiceStub.php
@@ -300,6 +300,7 @@ class ObjectStateServiceStub implements ObjectStateService
      * set to this state.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to create an object state
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the object state with provided identifier already exists in the same group
      *
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup $objectStateGroup
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateCreateStruct $objectStateCreateStruct
@@ -311,6 +312,15 @@ class ObjectStateServiceStub implements ObjectStateService
         if ( false === $this->repository->hasAccess( 'class', '*' ) )
         {
             throw new Exceptions\UnauthorizedExceptionStub( 'What error code should be used?' );
+        }
+
+        foreach ( $this->states as $state )
+        {
+            if ( $state->identifier == $objectStateCreateStruct->identifier
+                 && $state->stateGroup->id == $objectStateGroup->id )
+            {
+                throw new Exceptions\InvalidArgumentExceptionStub( 'What error code should be used?' );
+            }
         }
 
         $stateData = array();
@@ -370,7 +380,9 @@ class ObjectStateServiceStub implements ObjectStateService
      * updates an object state
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to update an object state
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the object state with provided identifier already exists in the same group
      *
+     * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectState $objectState
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateUpdateStruct $objectStateUpdateStruct
      *
      * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState
@@ -380,6 +392,16 @@ class ObjectStateServiceStub implements ObjectStateService
         if ( false === $this->repository->hasAccess( 'class', '*' ) )
         {
             throw new Exceptions\UnauthorizedExceptionStub( 'What error code should be used?' );
+        }
+
+        foreach ( $this->states as $state )
+        {
+            if ( $state->identifier == $objectStateUpdateStruct->identifier
+                 && $state->stateGroup->id == $objectState->stateGroup->id
+                 && $state->id != $objectState->id )
+            {
+                throw new Exceptions\InvalidArgumentExceptionStub( 'What error code should be used?' );
+            }
         }
 
         $stateData = array(

--- a/eZ/Publish/Core/Persistence/InMemory/ObjectStateHandler.php
+++ b/eZ/Publish/Core/Persistence/InMemory/ObjectStateHandler.php
@@ -79,13 +79,13 @@ class ObjectStateHandler implements ObjectStateHandlerInterface
      */
     public function loadGroupByIdentifier( $identifier )
     {
-        $objectStates = $this->backend->find( 'Content\\ObjectState\\Group', array( 'identifier' => $identifier ) );
-        if ( empty( $objectStates ) )
+        $objectStateGroups = $this->backend->find( 'Content\\ObjectState\\Group', array( 'identifier' => $identifier ) );
+        if ( empty( $objectStateGroups ) )
         {
             throw new NotFound( "Content\\ObjectState\\Group", array( "identifier" => $identifier ) );
         }
 
-        return reset( $objectStates );
+        return reset( $objectStateGroups );
     }
 
     /**
@@ -212,6 +212,34 @@ class ObjectStateHandler implements ObjectStateHandlerInterface
     public function load( $stateId )
     {
         return $this->backend->load( 'Content\\ObjectState', $stateId );
+    }
+
+    /**
+     * Loads an object state by identifier and group it belongs to
+     *
+     * @param string $identifier
+     * @param mixed $groupId
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the state was not found
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content\ObjectState
+     */
+    public function loadByIdentifier( $identifier, $groupId )
+    {
+        $objectStates = $this->backend->find(
+            'Content\\ObjectState',
+            array(
+                'identifier' => $identifier,
+                'groupId' => $groupId
+            )
+        );
+
+        if ( empty( $objectStates ) )
+        {
+            throw new NotFound( "Content\\ObjectState", array( "identifier" => $identifier, "groupId" => $groupId ) );
+        }
+
+        return reset( $objectStates );
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/InMemory/Tests/ObjectStateHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/InMemory/Tests/ObjectStateHandlerTest.php
@@ -284,6 +284,34 @@ class ObjectStateHandlerTest extends HandlerTest
     }
 
     /**
+     * @covers \eZ\Publish\Core\Persistence\InMemory\ObjectStateHandler::loadByIdentifier
+     */
+    public function testLoadByIdentifier()
+    {
+        $state = $this->handler->loadByIdentifier( 'not_locked', 2 );
+
+        $this->assertInstanceOf( 'eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState', $state );
+
+        $this->assertEquals( 1, $state->id );
+        $this->assertEquals( 2, $state->groupId );
+        $this->assertEquals( 'not_locked', $state->identifier );
+        $this->assertEquals( 'eng-US', $state->defaultLanguage );
+        $this->assertEquals( array( 'eng-US' ), $state->languageCodes );
+        $this->assertEquals( array( 'eng-US' => 'Not locked' ), $state->name );
+        $this->assertEquals( array( 'eng-US' => '' ), $state->description );
+        $this->assertEquals( 0, $state->priority );
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\Persistence\InMemory\ObjectStateHandler::loadByIdentifier
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function testLoadByIdentifierThrowsNotFoundException()
+    {
+        $this->handler->loadByIdentifier( 'unknown', 2 );
+    }
+
+    /**
      * @covers \eZ\Publish\Core\Persistence\InMemory\ObjectStateHandler::update
      */
     public function testUpdate()

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway.php
@@ -26,6 +26,15 @@ abstract class Gateway
     abstract public function loadObjectStateData( $stateId );
 
     /**
+     * Loads data for an object state by identifier
+     *
+     * @param string $identifier
+     * @param mixed $groupId
+     * @return array
+     */
+    abstract public function loadObjectStateDataByIdentifier( $identifier, $groupId );
+
+    /**
      * Loads data for all object states belonging to group with $groupId ID
      *
      * @param mixed $groupId

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/ExceptionConversion.php
@@ -57,6 +57,29 @@ class ExceptionConversion extends Gateway
     }
 
     /**
+     * Loads data for an object state by identifier
+     *
+     * @param string $identifier
+     * @param mixed $groupId
+     * @return array
+     */
+    public function loadObjectStateDataByIdentifier( $identifier, $groupId )
+    {
+        try
+        {
+            return $this->innerGateway->loadObjectStateDataByIdentifier( $identifier, $groupId );
+        }
+        catch ( \ezcDbException $e )
+        {
+            throw new \RuntimeException( 'Database error', 0, $e );
+        }
+        catch ( \PDOException $e )
+        {
+            throw new \RuntimeException( 'Database error', 0, $e );
+        }
+    }
+
+    /**
      * Loads data for all object states belonging to group with $groupId ID
      *
      * @param mixed $groupId

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/EzcDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/EzcDatabase.php
@@ -68,6 +68,35 @@ class EzcDatabase extends Gateway
     }
 
     /**
+     * Loads data for an object state by identifier
+     *
+     * @param string $identifier
+     * @param mixed $groupId
+     * @return array
+     */
+    public function loadObjectStateDataByIdentifier( $identifier, $groupId )
+    {
+        $query = $this->createObjectStateFindQuery();
+        $query->where(
+            $query->expr->lAnd(
+                $query->expr->eq(
+                    $this->dbHandler->quoteColumn( 'identifier', 'ezcobj_state' ),
+                    $query->bindValue( $identifier, null, \PDO::PARAM_STR )
+                ),
+                $query->expr->eq(
+                    $this->dbHandler->quoteColumn( 'group_id', 'ezcobj_state' ),
+                    $query->bindValue( $groupId, null, \PDO::PARAM_INT )
+                )
+            )
+        );
+
+        $statement = $query->prepare();
+        $statement->execute();
+
+        return $statement->fetchAll( \PDO::FETCH_ASSOC );
+    }
+
+    /**
      * Loads data for all object states belonging to group with $groupId ID
      *
      * @param mixed $groupId

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Handler.php
@@ -204,6 +204,28 @@ class Handler implements BaseObjectStateHandler
     }
 
     /**
+     * Loads an object state by identifier and group it belongs to
+     *
+     * @param string $identifier
+     * @param mixed $groupId
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the state was not found
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content\ObjectState
+     */
+    public function loadByIdentifier( $identifier, $groupId )
+    {
+        $data = $this->objectStateGateway->loadObjectStateDataByIdentifier( $identifier, $groupId );
+
+        if ( empty( $data ) )
+        {
+            throw new NotFoundException( "ObjectState", array( 'identifier' => $identifier, 'groupId' => $groupId ) );
+        }
+
+        return $this->objectStateMapper->createObjectStateFromData( $data );
+    }
+
+    /**
      * Updates an object state
      *
      * @param mixed $stateId

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ObjectState/Gateway/EzcDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ObjectState/Gateway/EzcDatabaseTest.php
@@ -96,6 +96,34 @@ class EzcDatabaseTest extends LanguageAwareTestCase
 
     /**
      * @return void
+     * @covers eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Gateway\EzcDatabase::loadObjectStateDataByIdentifier
+     */
+    public function testLoadObjectStateDataByIdentifier()
+    {
+        $gateway = $this->getDatabaseGateway();
+
+        $result = $gateway->loadObjectStateDataByIdentifier( 'not_locked', 2 );
+
+        $this->assertEquals(
+            array(
+                array(
+                    'ezcobj_state_default_language_id' => 2,
+                    'ezcobj_state_group_id' => 2,
+                    'ezcobj_state_id' => 1,
+                    'ezcobj_state_identifier' => 'not_locked',
+                    'ezcobj_state_language_mask' => 3,
+                    'ezcobj_state_priority' => 0,
+                    'ezcobj_state_language_description' => '',
+                    'ezcobj_state_language_language_id' => 3,
+                    'ezcobj_state_language_name' => 'Not locked'
+                )
+            ),
+            $result
+        );
+    }
+
+    /**
+     * @return void
      * @covers eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Gateway\EzcDatabase::loadObjectStateListData
      */
     public function testLoadObjectStateListData()

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ObjectState/ObjectStateHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ObjectState/ObjectStateHandlerTest.php
@@ -387,6 +387,52 @@ class ObjectStateHandlerTest extends LanguageAwareTestCase
 
     /**
      * @return void
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Handler::loadByIdentifier
+     */
+    public function testLoadByIdentifier()
+    {
+        $handler = $this->getObjectStateHandler();
+        $mapperMock = $this->getMapperMock();
+        $gatewayMock = $this->getGatewayMock();
+
+        $gatewayMock->expects( $this->once() )
+            ->method( 'loadObjectStateDataByIdentifier' )
+            ->with( $this->equalTo( 'not_locked' ), $this->equalTo( 2 ) )
+            ->will( $this->returnValue( array( array() ) ) );
+
+        $mapperMock->expects( $this->once() )
+            ->method( 'createObjectStateFromData' )
+            ->with( $this->equalTo( array( array() ) ) )
+            ->will( $this->returnValue( $this->getObjectStateFixture() ) );
+
+        $result = $handler->loadByIdentifier( 'not_locked', 2 );
+
+        $this->assertInstanceOf(
+            'eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState',
+            $result
+        );
+    }
+
+    /**
+     * @return void
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Handler::loadByIdentifier
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function testLoadByIdentifierThrowsNotFoundException()
+    {
+        $handler = $this->getObjectStateHandler();
+        $gatewayMock = $this->getGatewayMock();
+
+        $gatewayMock->expects( $this->once() )
+            ->method( 'loadObjectStateDataByIdentifier' )
+            ->with( $this->equalTo( 'unknown' ), $this->equalTo( 2 ) )
+            ->will( $this->returnValue( array() ) );
+
+        $handler->loadByIdentifier( 'unknown', 2 );
+    }
+
+    /**
+     * @return void
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Handler::update
      */
     public function testUpdate()

--- a/eZ/Publish/Core/REST/Client/ObjectStateService.php
+++ b/eZ/Publish/Core/REST/Client/ObjectStateService.php
@@ -225,6 +225,7 @@ class ObjectStateService implements \eZ\Publish\API\Repository\ObjectStateServic
      * set to this state.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to create an object state
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the object state with provided identifier already exists in the same group
      *
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup $objectStateGroup
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateCreateStruct $objectStateCreateStruct
@@ -270,6 +271,7 @@ class ObjectStateService implements \eZ\Publish\API\Repository\ObjectStateServic
      * Updates an object state
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to update an object state
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the object state with provided identifier already exists in the same group
      *
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectState $objectState
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateUpdateStruct $objectStateUpdateStruct

--- a/eZ/Publish/Core/Repository/Tests/Service/ObjectStateBase.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/ObjectStateBase.php
@@ -525,6 +525,29 @@ abstract class ObjectStateBase extends BaseServiceTest
     }
 
     /**
+     * Test service method for creating object state throwing InvalidArgumentException
+     * @covers \eZ\Publish\API\Repository\ObjectStateService::createObjectState
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testCreateObjectStateThrowsInvalidArgumentException()
+    {
+        $objectStateService = $this->repository->getObjectStateService();
+
+        $group = $objectStateService->loadObjectStateGroup( 2 );
+
+        $stateCreateStruct = $objectStateService->newObjectStateCreateStruct( 'not_locked' );
+        $stateCreateStruct->priority = 2;
+        $stateCreateStruct->defaultLanguageCode = 'eng-GB';
+        $stateCreateStruct->names = array( 'eng-GB' => 'Test' );
+        $stateCreateStruct->descriptions = array( 'eng-GB' => 'Test description' );
+
+        $objectStateService->createObjectState(
+            $group,
+            $stateCreateStruct
+        );
+    }
+
+    /**
      * Test service method for loading object state
      * @covers \eZ\Publish\API\Repository\ObjectStateService::loadObjectState
      */
@@ -653,6 +676,23 @@ abstract class ObjectStateBase extends BaseServiceTest
         );
 
         $this->assertEquals( $state->getObjectStateGroup()->id, $updatedState->getObjectStateGroup()->id );
+    }
+
+    /**
+     * Test service method for updating object state throwing InvalidArgumentException
+     * @covers \eZ\Publish\API\Repository\ObjectStateService::updateObjectState
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testUpdateObjectStateThrowsInvalidArgumentException()
+    {
+        $objectStateService = $this->repository->getObjectStateService();
+
+        $stateUpdateStruct = $objectStateService->newObjectStateUpdateStruct();
+        $stateUpdateStruct->identifier = 'locked';
+
+        $state = $objectStateService->loadObjectState( 1 );
+
+        $objectStateService->updateObjectState( $state, $stateUpdateStruct );
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/ObjectStateService.php
+++ b/eZ/Publish/Core/SignalSlot/ObjectStateService.php
@@ -155,6 +155,7 @@ class ObjectStateService implements ObjectStateServiceInterface
      * set to this state.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to create an object state
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the object state with provided identifier already exists in the same group
      *
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup $objectStateGroup
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateCreateStruct $objectStateCreateStruct
@@ -192,6 +193,7 @@ class ObjectStateService implements ObjectStateServiceInterface
      * Updates an object state
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to update an object state
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the object state with provided identifier already exists in the same group
      *
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectState $objectState
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateUpdateStruct $objectStateUpdateStruct

--- a/eZ/Publish/SPI/Persistence/Content/ObjectState/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/ObjectState/Handler.php
@@ -106,6 +106,18 @@ interface Handler
     public function load( $stateId );
 
     /**
+     * Loads an object state by identifier and group it belongs to
+     *
+     * @param string $identifier
+     * @param mixed $groupId
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the state was not found
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content\ObjectState
+     */
+    public function loadByIdentifier( $identifier, $groupId );
+
+    /**
      * Updates an object state
      *
      * @param mixed $stateId


### PR DESCRIPTION
_DO NOT MERGE!_

This PR adds exceptions to object state service when creating/updating object state/group.

1) Currently ugly runtime exceptions are thrown all the way down from exception converter because of violated unique constraints.

2) Solves REST server spec requirement for throwing exceptions in such cases

Needs review by @docb22 because of API and SPI changes and from @tobyS because of API integration tests changes.
