### PR TITLE
Temporarily removed integration tests with Solr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   - TEST_CONFIG="phpunit.xml" TIMEZONE="Asia/Calcutta"
   - TEST_CONFIG="phpunit.xml" TIMEZONE="America/New_York"
   - TEST_CONFIG="phpunit-integration-legacy.xml" TIMEZONE="Asia/Calcutta"
-  - TEST_CONFIG="phpunit-integration-legacy-solr.xml" TIMEZONE="America/New_York"
+#  - TEST_CONFIG="phpunit-integration-legacy-solr.xml" TIMEZONE="America/New_York"
 
 matrix:
   allow_failures:
@@ -25,16 +25,16 @@ matrix:
       env: TEST_CONFIG="phpunit.xml" TIMEZONE="Asia/Calcutta"
     - php: 5.3
       env: TEST_CONFIG="phpunit-integration-legacy.xml" TIMEZONE="Asia/Calcutta"
-    - php: 5.3
-      env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" TIMEZONE="America/New_York"
+#    - php: 5.3
+#      env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" TIMEZONE="America/New_York"
     - php: 5.4
       env: TEST_CONFIG="phpunit.xml" TIMEZONE="America/New_York"
     - php: 5.5
       env: TEST_CONFIG="phpunit.xml" TIMEZONE="Asia/Calcutta"
     - php: 5.5
       env: TEST_CONFIG="phpunit-integration-legacy.xml" TIMEZONE="Asia/Calcutta"
-    - php: 5.5
-      env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" TIMEZONE="America/New_York"
+#    - php: 5.5
+#      env: TEST_CONFIG="phpunit-integration-legacy-solr.xml" TIMEZONE="America/New_York"
 
 # test only master (+ Pull requests)
 branches:
@@ -46,7 +46,7 @@ before_script:
   - cp config.php-DEVELOPMENT config.php
   - ./composer_install_github_key.sh
   - composer install --dev --prefer-source
-  - "if [ \"$TEST_CONFIG\" = \"phpunit-integration-legacy-solr.xml\" ] ; then curl https://raw.github.com/patrickallaert/travis-solr/master/travis-solr.sh | SOLR_VERSION=3.6.2 SOLR_CONFS=eZ/Publish/Core/Persistence/Solr/Content/Search/schema.xml bash ; fi"
+#  - "if [ \"$TEST_CONFIG\" = \"phpunit-integration-legacy-solr.xml\" ] ; then curl https://raw.github.com/patrickallaert/travis-solr/master/travis-solr.sh | SOLR_VERSION=3.6.2 SOLR_CONFS=eZ/Publish/Core/Persistence/Solr/Content/Search/schema.xml bash ; fi"
 
 # execute phpunit as the script command
 script: "phpunit -d date.timezone=$TIMEZONE -d memory_limit=-1 -c $TEST_CONFIG"


### PR DESCRIPTION
Commented Solr integration tests out from `.travis.yml` as they often time out and are not really useful for now.
