### PR TITLE
Fix EZP-20576 - add use case when there is a custom pagelayout defined in legacy

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Controller/LegacyKernelController.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Controller/LegacyKernelController.php
@@ -81,7 +81,7 @@ class LegacyKernelController
 
         $moduleResult = $result->getAttribute( 'module_result' );
 
-        if ( isset( $this->legacyLayout ) && !$legacyMode )
+        if ( isset( $this->legacyLayout ) && !$legacyMode && !isset( $moduleResult['pagelayout'] ) )
         {
             $response = $this->render(
                 $this->legacyLayout,


### PR DESCRIPTION
We shouldn't use new stack pagelayout when the legacy module is asking for a custom pagelayout.

Example use-case :
- Loading ezoe in new stack : While inserting an image the eZ OE popup loads the new stack layout but it should the layout defined in legacy : popup_pagelayout.tpl

Tested manually with master
