### PR TITLE
Fix EZP-21188: "Notice: Undefined variable: response" triggered when vie...

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
@@ -90,11 +90,10 @@ class ViewController extends Controller
     public function viewLocation( $locationId, $viewType, $layout = false, array $params = array() )
     {
         $this->performAccessChecks();
+        $response = $this->buildResponse();
 
         try
         {
-            $response = $this->buildResponse();
-
             $response->headers->set( 'X-Location-Id', $locationId );
             $response->setContent(
                 $this->renderLocation(
@@ -130,17 +129,11 @@ class ViewController extends Controller
     public function viewContent( $contentId, $viewType, $layout = false, array $params = array() )
     {
         $this->performAccessChecks();
+        $response = $this->buildResponse();
 
         try
         {
             $content = $this->getRepository()->getContentService()->loadContent( $contentId );
-
-            // @todo: Use a dedicated etag generator, generating a hash
-            // instead of plain text
-            $response = $this->buildResponse(
-                "ezpublish-content-$contentId-$viewType-$layout",
-                $content->contentInfo->modificationDate
-            );
 
             if ( $response->isNotModified( $this->getRequest() ) )
             {


### PR DESCRIPTION
...wing a content with ezobjectrelationlist.

Moved build of the response out of the try block in viewLocation() and viewContent(), to ensure $response is always correctly generated.
Furthermore got rid of Etag / LastModified response headers when viewing a content since it's useless / error prone because of client cache (aligned on cache of viewLocation).
