### PR TITLE
Fixed HTTP status code for session creation

### DIFF
--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/UserSession.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/UserSession.php
@@ -34,6 +34,8 @@ class UserSession extends ValueObjectVisitor
         //@todo Needs refactoring, disabling certain headers should not be done this way
         $visitor->setHeader( 'Accept-Patch', false );
 
+        $visitor->setStatus( 201 );
+
         $generator->startObjectElement( 'Session' );
 
         $generator->startAttribute(

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/SessionTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/SessionTest.php
@@ -36,6 +36,10 @@ class SessionTest extends ValueObjectVisitorBaseTest
             "csrfToken"
         );
 
+        $this->getVisitorMock()->expects( $this->once() )
+            ->method( 'setStatus' )
+            ->with( $this->equalTo( 201 ) );
+
         $visitor->visit(
             $this->getVisitorMock(),
             $generator,


### PR DESCRIPTION
This PR fixes status code for create session resource, changing it from `200 OK` to `201 Created`, as is specified.
