### PR TITLE
Fix EZP-21238: Error when an image alias isn't found

### DIFF
--- a/eZ/Publish/Core/REST/Server/Controller/BinaryContent.php
+++ b/eZ/Publish/Core/REST/Server/Controller/BinaryContent.php
@@ -18,6 +18,7 @@ use eZ\Publish\Core\REST\Server\Controller as RestController;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\SPI\Variation\VariationHandler;
+use eZ\Publish\API\Repository\Exceptions\InvalidVariationException;
 
 /**
  * Binary content controller
@@ -81,7 +82,7 @@ class BinaryContent extends RestController
         }
         catch ( InvalidVariationException $e )
         {
-            throw new Exceptions\NotFoundException( "Invalid image variation $variationIdentifier", 0, $e );
+            throw new Exceptions\NotFoundException( "Invalid image variation $variationIdentifier" );
         }
     }
 


### PR DESCRIPTION
http://jira.ez.no/browse/EZP-21238

The catch block was incorrect (missing use statement), and for some reason, the extra arguments when throwing the exception were causing this error.
