### PR TITLE
EZP-20389 - Implement old .tpl engine as a real Symfony template engine

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/DependencyInjection/Compiler/TwigPass.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/DependencyInjection/Compiler/TwigPass.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * File containing the TwigPass class.
+ *
+ * @copyright Copyright (C) 1999-2012 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class TwigPass implements CompilerPassInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function process( ContainerBuilder $container )
+    {
+        if ( !$container->hasDefinition( 'twig' ) )
+            return;
+
+        // Adding setLegacyEngine method call here to avoid side effect in redefining the twig service completely.
+        // Mentioned side effects are losing extensions/loaders addition for which method calls are added in the TwigEnvironmentPass
+        $def = $container->getDefinition( 'twig' );
+        $def->addMethodCall( 'setEzLegacyEngine', array( new Reference( 'templating.engine.eztpl' ) ) );
+    }
+}

--- a/eZ/Bundle/EzPublishLegacyBundle/EzPublishLegacyBundle.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/EzPublishLegacyBundle.php
@@ -11,6 +11,7 @@ namespace eZ\Bundle\EzPublishLegacyBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler\LegacyPass;
+use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler\TwigPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class EzPublishLegacyBundle extends Bundle
@@ -31,5 +32,6 @@ class EzPublishLegacyBundle extends Bundle
     {
         parent::build( $container );
         $container->addCompilerPass( new LegacyPass() );
+        $container->addCompilerPass( new TwigPass() );
     }
 }

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/templating.yml
@@ -7,10 +7,15 @@ parameters:
     ezpublish.templating.global_helper.core.class: eZ\Publish\Core\MVC\Legacy\Templating\GlobalHelper
     ezpublish_legacy.templating.legacy_helper.class: eZ\Publish\Core\MVC\Legacy\Templating\LegacyHelper
 
+    # eZ Template as a real template engine
+    templating.engine.eztpl.class: eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine
+    assetic.eztpl_formula_loader.class: eZ\Publish\Core\MVC\Legacy\Templating\LegacyFormulaLoader
+    twig.class: eZ\Publish\Core\MVC\Legacy\Templating\Twig\Environment
+
 services:
     ezpublish_legacy.twig.extension:
         class: %ezpublish_legacy.twig.extension.class%
-        arguments: [@ezpublish_legacy.kernel, @ezpublish_legacy.templating.delegating_converter]
+        arguments: [@templating.engine.eztpl]
         tags:
             - {name: twig.extension}
 
@@ -33,3 +38,12 @@ services:
 
     ezpublish_legacy.templating.legacy_helper:
         class: %ezpublish_legacy.templating.legacy_helper.class%
+
+    templating.engine.eztpl:
+        class: %templating.engine.eztpl.class%
+        arguments: [@ezpublish_legacy.kernel, @ezpublish_legacy.templating.object_converter]
+
+    assetic.eztpl_formula_loader:
+        class: %assetic.eztpl_formula_loader.class%
+        tags:
+            - {name: assetic.formula_loader, alias: eztpl}

