### PR TITLE
Fix wrong secret code generated after #412

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
@@ -17,6 +17,7 @@ parameters:
     ezpublish_legacy.kernel_handler.cli.options: {}
 
     # See ezpublish_legacy.webconfigurator
+    ezpublish_legacy.webconfigurator.factory.class: eZ\Bundle\EzPublishLegacyBundle\SetupWizard\ConfiguratorFactory
     ezpublish_legacy.webconfigurator.class: Sensio\Bundle\DistributionBundle\Configurator\Configurator
 
     ezpublish_legacy.router.class: eZ\Bundle\EzPublishLegacyBundle\Routing\FallbackRouter
@@ -176,10 +177,16 @@ services:
             - @ezpublish_legacy.webconfigurator
 
     # eZ alias for sensio.distribution.webconfigurator to make it available despite Bundle being disabled in prod env
+    # uses factory to make sure steps are injected only when service is needed
     ezpublish_legacy.webconfigurator:
         class: %ezpublish_legacy.webconfigurator.class%
+        factory_service: ezpublish_legacy.webconfigurator.factory
+        factory_method: buildWebConfigurator
         arguments:
             - %kernel.root_dir%
+
+    ezpublish_legacy.webconfigurator.factory:
+        class: %ezpublish_legacy.webconfigurator.factory.class%
 
     # Image alias generator using legacy
     ezpublish_legacy.fieldType.ezimage.variation_service:

--- a/eZ/Bundle/EzPublishLegacyBundle/SetupWizard/ConfiguratorFactory.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/SetupWizard/ConfiguratorFactory.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * File containing the ConfiguratorFactory class.
+ *
+ * @copyright Copyright (C) 2012 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishLegacyBundle\SetupWizard;
+
+use Sensio\Bundle\DistributionBundle\Configurator\Configurator;
+use Sensio\Bundle\DistributionBundle\Configurator\Step\DoctrineStep;
+use Sensio\Bundle\DistributionBundle\Configurator\Step\SecretStep;
+
+/**
+ * Factory for DistributionBundle\Configurator\Configurator with 'secret' step
+ */
+class ConfiguratorFactory
+{
+    /**
+     * Factory for DistributionBundle\Configurator\Configurator with 'secret' step
+     *
+     * This is kept similar to SensioDistributionBundle::boot() for compatibility
+     *
+     * @param string $kernelDir
+     *
+     * @return \Sensio\Bundle\DistributionBundle\Configurator\Configurator
+     */
+    public function buildWebConfigurator( $kernelDir )
+    {
+        $configurator = new Configurator( $kernelDir );
+        $configurator->addStep( new DoctrineStep( $configurator->getParameters() ) );
+        $configurator->addStep( new SecretStep( $configurator->getParameters() ) );
+        return $configurator;
+    }
+}


### PR DESCRIPTION
#412  was missing injection of steps, this change introduces a factory that does the same thing SensioDistributionBundle does at boot time to fix it.

This should fix issue described by @pspanja in https://github.com/ezsystems/ezpublish-community/pull/34
