### PR TITLE
Fix EZP-19978: literal tag in eZXML

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/stylesheets/eZXml2Html5_core.xsl
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/stylesheets/eZXml2Html5_core.xsl
@@ -111,6 +111,10 @@
 <xsl:value-of select="text()" disable-output-escaping="yes"/>
 </xsl:template>
 
+<xsl:template match="literal">
+<pre><xsl:copy-of select="@*"/><xsl:apply-templates/></pre>
+</xsl:template>
+
 <!-- copy unknown elements as-is -->
 <xsl:template match="@* | node()">
 <xsl:copy>


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-19978

The `<literal>` tags are not handled by the default XSLT stylesheet.

Note: the `class` attribute (and its special value `html`) is not handled at the moment, as this is the case for most elements. This is the topic of this related issue: https://jira.ez.no/browse/EZP-19979
