### PR TITLE
Role limitation fix

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Stubs/RepositoryStub.php
+++ b/eZ/Publish/API/Repository/Tests/Stubs/RepositoryStub.php
@@ -181,7 +181,7 @@ class RepositoryStub implements Repository
                     return true;
                 }
 
-                if ( $policy->module !== $module )
+                if ( $policy->module !== $module && $policy->module !== "*"  )
                     continue;
 
                 if ( $policy->function === '*' && $roleLimitation === null )
@@ -190,7 +190,7 @@ class RepositoryStub implements Repository
                     return true;
                 }
 
-                if ( $policy->function !== $function )
+                if ( $policy->function !== $function && $policy->function !== "*"  )
                     continue;
 
                 $permissionSet['policies'][] = $policy;

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -262,13 +262,13 @@ class Repository implements RepositoryInterface
                 if ( $spiPolicy->module === '*' && $spiRoleAssignment->limitationIdentifier === null )
                     return true;
 
-                if ( $spiPolicy->module !== $module )
+                if ( $spiPolicy->module !== $module && $spiPolicy->module !== "*" )
                     continue;
 
                 if ( $spiPolicy->function === '*' && $spiRoleAssignment->limitationIdentifier === null )
                     return true;
 
-                if ( $spiPolicy->function !== $function )
+                if ( $spiPolicy->function !== $function && $spiPolicy->function !== "*" )
                     continue;
 
                 if ( $spiPolicy->limitations === '*' && $spiRoleAssignment->limitationIdentifier === null )


### PR DESCRIPTION
This PR fixes edge case for Repository::hasAccess().

Method was returning false when processing role containing policy defining access to all modules and all functions, assigned to User/UserGroup with limitation.
