### PR TITLE
Fix EZP-21089: Creating an article with public api throw warning on xmltext in reagards to relations

### DIFF
--- a/eZ/Publish/Core/Repository/RelationProcessor.php
+++ b/eZ/Publish/Core/Repository/RelationProcessor.php
@@ -105,7 +105,7 @@ class RelationProcessor
                 {
                     $relations[$relationType][$fieldDefinitionId] = array();
                 }
-                $relations[$relationType][$fieldDefinitionId] += array_flip( array_filter($destinationIds) );
+                $relations[$relationType][$fieldDefinitionId] += array_flip( array_filter( $destinationIds ) );
             }
             // Using bitwise operators as Legacy Stack stores COMMON, LINK and EMBED relation types
             // in the same entry using bitmask


### PR DESCRIPTION
Warning: array_flip(): Can only flip STRING and INTEGER values! in /var/www/apache2php53/ezp5/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Repository/RelationProcessor.php on line 108

Issue: https://jira.ez.no/browse/EZP-21089
