### PR TITLE
EZP-20812: Search with offset can ends up in an exception if there is no result

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Search/Gateway/EzcDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Search/Gateway/EzcDatabase.php
@@ -114,7 +114,7 @@ class EzcDatabase extends Gateway
         $limit = $limit !== null ? $limit : self::MAX_LIMIT;
 
         $count = $this->getResultCount( $criterion, $sort, $translations );
-        if ( $count === 0 || $limit === 0 )
+        if ( $limit === 0 || $count <= $offset )
         {
             return array( 'count' => $count, 'rows' => array() );
         }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/SearchHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/SearchHandlerTest.php
@@ -319,6 +319,37 @@ class SearchHandlerTest extends LanguageAwareTestCase
     }
 
     /**
+     * Issue with offsetting to the nonexistent results produces \ezcQueryInvalidParameterException exception.
+     *
+     * @return void
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Search\Gateway\EzcDatabase::find
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Search\Handler::findContent
+     */
+    public function testFindWithOffsetToNonexistent()
+    {
+        $locator = $this->getContentSearchHandler();
+
+        $result = $locator->findContent(
+            new Query(
+                array(
+                    'criterion' => new Criterion\ContentId( 10 ),
+                    'offset'    => 1000,
+                    'limit'     => null,
+                )
+            )
+        );
+
+        $this->assertEquals(
+            1,
+            $result->totalCount
+        );
+        $this->assertEquals(
+            0,
+            count( $result->searchHits )
+        );
+    }
+
+    /**
      * @return void
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Search\Gateway\EzcDatabase::find
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Search\Handler::findContent


### PR DESCRIPTION
This PR fixes issue https://jira.ez.no/browse/EZP-20812

Check if offset points to existing results was missing, therefore offsetting too far would result in empty array being passed to the `in` expression.

In turn this resulted in `ezcQueryInvalidParameterException` being thrown, converted to the `RuntimeException` and crashing the application.

Added condition check that offset does not exceed the total number of results + test.
