### PR TITLE
Fix #EZP-20434 - LocalFileService::remove accepts empty paths, causing recursive delete of install root

### DIFF
--- a/eZ/Publish/Core/FieldType/FileService/LocalFileService.php
+++ b/eZ/Publish/Core/FieldType/FileService/LocalFileService.php
@@ -10,8 +10,8 @@
 namespace eZ\Publish\Core\FieldType\FileService;
 
 use eZ\Publish\Core\FieldType\FileService;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use RuntimeException;
-use InvalidArgumentException;
 
 class LocalFileService implements FileService
 {
@@ -140,7 +140,7 @@ class LocalFileService implements FileService
         if ( empty( $storageIdentifier ) )
         {
             throw new InvalidArgumentException(
-                'First argument ($storageIdentifier) cannot be empty.'
+                'storageIdentifier', 'Cannot be empty'
             );
         }
 

--- a/eZ/Publish/Core/FieldType/Tests/FileService/LocalFileServiceTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FileService/LocalFileServiceTest.php
@@ -278,7 +278,7 @@ class LocalFileServiceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException
      */
     public function testRemoveEmptyPath()
     {


### PR DESCRIPTION
This is a fix proposal for https://jira.ez.no/browse/EZP-20434

Admittedly it's a hammer-handed approach, perhaps a more ideal fix would be to make sure an empty path does not actually reach `LocalFileService::remove`, i.e, through the `ImageStore::deleteFieldData` method. Nonetheless, this PR is at least a pointer on where the problem lies.
