### PR TITLE
Fix EZP-19923: Missing config for Null type FieldTypes causes exceptions

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtypes.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtypes.yml
@@ -48,15 +48,13 @@ parameters:
     ezpublish.fieldType.ezpage.pageService.class: eZ\Publish\Core\FieldType\Page\Service
     ezpublish.fieldtype.ezpage.zoneDefinition: {}
     ezpublish.fieldType.ezpage.blockDefinition: {}
-    # Temporary workaround to treat those field types as a ezstring until proper implementation will be in place
+
     ezpublish.fieldType.ezgmaplocation.class: eZ\Publish\Core\FieldType\MapLocation\Type
     ezpublish.fieldType.ezgmaplocation.externalStorage.class: eZ\Publish\Core\FieldType\MapLocation\MapLocationStorage
-    ezpublish.fieldType.ezcomcomments.class: eZ\Publish\Core\FieldType\TextLine\Type
     ezpublish.fieldType.ezobjectrelationlist.class: eZ\Publish\Core\FieldType\RelationList\Type
     ezpublish.fieldType.ezobjectrelationlist.externalStorage.class: eZ\Publish\Core\FieldType\Relation\RelationStorage
     ezpublish.fieldType.ezuser.class: eZ\Publish\Core\FieldType\User\Type
     ezpublish.fieldType.ezuser.externalStorage.class: eZ\Publish\Core\FieldType\User\UserStorage
-    ezpublish.fieldType.ezpaex.class: eZ\Publish\Core\FieldType\Null\Type
     ezpublish.fieldType.ezcountry.class: eZ\Publish\Core\FieldType\Country\Type
     ezpublish.fieldType.ezcountry.data:
         AF: {Name: "Afghanistan", Alpha2: "AF", Alpha3: "AFG", IDC: "93"}
@@ -306,6 +304,8 @@ parameters:
         ZM: {Name: "Zambia", Alpha2: "ZM", Alpha3: "ZMB", IDC: "260"}
         ZW: {Name: "Zimbabwe", Alpha2: "ZW", Alpha3: "ZWE", IDC: "263"}
 
+    ezpublish.fieldType.eznull.class: eZ\Publish\Core\FieldType\Null\Type
+
 services:
     ezpublish.fieldType:
         class: %ezpublish.fieldType.class%
@@ -520,7 +520,7 @@ services:
         tags:
             - {name: ezpublish.fieldType, alias: ezgmaplocation}
 
-    # Temporary workaround for ezemail, ezgmaplocation, ezcomcomments, ezobjectrelationlist to treat those field types as
+    # Temporary workaround for ezemail, ezgmaplocation, ezobjectrelationlist to treat those field types as
     # a ezstring until proper implementation will be in place
 
     ezpublish.fieldType.ezemail:
@@ -534,12 +534,6 @@ services:
         arguments: [[]]
         tags:
             - {name: ezpublish.fieldType.externalStorageHandler, alias: ezgmaplocation}
-
-    ezpublish.fieldType.ezcomcomments:
-        class: %ezpublish.fieldType.ezcomcomments.class%
-        parent: ezpublish.fieldType
-        tags:
-            - {name: ezpublish.fieldType, alias: ezcomcomments}
 
     ezpublish.fieldType.ezobjectrelationlist:
         class: %ezpublish.fieldType.ezobjectrelationlist.class%
@@ -566,8 +560,119 @@ services:
         tags:
             - {name: ezpublish.fieldType.externalStorageHandler, alias: ezuser}
 