--- a/eZ/Publish/Core/MVC/Legacy/Templating/LegacyEngine.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/LegacyEngine.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * File containing the LegacyEngine class.
+ *
+ * @copyright Copyright (C) 1999-2012 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Legacy\Templating;
+
+use Symfony\Component\Templating\EngineInterface;
+use Symfony\Component\Templating\TemplateNameParserInterface;
+use eZ\Publish\Core\MVC\Legacy\Templating\Converter\MultipleObjectConverter;
+use eZ\Publish\Core\MVC\Legacy\Templating\LegacyCompatible;
+use eZTemplate;
+
+class LegacyEngine implements EngineInterface
+{
+    const SUPPORTED_SUFFIX = '.tpl';
+
+    /**
+     * @var \Closure
+     */
+    private $legacyKernelClosure;
+
+    /**
+     * @var \eZ\Publish\Core\MVC\Legacy\Templating\Converter\MultipleObjectConverter
+     */
+    private $objectConverter;
+
+    private $supportedTemplates;
+
+    public function __construct( \Closure $legacyKernelClosure, MultipleObjectConverter $objectConverter )
+    {
+        $this->legacyKernelClosure = $legacyKernelClosure;
+        $this->objectConverter = $objectConverter;
+        $this->supportedTemplates = array();
+    }
+
+    /**
+     * @return \eZ\Publish\Core\MVC\Legacy\Kernel
+     */
+    protected function getLegacyKernel()
+    {
+        $closure = $this->legacyKernelClosure;
+        return $closure();
+    }
+
+    /**
+     * Renders a template.
+     *
+     * @param mixed $name       A template name or a TemplateReferenceInterface instance
+     * @param array $parameters An array of parameters to pass to the template
+     *
+     * @return string The evaluated template as a string
+     *
+     * @throws \RuntimeException if the template cannot be rendered
+     *
+     * @api
+     */
+    public function render( $name, array $parameters = array() )
+    {
+        $objectConverter = $this->objectConverter;
+        return $this->getLegacyKernel()->runCallback(
+            function () use ( $name, $parameters, $objectConverter )
+            {
+                $tpl = eZTemplate::factory();
+                foreach ( $parameters as $varName => $param )
+                {
+                    if ( !is_object( $param ) || $param instanceof LegacyCompatible )
+                    {
+                        $tpl->setVariable( $varName, $param );
+                    }
+                    else
+                    {
+                        $objectConverter->register( $param, $varName );
+                    }
+                }
+
+                // Get converted objects if any and pass them to the template
+                foreach ( $objectConverter->convertAll() as $varName => $obj )
+                {
+                    $tpl->setVariable( $varName, $obj );
+                }
+
+                return $tpl->fetch( $name );
+            }
+        );
+    }
+
+    /**
+     * Returns true if the template exists.
+     *
+     * @param mixed $name A template name or a TemplateReferenceInterface instance
+     *
+     * @return bool true if the template exists, false otherwise
+     */
+    public function exists( $name )
+    {
+        return $this->getLegacyKernel()->runCallback(
+            function () use ( $name )
+            {
+                return eZTemplate::factory()->fetch( $name ) !== false;
+            }
+        );
+    }
+
+    /**
+     * Returns true if this class is able to render the given template.
+     *
+     * @param mixed $name A template name
+     *
+     * @return bool true if this class supports the given template, false otherwise
+     */
+    public function supports( $name )
+    {
+        if ( isset( $this->supportedTemplates[$name] ) )
+        {
+            return $this->supportedTemplates[$name];
+        }
+
+        // Template URI must begin by "design:" or "file:" and have a .tpl suffix
+        $this->supportedTemplates[$name] =
+            (
+                strpos( $name, 'design:' ) === 0 ||
+                strpos( $name, 'file:' ) === 0
+            ) &&
+            ( substr( $name, -strlen( self::SUPPORTED_SUFFIX ) ) === self::SUPPORTED_SUFFIX );
+
+        return $this->supportedTemplates[$name];
+    }
+}

--- a/eZ/Publish/Core/MVC/Legacy/Templating/LegacyFormulaLoader.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/LegacyFormulaLoader.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * File containing the LegacyFormulaLoader class.
+ *
+ * @copyright Copyright (C) 1999-2012 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Legacy\Templating;
+
+use Assetic\Factory\Loader\FormulaLoaderInterface;
+use Assetic\Factory\Resource\ResourceInterface;
+
+/**
+ * This class does nothing.
+ * It just avoids Assetic to bark because eztpl doesn't have a formula loader.
+ */
+class LegacyFormulaLoader implements FormulaLoaderInterface
+{
+    /**
+     * Loads formulae from a resource.
+     *
+     * Formulae should be loaded the same regardless of the current debug
+     * mode. Debug considerations should happen downstream.
+     *
+     * @param ResourceInterface $resource A resource
+     *
+     * @return array An array of formulae
+     */
+    public function load( ResourceInterface $resource )
+    {
+        return array();
+    }
+}

