### PR TITLE
Fixed EZP-20755: Names are supposed to have a default limit of 150 characters

### DIFF
--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -185,10 +185,7 @@ class Repository implements RepositoryInterface
             'fieldType' => array(),
             'urlAlias' => array(),
             'urlWildcard' => array(),
-            'nameSchema' => array(
-                'limit' => 0,
-                'sequence' => ''
-            ),
+            'nameSchema' => array(),
             'languages' => array()
         );
 


### PR DESCRIPTION
Name should have a default maximum length as defined in https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/Repository/NameSchemaService.php#L72, however it is overriden at: https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/Repository/Repository.php#L189 with a wrong default value of "0"
