### PR TITLE
Fixed EZP-19971 - Forms from 5.x to LS stack not supported by ezformtoken

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/LegacyMapper/Configuration.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/LegacyMapper/Configuration.php
@@ -162,6 +162,11 @@ class Configuration implements EventSubscriberInterface
             ezxFormToken::setSecret( $this->container->getParameter( 'kernel.secret' ) );
             ezxFormToken::setFormField( $this->container->getParameter( 'form.type_extension.csrf.field_name' ) );
         }
+        // csrf protection is disabled, disable it in legacy extension as well.
+        else
+        {
+            ezxFormToken::setIsEnabled( false );
+        }
 
         // Register http cache content/cache event listener
         ezpEvent::getInstance()->attach( 'content/cache', array( $this->gatewayCachePurger, 'purge' ) );

--- a/eZ/Publish/Core/MVC/Legacy/View/Provider/Block.php
+++ b/eZ/Publish/Core/MVC/Legacy/View/Provider/Block.php
@@ -90,7 +90,7 @@ class Block extends Provider implements BlockViewProviderInterface
                     );
                     if ( is_array( $children ) && isset( $children[0] ) )
                     {
-                        return $children[0];
+                        return ezpEvent::getInstance()->filter( 'response/output', $children[0] );
                     }
                     return '';
                 },

--- a/eZ/Publish/Core/MVC/Legacy/View/Provider/Content.php
+++ b/eZ/Publish/Core/MVC/Legacy/View/Provider/Content.php
@@ -71,7 +71,7 @@ class Content extends Provider implements ContentViewProviderInterface
                     );
                     if ( is_array( $children ) && isset( $children[0] ) )
                     {
-                        return $children[0];
+                        return ezpEvent::getInstance()->filter( 'response/output', $children[0] );
                     }
                     return '';
                 },

--- a/eZ/Publish/Core/MVC/Legacy/View/Provider/Location.php
+++ b/eZ/Publish/Core/MVC/Legacy/View/Provider/Location.php
@@ -18,6 +18,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 use eZModule;
 use ezjscPacker;
 use eZINI;
+use ezpEvent;
 use Symfony\Component\HttpFoundation\Request;
 
 class Location extends Provider implements LocationViewProviderInterface
@@ -131,7 +132,7 @@ class Location extends Provider implements LocationViewProviderInterface
                         )
                     );
 
-                    return $moduleResult['content'];
+                    return ezpEvent::getInstance()->filter( 'response/output', $moduleResult['content'] );
                 },
                 false
             );


### PR DESCRIPTION
`response/output` legacy filter was not triggered in Location/Content/BlockViewProvider services.

Also deactivates CSRF protection in legacy when it's deactivated in `config.yml`.

See:
- https://github.com/ezsystems/ezpublish-legacy/pull/616
- https://github.com/ezsystems/ezpublish-community/pull/47