--- a/eZ/Publish/Core/MVC/Legacy/Templating/Tests/LegacyEngineTest.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/Tests/LegacyEngineTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * File containing the LegacyEngineTest class.
+ *
+ * @copyright Copyright (C) 1999-2012 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Legacy\Templating\Tests;
+
+use eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine;
+
+class LegacyEngineTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine
+     */
+    private $engine;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->engine = new LegacyEngine(
+            function ()
+            {
+            },
+            $this->getMock( 'eZ\\Publish\\Core\\MVC\\Legacy\\Templating\\Converter\\MultipleObjectConverter' )
+        );
+    }
+
+    /**
+     * @param $tplName
+     * @param $expected
+     *
+     * @covers \eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine::supports
+     *
+     * @dataProvider supportTestProvider
+     */
+    public function testSupports( $tplName, $expected )
+    {
+        $this->assertSame( $expected, $this->engine->supports( $tplName ) );
+    }
+
+    public function supportTestProvider()
+    {
+        return array(
+            array( 'design:foo/bar.tpl', true ),
+            array( 'file:some/path.tpl', true ),
+            array( 'unsupported.php', false ),
+            array( 'unsupported.tpl', false ),
+            array( 'design:unsupported.php', false ),
+            array( 'design:foo/bar.php', false ),
+            array( 'file:some/path.php', false )
+        );
+    }
+}

--- a/eZ/Publish/Core/MVC/Legacy/Templating/Tests/Twig/EnvironmentTest.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/Tests/Twig/EnvironmentTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * File containing the TwigEnvironmentTest class.
+ *
+ * @copyright Copyright (C) 1999-2012 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Legacy\Templating\Tests\Twig;
+
+use eZ\Publish\Core\MVC\Legacy\Templating\Twig\Environment;
+
+class EnvironmentTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers eZ\Publish\Core\MVC\Legacy\Templating\Twig\Environment:loadTemplate
+     * @covers eZ\Publish\Core\MVC\Legacy\Templating\Twig\Template::getTemplateName
+     */
+    public function testLoadTemplateLegacy()
+    {
+        $legacyEngine = $this->getMockBuilder( 'eZ\\Publish\\Core\\MVC\\Legacy\\Templating\\LegacyEngine' )
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $templateName = 'design:test/helloworld.tpl';
+        $legacyEngine->expects( $this->any() )
+            ->method( 'supports' )
+            ->with( $templateName )
+            ->will( $this->returnValue( true ) );
+
+        $twigEnv = new Environment( $this->getMock( 'Twig_LoaderInterface' ) );
+        $twigEnv->setEzLegacyEngine( $legacyEngine );
+        $template = $twigEnv->loadTemplate( $templateName );
+        $this->assertInstanceOf( 'eZ\\Publish\\Core\\MVC\\Legacy\\Templating\\Twig\\Template', $template );
+        $this->assertSame( $templateName, $template->getTemplateName() );
+
+        // Calling loadTemplate a 2nd time with the same template name should return the very same Template object.
+        $this->assertSame( $template, $twigEnv->loadTemplate( $templateName ) );
+    }
+}