+    # Not implemented fieldtypes
+    # Configured to use the Null type to not throw exception
+    ezpublish.fieldType.ezdate:
+        class: %ezpublish.fieldType.eznull.class%
+        parent: ezpublish.fieldType
+        tags:
+            - {name: ezpublish.fieldType, alias: ezdate}
+
+    ezpublish.fieldType.ezenum:
+        class: %ezpublish.fieldType.eznull.class%
+        parent: ezpublish.fieldType
+        tags:
+            - {name: ezpublish.fieldType, alias: ezenum}
+
+    ezpublish.fieldType.ezidentifier:
+        class: %ezpublish.fieldType.eznull.class%
+        parent: ezpublish.fieldType
+        tags:
+            - {name: ezpublish.fieldType, alias: ezidentifier}
+
+    ezpublish.fieldType.ezinisetting:
+        class: %ezpublish.fieldType.eznull.class%
+        parent: ezpublish.fieldType
+        tags:
+            - {name: ezpublish.fieldType, alias: ezinisetting}
+
+    ezpublish.fieldType.ezisbn:
+        class: %ezpublish.fieldType.eznull.class%
+        parent: ezpublish.fieldType
+        tags:
+            - {name: ezpublish.fieldType, alias: ezisbn}
+
+    ezpublish.fieldType.ezmatrix:
+        class: %ezpublish.fieldType.eznull.class%
+        parent: ezpublish.fieldType
+        tags:
+            - {name: ezpublish.fieldType, alias: ezmatrix}
+
+    ezpublish.fieldType.ezmultioption:
+        class: %ezpublish.fieldType.eznull.class%
+        parent: ezpublish.fieldType
+        tags:
+            - {name: ezpublish.fieldType, alias: ezmultioption}
+
+    ezpublish.fieldType.ezmultioption2:
+        class: %ezpublish.fieldType.eznull.class%
+        parent: ezpublish.fieldType
+        tags:
+            - {name: ezpublish.fieldType, alias: ezmultioption2}
+
+    ezpublish.fieldType.ezmultiprice:
+        class: %ezpublish.fieldType.eznull.class%
+        parent: ezpublish.fieldType
+        tags:
+            - {name: ezpublish.fieldType, alias: ezmultiprice}
+
+    ezpublish.fieldType.ezoption:
+        class: %ezpublish.fieldType.eznull.class%
+        parent: ezpublish.fieldType
+        tags:
+            - {name: ezpublish.fieldType, alias: ezoption}
+
+    ezpublish.fieldType.ezpackage:
+        class: %ezpublish.fieldType.eznull.class%
+        parent: ezpublish.fieldType
+        tags:
+            - {name: ezpublish.fieldType, alias: ezpackage}
+
+    ezpublish.fieldType.ezprice:
+        class: %ezpublish.fieldType.eznull.class%
+        parent: ezpublish.fieldType
+        tags:
+            - {name: ezpublish.fieldType, alias: ezprice}
+
+    ezpublish.fieldType.ezproductcategory:
+        class: %ezpublish.fieldType.eznull.class%
+        parent: ezpublish.fieldType
+        tags:
+            - {name: ezpublish.fieldType, alias: ezproductcategory}
+
+    ezpublish.fieldType.ezrangeoption:
+        class: %ezpublish.fieldType.eznull.class%
+        parent: ezpublish.fieldType
+        tags:
+            - {name: ezpublish.fieldType, alias: ezrangeoption}
+
+    ezpublish.fieldType.ezsubtreesubscription:
+        class: %ezpublish.fieldType.eznull.class%
+        parent: ezpublish.fieldType
+        tags:
+            - {name: ezpublish.fieldType, alias: ezsubtreesubscription}
+
+    ezpublish.fieldType.eztime:
+        class: %ezpublish.fieldType.eznull.class%
+        parent: ezpublish.fieldType
+        tags:
+            - {name: ezpublish.fieldType, alias: eztime}
+
+    # not implemented fieldtypes from extensions
+    ezpublish.fieldType.ezcomcomments:
+        class: %ezpublish.fieldType.eznull.class%
+        parent: ezpublish.fieldType
+        tags:
+            - {name: ezpublish.fieldType, alias: ezcomcomments}
+
     ezpublish.fieldType.ezpaex:
-        class: %ezpublish.fieldType.ezpaex.class%
+        class: %ezpublish.fieldType.eznull.class%
         parent: ezpublish.fieldType
         tags:
             - {name: ezpublish.fieldType, alias: ezpaex}
