### PR TITLE
Fix #EZP-20155: Normalization workaround breaks with multiple yaml files

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -124,7 +124,7 @@ class EzPublishCoreExtension extends Extension
                         if ( !isset( $configurationBlock[$affectedKey] ) )
                             continue;
                         $result = $this->fixUpKeyReference( $configurationBlock[$affectedKey] );
-                        if ( count( $result ) )
+                        if ( !empty( $result ) )
                             $this->fixedUpKeys['system'][$configurationKey][$affectedKey] = $result;
                     }
                 }


### PR DESCRIPTION
Adds one level of iteration so that multiple files are taken into account. Tested with a distinct image_variations.yml, everything was normalized as expected.
