### PR TITLE
REST: Remove invalid error code from spec

### DIFF
--- a/doc/specifications/rest/REST-API-V2.html
+++ b/doc/specifications/rest/REST-API-V2.html
@@ -11175,8 +11175,6 @@ Content-Length: <span class="nt">&lt;length&gt;</span>
 <tbody valign="top">
 <tr class="field"><th class="field-name">401:</th><td class="field-body">If the user is not authorized to assign this role</td>
 </tr>
-<tr class="field"><th class="field-name">403:</th><td class="field-body">If the role is already assigned to the user or user group</td>
-</tr>
 </tbody>
 </table>
 </td>

--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -5293,7 +5293,6 @@ Assign Role to User or User Group
 
 :Error Codes:
     :401: If the user is not authorized to assign this role
-    :403: If the role is already assigned to the user or user group
 
 XML Example
 '''''''''''

--- a/eZ/Publish/Core/REST/Server/Controller/Role.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Role.php
@@ -324,9 +324,6 @@ class Role extends RestController
      */
     public function assignRoleToUser()
     {
-        //@todo error handling if the role is already assigned to user
-        //problem being that PAPI does not specify throwing an exception in this case
-
         $values = $this->urlHandler->parse( 'userRoleAssignments', $this->request->path );
 
         $roleAssignment = $this->inputDispatcher->parse(
@@ -352,9 +349,6 @@ class Role extends RestController
      */
     public function assignRoleToUserGroup()
     {
-        //@todo error handling if the role is already assigned to user group
-        //problem being that PAPI does not specify throwing an exception in this case
-
         $values = $this->urlHandler->parse( 'groupRoleAssignments', $this->request->path );
 
         $roleAssignment = $this->inputDispatcher->parse(


### PR DESCRIPTION
_DO NOT MERGE!_

REST spec says that assigning role to user or user group should return 403 Forbidden in case the role is already assigned to user or user group. This does not make sense, since the same role can be assigned multiple times to given user or user group.

Review needed by @docb22
