### PR TITLE
Fix EZP-20125: Siteaccess matching error when SA name is in the URL

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIElement.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIElement.php
@@ -104,8 +104,11 @@ class URIElement implements Matcher, URILexer
      */
     public function analyseURI( $uri )
     {
-        $uriElements = implode( '/', $this->getURIElements() );
-        $uri = str_replace( "/$uriElements", '', $uri );
+        $uriElements = '/' . implode( '/', $this->getURIElements() );
+        if ( strpos( $uri, $uriElements ) === 0 )
+        {
+            sscanf( $uri, "$uriElements%s", $uri );
+        }
         return $uri;
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElement2Test.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElement2Test.php
@@ -117,9 +117,9 @@ class RouterURIElement2Test extends PHPUnit_Framework_TestCase
      * @covers \eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIElement::setRequest
      * @covers \eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIElement::getURIElements
      */
-    public function testAnalyseURI( $uri, $expectedFixedUpURI )
+    public function testAnalyseURI( $level, $uri, $expectedFixedUpURI )
     {
-        $matcher = new URIElementMatcher( 2 );
+        $matcher = new URIElementMatcher( $level );
         $matcher->setRequest(
             new SimplifiedRequest( array( 'pathinfo' => $uri ) )
         );
@@ -132,9 +132,9 @@ class RouterURIElement2Test extends PHPUnit_Framework_TestCase
      * @dataProvider analyseProvider
      * @covers \eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIElement::analyseLink
      */
-    public function testAnalyseLink( $fullUri, $linkUri )
+    public function testAnalyseLink( $level, $fullUri, $linkUri )
     {
-        $matcher = new URIElementMatcher( 2 );
+        $matcher = new URIElementMatcher( $level );
         $matcher->setRequest(
             new SimplifiedRequest( array( 'pathinfo' => $fullUri ) )
         );
@@ -144,8 +144,13 @@ class RouterURIElement2Test extends PHPUnit_Framework_TestCase
     public function analyseProvider()
     {
         return array(
-            array( '/my/siteaccess/foo/bar', '/foo/bar' ),
-            array( '/vive/le/sucre/en-poudre', '/sucre/en-poudre' )
+            array( 2, '/my/siteaccess/foo/bar', '/foo/bar' ),
+            array( 2, '/vive/le/sucre/en-poudre', '/sucre/en-poudre' ),
+            // Issue https://jira.ez.no/browse/EZP-20125
+            array( 1, '/fre/content/edit/104/1/fre-FR', '/content/edit/104/1/fre-FR' ),
+            array( 1, '/fre/utf8-with-accent/é/fre/à/à/fre/é', '/utf8-with-accent/é/fre/à/à/fre/é' ),
+            array( 2, '/é/fre/utf8-with-accent/é/fre/à/à/fre/é', '/utf8-with-accent/é/fre/à/à/fre/é' ),
+            array( 2, '/prefix/fre/url/alias/prefix/fre/prefix/fre/url', '/url/alias/prefix/fre/prefix/fre/url' ),
         );
     }
 }


### PR DESCRIPTION
Issue https://jira.ez.no/browse/EZP-20125
# Description

URIElement matcher does a str_replace to generate the URI without the siteaccess (and the subdir prefix). As a result, if the URI contains the siteaccess name (and the subdir prefix), the generated URI is wrong.
# Tests

manual tests + unit tests
