### PR TITLE
Fix EZP-21115: remove IOService from ezimage field type

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtypes.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtypes.yml
@@ -392,7 +392,6 @@ services:
     ezpublish.fieldType.ezimage:
         class: %ezpublish.fieldType.ezimage.class%
         parent: ezpublish.fieldType
-        arguments: [ @ezpublish.fieldType.ezimage.IOService ]
         tags:
             - {name: ezpublish.fieldType, alias: ezimage}
 

--- a/eZ/Publish/Core/FieldType/Image/Type.php
+++ b/eZ/Publish/Core/FieldType/Image/Type.php
@@ -10,7 +10,6 @@
 namespace eZ\Publish\Core\FieldType\Image;
 
 use eZ\Publish\Core\FieldType\FieldType;
-use eZ\Publish\Core\IO\IOService;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\Core\FieldType\ValidationError;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
@@ -32,19 +31,6 @@ class Type extends FieldType
             )
         )
     );
-
-    /** @var IOService */
-    protected $IOService;
-
-    /**
-     * Creates a new Image FieldType
-     *
-     * @param IOService $IOService
-     */
-    public function __construct( IOService $IOService )
-    {
-        $this->IOService = $IOService;
-    }
 
     /**
      * Returns the field type identifier for this field type
@@ -156,22 +142,6 @@ class Type extends FieldType
     public function isEmptyValue( $value )
     {
         return $value === null || $value->fileName === null;
-    }
-
-    /**
-     * Returns if the given $path exists on the local disc or in the file
-     * storage
-     *
-     * @param string $path
-     *
-     * @return boolean
-     */
-    protected function fileExists( $path )
-    {
-        return (
-            ( substr( $path, 0, 1 ) === '/' && file_exists( $path ) )
-            || $this->IOService->loadBinaryFile( $path ) !== false
-        );
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/Tests/ImageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageTest.php
@@ -19,36 +19,9 @@ use ReflectionObject;
  */
 class ImageTest extends FieldTypeTest
 {
-    /**
-     * FileService mock
-     *
-     * @var \PHPUnit_Framework_Mock
-     */
-    private $IOServiceMock;
-
     public function getImageInputPath()
     {
         return __DIR__ . '/squirrel-developers.jpg';
-    }
-
-    /**
-     * Returns a mock for the FileService
-     *
-     * @return \eZ\Publish\Core\FieldType\FileService
-     */
-    protected function getIOServiceMock()
-    {
-        if ( !isset( $this->IOServiceMock) )
-        {
-            $this->IOServiceMock = $this->getMock(
-                'eZ\\Publish\\Core\\IO\\IOService',
-                array(),
-                array(),
-                '',
-                false
-            );
-        }
-        return $this->IOServiceMock;
     }
 
     /**
@@ -82,9 +55,7 @@ class ImageTest extends FieldTypeTest
      */
     protected function createFieldTypeUnderTest()
     {
-        return new ImageType(
-            $this->getIOServiceMock()
-        );
+        return new ImageType();
     }
 
     /**

--- a/eZ/Publish/Core/settings/service.ini
+++ b/eZ/Publish/Core/settings/service.ini
@@ -528,7 +528,6 @@ class=eZ\Publish\Core\FieldType\Float\Type
 
 [ezimage:field_type]
 class=eZ\Publish\Core\FieldType\Image\Type
-arguments[ioService]=@ezimage:io_service
 
 [ezpage:field_type]
 class=eZ\Publish\Core\FieldType\Page\Type


### PR DESCRIPTION
This PR resolves issue https://jira.ez.no/browse/EZP-21115

IOService was injected, but not used in `ezimage` field type since it was moved to external storage.
This removes unused dependecy.
