### PR TITLE
Bundle permissions

### DIFF
--- a/eZ/Publish/API/Repository/Repository.php
+++ b/eZ/Publish/API/Repository/Repository.php
@@ -36,13 +36,13 @@ interface Repository
     public function setCurrentUser( User $user );
 
     /**
-     * @param string $module The module, aka controller identifier to check permissions on
-     * @param string $function The function, aka the controller action to check permissions on
+     * @param string $controller The controller (legacy:module) identifier to check permissions on, example: 'Bundle:controller'
+     * @param string $action The controller action (legacy:function) to check permissions on, example: 'read'
      * @param \eZ\Publish\API\Repository\Values\User\User $user
      *
      * @return boolean|array if limitations are on this function an array of limitations is returned
      */
-    public function hasAccess( $module, $function, User $user = null );
+    public function hasAccess( $controller, $action, User $user = null );
 
     /**
      * Indicates if the current user is allowed to perform an action given by the function on the given
@@ -58,14 +58,14 @@ interface Repository
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
      *
-     * @param string $module The module, aka controller identifier to check permissions on
-     * @param string $function The function, aka the controller action to check permissions on
+     * @param string $controller The controller (legacy:module) identifier to check permissions on, example: 'Bundle:controller'
+     * @param string $action The controller action (legacy:function) to check permissions on, example: 'read'
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object The object to check if the user has access to
      * @param \eZ\Publish\API\Repository\Values\ValueObject $target The location, parent or "assignment" value object
      *
      * @return boolean
      */
-    public function canUser( $module, $function, ValueObject $object, ValueObject $target = null );
+    public function canUser( $controller, $action, ValueObject $object, ValueObject $target = null );
 
     /**
      * Get Content Service

--- a/eZ/Publish/API/Repository/RoleService.php
+++ b/eZ/Publish/API/Repository/RoleService.php
@@ -230,12 +230,12 @@ interface RoleService
     /**
      * Instantiates a policy create class
      *
-     * @param string $module
-     * @param string $function
+     * @param string $controller The controller (legacy:module) identifier, example: 'Bundle:controller' or 'content'
+     * @param string $action The controller action (legacy:function) to check permissions on, example: 'read'
      *
      * @return \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct
      */
-    public function newPolicyCreateStruct( $module, $function );
+    public function newPolicyCreateStruct( $controller, $action );
 
     /**
      * Instantiates a policy update class
@@ -263,19 +263,25 @@ interface RoleService
     public function getLimitationType( $identifier );
 
     /**
-     * Returns the LimitationType's assigned to a given module/function
+     * @deprecated Since 5.1
+     * @uses getLimitationTypesByControllerAction()
+     */
+    public function getLimitationTypesByModuleFunction( $module, $function );
+
+    /**
+     * Returns the LimitationType's assigned to a given controller/action
      *
      * Typically used for:
      *  - Internal validation limitation value use on Policies
      *  - Role admin gui for editing policy limitations incl list limitation options via valueSchema()
      *
-     * @param string $module Legacy name of "controller", it's a unique identifier like "content"
-     * @param string $function Legacy name of a controller "action", it's a unique within the controller like "read"
+     * @param string $controller The controller (legacy: module) identifier, example: 'Bundle:controller' or 'content'
+     * @param string $action Controller action (legacy: function), it's a unique within the controller like 'read'
      *
      * @return \eZ\Publish\SPI\Limitation\Type[]
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If module/function to limitation type mapping
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If $controller/$action to limitation type mapping
      *                                                                 refers to a non existing identifier.
      */
-    public function getLimitationTypesByModuleFunction( $module, $function );
+    public function getLimitationTypesByControllerAction( $controller, $action );
 }

--- a/eZ/Publish/API/Repository/Tests/Stubs/RepositoryStub.php
+++ b/eZ/Publish/API/Repository/Tests/Stubs/RepositoryStub.php
@@ -151,13 +151,13 @@ class RepositoryStub implements Repository
     }
 
     /**
-     * @param string $module
-     * @param string $function
+     * @param string $controller
+     * @param string $action
      * @param \eZ\Publish\API\Repository\Values\User\User $user
      *
      * @return boolean|\eZ\Publish\API\Repository\Values\User\Limitation[] if limitations are on this function an array of limitations is returned
      */
-    public function hasAccess( $module, $function, User $user = null )
+    public function hasAccess( $controller, $action, User $user = null )
     {
         if ( $this->permissionChecks > 0 )
         {
@@ -181,7 +181,7 @@ class RepositoryStub implements Repository
                     return true;
                 }
 
-                if ( $policy->module !== $module && $policy->module !== "*" )
+                if ( $policy->module !== $controller && $policy->module !== "*" )
                     continue;
 
                 if ( $policy->function === '*' && $roleLimitation === null )
@@ -190,7 +190,7 @@ class RepositoryStub implements Repository
                     return true;
                 }
 
-                if ( $policy->function !== $function && $policy->function !== "*" )
+                if ( $policy->function !== $action && $policy->function !== "*" )
                     continue;
 
                 $permissionSet['policies'][] = $policy;
@@ -212,7 +212,7 @@ class RepositoryStub implements Repository
         if ( !empty( $permissionSets ) )
             return $permissionSets;
 
-        return false;// No policies matching $module and $function
+        return false;// No policies matching $controller and $action
     }
 
     /**
@@ -222,21 +222,21 @@ class RepositoryStub implements Repository
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
      *
-     * @param string $module The module, aka controller identifier to check permissions on
-     * @param string $function The function, aka the controller action to check permissions on
+     * @param string $controller The module, aka controller identifier to check permissions on
+     * @param string $action The function, aka the controller action to check permissions on
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object The object to check if the user has access to
      * @param \eZ\Publish\API\Repository\Values\ValueObject $target The location, parent or "assignment" value object
      *
      * @return boolean
      */
