### PR TITLE
Fixed 20617 - eZ MB Password Expiry confirmation link throws an UnauthorizedException

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Cache/PersistenceCachePurger.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Cache/PersistenceCachePurger.php
@@ -10,7 +10,7 @@
 namespace eZ\Bundle\EzPublishLegacyBundle\Cache;
 
 use Tedivm\StashBundle\Service\CacheService;
-use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandlerInterface;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 
 class PersistenceCachePurger
@@ -21,9 +21,9 @@ class PersistenceCachePurger
     protected $cache;
 
     /**
-     * @var \eZ\Publish\API\Repository\LocationService
+     * @var \eZ\Publish\SPI\Persistence\Content\Location\Handler
      */
-    protected $locationService;
+    protected $locationHandler;
 
     /**
      * Avoid clearing sub elements if all cache is already cleared, avoids redundant calls to Stash.
@@ -43,12 +43,12 @@ class PersistenceCachePurger
      * Setups current handler with everything needed
      *
      * @param \Tedivm\StashBundle\Service\CacheService $cache
-     * @param \eZ\Publish\API\Repository\LocationService $locationService
+     * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $locationHandler
      */
-    public function __construct( CacheService $cache, LocationService $locationService )
+    public function __construct( CacheService $cache, LocationHandlerInterface $locationHandler )
     {
         $this->cache = $cache;
-        $this->locationService = $locationService;
+        $this->locationHandler = $locationHandler;
     }
 
     /**
@@ -140,7 +140,7 @@ class PersistenceCachePurger
             if ( !is_scalar( $id ) )
                 throw new InvalidArgumentType( "\$id", "int[]|null", $id );
 
-            $location = $this->locationService->loadLocation( $id );
+            $location = $this->locationHandler->load( $id );
             $this->cache->clear( 'content', $location->contentId );
             $this->cache->clear( 'content', 'info', $location->contentId );
         }

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
@@ -139,7 +139,7 @@ services:
 
     ezpublish_legacy.persistence_cache_purger:
         class: %ezpublish_legacy.persistence_cache_purger.class%
-        arguments: [@cache, @ezpublish.api.service.location]
+        arguments: [@cache, @ezpublish.spi.persistence.cache.locationHandler]
 
     ezpublish_legacy.content_exception_handler:
         class: %ezpublish_legacy.content_exception_handler.class%

--- a/eZ/Bundle/EzPublishLegacyBundle/Tests/Cache/PersistenceCachePurgerTest.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Tests/Cache/PersistenceCachePurgerTest.php
@@ -10,7 +10,7 @@
 namespace eZ\Bundle\EzPublishLegacyBundle\Tests\Cache;
 
 use eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger;
-use eZ\Publish\Core\Repository\Values\Content\Location;
+use eZ\Publish\SPI\Persistence\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 
 class PersistenceCachePurgerTest extends \PHPUnit_Framework_TestCase
@@ -23,7 +23,7 @@ class PersistenceCachePurgerTest extends \PHPUnit_Framework_TestCase
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
-    private $locationService;
+    private $locationHandler;
 
     /**
      * @var \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger
@@ -38,9 +38,9 @@ class PersistenceCachePurgerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->locationService = $this->getMock( 'eZ\\Publish\\API\\Repository\\LocationService' );
+        $this->locationHandler = $this->getMock( 'eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler' );
 
-        $this->cachePurger = new PersistenceCachePurger( $this->cacheService, $this->locationService );
+        $this->cachePurger = new PersistenceCachePurger( $this->cacheService, $this->locationHandler );
     }
 
     /**
@@ -150,9 +150,9 @@ class PersistenceCachePurgerTest extends \PHPUnit_Framework_TestCase
         $locationId3 = 3;
         $contentId3 = 30;
 
-        $this->locationService
+        $this->locationHandler
             ->expects( $this->exactly( 3 ) )
-            ->method( 'loadLocation' )
+            ->method( 'load' )
             ->will(
                 $this->returnValueMap(
                     array(
@@ -193,9 +193,9 @@ class PersistenceCachePurgerTest extends \PHPUnit_Framework_TestCase
         $locationId = 1;
         $contentId = 10;
 
-        $this->locationService
+        $this->locationHandler
             ->expects( $this->once() )
-            ->method( 'loadLocation' )
+            ->method( 'load' )
             ->will( $this->returnValue( $this->buildLocation( $locationId, $contentId ) ) );
         $this->cacheService
             ->expects( $this->any() )
@@ -217,18 +217,14 @@ class PersistenceCachePurgerTest extends \PHPUnit_Framework_TestCase
     /**
      * @param $locationId
      * @param $contentId
-     * @return \eZ\Publish\Core\Repository\Values\Content\Location
+     * @return \eZ\Publish\SPI\Persistence\Content\Location
      */
     private function buildLocation( $locationId, $contentId )
     {
         return new Location(
             array(
                 'id'           => $locationId,
-                'contentInfo'  => new ContentInfo(
-                    array(
-                        'id' => $contentId
-                    )
-                )
+                'contentId'    => $contentId
             )
         );
     }


### PR DESCRIPTION
Also fixes EZP-20619 - Star rating access error popup where it should not be showed

SPI Cache purge should not be limited by user permissions.
This PR makes use of `Cache\LocationHandler` instead of `LocationService` as it's pure SPI related.

Tests have been refactored accordingly.
