### PR TITLE
Fixed EZP-21300: rest 404 catch all description

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RootTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RootTest.php
@@ -34,7 +34,9 @@ class RootTest extends RESTFunctionalTestCase
             $this->createHttpRequest( "GET", "/api/ezp/v2/" . uniqid( 'rest' ), '', 'Stuff+json' )
         );
         self::assertHttpResponseCodeEquals( $response, 404 );
-        self::assertArrayHasKey( 'ErrorMessage', json_decode( $response->getContent(), true ) );
+        $responseArray = json_decode( $response->getContent(), true );
+        self::assertArrayHasKey( 'ErrorMessage', $responseArray );
+        self::assertEquals( "No such route", $responseArray['ErrorMessage']['errorDescription'] );
     }
 
     public function getRandomUriSet()

--- a/eZ/Publish/Core/REST/Server/Controller/Root.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Root.php
@@ -35,6 +35,6 @@ class Root extends RestController
      */
     public function catchAll()
     {
-        throw new NotFoundException;
+        throw new NotFoundException( "No such route" );
     }
 }


### PR DESCRIPTION
http://jira.issues.ez.no/browse/EZP-21300

Not much to say. Uses "Route not found" as a message. The route + method aren't printed for security reasons.
