### PR TITLE
Fixed EZP-19714: Move childCount out of Location Value object (part1)

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/ApiLoader/Factory.php
+++ b/eZ/Bundle/EzPublishRestBundle/ApiLoader/Factory.php
@@ -283,13 +283,13 @@ class Factory
             // Location
 
             '\\eZ\\Publish\\Core\\REST\\Server\\Values\\CreatedLocation'             => new Output\ValueObjectVisitor\CreatedLocation( $urlHandler ),
-            '\\eZ\\Publish\\API\\Repository\\Values\\Content\\Location'              => new Output\ValueObjectVisitor\Location( $urlHandler ),
+            '\\eZ\\Publish\\Core\\REST\\Server\\Values\\RestLocation'                => new Output\ValueObjectVisitor\RestLocation( $urlHandler ),
             '\\eZ\\Publish\\Core\\REST\\Server\\Values\\LocationList'                => new Output\ValueObjectVisitor\LocationList( $urlHandler ),
 
             // Trash
 
             '\\eZ\\Publish\\Core\\REST\\Server\\Values\\Trash'                       => new Output\ValueObjectVisitor\Trash( $urlHandler ),
-            '\\eZ\\Publish\\API\\Repository\\Values\\Content\\TrashItem'             => new Output\ValueObjectVisitor\TrashItem( $urlHandler ),
+            '\\eZ\\Publish\\Core\\REST\\Server\\Values\\RestTrashItem'               => new Output\ValueObjectVisitor\RestTrashItem( $urlHandler ),
 
             // Views
 

--- a/eZ/Publish/API/Repository/LocationService.php
+++ b/eZ/Publish/API/Repository/LocationService.php
@@ -94,6 +94,15 @@ interface LocationService
     public function loadLocationChildren( Location $location, $offset = 0, $limit = -1 );
 
     /**
+     * Returns the number of children which are readable by the current user of a location object
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $location
+     *
+     * @return int
+     */
+    public function getLocationChildCount( Location $location );
+
+    /**
      * Creates the new $location in the content repository for the given content
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user user is not allowed to create this location
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException  if the content is already below the specified parent

--- a/eZ/Publish/API/Repository/Tests/Stubs/TrashServiceStub.php
+++ b/eZ/Publish/API/Repository/Tests/Stubs/TrashServiceStub.php
@@ -115,7 +115,6 @@ class TrashServiceStub implements TrashService
         return new TrashItemStub(
             array(
                 'id' => $location->id,
-                'childCount' => $location->childCount,
                 'depth' => $location->depth,
                 'hidden' => $location->hidden,
                 'invisible' => $location->invisible,

--- a/eZ/Publish/API/Repository/Tests/Stubs/Values/Content/LocationStub.php
+++ b/eZ/Publish/API/Repository/Tests/Stubs/Values/Content/LocationStub.php
@@ -118,13 +118,6 @@ class LocationStub extends Location
     // protected $sortOrder;
 
     /**
-     * the number of children visible to the authenticated user which has loaded this instance.
-     *
-     * @var integer
-     */
-    // protected $childCount;
-
-    /**
      * ContentInfo
      *
      * @var \eZ\Publish\API\Repository\Values\Content\ContentInfo
@@ -139,17 +132,6 @@ class LocationStub extends Location
     public function getContentInfo()
     {
         return $this->contentInfo;
-    }
-
-    /**
-     * FOR TEST USE ONLY!
-     *
-     * @param int $childCount
-     * @return void
-     */
-    public function __setChildCount( $childCount )
-    {
-        $this->childCount = $childCount;
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
@@ -61,7 +61,6 @@ class TrashServiceTest extends BaseTrashServiceTest
 
         $expected = array(
             'id' => $location->id,
-            'childCount' => $location->childCount,
             'depth' => $location->depth,
             'hidden' => $location->hidden,
             'invisible' => $location->invisible,
@@ -160,13 +159,15 @@ class TrashServiceTest extends BaseTrashServiceTest
 
         $baseLocationId = $this->generateId( 'location', 1 );
 
-        $childCount = $locationService->loadLocation( $baseLocationId )->childCount;
+        $location = $locationService->loadLocation( $baseLocationId );
+
+        $childCount = count( $locationService->loadLocationChildren( $location ) );
 
         $this->createTrashItem();
 
         $this->assertEquals(
             $childCount - 1,
-            $locationService->loadLocation( $baseLocationId )->childCount
+            count( $locationService->loadLocationChildren( $location ) )
         );
     }
 
@@ -341,7 +342,6 @@ class TrashServiceTest extends BaseTrashServiceTest
                 'remoteId' => $trashItem->remoteId,
                 'parentLocationId' => $homeLocationId,
                 // Not the full sub tree is restored
-                'childCount' => 0,
                 'depth' => $newParentLocation->depth + 1,
                 'hidden' => false,
                 'invisible' => $trashItem->invisible,
@@ -417,7 +417,9 @@ class TrashServiceTest extends BaseTrashServiceTest
 
         $homeLocationId = $this->generateId( 'location', 2 );
 
-        $childCount = $locationService->loadLocation( $homeLocationId )->childCount;
+        $location = $locationService->loadLocation( $homeLocationId );
+
+        $childCount = count( $locationService->loadLocationChildren( $location ) );
 
         /* BEGIN: Use Case */
         // $homeLocationId is the ID of the "Home" location in an eZ Publish
@@ -434,7 +436,7 @@ class TrashServiceTest extends BaseTrashServiceTest
 
         $this->assertEquals(
             $childCount + 1,
-            $locationService->loadLocation( $homeLocationId )->childCount
+            count( $locationService->loadLocationChildren( $location ) )
         );
     }
 