--- a/eZ/Publish/Core/MVC/Legacy/Templating/Tests/Twig/TemplateTest.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/Tests/Twig/TemplateTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * File containing the TemplateTest class.
+ *
+ * @copyright Copyright (C) 1999-2012 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Legacy\Templating\Tests\Twig;
+
+use eZ\Publish\Core\MVC\Legacy\Templating\Twig\Template;
+
+class TemplateTest extends \PHPUnit_Framework_TestCase
+{
+    const TEMPLATE_NAME = 'design:hello_world.tpl';
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $legacyEngine;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $twigEnv;
+
+    /**
+     * @var \eZ\Publish\Core\MVC\Legacy\Templating\Twig\Template
+     */
+    private $template;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->legacyEngine = $this->getMockBuilder( 'eZ\\Publish\\Core\\MVC\\Legacy\\Templating\\LegacyEngine' )
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->twigEnv = $this->getMockBuilder( 'eZ\\Publish\\Core\\MVC\\Legacy\\Templating\\Twig\\Environment' )
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->template = new Template( self::TEMPLATE_NAME, $this->twigEnv, $this->legacyEngine );
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\MVC\Legacy\Templating\Twig\Template::getEnvironment
+     */
+    public function testGetEnvironment()
+    {
+        $this->assertSame( $this->twigEnv, $this->template->getEnvironment() );
+    }
+    /**
+     * @covers \eZ\Publish\Core\MVC\Legacy\Templating\Twig\Template::getName
+     */
+    public function testGetName()
+    {
+        $this->assertSame( self::TEMPLATE_NAME, $this->template->getTemplateName() );
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\MVC\Legacy\Templating\Twig\Template::render
+     */
+    public function testRender()
+    {
+        $tplParams = array( 'foo' => 'bar', 'truc' => 'muche' );
+        $this->legacyEngine
+            ->expects( $this->once() )
+            ->method( 'render' )
+            ->with( self::TEMPLATE_NAME, $tplParams );
+        $this->template->render( $tplParams );
+    }
+}

--- a/eZ/Publish/Core/MVC/Legacy/Templating/Twig/Environment.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/Twig/Environment.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * File containing the Twig Environment class.
+ *
+ * @copyright Copyright (C) 1999-2012 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Legacy\Templating\Twig;
+
+use Twig_Environment;
+use eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine;
+use eZ\Publish\Core\MVC\Legacy\Templating\Twig\Template;
+
+class Environment extends Twig_Environment
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine
+     */
+    private $legacyEngine;
+
+    /**
+     * Template objects indexed by their identifier.
+     *
+     * @var \eZ\Publish\Core\MVC\Legacy\Templating\Twig\Template[]
+     */
+    protected $legacyTemplatesCache = array();
+
+    public function setEzLegacyEngine( LegacyEngine $legacyEngine )
+    {
+        $this->legacyEngine = $legacyEngine;
+    }
+
+    public function loadTemplate( $name, $index = null )
+    {
+        // If legacy engine supports given template, delegate it.
+        if ( isset( $this->legacyTemplatesCache[$name] ) )
+            return $this->legacyTemplatesCache[$name];
+
+        if ( $this->legacyEngine->supports( $name ) )
+        {
+            $this->legacyTemplatesCache[$name] = new Template( $name, $this, $this->legacyEngine );
+            return $this->legacyTemplatesCache[$name];
+        }
+
+        return parent::loadTemplate( $name, $index );
+    }
+}

--- a/eZ/Publish/Core/MVC/Legacy/Templating/Twig/Extension/LegacyExtension.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/Twig/Extension/LegacyExtension.php
@@ -10,8 +10,7 @@
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Twig\Extension;
 
 use eZ\Publish\Core\MVC\Legacy\Templating\Twig\TokenParser\LegacyIncludeParser;
-use eZ\Publish\Core\MVC\Legacy\Templating\LegacyCompatible;
-use eZ\Publish\Core\MVC\Legacy\Templating\Converter\MultipleObjectConverter;
+use eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine;
 use eZTemplate;
 use Twig_Extension;
 
