### PR TITLE
Implemented EZP-21099: refactor REST FieldTypeProcessors to use service tags

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/DependencyInjection/Compiler/FieldTypeProcessorPass.php
+++ b/eZ/Bundle/EzPublishRestBundle/DependencyInjection/Compiler/FieldTypeProcessorPass.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * File containing the FieldTypeProcessorPass class.
+ *
+ * @copyright Copyright (C) 2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishRestBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class FieldTypeProcessorPass implements CompilerPassInterface
+{
+    public function process( ContainerBuilder $container )
+    {
+        if ( !$container->hasDefinition( 'ezpublish_rest.field_type_processor_registry' ) )
+        {
+            return;
+        }
+
+        $definition = $container->getDefinition( 'ezpublish_rest.field_type_processor_registry' );
+
+        foreach ( $container->findTaggedServiceIds( 'ezpublish_rest.field_type_processor' ) as $id => $attributes )
+        {
+            if ( !isset( $attributes[0]['alias'] ) )
+                throw new \LogicException( 'ezpublish_rest.field_type_processor service tag needs an "alias" attribute to identify the field type. None given.' );
+
+            $definition->addMethodCall(
+                'registerProcessor',
+                array( $attributes[0]["alias"], new Reference( $id ) )
+            );
+        }
+
+    }
+}

--- a/eZ/Bundle/EzPublishRestBundle/EzPublishRestBundle.php
+++ b/eZ/Bundle/EzPublishRestBundle/EzPublishRestBundle.php
@@ -3,7 +3,14 @@
 namespace eZ\Bundle\EzPublishRestBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use eZ\Bundle\EzPublishRestBundle\DependencyInjection\Compiler\FieldTypeProcessorPass;
 
 class EzPublishRestBundle extends Bundle
 {
+    public function build( ContainerBuilder $container )
+    {
+        parent::build( $container );
+        $container->addCompilerPass( new FieldTypeProcessorPass() );
+    }
 }

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
@@ -21,8 +21,19 @@ parameters:
     ezpublish_rest.field_type_parser.class: eZ\Publish\Core\REST\Common\Input\FieldTypeParser
     ezpublish_rest.listener.class: eZ\Bundle\EzPublishRestBundle\EventListener\RestListener
     ezpublish_rest.field_type_serializer.class: eZ\Publish\Core\REST\Common\Output\FieldTypeSerializer
-    ezpublish_rest.field_type_processor_registry.class: eZ\Publish\Core\REST\Common\FieldTypeProcessorRegistry
     ezpublish_rest.request.class: eZ\Publish\Core\REST\Server\Request
+
+    ezpublish_rest.field_type_processor_registry.class: eZ\Publish\Core\REST\Common\FieldTypeProcessorRegistry
+    ezpublish_rest.field_type_processor.ezimage.class: eZ\Publish\Core\REST\Common\FieldTypeProcessor\ImageProcessor
+    ezpublish_rest.field_type_processor.ezdatetime.class: eZ\Publish\Core\REST\Common\FieldTypeProcessor\DateAndTimeProcessor
+    ezpublish_rest.field_type_processor.ezdate.class: eZ\Publish\Core\REST\Common\FieldTypeProcessor\DateProcessor
+    ezpublish_rest.field_type_processor.ezmedia.class: eZ\Publish\Core\REST\Common\FieldTypeProcessor\MediaProcessor
+    ezpublish_rest.field_type_processor.ezobjectrelationlist.class: eZ\Publish\Core\REST\Common\FieldTypeProcessor\RelationListProcessor
+    ezpublish_rest.field_type_processor.ezobjectrelation.class: eZ\Publish\Core\REST\Common\FieldTypeProcessor\RelationProcessor
+    ezpublish_rest.field_type_processor.eztime.class: eZ\Publish\Core\REST\Common\FieldTypeProcessor\TimeProcessor
+    ezpublish_rest.field_type_processor.ezxmltext.class: eZ\Publish\Core\REST\Common\FieldTypeProcessor\XmlTextProcessor
+    ezpublish_rest.field_type_processor.ezbinaryfile.class: eZ\Publish\Core\REST\Common\FieldTypeProcessor\BinaryProcessor
+    ezpublish_rest.field_type_processor.ezpage.class: eZ\Publish\Core\REST\Common\FieldTypeProcessor\PageProcessor
 
 services:
     ezpublish_rest.field_type_serializer:
