### PR TITLE
Fix EZP-20769: hardcoded path to image variants in REST

### DIFF
--- a/eZ/Publish/Core/REST/Common/FieldTypeProcessor/ImageProcessor.php
+++ b/eZ/Publish/Core/REST/Common/FieldTypeProcessor/ImageProcessor.php
@@ -45,31 +45,6 @@ class ImageProcessor extends BinaryInputProcessor
     }
 
     /**
-     * {@inheritDoc}
-     */
-    public function postProcessValueHash( $outgoingValueHash )
-    {
-        if ( !is_array( $outgoingValueHash ) )
-        {
-            return $outgoingValueHash;
-        }
-
-        $outgoingValueHash['variants'] = array();
-        foreach ( $this->variants as $variant => $mimeType )
-        {
-            $outgoingValueHash['variants'][] = array(
-                'variant' => $variant,
-                'contentType' => $mimeType,
-                'url' => $this->generateUrl(
-                    $outgoingValueHash['path'],
-                    $variant
-                ),
-            );
-        }
-        return $outgoingValueHash;
-    }
-
-    /**
      * Generates a URL for $path in $variant
      *
      * @param string $path

--- a/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/ImageProcessorTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/ImageProcessorTest.php
@@ -29,18 +29,6 @@ class ImageProcessorTest extends BinaryInputProcessorTest
         $this->assertEquals(
             array(
                 'path' => 'var/some_site/223-1-eng-US/Cool-File.jpg',
-                'variants' => array(
-                    array(
-                        'variant' => 'original',
-                        'contentType' => 'image/jpeg',
-                        'url' => 'http://example.com/images/223-1/original',
-                    ),
-                    array(
-                        'variant' => 'thumbnail',
-                        'contentType' => 'image/png',
-                        'url' => 'http://example.com/images/223-1/thumbnail',
-                    ),
-                ),
             ),
             $outputHash
         );


### PR DESCRIPTION
See https://jira.ez.no/browse/EZP-20769.

Path to variants was included in REST output with an Accept header vnd.api.ez.Content, but weren't properly generated. On top of that, it was referencing the path to images that may actually not exist.

The pull request removes the variants list altogether, but keeps the path to the original image, as this one is always there.

Further specifications & improvements are required on that part. Follow-up story: https://jira.ez.no/browse/EZP-20831.
## XML response

GET /api/ezp/v2/content/objects/<id> Accept:application/vnd.ez.api.Content+xml
### before patch

``` xml
<field>
    <id>35804</id>
    <fieldDefinitionIdentifier>image</fieldDefinitionIdentifier>
    <languageCode>eng-GB</languageCode>
    <fieldValue>
        <value key="alternativeText"></value>
        <value key="fileName">Challenge-accepted.jpg</value>
        <value key="fileSize">7208</value>
        <value key="path">var/ezdemo_site/storage/images/media/images/challenge-accepted/35804-1-eng-GB/Challenge-accepted.jpg</value>
        <value key="variants">
            <value>
                <value key="variant">original</value>
                <value key="contentType">image/jpeg</value>
                <value key="url">http://example.com/fancy_site/original/images/{path}</value>
            </value>
            <value>
                <value key="variant">gallery</value>
                <value key="contentType">image/jpeg</value>
                <value key="url">http://example.com/fancy_site/gallery/images/{path}</value>
            </value>
            <value>
                <value key="variant">thumbnail</value>
                <value key="contentType">image/png</value>
                <value key="url">http://example.com/fancy_site/thumbnail/images/{path}</value>
            </value>
        </value>
    </fieldValue>
</field>
```
### after patch

``` xml
<field>
    <id>35804</id>
    <fieldDefinitionIdentifier>image</fieldDefinitionIdentifier>
    <languageCode>eng-GB</languageCode>
    <fieldValue>
        <value key="alternativeText"></value>
        <value key="fileName">Challenge-accepted.jpg</value>
        <value key="fileSize">7208</value>
        <value key="path">var/ezdemo_site/storage/images/media/images/challenge-accepted/35804-1-eng-GB/Challenge-accepted.jpg</value>
    </fieldValue>
</field>
```
