### PR TITLE
Corrected Missing Branch Referenced in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "symfony-cmf/routing": "1.0.*",
         "qafoo/rmf": "1.0.0",
         "kriswallsmith/buzz": "dev-master",
-        "tedivm/stash-bundle": "dev-blackhole"
+        "tedivm/stash-bundle": "dev-master"
     },
     "require-dev": {
         "ezsystems/ezpublish-legacy": "dev-master",


### PR DESCRIPTION
The blackhole branch does not appear to exist in tedivm/TedivmStashBundle - repointing to dev-master instead in order to fix composer builds.