@@ -40,10 +51,6 @@ services:
     ezpublish_rest.parser_tools:
         class: %ezpublish_rest.parser_tools.class%
 
-    ezpublish_rest.field_type_processor_registry:
-        class: %ezpublish_rest.field_type_processor_registry.class%
-        factory_service: ezpublish_rest.factory
-        factory_method: buildFieldTypeProcessorRegistry
 
     ezpublish_rest.field_type_parser:
         class: %ezpublish_rest.field_type_parser.class%
@@ -174,3 +181,64 @@ services:
     ezpublish_rest.request:
         class: %ezpublish_rest.request.class%
 
+    ezpublish_rest.field_type_processor_registry:
+        class: %ezpublish_rest.field_type_processor_registry.class%
+
+    ezpublish_rest.field_type_processor.ezimage:
+        class: %ezpublish_rest.field_type_processor.ezimage.class%
+        factory_service: ezpublish_rest.factory
+        factory_method: getImageFieldTypeProcessor
+        arguments:
+            # @todo change to @router
+            - @ezpublish_rest.url_handler
+        tags:
+            - { name: ezpublish_rest.field_type_processor, alias: ezimage }
+
+    ezpublish_rest.field_type_processor.ezdatetime:
+        class: %ezpublish_rest.field_type_processor.ezdatetime.class%
+        tags:
+            - { name: ezpublish_rest.field_type_processor, alias: ezdatetime }
+
+    ezpublish_rest.field_type_processor.ezdate:
+        class: %ezpublish_rest.field_type_processor.ezdate.class%
+        tags:
+            - { name: ezpublish_rest.field_type_processor, alias: ezdate }
+
+    ezpublish_rest.field_type_processor.ezmedia:
+        class: %ezpublish_rest.field_type_processor.ezmedia.class%
+        tags:
+            - { name: ezpublish_rest.field_type_processor, alias: ezmedia }
+
+    ezpublish_rest.field_type_processor.ezobjectrelationlist:
+        class: %ezpublish_rest.field_type_processor.ezobjectrelationlist.class%
+        tags:
+            - { name: ezpublish_rest.field_type_processor, alias: ezobjectrelationlist }
+
+    ezpublish_rest.field_type_processor.ezobjectrelation:
+        class: %ezpublish_rest.field_type_processor.ezobjectrelation.class%
+        tags:
+            - { name: ezpublish_rest.field_type_processor, alias: ezobjectrelation }
+
+    ezpublish_rest.field_type_processor.eztime:
+        class: %ezpublish_rest.field_type_processor.eztime.class%
+        tags:
+            - { name: ezpublish_rest.field_type_processor, alias: eztime }
+
+    ezpublish_rest.field_type_processor.ezxmltext:
+        class: %ezpublish_rest.field_type_processor.ezxmltext.class%
+        tags:
+            - { name: ezpublish_rest.field_type_processor, alias: ezxmltext }
+
+    ezpublish_rest.field_type_processor.ezbinaryfile:
+        class: %ezpublish_rest.field_type_processor.ezbinaryfile.class%
+        factory_service: ezpublish_rest.factory
+        factory_method: getBinaryFileFieldTypeProcessor
+        arguments:
+            - @ezpublish.fieldtype.ezbinaryfile.ioservice
+        tags:
+            - { name: ezpublish_rest.field_type_processor, alias: ezbinaryfile }
+
+    ezpublish_rest.field_type_processor.ezpage:
+        class: %ezpublish_rest.field_type_processor.ezpage.class%
+        tags:
+            - { name: ezpublish_rest.field_type_processor, alias: ezpage }

--- a/eZ/Publish/Core/REST/Server/Request.php
+++ b/eZ/Publish/Core/REST/Server/Request.php
@@ -49,9 +49,6 @@ class Request extends RMFRequest
 
         $this->addHandler( 'destination', new PropertyHandler\Server( 'HTTP_DESTINATION' ) );
 
-        // @todo: ATTENTION, only used for test setup
-        $this->addHandler( 'testUser', new PropertyHandler\Server( 'HTTP_X_TEST_USER' ) );
-
         parent::__construct( $handlers );
     }
 }


### PR DESCRIPTION
See https://jira.ez.no/browse/EZP-21101 (subtask of https://jira.ez.no/browse/EZP-20829).

This PR implements field type processors (process input & output custom field type data) to be instanciated using service tags instead of a hardcoded factory.

Note: this most like totally breaks the REST client tests. @pspanja ? :-)
