### PR TITLE
Fix errors in content type integration tests

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
@@ -2901,6 +2901,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
                 'title', 'ezstring'
             );
             $titleFieldCreate->names = array( 'eng-GB' => 'Title' );
+            $titleFieldCreate->position = 1;
             $typeCreate->addFieldDefinition( $titleFieldCreate );
 
             $groups = array(
@@ -2970,6 +2971,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
                 'title', 'ezstring'
             );
             $titleFieldCreate->names = array( 'eng-GB' => 'Title' );
+            $titleFieldCreate->position = 1;
             $typeCreate->addFieldDefinition( $titleFieldCreate );
 
             $groups = array(


### PR DESCRIPTION
Caused by fix for EZP-19689: publicAPI : field definitions order (position/placement) must be used with Legacy
