### PR TITLE
Fix EZP-21227: copy content type generates wrong identifier

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
@@ -409,7 +409,9 @@ class Handler implements BaseContentTypeHandler
         $createStruct->modifierId = $userId;
         $createStruct->created = $createStruct->modified = time();
         $createStruct->creatorId = $userId;
-        $createStruct->identifier .= '_' . ( $createStruct->remoteId = md5( uniqid( get_class( $createStruct ), true ) ) );
+        $createStruct->remoteId = md5( uniqid( get_class( $createStruct ), true ) );
+        $createStruct->identifier = 'copy_of_' . $createStruct->identifier . '_' . $createStruct->remoteId;
+
         // Set FieldDefinition ids to null to trigger creating new id
         foreach ( $createStruct->fieldDefinitions as $fieldDefinition )
         {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
@@ -796,7 +796,7 @@ class ContentTypeHandlerTest extends PHPUnit_Framework_TestCase
                     'eZ\\Publish\\SPI\\Persistence\\Content\\Type'
                 )
             )->will(
-                $this->returnValue( new CreateStruct() )
+                $this->returnValue( new CreateStruct( array( 'identifier' => 'testCopy' ) ) )
             );
 
         $handlerMock = $this->getMock(
@@ -834,6 +834,10 @@ class ContentTypeHandlerTest extends PHPUnit_Framework_TestCase
                             time()
                         ),
                         'created'
+                    ),
+                    $this->attribute(
+                        $this->matchesRegularExpression( "/^copy_of_testCopy_([a-z0-9]+)$/" ),
+                        'identifier'
                     )
                 )
             )->will(

--- a/eZ/Publish/SPI/Persistence/Content/Type/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/Handler.php
@@ -147,7 +147,7 @@ interface Handler
      * Copy a Type incl fields and group-relations from a given status to a new Type with status {@link Type::STATUS_DRAFT}
      *
      * New Content Type will have $userId as creator / modifier, created / modified should be updated, new remoteId created
-     * and identifier should be appended with '_' + the new remoteId or another unique number.
+     * and identifier should be 'copy_of_<identifier>_' + the new remoteId or another unique number.
      *
      * @param mixed $userId
      * @param mixed $contentTypeId


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-21227

Quite easy. My main concern is that the error may very well in the REST specs, since the involved code is part of the Legacy ContentType handler.

Note: no tests updates, waiting for Travis to list the errors.
