### PR TITLE
EZP-24832: Remove DOMDocument handling from legacy converters

### DIFF
--- a/doc/bc/changes-6.0.md
+++ b/doc/bc/changes-6.0.md
@@ -214,6 +214,14 @@ Changes affecting version compatibility with former or future versions.
 * Deprecated virtual property `$criterion` on class `eZ\Publish\API\Repository\Values\Content\Query`,
   is removed.
 
+* Removed support for XML DOMDocument values on `eZ\Publish\SPI\Persistence\Content\FieldValue`
+
+  As part of EZP-24832, `$data` property now needs to be scalar/array type, so it can be json
+  serialized in future storage engine improvements. Likewise `$externalData`, like any other
+  `eZ\Publish\SPI\Persistence\ValueObject` property, has been documented to have to be
+  serializable, as it is cached by Persistence Cache which depends on this.
+
+
 ## Changes from 2015.01 (6.0.0-alpha1)
 
 * Bundle `EzPublishElasticsearchBundle` has been renamed to `EzPublishElasticsearchSearchEngineBundle`

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Gateway/LegacyStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Gateway/LegacyStorageTest.php
@@ -13,7 +13,6 @@ namespace eZ\Publish\Core\FieldType\Tests\XmlText\Gateway;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
-use DOMDocument;
 use PHPUnit_Framework_TestCase;
 
 /**
@@ -201,10 +200,8 @@ class LegacyStorageTest extends PHPUnit_Framework_TestCase
         $expectedReturnValue,
         $expectedResultXML
     ) {
-        $inputDomDocument = new DOMDocument();
-        $inputDomDocument->loadXML($inputXML);
         $versionInfo = new VersionInfo();
-        $field = new Field(array('value' => new FieldValue(array('data' => $inputDomDocument))));
+        $field = new Field(array('value' => new FieldValue(array('data' => $inputXML))));
         $legacyStorage = $this->getPartlyMockedLegacyStorage(array('getUrlIdMap', 'getObjectId', 'insertUrl', 'linkUrl'));
 
         $methodMap = array(
@@ -226,7 +223,7 @@ class LegacyStorageTest extends PHPUnit_Framework_TestCase
         }
 
         $this->assertEquals($expectedReturnValue, $legacyStorage->storeFieldData($versionInfo, $field));
-        $this->assertEquals($expectedResultXML, $field->value->data->saveXML());
+        $this->assertEquals($expectedResultXML, $field->value->data);
     }
 
     /**
@@ -293,10 +290,8 @@ class LegacyStorageTest extends PHPUnit_Framework_TestCase
         $getObjectIdData,
         $insertLinkData
     ) {
-        $inputDomDocument = new DOMDocument();
-        $inputDomDocument->loadXML($inputXML);
         $versionInfo = new VersionInfo();
-        $field = new Field(array('value' => new FieldValue(array('data' => $inputDomDocument))));
+        $field = new Field(array('value' => new FieldValue(array('data' => $inputXML))));
         $legacyStorage = $this->getPartlyMockedLegacyStorage(array('getUrlIdMap', 'getObjectId', 'insertUrl'));
 
         $methodMap = array(
@@ -369,9 +364,7 @@ class LegacyStorageTest extends PHPUnit_Framework_TestCase
         $getLinksUrlData,
         $expectedResultXML
     ) {
-        $inputDomDocument = new DOMDocument();
-        $inputDomDocument->loadXML($inputXML);
-        $field = new Field(array('value' => new FieldValue(array('data' => $inputDomDocument))));
+        $field = new Field(array('value' => new FieldValue(array('data' => $inputXML))));
         $legacyStorage = $this->getPartlyMockedLegacyStorage(array('getIdUrlMap'));
 
         if (empty($getLinksUrlData)) {
@@ -385,6 +378,6 @@ class LegacyStorageTest extends PHPUnit_Framework_TestCase
         }
 
         $legacyStorage->getFieldData($field);
-        $this->assertEquals($expectedResultXML, $field->value->data->saveXML());
+        $this->assertEquals($expectedResultXML, $field->value->data);
     }
 }

--- a/eZ/Publish/Core/FieldType/Tests/XmlTextTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/XmlTextTest.php
@@ -146,8 +146,8 @@ class XmlTextTest extends PHPUnit_Framework_TestCase
 
         $fieldValue = $ft->toPersistenceValue($ft->acceptValue($xmlData));
 
-        self::assertInstanceOf('DOMDocument', $fieldValue->data);
-        self::assertSame($xmlDoc->saveXML(), $fieldValue->data->saveXML());
+        self::assertInternalType('string', $fieldValue->data);
+        self::assertSame($xmlDoc->saveXML(), $fieldValue->data);
     }
 
     public static function providerForTestAcceptValueValidFormat()

--- a/eZ/Publish/Core/FieldType/XmlText/Type.php
+++ b/eZ/Publish/Core/FieldType/XmlText/Type.php
@@ -138,9 +138,7 @@ class Type extends FieldType
         }
 
         if ($inputValue instanceof Input) {
-            $doc = new DOMDocument();
-            $doc->loadXML($inputValue->getInternalRepresentation());
-            $inputValue = new Value($doc);
+            $inputValue = new Value($inputValue->getInternalRepresentation());
         }
 
         return $inputValue;
@@ -193,10 +191,7 @@ class Type extends FieldType
             throw new RuntimeException("'xml' index is missing in hash.");
         }
 
-        $doc = new DOMDocument();
-        $doc->loadXML($hash['xml']);
-
-        return new Value($doc);
+        return new Value($hash['xml']);
     }
 
     /**
@@ -213,7 +208,7 @@ class Type extends FieldType
 
     /**
      * Creates a new Value object from persistence data.
-     * $fieldValue->data is supposed to be a DOMDocument object.
+     * $fieldValue->data is supposed to be a string.
      *
      * @param \eZ\Publish\SPI\Persistence\Content\FieldValue $fieldValue
      *
@@ -233,7 +228,7 @@ class Type extends FieldType
     {
         return new FieldValue(
             array(
-                'data' => $value->xml,
+                'data' => $value->xml->saveXML(),
                 'externalData' => null,
                 'sortKey' => $this->getSortInfo($value),
             )

--- a/eZ/Publish/Core/FieldType/XmlText/Value.php
+++ b/eZ/Publish/Core/FieldType/XmlText/Value.php
@@ -33,16 +33,16 @@ EOT;
     /**
      * Initializes a new XmlText Value object with $xmlDoc in.
      *
-     * @param \DOMDocument $xmlDoc
+     * @param \DOMDocument|string $xmlDoc
      */