+
+    ezpublish.fieldType.ezsurvey:
+        class: %ezpublish.fieldType.eznull.class%
+        parent: ezpublish.fieldType
+        tags:
+            - {name: ezpublish.fieldType, alias: ezsurvey}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage_engines.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage_engines.yml
@@ -72,10 +72,8 @@ parameters:
     ezpublish.fieldType.ezuser.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Null
     ezpublish.fieldType.ezuser.storage_gateway.class: eZ\Publish\Core\FieldType\User\UserStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezpage.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Page
-    ezpublish.fieldType.ezpaex.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Null
 
-    # Temporary workaround  to treat those field types as a ezstring until proper implementation will be in place
-    ezpublish.fieldType.ezcomcomments.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLine
+    ezpublish.fieldType.eznull.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Null
 
 services:
     ezpublish.api.storage_engine.in_memory:
@@ -259,18 +257,10 @@ services:
         tags:
             - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezgmaplocation, identifier: LegacyStorage}
 
-    # Temporary workaround for ezemail, ezgmaplocation, ezcomcomments, ezobjectrelationlist to treat those field types as
-    # a ezstring until proper implementation will be in place
-
     ezpublish.fieldType.ezemail.converter:
         class: %ezpublish.fieldType.ezemail.converter.class%
         tags:
             - {name: ezpublish.storageEngine.legacy.converter, alias: ezemail, lazy: true, callback: '::create'}
-
-    ezpublish.fieldType.ezcomcomments.converter:
-        class: %ezpublish.fieldType.ezcomcomments.converter.class%
-        tags:
-            - {name: ezpublish.storageEngine.legacy.converter, alias: ezcomcomments, lazy: true, callback: '::create'}
 
     ezpublish.fieldType.ezobjectrelation.converter:
         class: %ezpublish.fieldType.ezobjectrelation.converter.class%
@@ -298,7 +288,100 @@ services:
         tags:
             - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezuser, identifier: LegacyStorage}
 