--- a/eZ/Publish/API/Repository/Tests/_fixtures/LocationFixture.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/LocationFixture.php
@@ -15,7 +15,6 @@ return array(
                 "depth" => 0,
                 "sortField" => 1,
                 "sortOrder" => 1,
-                "childCount" => null,
             )
         ),
         2 => new \eZ\Publish\API\Repository\Tests\Stubs\Values\Content\LocationStub(
@@ -32,7 +31,6 @@ return array(
                 "depth" => 1,
                 "sortField" => 8,
                 "sortOrder" => 1,
-                "childCount" => null,
             )
         ),
         5 => new \eZ\Publish\API\Repository\Tests\Stubs\Values\Content\LocationStub(
@@ -49,7 +47,6 @@ return array(
                 "depth" => 1,
                 "sortField" => 1,
                 "sortOrder" => 1,
-                "childCount" => null,
             )
         ),
         12 => new \eZ\Publish\API\Repository\Tests\Stubs\Values\Content\LocationStub(
@@ -66,7 +63,6 @@ return array(
                 "depth" => 2,
                 "sortField" => 1,
                 "sortOrder" => 1,
-                "childCount" => null,
             )
         ),
         13 => new \eZ\Publish\API\Repository\Tests\Stubs\Values\Content\LocationStub(
@@ -83,7 +79,6 @@ return array(
                 "depth" => 2,
                 "sortField" => 1,
                 "sortOrder" => 1,
-                "childCount" => null,
             )
         ),
         14 => new \eZ\Publish\API\Repository\Tests\Stubs\Values\Content\LocationStub(
@@ -100,7 +95,6 @@ return array(
                 "depth" => 2,
                 "sortField" => 1,
                 "sortOrder" => 1,
-                "childCount" => null,
             )
         ),
         15 => new \eZ\Publish\API\Repository\Tests\Stubs\Values\Content\LocationStub(
@@ -117,7 +111,6 @@ return array(
                 "depth" => 3,
                 "sortField" => 1,
                 "sortOrder" => 1,
-                "childCount" => null,
             )
         ),
         43 => new \eZ\Publish\API\Repository\Tests\Stubs\Values\Content\LocationStub(
@@ -134,7 +127,6 @@ return array(
                 "depth" => 1,
                 "sortField" => 9,
                 "sortOrder" => 1,
-                "childCount" => null,
             )
         ),
         44 => new \eZ\Publish\API\Repository\Tests\Stubs\Values\Content\LocationStub(
@@ -151,7 +143,6 @@ return array(
                 "depth" => 2,
                 "sortField" => 9,
                 "sortOrder" => 1,
-                "childCount" => null,
             )
         ),
         45 => new \eZ\Publish\API\Repository\Tests\Stubs\Values\Content\LocationStub(
@@ -168,7 +159,6 @@ return array(
                 "depth" => 3,
                 "sortField" => 9,
                 "sortOrder" => 1,
-                "childCount" => null,
             )
         ),
         48 => new \eZ\Publish\API\Repository\Tests\Stubs\Values\Content\LocationStub(
@@ -185,7 +175,6 @@ return array(
                 "depth" => 1,
                 "sortField" => 9,
                 "sortOrder" => 1,
-                "childCount" => null,
             )
         ),
         51 => new \eZ\Publish\API\Repository\Tests\Stubs\Values\Content\LocationStub(
@@ -202,7 +191,6 @@ return array(
                 "depth" => 2,
                 "sortField" => 9,
                 "sortOrder" => 1,
-                "childCount" => null,
             )
         ),
         52 => new \eZ\Publish\API\Repository\Tests\Stubs\Values\Content\LocationStub(
@@ -219,7 +207,6 @@ return array(
                 "depth" => 2,
                 "sortField" => 9,
                 "sortOrder" => 1,
-                "childCount" => null,
             )
         ),
         53 => new \eZ\Publish\API\Repository\Tests\Stubs\Values\Content\LocationStub(
@@ -236,7 +223,6 @@ return array(
                 "depth" => 2,
                 "sortField" => 9,
                 "sortOrder" => 1,
-                "childCount" => null,
             )
         ),
         54 => new \eZ\Publish\API\Repository\Tests\Stubs\Values\Content\LocationStub(
@@ -253,7 +239,6 @@ return array(
                 "depth" => 2,
                 "sortField" => 1,
                 "sortOrder" => 1,
-                "childCount" => null,
             )
         ),
         56 => new \eZ\Publish\API\Repository\Tests\Stubs\Values\Content\LocationStub(
@@ -270,7 +255,6 @@ return array(
                 "depth" => 2,
                 "sortField" => 1,
                 "sortOrder" => 1,
-                "childCount" => null,
             )
         ),
         58 => new \eZ\Publish\API\Repository\Tests\Stubs\Values\Content\LocationStub(
@@ -287,7 +271,6 @@ return array(
                 "depth" => 1,
                 "sortField" => 2,
                 "sortOrder" => 0,
-                "childCount" => null,
             )
         ),
         60 => new \eZ\Publish\API\Repository\Tests\Stubs\Values\Content\LocationStub(
@@ -304,7 +287,6 @@ return array(
                 "depth" => 2,
                 "sortField" => 8,
                 "sortOrder" => 1,
-                "childCount" => null,
             )
         ),
         61 => new \eZ\Publish\API\Repository\Tests\Stubs\Values\Content\LocationStub(
@@ -321,7 +303,6 @@ return array(
                 "depth" => 2,
                 "sortField" => 1,
                 "sortOrder" => 1,
-                "childCount" => null,
             )
         ),
     ),

--- a/eZ/Publish/API/Repository/Tests/_fixtures/generate-fixtures.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/generate-fixtures.php
@@ -454,8 +454,6 @@ function generateLocationFixture( array $fixture )
             'depth' => $data['depth'],
             'sortField' => $data['sort_field'],
             'sortOrder' => $data['sort_order'],
