### PR TITLE
EZP-21206 - Disable key normalization for ezpublish.system's children

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
@@ -155,6 +155,7 @@ class Configuration implements ConfigurationInterface
                     )
                     ->useAttributeAsKey( 'key' )
                     ->requiresAtLeastOneElement()
+                    ->normalizeKeys( false )
                     ->prototype( 'array' )
                         ->children();
 


### PR DESCRIPTION
This PR fixes an issue with siteaccess matching, where siteaccesses with dashes, i.e `por-PT` appear to match correctly, but its prioritized language list is ignored, and falls-back to the default configurations.

Further details available here:
**JIRA**: https://jira.ez.no/browse/EZP-21206
