### PR TITLE
Fix EZP-20657 : EmbedToHtml5 Converter doesn't define alignment paramete...

### DIFF
--- a/eZ/Publish/Core/FieldType/XmlText/Converter/EmbedToHtml5.php
+++ b/eZ/Publish/Core/FieldType/XmlText/Converter/EmbedToHtml5.php
@@ -62,6 +62,11 @@ class EmbedToHtml5 implements Converter
                 "objectParameters" => array()
             );
 
+            if ( $attribute = $embed->getAttribute( "align" ) )
+            {
+                $parameters["objectParameters"]["align"] = $attribute;
+            }
+
             if ( $attribute = $embed->getAttribute( "size" ) )
             {
                 $parameters["objectParameters"]["size"] = $attribute;


### PR DESCRIPTION
...rs

Define align parameters from XML to give to the view renderer.
A simple use case is the alignment of an image
