### PR TITLE
Throw exception in UserService::assignUserToUserGroup if user is already in group

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Stubs/UserServiceStub.php
+++ b/eZ/Publish/API/Repository/Tests/Stubs/UserServiceStub.php
@@ -534,12 +534,11 @@ class UserServiceStub implements UserService
     /**
      * Assigns a new user group to the user
      *
-     * If the user is already in the given user group this method does nothing.
-     *
      * @param \eZ\Publish\API\Repository\Values\User\User $user
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to assign the user group to the user
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the user is already in the given user group
      */
     public function assignUserToUserGroup( User $user, UserGroup $userGroup )
     {
@@ -547,6 +546,11 @@ class UserServiceStub implements UserService
         {
             throw new UnauthorizedExceptionStub( 'What error code should be used?' );
         }
+        if ( true === isset( $this->user2groups[$user->id][$userGroup->id] ) )
+        {
+            throw new InvalidArgumentExceptionStub( 'What error code should be used?' );
+        }
+
         if ( false === isset( $this->user2groups[$user->id] ) )
         {
             $this->user2groups[$user->id] = array();

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -1532,6 +1532,34 @@ class UserServiceTest extends BaseTest
     }
 
     /**
+     * Test for the assignUserToUserGroup() method.
+     *
+     * @return void
+     * @see \eZ\Publish\API\Repository\UserService::assignUserToUserGroup()
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @depends eZ\Publish\API\Repository\Tests\UserServiceTest::testAssignUserToUserGroup
+     */
+    public function testAssignUserToUserGroupThrowsInvalidArgumentException()
+    {
+        $repository = $this->getRepository();
+        $userService = $repository->getUserService();
+
+        $editorsGroupId = $this->generateId( 'group', 13 );
+        /* BEGIN: Use Case */
+        $user = $this->createUserVersion1();
+        // $editorsGroupId is the ID of the "Editors" group in an
+        // eZ Publish demo installation
+
+        // This call will fail with an "InvalidArgumentException", because the
+        // user is already assigned to the "Editors" group
+        $userService->assignUserToUserGroup(
+            $user,
+            $userService->loadUserGroup( $editorsGroupId )
+        );
+        /* END: Use Case */
+    }
+
+    /**
      * Test for the unAssignUssrFromUserGroup() method.
      *
      * @return void

--- a/eZ/Publish/Core/REST/Client/UserService.php
+++ b/eZ/Publish/Core/REST/Client/UserService.php
@@ -270,12 +270,11 @@ class UserService implements \eZ\Publish\API\Repository\UserService, Sessionable
     /**
      * Assigns a new user group to the user
      *
-     * If the user is already in the given user group this method does nothing.
-     *
      * @param \eZ\Publish\API\Repository\Values\User\User $user
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to assign the user group to the user
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the user is already in the given user group
      */
     public function assignUserToUserGroup( User $user, UserGroup $userGroup )
     {

--- a/eZ/Publish/Core/REST/Server/Controller/User.php
+++ b/eZ/Publish/Core/REST/Server/Controller/User.php
@@ -799,10 +799,14 @@ class User extends RestController
             throw new Exceptions\ForbiddenException( $e->getMessage() );
         }
 
-        //@todo Error handling if user is already in the group
-        //Reason being that UserService::assignUserToUserGroup by specs
-        // does nothing if the user is already a member of the group
-        $this->userService->assignUserToUserGroup( $user, $userGroup );
+        try
+        {
+            $this->userService->assignUserToUserGroup( $user, $userGroup );
+        }
+        catch ( InvalidArgumentException $e )
+        {
+            throw new Exceptions\ForbiddenException( $e->getMessage() );
+        }
 
         $userGroups = $this->userService->loadUserGroupsOfUser( $user );
         $restUserGroups = array();

--- a/eZ/Publish/Core/Repository/Tests/Service/UserBase.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/UserBase.php
@@ -719,6 +719,20 @@ abstract class UserBase extends BaseServiceTest
     }
 
     /**
+     * Test assigning a user group to user throwing InvalidArgumentException
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @covers \eZ\Publish\API\Repository\UserService::assignUserToUserGroup
+     */
+    public function testAssignUserToUserGroupThrowsInvalidArgumentException()
+    {
+        $userService = $this->repository->getUserService();
+
+        $user = $userService->loadUser( 14 );
+        $userGroup = $userService->loadUserGroup( 12 );
+        $userService->assignUserToUserGroup( $user, $userGroup );
+    }
+
+    /**
      * Test removing a user from user group
      * @covers \eZ\Publish\API\Repository\UserService::unAssignUserFromUserGroup
      */

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -753,12 +753,11 @@ class UserService implements UserServiceInterface
     /**
      * Assigns a new user group to the user
      *
-     * If the user is already in the given user group this method does nothing.
-     *
      * @param \eZ\Publish\API\Repository\Values\User\User $user
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to assign the user group to the user
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the user is already in the given user group
      */
     public function assignUserToUserGroup( APIUser $user, APIUserGroup $userGroup )
     {
@@ -780,11 +779,15 @@ class UserService implements UserServiceInterface
         }
 
         if ( $loadedGroup->getVersionInfo()->getContentInfo()->mainLocationId === null )
+        {
             throw new BadStateException( "userGroup", "user group has no main location or no locations" );
+        }
 
         if ( in_array( $loadedGroup->getVersionInfo()->getContentInfo()->mainLocationId, $existingGroupIds ) )
+        {
             // user is already assigned to the user group
-            return;
+            throw new InvalidArgumentException( "user", "user is already in the given user group" );
+        }
 
         $locationCreateStruct = $locationService->newLocationCreateStruct(
             $loadedGroup->getVersionInfo()->getContentInfo()->mainLocationId

--- a/eZ/Publish/Core/SignalSlot/UserService.php
+++ b/eZ/Publish/Core/SignalSlot/UserService.php
@@ -286,12 +286,11 @@ class UserService implements UserServiceInterface
     /**
      * Assigns a new user group to the user
      *
-     * If the user is already in the given user group this method does nothing.
-     *
      * @param \eZ\Publish\API\Repository\Values\User\User $user
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to assign the user group to the user
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the user is already in the given user group
      */
     public function assignUserToUserGroup( \eZ\Publish\API\Repository\Values\User\User $user, \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup )
     {


### PR DESCRIPTION
_DO NOT MERGE!_

UserService::assignUserToUserGroup does nothing if user is already assigned to the group(!)

This PR adds the exception for that usecase for two reasons:

1) To be in line with unAssignUserFromUserGroup that throws when user is not in the group
2) To be able to implement correctly REST server specified exception

Needs review from @docb22 because of API change and from @tobyS because of API integration tests change.
