### PR TITLE
Fix EZP-19687 ezkeyword update

### DIFF
--- a/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway/LegacyStorage.php
@@ -332,6 +332,9 @@ class LegacyStorage extends Gateway
     /**
      * Deletes all orphaned keywords.
      *
+     * @todo using two queries because zeta Database does not support joins in delete query.
+     * That could be avoided if the feature is implemented there.
+     *
      * Keyword is orphaned if it is not linked to a content attribute through ezkeyword_attribute_link table.
      *
      * @return void


### PR DESCRIPTION
This PR fixes https://jira.ez.no/browse/EZP-19687

In Legacy Stack orphaned keywords are deleted on every update.
This implements the same behavior for keyword FieldType.
