### PR TITLE
- Added eZ LS Debug information on Symfony2 toolbar

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Collector/LegacyDebugCollector.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Collector/LegacyDebugCollector.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * File containing the LegacyDebugCollector class.
+ *
+ * @copyright Copyright (C) 1999-2012 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishLegacyBundle\Collector;
+
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use \eZDebug;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use eZ\Bundle\EzPublishCoreBundle\Controller;
+
+class LegacyDebugCollector extends DataCollector
+{
+    /**
+     * The eZ 5 container 
+     * 
+     * @var Symfony\Component\DependencyInjection\ContainerInterface; 
+     */
+    private $container;
+
+    public function __construct( ContainerInterface $container )
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Collects data for the given Request and Response.
+     *
+     * @param Request    $request   A Request instance
+     * @param Response   $response  A Response instance
+     * @param \Exception $exception An Exception instance
+     *
+     * @api
+     */
+    public function collect( Request $request, Response $response, \Exception $exception = null )
+    {
+        $currentSA = $request->attributes->get( 'siteaccess' )->name;
+
+        $this->data = array(
+            'legacymode' => $this->container->getParameter( "ezsettings.$currentSA.legacy_mode" ),
+            'info' => array(
+                'error' => $this->getInfoCount( $request->get( 'ContentId' ), "Error" ),
+                'warning' => $this->getInfoCount( $request->get( 'ContentId' ), "Warning" ),
+                'debug' => $this->getInfoCount( $request->get( 'ContentId' ), "Debug" )
+            ),
+        );
+    }
+
+    /**
+     * Returns the name of the collector parameter.
+     *
+     * @return string The collector name parameter
+     *
+     * @api
+     */
+    public function getInfo()
+    {
+        return $this->data['info'];
+    }
+
+    /**
+     * Returns the name of the collector parameter.
+     *
+     * @return string The collector name parameter
+     *
+     * @api
+     */
+    public function getLegacyMode()
+    {
+        return $this->data['legacymode'];
+    }
+
+    /**
+     * Returns the name of the collector.
+     *
+     * @return string The collector name
+     *
+     */
+    public function getName()
+    {
+        return 'legacy_data';
+    }
+
+    /**
+     * Returns the debug output from Legacy.
+     *
+     * @return string The debug output (html)
+     *
+     */
+    public function getLegacyDebug( $contentId )
+    {
+        $serviceLegacy = $this->container->get( 'ezpublish_legacy.kernel' );
+
+        $debugOutput = $serviceLegacy()->runCallback(
+
+            function () use ( $contentId )
+            {
+                $ezDebugInstance = eZDebug::instance();
+                //($as_html, $returnReport, $allowedDebugLevels, $useAccumulators, $useTiming, $useIncludedFiles)
+                $report = $ezDebugInstance->printReportInternal( true, true, false, false, false, false );
+
+                return $report;
+            }
+        );
+
+        return $debugOutput;
+    }
+
+    /**
+     * Returns number of matches found on debug output.
+     *
+     * @return integer The number of error / warning / debug found
+     *
+     */
+    public function getInfoCount( $contentId, $type )
+    {
+        $html = $this->getLegacyDebug( $contentId );
+
+        $out = array();
+        preg_match_all( "/(". $type . "\:)/", $html, $out );
+
+        return count( $out[0] );
+    }
+}

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
@@ -38,6 +38,13 @@ parameters:
     ezpublish_legacy.fieldType.ezimage.variation_service.class: eZ\Publish\Core\MVC\Legacy\Image\AliasGenerator
 
 services:
