### PR TITLE
Fix EZP-21055: creating content using API causes memory leaks

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Collector/SPIPersistenceDataCollector.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Collector/SPIPersistenceDataCollector.php
@@ -45,6 +45,7 @@ class SPIPersistenceDataCollector extends DataCollector
     {
         $this->data = array(
             'count' => $this->logger->getCount(),
+            'calls_logging_enabled' => $this->logger->isCallsLoggingEnabled(),
             'calls' => $this->logger->getCalls(),
             'handlers' => $this->logger->getLoadedUnCachedHandlers()
         );
@@ -70,6 +71,18 @@ class SPIPersistenceDataCollector extends DataCollector
     public function getCount()
     {
         return $this->data['count'];
+    }
+
+    /**
+     * Returns flag to indicate if logging of calls is enabled or not
+     *
+     * Typically not enabled in prod.
+     *
+     * @return bool
+     */
+    public function getCallsLoggingEnabled()
+    {
+        return $this->data['calls_logging_enabled'];
     }
 
     /**
@@ -104,14 +117,11 @@ class SPIPersistenceDataCollector extends DataCollector
      */
     public function getHandlers()
     {
-        $count = array();
         $handlers = array();
-        foreach ( $this->data['handlers'] as $handler )
+        foreach ( $this->data['handlers'] as $handler => $count )
         {
             list( $class, $method ) = explode( '::', $handler );
-
-            $count[$method] = ( isset($count[$method]) ? $count[$method] : 0 ) + 1;
-            $handlers[$method] = $method . '(' . $count[$method] . ')';
+            $handlers[$method] = $method . '(' . $count . ')';
         }
         return $handlers;
     }
@@ -123,11 +133,6 @@ class SPIPersistenceDataCollector extends DataCollector
      */
     public function getHandlersCount()
     {
-        $count = array();
-        foreach ( $this->data['handlers'] as $handler )
-        {
-            $count[$handler] = ( isset($count[$handler]) ? $count[$handler] : 0 ) + 1;
-        }
-        return count( $count );
+        return array_sum( $this->data['handlers'] );
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage_engines.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage_engines.yml
@@ -11,6 +11,8 @@ parameters:
     ezpublish.spi.persistence.cache.searchHandler.class: eZ\Publish\Core\Persistence\Cache\SearchHandler
     ezpublish.spi.persistence.cache.urlAliasHandler.class: eZ\Publish\Core\Persistence\Cache\UrlAliasHandler
     ezpublish.spi.persistence.cache.persistenceLogger.class: eZ\Publish\Core\Persistence\Cache\PersistenceLogger
+    # Make sure logging is only enabled for debug by default
+    ezpublish.spi.persistence.cache.persistenceLogger.enableCallLogging: %kernel.debug%
     ezpublish.spi.persistence.default_id: synthetical-parameter-set-in-RegisterStorageEnginePass
 
     # storage engines
@@ -117,6 +119,8 @@ services:
 
     ezpublish.spi.persistence.cache.persistenceLogger:
         class: %ezpublish.spi.persistence.cache.persistenceLogger.class%
+        arguments:
+            - %ezpublish.spi.persistence.cache.persistenceLogger.enableCallLogging%
 
     ezpublish.spi.persistence.cache.abstractHandler:
         class: %ezpublish.spi.persistence.cache.abstractHandler.class%

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/Profiler/layout.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/Profiler/layout.html.twig
@@ -41,19 +41,21 @@
         {% endif %}
     </table>
 
-    <h3>Uncached SPI calls</h3>
-    <table>
-        <tr>
-            <th>Class</th>
-            <th>Method</th>
-            <th>Arguments</th>
-        </tr>
-        {% for call in collector.calls %}
+    {% if collector.callsLoggingEnabled %}
+        <h3>Uncached SPI calls</h3>
+        <table>
             <tr>
-                <td>{{ call.class }}</td>
-                <td>{{ call.method }}</td>
-                <td>{{ call.arguments }}</td>
+                <th>Class</th>
+                <th>Method</th>
+                <th>Arguments</th>
             </tr>
-        {% endfor %}
-    </table>
+            {% for call in collector.calls %}
+                <tr>
+                    <td>{{ call.class }}</td>
+                    <td>{{ call.method }}</td>
+                    <td>{{ call.arguments }}</td>
+                </tr>
+            {% endfor %}
+        </table>
+    {% endif %}
 {% endblock %}

--- a/eZ/Publish/Core/Persistence/Cache/SearchHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/SearchHandler.php
@@ -24,7 +24,7 @@ class SearchHandler extends AbstractHandler implements SearchHandlerInterface
      */
     function findContent( Query $query, array $fieldFilters = array() )
     {
-        $this->logger->logCall( __METHOD__, array( 'query' => $query, 'fieldFilters' => $fieldFilters ) );
+        $this->logger->logCall( __METHOD__, array( 'query' => get_class( $query ), 'fieldFilters' => $fieldFilters ) );
         return $this->persistenceFactory->getSearchHandler()->findContent( $query, $fieldFilters );
     }
 
@@ -33,7 +33,7 @@ class SearchHandler extends AbstractHandler implements SearchHandlerInterface
      */
     public function findSingle( Criterion $criterion, array $fieldFilters = array() )
     {
-        $this->logger->logCall( __METHOD__, array( 'criterion' => $criterion, 'fieldFilters' => $fieldFilters ) );
+        $this->logger->logCall( __METHOD__, array( 'criterion' => get_class( $criterion ), 'fieldFilters' => $fieldFilters ) );
         return $this->persistenceFactory->getSearchHandler()->findSingle( $criterion, $fieldFilters );
     }
 
@@ -48,7 +48,7 @@ class SearchHandler extends AbstractHandler implements SearchHandlerInterface
                 'prefix' => $prefix,
                 'fieldPaths' => $fieldPaths,
                 'limit' => $limit,
-                'filter' => $filter
+                'filter' => ( $filter === null ? 'null' : get_class( $filter ) )
             )
         );
 


### PR DESCRIPTION
This has been reported by @gggeek / KeyTech, and as the issue spans across eZ Publish, StashBundle and Stash there are 3 parts:
- This PR
- https://github.com/tedivm/TedivmStashBundle/pull/23
- https://github.com/tedivm/Stash/issues/79

This PR handles the eZ Publish issues in the following way:
- Change unCachedHandler logging data structure to be more efficient
- Set a configurable $maxLogCalls to limit number of uncached SPI calls
- Change how Search calls are logged to not keep the argument objects in memory, just log class name

An optional follow up would be to configure prod to set $maxLogCalls to 0, but by default these measures should stop the memory use to increase forever already.