-    public function canUser( $module, $function, ValueObject $object, ValueObject $target = null )
+    public function canUser( $controller, $action, ValueObject $object, ValueObject $target = null )
     {
         if ( $this->permissionChecks > 0 )
         {
             return true;
         }
 
-        $permissionSets = $this->hasAccess( $module, $function );
+        $permissionSets = $this->hasAccess( $controller, $action );
         if ( $permissionSets === false || $permissionSets === true )
         {
             return $permissionSets;

--- a/eZ/Publish/API/Repository/Tests/Stubs/RoleServiceStub.php
+++ b/eZ/Publish/API/Repository/Tests/Stubs/RoleServiceStub.php
@@ -678,14 +678,14 @@ class RoleServiceStub implements RoleService
     /**
      * Instantiates a policy create class
      *
-     * @param string $module
-     * @param string $function
+     * @param string $controller
+     * @param string $action
      *
      * @return \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct
      */
-    public function newPolicyCreateStruct( $module, $function )
+    public function newPolicyCreateStruct( $controller, $action )
     {
-        return new PolicyCreateStructStub( $module, $function );
+        return new PolicyCreateStructStub( $controller, $action );
     }
 
     /**
@@ -723,21 +723,30 @@ class RoleServiceStub implements RoleService
     }
 
     /**
-     * Returns the LimitationType's assigned to a given module/function
+     * @deprecated Since 5.1
+     * @uses getLimitationTypesByControllerAction()
+     */
+    public function getLimitationTypesByModuleFunction( $module, $function )
+    {
+        return $this->getLimitationTypesByControllerAction( $module, $function );
+    }
+
+    /**
+     * Returns the LimitationType's assigned to a given controller/action
      *
      * Typically used for:
      *  - Internal validation limitation value use on Policies
      *  - Role admin gui for editing policy limitations incl list limitation options via valueSchema()
      *
-     * @param string $module Legacy name of "controller", it's a unique identifier like "content"
-     * @param string $function Legacy name of a controller "action", it's a unique within the controller like "read"
+     * @param string $controller The controller (legacy: module) identifier, example: 'Bundle:controller' or 'content'
+     * @param string $action Controller action (legacy: function), it's a unique within the controller like 'read'
      *
      * @return \eZ\Publish\SPI\Limitation\Type[]
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If module/function to limitation type mapping
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If $controller/$action to limitation type mapping
      *                                                                 refers to a non existing identifier.
      */
-    public function getLimitationTypesByModuleFunction( $module, $function )
+    public function getLimitationTypesByControllerAction( $controller, $action )
     {
         throw new \eZ\Publish\API\Repository\Exceptions\NotImplementedException( __METHOD__ );
     }

--- a/eZ/Publish/API/Repository/Tests/Stubs/Values/User/PolicyCreateStructStub.php
+++ b/eZ/Publish/API/Repository/Tests/Stubs/Values/User/PolicyCreateStructStub.php
@@ -28,15 +28,15 @@ class PolicyCreateStructStub extends PolicyCreateStruct
     /**
      * Instantiates a policy create struct.
      *
-     * @param string $module
-     * @param string $function
+     * @param string $controller
+     * @param string $action
      */
-    public function __construct( $module, $function )
+    public function __construct( $controller, $action )
     {
         parent::__construct(
             array(
-                'module' => $module,
-                'function' => $function
+                'controller' => $controller,
+                'action' => $action
             )
         );
     }

--- a/eZ/Publish/API/Repository/Values/User/Policy.php
+++ b/eZ/Publish/API/Repository/Values/User/Policy.php
@@ -16,12 +16,37 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  *
  * @property-read mixed $id internal id of the policy
  * @property-read mixed $roleId the role id this policy belongs to
- * @property-read string $module Name of module, associated with the Policy
- * @property-read string $function  Name of the module function Or all functions with '*'
+ * @property-read string $controller The controller (legacy:module) identifier, example: 'Bundle:controller' or 'content'
+ * @property-read string $action Controller action (legacy:function), unique within controller: 'read', or all: '*'
  * @property-read array $limitations an array of \eZ\Publish\API\Repository\Values\User\Limitation
+ *
+ * @property-read string $module @deprecated alias for $controller
+ * @property-read string $function @deprecated alias for $action
  */
 abstract class Policy extends ValueObject
 {
+    /**
+     * Re route deprecated module & function properties to controller & action
+     *
+     * @deprecated Since 5.1
+     * @param array $properties
+     */
+    public function __construct( array $properties = array() )
+    {
+        if ( isset( $properties['module'] ) )
+        {
+            $properties['controller'] = $properties['module'];
+            unset( $properties['module'] );
+        }
+        if ( isset( $properties['function'] ) )
+        {
+            $properties['action'] = $properties['function'];
+            unset( $properties['function'] );
+        }
+
+        return parent::__construct( $properties );
+    }
+
     /**
      * ID of the policy
      *
@@ -37,13 +62,13 @@ abstract class Policy extends ValueObject
     protected $roleId;
 
     /**
-     * Name of module, associated with the Policy
+     * The controller (legacy:module) identifier
      *
-     * Eg: content
+     * Eg: 'Bundle:controller' or 'content'
      *
      * @var string
      */
-    protected $module;
+    protected $controller;
 
     /**
      * Name of the module function Or all functions with '*'
@@ -52,10 +77,65 @@ abstract class Policy extends ValueObject
      *
      * @var string
      */
-    protected $function;
+    protected $action;
 
     /**
      * @return \eZ\Publish\API\Repository\Values\User\Limitation[]
      */
     abstract public function getLimitations();
+
+    /**
+     * Magic getter for supporting $module and $function
+     *
+     * @deprecated Since 5.1
+     * @param string $property The name of the property to retrieve
+     *
+     * @return mixed
+     */
+    public function __get( $property )
+    {
+        if ( $property === 'module' )
+            return parent::__get( 'controller' );
+
+        if ( $property === 'function' )
+            return parent::__get( 'action' );
+
+        return parent::__get( $property );
+    }
+
+    /**
+     * Magic set for supporting $module and $function
+     *
+     * @deprecated Since 5.1
+     * @param string $property
+     * @param mixed $propertyValue
+     */
+    public function __set( $property, $propertyValue )
+    {
+        if ( $property === 'module' )
+            parent::__set( 'controller', $propertyValue );
+        else if ( $property === 'function' )
+            parent::__set( 'action', $propertyValue );
+        else
+            parent::__set( $property, $propertyValue );
+    }
+
+    /**
+     * Magic isset for supporting $module and $function
+     *
+     * @deprecated Since 5.1
+     * @param string $property
+     *
+     * @return boolean
+     */
+    public function __isset( $property )
+    {
+        if ( $property === 'module' )
+            return true;
+
+        if ( $property === 'function' )
+            return true;
+
+        return parent::__isset( $property );
+    }
 }

--- a/eZ/Publish/API/Repository/Values/User/PolicyCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/PolicyCreateStruct.php
@@ -13,26 +13,29 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 
 /**
  * This class is used to create a policy
+ *
+ * @property string $module @deprecated alias for $controller
+ * @property string $function @deprecated alias for $action
  */
 abstract class PolicyCreateStruct extends ValueObject
 {
     /**
-     * Name of module, associated with the Policy
+     * The controller (legacy:module) identifier
      *
-     * Eg: content
+     * Eg: 'Bundle:controller' or 'content'
      *
      * @var string
      */
-    public $module;
+    public $controller;
 
     /**
-     * Name of the module function Or all functions with '*'
+     * Controller action (legacy:function), unique within controller
      *
-     * Eg: read
+     * Eg: 'read' or '*'
      *
      * @var string
      */
-    public $function;
+    public $action;
 
     /**
      * Returns list of limitations added to policy
@@ -46,4 +49,59 @@ abstract class PolicyCreateStruct extends ValueObject
      * @param Limitation $limitation
      */
     abstract public function addLimitation( Limitation $limitation );
+
+    /**
+     * Magic getter for supporting $module and $function
+     *
+     * @deprecated Since 5.1
+     * @param string $property The name of the property to retrieve
+     *
+     * @return mixed
+     */
+    public function __get( $property )
+    {
+        if ( $property === 'module' )
+            return $this->controller;
+
+        if ( $property === 'function' )
+            return $this->action;
+
+        return parent::__get( $property );
+    }
+
+    /**
+     * Magic set for supporting $module and $function
+     *
+     * @deprecated Since 5.1
+     * @param string $property
+     * @param mixed $propertyValue
+     */
+    public function __set( $property, $propertyValue )
+    {
+        if ( $property === 'module' )
+            $this->controller = $propertyValue;
+        else if ( $property === 'function' )
+            $this->action = $propertyValue;
+        else
+            parent::__set( $property, $propertyValue );
+    }
+
+    /**
+     * Magic isset for supporting $module and $function
+     *
+     * @deprecated Since 5.1
+     * @param string $property
+     *
+     * @return boolean
+     */
+    public function __isset( $property )
+    {
+        if ( $property === 'module' )
+            return true;
+
+        if ( $property === 'function' )
+            return true;
+
+        return parent::__isset( $property );
+    }
 }

--- a/eZ/Publish/Core/Base/Exceptions/UnauthorizedException.php
+++ b/eZ/Publish/Core/Base/Exceptions/UnauthorizedException.php
@@ -21,16 +21,16 @@ use Exception;
 class UnauthorizedException extends APIUnauthorizedException implements Httpable
 {
     /**
-     * Generates: User does not have access to '{$function}' '{$module}'[ with identifier '{$identifier}']
+     * Generates: User does not have access to '{$action}' '{$controller}'[ with identifier '{$identifier}']
      *
      * Example: User does not have access to 'read' 'content' with identifier '42'
      *
-     * @param string $module The module name should be in sync with the name of the domain object in question
-     * @param string $function
-     * @param string|null $identifier
+     * @param string $controller The $controller name should be in sync with the name of the domain object in question
+     * @param string $action
+     * @param array|null $properties List of identifiers for object user did not have access to
      * @param \Exception|null $previous
      */
-    public function __construct( $module, $function, array $properties = null, Exception $previous = null )
+    public function __construct( $controller, $action, array $properties = null, Exception $previous = null )
     {
         $identificationString = '';
         if ( $properties !== null )
@@ -43,7 +43,7 @@ class UnauthorizedException extends APIUnauthorizedException implements Httpable
         }
 
         parent::__construct(
-            "User does not have access to '{$function}' '{$module}'" . $identificationString,
+            "User does not have access to '{$action}' '{$controller}'" . $identificationString,
             self::UNAUTHORIZED,
             $previous
         );

--- a/eZ/Publish/Core/Persistence/InMemory/Tests/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/InMemory/Tests/UserHandlerTest.php
@@ -372,8 +372,8 @@ class UserHandlerTest extends HandlerTest
             $obj->id,
             new Policy(
                 array(
-                    'module' => 'Foo',
-                    'function' => 'Bar',
+                    'controller' => 'Foo',
+                    'action' => 'Bar',
                     'limitations' => array( 'Limit' => array( 'Test' ) )
                 )
             )
@@ -408,7 +408,7 @@ class UserHandlerTest extends HandlerTest
         // $role->description = array( 'eng-GB' => 'Test2 role' );
 
         $role->policies = array(
-            new Policy( array( 'module' => 'tag', 'function' => '*', 'limitations' => '*' ) ),
+            new Policy( array( 'controller' => 'tag', 'action' => '*', 'limitations' => '*' ) ),
         );
         $obj = $handler->createRole( $role );
         $handler->assignRole( 4, $obj->id );// 4: Users
@@ -484,8 +484,8 @@ class UserHandlerTest extends HandlerTest
         $role->policies = array(
             new Policy(
                 array(
-                    'module' => $obj->policies[2]->module,
-                    'function' => $obj->policies[2]->function,
+                    'controller' => $obj->policies[2]->controller,
+                    'action' => $obj->policies[2]->action,
                     'limitations' => $obj->policies[2]->limitations,
                 )
             ),
@@ -563,8 +563,8 @@ class UserHandlerTest extends HandlerTest
             $id,
             new Policy(
                 array(
-                    'module' => 'Foo',
-                    'function' => 'Bar',
+                    'controller' => 'Foo',
+                    'action' => 'Bar',
                     'limitations' => array( 'Limit' => array( 'Test' ) )
                 )
             )
@@ -573,9 +573,9 @@ class UserHandlerTest extends HandlerTest
         $this->assertInstanceOf( 'eZ\\Publish\\SPI\\Persistence\\User\\Role', $obj );
         $this->assertEquals( 4, count( $obj->policies ) );
         $this->assertInstanceOf( 'eZ\\Publish\\SPI\\Persistence\\User\\Policy', $obj->policies[3] );
-        $this->assertEquals( 'Foo', $obj->policies[3]->module );
+        $this->assertEquals( 'Foo', $obj->policies[3]->controller );
         $this->assertEquals( $id, $obj->policies[3]->roleId );
-        $this->assertEquals( 'Bar', $obj->policies[3]->function );
+        $this->assertEquals( 'Bar', $obj->policies[3]->action );
         $this->assertEquals( 1, count( $obj->policies[3]->limitations ) );
         $this->assertEquals( array( 'Test' ), $obj->policies[3]->limitations['Limit'] );
     }
@@ -591,8 +591,8 @@ class UserHandlerTest extends HandlerTest
         $obj = $handler->createRole( self::getRole() );
         $this->assertInstanceOf( 'eZ\\Publish\\SPI\\Persistence\\User\\Role', $obj );
         $this->assertEquals( 3, count( $obj->policies ) );
-        $this->assertEquals( 'content', $obj->policies[0]->module );
-        $this->assertEquals( 'write', $obj->policies[0]->function );
+        $this->assertEquals( 'content', $obj->policies[0]->controller );
+        $this->assertEquals( 'write', $obj->policies[0]->action );
         $this->assertEquals( array( 'SubTree' => array( '/1/2/' ) ), $obj->policies[0]->limitations );
 
         $id = $obj->id;
@@ -604,8 +604,8 @@ class UserHandlerTest extends HandlerTest
         $this->assertInstanceOf( 'eZ\\Publish\\SPI\\Persistence\\User\\Role', $obj );
         $this->assertEquals( 3, count( $obj->policies ) );
         $this->assertInstanceOf( 'eZ\\Publish\\SPI\\Persistence\\User\\Policy', $obj->policies[0] );
-        $this->assertEquals( 'content', $obj->policies[0]->module );
-        $this->assertEquals( 'write', $obj->policies[0]->function );
+        $this->assertEquals( 'content', $obj->policies[0]->controller );
+        $this->assertEquals( 'write', $obj->policies[0]->action );
         $this->assertEquals( array( 'Node' => array( 2, 45 ) ), $obj->policies[0]->limitations );
     }
 
@@ -795,8 +795,8 @@ class UserHandlerTest extends HandlerTest
             $obj->id,
             new Policy(
                 array(
-                    'module' => 'Foo',
-                    'function' => 'Bar',
+                    'controller' => 'Foo',
+                    'action' => 'Bar',
                     'limitations' => array( 'Limit' => array( 'Test' ) )
                 )
             )
@@ -804,8 +804,8 @@ class UserHandlerTest extends HandlerTest
         $list = $handler->loadPoliciesByUserId( 10 );
         $this->assertEquals( 4, count( $list ) );
         $this->assertInstanceOf( 'eZ\\Publish\\SPI\\Persistence\\User\\Policy', $list[3] );
-        $this->assertEquals( 'Foo', $list[3]->module );
-        $this->assertEquals( 'Bar', $list[3]->function );
+        $this->assertEquals( 'Foo', $list[3]->controller );
+        $this->assertEquals( 'Bar', $list[3]->action );
         $this->assertEquals( array( 'Test' ), $list[3]->limitations['Limit'] );
     }
 
@@ -830,7 +830,7 @@ class UserHandlerTest extends HandlerTest
         // $role->description = array( 'eng-GB' => 'Test2 role' );
 
         $role->policies = array(
-            new Policy( array( 'module' => 'tag', 'function' => '*', 'limitations' => '*' ) ),
+            new Policy( array( 'controller' => 'tag', 'action' => '*', 'limitations' => '*' ) ),
         );
         $obj = $handler->createRole( $role );
         $handler->assignRole( 4, $obj->id );// 4: Users
@@ -838,8 +838,8 @@ class UserHandlerTest extends HandlerTest
         $list = $handler->loadPoliciesByUserId( 10 );// 10: Anonymous User
         $this->assertEquals( 4, count( $list ) );
         $this->assertInstanceOf( 'eZ\\Publish\\SPI\\Persistence\\User\\Policy', $list[3] );
-        $this->assertEquals( 'tag', $list[3]->module );
-        $this->assertEquals( '*', $list[3]->function );
+        $this->assertEquals( 'tag', $list[3]->controller );
+        $this->assertEquals( '*', $list[3]->action );
         $this->assertEquals( '*', $list[3]->limitations );
     }
 
