### PR TITLE
EZP-20437 - Php Warning while clearing caches from console

### DIFF
--- a/eZ/Publish/Core/MVC/Legacy/Templating/Twig/Environment.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/Twig/Environment.php
@@ -35,10 +35,10 @@ class Environment extends Twig_Environment
     public function loadTemplate( $name, $index = null )
     {
         // If legacy engine supports given template, delegate it.
-        if ( isset( $this->legacyTemplatesCache[$name] ) )
+        if ( is_string( $name ) && isset( $this->legacyTemplatesCache[$name] ) )
             return $this->legacyTemplatesCache[$name];
 
-        if ( $this->legacyEngine->supports( $name ) )
+        if ( is_string( $name ) && $this->legacyEngine->supports( $name ) )
         {
             $this->legacyTemplatesCache[$name] = new Template( $name, $this, $this->legacyEngine );
             return $this->legacyTemplatesCache[$name];


### PR DESCRIPTION
Please refer to jira issue for complete information 
https://jira.ez.no/browse/EZP-20437

Briefly, what i think is that when cache is cleared, loadTemplate method can receive objects too. 

I decided to add a check for name being an string in our extended Twig_Environment. The parent class method phpdoc says $name param is a string, but i do believe that there are options where it can be an object too. 

Added an issue in twig repo too. 
https://github.com/fabpot/Twig/issues/992
