### PR TITLE
Enable php functions to xsl format

### DIFF
--- a/eZ/Publish/Core/FieldType/XmlText/Converter/Html5.php
+++ b/eZ/Publish/Core/FieldType/XmlText/Converter/Html5.php
@@ -75,6 +75,7 @@ class Html5 implements Converter
         $xslDoc = new DOMDocument;
         $xslDoc->load( $this->stylesheet );
         $xsl = new XSLTProcessor();
+        $xsl->registerPHPFunctions();
         $xsl->importStyleSheet( $xslDoc );
 
         return $xsl->transformToXML( $xmlDoc );


### PR DESCRIPTION
(Jira is down so i can't open an issue request)

Idea is simple: extends xsl format in order to inject some php class/method on different tags. For example: i would like to add syntax color on literal tag.

An example:

```
<!-- xsl:
<xsl:value-of select="php:function ('My\Name\Space\MyClassName::methodName',1+2)"/>
--->
```

``` php
<?php
namespace My\Name\Space;

   class MyClassName
   {
      static public function methodName($someArgument)
      {
         return "resultis:".$someArgument;
      }
   }
?>
```

```
<!-- result:
resultis:3
-->
```

What is your opinion ?
Cheers.
