### PR TITLE
Fixed wrong lazy loading of legacy kernel in IO\Handler\Legacy

### DIFF
--- a/eZ/Publish/Core/IO/Handler/Legacy.php
+++ b/eZ/Publish/Core/IO/Handler/Legacy.php
@@ -50,6 +50,13 @@ class Legacy implements IOHandlerInterface
     private $legacyKernel;
 
     /**
+     * Closure containing legacy kernel bootstrap
+     *
+     * @var \Closure
+     */
+    private $legacyKernelClosure;
+
+    /**
      * The storage directory where data is stored
      * Example: var/site/storage
      * @var string
@@ -73,7 +80,7 @@ class Legacy implements IOHandlerInterface
 
     public function setLegacyKernelClosure( \Closure $kernelClosure )
     {
-        $this->legacyKernel = $kernelClosure();
+        $this->legacyKernelClosure = $kernelClosure;
     }
 
     public function setLegacyKernel( LegacyKernel $kernel )
@@ -86,6 +93,12 @@ class Legacy implements IOHandlerInterface
      */
     protected function getLegacyKernel()
     {
+        if ( !isset( $this->legacyKernel ) && isset( $this->legacyKernelClosure ) )
+        {
+            $kernelClosure = $this->legacyKernelClosure;
+            $this->legacyKernel = $kernelClosure();
+        }
+
         return $this->legacyKernel;
     }
 
@@ -391,7 +404,7 @@ class Legacy implements IOHandlerInterface
 
         return $this->getLegacyKernel()->runCallback(
             /** @var $clusterHandler \eZClusterFileHandlerInterface */
-            function () use( $clusterHandler, $metadataHandler )
+            function() use( $clusterHandler, $metadataHandler )
             {
                 $temporaryFileName = $clusterHandler->fetchUnique();
                 $metadata = $metadataHandler->extract( $temporaryFileName );


### PR DESCRIPTION
This leads to weird exception message (_No security token found_) when IO handler is loaded early in the request, which is the case when we load the current user (user class has an `ezimage` field type).

The _No security token found_ can be triggered because when the legacy kernel is booted and multi site is activated with a non-existing locationId. A generic `NotFoundException` is fired and caught in the user provider.

This PR fixes this side effect.
