### PR TITLE
Implemented Url::getName()

### DIFF
--- a/eZ/Publish/Core/FieldType/Url/Type.php
+++ b/eZ/Publish/Core/FieldType/Url/Type.php
@@ -41,7 +41,12 @@ class Type extends FieldType
      */
     public function getName( $value )
     {
-        throw new \RuntimeException( 'Implement this method' );
+        if ( $value === null )
+        {
+            return '';
+        }
+        $value = $this->acceptValue( $value );
+        return (string)$value->text;
     }
 
     /**


### PR DESCRIPTION
without this change, it's impossible to update or create a content with an Url field in the name or url alias alias pattern.

(Note: as far as I can see, the field types' getName method are not covered by unit tests...)
