### PR TITLE
Fixed EZP-20759: eznode_assignment table not cleaned between tests

### DIFF
--- a/eZ/Publish/Core/Repository/Tests/Service/Integration/Legacy/_fixtures/clean_ezdemo_47_dump.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Integration/Legacy/_fixtures/clean_ezdemo_47_dump.php
@@ -19230,6 +19230,7 @@ array (
 'ezmultipricedata' =>
 array (
 ),
+*/
 'eznode_assignment' =>
 array (
  0 =>
@@ -19527,6 +19528,7 @@ array (
   'sort_order' => '1',
  ),
 ),
+/*
 'eznotificationcollection' =>
 array (
 ),


### PR DESCRIPTION
Since `eznode_assignment` table is not part of the `eZ/Publish/Core/Repository/Tests/Service/Integration/Legacy/_fixtures/clean_ezdemo_47_dump.php` file, it won't get cleaned between tests and would cause side effects.
