### PR TITLE
Fix EZP-20867: Error when creating Image fieldtype without validator configuration

### DIFF
--- a/eZ/Publish/Core/FieldType/Image/Type.php
+++ b/eZ/Publish/Core/FieldType/Image/Type.php
@@ -225,7 +225,7 @@ class Type extends FieldType
     {
         $validationErrors = array();
 
-        foreach ( $validatorConfiguration as $validatorIdentifier => $parameters )
+        foreach ( (array)$validatorConfiguration as $validatorIdentifier => $parameters )
         {
             switch ( $validatorIdentifier )
             {


### PR DESCRIPTION
Proposed fix for:
https://jira.ez.no/browse/EZP-20867

Similar approach used in: https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/FieldType/TextLine/Type.php#L48
