### PR TITLE
Fixed EZP-20143: Many wrong @covers annotation

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Tests/SiteAccess/LegacyMapperTest.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Tests/SiteAccess/LegacyMapperTest.php
@@ -19,7 +19,7 @@ class LegacyMapperTest extends LegacyBasedTestCase
     /**
      * @dataProvider siteAccessMatchProvider
      * @covers \eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\SiteAccess::__construct
-     * @covers \eZ\Bundle\EzPublishCoreBundle\EventListener\SiteAccessListener:onSiteAccessMatch
+     * @covers \eZ\Bundle\EzPublishCoreBundle\EventListener\SiteAccessListener::onSiteAccessMatch
      */
     public function testOnSiteAccessMatch( $pathinfo, $semanticPathinfo, SiteAccess $siteaccess, $expectedAccess )
     {

--- a/eZ/Publish/Core/FieldType/Tests/AuthorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/AuthorTest.php
@@ -418,7 +418,7 @@ class AuthorTest extends StandardizedFieldTypeTest
     }
 
     /**
-     * @covers \eZ\Publish\Core\FieldType\Author\Value::getName
+     * @covers \eZ\Publish\Core\FieldType\Author\Type::getName
      */
     public function testFieldValueTitle()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/Gateway/EzcDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/Gateway/EzcDatabaseTest.php
@@ -274,7 +274,7 @@ class EzcDatabaseTest extends TestCase
     /**
      * @return array
      */
-    public function providerForTestDowngradeMarksAsHistory()
+    public function providerForTestCleanupAfterPublishMarksAsHistory()
     {
         return array(
             array(
@@ -293,13 +293,13 @@ class EzcDatabaseTest extends TestCase
     }
 
     /**
-     * Test for the downgrade() method.
+     * Test for the cleanupAfterPublish() method.
      *
-     * @covers eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Gateway\EzcDatabase::downgrade
+     * @covers eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Gateway\EzcDatabase::cleanupAfterPublish
      * @covers eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Gateway\EzcDatabase::markAsHistory
-     * @dataProvider providerForTestDowngradeMarksAsHistory
+     * @dataProvider providerForTestCleanupAfterPublishMarksAsHistory
      */
-    public function testDowngradeMarksAsHistory( $action, $languageId, $parentId, $textMD5 )
+    public function testCleanupAfterPublishMarksAsHistory( $action, $languageId, $parentId, $textMD5 )
     {
         $this->insertDatabaseFixture( __DIR__ . "/_fixtures/urlaliases_downgrade.php" );
         $gateway = $this->getGateway();
@@ -319,7 +319,7 @@ class EzcDatabaseTest extends TestCase
     /**
      * @return array
      */
-    public function providerForTestDowngradeRemovesLanguage()
+    public function providerForTestCleanupAfterPublishRemovesLanguage()
     {
         return array(
             array(
@@ -338,13 +338,13 @@ class EzcDatabaseTest extends TestCase
     }
 
     /**
-     * Test for the downgrade() method.
+     * Test for the cleanupAfterPublish() method.
      *
-     * @covers eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Gateway\EzcDatabase::downgrade
+     * @covers eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Gateway\EzcDatabase::cleanupAfterPublish
      * @covers eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Gateway\EzcDatabase::removeLanguage
-     * @dataProvider providerForTestDowngradeRemovesLanguage
+     * @dataProvider providerForTestCleanupAfterPublishRemovesLanguage
      */
-    public function testDowngradeRemovesLanguage( $action, $languageId, $parentId, $textMD5 )
+    public function testCleanupAfterPublishRemovesLanguage( $action, $languageId, $parentId, $textMD5 )
     {
         $this->insertDatabaseFixture( __DIR__ . "/_fixtures/urlaliases_downgrade.php" );
         $gateway = $this->getGateway();


### PR DESCRIPTION
Previous `downgrade()` function of `eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Gateway\EzcDatabase` has been renamed to: `cleanupAfterPublish,()` test functions and data providers have been renamed accordingly.
