### PR TITLE
Missing use statement in class eZ\Publish\Core\MVC\Legacy\View\Provider\Content caused fatal error

### DIFF
--- a/eZ/Publish/Core/MVC/Legacy/View/Provider/Content.php
+++ b/eZ/Publish/Core/MVC/Legacy/View/Provider/Content.php
@@ -17,6 +17,7 @@ use eZ\Publish\Core\MVC\Symfony\View\ViewProviderMatcher;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZContentObject;
 use eZTemplate;
+use ezpEvent;
 
 class Content extends Provider implements ContentViewProviderInterface
 {


### PR DESCRIPTION
PHP Fatal error:  Class 'eZ\Publish\Core\MVC\Legacy\View\Provider\ezpEvent' not found in .../ezpublish-kernel/eZ/Publish/Core/MVC/Legacy/View/Provider/Content.php on line 74

Added use ezpEvent in class.
