### PR TITLE
Fix EZP-21176: Prevent REST hrefs without prefixes in payloads

### DIFF
--- a/doc/bc/changes-5.2.md
+++ b/doc/bc/changes-5.2.md
@@ -13,7 +13,8 @@ Changes affecting version compatibility with former or future versions.
 
 ## Deprecations
 
-
+* It was incidentally possible to reference resources in REST API payloads without
+  the REST prefix. This is no longer possible, and will throw an exception, as expected.
 
 ## Removals
 

--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -106,6 +106,14 @@ Starting from the root resources (ListRoot_) every response includes further lin
 The uris should be used directly as identifiers on the client side and the client should not
 contruct an uri by using an id.
 
+URIs prefix
+-----------
+
+In  this document, we condider, for the sake of readability, that no prefix is used in the URIs. In a real life
+situation, the prefix /api/ezp/v2 is used in all REST hrefs.
+
+Remember in any case that URIs to REST resources should never be generated manually, but obtained from earlier REST
+ calls.
 
 Authentication
 ==============

--- a/eZ/Bundle/EzPublishRestBundle/RequestParser/Router.php
+++ b/eZ/Bundle/EzPublishRestBundle/RequestParser/Router.php
@@ -21,7 +21,7 @@ use eZ\Publish\Core\REST\Common\Exceptions\InvalidArgumentException;
 class Router implements RequestParser
 {
     /**
-     * @var \Symfony\Component\Routing\RouterInterface
+     * @var \Symfony\Cmf\Component\Routing\ChainRouter
      */
     private $router;
 
@@ -42,13 +42,7 @@ class Router implements RequestParser
      */
     public function parse( $url )
     {
-        if ( strpos( $url, $this->restRoutesPrefix ) !== 0 )
-        {
-            // @todo mark as deprecated (see EZP-21176)
-            $url = $this->restRoutesPrefix . $url;
-        }
-
-        // we create a request with a new context in order to match $url to a route and get its a properties
+        // we create a request with a new context in order to match $url to a route and get its properties
         $request = Request::create( $url, "GET" );
         $originalContext = $this->router->getContext();
         $context = clone $originalContext;

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ContentTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ContentTest.php
@@ -25,19 +25,19 @@ class ContentTest extends RESTFunctionalTestCase
         $body = <<< XML
 <?xml version="1.0" encoding="UTF-8"?>
 <ContentCreate>
-  <ContentType href="/content/types/1" />
+  <ContentType href="/api/ezp/v2/content/types/1" />
   <mainLanguageCode>eng-GB</mainLanguageCode>
   <LocationCreate>
-    <ParentLocation href="/content/locations/1/2" />
+    <ParentLocation href="/api/ezp/v2/content/locations/1/2" />
     <priority>0</priority>
     <hidden>false</hidden>
     <sortField>PATH</sortField>
     <sortOrder>ASC</sortOrder>
   </LocationCreate>
-  <Section href="/content/sections/1" />
+  <Section href="/api/ezp/v2/content/sections/1" />
   <alwaysAvailable>true</alwaysAvailable>
   <remoteId>{$string}</remoteId>
-  <User href="/user/users/14" />
+  <User href="/api/ezp/v2/user/users/14" />
   <modificationDate>2012-09-30T12:30:00</modificationDate>
   <fields>
     <field>
@@ -111,7 +111,7 @@ XML;
         $content = <<< XML
 <?xml version="1.0" encoding="UTF-8"?>
 <ContentUpdate>
-  <Owner href="/user/users/10"/>
+  <Owner href="/api/ezp/v2/user/users/10"/>
   <remoteId>{$string}</remoteId>
 </ContentUpdate>
 XML;
@@ -320,7 +320,7 @@ XML;
         $content = <<< XML
 <?xml version="1.0" encoding="UTF-8"?>
 <RelationCreate>
-  <Destination href="/content/objects/10"/>
+  <Destination href="/api/ezp/v2/content/objects/10"/>
 </RelationCreate>
 XML;
 

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ContentTypeTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ContentTypeTest.php
@@ -508,7 +508,7 @@ XML;
     public function testLinkContentTypeToGroup( $contentTypeHref )
     {
         // @todo Spec example is invalid, missing parameter name
-        $request = $this->createHttpRequest( "POST", "$contentTypeHref/groups?group=/content/typegroups/1" );
+        $request = $this->createHttpRequest( "POST", "$contentTypeHref/groups?group=/api/ezp/v2/content/typegroups/1" );
         $response = $this->sendHttpRequest( $request );
         self::assertHttpResponseCodeEquals( $response, 200 );
 

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/LocationTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/LocationTest.php
@@ -20,7 +20,7 @@ class LocationTest extends RESTFunctionalTestCase
      */
     public function testCreateLocation()
     {
-        $content = $this->createFolder( 'testCreateLocation', '/content/locations/1/2' );
+        $content = $this->createFolder( 'testCreateLocation', '/api/ezp/v2/content/locations/1/2' );
         $contentHref = $content['_href'];
 
         $remoteId = $this->addTestSuffix( "testCreatelocation" );
@@ -28,7 +28,7 @@ class LocationTest extends RESTFunctionalTestCase
         $body = <<< XML
 <?xml version="1.0" encoding="UTF-8"?>
 <LocationCreate>
-  <ParentLocation href="/content/locations/1/43" />
+  <ParentLocation href="/api/ezp/v2/content/locations/1/43" />
   <remoteId>{$remoteId}</remoteId>
   <priority>0</priority>
   <hidden>false</hidden>
@@ -97,7 +97,7 @@ XML;
     public function testCopySubtree( $locationHref )
     {
         $request = $this->createHttpRequest( 'COPY', $locationHref );
-        $request->addHeader( 'Destination: /content/locations/1/43' );
+        $request->addHeader( 'Destination: /api/ezp/v2/content/locations/1/43' );
         $response = $this->sendHttpRequest( $request );
 
         self::assertHttpResponseCodeEquals( $response, 201 );
@@ -113,7 +113,7 @@ XML;
     public function testMoveSubtree( $locationHref )
     {
         $request = $this->createHttpRequest( 'MOVE', $locationHref );
-        $request->addHeader( 'Destination: /content/locations/1/5' );
+        $request->addHeader( 'Destination: /api/ezp/v2/content/locations/1/5' );
         $response = $this->sendHttpRequest( $request );
 
         self::assertHttpResponseCodeEquals( $response, 201 );
@@ -137,7 +137,7 @@ XML;
     {
         self::markTestSkipped( "@todo Implement" );
 
-        /*$content = $this->createFolder( __FUNCTION__, "/content/locations/1/2" );
+        /*$content = $this->createFolder( __FUNCTION__, "/api/ezp/v2/content/locations/1/2" );
 
         $request = $this->createHttpRequest( 'SWAP', $locationHref );
         $request->addHeader( "Destination: $newFolderHref" );

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ObjectStateTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ObjectStateTest.php
@@ -149,13 +149,12 @@ XML;
      */
     public function testSetObjectStatesForContent( $objectStateHref )
     {
-        $objectStateId = $this->hrefToId( $objectStateHref );
-        $folder = $this->createFolder( __FUNCTION__, '/content/locations/1/2' );
+        $folder = $this->createFolder( __FUNCTION__, '/api/ezp/v2/content/locations/1/2' );
 
         $xml = <<< XML
 <?xml version="1.0" encoding="UTF-8"?>
 <ContentObjectStates>
- <ObjectState href="{$objectStateId}"/>
+ <ObjectState href="$objectStateHref"/>
 </ContentObjectStates>
 XML;
 

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RoleTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RoleTest.php
@@ -104,8 +104,6 @@ XML;
     public function testAddPolicy( $roleHref )
     {
         // @todo Error in Resource URL in spec @ https://github.com/ezsystems/ezpublish-kernel/blob/master/doc/specifications/rest/REST-API-V2.rst#151213create-policy
-        $roleId = $this->hrefToId( $roleHref );
-
         $xml = <<< XML
 <?xml version="1.0" encoding="UTF-8"?>
 <PolicyCreate>
@@ -170,7 +168,7 @@ XML;
   <limitations>
     <limitation identifier="Class">
       <values>
-        <ref href="16"/>
+        <ref href="1"/>
       </values>
     </limitation>
   </limitations>
@@ -192,14 +190,13 @@ XML;
      */
     public function testAssignRoleToUser( $roleHref )
     {
-        $roleId = $this->hrefToId( $roleHref );
         $xml = <<< XML
 <?xml version="1.0" encoding="UTF-8"?>
 <RoleAssignInput>
-  <Role href="{$roleId}" media-type="application/vnd.ez.api.RoleAssignInput+xml"/>
+  <Role href="{$roleHref}" media-type="application/vnd.ez.api.RoleAssignInput+xml"/>
   <limitation identifier="Section">
       <values>
-          <ref href="/content/sections/1" media-type="application/vnd.ez.api.Section+xml" />
+          <ref href="/api/ezp/v2/content/sections/1" media-type="application/vnd.ez.api.Section+xml" />
       </values>
   </limitation>
 </RoleAssignInput>
@@ -254,14 +251,13 @@ XML;
      */
     public function testAssignRoleToUserGroup( $roleHref )
     {
-        $roleId = $this->hrefToId( $roleHref );
         $xml = <<< XML
 <?xml version="1.0" encoding="UTF-8"?>
 <RoleAssignInput>
-  <Role href="{$roleId}" media-type="application/vnd.ez.api.RoleAssignInput+xml"/>
+  <Role href="{$roleHref}" media-type="application/vnd.ez.api.RoleAssignInput+xml"/>
   <limitation identifier="Section">
       <values>
-          <ref href="/content/sections/1" media-type="application/vnd.ez.api.Section+xml" />
+          <ref href="/api/ezp/v2/content/sections/1" media-type="application/vnd.ez.api.Section+xml" />
       </values>
   </limitation>
 </RoleAssignInput>

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/TestCase.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/TestCase.php
@@ -145,7 +145,7 @@ class TestCase extends PHPUnit_Framework_TestCase
         $xml = <<< XML
 <?xml version="1.0" encoding="UTF-8"?>
 <ContentCreate>
-  <ContentType href="/content/types/1" />
+  <ContentType href="/api/ezp/v2/content/types/1" />
   <mainLanguageCode>eng-GB</mainLanguageCode>
   <LocationCreate>
     <ParentLocation href="{$parentLocationId}" />
@@ -154,10 +154,10 @@ class TestCase extends PHPUnit_Framework_TestCase
     <sortField>PATH</sortField>
     <sortOrder>ASC</sortOrder>
   </LocationCreate>
-  <Section href="/content/sections/1" />
+  <Section href="/api/ezp/v2/content/sections/1" />
   <alwaysAvailable>true</alwaysAvailable>
   <remoteId>{$string}</remoteId>
-  <User href="/user/users/14" />
+  <User href="/api/ezp/v2/user/users/14" />
   <modificationDate>2012-09-30T12:30:00</modificationDate>
   <fields>
     <field>
@@ -216,16 +216,6 @@ XML;
         $folderLocations = json_decode( $response->getContent(), true );
 
         return $folderLocations;
-    }
-
-    /**
-     * Converts a REST href to an ID
-     * @param string $href
-     * @return string
-     */
-    protected function hrefToId( $href )
-    {
-        return str_replace( '/api/ezp/v2', '', $href );
     }
 
     protected function addTestSuffix( $string )

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/TrashTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/TrashTest.php
@@ -84,7 +84,7 @@ class TrashTest extends RESTFunctionalTestCase
         $trashItemHref = $this->createTrashItem( __FUNCTION__ );
 
         $request = $this->createHttpRequest( "MOVE", $trashItemHref );
-        $request->addHeader( 'Destination: /content/locations/1/2' );
+        $request->addHeader( 'Destination: /api/ezp/v2/content/locations/1/2' );
 
         $response = $this->sendHttpRequest( $request );
 
@@ -112,7 +112,7 @@ class TrashTest extends RESTFunctionalTestCase
         self::markTestSkipped( "Makes the DB inconsistent" );
 
         // create a folder
-        $folderArray = $this->createFolder( __FUNCTION__, '/content/locations/1/2' );
+        $folderArray = $this->createFolder( __FUNCTION__, '/api/ezp/v2/content/locations/1/2' );
 
         // send its main location to trash
         $folderLocations = $this->getContentLocations( $folderArray['_href'] );
@@ -132,7 +132,7 @@ class TrashTest extends RESTFunctionalTestCase
      */
     private function createTrashItem( $id )
     {
-        $folder = $this->createFolder( $id, '/content/locations/1/2' );
+        $folder = $this->createFolder( $id, '/api/ezp/v2/content/locations/1/2' );
         $folderLocations = $this->getContentLocations( $folder['_href'] );
         return $this->sendLocationToTrash( $folderLocations['LocationList']['Location'][0]['_href'] );
     }
@@ -145,7 +145,7 @@ class TrashTest extends RESTFunctionalTestCase
     private function sendLocationToTrash( $contentHref )
     {
         $trashRequest = $this->createHttpRequest( "MOVE", $contentHref );
-        $trashRequest->addHeader( 'Destination: /content/trash' );
+        $trashRequest->addHeader( 'Destination: /api/ezp/v2/content/trash' );
 
         $response = $this->sendHttpRequest( $trashRequest );
 

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/UrlAliasTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/UrlAliasTest.php
@@ -19,7 +19,7 @@ class UrlAliasTest extends RESTFunctionalTestCase
      */
     public function testCreateFolder()
     {
-        $folderArray = $this->createFolder( __METHOD__, '/content/locations/1/2' );
+        $folderArray = $this->createFolder( __METHOD__, '/api/ezp/v2/content/locations/1/2' );
         $folderLocations = $this->getContentLocations( $folderArray['_href'] );
         return $folderLocations['LocationList']['Location'][0]['_href'];
     }
@@ -43,8 +43,6 @@ class UrlAliasTest extends RESTFunctionalTestCase
      */
     public function testCreateUrlAlias( $locationHref )
     {
-        $locationId = $this->hrefToId( $locationHref );
-
         $text = $this->addTestSuffix( __FUNCTION__ );
         $xml = <<< XML
 <?xml version="1.0" encoding="UTF-8"?>

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/UserTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/UserTest.php
@@ -349,7 +349,7 @@ XML;
     public function testMoveUserGroup( $groupHref )
     {
         $request = $this->createHttpRequest( "MOVE", $groupHref );
-        $request->addHeader( 'Destination: /user/groups/1/5/12' );
+        $request->addHeader( 'Destination: /api/ezp/v2/user/groups/1/5/12' );
 
         $response = $this->sendHttpRequest( $request );
         self::assertHttpResponseCodeEquals( $response, 201 );

--- a/eZ/Bundle/EzPublishRestBundle/Tests/RequestParser/RouterTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/RequestParser/RouterTest.php
@@ -68,8 +68,15 @@ class RouterTest extends PHPUnit_Framework_TestCase
      */
     public function testParseNoPrefix()
     {
-        self::markTestSkipped( "Requires that EZP-21176 is fixed" );
-        $this->getRequestParser()->parse( '/no/prefix' );
+        $uri = '/no/prefix';
+
+        $this->getRouterMock()
+            ->expects( $this->once() )
+            ->method( 'matchRequest' )
+            ->with( $this->attributeEqualTo( 'pathInfo', $uri ) )
+            ->will( $this->throwException( new ResourceNotFoundException ) );
+
+        $this->getRequestParser()->parse( $uri );
     }
 
     public function testParseHref()


### PR DESCRIPTION
For some reason, we had ended up accepting hrefs without the prefix in payloads.

This "feature" (that wasn't meant to be) has been removed, and all tests updated.
