### PR TITLE
Fix in ezcomcomments fieldtype typoo

### DIFF
--- a/eZ/Publish/Core/settings/service.ini
+++ b/eZ/Publish/Core/settings/service.ini
@@ -214,7 +214,7 @@ arguments[map][ezsubtreesubscription]=eZ\Publish\Core\Persistence\Legacy\Content
 arguments[map][ezoption]=eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Integer::create
 
 # New data fixture
-arguments[map][ezcomcomments]=eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Null::create
+arguments[map][ezcomments]=eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Null::create
 arguments[map][ezdate]=eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Null::create
 arguments[map][ezenum]=eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Null::create
 arguments[map][ezidentifier]=eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Null::create
@@ -421,9 +421,9 @@ shared=false
 
 # START dummy types for data fixture
 # Needs correct implementation
-[ezcomcomments:field_type]
+[ezcomments:field_type]
 class=eZ\Publish\Core\FieldType\Null\Type
-arguments[fieldTypeIdentifier]=ezcomcomments
+arguments[fieldTypeIdentifier]=ezcomments
 
 [ezpackage:field_type]
 class=eZ\Publish\Core\FieldType\Null\Type


### PR DESCRIPTION
While testing I found a typoo introduced by a previous commit. Where it should be ezcomments it was ezcomcomments
