### PR TITLE
Renamed url_alias_router to legacy_mode for clarity and genericity

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
@@ -65,9 +65,9 @@ class Common extends AbstractParser
                 ->cannotBeEmpty()
                 ->info( 'Directory where binary files (from ezbinaryfile field type) are stored. Default value is "original"' )
             ->end()
-            ->booleanNode( 'url_alias_router' )
-                ->info( 'Whether to use UrlAliasRouter or not. If false, will let the legacy kernel handle url aliases.' )
-                ->defaultValue( true )
+            ->booleanNode( 'legacy_mode' )
+                ->info( 'Whether to use legacy mode or not. If true, will let the legacy kernel handle url aliases.' )
+                ->defaultValue( false )
             ->end()
             ->scalarNode( 'session_name' )
                 ->info( 'The session name. If you want a session name per siteaccess, use "{siteaccess_hash}" token. Will override default session name from framework.session.name' )
@@ -124,8 +124,11 @@ class Common extends AbstractParser
         }
         foreach ( $config[$this->baseKey] as $sa => $settings )
         {
-            if ( isset( $settings['url_alias_router'] ) )
-                $container->setParameter( "ezsettings.$sa.url_alias_router", $settings['url_alias_router'] );
+            if ( isset( $settings['legacy_mode'] ) )
+            {
+                $container->setParameter( "ezsettings.$sa.legacy_mode", $settings['legacy_mode'] );
+                $container->setParameter( "ezsettings.$sa.url_alias_router", !$settings['legacy_mode'] );
+            }
             if ( isset( $settings['var_dir'] ) )
                 $container->setParameter( "ezsettings.$sa.var_dir", $settings['var_dir'] );
             if ( isset( $settings['storage_dir'] ) )

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -13,6 +13,7 @@ parameters:
     # Common settings
     ezsettings.default.database.params: ~
     ezsettings.default.session_name: "eZSESSID{siteaccess_hash}"    # Using "{siteaccess_hash}" in session name makes it unique per siteaccess
+    ezsettings.default.legacy_mode: false
     ezsettings.default.url_alias_router: true                       # Use UrlAliasRouter by default
     ezsettings.default.languages: []
     ezsettings.default.var_dir: "var"                   # The root directory where all log files, cache files and other stored files are created

--- a/eZ/Bundle/EzPublishLegacyBundle/SetupWizard/ConfigurationConverter.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/SetupWizard/ConfigurationConverter.php
@@ -94,17 +94,17 @@ class ConfigurationConverter
         $settings['ezpublish']['system'][$defaultSiteaccess] = array();
         $settings['ezpublish']['system'][$adminSiteaccess] = array();
 
-        // If package is not supported, all siteaccesses will have individually url_alias_router to false, forcing legacy fallback
+        // If package is not supported, all siteaccesses will have individually legacy_mode to true, forcing legacy fallback
         if ( !isset( $this->supportedPackages[$sitePackage] ) )
         {
             foreach ( $siteList as $siteaccess )
             {
-                $settings['ezpublish']['system'][$siteaccess] = array( 'url_alias_router' => false );
+                $settings['ezpublish']['system'][$siteaccess] = array( 'legacy_mode' => true );
             }
         }
         else
         {
-            $settings['ezpublish']['system'][$adminSiteaccess] += array( 'url_alias_router' => false );
+            $settings['ezpublish']['system'][$adminSiteaccess] += array( 'legacy_mode' => true );
         }
 
         // FileSettings

--- a/eZ/Bundle/EzPublishLegacyBundle/Tests/SetupWizard/ConfigurationConverterTest.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Tests/SetupWizard/ConfigurationConverterTest.php
@@ -144,7 +144,7 @@ class ConfigurationConverterTest extends LegacyBasedTestCase
                             ) ),
                         )
                     ),
-                    'ezdemo_site_admin' => array( 'url_alias_router' => false )
+                    'ezdemo_site_admin' => array( 'legacy_mode' => true )
                 ),
                 'imagemagick' => array(
                     'enabled' => true,
@@ -306,7 +306,7 @@ class ConfigurationConverterTest extends LegacyBasedTestCase
                     ),
                     'ezdemo_site_admin' =>
                     array(
-                        'url_alias_router' => false,
+                        'legacy_mode' => true,
                     )
                 ),
             ),


### PR DESCRIPTION
`legacy_mode` is indeed more understandable.

`legacy_mode: true` will deactivate **UrlAliasRouter** (like it was the case with `url_alias_router: false`). Furthermore this change has the benefit to be reusable in some places if needed, even in 3rd party extensions.