@@ -909,8 +909,8 @@ class UserHandlerTest extends HandlerTest
         $role->policies = array(
             new Policy(
                 array(
-                    'module' => $obj->policies[2]->module,
-                    'function' => $obj->policies[2]->function,
+                    'controller' => $obj->policies[2]->controller,
+                    'action' => $obj->policies[2]->action,
                     'limitations' => $obj->policies[2]->limitations,
                 )
             ),
@@ -937,9 +937,9 @@ class UserHandlerTest extends HandlerTest
         // $role->description = array( 'eng-GB' => 'Test role' );
 
         $role->policies = array(
-            new Policy( array( 'module' => 'content', 'function' => 'write', 'limitations' => array( 'SubTree' => array( '/1/2/' ) ) ) ),
-            new Policy( array( 'module' => 'content', 'function' => 'read', 'limitations' => '*' ) ),
-            new Policy( array( 'module' => 'user', 'function' => '*', 'limitations' => '*' ) ),
+            new Policy( array( 'controller' => 'content', 'action' => 'write', 'limitations' => array( 'SubTree' => array( '/1/2/' ) ) ) ),
+            new Policy( array( 'controller' => 'content', 'action' => 'read', 'limitations' => '*' ) ),
+            new Policy( array( 'controller' => 'user', 'action' => '*', 'limitations' => '*' ) ),
         );
         return $role;
     }

