### PR TITLE
Add Core & Legacy Composer ScriptHandlers

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * File containing the ScriptHandler class.
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Composer;
+
+use Sensio\Bundle\DistributionBundle\Composer\ScriptHandler as DistributionBundleScriptHandler;
+use Composer\Script\CommandEvent;
+
+class ScriptHandler extends DistributionBundleScriptHandler
+{
+    /**
+     * Dump minified assets for prod environment under the web root directory.
+     *
+     * @param $event CommandEvent A instance
+     */
+    public static function dumpAssets( CommandEvent $event )
+    {
+        $options = self::getOptions( $event );
+        $appDir = $options['symfony-app-dir'];
+        $webDir = $options['symfony-web-dir'];
+
+        if ( !is_dir( $appDir ) )
+        {
+            echo 'The symfony-app-dir (' . $appDir . ') specified in composer.json was not found in ' . getcwd() . ', can not install assets.' . PHP_EOL;
+            return;
+        }
+
+        if ( !is_dir( $webDir ) )
+        {
+            echo 'The symfony-web-dir (' . $webDir . ') specified in composer.json was not found in ' . getcwd() . ', can not install assets.' . PHP_EOL;
+            return;
+        }
+
+        static::executeCommand( $event, $appDir, 'assetic:dump --env=prod ' . escapeshellarg( $webDir ) );
+    }
+}

--- a/eZ/Bundle/EzPublishLegacyBundle/Composer/ScriptHandler.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Composer/ScriptHandler.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * File containing the ScriptHandler class.
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishLegacyBundle\Composer;
+
+use Sensio\Bundle\DistributionBundle\Composer\ScriptHandler as DistributionBundleScriptHandler;
+use Composer\Script\CommandEvent;
+
+class ScriptHandler extends DistributionBundleScriptHandler
+{
+    /**
+     * Installs the legacy assets under the web root directory.
+     *
+     * For better interoperability, assets are copied instead of symlinked by default.
+     *
+     * Even if symlinks work on Windows, this is only true on Windows Vista and later,
+     * but then, only when running the console with admin rights or when disabling the
+     * strict user permission checks (which can be done on Windows 7 but not on Windows
+     * Vista).
+     *
+     * @param $event CommandEvent A instance
+     */
+    public static function installAssets( CommandEvent $event )
+    {
+        $options = self::getOptions( $event );
+        $appDir = $options['symfony-app-dir'];
+        $webDir = $options['symfony-web-dir'];
+
+        $symlink = '';
+        if ( $options['symfony-assets-install'] === 'symlink' )
+        {
+            $symlink = '--symlink ';
+        }
+        else if ( $options['symfony-assets-install'] === 'relative' )
+        {
+            $symlink = '--symlink --relative ';
+        }
+
+        if ( !is_dir( $appDir ) )
+        {
+            echo 'The symfony-app-dir (' . $appDir . ') specified in composer.json was not found in ' . getcwd() . ', can not install assets.' . PHP_EOL;
+            return;
+        }
+
+        if ( !is_dir( $webDir ) )
+        {
+            echo 'The symfony-web-dir (' . $webDir . ') specified in composer.json was not found in ' . getcwd() . ', can not install assets.' . PHP_EOL;
+            return;
+        }
+
+        static::executeCommand( $event, $appDir, 'ezpublish:legacy:assets_install ' . $symlink . escapeshellarg( $webDir ) );
+    }
+}


### PR DESCRIPTION
This is for use in https://github.com/ezsystems/ezpublish-community/pull/34
Allows legacy assets to be symlinked and prod assets to be dumped as part of
composer install / update command to reduce amounts of steps needed for install.

Todo:
- [x] Add change as suggested by PS
- [x] Rebase with issue number in commit + PR title when done in ezsystems/ezpublish-community#34
