### PR TITLE
Activated TTL cache by default

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -23,7 +23,7 @@ parameters:
 
     # Content settings
     ezsettings.default.content.view_cache: true         # Whether to use content view cache or not (Etag/Last-Modified based)
-    ezsettings.default.content.ttl_cache: false         # Whether to use TTL Cache for content (i.e. Max-Age response header)
+    ezsettings.default.content.ttl_cache: true          # Whether to use TTL Cache for content (i.e. Max-Age response header)
     ezsettings.default.content.default_ttl: 60          # Default TTL cache value for content
     ezsettings.default.content.tree_root.location_id: ~ # Root locationId for routing and link generation. Useful for multisite apps with one repository.
     ezsettings.default.content.tree_root.excluded_uri_prefixes: [] # URI prefixes that are allowed to be outside the content tree


### PR DESCRIPTION
Makes sense now since we don't have etag any more and purge is now OK from legacy scripts using:

``` bash
php ezpublish/console ezpublish:legacy:script bin/php/ezcache.php --clear-all
```
