### PR TITLE
Fix EZP-20127: Failing unit test on Page FieldType 

### DIFF
--- a/eZ/Publish/Core/FieldType/Tests/PageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/PageTest.php
@@ -124,10 +124,6 @@ class PageTest extends StandardizedFieldTypeTest
                 new \stdClass(),
                 'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException'
             ),
-            array(
-                null,
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException'
-            ),
         );
     }
 
@@ -163,6 +159,10 @@ class PageTest extends StandardizedFieldTypeTest
     public function provideValidInputForAcceptValue()
     {
         return array(
+            array(
+                null,
+                new PageValue()
+            ),
             array(
                 new PageValue(),
                 new PageValue()


### PR DESCRIPTION
This PR fixes one remaining failed test in unit test for FieldTypes.

Caused by expecting exception for null as field value, which is handled as empty value instead.
