### PR TITLE
Fix creation of custom alias for Location

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Stubs/URLAliasServiceStub.php
+++ b/eZ/Publish/API/Repository/Tests/Stubs/URLAliasServiceStub.php
@@ -110,8 +110,36 @@ class URLAliasServiceStub implements URLAliasService
      *
      * @return \eZ\Publish\API\Repository\Values\Content\URLAlias
      */
-    public function createGlobalUrlAlias( $resource, $path, $languageCode, $forward = false, $alwaysAvailable = false )
+    public function createGlobalUrlAlias( $resource, $path, $languageCode, $forwarding = false, $alwaysAvailable = false )
     {
+        if ( !preg_match( "#^([a-zA-Z0-9_]+):(.+)$#", $resource, $matches ) )
+        {
+            throw new Exceptions\InvalidArgumentExceptionStub(
+                'What error code should be used?'
+            );
+        }
+
+        if ( $matches[1] === "eznode" || 0 === strpos( $resource, "module:content/view/full/" ) )
+        {
+            if ( $matches[1] === "eznode" )
+            {
+                $locationId = $matches[2];
+            }
+            else
+            {
+                $resourcePath = explode( "/", $matches[2] );
+                $locationId = end( $resourcePath );
+            }
+
+            return $this->createUrlAlias(
+                $this->repository->getLocationService()->loadLocation( $locationId ),
+                $path,
+                $languageCode,
+                $forwarding,
+                $alwaysAvailable
+            );
+        }
+
         $this->checkAliasNotExists( $path, $languageCode, true );
 
         $data = array(
@@ -127,7 +155,7 @@ class URLAliasServiceStub implements URLAliasService
             'alwaysAvailable' => $alwaysAvailable,
             'isHistory' => false,
             'isCustom' => true,
-            'forward' => $forward,
+            'forward' => $forwarding,
         );
         return ( $this->aliases[$data['id']] = new URLAlias( $data ) );
     }

--- a/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
@@ -382,7 +382,7 @@ class URLAliasServiceTest extends BaseTest
      * Test for the createGlobalUrlAlias() method.
      *
      * @return void
-     * @see \eZ\Publish\API\Repository\URLAliasService::createGlobalUrlAlias($resource, $path, $languageCode, $forward, $alwaysAvailable)
+     * @see \eZ\Publish\API\Repository\URLAliasService::createGlobalUrlAlias($resource, $path, $languageCode, $forwarding, $alwaysAvailable)
      *
      */
     public function testCreateGlobalUrlAliasWithAlwaysAvailable()
@@ -428,6 +428,106 @@ class URLAliasServiceTest extends BaseTest
             ),
             $createdUrlAlias
         );
+    }
+
+    /**
+     * Test for the createUrlAlias() method.
+     *
+     * @see \eZ\Publish\API\Repository\URLAliasService::createGlobalUrlAlias($resource, $path, $languageCode, $forwarding, $alwaysAvailable)
+     */
+    public function testCreateGlobalUrlAliasForLocation()
+    {
+        $repository = $this->getRepository();
+
+        $locationId = $this->generateId( 'location', 5 );
+        $locationService = $repository->getLocationService();
+        $location = $locationService->loadLocation( $locationId );
+
+        /* BEGIN: Use Case */
+        // $locationId is the ID of an existing location
+
+        $urlAliasService = $repository->getURLAliasService();
+
+        $createdUrlAlias = $urlAliasService->createGlobalUrlAlias(
+            'module:content/view/full/' . $locationId, '/Home/My-New-Site-global', 'eng-US', false, true
+        );
+        /* END: Use Case */
+
+        $this->assertInstanceOf(
+            'eZ\\Publish\\API\\Repository\\Values\\Content\\URLAlias',
+            $createdUrlAlias
+        );
+        return array( $createdUrlAlias, $location->id );
+    }
+
+    /**
+     * Test for the createUrlAlias() method.
+     *
+     * @see \eZ\Publish\API\Repository\URLAliasService::createGlobalUrlAlias($resource, $path, $languageCode, $forwarding, $alwaysAvailable)
+     */
+    public function testCreateGlobalUrlAliasForLocationVariation()
+    {
+        $repository = $this->getRepository();
+
+        $locationId = $this->generateId( 'location', 5 );
+        $locationService = $repository->getLocationService();
+        $location = $locationService->loadLocation( $locationId );
+
+        /* BEGIN: Use Case */
+        // $locationId is the ID of an existing location
+
+        $urlAliasService = $repository->getURLAliasService();
+
+        $createdUrlAlias = $urlAliasService->createGlobalUrlAlias(
+            'eznode:' . $locationId, '/Home/My-New-Site-global', 'eng-US', false, true
+        );
+        /* END: Use Case */
+
+        $this->assertInstanceOf(
+            'eZ\\Publish\\API\\Repository\\Values\\Content\\URLAlias',
+            $createdUrlAlias
+        );
+        return array( $createdUrlAlias, $location->id );
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\URLAlias
+     *
+     * @depends testCreateGlobalUrlAliasForLocation
+     *
+     * @return void
+     */
+    public function testCreateGlobalUrlAliasForLocationPropertyValues( $testData )
+    {
+        list( $createdUrlAlias, $locationId ) = $testData;
+
+        $this->assertNotNull( $createdUrlAlias->id );
+
+        $this->assertPropertiesCorrect(
+            array(
+                'type' => URLAlias::LOCATION,
+                'destination' => $locationId,
+                'path' => '/Home/My-New-Site-global',
+                'languageCodes' => array( 'eng-US' ),
+                'alwaysAvailable' => true,
+                'isHistory' => false,
+                'isCustom' => true,
+                'forward' => false,
+            ),
+            $createdUrlAlias
+        );
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\URLAlias
+     *
+     * @depends testCreateGlobalUrlAliasForLocationVariation
+     *
+     * @return void
+     */
+    public function testCreateGlobalUrlAliasForLocationVariationPropertyValues( $testData )
+    {
+        $this->testCreateGlobalUrlAliasForLocationPropertyValues( $testData );
     }
 
     /**

--- a/eZ/Publish/Core/Repository/URLAliasService.php
+++ b/eZ/Publish/Core/Repository/URLAliasService.php
@@ -145,7 +145,7 @@ class URLAliasService implements URLAliasServiceInterface
 
         $path = $this->cleanUrl( $path );
 
-        if ( $matches[1] === "eznode" || 0 === strpos( $matches[2], "module:content/view/full/" ) )
+        if ( $matches[1] === "eznode" || 0 === strpos( $resource, "module:content/view/full/" ) )
         {
             if ( $matches[1] === "eznode" )
             {
@@ -158,7 +158,7 @@ class URLAliasService implements URLAliasServiceInterface
             }
 
             return $this->createUrlAlias(
-                $locationId,
+                $this->repository->getLocationService()->loadLocation( $locationId ),
                 $path,
                 $languageCode,
                 $forwarding,


### PR DESCRIPTION
This PR fixes issue with creation of custom alias for Location.

`module:content/view/full/<id>` was not correctly recognized, also Location id was passed instead of Location object when calling `createUrlAlias` method.

Core implementation is fixed and integration tests stub updated.
Tests are added to the integration suite.