+    # Not implemented converters
+    # Configured to use the Null converter which does not nothing
+    ezpublish.fieldType.ezdate.converter:
+        class: %ezpublish.fieldType.eznull.converter.class%
+        tags:
+            - {name: ezpublish.storageEngine.legacy.converter, alias: ezdate, lazy: true, callback: '::create'}
+
+    ezpublish.fieldType.ezenum.converter:
+        class: %ezpublish.fieldType.eznull.converter.class%
+        tags:
+            - {name: ezpublish.storageEngine.legacy.converter, alias: ezenum, lazy: true, callback: '::create'}
+
+    ezpublish.fieldType.ezidentifier.converter:
+        class: %ezpublish.fieldType.eznull.converter.class%
+        tags:
+            - {name: ezpublish.storageEngine.legacy.converter, alias: ezidentifier, lazy: true, callback: '::create'}
+
+    ezpublish.fieldType.ezinisetting.converter:
+        class: %ezpublish.fieldType.eznull.converter.class%
+        tags:
+            - {name: ezpublish.storageEngine.legacy.converter, alias: ezinisetting, lazy: true, callback: '::create'}
+
+    ezpublish.fieldType.ezisbn.converter:
+        class: %ezpublish.fieldType.eznull.converter.class%
+        tags:
+            - {name: ezpublish.storageEngine.legacy.converter, alias: ezisbn, lazy: true, callback: '::create'}
+
+    ezpublish.fieldType.ezmatrix.converter:
+        class: %ezpublish.fieldType.eznull.converter.class%
+        tags:
+            - {name: ezpublish.storageEngine.legacy.converter, alias: ezmatrix, lazy: true, callback: '::create'}
+
+    ezpublish.fieldType.ezmultioption.converter:
+        class: %ezpublish.fieldType.eznull.converter.class%
+        tags:
+            - {name: ezpublish.storageEngine.legacy.converter, alias: ezmultioption, lazy: true, callback: '::create'}
+
+    ezpublish.fieldType.ezmultioption2.converter:
+        class: %ezpublish.fieldType.eznull.converter.class%
+        tags:
+            - {name: ezpublish.storageEngine.legacy.converter, alias: ezmultioption2, lazy: true, callback: '::create'}
+
+    ezpublish.fieldType.ezmultiprice.converter:
+        class: %ezpublish.fieldType.eznull.converter.class%
+        tags:
+            - {name: ezpublish.storageEngine.legacy.converter, alias: ezmultiprice, lazy: true, callback: '::create'}
+
+    ezpublish.fieldType.ezoption.converter:
+        class: %ezpublish.fieldType.eznull.converter.class%
+        tags:
+            - {name: ezpublish.storageEngine.legacy.converter, alias: ezoption, lazy: true, callback: '::create'}
+
+    ezpublish.fieldType.ezpackage.converter:
+        class: %ezpublish.fieldType.eznull.converter.class%
+        tags:
+            - {name: ezpublish.storageEngine.legacy.converter, alias: ezpackage, lazy: true, callback: '::create'}
+
+    ezpublish.fieldType.ezprice.converter:
+        class: %ezpublish.fieldType.eznull.converter.class%
+        tags:
+            - {name: ezpublish.storageEngine.legacy.converter, alias: ezprice, lazy: true, callback: '::create'}
+
+    ezpublish.fieldType.ezproductcategory.converter:
+        class: %ezpublish.fieldType.eznull.converter.class%
+        tags:
+            - {name: ezpublish.storageEngine.legacy.converter, alias: ezproductcategory, lazy: true, callback: '::create'}
+
+    ezpublish.fieldType.ezrangeoption.converter:
+        class: %ezpublish.fieldType.eznull.converter.class%
+        tags:
+            - {name: ezpublish.storageEngine.legacy.converter, alias: ezrangeoption, lazy: true, callback: '::create'}
+
+    ezpublish.fieldType.ezsubtreesubscription.converter:
+        class: %ezpublish.fieldType.eznull.converter.class%
+        tags:
+            - {name: ezpublish.storageEngine.legacy.converter, alias: ezsubtreesubscription, lazy: true, callback: '::create'}
+
+    ezpublish.fieldType.eztime.converter:
+        class: %ezpublish.fieldType.eznull.converter.class%
+        tags:
+            - {name: ezpublish.storageEngine.legacy.converter, alias: eztime, lazy: true, callback: '::create'}
+
+    # not implemented converters from extensions
+    ezpublish.fieldType.ezcomcomments.converter:
+        class: %ezpublish.fieldType.eznull.converter.class%
+        tags:
+            - {name: ezpublish.storageEngine.legacy.converter, alias: ezcomcomments, lazy: true, callback: '::create'}
+
     ezpublish.fieldType.ezpaex.converter:
-        class: %ezpublish.fieldType.ezstring.converter.class%
+        class: %ezpublish.fieldType.eznull.converter.class%
         tags:
             - {name: ezpublish.storageEngine.legacy.converter, alias: ezpaex, lazy: true, callback: '::create'}
+
+    ezpublish.fieldType.ezsurvey.converter:
+        class: %ezpublish.fieldType.eznull.converter.class%
+        tags:
+            - {name: ezpublish.storageEngine.legacy.converter, alias: ezsurvey, lazy: true, callback: '::create'}


### PR DESCRIPTION
Fixes the configuration so that the use of the following fieldtypes does not throw an exception:
- ezdate
- ezenum
- ezidentifier
- ezinisetting
- ezisbn
- ezmatrix
- ezmultioption
- ezmultioption2
- ezmultiprice
- ezoption
- ezpackage
- ezprice (the field type seems to exist, but not the converter)
- ezproductcategory
- ezrangeoption
- ezsubtreesubscription
- eztime
- ezpaex
- ezcomments
- ezsurvey

Tested by loading a content with those fieldtypes with the REST API
