### PR TITLE
Fixed EZP-21219: versionread policy not checked in ContentService::loadContent

### DIFF
--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -320,6 +320,12 @@ class ContentService implements ContentServiceInterface
         if ( !$this->repository->canUser( 'content', 'read', $content ) )
             throw new UnauthorizedException( 'content', 'read' );
 
+        if (
+            $versionNo !== null
+            && !$this->repository->canUser( 'content', 'versionread', $content )
+        )
+            throw new UnauthorizedException( 'content', 'versionread' );
+
         return $content;
     }
 
@@ -417,6 +423,12 @@ class ContentService implements ContentServiceInterface
 
         if ( !$this->repository->canUser( 'content', 'read', $content ) )
             throw new UnauthorizedException( 'content', 'read' );
+
+        if (
+            $versionNo !== null
+            && !$this->repository->canUser( 'content', 'versionread', $content )
+        )
+            throw new UnauthorizedException( 'content', 'versionread' );
 
         return $content;
     }

--- a/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentBase.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentBase.php
@@ -466,6 +466,24 @@ abstract class ContentBase extends BaseServiceTest
      * Test for the loadContent() method.
      *
      * @covers \eZ\Publish\Core\Repository\ContentService::loadContent
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testLoadContentWithVersionThrowsUnauthorizedException()
+    {
+        list( $draft, ) = $this->createTestContent();
+        $this->repository->setCurrentUser( $this->getStubbedUser( 10 ) );
+
+        $this->repository->getContentService()->loadContent(
+            $draft->id,
+            null,
+            $draft->versionInfo->versionNo
+        );
+    }
+
+    /**
+     * Test for the loadContent() method.
+     *
+     * @covers \eZ\Publish\Core\Repository\ContentService::loadContent
      * @expectedException \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     public function testLoadContentThrowsNotFoundExceptionContentNotFound()
@@ -597,6 +615,27 @@ abstract class ContentBase extends BaseServiceTest
         $this->repository->setCurrentUser( $this->getStubbedUser( 10 ) );
 
         $this->repository->getContentService()->loadContentByRemoteId( "f5c88a2209584891056f987fd965b0ba" );
+    }
+
+    /**
+     * Test for the loadContentByRemoteId() method.
+     *
+     * @covers \eZ\Publish\Core\Repository\ContentService::loadContentByRemoteId
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testLoadContentByRemoteIdWithVersionThrowsUnauthorizedException()
+    {
+        $contentService = $this->repository->getContentService();
+
+        $content = $contentService->loadContent( 4 );
+        $draft = $contentService->createContentDraft( $content->contentInfo );
+        $this->repository->setCurrentUser( $this->getStubbedUser( 10 ) );
+
+        $contentService->loadContentByRemoteId(
+            $draft->contentInfo->remoteId,
+            null,
+            $draft->versionInfo->versionNo
+        );
     }
 
     /**


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-21219
# Description

`ContentService::loadContent` allows to read any version of a content provided the user can read this content. The same issue exists in `ContentService::loadContentByRemoteId`.

This patch adds a check on content/versionread policy when a specific version is requested.
# Tests

manual tests + relevant unit test (waiting for travis to run the whole test suite)
