### PR TITLE
Fix Legacy slots to always call eZContentObject::clearCache()

### DIFF
--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyAssignSectionSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyAssignSectionSlot.php
@@ -12,6 +12,7 @@ namespace eZ\Publish\Core\SignalSlot\Slot;
 use eZ\Publish\Core\SignalSlot\Signal;
 use eZ\Publish\Core\SignalSlot\Slot\AbstractLegacySlot;
 use eZContentCacheManager;
+use eZContentObject;
 use eZSearch;
 
 /**
@@ -37,6 +38,7 @@ class LegacyAssignSectionSlot extends AbstractLegacySlot
             {
                 eZContentCacheManager::clearContentCacheIfNeeded( $signal->contentId );
                 eZSearch::updateObjectsSection( array( $signal->contentId ), $signal->sectionId );
+                eZContentObject::clearCache();// Clear all object memory cache to free memory
             },
             false
         );

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyCopyContentSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyCopyContentSlot.php
@@ -11,6 +11,9 @@ namespace eZ\Publish\Core\SignalSlot\Slot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
 use eZ\Publish\Core\SignalSlot\Slot\AbstractLegacySlot;
+use eZContentCacheManager;
+use eZContentObject;
+use eZSearch;
 
 /**
  * A legacy slot handling CopyContentSignal.
@@ -33,9 +36,10 @@ class LegacyCopyContentSlot extends AbstractLegacySlot
         $kernel->runCallback(
             function () use ( $signal )
             {
-                \eZContentCacheManager::clearContentCacheIfNeeded( $signal->dstContentId );
-                $object = \eZContentObject::fetch( $signal->dstContentId );
-                \eZSearch::addObject( $object, false );
+                eZContentCacheManager::clearContentCacheIfNeeded( $signal->dstContentId );
+                $object = eZContentObject::fetch( $signal->dstContentId );
+                eZSearch::addObject( $object, false );
+                eZContentObject::clearCache();// Clear all object memory cache to free memory
             },
             false
         );

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyCreateLocationSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyCreateLocationSlot.php
@@ -11,6 +11,9 @@ namespace eZ\Publish\Core\SignalSlot\Slot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
 use eZ\Publish\Core\SignalSlot\Slot\AbstractLegacySlot;
+use eZContentCacheManager;
+use eZContentObject;
+use eZSearch;
 
 /**
  * A legacy slot handling CreateLocationSignal.
@@ -33,9 +36,10 @@ class LegacyCreateLocationSlot extends AbstractLegacySlot
         $kernel->runCallback(
             function () use ( $signal )
             {
-                \eZContentCacheManager::clearContentCacheIfNeeded( $signal->contentId, true, array( $signal->locationId ) );
-                $object = \eZContentObject::fetch( $signal->contentId );
-                \eZSearch::addNodeAssignment( $object->mainNodeID(), $signal->contentId, $signal->locationId );
+                eZContentCacheManager::clearContentCacheIfNeeded( $signal->contentId, true, array( $signal->locationId ) );
+                $object = eZContentObject::fetch( $signal->contentId );
+                eZSearch::addNodeAssignment( $object->mainNodeID(), $signal->contentId, $signal->locationId );
+                eZContentObject::clearCache();// Clear all object memory cache to free memory
             },
             false
         );

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyDeleteContentSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyDeleteContentSlot.php
@@ -11,6 +11,9 @@ namespace eZ\Publish\Core\SignalSlot\Slot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
 use eZ\Publish\Core\SignalSlot\Slot\AbstractLegacySlot;
+use eZContentCacheManager;
+use eZContentObject;
+use eZSearch;
 
 /**
  * A legacy slot handling DeleteContentSignal.
@@ -33,8 +36,9 @@ class LegacyDeleteContentSlot extends AbstractLegacySlot
         $kernel->runCallback(
             function () use ( $signal )
             {
-                \eZContentCacheManager::clearContentCacheIfNeeded( $signal->contentId );
-                \eZSearch::removeObjectById( $signal->contentId, false );
+                eZContentCacheManager::clearContentCacheIfNeeded( $signal->contentId );
+                eZSearch::removeObjectById( $signal->contentId, false );
+                eZContentObject::clearCache();// Clear all object memory cache to free memory
             },
             false
         );

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyDeleteLocationSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyDeleteLocationSlot.php
@@ -11,6 +11,9 @@ namespace eZ\Publish\Core\SignalSlot\Slot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
 use eZ\Publish\Core\SignalSlot\Slot\AbstractLegacySlot;
+use eZContentCacheManager;
+use eZContentObject;
+use eZSearch;
 
 /**
  * A legacy slot handling DeleteLocationSignal.
@@ -33,8 +36,9 @@ class LegacyDeleteLocationSlot extends AbstractLegacySlot
         $kernel->runCallback(
             function () use ( $signal )
             {
-                \eZContentCacheManager::clearContentCacheIfNeeded( $signal->contentId, true, array( $signal->locationId ) );
-                \eZSearch::removeNodes( array( $signal->locationId ) );
+                eZContentCacheManager::clearContentCacheIfNeeded( $signal->contentId, true, array( $signal->locationId ) );
+                eZSearch::removeNodes( array( $signal->locationId ) );
+                eZContentObject::clearCache();// Clear all object memory cache to free memory
             },
             false
         );

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyDeleteVersionSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyDeleteVersionSlot.php
@@ -11,6 +11,9 @@ namespace eZ\Publish\Core\SignalSlot\Slot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
 use eZ\Publish\Core\SignalSlot\Slot\AbstractLegacySlot;
+use eZContentCacheManager;
+use eZContentObject;
+use eZSearch;
 
 /**
  * A legacy slot handling DeleteVersionSignal.
@@ -33,10 +36,11 @@ class LegacyDeleteVersionSlot extends AbstractLegacySlot
         $kernel->runCallback(
             function () use ( $signal )
             {
-                \eZContentCacheManager::clearContentCacheIfNeeded( $signal->contentId );
-                \eZSearch::removeObjectById( $signal->contentId, false );
-                $object = \eZContentObject::fetch( $signal->contentId );
-                \eZSearch::addObject( $object, false );
+                eZContentCacheManager::clearContentCacheIfNeeded( $signal->contentId );
+                eZSearch::removeObjectById( $signal->contentId, false );
+                $object = eZContentObject::fetch( $signal->contentId );
+                eZSearch::addObject( $object, false );
+                eZContentObject::clearCache();// Clear all object memory cache to free memory
             },
             false
         );

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyHideLocationSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyHideLocationSlot.php
@@ -11,6 +11,9 @@ namespace eZ\Publish\Core\SignalSlot\Slot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
 use eZ\Publish\Core\SignalSlot\Slot\AbstractLegacySlot;
+use eZContentObject;
+use eZContentObjectTreeNode;
+use eZSearch;
 
 /**
  * A legacy slot handling HideLocationSignal.
@@ -33,9 +36,10 @@ class LegacyHideLocationSlot extends AbstractLegacySlot
         $kernel->runCallback(
             function () use ( $signal )
             {
-                $node = \eZContentObjectTreeNode::fetch( $signal->locationId );
-                \eZContentObjectTreeNode::clearViewCacheForSubtree( $node );
-                \eZSearch::updateNodeVisibility( $signal->locationId, 'hide' );
+                $node = eZContentObjectTreeNode::fetch( $signal->locationId );
+                eZContentObjectTreeNode::clearViewCacheForSubtree( $node );
+                eZSearch::updateNodeVisibility( $signal->locationId, 'hide' );
+                eZContentObject::clearCache();// Clear all object memory cache to free memory
             },
             false
         );

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyMoveSubtreeSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyMoveSubtreeSlot.php
@@ -11,6 +11,8 @@ namespace eZ\Publish\Core\SignalSlot\Slot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
 use eZ\Publish\Core\SignalSlot\Slot\AbstractLegacySlot;
+use eZContentObject;
+use eZContentObjectTreeNode;
 
 /**
  * A legacy slot handling MoveSubtreeSignal.
@@ -33,9 +35,10 @@ class LegacyMoveSubtreeSlot extends AbstractLegacySlot
         $kernel->runCallback(
             function () use ( $signal )
             {
-                $node = \eZContentObjectTreeNode::fetch( $signal->locationId );
-                \eZContentObjectTreeNode::clearViewCacheForSubtree( $node );
+                $node = eZContentObjectTreeNode::fetch( $signal->locationId );
+                eZContentObjectTreeNode::clearViewCacheForSubtree( $node );
                 // @todo What about eZSearch in this case?
+                eZContentObject::clearCache();// Clear all object memory cache to free memory
             },
             false
         );

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyPublishVersionSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyPublishVersionSlot.php
@@ -11,6 +11,9 @@ namespace eZ\Publish\Core\SignalSlot\Slot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
 use eZ\Publish\Core\SignalSlot\Slot\AbstractLegacySlot;
+use eZContentCacheManager;
+use eZContentObject;
+use eZSearch;
 
 /**
  * A legacy slot handling PublishVersionSignal.
@@ -33,9 +36,10 @@ class LegacyPublishVersionSlot extends AbstractLegacySlot
         $kernel->runCallback(
             function () use ( $signal )
             {
-                \eZContentCacheManager::clearContentCacheIfNeeded( $signal->contentId );
-                $object = \eZContentObject::fetch( $signal->contentId );
-                \eZSearch::addObject( $object, false );
+                eZContentCacheManager::clearContentCacheIfNeeded( $signal->contentId );
+                $object = eZContentObject::fetch( $signal->contentId );
+                eZSearch::addObject( $object, false );
+                eZContentObject::clearCache();// Clear all object memory cache to free memory
             },
             false
         );

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacySetContentStateSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacySetContentStateSlot.php
@@ -11,6 +11,9 @@ namespace eZ\Publish\Core\SignalSlot\Slot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
 use eZ\Publish\Core\SignalSlot\Slot\AbstractLegacySlot;
+use eZContentCacheManager;
+use eZContentObject;
+use eZSearch;
 
 /**
  * A legacy slot handling SetContentStateSignal.
@@ -33,8 +36,9 @@ class LegacySetContentStateSlot extends AbstractLegacySlot
         $kernel->runCallback(
             function () use ( $signal )
             {
-                \eZContentCacheManager::clearContentCacheIfNeeded( $signal->contentId );
-                \eZSearch::updateObjectState( $signal->contentId, array( $signal->objectStateId ) );
+                eZContentCacheManager::clearContentCacheIfNeeded( $signal->contentId );
+                eZSearch::updateObjectState( $signal->contentId, array( $signal->objectStateId ) );
+                eZContentObject::clearCache();// Clear all object memory cache to free memory
             },
             false
         );

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacySwapLocationSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacySwapLocationSlot.php
@@ -11,6 +11,9 @@ namespace eZ\Publish\Core\SignalSlot\Slot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
 use eZ\Publish\Core\SignalSlot\Slot\AbstractLegacySlot;
+use eZContentCacheManager;
+use eZContentObject;
+use eZSearch;
 
 /**
  * A legacy slot handling SwapLocationSignal.
@@ -33,9 +36,10 @@ class LegacySwapLocationSlot extends AbstractLegacySlot
         $kernel->runCallback(
             function () use ( $signal )
             {
-                \eZContentCacheManager::clearContentCacheIfNeeded( $signal->content1Id );
-                \eZContentCacheManager::clearContentCacheIfNeeded( $signal->content2Id );
-                \eZSearch::swapNode( $signal->location1Id, $signal->location2Id );
+                eZContentCacheManager::clearContentCacheIfNeeded( $signal->content1Id );
+                eZContentCacheManager::clearContentCacheIfNeeded( $signal->content2Id );
+                eZSearch::swapNode( $signal->location1Id, $signal->location2Id );
+                eZContentObject::clearCache();// Clear all object memory cache to free memory
             },
             false
         );

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyUnhideLocationSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyUnhideLocationSlot.php
@@ -11,6 +11,9 @@ namespace eZ\Publish\Core\SignalSlot\Slot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
 use eZ\Publish\Core\SignalSlot\Slot\AbstractLegacySlot;
+use eZContentObject;
+use eZContentObjectTreeNode;
+use eZSearch;
 
 /**
  * A legacy slot handling UnhideLocationSignal.
@@ -33,9 +36,10 @@ class LegacyUnhideLocationSlot extends AbstractLegacySlot
         $kernel->runCallback(
             function () use ( $signal )
             {
-                $node = \eZContentObjectTreeNode::fetch( $signal->locationId );
-                \eZContentObjectTreeNode::clearViewCacheForSubtree( $node );
-                \eZSearch::updateNodeVisibility( $signal->locationId, 'show' );
+                $node = eZContentObjectTreeNode::fetch( $signal->locationId );
+                eZContentObjectTreeNode::clearViewCacheForSubtree( $node );
+                eZSearch::updateNodeVisibility( $signal->locationId, 'show' );
+                eZContentObject::clearCache();// Clear all object memory cache to free memory
             },
             false
         );

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyUpdateLocationSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyUpdateLocationSlot.php
@@ -11,6 +11,8 @@ namespace eZ\Publish\Core\SignalSlot\Slot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
 use eZ\Publish\Core\SignalSlot\Slot\AbstractLegacySlot;
+use eZContentCacheManager;
+use eZContentObject;
 
 /**
  * A legacy slot handling UpdateLocationSignal.
@@ -33,7 +35,8 @@ class LegacyUpdateLocationSlot extends AbstractLegacySlot
         $kernel->runCallback(
             function () use ( $signal )
             {
-                \eZContentCacheManager::clearContentCacheIfNeeded( $signal->contentId );
+                eZContentCacheManager::clearContentCacheIfNeeded( $signal->contentId );
+                eZContentObject::clearCache();// Clear all object memory cache to free memory
             },
             false
         );


### PR DESCRIPTION
Always call eZContentObject::clearCache() at the end of the slot if content related operations have been done.
