### PR TITLE
EZP-20657: Fixed missing wrapper around embed in XMLText XSL

### DIFF
--- a/eZ/Publish/Core/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl
+++ b/eZ/Publish/Core/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl
@@ -167,7 +167,15 @@
     </xsl:template>
 
     <xsl:template match="embed">
-        <xsl:value-of select="text()" disable-output-escaping="yes"/>
+        <div>
+            <xsl:if test="@align">
+                <xsl:attribute name="class"><xsl:value-of select="concat('object-', @align)"/></xsl:attribute>
+            </xsl:if>
+            <xsl:if test="@id">
+                <xsl:attribute name="id"><xsl:value-of select="@id"/></xsl:attribute>
+            </xsl:if>
+            <xsl:value-of select="text()" disable-output-escaping="yes"/>
+        </div>
     </xsl:template>
 
     <xsl:template match="literal">


### PR DESCRIPTION
Same as #385, but correctly rebased after indentation changes made in #383 

This PR fixes `align` and `id` attributes if set, with a div wrapper like the old `embed.tpl`.
