### PR TITLE
Fixed EZP-19949: incorrect Basic authentication RFC number

### DIFF
--- a/doc/specifications/rest/REST-API-V2.html
+++ b/doc/specifications/rest/REST-API-V2.html
@@ -837,7 +837,7 @@ contruct an uri by using an id.</p>
 <h1><a class="toc-backref" href="#id50">2&nbsp;&nbsp;&nbsp;Authentication</a></h1>
 <div class="section" id="basic-authentication">
 <h2><a class="toc-backref" href="#id51">2.1&nbsp;&nbsp;&nbsp;Basic Authentication</a></h2>
-<p>See <a class="reference external" href="http://tools.ietf.org/html/rfc261">http://tools.ietf.org/html/rfc261</a></p>
+<p>See <a class="reference external" href="http://tools.ietf.org/html/rfc2617">http://tools.ietf.org/html/rfc2617</a></p>
 </div>
 <div class="section" id="oauth">
 <h2><a class="toc-backref" href="#id52">2.2&nbsp;&nbsp;&nbsp;OAuth</a></h2>

--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -113,7 +113,7 @@ Authentication
 Basic Authentication
 --------------------
 
-See http://tools.ietf.org/html/rfc261
+See http://tools.ietf.org/html/rfc2617
 
 OAuth
 -----


### PR DESCRIPTION
Basic authentication RFC is specified as #261,  the correct number is #2617
