### PR TITLE
Fix EZP-21302: Circular reference detected for service "ezpublish.urlalias_generator"

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
@@ -41,7 +41,7 @@ services:
 
     ezpublish.urlalias_generator:
         class: %ezpublish.urlalias_generator.class%
-        arguments: [@ezpublish.api.repository.lazy, @router, @?logger]
+        arguments: [@ezpublish.api.repository.lazy, @router.default, @?logger]
         parent: ezpublish.url_generator.base
 
     ezpublish.siteaccess.matcher_builder:

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -27,9 +27,11 @@ class UrlAliasGenerator extends Generator
     private $lazyRepository;
 
     /**
+     * The default router (that works with declared routes).
+     *
      * @var \Symfony\Component\Routing\RouterInterface
      */
-    private $router;
+    private $defaultRouter;
 
     /**
      * @var \Psr\Log\LoggerInterface
@@ -56,10 +58,10 @@ class UrlAliasGenerator extends Generator
      */
     private $siteAccess;
 
-    public function __construct( \Closure $lazyRepository, RouterInterface $router, LoggerInterface $logger = null )
+    public function __construct( \Closure $lazyRepository, RouterInterface $defaultRouter, LoggerInterface $logger = null )
     {
         $this->lazyRepository = $lazyRepository;
-        $this->router = $router;
+        $this->defaultRouter = $defaultRouter;
         $this->logger = $logger;
     }
 
@@ -120,7 +122,7 @@ class UrlAliasGenerator extends Generator
         }
         else
         {
-            $path = $this->router->generate(
+            $path = $this->defaultRouter->generate(
                 self::INTERNAL_LOCATION_ROUTE,
                 array( 'locationId' => $location->id )
             );


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-21302

The chain router was injected in `ezpublish.urlalias_generator` service while we only needed the default one (that works with declared routes).