-            'childCount' => null, // Cannot be easily calculated
-
         );
         $nextId = max( $nextId, $data['node_id'] );
     }

--- a/eZ/Publish/API/Repository/Values/Content/Location.php
+++ b/eZ/Publish/API/Repository/Values/Content/Location.php
@@ -28,7 +28,6 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read int $depth Depth location has in the location tree
  * @property-read int $sortField Specifies which property the child locations should be sorted on. Valid values are found at {@link Location::SORT_FIELD_*}
  * @property-read int $sortOrder Specifies whether the sort order should be ascending or descending. Valid values are {@link Location::SORT_ORDER_*}
- * @property-read int $childCount the number of children visible to the authenticated user which has loaded this instance.
  */
 abstract class Location extends ValueObject
 {
@@ -142,11 +141,4 @@ abstract class Location extends ValueObject
      * @var mixed
      */
     protected $sortOrder;
-
-    /**
-     * the number of children visible to the authenticated user which has loaded this instance.
-     *
-     * @var integer
-     */
-    protected $childCount;
 }

--- a/eZ/Publish/Core/REST/Client/Input/Parser/Location.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/Location.php
@@ -63,7 +63,6 @@ class Location extends Parser
                 'depth' => (int) $data['depth'],
                 'sortField' => $this->parserTools->parseDefaultSortField( $data['sortField'] ),
                 'sortOrder' => $this->parserTools->parseDefaultSortOrder( $data['sortOrder'] ),
-                'childCount' => (int) $data['childCount']
             )
         );
     }

--- a/eZ/Publish/Core/REST/Client/LocationService.php
+++ b/eZ/Publish/Core/REST/Client/LocationService.php
@@ -256,6 +256,18 @@ class LocationService implements \eZ\Publish\API\Repository\LocationService, Ses
     }
 
     /**
+     * Returns the number of children which are readable by the current user of a location object
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $location
+     *
+     * @return int
+     */
+    public function getLocationChildCount( Location $location )
+    {
+        throw new \Exception( "@TODO: Implement." );
+    }
+
+    /**
      * Swaps the contents hold by the $location1 and $location2
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user user is not allowed to swap content

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/LocationTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/LocationTest.php
@@ -41,7 +41,6 @@ class LocationTest extends BaseTest
             ),
             'sortField' => 'PATH',
             'sortOrder' => 'ASC',
-            'childCount' => '0'
         );
 
         $result = $locationParser->parse( $inputArray, $this->getParsingDispatcherMock() );
@@ -216,20 +215,6 @@ class LocationTest extends BaseTest
         $this->assertEquals(
             Location::SORT_ORDER_ASC,
             $result->sortOrder
-        );
-    }
-
-    /**
-     * Tests that the resulting location contains child count
-     *
-     * @param \eZ\Publish\API\Repository\Values\Content\Location $result
-     * @depends testParse
-     */
-    public function testResultContainsChildCount( $result )
-    {
-        $this->assertEquals(
-            0,
-            $result->childCount
         );
     }
 

--- a/eZ/Publish/Core/REST/Client/TrashService.php
+++ b/eZ/Publish/Core/REST/Client/TrashService.php
@@ -246,7 +246,6 @@ class TrashService implements \eZ\Publish\API\Repository\TrashService, Sessionab
                 'depth' => (int) $location->depth,
                 'sortField' => $location->sortField,
                 'sortOrder' => $location->sortOrder,
-                'childCount' => $location->childCount
             )
         );
     }

--- a/eZ/Publish/Core/REST/Server/Controller/Trash.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Trash.php
@@ -67,10 +67,22 @@ class Trash extends RestController
         $query->offset = $offset >= 0 ? $offset : null;
         $query->limit = $limit >= 0 ? $limit : null;
 
-        return new Values\Trash(
+        $trashItems = array();
+
+        foreach (
             $this->trashService->findTrashItems(
                 $query
-            )->items,
+            )->items as $trashItem
+        )
+        {
+            $trashItems[] = new Values\RestTrashItem(
+                $trashItem,
+                $this->locationService->getLocationChildCount( $trashItem )
+            );
+        }
+
+        return new Values\Trash(
+            $trashItems,
             $this->request->path
         );
     }
@@ -79,11 +91,15 @@ class Trash extends RestController
      * Returns the trash item given by id
      *
      * @return \eZ\Publish\API\Repository\Values\Content\TrashItem
+     * @return \eZ\Publish\Core\REST\Server\Values\RestTrashItem
      */
     public function loadTrashItem()
     {
         $values = $this->urlHandler->parse( 'trash', $this->request->path );
-        return $this->trashService->loadTrashItem( $values['trash'] );
+        return new Values\RestTrashItem(
+            $trashItem = $this->trashService->loadTrashItem( $values['trash'] ),
+            $this->locationService->getLocationChildCount( $trashItem )
+        );
     }
 
     /**

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/CreatedLocation.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/CreatedLocation.php
@@ -15,7 +15,7 @@ use eZ\Publish\Core\REST\Common\Output\Visitor;
 /**
  * CreatedLocation value object visitor
  */
