### PR TITLE
EZP-21244: Let custom eZXML pre-converters register to base HTML5 converter

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/XmlTextConverterPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/XmlTextConverterPass.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * File containing the XmlTextConverterPass class.
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Compiler pass adding pre-converters to HTML5 converter.
+ * Useful for manipulating internal XML before XSLT rendering.
+ */
+class XmlTextConverterPass implements CompilerPassInterface
+{
+    public function process( ContainerBuilder $container )
+    {
+        if ( !$container->hasDefinition( 'ezpublish.fieldType.ezxmltext.converter.html5' ) )
+        {
+            return;
+        }
+
+        $html5ConverterDef = $container->getDefinition( 'ezpublish.fieldType.ezxmltext.converter.html5' );
+        foreach ( $container->findTaggedServiceIds( 'ezpublish.ezxml.converter' ) as $id => $attributes )
+        {
+            $html5ConverterDef->addMethodCall( 'addPreConverter', array( new Reference( $id ) ) );
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
@@ -21,6 +21,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\ContentViewPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\LocationViewPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\BlockViewPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\SignalSlotPass;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\XmlTextConverterPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser as ConfigParser;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\Factory as EzPublishSecurityFactory;
@@ -45,6 +46,7 @@ class EzPublishCoreBundle extends Bundle
         $container->addCompilerPass( new BlockViewPass );
         $container->addCompilerPass( new SignalSlotPass );
         $container->addCompilerPass( new IdentityDefinerPass );
+        $container->addCompilerPass( new XmlTextConverterPass );
 
         $securityExtension = $container->getExtension( 'security' );
         $securityExtension->addSecurityListenerFactory( new EzPublishSecurityFactory );

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtypes.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtypes.yml
@@ -508,7 +508,6 @@ services:
         arguments:
             - %ezpublish.fieldType.ezxmltext.converter.html5.resources%
             - @ezpublish.config.resolver
-            - [@ezpublish.fieldType.ezxmltext.converter.embedToHtml5, @ezpublish.fieldType.ezxmltext.converter.ezLinkToHtml5]
 
     ezpublish.fieldType.ezxmltext.converter.embedToHtml5:
         class: %ezpublish.fieldType.ezxmltext.converter.embedToHtml5.class%
@@ -516,10 +515,14 @@ services:
             - @ezpublish.view_manager
             - @ezpublish.api.repository
             - %ezpublish.fieldType.ezxmlText.converter.embedToHtml5.excludedAttributes%
+        tags:
+            - { name: ezpublish.ezxml.converter }
 
     ezpublish.fieldType.ezxmltext.converter.ezLinkToHtml5:
         class: %ezpublish.fieldType.ezxmltext.converter.ezLinkToHtml5.class%
         arguments: [@ezpublish.api.repository, @?logger]
+        tags:
+            - { name: ezpublish.ezxml.converter }
 
     ezpublish.fieldType.ezpage:
         class: %ezpublish.fieldType.ezpage.class%

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/XmlTextConverterPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/XmlTextConverterPassTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * File containing the XmlTextConverterPassTest class.
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\XmlTextConverterPass;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class XmlTextConverterPassTest extends PHPUnit_Framework_TestCase
+{
+    public function testProcess()
+    {
+        $container = new ContainerBuilder();
+        $html5ConvertDef = new Definition();
+        $container->setDefinition( 'ezpublish.fieldType.ezxmltext.converter.html5', $html5ConvertDef );
+
+        $preConverterDef = new Definition();
+        $preConverterDef->addTag( 'ezpublish.ezxml.converter' );
+        $container->setDefinition( 'foo.converter', $preConverterDef );
+
+        $this->assertFalse( $html5ConvertDef->hasMethodCall( 'addPreConverter' ) );
+        $pass = new XmlTextConverterPass();
+        $pass->process( $container );
+        $this->assertTrue( $html5ConvertDef->hasMethodCall( 'addPreConverter' ) );
+        $calls = $html5ConvertDef->getMethodCalls();
+        $this->assertSame( 1, count( $calls ) );
+        list( $method, $arguments ) = $calls[0];
+        $this->assertSame( 'addPreConverter', $method );
+        $this->assertInstanceOf( 'Symfony\\Component\\DependencyInjection\\Reference', $arguments[0] );
+        $this->assertSame( 'foo.converter', (string)$arguments[0] );
+    }
+}

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/Html5Test.php
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/Html5Test.php
@@ -143,4 +143,15 @@ class Html5Test extends PHPUnit_Framework_TestCase
         $xpath = new DomXPath( $result );
         $checkClosure( $xpath->query( $xpathCheck ) );
     }
+
+    public function testAddPreConverter()
+    {
+        $html5Converter = new Html5( 'foo.xsl' );
+        $converter1 = $this->getPreConvertMock();
+        $html5Converter->addPreConverter( $converter1 );
+        $converter2 = $this->getPreConvertMock();
+        $html5Converter->addPreConverter( $converter2 );
+
+        $this->assertSame( array( $converter1, $converter2 ), $html5Converter->getPreConverters() );
+    }
 }

--- a/eZ/Publish/Core/FieldType/XmlText/Converter/Html5.php
+++ b/eZ/Publish/Core/FieldType/XmlText/Converter/Html5.php
@@ -43,7 +43,7 @@ class Html5 implements Converter
      *
      * @var \eZ\Publish\Core\FieldType\XmlText\Converter[]
      */
-    protected $preConverters;
+    private $preConverters;
 
     /**
      * Constructor
@@ -80,6 +80,25 @@ class Html5 implements Converter
         }
 
         $this->preConverters = $preConverters;
+    }
+
+    /**
+     * Adds a pre-converter to the list.
+     * Use a pre-converter when you need some processing before XSLT transformation (e.g. for custom tags).
+     *
+     * @param Converter $preConverter
+     */
+    public function addPreConverter( Converter $preConverter )
+    {
+        $this->preConverters[] = $preConverter;
+    }
+
+    /**
+     * @return array|\eZ\Publish\Core\FieldType\XmlText\Converter[]
+     */
+    public function getPreConverters()
+    {
+        return $this->preConverters;
     }
 
     /**
@@ -145,7 +164,7 @@ class Html5 implements Converter
      */
     public function convert( DOMDocument $xmlDoc )
     {
-        foreach ( $this->preConverters as $preConverter )
+        foreach ( $this->getPreConverters() as $preConverter )
         {
             $preConverter->convert( $xmlDoc );
         }


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-21244

Goes together with #456. Allows ezxml to be pre-processed, for example for custom tags rendering.