@@ -21,21 +20,13 @@ use Twig_Extension;
 class LegacyExtension extends Twig_Extension
 {
     /**
-     * Closure encapsulating the legacy kernel
-     *
-     * @var \Closure
+     * @var \eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine
      */
-    private $legacyKernelClosure;
+    private $legacyEngine;
 
-    /**
-     * @var \eZ\Publish\Core\MVC\Legacy\Templating\Converter\MultipleObjectConverter
-     */
-    private $objectConverter;
-
-    public function __construct( \Closure $legacyKernelClosure, MultipleObjectConverter $objectConverter )
+    public function __construct( LegacyEngine $legacyEngine )
     {
-        $this->legacyKernelClosure = $legacyKernelClosure;
-        $this->objectConverter = $objectConverter;
+        $this->legacyEngine = $legacyEngine;
     }
 
     /**
@@ -44,47 +35,14 @@ class LegacyExtension extends Twig_Extension
      * @param string $tplPath Path to template (i.e. "design:setup/info.tpl")
      * @param array $params Parameters to pass to template.
      *                      Consists of a hash with key as the variable name available in the template.
+     *
      * @return string The legacy template result
+     *
+     * @deprecated since 5.1
      */
     public function renderTemplate( $tplPath, array $params = array() )
     {
-        $objectConverter = $this->objectConverter;
-        return $this->getLegacyKernel()->runCallback(
-            function() use ( $tplPath, $params, $objectConverter )
-            {
-                $tpl = eZTemplate::factory();
-                foreach ( $params as $varName => $param )
-                {
-                    if ( !is_object( $param ) || $param instanceof LegacyCompatible )
-                    {
-                        $tpl->setVariable( $varName, $param );
-                    }
-                    else
-                    {
-                        $objectConverter->register( $param, $varName );
-                    }
-                }
-
-                // Get converted objects if any and pass them to the template
-                foreach ( $objectConverter->convertAll() as $varName => $obj )
-                {
-                    $tpl->setVariable( $varName, $obj );
-                }
-
-                return $tpl->fetch( $tplPath );
-            }
-        );
-    }
-
-    /**
-     * Returns the legacy kernel object.
-     *
-     * @return \eZ\Publish\Core\MVC\Legacy\Kernel
-     */
-    final protected function getLegacyKernel()
-    {
-        $closure = $this->legacyKernelClosure;
-        return $closure();
+        return $this->legacyEngine->render( $tplPath, $params );
     }
 
     public function getTokenParsers()

--- a/eZ/Publish/Core/MVC/Legacy/Templating/Twig/Node/LegacyIncludeNode.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/Twig/Node/LegacyIncludeNode.php
@@ -15,6 +15,8 @@ use Twig_Compiler;
 
 /**
  * Represents an ez_legacy_include node
+ *
+ * @deprecated since 5.1
  */
 class LegacyIncludeNode extends Twig_Node
 {

--- a/eZ/Publish/Core/MVC/Legacy/Templating/Twig/Template.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/Twig/Template.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * File containing the Template class.
+ *
+ * @copyright Copyright (C) 1999-2012 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Legacy\Templating\Twig;
+
+use Twig_Environment;
+use Twig_TemplateInterface;
+use eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine;
+
+/**
+ * Twig Template class representation for a legacy template.
+ */
+class Template implements Twig_TemplateInterface
+{
+    private $templateName;
+
+    /**
+     * @var \Twig_Environment
+     */
+    private $env;
+
+    /**
+     * @var \eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine
+     */
+    private $legacyEngine;
+
+    public function __construct( $templateName, Twig_Environment $env, LegacyEngine $legacyEngine )
+    {
+        $this->templateName = $templateName;
+        $this->env = $env;
+        $this->legacyEngine = $legacyEngine;
+    }
+
+    /**
+     * Renders the template with the given context and returns it as string.
+     *
+     * @param array $context An array of parameters to pass to the template
+     *
+     * @return string The rendered template
+     */
+    public function render( array $context )
+    {
+        return $this->legacyEngine->render( $this->templateName, $context );
+    }
+
+    /**
+     * Displays the template with the given context.
+     *
+     * @param array $context An array of parameters to pass to the template
+     * @param array $blocks  An array of blocks to pass to the template
+     */
+    public function display( array $context, array $blocks = array() )
+    {
+        echo $this->render( $context );
+    }
+
+    /**
+     * Returns the bound environment for this template.
+     *
+     * @return Twig_Environment The current environment
+     */
+    public function getEnvironment()
+    {
+        return $this->env;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTemplateName()
+    {
+        return $this->templateName;
+    }
+}

--- a/eZ/Publish/Core/MVC/Legacy/Templating/Twig/TokenParser/LegacyIncludeParser.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/Twig/TokenParser/LegacyIncludeParser.php
@@ -13,6 +13,11 @@ use eZ\Publish\Core\MVC\Legacy\Templating\Twig\Node\LegacyIncludeNode;
 use Twig_Token;
 use Twig_Node_Expression_Array;
 
+/**
+ * Parser for ez_legacy_include tag.
+ *
+ * @deprecated since 5.1
+ */
 class LegacyIncludeParser extends \Twig_TokenParser
 {
 


### PR DESCRIPTION
This PR standardizes the legacy _eZ Template_ engine as a real Symfony template engine, which allows to render the result of a controller in a legacy template (can be useful in the case of module migration).

Furthermore, it allows to include legacy templates directly with `include` Twig tag :

``` jinja
{% include 'design:test/helloworld.tpl' with {'foo': 'bar'} %}
```

This replace the following:

``` jinja
{% ez_legacy_include 'design:test/helloworld.tpl' with {'foo': 'bar'} %}
```

Usage of `include` is more transparent and avoids confusion for developers.