-class CreatedLocation extends Location
+class CreatedLocation extends RestLocation
 {
     /**
      * Visit struct returned by controllers
@@ -26,12 +26,12 @@ class CreatedLocation extends Location
      */
     public function visit( Visitor $visitor, Generator $generator, $data )
     {
-        parent::visit( $visitor, $generator, $data->location );
+        parent::visit( $visitor, $generator, $data->restLocation );
         $visitor->setHeader(
             'Location',
             $this->urlHandler->generate(
                 'location',
-                array( 'location' => rtrim( $data->location->pathString, '/' ) )
+                array( 'location' => rtrim( $data->restLocation->location->pathString, '/' ) )
             )
         );
         $visitor->setStatus( 201 );

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/LocationList.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/LocationList.php
@@ -35,12 +35,12 @@ class LocationList extends ValueObjectVisitor
 
         $generator->startList( 'Location' );
 
-        foreach ( $data->locations as $location )
+        foreach ( $data->locations as $restLocation )
         {
             $generator->startObjectElement( 'Location' );
             $generator->startAttribute(
                 'href',
-                $this->urlHandler->generate( 'location', array( 'location' => rtrim( $location->pathString, '/' ) ) )
+                $this->urlHandler->generate( 'location', array( 'location' => rtrim( $restLocation->location->pathString, '/' ) ) )
             );
             $generator->endAttribute( 'href' );
             $generator->endObjectElement( 'Location' );

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestLocation.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestLocation.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the Location ValueObjectVisitor class
+ * File containing the RestLocation ValueObjectVisitor class
  *
  * @copyright Copyright (C) 1999-2012 eZ Systems AS. All rights reserved.
  * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
@@ -14,16 +14,16 @@ use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
 
 /**
- * Location value object visitor
+ * RestLocation value object visitor
  */
-class Location extends ValueObjectVisitor
+class RestLocation extends ValueObjectVisitor
 {
     /**
      * Visit struct returned by controllers
      *
      * @param \eZ\Publish\Core\REST\Common\Output\Visitor $visitor
      * @param \eZ\Publish\Core\REST\Common\Output\Generator $generator
-     * @param \eZ\Publish\API\Repository\Values\Content\Location $data
+     * @param \eZ\Publish\Core\REST\Server\Values\RestLocation $data
      */
     public function visit( Visitor $visitor, Generator $generator, $data )
     {
@@ -33,20 +33,20 @@ class Location extends ValueObjectVisitor
 
         $generator->startAttribute(
             'href',
-            $this->urlHandler->generate( 'location', array( 'location' => rtrim( $data->pathString, '/' ) ) )
+            $this->urlHandler->generate( 'location', array( 'location' => rtrim( $data->location->pathString, '/' ) ) )
         );
         $generator->endAttribute( 'href' );
 
-        $generator->startValueElement( 'id', $data->id );
+        $generator->startValueElement( 'id', $data->location->id );
         $generator->endValueElement( 'id' );
 
-        $generator->startValueElement( 'priority', $data->priority );
+        $generator->startValueElement( 'priority', $data->location->priority );
         $generator->endValueElement( 'priority' );
 
-        $generator->startValueElement( 'hidden', $data->hidden ? 'true' : 'false' );
+        $generator->startValueElement( 'hidden', $data->location->hidden ? 'true' : 'false' );
         $generator->endValueElement( 'hidden' );
 
-        $generator->startValueElement( 'invisible', $data->invisible ? 'true' : 'false' );
+        $generator->startValueElement( 'invisible', $data->location->invisible ? 'true' : 'false' );
         $generator->endValueElement( 'invisible' );
 
         $generator->startObjectElement( 'ParentLocation', 'Location' );
@@ -55,27 +55,27 @@ class Location extends ValueObjectVisitor
             $this->urlHandler->generate(
                 'location',
                 array(
-                    'location' => '/' . implode( '/', array_slice( $data->path, 0, count( $data->path ) - 1 ) )
+                    'location' => '/' . implode( '/', array_slice( $data->location->path, 0, count( $data->location->path ) - 1 ) )
                 )
             )
         );
         $generator->endAttribute( 'href' );
         $generator->endObjectElement( 'ParentLocation' );
 
-        $generator->startValueElement( 'pathString', $data->pathString );
+        $generator->startValueElement( 'pathString', $data->location->pathString );
         $generator->endValueElement( 'pathString' );
 
         // 'c' is the PHP date/time format compatible with XSD dateTime datatype
-        $generator->startValueElement( 'subLocationModificationDate', date( 'c', $data->modifiedSubLocationDate->getTimestamp() ) );
+        $generator->startValueElement( 'subLocationModificationDate', date( 'c', $data->location->modifiedSubLocationDate->getTimestamp() ) );
         $generator->endValueElement( 'subLocationModificationDate' );
 
-        $generator->startValueElement( 'depth', $data->depth );
+        $generator->startValueElement( 'depth', $data->location->depth );
         $generator->endValueElement( 'depth' );
 
         $generator->startValueElement( 'childCount', $data->childCount );
         $generator->endValueElement( 'childCount' );
 
-        $generator->startValueElement( 'remoteId', $data->remoteId );
+        $generator->startValueElement( 'remoteId', $data->location->remoteId );
         $generator->endValueElement( 'remoteId' );
 
         $generator->startObjectElement( 'Children', 'LocationList' );
@@ -84,7 +84,7 @@ class Location extends ValueObjectVisitor
             $this->urlHandler->generate(
                 'locationChildren',
                 array(
-                    'location' => rtrim( $data->pathString, '/' )
+                    'location' => rtrim( $data->location->pathString, '/' )
                 )
             )
         );
@@ -92,14 +92,14 @@ class Location extends ValueObjectVisitor
         $generator->endObjectElement( 'Children' );
 
         $generator->startObjectElement( 'Content' );
-        $generator->startAttribute( 'href', $this->urlHandler->generate( 'object', array( 'object' => $data->contentId ) ) );
+        $generator->startAttribute( 'href', $this->urlHandler->generate( 'object', array( 'object' => $data->location->contentId ) ) );
         $generator->endAttribute( 'href' );
         $generator->endObjectElement( 'Content' );
 
-        $generator->startValueElement( 'sortField', $this->serializeSortField( $data->sortField ) );
+        $generator->startValueElement( 'sortField', $this->serializeSortField( $data->location->sortField ) );
         $generator->endValueElement( 'sortField' );
 
-        $generator->startValueElement( 'sortOrder', $this->serializeSortOrder( $data->sortOrder ) );
+        $generator->startValueElement( 'sortOrder', $this->serializeSortOrder( $data->location->sortOrder ) );
         $generator->endValueElement( 'sortOrder' );
 
         $generator->endObjectElement( 'Location' );

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestTrashItem.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestTrashItem.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the TrashItem ValueObjectVisitor class
+ * File containing the RestTrashItem ValueObjectVisitor class
  *
  * @copyright Copyright (C) 1999-2012 eZ Systems AS. All rights reserved.
  * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
@@ -14,16 +14,16 @@ use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
 
 /**
- * TrashItem value object visitor
+ * RestTrashItem value object visitor
  */
-class TrashItem extends ValueObjectVisitor
+class RestTrashItem extends ValueObjectVisitor
 {
     /**
      * Visit struct returned by controllers
      *
      * @param \eZ\Publish\Core\REST\Common\Output\Visitor $visitor
      * @param \eZ\Publish\Core\REST\Common\Output\Generator $generator
-     * @param \eZ\Publish\API\Repository\Values\Content\TrashItem $data
+     * @param \eZ\Publish\Core\REST\Server\Values\RestTrashItem $data
      */
     public function visit( Visitor $visitor, Generator $generator, $data )
     {
@@ -32,23 +32,23 @@ class TrashItem extends ValueObjectVisitor
 
         $generator->startAttribute(
             'href',
-            $this->urlHandler->generate( 'trash', array( 'trash' => $data->id ) )
+            $this->urlHandler->generate( 'trash', array( 'trash' => $data->trashItem->id ) )
         );
         $generator->endAttribute( 'href' );
 
-        $generator->startValueElement( 'id', $data->id );
+        $generator->startValueElement( 'id', $data->trashItem->id );
         $generator->endValueElement( 'id' );
 
-        $generator->startValueElement( 'priority', $data->priority );
+        $generator->startValueElement( 'priority', $data->trashItem->priority );
         $generator->endValueElement( 'priority' );
 
-        $generator->startValueElement( 'hidden', $data->hidden ? 'true' : 'false' );
+        $generator->startValueElement( 'hidden', $data->trashItem->hidden ? 'true' : 'false' );
         $generator->endValueElement( 'hidden' );
 
-        $generator->startValueElement( 'invisible', $data->invisible ? 'true' : 'false' );
+        $generator->startValueElement( 'invisible', $data->trashItem->invisible ? 'true' : 'false' );
         $generator->endValueElement( 'invisible' );
 
-        $pathStringParts = explode( '/', trim( $data->pathString, '/' ) );
+        $pathStringParts = explode( '/', trim( $data->trashItem->pathString, '/' ) );
         $pathStringParts = array_slice( $pathStringParts, 0, count( $pathStringParts ) - 1 );
 
         $generator->startObjectElement( 'ParentLocation', 'Location' );
@@ -64,31 +64,31 @@ class TrashItem extends ValueObjectVisitor
         $generator->endAttribute( 'href' );
         $generator->endObjectElement( 'ParentLocation' );
 
-        $generator->startValueElement( 'pathString', $data->pathString );
+        $generator->startValueElement( 'pathString', $data->trashItem->pathString );
         $generator->endValueElement( 'pathString' );
 
         // 'c' is the PHP date/time format compatible with XSD dateTime datatype
-        $generator->startValueElement( 'subLocationModificationDate', date( 'c', $data->modifiedSubLocationDate->getTimestamp() ) );
+        $generator->startValueElement( 'subLocationModificationDate', date( 'c', $data->trashItem->modifiedSubLocationDate->getTimestamp() ) );
         $generator->endValueElement( 'subLocationModificationDate' );
 
-        $generator->startValueElement( 'depth', $data->depth );
+        $generator->startValueElement( 'depth', $data->trashItem->depth );
         $generator->endValueElement( 'depth' );
 
         $generator->startValueElement( 'childCount', $data->childCount );
         $generator->endValueElement( 'childCount' );
 
-        $generator->startValueElement( 'remoteId', $data->remoteId );
+        $generator->startValueElement( 'remoteId', $data->trashItem->remoteId );
         $generator->endValueElement( 'remoteId' );
 
         $generator->startObjectElement( 'Content' );
-        $generator->startAttribute( 'href', $this->urlHandler->generate( 'object', array( 'object' => $data->contentId ) ) );
+        $generator->startAttribute( 'href', $this->urlHandler->generate( 'object', array( 'object' => $data->trashItem->contentId ) ) );
         $generator->endAttribute( 'href' );
         $generator->endObjectElement( 'Content' );
 
-        $generator->startValueElement( 'sortField', $this->serializeSortField( $data->sortField ) );
+        $generator->startValueElement( 'sortField', $this->serializeSortField( $data->trashItem->sortField ) );
         $generator->endValueElement( 'sortField' );
 
-        $generator->startValueElement( 'sortOrder', $this->serializeSortOrder( $data->sortOrder ) );
+        $generator->startValueElement( 'sortOrder', $this->serializeSortOrder( $data->trashItem->sortOrder ) );
         $generator->endValueElement( 'sortOrder' );
 
         $generator->endObjectElement( 'TrashItem' );

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestLocationTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestLocationTest.php
@@ -11,11 +11,12 @@ namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Server\Values\RestLocation;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\Core\Repository\Values\Content\ContentInfo;
 use eZ\Publish\Core\REST\Common;
 
-class LocationTest extends ValueObjectVisitorBaseTest
+class RestLocationTest extends ValueObjectVisitorBaseTest
 {
     /**
      * Test the Location visitor
@@ -29,26 +30,29 @@ class LocationTest extends ValueObjectVisitorBaseTest
 
         $generator->startDocument( null );
 
-        $location = new Location(
-            array(
-                'id' => 42,
-                'priority' => 0,
-                'hidden' => false,
-                'invisible' => true,
-                'remoteId' => 'remote-id',
-                'parentLocationId' => 21,
-                'pathString' => '/1/2/21/42/',
-                'modifiedSubLocationDate' => new \DateTime( '2012-09-05 15:27 Europe/Zagreb' ),
-                'depth' => 3,
-                'sortField' => Location::SORT_FIELD_PATH,
-                'sortOrder' => Location::SORT_ORDER_ASC,
-                'childCount' => 0,
-                'contentInfo' => new ContentInfo(
-                    array(
-                        'id' => 42
+        $location = new RestLocation(
+            new Location(
+                array(
+                    'id' => 42,
+                    'priority' => 0,
+                    'hidden' => false,
+                    'invisible' => true,
+                    'remoteId' => 'remote-id',
+                    'parentLocationId' => 21,
+                    'pathString' => '/1/2/21/42/',
+                    'modifiedSubLocationDate' => new \DateTime( '2012-09-05 15:27 Europe/Zagreb' ),
+                    'depth' => 3,
+                    'sortField' => Location::SORT_FIELD_PATH,
+                    'sortOrder' => Location::SORT_ORDER_ASC,
+                    'contentInfo' => new ContentInfo(
+                        array(
+                            'id' => 42
+                        )
                     )
                 )
-            )
+            ),
+            // Dummy value for ChildCount
+            0
         );
 
         $visitor->visit(
@@ -439,11 +443,11 @@ class LocationTest extends ValueObjectVisitorBaseTest
     /**
      * Get the Location visitor
      *
-     * @return \eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\Location
+     * @return \eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\RestLocation
      */
     protected function getLocationVisitor()
     {
-        return new ValueObjectVisitor\Location(
+        return new ValueObjectVisitor\RestLocation(
             new Common\UrlHandler\eZPublish()
         );
     }

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestTrashItemTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestTrashItemTest.php
@@ -11,11 +11,12 @@ namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Server\Values\RestTrashItem;
 use eZ\Publish\Core\Repository\Values\Content\TrashItem;
 use eZ\Publish\Core\Repository\Values\Content\ContentInfo;
 use eZ\Publish\Core\REST\Common;
 
-class TrashItemTest extends ValueObjectVisitorBaseTest
+class RestTrashItemTest extends ValueObjectVisitorBaseTest
 {
     /**
      * Test the TrashItem visitor
@@ -29,26 +30,29 @@ class TrashItemTest extends ValueObjectVisitorBaseTest
 
         $generator->startDocument( null );
 
-        $trashItem = new TrashItem(
-            array(
-                'id' => 42,
-                'priority' => 0,
-                'hidden' => false,
-                'invisible' => true,
-                'remoteId' => 'remote-id',
-                'parentLocationId' => 21,
-                'pathString' => '/1/2/21/42/',
-                'modifiedSubLocationDate' => new \DateTime( '2012-09-05 15:27 Europe/Zagreb' ),
-                'depth' => 3,
-                'childCount' => 0,
-                'contentInfo' => new ContentInfo(
-                    array(
-                        'id' => 84
-                    )
-                ),
-                'sortField' => TrashItem::SORT_FIELD_NAME,
-                'sortOrder' => TrashItem::SORT_ORDER_DESC
-            )
+        $trashItem = new RestTrashItem(
+            new TrashItem(
+                array(
+                    'id' => 42,
+                    'priority' => 0,
+                    'hidden' => false,
+                    'invisible' => true,
+                    'remoteId' => 'remote-id',
+                    'parentLocationId' => 21,
+                    'pathString' => '/1/2/21/42/',
+                    'modifiedSubLocationDate' => new \DateTime( '2012-09-05 15:27 Europe/Zagreb' ),
+                    'depth' => 3,
+                    'contentInfo' => new ContentInfo(
+                        array(
+                            'id' => 84
+                        )
+                    ),
+                    'sortField' => TrashItem::SORT_FIELD_NAME,
+                    'sortOrder' => TrashItem::SORT_ORDER_DESC
+                )
+            ),
+            // Dummy value for ChildCount
+            0
         );
 
         $visitor->visit(
@@ -399,11 +403,11 @@ class TrashItemTest extends ValueObjectVisitorBaseTest
     /**
      * Get the TrashItem visitor
      *
-     * @return \eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\TrashItem
+     * @return \eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\RestTrashItem
      */
     protected function getTrashItemVisitor()
     {
-        return new ValueObjectVisitor\TrashItem(
+        return new ValueObjectVisitor\RestTrashItem(
             new Common\UrlHandler\eZPublish()
         );
     }

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/TrashTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/TrashTest.php
@@ -12,6 +12,7 @@ use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Server\Values\Trash;
+use eZ\Publish\Core\REST\Server\Values\RestTrashItem;
 use eZ\Publish\Core\REST\Common;
 use eZ\Publish\Core\Repository\Values\Content;
 
@@ -96,15 +97,23 @@ class TrashTest extends ValueObjectVisitorBaseTest
 
         $trashList = new Trash(
             array(
-                new Content\TrashItem(),
-                new Content\TrashItem(),
+                new RestTrashItem(
+                    new Content\TrashItem(),
+                    // Dummy value for ChildCount
+                    0
+                ),
+                new RestTrashItem(
+                    new Content\TrashItem(),
+                    // Dummy value for ChildCount
+                    0
+                ),
             ),
             '/content/trash'
         );
 
         $this->getVisitorMock()->expects( $this->exactly( 2 ) )
             ->method( 'visitValueObject' )
-            ->with( $this->isInstanceOf( 'eZ\\Publish\\API\\Repository\\Values\\Content\\TrashItem' ) );
+            ->with( $this->isInstanceOf( 'eZ\\Publish\\Core\\REST\\Server\\Values\\RestTrashItem' ) );
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Values/CreatedLocation.php
+++ b/eZ/Publish/Core/REST/Server/Values/CreatedLocation.php
@@ -18,7 +18,7 @@ class CreatedLocation extends ValueObject
     /**
      * The created location
      *
-     * @var \eZ\Publish\API\Repository\Values\Content\Location
+     * @var \eZ\Publish\Core\REST\Server\Values\RestLocation
      */
-    public $location;
+    public $restLocation;
 }

--- a/eZ/Publish/Core/REST/Server/Values/LocationList.php
+++ b/eZ/Publish/Core/REST/Server/Values/LocationList.php
@@ -19,7 +19,7 @@ class LocationList extends RestValue
     /**
      * Locations
      *
-     * @var \eZ\Publish\API\Repository\Values\Content\Location[]
+     * @var \eZ\Publish\Core\REST\Server\Values\RestLocation[]
      */
     public $locations;
 
@@ -33,7 +33,7 @@ class LocationList extends RestValue
     /**
      * Construct
      *
-     * @param \eZ\Publish\API\Repository\Values\Content\Location[] $locations
+     * @param \eZ\Publish\Core\REST\Server\Values\RestLocation[] $locations
      * @param string $path
      */
     public function __construct( array $locations, $path )

--- a/eZ/Publish/Core/REST/Server/Values/RestLocation.php
+++ b/eZ/Publish/Core/REST/Server/Values/RestLocation.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * File containing the RestLocation class
+ *
+ * @copyright Copyright (C) 1999-2012 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\REST\Server\Values;
+
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\Core\REST\Common\Value as RestValue;
+
+/**
+ * RestLocation view model
+ */
+class RestLocation extends RestValue
+{
+    /**
+     * A location
+     *
+     * @var \eZ\Publish\API\Repository\Values\Content\Location
+     */
+    public $location;
+
+    /**
+     * Number of children of the location
+     *
+     * @var int
+     */
+    public $childCount;
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $location
+     * @param int $childCount
+     */
+    public function __construct( Location $location, $childCount )
+    {
+        $this->location = $location;
+        $this->childCount = $childCount;
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Values/RestTrashItem.php
+++ b/eZ/Publish/Core/REST/Server/Values/RestTrashItem.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * File containing the RestTrashItem class
+ *
+ * @copyright Copyright (C) 1999-2012 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\REST\Server\Values;
+
+use eZ\Publish\API\Repository\Values\Content\TrashItem;
+use eZ\Publish\Core\REST\Common\Value as RestValue;
+
+/**
+ * RestTrashItem view model
+ */
+class RestTrashItem extends RestValue
+{
+    /**
+     * A trash item
+     *
+     * @var \eZ\Publish\API\Repository\Values\Content\TrashItem
+     */
+    public $trashItem;
+
+    /**
+     * Number of children of the trash item
+     *
+     * @var int
+     */
+    public $childCount;
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\TrashItem $trashItem
+     * @param int $childCount
+     */
+    public function __construct( TrashItem $trashItem, $childCount )
+    {
+        $this->trashItem = $trashItem;
+        $this->childCount = $childCount;
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Values/Trash.php
+++ b/eZ/Publish/Core/REST/Server/Values/Trash.php
@@ -19,7 +19,7 @@ class Trash extends RestValue
     /**
      * Trash items
      *
-     * @var \eZ\Publish\API\Repository\Values\Content\TrashItem[]
+     * @var \eZ\Publish\Core\REST\Server\Values\RestTrashItem[]
      */
     public $trashItems;
 
@@ -33,7 +33,7 @@ class Trash extends RestValue
     /**
      * Construct
      *
-     * @param \eZ\Publish\API\Repository\Values\Content\TrashItem[] $trashItems
+     * @param \eZ\Publish\Core\REST\Server\Values\RestTrashItem[] $trashItems
      * @param string $path
      */
     public function __construct( array $trashItems, $path )

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -283,6 +283,27 @@ class LocationService implements LocationServiceInterface
     }
 
     /**
+     * Returns the number of children which are readable by the current user of a location object
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $location
+     *
+     * @return int
+     */
+    public function getLocationChildCount( APILocation $location )
+    {
+        if ( !is_numeric( $location->id ) )
+            throw new InvalidArgumentValue( "id", $location->id, "Location" );
+
+        return $this->searchChildrenLocations(
+            $location->id,
+            null,
+            APILocation::SORT_ORDER_ASC,
+            0,
+            0
+        )->totalCount;
+    }
+
+    /**
      * Searches children locations of the provided parent location id
      *
      * @param int $parentLocationId
@@ -763,8 +784,6 @@ class LocationService implements LocationServiceInterface
         else // @todo This should not be loaded separately, SPI need to change to fix this.
             $contentInfo = $this->repository->getContentService()->internalLoadContentInfo( $spiLocation->contentId );
 
-        $childrenLocations = $this->searchChildrenLocations( $spiLocation->id, null, APILocation::SORT_ORDER_ASC, 0, 0 );
-
         return new Location(
             array(
                 'contentInfo' => $contentInfo,
@@ -779,7 +798,6 @@ class LocationService implements LocationServiceInterface
                 'depth' => (int) $spiLocation->depth,
                 'sortField' => (int) $spiLocation->sortField,
                 'sortOrder' => (int) $spiLocation->sortOrder,
-                'childCount' => $childrenLocations->totalCount
             )
         );
     }

--- a/eZ/Publish/Core/Repository/Tests/Service/LocationBase.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/LocationBase.php
@@ -44,7 +44,6 @@ abstract class LocationBase extends BaseServiceTest
                 'depth' => null,
                 'sortField' => null,
                 'sortOrder' => null,
-                'childCount' => null
             ),
             $location
         );
@@ -464,7 +463,6 @@ abstract class LocationBase extends BaseServiceTest
                 'depth' => $parentLocation->depth + 1,
                 'sortField' => $locationCreateStruct->sortField,
                 'sortOrder' => $locationCreateStruct->sortOrder,
-                'childCount' => 0
             ),
             $createdLocation
         );

--- a/eZ/Publish/Core/Repository/Tests/Service/TrashBase.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/TrashBase.php
@@ -44,7 +44,6 @@ abstract class TrashBase extends BaseServiceTest
                 'depth' => null,
                 'sortField' => null,
                 'sortOrder' => null,
-                'childCount' => null
             ),
             $trashItem
         );
@@ -136,7 +135,6 @@ abstract class TrashBase extends BaseServiceTest
                 'depth',
                 'sortField',
                 'sortOrder',
-                'childCount'
             ),
             $trashItem,
             $loadedTrashItem
@@ -183,9 +181,7 @@ abstract class TrashBase extends BaseServiceTest
                 'sortOrder'
             ),
             $location,
-            $trashItem,
-            //@todo: enable the following properties
-            array( 'childCount' )
+            $trashItem
         );
     }
 
@@ -266,9 +262,7 @@ abstract class TrashBase extends BaseServiceTest
                 'sortOrder'
             ),
             $location,
-            $recoveredLocation,
-            //@todo: assert child count
-            array( 'childCount' )
+            $recoveredLocation
         );
 
         $parentLocation = $locationService->loadLocation( $location->parentLocationId );
@@ -329,13 +323,12 @@ abstract class TrashBase extends BaseServiceTest
             ),
             $location,
             $recoveredLocation,
-            array( "childCount", "depth" )
+            array( "depth" )
         );
 
         $parentLocation = $locationService->loadLocation( $recoveredLocation->parentLocationId );
         $newPathString = $parentLocation->pathString . $recoveredLocation->id . "/";
 
-        self::assertEquals( 1, $parentLocation->childCount );
         self::assertEquals( $parentLocation->depth + 1, $recoveredLocation->depth );
         self::assertEquals( $newPathString, $recoveredLocation->pathString );
         self::assertGreaterThan( 0, $recoveredLocation->id );

--- a/eZ/Publish/Core/Repository/Tests/Values/Content/LocationTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/Content/LocationTest.php
@@ -39,7 +39,6 @@ class LocationTest extends PHPUnit_Framework_TestCase
         self::assertContains( 'depth', $properties, 'Property not found' );
         self::assertContains( 'sortField', $properties, 'Property not found' );
         self::assertContains( 'sortOrder', $properties, 'Property not found' );
-        self::assertContains( 'childCount', $properties, 'Property not found' );
 
         // check for duplicates and double check existence of property
         $propertiesHash = array();

--- a/eZ/Publish/Core/Repository/Tests/Values/Content/TrashItemTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/Content/TrashItemTest.php
@@ -39,7 +39,6 @@ class TrashItemTest extends PHPUnit_Framework_TestCase
         self::assertContains( 'depth', $properties, 'Property not found' );
         self::assertContains( 'sortField', $properties, 'Property not found' );
         self::assertContains( 'sortOrder', $properties, 'Property not found' );
-        self::assertContains( 'childCount', $properties, 'Property not found' );
 
         // check for duplicates and double check existence of property
         $propertiesHash = array();

--- a/eZ/Publish/Core/Repository/TrashService.php
+++ b/eZ/Publish/Core/Repository/TrashService.php
@@ -315,21 +315,9 @@ class TrashService implements TrashServiceInterface
      */
     protected function buildDomainTrashItemObject( Trashed $spiTrashItem )
     {
-        $contentInfo = $this->repository->getContentService()->loadContentInfo( $spiTrashItem->contentId );
-
-        $trashedChildren = array_filter(
-            $this->persistenceHandler->trashHandler()->findTrashItems(
-                new ParentLocationId( $spiTrashItem->id )
-            ),
-            function( $trashedChild ) use ( $spiTrashItem )
-            {
-                return $trashedChild->parentId === $spiTrashItem->id;
-            }
-        );
-
         return new TrashItem(
             array(
-                'contentInfo' => $contentInfo,
+                'contentInfo' => $this->repository->getContentService()->loadContentInfo( $spiTrashItem->contentId ),
                 'id' => (int) $spiTrashItem->id,
                 'priority' => (int) $spiTrashItem->priority,
                 'hidden' => (bool) $spiTrashItem->hidden,
@@ -341,7 +329,6 @@ class TrashService implements TrashServiceInterface
                 'depth' => (int) $spiTrashItem->depth,
                 'sortField' => (int) $spiTrashItem->sortField,
                 'sortOrder' => (int) $spiTrashItem->sortOrder,
-                'childCount' => count( $trashedChildren )
             )
         );
     }

--- a/eZ/Publish/Core/SignalSlot/LocationService.php
+++ b/eZ/Publish/Core/SignalSlot/LocationService.php
@@ -152,6 +152,18 @@ class LocationService implements LocationServiceInterface
     }
 
     /**
+     * Returns the number of children which are readable by the current user of a location object
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $location
+     *
+     * @return int
+     */
+    public function getLocationChildCount( Location $location )
+    {
+        return $this->service->getLocationChildCount( $location );
+    }
+
+    /**
      * Creates the new $location in the content repository for the given content
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user user is not allowed to create this location
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException  if the content is already below the specified parent


### PR DESCRIPTION
Refactoring of Location by removing the childCount property, to make this data loaded on demand instead of loaded on every location. Furthermore this data needs to be unique based on user permissions which means this Value object can not be easily cached if left as is.
