### PR TITLE
Fixed: Permission check for VersionInfo remove

### DIFF
--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1317,8 +1317,8 @@ class ContentService implements ContentServiceInterface
             );
         }
 
-        if ( !$this->repository->canUser( 'content', 'remove', $versionInfo ) )
-            throw new UnauthorizedException( 'content', 'remove' );
+        if ( !$this->repository->canUser( 'content', 'versionremove', $versionInfo ) )
+            throw new UnauthorizedException( 'content', 'versionremove' );
 
         $this->repository->beginTransaction();
         try


### PR DESCRIPTION
As discussed with @andrerom I have changed to permission check for removing a VersionInfo from `content::remove` to `content::versionremove`.
