### PR TITLE
Fix #EZP-20034: Relation Field external data is not stored

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtypes.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtypes.yml
@@ -20,6 +20,7 @@ parameters:
     ezpublish.fieldType.ezmedia.class: eZ\Publish\Core\FieldType\Media\Type
     ezpublish.fieldType.ezmedia.externalStorage.class: eZ\Publish\Core\FieldType\Media\MediaStorage
     ezpublish.fieldType.ezobjectrelation.class: eZ\Publish\Core\FieldType\Relation\Type
+    ezpublish.fieldType.ezobjectrelation.externalStorage.class: eZ\Publish\Core\FieldType\Relation\RelationStorage
     ezpublish.fieldType.ezsrrating.class: eZ\Publish\Core\FieldType\Rating\Type
     ezpublish.fieldType.ezselection.class: eZ\Publish\Core\FieldType\Selection\Type
     ezpublish.fieldType.eztext.class: eZ\Publish\Core\FieldType\TextBlock\Type
@@ -421,6 +422,12 @@ services:
         tags:
             - {name: ezpublish.fieldType, alias: ezobjectrelation}
 
+    ezpublish.fieldType.ezobjectrelation.externalStorage:
+        class: %ezpublish.fieldType.ezobjectrelation.externalStorage.class%
+        arguments: [[]]
+        tags:
+            - {name: ezpublish.fieldType.externalStorageHandler, alias: ezobjectrelation}
+
     ezpublish.fieldType.ezsrrating:
         class: %ezpublish.fieldType.ezsrrating.class%
         parent: ezpublish.fieldType
@@ -517,7 +524,6 @@ services:
         arguments: [[]]
         tags:
             - {name: ezpublish.fieldType.externalStorageHandler, alias: ezobjectrelationlist}
-
 
     ezpublish.fieldType.ezuser:
         class: %ezpublish.fieldType.ezuser.class%

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage_engines.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage_engines.yml
@@ -59,6 +59,7 @@ parameters:
     ezpublish.fieldType.ezmedia.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Media
     ezpublish.fieldType.ezmedia.storage_gateway.class: eZ\Publish\Core\FieldType\Media\MediaStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezobjectrelation.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Relation
+    ezpublish.fieldType.externalStorageHandler.ezobjectrelation.gateway.class: eZ\Publish\Core\FieldType\Relation\RelationStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezobjectrelationlist.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RelationList
     ezpublish.fieldType.externalStorageHandler.ezobjectrelationlist.gateway.class: eZ\Publish\Core\FieldType\RelationList\RelationListStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezselection.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Selection
@@ -272,6 +273,11 @@ services:
         arguments: [@ezpublish.api.storage_engine.legacy.dbhandler]
         tags:
             - {name: ezpublish.storageEngine.legacy.converter, alias: ezobjectrelationlist}
+
+    ezpublish.fieldType.externalStorageHandler.ezobjectrelation.gateway:
+        class: %ezpublish.fieldType.externalStorageHandler.ezobjectrelation.gateway.class%
+        tags:
+            - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezobjectrelation, identifier: LegacyStorage}
 
     ezpublish.fieldType.externalStorageHandler.ezobjectrelationlist.gateway:
         class: %ezpublish.fieldType.externalStorageHandler.ezobjectrelationlist.gateway.class%


### PR DESCRIPTION
This pull request adds the missing configuration for the Relation Field storage.

After thorough investigation of the legacy relations handling, it is actually correct. The whole op_code logic only applies to object level relations.

The only missing answer is deletion. Since deleting a content / version seems to delete relations, we should be fine, but I would like confirmation for this. 
