### PR TITLE
Fix EZP-20125: Siteaccess matching error when SA name is in the URL

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIElement.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIElement.php
@@ -105,7 +105,11 @@ class URIElement implements Matcher, URILexer
     public function analyseURI( $uri )
     {
         $uriElements = '/' . implode( '/', $this->getURIElements() );
-        if ( strpos( $uri, $uriElements ) === 0 )
+        if ( $uri == $uriElements )
+        {
+            $uri = '';
+        }
+        elseif ( strpos( $uri, $uriElements ) === 0 )
         {
             sscanf( $uri, "$uriElements%s", $uri );
         }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElement2Test.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElement2Test.php
@@ -151,6 +151,11 @@ class RouterURIElement2Test extends PHPUnit_Framework_TestCase
             array( 1, '/fre/utf8-with-accent/é/fre/à/à/fre/é', '/utf8-with-accent/é/fre/à/à/fre/é' ),
             array( 2, '/é/fre/utf8-with-accent/é/fre/à/à/fre/é', '/utf8-with-accent/é/fre/à/à/fre/é' ),
             array( 2, '/prefix/fre/url/alias/prefix/fre/prefix/fre/url', '/url/alias/prefix/fre/prefix/fre/url' ),
+            // regression after the first fix of EZP-20125
+            array( 1, '/sitaccess', '' ),
+            array( 1, '/sitaccess/', '/' ),
+            array( 2, '/prefix/siteaccess', '' ),
+            array( 2, '/prefix/siteaccess/', '/' ),
         );
     }
 }


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-20125#comment-68737
Fixed regression introduced in bf265d5f
# Description

while using the url http://ezpublish5.loc/ezdemo_site_admin, you are redirected to http://ezpublish5.loc/ezdemo_site_admin/ezdemo_site_admin after begin logged in.
# Tests

Added unit tests for this case + manual tests
