### PR TITLE
Fix EZP-20652: Database error when creating content with the API in PostreSQL

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/EzcDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/EzcDatabase.php
@@ -608,18 +608,31 @@ class EzcDatabase extends Gateway
      */
     public function getNextId()
     {
+        $sequence = $this->dbHandler->getSequenceName(
+            'ezurlalias_ml_incr', 'id'
+        );
         /** @var $query \ezcQueryInsert */
         $query = $this->dbHandler->createInsertQuery();
         $query->insertInto(
             $this->dbHandler->quoteTable( "ezurlalias_ml_incr" )
-        )->set(
-            $this->dbHandler->quoteColumn( "id" ),
-            $query->bindValue( null, null, \PDO::PARAM_NULL )
-        )->prepare()->execute();
-
-        return $this->dbHandler->lastInsertId(
-            $this->dbHandler->getSequenceName( "ezurlalias_ml_incr", "id" )
         );
+        if ( $this->dbHandler->getName() === 'pgsql' )
+        {
+            $query->set(
+                $this->dbHandler->quoteColumn( "id" ),
+                "nextval('{$sequence}')"
+            );
+        }
+        else
+        {
+            $query->set(
+                $this->dbHandler->quoteColumn( "id" ),
+                $query->bindValue( null, null, \PDO::PARAM_NULL )
+            );
+        }
+        $query->prepare()->execute();
+
+        return $this->dbHandler->lastInsertId( $sequence );
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/Gateway/EzcDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/Gateway/EzcDatabaseTest.php
@@ -438,7 +438,7 @@ class EzcDatabaseTest extends TestCase
     }
 
     /**
-     * Test for the getNewId() method.
+     * Test for the getNextId() method.
      *
      * @covers eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Gateway\EzcDatabase::getNextId
      */
@@ -446,12 +446,8 @@ class EzcDatabaseTest extends TestCase
     {
         $gateway = $this->getGateway();
 
-        $refObject = new \ReflectionObject( $gateway );
-        $refMethod = $refObject->getMethod( "getNextId" );
-        $refMethod->setAccessible( true );
-
-        self::assertEquals( 1, $refMethod->invoke( $gateway ) );
-        self::assertEquals( 2, $refMethod->invoke( $gateway ) );
+        self::assertEquals( 1, $gateway->getNextId() );
+        self::assertEquals( 2, $gateway->getNextId() );
     }
 
     /**


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-20652
# Description

Creating a content with the public API in PostgreSQL does not work because an error occurs while creating the url alias for the newly created content. This error is triggered by the method that retrieves the new id of the url alias because we generate an invalid SQL query for PostgreSQL.

Unfortunately, ezcDatabase does not really abstract the auto increment ids (see for instance [this _hack_](https://github.com/zetacomponents/Database/blob/master/src/sqlabstraction/query_insert.php#L115)) so the query builder does not really help.

Another solution would have been to run the following SQL query:

``` sql
INSERT INTO ezurlalias_ml_incr VALUES(DEFAULT)
```

but this might not work as expected in MySQL due to [this bug](http://bugs.mysql.com/bug.php?id=42270).

Result: a big _if postgresql do something else do something else_... not very clean, but at least that works.
# Tests

unit tests (SQLite, MySQL and PostgreSQL with some pain) + script creating content
