### PR TITLE
Fix EZP-20184:  content.ttl_cache parameter is send to the browser

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
@@ -55,7 +55,7 @@ class ViewController extends Controller
                 && $this->getParameter( 'content.ttl_cache' ) === true )
             {
                 $response->setVary( 'If-None-Match' );
-                $response->setMaxAge(
+                $response->setSharedMaxAge(
                     $this->getParameter( 'content.default_ttl' )
                 );
             }


### PR DESCRIPTION
The value of this parameter is sent to the browser because we set the Cache control "max-age" (with Response::setMaxAge()), we should rather set the value in Cache control "smax-age" (with Response()::setSharedMaxAge() to only modify the behavior of the reverse proxy otherwise the browser might store the page for a long time without checking if it's fresh.
