### PR TITLE
Fix EZP-20583: Install assets fails with "UrlAliasRouter contains 1 abstract method"

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
@@ -264,7 +264,9 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
         return $name instanceof Location || $name === self::URL_ALIAS_ROUTE_NAME;
     }
     
-    
+    /**
+     * @see Symfony\Cmf\Component\Routing\VersatileGeneratorInterface::getRouteDebugMessage()
+     */
     public function getRouteDebugMessage($name, array $parameters = array())
     {
         if ($name instanceof RouteObjectInterface) {
@@ -277,4 +279,5 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
 
         return $name;
     }
+    
 }


### PR DESCRIPTION
...ract method and must therefore be declared abstract or implement the remaining methods (Symfony\Cmf\Component\Routing\VersatileGeneratorInterface::getRouteDebugMessage)
