### PR TITLE
[travis-ci] removing xdebug extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ branches:
 
 # setup requirements for running unit tests
 before_script:
+  - echo '' > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
   - cp config.php-DEVELOPMENT config.php
   - ./composer_install_github_key.sh
   - composer install --dev --prefer-source


### PR DESCRIPTION
ezpublish testsuite doesn't need it (no coverage), and removing it speeds travis build (composer + phpunit)
before :  11 min 41 sec PHP 5.3 TEST_CONFIG="phpunit.xml"
after :  6 min 30 sec   PHP 5.3 TEST_CONFIG="phpunit.xml"
