### PR TITLE
Fix EZP-20696: REST v2: Not possible to create content with an ezbinaryfile

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/ApiLoader/Factory.php
+++ b/eZ/Bundle/EzPublishRestBundle/ApiLoader/Factory.php
@@ -171,6 +171,14 @@ class Factory
 
     public function buildFieldTypeProcessorRegistry()
     {
+        $urlPrefix = '';
+        if ( $this->container->isScopeActive( 'request' ) )
+        {
+            $urlPrefix = $this->container->get( 'request' )->getUriForPath( '/' );
+        }
+        $binaryIOService = $this->container->get(
+            'ezpublish.fieldtype.ezbinaryfile.ioservice'
+        );
         return new Common\FieldTypeProcessorRegistry(
             array(
                 'ezimage' => new FieldTypeProcessor\ImageProcessor(
@@ -195,6 +203,10 @@ class Factory
                 'ezobjectrelation' => new FieldTypeProcessor\RelationProcessor(),
                 'eztime' => new FieldTypeProcessor\TimeProcessor(),
                 'ezxmltext' => new FieldTypeProcessor\XmlTextProcessor(),
+                'ezbinaryfile' => new FieldTypeProcessor\BinaryProcessor(
+                    sys_get_temp_dir(),
+                    $urlPrefix . $binaryIOService->getInternalPath( '{path}' )
+                ),
             )
         );
     }

--- a/eZ/Publish/Core/REST/Common/FieldTypeProcessor/BinaryProcessor.php
+++ b/eZ/Publish/Core/REST/Common/FieldTypeProcessor/BinaryProcessor.php
@@ -56,11 +56,6 @@ class BinaryProcessor extends BinaryInputProcessor
      */
     protected function generateUrl( $path )
     {
-        if ( preg_match( '((?:^|/)([0-9a-f]+)(?:\.[a-z0-9]+)?)', $path, $matches ) )
-        {
-            $path = $matches[1];
-        }
-
         return str_replace(
             '{path}',
             $path,

--- a/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/BinaryProcessorTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/BinaryProcessorTest.php
@@ -13,20 +13,23 @@ use eZ\Publish\Core\REST\Common\FieldTypeProcessor\BinaryProcessor;
 
 class BinaryProcessorTest extends BinaryInputProcessorTest
 {
+    const TEMPLATE_URL = 'http://ez.no/subdir/var/rest_test/storage/original/{path}';
+
     public function testPostProcessValueHash()
     {
+        $path = 'application/815b3aa9.pdf';
         $processor = $this->getProcessor();
 
         $inputHash = array(
-            'path' => 'var/some_site/12ace8436c64ceb907536640b58788f0.pdf',
+            'path' => $path,
         );
 
         $outputHash = $processor->postProcessValueHash( $inputHash );
 
         $this->assertEquals(
             array(
-                'path' => 'var/some_site/12ace8436c64ceb907536640b58788f0.pdf',
-                'url' => 'http://example.com/binaries/12ace8436c64ceb907536640b58788f0',
+                'path' => $path,
+                'url' => str_replace( '{path}', $path, self::TEMPLATE_URL )
             ),
             $outputHash
         );
@@ -41,7 +44,7 @@ class BinaryProcessorTest extends BinaryInputProcessorTest
     {
         return new BinaryProcessor(
             $this->getTempDir(),
-            'http://example.com/binaries/{path}'
+            self::TEMPLATE_URL
         );
     }
 }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-20696
# Description

When creating a content with an ezbinaryfile field, the REST API returns an error 406. This patch fixes this by registering the BinaryProcessor for the ezbinaryfile field type. This also fixes the issue where the output struct for ezbinaryfile fields does not contain anything that allows to retrieve the file in the field.
# Tests

manual test + unit tests
