### PR TITLE
Fixed EZP-21094: POST /user/sessions misses the location header

### DIFF
--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/UserSession.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/UserSession.php
@@ -27,21 +27,22 @@ class UserSession extends ValueObjectVisitor
      */
     public function visit( Visitor $visitor, Generator $generator, $data )
     {
+        $visitor->setStatus( 201 );
+
         $visitor->setHeader( 'Content-Type', $generator->getMediaType( 'Session' ) );
+
+        $sessionHref = $this->urlHandler->generate( 'userSession', array( 'sessionId' => $data->sessionId ) );
+        $visitor->setHeader( 'Location', $sessionHref );
+
         // @deprecated Since 5.0, this cookie is used for legacy until Static cache support is removed along with this cookie
         $visitor->setHeader( 'Set-Cookie', 'is_logged_in=true; path=/' );
 
         //@todo Needs refactoring, disabling certain headers should not be done this way
         $visitor->setHeader( 'Accept-Patch', false );
 
-        $visitor->setStatus( 201 );
-
         $generator->startObjectElement( 'Session' );
 
-        $generator->startAttribute(
-            'href',
-            $this->urlHandler->generate( 'userSession', array( 'sessionId' => $data->sessionId ) )
-        );
+        $generator->startAttribute( 'href', $sessionHref );
         $generator->endAttribute( 'href' );
 
         $generator->startValueElement( 'name', $data->sessionName );

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserSessionTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserSessionTest.php
@@ -15,7 +15,7 @@ use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Server\Values;
 use eZ\Publish\Core\REST\Common;
 
-class SessionTest extends ValueObjectVisitorBaseTest
+class UserSessionTest extends ValueObjectVisitorBaseTest
 {
     /**
      * Test the Session visitor
@@ -36,9 +36,17 @@ class SessionTest extends ValueObjectVisitorBaseTest
             "csrfToken"
         );
 
-        $this->getVisitorMock()->expects( $this->once() )
+        $this->getVisitorMock()->expects( $this->at( 0 ) )
             ->method( 'setStatus' )
             ->with( $this->equalTo( 201 ) );
+
+        $this->getVisitorMock()->expects( $this->at( 1 ) )
+            ->method( 'setHeader' )
+            ->with( $this->equalTo( 'Content-Type' ), $this->equalTo( 'application/vnd.ez.api.Session+xml' ) );
+
+        $this->getVisitorMock()->expects( $this->at( 2 ) )
+            ->method( 'setHeader' )
+            ->with( $this->equalTo( 'Location' ), $this->matchesRegularExpression( '#/user/sessions/[a-z0-9]+#i' ) );
 
         $visitor->visit(
             $this->getVisitorMock(),


### PR DESCRIPTION
See http://jira.ez.no/browse/EZP-21094.

The title says it all. It fixes the test in `eZ/Publish/Core/REST/Server/Tests/Functional/User::createSession()`.
