### PR TITLE
EZP-20399 - Fixed multiple compound matcher with different configuration

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
@@ -109,7 +109,6 @@ class Configuration implements ConfigurationInterface
                                         }
                                     )
                                 ->end()
-                                ->useAttributeAsKey( 'key' )
                                 ->normalizeKeys( false )
                                 ->prototype( 'variable' )->end()
                             ->end()

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Compound/LogicalAnd.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Compound/LogicalAnd.php
@@ -18,20 +18,23 @@ class LogicalAnd extends Compound
 {
     const NAME = 'logicalAnd';
 
-    /**
-     * @inheritDoc
-     */
     public function match()
     {
-        foreach ( $this->matchersMap as $subMatcher )
+        foreach ( $this->config as $i => $rule )
         {
-            // All submatchers must match, so if only one doesn't, return false.
-            if ( $subMatcher->match() === false )
+            foreach ( $rule['matchers'] as $subMatcherClass => $matchingConfig )
             {
-                return false;
+                // If at least one sub matcher doesn't match, jump to the next rule set.
+                if ( $this->matchersMap[$i][$subMatcherClass]->match() === false )
+                {
+                    continue 2;
+                }
             }
+
+            $this->subMatchers = $this->matchersMap[$i];
+            return $rule['match'];
         }
 
-        return $this->siteaccessName;
+        return false;
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Compound/LogicalOr.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Compound/LogicalOr.php
@@ -18,17 +18,17 @@ class LogicalOr extends Compound
 {
     const NAME = 'logicalOr';
 
-    /**
-     * @inheritDoc
-     */
     public function match()
     {
-        foreach ( $this->matchersMap as $subMatcher )
+        foreach ( $this->config as $i => $rule )
         {
-            // It's a logical OR, so first matched => return configured siteaccess name
-            if ( $subMatcher->match() )
+            foreach ( $rule['matchers'] as $subMatcherClass => $matchingConfig )
             {
-                return $this->siteaccessName;
+                if ( $this->matchersMap[$i][$subMatcherClass]->match() )
+                {
+                    $this->subMatchers = $this->matchersMap[$i];
+                    return $rule['match'];
+                }
             }
         }
 

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/CompoundInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/CompoundInterface.php
@@ -20,4 +20,11 @@ interface CompoundInterface extends Matcher
      * @param \eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilderInterface $matcherBuilder
      */
     public function setMatcherBuilder( MatcherBuilderInterface $matcherBuilder );
+
+    /**
+     * Returns all used sub-matchers.
+     *
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher[]
+     */
+    public function getSubMatchers();
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Compound/CompoundOrTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Compound/CompoundOrTest.php
@@ -33,13 +33,30 @@ class CompoundOrTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstruct()
     {
+        return $this->buildMatcher();
+    }
+
+    /**
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Compound\LogicalOr
+     */
+    private function buildMatcher()
+    {
         return new LogicalOr(
             array(
-                'matchers'  => array(
-                    'Map\\URI' => array( 'eng' => true ),
-                    'Map\\Host' => array( 'fr.ezpublish.dev' => true )
+                array(
+                    'matchers'  => array(
+                        'Map\\URI' => array( 'eng' => true ),
+                        'Map\\Host' => array( 'fr.ezpublish.dev' => true )
+                    ),
+                    'match'     => 'fr_eng'
                 ),
-                'match'     => 'fr_eng'
+                array(
+                    'matchers'  => array(
+                        'Map\\URI' => array( 'fre' => true ),
+                        'Map\\Host' => array( 'jp.ezpublish.dev' => true )
+                    ),
+                    'match'     => 'fr_jp'
+                ),
             )
         );
     }
@@ -67,7 +84,6 @@ class CompoundOrTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @depends testConstruct
      * @dataProvider matchProvider
      * @covers \eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Compound\LogicalOr::match
      *
@@ -75,8 +91,9 @@ class CompoundOrTest extends \PHPUnit_Framework_TestCase
      * @param \eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest $request
      * @param $expectedMatch
      */
-    public function testMatch( SimplifiedRequest $request, $expectedMatch, Compound $compoundMatcher )
+    public function testMatch( SimplifiedRequest $request, $expectedMatch )
     {
+        $compoundMatcher = $this->buildMatcher();
         $compoundMatcher->setRequest( $request );
         $compoundMatcher->setMatcherBuilder( new MatcherBuilder() );
         $this->assertSame( $expectedMatch, $compoundMatcher->match() );
@@ -90,7 +107,9 @@ class CompoundOrTest extends \PHPUnit_Framework_TestCase
             array( SimplifiedRequest::fromUrl( 'http://fr.ezpublish.dev/fre' ), 'fr_eng' ),
             array( SimplifiedRequest::fromUrl( 'http://fr.ezpublish.dev/' ), 'fr_eng' ),
             array( SimplifiedRequest::fromUrl( 'http://us.ezpublish.dev/eng' ), 'fr_eng' ),
-            array( SimplifiedRequest::fromUrl( 'http://us.ezpublish.dev/fre' ), false ),
+            array( SimplifiedRequest::fromUrl( 'http://us.ezpublish.dev/foo' ), false ),
+            array( SimplifiedRequest::fromUrl( 'http://us.ezpublish.dev/fre' ), 'fr_jp' ),
+            array( SimplifiedRequest::fromUrl( 'http://jp.ezpublish.dev/foo' ), 'fr_jp' ),
             array( SimplifiedRequest::fromUrl( 'http://ezpublish.dev/fr' ), false ),
         );
     }


### PR DESCRIPTION
This PR fixes [the issue mentioned during QA testing](https://jira.ez.no/browse/EZP-20399?focusedCommentId=71908&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-71908).

It changes the configuration of the compound `LogicalAnd` and `LogicalOr` matchers :

**Before (broken)**

``` yaml
ezpublish:
    siteaccess:
        default_siteaccess: eng
        list:
            - ezdemo_site
            - ezdemo_site_admin
        match:
            Compound\LogicalAnd:
                matchers:
                    Map\URI:
                        front: true
                    Map\Host:
                        ezpublish.dev: true
                match: ezdemo_site 
            Compound\LogicalAnd:
                matchers:
                    Map\URI:
                        admin: true
                    Map\Host:
                        ezpublish.dev: true
                match: ezdemo_site_admin
```

**After**

``` yaml
ezpublish:
    siteaccess:
        default_siteaccess: eng
        list:
            - ezdemo_site
            - ezdemo_site_admin
        match:
            Compound\LogicalAnd:
                -
                    matchers:
                        Map\URI:
                            front: true
                        Map\Host:
                            ezpublish.dev: true
                    match: ezdemo_site 
                -
                    matchers:
                        Map\URI:
                            admin: true
                        Map\Host:
                            ezpublish.dev: true
                    match: ezdemo_site_admin
```
