### PR TITLE
Fixed EZP-20791: PHP Fatal error: Method eZ\Publish\Core\FieldType\XmlText\Value::__toString() must return a string value

### DIFF
--- a/eZ/Publish/Core/FieldType/XmlText/Value.php
+++ b/eZ/Publish/Core/FieldType/XmlText/Value.php
@@ -50,6 +50,6 @@ EOT;
      */
     public function __toString()
     {
-        return isset( $this->xml ) ? $this->xml->saveXML() : self::EMPTY_VALUE;
+        return isset( $this->xml ) ? (string)$this->xml->saveXML() : self::EMPTY_VALUE;
     }
 }


### PR DESCRIPTION
If the call to DOMDocument->saveXML() returns `NULL`, a PHP fatal error is triggered.
