### PR TITLE
Incorrect definition for exception

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Security/Authentication/BasicAuthProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Authentication/BasicAuthProvider.php
@@ -54,7 +54,7 @@ class BasicAuthProvider extends UserAuthenticationProvider
         }
         catch ( NotFoundException $e )
         {
-            throw new AuthenticationException( 'Authentication to eZ Publish failed', null, $e->getCode(), $e );
+            throw new AuthenticationException( 'Authentication to eZ Publish failed', $e->getCode(), $e );
         }
     }
 


### PR DESCRIPTION
Error: Wrong parameters for Exception([string $exception [, long $code [, Exception $previous = NULL]]])
