### PR TITLE
Fix EZP-21064: Added module_result in a LegacyResponse call

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Controller/LegacyKernelController.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Controller/LegacyKernelController.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Bundle\EzPublishLegacyBundle\Controller;
 
-use Symfony\Component\HttpFoundation\Response;
+use eZ\Bundle\EzPublishLegacyBundle\LegacyResponse;
 use Symfony\Component\Templating\EngineInterface;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 
@@ -56,11 +56,11 @@ class LegacyKernelController
      * @param string $view The view name
      * @param array $parameters An array of parameters to pass to the view
      *
-     * @return Response A Response instance
+     * @return LegacyResponse A LegacyResponse instance
      */
     public function render( $view, array $parameters = array() )
     {
-        $response = new Response();
+        $response = new LegacyResponse();
         $response->setContent( $this->templateEngine->render( $view, $parameters ) );
         return $response;
     }
@@ -87,13 +87,15 @@ class LegacyKernelController
                 $this->legacyLayout,
                 array( 'module_result' => $moduleResult )
             );
+
+            $response->setModuleResult( $moduleResult );
         }
         else
         {
-            $response = new Response( $result->getContent() );
+            $response = new LegacyResponse( $result->getContent() );
         }
 
-        // Handling error codes sent from the legacy stack
+        // Handling error codes sent by the legacy stack
         if ( isset( $moduleResult['errorCode'] ) )
         {
             $response->setStatusCode(

--- a/eZ/Bundle/EzPublishLegacyBundle/LegacyResponse.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/LegacyResponse.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * File containing the LegacyResponse class.
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishLegacyBundle;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Class LegacyResponse
+ *
+ * An extend of the Symfony Response class with an extra module result attribute.
+ * It can be useful if you need to access module result information in an event listener.
+ *
+ */
+class LegacyResponse extends Response
+{
+    /**
+     * Module result sent by the legacy stack.
+     *
+     * @var array
+     */
+    protected $moduleResult = null;
+
+    /*
+     * Sets the module result in the response.
+     *
+     * @param array $moduleResult
+     */
+    public function setModuleResult( $moduleResult )
+    {
+        $this->moduleResult = $moduleResult;
+    }
+
+    /**
+     * Gets the module result if it exists.
+     *
+     * @return array result or null if it doesn't exist.
+     */
+    public function getModuleResult()
+    {
+        return $this->moduleResult;
+    }
+
+}


### PR DESCRIPTION
# Description

This PR creates a LegacyResponse object that extends the Symfony Response, adding an extra attribute : the module_result
It allows to have access to the module_result after the LegacyController's execution.
# Test

Manual tests.