--- a/eZ/Publish/Core/Persistence/InMemory/data.json
+++ b/eZ/Publish/Core/Persistence/InMemory/data.json
@@ -133,15 +133,15 @@
         {"id": 2, "identifier": "Administrator", "groupIds": [12]}
     ],
     "User\\Policy" : [
-        {"id": 1, "roleId": 2, "module": "*", "function": "*", "limitations": "*" },
-        {"id": 2, "roleId": 1, "module": "content", "function": "pdf", "limitations": { "Section" : [ 1 ] } },
-        {"id": 3, "roleId": 1, "module": "content", "function": "read", "limitations": { "Section" : [ 1 ] }},
-        {"id": 4, "roleId": 1, "module": "content", "function": "read", "limitations": { "Class" : [ 29, 30, 32, 33, 34, 42 ], "Section" : [ 3 ] } },
-        {"id": 5, "roleId": 1, "module": "rss", "function": "feed", "limitations": "*" },
-        {"id": 6, "roleId": 1, "module": "user", "function": "login", "limitations": { "SiteAccess" : [ 2576532274 ] } },
-        {"id": 7, "roleId": 1, "module": "user", "function": "login", "limitations": { "SiteAccess" : [ 2582995467 ] } },
-        {"id": 8, "roleId": 1, "module": "user", "function": "login", "limitations": { "SiteAccess" : [ 2479546403 ] } },
-        {"id": 9, "roleId": 1, "module": "user", "function": "login", "limitations": { "SiteAccess" : [ 3781580864 ] } }
+        {"id": 1, "roleId": 2, "controller": "*", "action": "*", "limitations": "*" },
+        {"id": 2, "roleId": 1, "controller": "content", "action": "pdf", "limitations": { "Section" : [ 1 ] } },
+        {"id": 3, "roleId": 1, "controller": "content", "action": "read", "limitations": { "Section" : [ 1 ] }},
+        {"id": 4, "roleId": 1, "controller": "content", "action": "read", "limitations": { "Class" : [ 29, 30, 32, 33, 34, 42 ], "Section" : [ 3 ] } },
+        {"id": 5, "roleId": 1, "controller": "rss", "action": "feed", "limitations": "*" },
+        {"id": 6, "roleId": 1, "controller": "user", "action": "login", "limitations": { "SiteAccess" : [ 2576532274 ] } },
+        {"id": 7, "roleId": 1, "controller": "user", "action": "login", "limitations": { "SiteAccess" : [ 2582995467 ] } },
+        {"id": 8, "roleId": 1, "controller": "user", "action": "login", "limitations": { "SiteAccess" : [ 2479546403 ] } },
+        {"id": 9, "roleId": 1, "controller": "user", "action": "login", "limitations": { "SiteAccess" : [ 3781580864 ] } }
     ],
     "User\\RoleAssignment" : [
         {"id": 1, "_roleId": 1, "contentId": 11, "limitationIdentifier": null, "values": null},

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
@@ -286,8 +286,8 @@ class UserHandlerTest extends TestCase
         $role = $handler->createRole( $role );
 
         $policy = new Persistence\User\Policy();
-        $policy->module = 'foo';
-        $policy->function = 'bar';
+        $policy->controller = 'foo';
+        $policy->action = 'bar';
 
         $handler->addPolicy( $role->id, $policy );
 
@@ -298,8 +298,8 @@ class UserHandlerTest extends TestCase
                     array(
                         'id' => 1,
                         'roleId' => 1,
-                        'module' => 'foo',
-                        'function' => 'bar',
+                        'controller' => 'foo',
+                        'action' => 'bar',
                         'limitations' => '*',
                     )
                 )
@@ -318,8 +318,8 @@ class UserHandlerTest extends TestCase
         $role = $handler->createRole( $role );
 
         $policy = new Persistence\User\Policy();
-        $policy->module = 'foo';
-        $policy->function = 'bar';
+        $policy->controller = 'foo';
+        $policy->action = 'bar';
 
         $handler->addPolicy( $role->id, $policy );
 
@@ -333,8 +333,8 @@ class UserHandlerTest extends TestCase
                     array(
                         'id' => 1,
                         'roleId' => 1,
-                        'module' => 'foo',
-                        'function' => 'bar',
+                        'controller' => 'foo',
+                        'action' => 'bar',
                         'limitations' => '*',
                     )
                 )
@@ -358,8 +358,8 @@ class UserHandlerTest extends TestCase
         $role = $handler->createRole( $role );
 
         $policy = new Persistence\User\Policy();
