### PR TITLE
Fixed EZP-20618: Multiupload freezes on the end of the first file

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
@@ -139,7 +139,7 @@ services:
 
     ezpublish_legacy.persistence_cache_purger:
         class: %ezpublish_legacy.persistence_cache_purger.class%
-        arguments: [@cache, @ezpublish.spi.persistence.cache.locationHandler]
+        arguments: [@cache, @ezpublish.spi.persistence.cache.locationHandler, @logger]
 
     ezpublish_legacy.content_exception_handler:
         class: %ezpublish_legacy.content_exception_handler.class%


### PR DESCRIPTION
Jira issue: https://jira.ez.no/browse/EZP-20618
# Description

The complete object creation done by eZContentUpload is inside a DB transaction, as a result when the PersistenceCachePurger tries to clear the cache for the newly created location, the location handler is not yet able to load this location.
# Tests

Manual + unit tests
