### PR TITLE
EZP-11166: enable Create User with runCallBack on Legacy

### DIFF
--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -501,7 +501,6 @@ class UserService implements UserServiceInterface
                     )
                 )
             );
-            $publishedContent = $contentService->publishVersion( $contentDraft->getVersionInfo() );
 
             $this->repository->commit();
         }
@@ -510,6 +509,7 @@ class UserService implements UserServiceInterface
             $this->repository->rollback();
             throw $e;
         }
+        $publishedContent = $contentService->publishVersion( $contentDraft->getVersionInfo() );
 
         return $this->buildDomainUserObject( $spiUser, $publishedContent );
     }


### PR DESCRIPTION
eZ 5 and Legacy used 2 different DDB session.

Context : ContentService is replace by a custom one to call a runCallBack function to publish content with Legacy kernel.

Case: when creating a user, the CreateUser function (in UserService) is called. 
process : We create the draft in a "5" transaction but, in the same transaction, we call publishVersion() function that is the runCallBack on Legacy.
So, obviously, draft is not commited yet and is not available in the Legacy publishing.
With this modification, Legacy publishing can be well done.