-        $policy->module = 'foo';
-        $policy->function = 'bar';
+        $policy->controller = 'foo';
+        $policy->action = 'bar';
         $policy->limitations = array(
             'Subtree' => array( '/1', '/1/2' ),
             'Foo' => array( 'Bar' ),
@@ -374,8 +374,8 @@ class UserHandlerTest extends TestCase
                     array(
                         'id' => 1,
                         'roleId' => 1,
-                        'module' => 'foo',
-                        'function' => 'bar',
+                        'controller' => 'foo',
+                        'action' => 'bar',
                         'limitations' => array(
                             'Subtree' => array( '/1', '/1/2' ),
                             'Foo' => array( 'Bar' ),
@@ -465,8 +465,8 @@ class UserHandlerTest extends TestCase
         $handler->createRole( $role );
 
         $policy = new Persistence\User\Policy();
-        $policy->module = 'foo';
-        $policy->function = 'bar';
+        $policy->controller = 'foo';
+        $policy->action = 'bar';
 
         $handler->addPolicy( $role->id, $policy );
 
@@ -486,8 +486,8 @@ class UserHandlerTest extends TestCase
         $handler->createRole( $role );
 
         $policy = new Persistence\User\Policy();
-        $policy->module = 'foo';
-        $policy->function = 'bar';
+        $policy->controller = 'foo';
+        $policy->action = 'bar';
 
         $policy = $handler->addPolicy( $role->id, $policy );
 
@@ -503,8 +503,8 @@ class UserHandlerTest extends TestCase
         $handler->createRole( $role );
 
         $policy = new Persistence\User\Policy();
-        $policy->module = 'foo';
-        $policy->function = 'bar';
+        $policy->controller = 'foo';
+        $policy->action = 'bar';
         $policy->limitations = array(
             'Subtree' => array( '/1', '/1/2' ),
             'Foo' => array( 'Bar' ),
@@ -531,8 +531,8 @@ class UserHandlerTest extends TestCase
         $handler->createRole( $role );
 
         $policy = new Persistence\User\Policy();
-        $policy->module = 'foo';
-        $policy->function = 'bar';
+        $policy->controller = 'foo';
+        $policy->action = 'bar';
         $policy->limitations = array(
             'Subtree' => array( '/1', '/1/2' ),
             'Foo' => array( 'Bar' ),
@@ -556,16 +556,16 @@ class UserHandlerTest extends TestCase
         $handler = $this->getUserHandler();
 
         $policy1 = new Persistence\User\Policy();
-        $policy1->module = 'foo';
-        $policy1->function = 'bar';
+        $policy1->controller = 'foo';
+        $policy1->action = 'bar';
         $policy1->limitations = array(
             'Subtree' => array( '/1', '/1/2' ),
             'Foo' => array( 'Bar' ),
         );
 
         $policy2 = new Persistence\User\Policy();
-        $policy2->module = 'foo';
-        $policy2->function = 'blubb';
+        $policy2->controller = 'foo';
+        $policy2->action = 'blubb';
         $policy2->limitations = array(
             'Foo' => array( 'Blubb' ),
         );

--- a/eZ/Publish/Core/Persistence/Legacy/User/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Mapper.php
@@ -81,8 +81,8 @@ class Mapper
                     array(
                         'id' => $row['ezpolicy_id'],
                         'roleId' => $row['ezrole_id'],
-                        'module' => $row['ezpolicy_module_name'],
-                        'function' => $row['ezpolicy_function_name'],
+                        'controller' => $row['ezpolicy_module_name'],
+                        'action' => $row['ezpolicy_function_name'],
                         'limitations' => '*' // limitations must be '*' if not a non empty array of limitations
                     )
                 );

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/EzcDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/EzcDatabase.php
@@ -510,10 +510,10 @@ class EzcDatabase extends Gateway
                 $this->handler->getAutoIncrementValue( 'ezpolicy', 'id' )
             )->set(
                 $this->handler->quoteColumn( 'function_name' ),
-                $query->bindValue( $policy->function )
+                $query->bindValue( $policy->action )
             )->set(
                 $this->handler->quoteColumn( 'module_name' ),
-                $query->bindValue( $policy->module )
+                $query->bindValue( $policy->controller )
             )->set(
                 $this->handler->quoteColumn( 'original_id' ),
                 0

--- a/eZ/Publish/Core/REST/Client/Repository.php
+++ b/eZ/Publish/Core/REST/Client/Repository.php
@@ -164,13 +164,13 @@ class Repository implements APIRepository
     }
 
     /**
-     * @param string $module
-     * @param string $function
+     * @param string $controller
+     * @param string $action
      * @param \eZ\Publish\API\Repository\Values\User\User $user
      *
      * @return boolean|\eZ\Publish\API\Repository\Values\User\Limitation[] if limitations are on this function an array of limitations is returned
      */
-    public function hasAccess( $module, $function, User $user = null )
+    public function hasAccess( $controller, $action, User $user = null )
     {
         // @todo: Implement
     }
@@ -182,14 +182,14 @@ class Repository implements APIRepository
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
      *
-     * @param string $module The module, aka controller identifier to check permissions on
-     * @param string $function The function, aka the controller action to check permissions on
+     * @param string $controller The module, aka controller identifier to check permissions on
+     * @param string $action The function, aka the controller action to check permissions on
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object The object to check if the user has access to
      * @param \eZ\Publish\API\Repository\Values\ValueObject $target The location, parent or "assignment" value object
      *
      * @return boolean
      */
-    public function canUser( $module, $function, ValueObject $object, ValueObject $target = null )
+    public function canUser( $controller, $action, ValueObject $object, ValueObject $target = null )
     {
         // @todo: Implement
     }

--- a/eZ/Publish/Core/REST/Client/RoleService.php
+++ b/eZ/Publish/Core/REST/Client/RoleService.php
@@ -664,14 +664,14 @@ class RoleService implements APIRoleService, Sessionable
     /**
      * Instantiates a policy create class
      *
-     * @param string $module
-     * @param string $function
+     * @param string $controller
+     * @param string $action
      *
      * @return \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct
      */
-    public function newPolicyCreateStruct( $module, $function )
+    public function newPolicyCreateStruct( $controller, $action )
     {
-        return new PolicyCreateStruct( $module, $function );
+        return new PolicyCreateStruct( $controller, $action );
     }
 
     /**
@@ -709,21 +709,30 @@ class RoleService implements APIRoleService, Sessionable
     }
 
     /**
-     * Returns the LimitationType's assigned to a given module/function
+     * @deprecated Since 5.1
+     * @uses getLimitationTypesByControllerAction()
+     */
+    public function getLimitationTypesByModuleFunction( $module, $function )
+    {
+        return $this->getLimitationTypesByControllerAction( $module, $function );
+    }
+
+    /**
+     * Returns the LimitationType's assigned to a given controller/action
      *
      * Typically used for:
      *  - Internal validation limitation value use on Policies
      *  - Role admin gui for editing policy limitations incl list limitation options via valueSchema()
      *
-     * @param string $module Legacy name of "controller", it's a unique identifier like "content"
-     * @param string $function Legacy name of a controller "action", it's a unique within the controller like "read"
+     * @param string $controller The controller (legacy: module) identifier, example: 'Bundle:controller' or 'content'
+     * @param string $action Controller action (legacy: function), it's a unique within the controller like 'read'
      *
      * @return \eZ\Publish\SPI\Limitation\Type[]
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If module/function to limitation type mapping
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If $controller/$action to limitation type mapping
      *                                                                 refers to a non existing identifier.
      */
-    public function getLimitationTypesByModuleFunction( $module, $function )
+    public function getLimitationTypesByControllerAction( $controller, $action )
     {
         throw new \eZ\Publish\API\Repository\Exceptions\NotImplementedException( __METHOD__ );
     }

--- a/eZ/Publish/Core/REST/Client/Values/User/PolicyCreateStruct.php
+++ b/eZ/Publish/Core/REST/Client/Values/User/PolicyCreateStruct.php
@@ -29,15 +29,15 @@ class PolicyCreateStruct extends \eZ\Publish\API\Repository\Values\User\PolicyCr
     /**
      * Instantiates a policy create struct.
      *
-     * @param string $module
-     * @param string $function
+     * @param string $controller
+     * @param string $action
      */
-    public function __construct( $module, $function )
+    public function __construct( $controller, $action )
     {
         parent::__construct(
             array(
-                'module'    => $module,
-                'function'  => $function
+                'module'    => $controller,
+                'function'  => $action
             )
         );
     }

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -265,16 +265,16 @@ class Repository implements RepositoryInterface
             $permissionSet = array( 'limitation' => null, 'policies' => array() );
             foreach ( $spiRoleAssignment->role->policies as $spiPolicy )
             {
-                if ( $spiPolicy->module === '*' && $spiRoleAssignment->limitationIdentifier === null )
+                if ( $spiPolicy->controller === '*' && $spiRoleAssignment->limitationIdentifier === null )
                     return true;
 
-                if ( $spiPolicy->module !== $controller && $spiPolicy->module !== '*' )
+                if ( $spiPolicy->controller !== $controller && $spiPolicy->controller !== '*' )
                     continue;
 
-                if ( $spiPolicy->function === '*' && $spiRoleAssignment->limitationIdentifier === null )
+                if ( $spiPolicy->action === '*' && $spiRoleAssignment->limitationIdentifier === null )
                     return true;
 
-                if ( $spiPolicy->function !== $action && $spiPolicy->function !== '*' )
+                if ( $spiPolicy->action !== $action && $spiPolicy->action !== '*' )
                     continue;
 
                 if ( $spiPolicy->limitations === '*' && $spiRoleAssignment->limitationIdentifier === null )

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -245,13 +245,13 @@ class Repository implements RepositoryInterface
      *
      * Low level function, use canUser instead if you have objects to check against.
      *
-     * @param string $module
-     * @param string $function
+     * @param string $controller
+     * @param string $action
      * @param \eZ\Publish\API\Repository\Values\User\User $user
      *
      * @return boolean|array Bool if user has full or no access, array if limitations if not
      */
-    public function hasAccess( $module, $function, User $user = null )
+    public function hasAccess( $controller, $action, User $user = null )
     {
         if ( $user === null )
             $user = $this->getCurrentUser();
@@ -268,13 +268,13 @@ class Repository implements RepositoryInterface
                 if ( $spiPolicy->module === '*' && $spiRoleAssignment->limitationIdentifier === null )
                     return true;
 
-                if ( $spiPolicy->module !== $module && $spiPolicy->module !== '*' )
+                if ( $spiPolicy->module !== $controller && $spiPolicy->module !== '*' )
                     continue;
 
                 if ( $spiPolicy->function === '*' && $spiRoleAssignment->limitationIdentifier === null )
                     return true;
 
-                if ( $spiPolicy->function !== $function && $spiPolicy->function !== '*' )
+                if ( $spiPolicy->function !== $action && $spiPolicy->function !== '*' )
                     continue;
 
                 if ( $spiPolicy->limitations === '*' && $spiRoleAssignment->limitationIdentifier === null )
@@ -297,7 +297,7 @@ class Repository implements RepositoryInterface
         if ( !empty( $permissionSets ) )
             return $permissionSets;
 
-        return false;// No policies matching $module and $function, or they contained limitations
+        return false;// No policies matching $controller and $action, or they contained limitations
     }
 
     /**
@@ -309,16 +309,16 @@ class Repository implements RepositoryInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
      *
-     * @param string $module The module, aka controller identifier to check permissions on
-     * @param string $function The function, aka the controller action to check permissions on
+     * @param string $controller The module, aka controller identifier to check permissions on
+     * @param string $action The function, aka the controller action to check permissions on
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object The object to check if the user has access to
      * @param \eZ\Publish\API\Repository\Values\ValueObject $target The location, parent or "assignment" value object
      *
      * @return boolean
      */
-    public function canUser( $module, $function, ValueObject $object, ValueObject $target = null )
+    public function canUser( $controller, $action, ValueObject $object, ValueObject $target = null )
     {
-        $permissionSets = $this->hasAccess( $module, $function );
+        $permissionSets = $this->hasAccess( $controller, $action );
         if ( $permissionSets === false || $permissionSets === true )
         {
             return $permissionSets;

--- a/eZ/Publish/Core/Repository/RoleService.php
+++ b/eZ/Publish/Core/Repository/RoleService.php
@@ -199,14 +199,14 @@ class RoleService implements RoleServiceInterface
         if ( !is_numeric( $role->id ) )
             throw new InvalidArgumentValue( "id", $role->id, "Role" );
 
-        if ( !is_string( $policyCreateStruct->module ) || empty( $policyCreateStruct->module ) )
-            throw new InvalidArgumentValue( "module", $policyCreateStruct->module, "PolicyCreateStruct" );
+        if ( !is_string( $policyCreateStruct->controller ) || empty( $policyCreateStruct->controller ) )
+            throw new InvalidArgumentValue( "controller", $policyCreateStruct->controller, "PolicyCreateStruct" );
 
-        if ( !is_string( $policyCreateStruct->function ) || empty( $policyCreateStruct->function ) )
-            throw new InvalidArgumentValue( "function", $policyCreateStruct->function, "PolicyCreateStruct" );
+        if ( !is_string( $policyCreateStruct->action ) || empty( $policyCreateStruct->action ) )
+            throw new InvalidArgumentValue( "action", $policyCreateStruct->action, "PolicyCreateStruct" );
 
-        if ( $policyCreateStruct->module === '*' && $policyCreateStruct->function !== '*' )
-            throw new InvalidArgumentValue( "module", $policyCreateStruct->module, "PolicyCreateStruct" );
+        if ( $policyCreateStruct->controller === '*' && $policyCreateStruct->action !== '*' )
+            throw new InvalidArgumentValue( "controller", $policyCreateStruct->controller, "PolicyCreateStruct" );
 
         if ( $this->repository->hasAccess( 'role', 'update' ) !== true )
             throw new UnauthorizedException( 'role', 'update' );
@@ -214,8 +214,8 @@ class RoleService implements RoleServiceInterface
         $loadedRole = $this->loadRole( $role->id );
 
         $spiPolicy = $this->buildPersistencePolicyObject(
-            $policyCreateStruct->module,
-            $policyCreateStruct->function,
+            $policyCreateStruct->controller,
+            $policyCreateStruct->action,
             $policyCreateStruct->getLimitations()
         );
 
@@ -291,18 +291,21 @@ class RoleService implements RoleServiceInterface
         if ( !is_numeric( $policy->roleId ) )
             throw new InvalidArgumentValue( "roleId", $policy->roleId, "Policy" );
 
-        if ( !is_string( $policy->module ) )
-            throw new InvalidArgumentValue( "module", $policy->module, "Policy" );
+        if ( !is_string( $policy->controller ) || empty( $policy->controller ) )
+            throw new InvalidArgumentValue( "controller", $policy->controller, "Policy" );
 
-        if ( !is_string( $policy->function ) )
-            throw new InvalidArgumentValue( "function", $policy->function, "Policy" );
+        if ( !is_string( $policy->action ) || empty( $policy->action ) )
+            throw new InvalidArgumentValue( "action", $policy->action, "Policy" );
+
+        if ( $policy->controller === '*' && $policy->action !== '*' )
+            throw new InvalidArgumentValue( "controller", $policy->controller, "PolicyCreateStruct" );
 
         if ( $this->repository->hasAccess( 'role', 'update' ) !== true )
             throw new UnauthorizedException( 'role', 'update' );
 
         $spiPolicy = $this->buildPersistencePolicyObject(
-            $policy->module,
-            $policy->function,
+            $policy->controller,
+            $policy->action,
             $policyUpdateStruct->getLimitations()
         );
 
@@ -757,17 +760,17 @@ class RoleService implements RoleServiceInterface
     /**
      * Instantiates a policy create class
      *
-     * @param string $module
-     * @param string $function
+     * @param string $controller
+     * @param string $action
      *
      * @return \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct
      */
-    public function newPolicyCreateStruct( $module, $function )
+    public function newPolicyCreateStruct( $controller, $action )
     {
         return new PolicyCreateStruct(
             array(
-                'module' => $module,
-                'function' => $function,
+                'controller' => $controller,
+                'action' => $action,
                 'limitations' => array()
             )
         );
@@ -833,7 +836,7 @@ class RoleService implements RoleServiceInterface
     public function buildDomainPolicyObject( SPIPolicy $policy, SPIRole $role = null )
     {
         $policyLimitations = array();
-        if ( $policy->module !== '*' && $policy->function !== '*' && $policy->limitations !== '*' )
+        if ( $policy->controller !== '*' && $policy->action !== '*' && $policy->limitations !== '*' )
         {
             foreach ( $policy->limitations as $identifier => $values )
             {
@@ -845,8 +848,8 @@ class RoleService implements RoleServiceInterface
             array(
                 'id' => (int)$policy->id,
                 'roleId' => $role !== null ? (int)$role->id : (int)$policy->roleId,
-                'module' => $policy->module,
-                'function' => $policy->function,
+                'controller' => $policy->controller,
+                'action' => $policy->action,
                 'limitations' => $policyLimitations
             )
         );
@@ -991,8 +994,8 @@ class RoleService implements RoleServiceInterface
         foreach ( $roleCreateStruct->getPolicies() as $policyCreateStruct )
         {
             $policiesToCreate[] = $this->buildPersistencePolicyObject(
-                $policyCreateStruct->module,
-                $policyCreateStruct->function,
+                $policyCreateStruct->controller,
+                $policyCreateStruct->action,
                 $policyCreateStruct->getLimitations()
             );
         }
@@ -1008,16 +1011,16 @@ class RoleService implements RoleServiceInterface
     /**
      * Creates SPI Policy value object from provided module, function and limitations
      *
-     * @param string $module
-     * @param string $function
+     * @param string $controller
+     * @param string $action
      * @param \eZ\Publish\API\Repository\Values\User\Limitation[] $limitations
      *
      * @return \eZ\Publish\SPI\Persistence\User\Policy
      */
-    protected function buildPersistencePolicyObject( $module, $function, array $limitations )
+    protected function buildPersistencePolicyObject( $controller, $action, array $limitations )
     {
         $limitationsToCreate = '*';
-        if ( $module !== '*' && $function !== '*' && !empty( $limitations ) )
+        if ( $controller !== '*' && $action !== '*' && !empty( $limitations ) )
         {
             $limitationsToCreate = array();
             foreach ( $limitations as $limitation )
@@ -1028,8 +1031,8 @@ class RoleService implements RoleServiceInterface
 
         return new SPIPolicy(
             array(
-                'module' => $module,
-                'function' => $function,
+                'controller' => $controller,
+                'action' => $action,
                 'limitations' => $limitationsToCreate
             )
         );

--- a/eZ/Publish/Core/Repository/RoleService.php
+++ b/eZ/Publish/Core/Repository/RoleService.php
@@ -935,33 +935,42 @@ class RoleService implements RoleServiceInterface
     }
 
     /**
-     * Returns the LimitationType's assigned to a given module/function
+     * @deprecated Since 5.1
+     * @uses getLimitationTypesByControllerAction()
+     */
+    public function getLimitationTypesByModuleFunction( $module, $function )
+    {
+        return $this->getLimitationTypesByControllerAction( $module, $function );
+    }
+
+    /**
+     * Returns the LimitationType's assigned to a given controller/action
      *
      * Typically used for:
      *  - Internal validation limitation value use on Policies
      *  - Role admin gui for editing policy limitations incl list limitation options via valueSchema()
      *
-     * @param string $module Legacy name of "controller", it's a unique identifier like "content"
-     * @param string $function Legacy name of a controller "action", it's a unique within the controller like "read"
+     * @param string $controller The controller (legacy: module) identifier, example: 'Bundle:controller' or 'content'
+     * @param string $action Controller action (legacy: function), it's a unique within the controller like 'read'
      *
      * @return \eZ\Publish\SPI\Limitation\Type[]
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If module/function to limitation type mapping
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If $controller/$action to limitation type mapping
      *                                                                 refers to a non existing identifier.
      */
-    public function getLimitationTypesByModuleFunction( $module, $function )
+    public function getLimitationTypesByControllerAction( $controller, $action )
     {
-        if ( empty( $this->settings['limitationMap'][$module][$function] ) )
+        if ( empty( $this->settings['limitationMap'][$controller][$action] ) )
             return array();
 
         $types = array();
-        foreach ( $this->settings['limitationMap'][$module][$function] as $identifier )
+        foreach ( $this->settings['limitationMap'][$controller][$action] as $identifier )
         {
             if ( !isset( $this->settings['limitationTypes'][$identifier] ) )
             {
                 throw new \eZ\Publish\Core\Base\Exceptions\BadStateException(
                     '$identifier',
-                    "'{$identifier}' does not exists but was configured as limitation on {$module}/{$function}"
+                    "'{$identifier}' does not exists but was configured as limitation on {$controller}/{$action}"
                 );
             }
             $types[$identifier] = $this->settings['limitationTypes'][$identifier];

--- a/eZ/Publish/Core/Repository/SearchService.php
+++ b/eZ/Publish/Core/Repository/SearchService.php
@@ -182,16 +182,16 @@ class SearchService implements SearchServiceInterface
      *
      * @return boolean|\eZ\Publish\API\Repository\Values\Content\Query\Criterion
      */
-    public function getPermissionsCriterion( $module = 'content', $function = 'read' )
+    public function getPermissionsCriterion( $controller = 'content', $action = 'read' )
     {
-        $permissionSets = $this->repository->hasAccess( $module, $function );
+        $permissionSets = $this->repository->hasAccess( $controller, $action );
         if ( $permissionSets === false || $permissionSets === true )
         {
             return $permissionSets;
         }
 
         if ( empty( $permissionSets ) )
-            throw new \RuntimeException( "Got an empty array of limitations from hasAccess( '{$module}', '{$function}' )" );
+            throw new \RuntimeException( "Got an empty array of limitations from hasAccess( '{$controller}', '{$action}' )" );
 
         /**
          * RoleAssignment is a OR condition, so is policy, while limitations is a AND condition

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/RepositoryTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/RepositoryTest.php
@@ -339,8 +339,8 @@ class RepositoryTest extends BaseServiceMockTest
         {
             $policies[] = new Policy(
                 array(
-                    "module" => $policyData[0],
-                    "function" => $policyData[1],
+                    "controller" => $policyData[0],
+                    "action" => $policyData[1],
                     "limitations" => $policyData[2],
                 )
             );

--- a/eZ/Publish/Core/SignalSlot/Repository.php
+++ b/eZ/Publish/Core/SignalSlot/Repository.php
@@ -180,15 +180,15 @@ class Repository implements RepositoryInterface
      *
      * Low level function, use canUser instead if you have objects to check against.
      *
-     * @param string $module
-     * @param string $function
+     * @param string $controller
+     * @param string $action
      * @param \eZ\Publish\API\Repository\Values\User\User $user
      *
      * @return boolean|array Bool if user has full or no access, array if limitations if not
      */
-    public function hasAccess( $module, $function, User $user = null )
+    public function hasAccess( $controller, $action, User $user = null )
     {
-        return $this->repository->hasAccess( $module, $function, $user );
+        return $this->repository->hasAccess( $controller, $action, $user );
     }
 
     /**
@@ -200,16 +200,16 @@ class Repository implements RepositoryInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
      *
-     * @param string $module The module, aka controller identifier to check permissions on
-     * @param string $function The function, aka the controller action to check permissions on
+     * @param string $controller The module, aka controller identifier to check permissions on
+     * @param string $action The function, aka the controller action to check permissions on
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object The object to check if the user has access to
      * @param \eZ\Publish\API\Repository\Values\ValueObject $target The location, parent or "assignment" value object
      *
      * @return boolean
      */
-    public function canUser( $module, $function, ValueObject $object, ValueObject $target = null )
+    public function canUser( $controller, $action, ValueObject $object, ValueObject $target = null )
     {
-        return $this->repository->canUser( $module, $function, $object, $target );
+        return $this->repository->canUser( $controller, $action, $object, $target );
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/RoleService.php
+++ b/eZ/Publish/Core/SignalSlot/RoleService.php
@@ -411,14 +411,14 @@ class RoleService implements RoleServiceInterface
     /**
      * Instantiates a policy create class
      *
-     * @param string $module
-     * @param string $function
+     * @param string $controller
+     * @param string $action
      *
      * @return \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct
      */
-    public function newPolicyCreateStruct( $module, $function )
+    public function newPolicyCreateStruct( $controller, $action )
     {
-        return $this->service->newPolicyCreateStruct( $module, $function );
+        return $this->service->newPolicyCreateStruct( $controller, $action );
     }
 
     /**
@@ -456,22 +456,31 @@ class RoleService implements RoleServiceInterface
     }
 
     /**
-     * Returns the LimitationType's assigned to a given module/function
+     * @deprecated Since 5.1
+     * @uses getLimitationTypesByControllerAction()
+     */
+    public function getLimitationTypesByModuleFunction( $module, $function )
+    {
+        return $this->getLimitationTypesByControllerAction( $module, $function );
+    }
+
+    /**
+     * Returns the LimitationType's assigned to a given controller/action
      *
      * Typically used for:
      *  - Internal validation limitation value use on Policies
      *  - Role admin gui for editing policy limitations incl list limitation options via valueSchema()
      *
-     * @param string $module Legacy name of "controller", it's a unique identifier like "content"
-     * @param string $function Legacy name of a controller "action", it's a unique within the controller like "read"
+     * @param string $controller The controller (legacy: module) identifier, example: 'Bundle:controller' or 'content'
+     * @param string $action Controller action (legacy: function), it's a unique within the controller like 'read'
      *
      * @return \eZ\Publish\SPI\Limitation\Type[]
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If module/function to limitation type mapping
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If $controller/$action to limitation type mapping
      *                                                                 refers to a non existing identifier.
      */
-    public function getLimitationTypesByModuleFunction( $module, $function )
+    public function getLimitationTypesByControllerAction( $controller, $action )
     {
-        return $this->service->getLimitationTypesByModuleFunction( $module, $function );
+        return $this->service->getLimitationTypesByControllerAction( $controller, $action );
     }
 }

--- a/eZ/Publish/SPI/Persistence/User/Policy.php
+++ b/eZ/Publish/SPI/Persistence/User/Policy.php
@@ -30,22 +30,22 @@ class Policy extends ValueObject
     public $roleId;
 
     /**
-     * Name of module, associated with the Policy
+     * Name of controller (legacy:module), associated with the Policy
      *
      * Eg: content
      *
      * @var string
      */
-    public $module;
+    public $controller;
 
     /**
-     * Name of the module function Or all functions with '*'
+     * Name of the controller action (legacy:function) Or all actions with '*'
      *
      * Eg: read
      *
      * @var string
      */
-    public $function;
+    public $action;
 
     /**
      * Array of policy limitations, which is just a random hash map.


### PR DESCRIPTION
<table>
<tr><td>Bug fix?</td><td>yes</td></tr>
<tr><td>New feature?</td><td>yes</td></tr>
<tr><td>Release?</td><td>5.?</td></tr>
<tr><td>BC breaks?</td><td>no</td></tr>
<tr><td>Deprecations?</td><td>yes</td></tr>
<tr><td>Tests pass?</td><td>yes</td></tr>
<tr><td>JIRA issue(s)</td><td>https://jira.ez.no/browse/EZP-20102</td></tr>
<tr><td>CLA</td><td>n/a</td></tr>
<tr><td>Doc link</td><td>n/a</td></tr>
</table>

Aim: Update permission system in API to reflect new stack terminology, and missing conventions for how bundles and controllers can hint that they should be protected by eZ Publish.

This should be done without braking BC, which means:
- $module => $controller, but including bundle name, so eg. 'DemoBundle:Demo' , in case of policy with full bundle access: 'DemoBundle:*'
- $function => $action, example: "read", or in case of policies: "*" if access to all actions   

TODO:
- [x] Rename module/function arguments and properties to controller/action
- [ ] Create a interface that Bundles can implement if they provide eZ Publish permissions, it should return list of controllers. If implemented but empty array, only "Bundle:*"/"*" or "*"/"*" permission is valid access.
- [ ] Create a interface that controllers can implement to provide list of actions and their limitations. If implemented but empty list of actions, then user must have access to all, as in "Bundle:Controller"/"*", "Bundle:*"/"*" or "*"/"*"
- [ ] Create a AliasPermission interface, so controllers can specify they use existing permission on other $controller, so CoreBundle:ContentController can set alias as LegacyBundle:ContentController
- [ ] Let the interface set custom name, so they can set the name which corresponds to legacy name, example: LegacyBundle:ContentController sets "content" while still providing list of actions and limitations for this permission.
- [ ] Create a compiler pass that generates API configuration based on info from bundles and Controllers, use that to validate addPolicy() & updatePolicy() as partly fixed in [EZP-20102](https://jira.ez.no/browse/EZP-20102)
- [ ] Take advantage of this in Security Firewall if possible, but at least in base controller permission check
- [ ] Document permission system for both api users and bundle creators