### PR TITLE
Fix EZP-19954:  Not possible to run a Location view outside of the pagelayout

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
@@ -1,6 +1,7 @@
 # Internal routes
 _ezpublishLocation:
-    pattern: /content/location/{locationId}/{viewType}
+    pattern: /content/location/{locationId}/{viewType}/{layout}
     defaults:
         _controller: ezpublish.controller.content.view:viewLocation
         viewType: full
+        layout: true

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
@@ -70,12 +70,12 @@ class ViewController extends Controller
      *
      * @param int $locationId
      * @param string $viewType
-     * @param boolean $noLayout
+     * @param boolean $layout
      * @throws \Symfony\Component\Security\Core\Exception\AccessDeniedException
      * @throws \Exception
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function viewLocation( $locationId, $viewType, $noLayout = false )
+    public function viewLocation( $locationId, $viewType, $layout = false )
     {
         if ( !$this->isGranted( new AuthorizationAttribute( 'content', 'read' ) ) )
             throw new AccessDeniedException();
@@ -88,7 +88,7 @@ class ViewController extends Controller
             // TODO: Use a dedicated etag generator, generating a hash
             // instead of plain text
             $response = $this->buildResponse(
-                "ezpublish-location-$locationId-$viewType-$noLayout",
+                "ezpublish-location-$locationId-$viewType-$layout",
                 $location->getContentInfo()->modificationDate
             );
 
@@ -102,7 +102,7 @@ class ViewController extends Controller
                 $this->viewManager->renderLocation(
                     $location,
                     $viewType,
-                    array( 'noLayout' => $noLayout )
+                    array( 'noLayout' => !$layout )
                 )
             );
 
@@ -140,12 +140,12 @@ class ViewController extends Controller
      *
      * @param int $contentId
      * @param string $viewType
-     * @param boolean $noLayout
+     * @param boolean $layout
      * @throws \Symfony\Component\Security\Core\Exception\AccessDeniedException
      * @throws \Exception
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function viewContent( $contentId, $viewType, $noLayout )
+    public function viewContent( $contentId, $viewType, $layout = false )
     {
         if ( !$this->isGranted( new AuthorizationAttribute( 'content', 'read' ) ) )
             throw new AccessDeniedException();
@@ -157,7 +157,7 @@ class ViewController extends Controller
             // TODO: Use a dedicated etag generator, generating a hash
             // instead of plain text
             $response = $this->buildResponse(
-                "ezpublish-content-$contentId-$viewType-$noLayout",
+                "ezpublish-content-$contentId-$viewType-$layout",
                 $content->contentInfo->modificationDate
             );
 
@@ -170,7 +170,7 @@ class ViewController extends Controller
                 $this->viewManager->renderContent(
                     $content,
                     $viewType,
-                    array( 'noLayout' => $noLayout )
+                    array( 'noLayout' => !$layout )
                 )
             );
 

--- a/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
@@ -112,9 +112,10 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
             {
                 case UrlAlias::LOCATION:
                     $params += array(
-                        '_controller'   => 'ezpublish.controller.content.view:viewLocation',
-                        'locationId'    => $urlAlias->destination->id,
-                        'viewType'      => ViewManager::VIEW_TYPE_FULL
+                        '_controller' => 'ezpublish.controller.content.view:viewLocation',
+                        'locationId' => $urlAlias->destination->id,
+                        'viewType' => ViewManager::VIEW_TYPE_FULL,
+                        'layout' => true,
                     );
 
                     $request->attributes->set( 'locationId', $urlAlias->destination->id );


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-19954

Make possible to run a location view without the complete pagelayout (it's already possible content views). So now the following code

``` jinja
{% render "ez_content:viewLocation" with {'locationId': location.id, 'viewType': 'full', 'noLayout': 1} %}
```

does the same as

``` smarty
{node_view_gui content_node=$node view="full"}
```