+    # Legacy Debug
+    data_collector.legacy_data:
+        class: eZ\Bundle\EzPublishLegacyBundle\Collector\LegacyDebugCollector
+        arguments: [@service_container][@twig]
+        tags:
+            - { name: data_collector, template: "EzPublishLegacyBundle:Collector:legacydebug", id: "legacy_data", priority: 300 }
+        
     ezpublish_legacy.kernel:
         alias: ezpublish_legacy.kernel.lazy
 

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/views/Collector/legacydebug.html.twig
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/views/Collector/legacydebug.html.twig
@@ -1,0 +1,122 @@
+{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+
+{% block toolbar %}
+    {% set color_code = 'green' %}
+    {% set icon %}
+    <span>
+            <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAACXBIWXMAAAsTAAALEwEAmpwYAAAK
+    T2lDQ1BQaG90b3Nob3AgSUNDIHByb2ZpbGUAAHjanVNnVFPpFj333vRCS4iAlEtvUhUIIFJCi4AU
+    kSYqIQkQSoghodkVUcERRUUEG8igiAOOjoCMFVEsDIoK2AfkIaKOg6OIisr74Xuja9a89+bN/rXX
+    Pues852zzwfACAyWSDNRNYAMqUIeEeCDx8TG4eQuQIEKJHAAEAizZCFz/SMBAPh+PDwrIsAHvgAB
+    eNMLCADATZvAMByH/w/qQplcAYCEAcB0kThLCIAUAEB6jkKmAEBGAYCdmCZTAKAEAGDLY2LjAFAt
+    AGAnf+bTAICd+Jl7AQBblCEVAaCRACATZYhEAGg7AKzPVopFAFgwABRmS8Q5ANgtADBJV2ZIALC3
+    AMDOEAuyAAgMADBRiIUpAAR7AGDIIyN4AISZABRG8lc88SuuEOcqAAB4mbI8uSQ5RYFbCC1xB1dX
+    Lh4ozkkXKxQ2YQJhmkAuwnmZGTKBNA/g88wAAKCRFRHgg/P9eM4Ors7ONo62Dl8t6r8G/yJiYuP+
+    5c+rcEAAAOF0ftH+LC+zGoA7BoBt/qIl7gRoXgugdfeLZrIPQLUAoOnaV/Nw+H48PEWhkLnZ2eXk
+    5NhKxEJbYcpXff5nwl/AV/1s+X48/Pf14L7iJIEyXYFHBPjgwsz0TKUcz5IJhGLc5o9H/LcL//wd
+    0yLESWK5WCoU41EScY5EmozzMqUiiUKSKcUl0v9k4t8s+wM+3zUAsGo+AXuRLahdYwP2SycQWHTA
+    4vcAAPK7b8HUKAgDgGiD4c93/+8//UegJQCAZkmScQAAXkQkLlTKsz/HCAAARKCBKrBBG/TBGCzA
+    BhzBBdzBC/xgNoRCJMTCQhBCCmSAHHJgKayCQiiGzbAdKmAv1EAdNMBRaIaTcA4uwlW4Dj1wD/ph
+    CJ7BKLyBCQRByAgTYSHaiAFiilgjjggXmYX4IcFIBBKLJCDJiBRRIkuRNUgxUopUIFVIHfI9cgI5
+    h1xGupE7yAAygvyGvEcxlIGyUT3UDLVDuag3GoRGogvQZHQxmo8WoJvQcrQaPYw2oefQq2gP2o8+
+    Q8cwwOgYBzPEbDAuxsNCsTgsCZNjy7EirAyrxhqwVqwDu4n1Y8+xdwQSgUXACTYEd0IgYR5BSFhM
+    WE7YSKggHCQ0EdoJNwkDhFHCJyKTqEu0JroR+cQYYjIxh1hILCPWEo8TLxB7iEPENyQSiUMyJ7mQ
+    AkmxpFTSEtJG0m5SI+ksqZs0SBojk8naZGuyBzmULCAryIXkneTD5DPkG+Qh8lsKnWJAcaT4U+Io
+    UspqShnlEOU05QZlmDJBVaOaUt2ooVQRNY9aQq2htlKvUYeoEzR1mjnNgxZJS6WtopXTGmgXaPdp
+    r+h0uhHdlR5Ol9BX0svpR+iX6AP0dwwNhhWDx4hnKBmbGAcYZxl3GK+YTKYZ04sZx1QwNzHrmOeZ
+    D5lvVVgqtip8FZHKCpVKlSaVGyovVKmqpqreqgtV81XLVI+pXlN9rkZVM1PjqQnUlqtVqp1Q61Mb
+    U2epO6iHqmeob1Q/pH5Z/YkGWcNMw09DpFGgsV/jvMYgC2MZs3gsIWsNq4Z1gTXEJrHN2Xx2KruY
+    /R27iz2qqaE5QzNKM1ezUvOUZj8H45hx+Jx0TgnnKKeX836K3hTvKeIpG6Y0TLkxZVxrqpaXllir
+    SKtRq0frvTau7aedpr1Fu1n7gQ5Bx0onXCdHZ4/OBZ3nU9lT3acKpxZNPTr1ri6qa6UbobtEd79u
+    p+6Ynr5egJ5Mb6feeb3n+hx9L/1U/W36p/VHDFgGswwkBtsMzhg8xTVxbzwdL8fb8VFDXcNAQ6Vh
+    lWGX4YSRudE8o9VGjUYPjGnGXOMk423GbcajJgYmISZLTepN7ppSTbmmKaY7TDtMx83MzaLN1pk1
+    mz0x1zLnm+eb15vft2BaeFostqi2uGVJsuRaplnutrxuhVo5WaVYVVpds0atna0l1rutu6cRp7lO
+    k06rntZnw7Dxtsm2qbcZsOXYBtuutm22fWFnYhdnt8Wuw+6TvZN9un2N/T0HDYfZDqsdWh1+c7Ry
+    FDpWOt6azpzuP33F9JbpL2dYzxDP2DPjthPLKcRpnVOb00dnF2e5c4PziIuJS4LLLpc+Lpsbxt3I
+    veRKdPVxXeF60vWdm7Obwu2o26/uNu5p7ofcn8w0nymeWTNz0MPIQ+BR5dE/C5+VMGvfrH5PQ0+B
+    Z7XnIy9jL5FXrdewt6V3qvdh7xc+9j5yn+M+4zw33jLeWV/MN8C3yLfLT8Nvnl+F30N/I/9k/3r/
+    0QCngCUBZwOJgUGBWwL7+Hp8Ib+OPzrbZfay2e1BjKC5QRVBj4KtguXBrSFoyOyQrSH355jOkc5p
+    DoVQfujW0Adh5mGLw34MJ4WHhVeGP45wiFga0TGXNXfR3ENz30T6RJZE3ptnMU85ry1KNSo+qi5q
+    PNo3ujS6P8YuZlnM1VidWElsSxw5LiquNm5svt/87fOH4p3iC+N7F5gvyF1weaHOwvSFpxapLhIs
+    OpZATIhOOJTwQRAqqBaMJfITdyWOCnnCHcJnIi/RNtGI2ENcKh5O8kgqTXqS7JG8NXkkxTOlLOW5
+    hCepkLxMDUzdmzqeFpp2IG0yPTq9MYOSkZBxQqohTZO2Z+pn5mZ2y6xlhbL+xW6Lty8elQfJa7OQ
+    rAVZLQq2QqboVFoo1yoHsmdlV2a/zYnKOZarnivN7cyzytuQN5zvn//tEsIS4ZK2pYZLVy0dWOa9
+    rGo5sjxxedsK4xUFK4ZWBqw8uIq2Km3VT6vtV5eufr0mek1rgV7ByoLBtQFr6wtVCuWFfevc1+1d
+    T1gvWd+1YfqGnRs+FYmKrhTbF5cVf9go3HjlG4dvyr+Z3JS0qavEuWTPZtJm6ebeLZ5bDpaql+aX
+    Dm4N2dq0Dd9WtO319kXbL5fNKNu7g7ZDuaO/PLi8ZafJzs07P1SkVPRU+lQ27tLdtWHX+G7R7ht7
+    vPY07NXbW7z3/T7JvttVAVVN1WbVZftJ+7P3P66Jqun4lvttXa1ObXHtxwPSA/0HIw6217nU1R3S
+    PVRSj9Yr60cOxx++/p3vdy0NNg1VjZzG4iNwRHnk6fcJ3/ceDTradox7rOEH0x92HWcdL2pCmvKa
+    RptTmvtbYlu6T8w+0dbq3nr8R9sfD5w0PFl5SvNUyWna6YLTk2fyz4ydlZ19fi753GDborZ752PO
+    32oPb++6EHTh0kX/i+c7vDvOXPK4dPKy2+UTV7hXmq86X23qdOo8/pPTT8e7nLuarrlca7nuer21
+    e2b36RueN87d9L158Rb/1tWeOT3dvfN6b/fF9/XfFt1+cif9zsu72Xcn7q28T7xf9EDtQdlD3YfV
+    P1v+3Njv3H9qwHeg89HcR/cGhYPP/pH1jw9DBY+Zj8uGDYbrnjg+OTniP3L96fynQ89kzyaeF/6i
+    /suuFxYvfvjV69fO0ZjRoZfyl5O/bXyl/erA6xmv28bCxh6+yXgzMV70VvvtwXfcdx3vo98PT+R8
+    IH8o/2j5sfVT0Kf7kxmTk/8EA5jz/GMzLdsAAAAgY0hSTQAAeiUAAICDAAD5/wAAgOkAAHUwAADq
+    YAAAOpgAABdvkl/FRgAAAyRJREFUeNrsls9rXFUUxz/n3DczL2+SdJJGSFotgqC7Gjf+CeLCRfwj
+    XNi1iP+Cohuh7gRBTLeBLqREkWIQikTEoKBFa0FK6yLJNJPJm3n3nuNiEvP7pyErD7zFfW/xuef7
+    /d57nrg7F1nKBdeFA7OdCxF5H3hRVTfM3TiF3KpqIpKllCaAX4GPgD8Bdtq2C1ir1V6fnp6+fn16
+    2i1G71eVqMixMDcjbzY9qMoPi4uyuLh4zcw+2wIe2mFRFDYzM8PbN25IFoKklE7cYb1el5gSn9y8
+    ydLSkpVlebykQFUUBWOt1pk9yvMcd0+AHRsaM5NOp8NhuzuuYoy0223MTIBwopSqKnIC3w6UK8sY
+    H7tEFkIFrJ5E0iOrqiImiqiwc0vuTj0M9u6agYoB/TMDU4zc/eZr/+rb73gaG4RaA1EfQB1SMi61
+    RhHJ5Mvbd9jo9qaAt4C/gDVg9lTATnedTz+f5datWXlGxUdypW+DVMhmhyEEBHW1vrx6JZvMQnjn
+    j5XKHnfi/VMDe9F58KjLWIz+wZs1eWky52k7kRy27DZzPDlFPsKVq6PSr2n+4Z1lvvh+tTi1pK6B
+    0Bjm2Rxee/kyU8+3YDlC2mzx35gzeNcKpEyZHAmo0D41UAANghl0VxOsJKp2IqXtDjftJEVoutFX
+    pd+z/5bSBMQEVE6snHgI0KPgwbED7uLsTAdOBo/IbiCAbn5zOeF4MjP2DmV3x823Yec1D1XViqIg
+    z/O9FzP1oRyHbfB5AEVEG43G/knQaKAaxHzg05akByaao4XY5WFZllMLCwuMj4+TUmJ9fZ1rz13l
+    8WqX3375kYkCQsigclLlJNsfmpiA6OCDVO/NzV7g73Nzc435+fkNMyPGKHmed5Mjy8srk6+80Bi5
+    3BqCXGk2FLf9KfAIMqTUMiXPdF+re1P6blmWE2VZ9jbXYW1t7REwCrzXLJpv+HANH1Zi5QdOPImQ
+    hpUyU7QuBESPAt47wusnS3/3+PjuKmO50tuIAw19v4n1XKlUuPewJLkPneUc1oCHPz8p7z+Yr3qZ
+    UKYjwhoGXOlGa0bnp10K/P8jfN71zwBjJG6OtSWWGAAAAABJRU5ErkJggg==" height="28" width="28" />
+
+            {% if collector.legacymode %}
+                {% if collector.info.error > 0 %}
+                    {% set color_code = 'red' %}
+                {% elseif collector.info.warning > 0 %}
+                    {% set color_code = 'yellow' %}
+                {% endif %}
+            {% endif %}
+            
+            <span class="sf-toolbar-status sf-toolbar-status-{{ color_code }}"></span>
+            <div class="sf-toolbar-status sf-toolbar-info-piece-additional">eZ LS Debug</div>
+    </span>
+    {% endset %}
+
+    {% if collector.legacymode %}
+        {% set text %}
+            <div class="sf-toolbar-info-piece">
+
+                <div class="sf-toolbar-info-piece">
+                    <b>Debug</b>
+                    <span>{{ collector.info.debug }}</span>
+                </div>
+
+                <div class="sf-toolbar-info-piece">
+                    <b>Warning</b>
+                    <span>{{ collector.info.warning }}</span>
+                </div>
+
+                <div class="sf-toolbar-info-piece">
+                    <b>Error</b>
+                    <span>{{ collector.info.error }}</span>
+                </div>
+
+                <div align="center" id="cacheClearResult"></div>
+            </div>
+        {% endset %}
+    {% endif %}
+
+    {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': false } %}
+
+{% endblock %}
+
+{% block head %}
+    
+{% endblock %}
+
+{% block menu %}
+
+{% endblock %}
+
+{% block panel %}
+    
+{% endblock %}

--- a/eZ/Bundle/EzPublishLegacyBundle/Tests/Collector/LegacyDebugCollectorTest.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Tests/Collector/LegacyDebugCollectorTest.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * File containing the LegacyDebugCollectorTest class.
+ *
+ * @copyright Copyright (C) 2012 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishLegacyBundle\Tests\Collector;
+
+use eZ\Publish\Core\MVC\Legacy\Tests\LegacyBasedTestCase;
+use eZ\Bundle\EzPublishLegacyBundle\SetupWizard\ConfigurationConverter;
+use eZ\Bundle\EzPublishLegacyBundle\Collector\LegacyDebugCollector;
+
+class LegacyDebugCollectorTest extends \PHPUnit_Framework_TestCase
+{
+
+    protected $container;
+    protected $collector;
+    protected $name;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->name = 'legacy_data';
+        $this->container = $this->getContainerMock();
+
+        $this->collector = new LegacyDebugCollector( $this->container );
+    }
+
+    public function testGetName()
+    {
+        $this->assertEquals( $this->name, $this->collector->getName() );
+    }
+
+    public function testCollect()
+    {
+        $this->markTestSkipped(
+            'Skipped due to legacy closure'
+        );
+    }
+    /**
+     * @dataProvider someContentId
+     * @covers \eZ\Bundle\EzPublishLegacyBundle\Collector\LegacyDebugCollector::getLegacyDebug
+     */
+    public function testGetLegacyDebug( $contentId )
+    {
+        $serviceLegacy = $this->getLegacyKernelMock();
+
+        $debugOutput = $serviceLegacy()->runCallback(
+
+            function () use ( $contentId )
+            {
+                $ezDebugInstance = eZDebug::instance();
+                //($as_html, $returnReport, $allowedDebugLevels, $useAccumulators, $useTiming, $useIncludedFiles)
+                $report = $ezDebugInstance->printReportInternal( true, true, false, false, false, false );
+
+                return $report;
+            }
+        );
+
+        $this->assertInternalType( 'string', $debugOutput );
+    }
+
+    /*
+     * Provide data for testing getLegacyDebug()
+     */
+    public function someContentId()
+    {
+        return array(
+            array( 57 )
+        );
+    }
+
+    public function testGetInfo()
+    {
+        $this->markTestSkipped(
+            'Skipped due to legacy closure'
+        );
+    }
+    /**
+     * @dataProvider infoArray 
+     */
+    public function testGetInfoCount( $contentId, $type )
+    {
+        $this->markTestSkipped(
+            'Skipped due to legacy closure'
+        );
+    }
+
+    /*
+     *  Data provide for testing getInfoCount()
+     */
+    public function infoArray()
+    {
+        return array(
+            array( 57, "Debug" ),
+            array( 57, "Warning" ),
+            array( 57, "Error" )
+        );
+    }
+
+    /**
+     * @param array $methodsToMock
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\HttpFoundation\Request
+     */
+    private function getRequestMock( array $methodsToMock = array() )
+    {
+        return $this
+            ->getMockBuilder( 'Symfony\\Component\\HttpFoundation\\Request' )
+            ->setMethods( array_merge( array( 'getPathInfo' ), $methodsToMock ) )
+            ->getMock();
+    }
+
+    /**
+     * @param array $methodsToMock
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\DependencyInjection\ContainerInterface
+     */
+    private function getContainerMock( array $methodsToMock = array() )
+    {
+        return $this
+            ->getMockBuilder( 'Symfony\\Component\\DependencyInjection\\ContainerInterface' )
+            ->setMethods( $methodsToMock )
+            ->getMock();
+    }
+
+    /**
+     * @param array $methodsToMock
+     * 
+     * @return \Closure
+     */
+    protected function getLegacyKernelMock()
+    {
+        $legacyKernelMock = $this->getMockBuilder( 'eZ\\Publish\\Core\\MVC\\Legacy\\Kernel' )
+                ->setMethods( array( 'runCallback' ) )
+                ->disableOriginalConstructor()
+                ->getMock();
+
+        $legacyKernelMock->expects( $this->any() )
+                ->method( 'runCallback' )
+                ->will( $this->returnValue( 'Debug: test - Warning: test - Error: test' ) );
+
+        $closureMock = function() use ( $legacyKernelMock )
+        {
+            return $legacyKernelMock;
+        };
+
+        return $closureMock;
+    }
+
+}


### PR DESCRIPTION
First implementation of eZ LS Debug toolbar on SF2 toolbar
-> next step add a profiler page
![Capture d e cran 2012-12-14 a 15 46 36](https://f.cloud.github.com/assets/329691/13380/1a8bf344-45fd-11e2-834e-c72c124748c6.png)
