### PR TITLE
EZP-21069 : Wrong results for a search with field criterion

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Search/Gateway/CriterionHandler/Field.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Search/Gateway/CriterionHandler/Field.php
@@ -211,7 +211,11 @@ class Field extends CriterionHandler
                     $this->dbHandler->quoteColumn( 'contentclassattribute_id' ),
                     $fieldsInfo['ids']
                 ),
-                $filter
+                $filter,
+                $subSelect->expr->eq(
+                    $this->dbHandler->quoteColumn( 'version', 'ezcontentobject_attribute' ),
+                    $this->dbHandler->quoteColumn( 'current_version', 'ezcontentobject' )
+                )
             );
         }
 


### PR DESCRIPTION
Search Service : when using the field criterion the query checks object attributes for all versions, it should use only attributes of the current version

Isssue: https://jira.ez.no/browse/EZP-21069
