### PR TITLE
Fix EZP-20785: only validate CSRF token when a session is running

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/EventListener/RestListener.php
+++ b/eZ/Bundle/EzPublishRestBundle/EventListener/RestListener.php
@@ -128,6 +128,10 @@ class RestListener implements EventSubscriberInterface
         if ( !$this->container->getParameter( 'form.type_extension.csrf.enabled' ) )
             return;
 
+        // skip CSRF validation if no session is running
+        if ( !$event->getRequest()->getSession()->isStarted() )
+            return;
+
         if ( $event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST )
             return;
 


### PR DESCRIPTION
See https://jira.ez.no/browse/EZP-20785.

The title says it all.
# Testing
1. Try to run an unsafe operation using REST with basic auth (create content). Check that it doesn't fail.
2. Create a session using REST (see the --session HTTPie option in recent versions), try to log out (DELETE /user/sessions/<id>) without a CSRF token => should fail, try to log out without it => should succeed