-    public function __construct(DOMDocument $xmlDoc = null)
+    public function __construct($xmlDoc = null)
     {
-        if ($xmlDoc === null) {
-            $xmlDoc = new DOMDocument();
-            $xmlDoc->loadXML(self::EMPTY_VALUE);
+        if ($xmlDoc instanceof DOMDocument) {
+            $this->xml = $xmlDoc;
+        } else {
+            $this->xml = new DOMDocument();
+            $this->xml->loadXML($xmlDoc === null ? self::EMPTY_VALUE : $xmlDoc);
         }
-
-        $this->xml = $xmlDoc;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -18,15 +18,12 @@ use eZ\Publish\SPI\Persistence\Content\CreateStruct;
 use eZ\Publish\SPI\Persistence\Content\UpdateStruct;
 use eZ\Publish\SPI\Persistence\Content\MetadataUpdateStruct;
 use eZ\Publish\SPI\Persistence\Content\Relation\CreateStruct as RelationCreateStruct;
-use DOMDocument;
 
 /**
  * @see eZ\Publish\SPI\Persistence\Content\Handler
  */
 class ContentHandler extends AbstractHandler implements ContentHandlerInterface
 {
-    const FIELD_VALUE_DOM_DOCUMENT_KEY = '§:DomDocument:§';
-
     const ALL_TRANSLATIONS_KEY = '0';
 
     /**
@@ -71,9 +68,7 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
         if ($cache->isMiss()) {
             $this->logger->logCall(__METHOD__, array('content' => $contentId, 'version' => $version, 'translations' => $translations));
             $content = $this->persistenceHandler->contentHandler()->load($contentId, $version, $translations);
-            $cache->set($this->cloneAndSerializeXMLFields($content));
-        } else {
-            $this->unSerializeXMLFields($content);
+            $cache->set($content);
         }
 
         return $content;
@@ -172,7 +167,7 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
         $this->cache->clear('content', $contentId, $versionNo);
         $this->cache
             ->getItem('content', $contentId, $versionNo, self::ALL_TRANSLATIONS_KEY)
-            ->set($this->cloneAndSerializeXMLFields($content));
+            ->set($content);
 
         return $content;
     }
@@ -293,82 +288,8 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
         $contentInfo = $content->versionInfo->contentInfo;
         $this->cache
             ->getItem('content', $contentInfo->id, $content->versionInfo->versionNo, self::ALL_TRANSLATIONS_KEY)
-            ->set($this->cloneAndSerializeXMLFields($content));
+            ->set($content);
         $this->cache->getItem('content', 'info', $contentInfo->id)->set($contentInfo);
-
-        return $content;
-    }
-
-    /**
-     * Custom serializer for Content.
-     *
-     * Needed for DomDocuments on field values as they can not be serialized directly.
-     *
-     * @todo Change SPI to document that fieldValue->data and external data *must* be serializable, then remove this.
-     *
-     * @param Content $content
-     *
-     * @return Content A serializable version of Content
-     */
-    protected function cloneAndSerializeXMLFields(Content $content)
-    {
-        $contentClone = clone $content;
-        foreach ($contentClone->fields as $key => $field) {
-            $contentClone->fields[$key] = $fieldClone = clone $field;
-            $fieldClone->value = clone $fieldClone->value;
-
-            // Add 'unique' string in front of xml string version of dom document, used by unSerializeXMLFields()
-            if ($fieldClone->value->data instanceof DOMDocument) {
-                $fieldClone->value->data =
-                    self::FIELD_VALUE_DOM_DOCUMENT_KEY .
-                    $fieldClone->value->data->saveXML();
-            }
-
-            if ($fieldClone->value->externalData instanceof DOMDocument) {
-                $fieldClone->value->externalData =
-                    self::FIELD_VALUE_DOM_DOCUMENT_KEY .
-                    $fieldClone->value->externalData->saveXML();
-            }
-        }
-
-        return $contentClone;
-    }
-
-    /**
-     * Custom unSerializer for Content.
-     *
-     * Needed for DomDocuments on field values as they can not be serialized directly.
-     *
-     * @see cloneAndSerializeXMLFields
-     *
-     * @param Content $content
-     *
-     * @return Content
-     */
-    protected function unSerializeXMLFields(Content $content)
-    {
-        foreach ($content->fields as $field) {
-            // Look for self::FIELD_VALUE_DOM_DOCUMENT_KEY, it indicates a xml string that needs to be DomDocument
-            if (
-                !empty($field->value->data) &&
-                is_string($field->value->data) &&
-                strpos($field->value->data, self::FIELD_VALUE_DOM_DOCUMENT_KEY) === 0
-            ) {
-                $dom = new DOMDocument('1.0', 'UTF-8');
-                $dom->loadXML(substr($field->value->data, strlen(self::FIELD_VALUE_DOM_DOCUMENT_KEY)));
-                $field->value->data = $dom;
-            }
-
-            if (
-                !empty($field->value->externalData) &&
-                is_string($field->value->externalData) &&
-                strpos($field->value->externalData, self::FIELD_VALUE_DOM_DOCUMENT_KEY) === 0
-            ) {
-                $dom = new DOMDocument('1.0', 'UTF-8');
-                $dom->loadXML(substr($field->value->externalData, strlen(self::FIELD_VALUE_DOM_DOCUMENT_KEY)));
-                $field->value->externalData = $dom;
-            }
-        }
 
         return $content;
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/XmlTextConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/XmlTextConverter.php
@@ -18,7 +18,6 @@ use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 use eZ\Publish\Core\FieldType\FieldSettings;
 use eZ\Publish\Core\FieldType\XmlText\Value;
-use DOMDocument;
 
 class XmlTextConverter implements Converter
 {
@@ -42,7 +41,7 @@ class XmlTextConverter implements Converter
      */
     public function toStorageValue(FieldValue $value, StorageFieldValue $storageFieldValue)
     {
-        $storageFieldValue->dataText = $value->data->saveXML();
+        $storageFieldValue->dataText = $value->data;
     }
 
     /**
@@ -53,9 +52,7 @@ class XmlTextConverter implements Converter
      */
     public function toFieldValue(StorageFieldValue $value, FieldValue $fieldValue)
     {
-        $domDoc = new DOMDocument();
-        $domDoc->loadXML($value->dataText ?: Value::EMPTY_VALUE);
-        $fieldValue->data = $domDoc;
+        $fieldValue->data = $value->dataText ?: Value::EMPTY_VALUE;
     }
 
     /**
@@ -68,8 +65,9 @@ class XmlTextConverter implements Converter
     {
         $storageDefinition->dataInt1 = $fieldDefinition->fieldTypeConstraints->fieldSettings['numRows'];
         $storageDefinition->dataText2 = $fieldDefinition->fieldTypeConstraints->fieldSettings['tagPreset'];
+
         if (!empty($fieldDefinition->defaultValue->data)) {
-            $storageDefinition->dataText1 = $fieldDefinition->defaultValue->data->saveXML();
+            $storageDefinition->dataText1 = $fieldDefinition->defaultValue->data;
         }
     }
 
@@ -90,9 +88,9 @@ class XmlTextConverter implements Converter
 
         $defaultValue = null;
         if (!empty($storageDefinition->dataText1)) {
-            $defaultValue = new DOMDocument();
-            $defaultValue->loadXML($storageDefinition->dataText1);
+            $defaultValue = $storageDefinition->dataText1;
         }
+
         $fieldDefinition->defaultValue->data = $defaultValue;
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/XmlTextTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/XmlTextTest.php
@@ -14,7 +14,6 @@ use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\XmlTextConverter;
 use PHPUnit_Framework_TestCase;
-use DOMDocument;
 
 /**
  * Test case for XmlText converter in Legacy storage.
@@ -57,12 +56,11 @@ EOT;
     public function testToStorageValue()
     {
         $value = new FieldValue();
-        $value->data = new DOMDocument();
-        $value->data->loadXML($this->xmlText);
+        $value->data = $this->xmlText;
         $storageFieldValue = new StorageFieldValue();
 
         $this->converter->toStorageValue($value, $storageFieldValue);
-        self::assertSame($value->data->saveXML(), $storageFieldValue->dataText);
+        self::assertSame($value->data, $storageFieldValue->dataText);
     }
 
     /**
@@ -75,6 +73,6 @@ EOT;
         $fieldValue = new FieldValue();
 
         $this->converter->toFieldValue($storageFieldValue, $fieldValue);
-        self::assertSame($storageFieldValue->dataText, $fieldValue->data->saveXML());
+        self::assertSame($storageFieldValue->dataText, $fieldValue->data);
     }
 }

--- a/eZ/Publish/SPI/Persistence/Content/FieldValue.php
+++ b/eZ/Publish/SPI/Persistence/Content/FieldValue.php
@@ -19,19 +19,24 @@ class FieldValue extends ValueObject
     /**
      * Mixed field data.
      *
-     * Either a primitive, an array (map) or an object
+     * Either a scalar (primitive), null or an array (map) of scalar values.
      *
      * @note: For the legacy storage engine we will need adaptors to map them to
      * the existing database fields, like data_int, data_float, data_text.
      *
-     * @var mixed
+     * @var int|float|bool|string|null|array
      */
     public $data;
 
     /**
+     * Mixed external field data.
+     *
      * Data which is not stored in the field but at an external place.
      * This data is processed by the field type storage interface method
-     * storeFieldData.
+     * storeFieldData, if used by the FieldType, otherwise null.
+     *
+     * Either a primitive, an array (map) or an object
+     * If object it *must* be serializable, for instance DOMDocument is not valid object.
      *
      * @var mixed
      */
@@ -43,7 +48,7 @@ class FieldValue extends ValueObject
      * @note: For the "old" storage engine we will need adaptors to map them to
      * the existing database fields, like sort_key_int, sort_key_string
      *
-     * @var mixed
+     * @var int|float|bool|string|null
      */
     public $sortKey;
 }

--- a/eZ/Publish/SPI/Persistence/ValueObject.php
+++ b/eZ/Publish/SPI/Persistence/ValueObject.php
@@ -13,6 +13,9 @@ namespace eZ\Publish\SPI\Persistence;
 use eZ\Publish\API\Repository\Values\ValueObject as APIValueObject;
 
 /**
+ * Base SPI Value object.
+ *
+ * All properties of SPI\ValueObject *must* be serializable for cache & NoSQL use.
  */
 abstract class ValueObject extends APIValueObject
 {

--- a/eZ/Publish/SPI/Tests/FieldType/XmlTextIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/XmlTextIntegrationTest.php
@@ -15,7 +15,6 @@ use eZ\Publish\Core\FieldType;
 use eZ\Publish\Core\FieldType\FieldSettings;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\SPI\Persistence\Content\FieldTypeConstraints;
-use DOMDocument;
 use eZ\Publish\Core\FieldType\XmlText\XmlTextStorage\Gateway\LegacyStorage;
 use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\LegacyStorage as UrlGateway;
 
@@ -120,8 +119,7 @@ class XmlTextIntegrationTest extends BaseIntegrationTest
      */
     public function getInitialValue()
     {
-        $xml = new DOMDocument();
-        $xml->loadXML('<?xml version="1.0" encoding="utf-8"?><section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"><paragraph>Paragraph content…</paragraph></section>');
+        $xml = '<?xml version="1.0" encoding="utf-8"?><section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"><paragraph>Paragraph content…</paragraph></section>';
 
         return new FieldValue(
             array(
@@ -141,8 +139,7 @@ class XmlTextIntegrationTest extends BaseIntegrationTest
      */
     public function getUpdatedValue()
     {
-        $xml = new DOMDocument();
-        $xml->loadXML('<?xml version="1.0" encoding="utf-8"?><section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"><paragraph>Some different content…</paragraph></section>');
+        $xml = '<?xml version="1.0" encoding="utf-8"?><section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"><paragraph>Some different content…</paragraph></section>';
 
         return new FieldValue(
             array(


### PR DESCRIPTION
As discussed with @kore, storage engines should not be aware of high level representation of XML field type, that is DOMDocument.


Todo:
- [x] BC Doc
- [x] Issue