### PR TITLE
Fixed EZP-20695: Errors when running Unit Tests with DATABASE=mysql://...

### DIFF
--- a/eZ/Publish/Core/Repository/Tests/Service/Integration/Legacy/Utils.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Integration/Legacy/Utils.php
@@ -25,6 +25,7 @@ abstract class Utils extends InMemoryUtils
         // Override to set legacy handlers
         $sc = self::getServiceContainer(
             'persistence_handler_legacy',
+            'io_handler_legacy',
             ( $dsn = getenv( "DATABASE" ) ) ? $dsn : "sqlite://:memory:"
         );
 


### PR DESCRIPTION
The second parameter (that was missing) is the IO Handler, not the DSN which is 3rd parameter.
