### PR TITLE
Fix EZP-21281: Warning: Could not generate user hash ! Fallback to anonymous hash

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Kernel.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Kernel.php
@@ -89,7 +89,9 @@ abstract class Kernel extends BaseKernel
      */
     protected function canGenerateUserHash( Request $request )
     {
-        return in_array( $request->getClientIp(), array( '127.0.0.1', '::1', 'fe80::1' ) );
+        return
+            $request->attributes->get( 'internalRequest' )
+            || in_array( $request->getClientIp(), array( '127.0.0.1', '::1', 'fe80::1' ) );
     }
 
     /**
@@ -121,6 +123,7 @@ abstract class Kernel extends BaseKernel
             $forwardReq = clone $request;
             $forwardReq->headers->set( 'X-HTTP-Override', 'AUTHENTICATE' );
             $forwardReq->headers->set( 'Accept', static::USER_HASH_ACCEPT_HEADER );
+            $forwardReq->attributes->set( 'internalRequest', true );
             $this->generatingUserHash = true;
             $resp = $this->handle( $forwardReq );
             if ( !$resp->headers->has( 'X-User-Hash' ) )


### PR DESCRIPTION
User hash generation was possible only if client IP was local (yeah I know, it looks stupid :sweat:, but makes sens when using a real reverse proxy like Varnish).

This patch adds a new check on a specific request attribute `internalRequest` which is added before forwarding the generation request to the kernel.
