### PR TITLE
Fix EZP-20724: Error when creating a content without filling an ezdatetime field

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Date.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Date.php
@@ -44,7 +44,7 @@ class Date implements Converter
     public function toStorageValue( FieldValue $value, StorageFieldValue $storageFieldValue )
     {
         $storageFieldValue->dataInt = ( $value->data !== null ? $value->data["timestamp"] : null );
-        $storageFieldValue->sortKeyInt = $value->sortKey;
+        $storageFieldValue->sortKeyInt = (int)$value->sortKey;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateAndTime.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateAndTime.php
@@ -46,7 +46,7 @@ class DateAndTime implements Converter
         // @todo: One should additionally store the timezone here. This could
         // be done in a backwards compatible way, I think…
         $storageFieldValue->dataInt = ( $value->data !== null ? $value->data['timestamp'] : null );
-        $storageFieldValue->sortKeyInt = $value->sortKey;
+        $storageFieldValue->sortKeyInt = (int)$value->sortKey;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Time.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Time.php
@@ -44,7 +44,7 @@ class Time implements Converter
     public function toStorageValue( FieldValue $value, StorageFieldValue $storageFieldValue )
     {
         $storageFieldValue->dataInt = ( $value->data !== null ? $value->data : null );
-        $storageFieldValue->sortKeyInt = $value->sortKey;
+        $storageFieldValue->sortKeyInt = (int)$value->sortKey;
     }
 
     /**


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-20724
# Description

When creating a content, if the value of a not required DateAndTime, Time or Date field is omitted and this field does not have any default value, a PDO exception is thrown because the persistence layer tries to set the sort_key_int DB field to NULL.
# Test

manual test with the REST API and the Public API. (And waiting for travis to run the unit tests, I have a segmentation fault at the moment...)
