### PR TITLE
Fixed EZP-20748: Setup wizard uses the default VarDir to create files

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Controller/LegacySetupController.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Controller/LegacySetupController.php
@@ -10,6 +10,7 @@ namespace eZ\Bundle\EzPublishLegacyBundle\Controller;
 
 use Symfony\Component\DependencyInjection\ContainerInterface as Container;
 use Symfony\Component\HttpFoundation\Response;
+use eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\Configuration;
 use eZ\Publish\Core\MVC\Symfony\ConfigDumperInterface;
 use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Configuration\LegacyConfigResolver;
 use eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger;
@@ -43,18 +44,25 @@ class LegacySetupController
     protected $container;
 
     /**
+     * @var \eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\Configuration
+     */
+    protected $legacyMapper;
+
+    /**
      * @todo Maybe following dependencies should be mutualized in an abstract controller
      *       Injection can be done through "parent service" feature for DIC : http://symfony.com/doc/master/components/dependency_injection/parentservices.html
      *
      * @param \Closure $kernelClosure
      * @param \eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Configuration\LegacyConfigResolver $legacyConfigResolver
      * @param \eZ\Bundle\EzPublishLegacyBundle\Cache\PersistenceCachePurger $persistenceCachePurger
+     * @param \eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\Configuration $legacyMapper
      */
-    public function __construct( \Closure $kernelClosure, LegacyConfigResolver $legacyConfigResolver, PersistenceCachePurger $persistenceCachePurger )
+    public function __construct( \Closure $kernelClosure, LegacyConfigResolver $legacyConfigResolver, PersistenceCachePurger $persistenceCachePurger, Configuration $legacyMapper )
     {
         $this->legacyKernelClosure = $kernelClosure;
         $this->legacyConfigResolver = $legacyConfigResolver;
         $this->persistenceCachePurger = $persistenceCachePurger;
+        $this->legacyMapper = $legacyMapper;
     }
 
     public function setContainer( Container $container )
@@ -76,6 +84,9 @@ class LegacySetupController
         // Ensure that persistence cache purger is disabled as legacy cache will be cleared by legacy setup wizard while
         // everything is not ready yet to clear SPI cache (no connection to repository yet).
         $this->persistenceCachePurger->setIsEnabled( false );
+
+        // we disable injection of settings to Legacy Kernel during setup
+        $this->legacyMapper->setIsEnabled( false );
 
         /** @var $request \Symfony\Component\HttpFoundation\Request */
         $request = $this->container->get( 'request' );

--- a/eZ/Bundle/EzPublishLegacyBundle/LegacyMapper/Configuration.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/LegacyMapper/Configuration.php
@@ -55,6 +55,12 @@ class Configuration implements EventSubscriberInterface
      */
     private $options;
 
+    /**
+     * Disables the feature when set using setIsEnabled()
+     * @var bool
+     */
+    private $isEnabled = false;
+
     public function __construct(
         ConfigResolverInterface $configResolver,
         GatewayCachePurger $gatewayCachePurger,
@@ -70,6 +76,15 @@ class Configuration implements EventSubscriberInterface
         $this->container = $container;
         $this->urlAliasGenerator = $urlAliasGenerator;
         $this->options = $options;
+    }
+
+    /**
+     * Toggles the feature
+     * @param bool $isEnabled
+     */
+    public function setIsEnabled( $isEnabled )
+    {
+        $this->isEnabled = (bool)$isEnabled;
     }
 
     public static function getSubscribedEvents()
@@ -88,6 +103,11 @@ class Configuration implements EventSubscriberInterface
      */
     public function onBuildKernel( PreBuildKernelEvent $event )
     {
+        if ( !$this->isEnabled )
+        {
+            return;
+        }
+
         $databaseSettings = $this->configResolver->getParameter( "database" );
         $settings = array();
         foreach (

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
@@ -100,7 +100,11 @@ services:
     ezpublish_legacy.setup.controller:
         class: %ezpublish_legacy.setup.controller.class%
         parent: ezpublish.controller.base
-        arguments: [@ezpublish_legacy.kernel, @ezpublish_legacy.config.resolver, @ezpublish_legacy.persistence_cache_purger]
+        arguments:
+            - @ezpublish_legacy.kernel
+            - @ezpublish_legacy.config.resolver
+            - @ezpublish_legacy.persistence_cache_purger
+            - @ezpublish_legacy.configuration_mapper
 
     ezpublish_legacy.router:
         class: %ezpublish_legacy.router.class%


### PR DESCRIPTION
This commit disables the LegacyMapper injection of configuration into LegacyKernel during setup. This prevents the setup from using the defaut (.yml) VarDir that hasn't been set yet.
