### PR TITLE
Fix 21334: Wrong XSLT rendering for some ezxml elements

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtypes.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtypes.yml
@@ -34,6 +34,7 @@ parameters:
     ezpublish.fieldType.ezxmltext.converter.embedToHtml5.class: eZ\Publish\Core\FieldType\XmlText\Converter\EmbedToHtml5
     ezpublish.fieldType.ezxmlText.converter.embedToHtml5.excludedAttributes: [view, node_id, object_id]
     ezpublish.fieldType.ezxmltext.converter.ezLinkToHtml5.class: eZ\Publish\Core\FieldType\XmlText\Converter\EzLinkToHtml5
+    ezpublish.fieldType.ezxmltext.converter.customTags.class: eZ\Publish\Core\FieldType\XmlText\Converter\CustomTags
     ezpublish.fieldType.ezpage.class: eZ\Publish\Core\FieldType\Page\Type
     ezpublish.fieldType.ezpage.pageService.class: eZ\Bundle\EzPublishCoreBundle\FieldType\Page\PageService
     ezpublish.fieldType.ezpage.pageService.factory.class: eZ\Publish\Core\MVC\Symfony\FieldType\Page\PageServiceFactory
@@ -521,6 +522,11 @@ services:
     ezpublish.fieldType.ezxmltext.converter.ezLinkToHtml5:
         class: %ezpublish.fieldType.ezxmltext.converter.ezLinkToHtml5.class%
         arguments: [@ezpublish.api.service.location, @ezpublish.api.service.content, @ezpublish.urlalias_router, @?logger]
+        tags:
+            - { name: ezpublish.ezxml.converter }
+
+    ezpublish.fieldType.ezxmltext.converter.customTags:
+        class: %ezpublish.fieldType.ezxmltext.converter.customTags.class%
         tags:
             - { name: ezpublish.ezxml.converter }
 

--- a/eZ/Publish/Core/FieldType/XmlText/Converter/CustomTags.php
+++ b/eZ/Publish/Core/FieldType/XmlText/Converter/CustomTags.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * File containing the CustomTags class.
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\FieldType\XmlText\Converter;
+
+use DOMDocument;
+use eZ\Publish\Core\FieldType\XmlText\Converter;
+
+/**
+ * Pre-converter for custom tags, used to determine if it's supposed to be inline or not.
+ * "block" custom tags are always contained in a <paragraph> declaring a local "tmp" namespace.
+ */
+class CustomTags implements Converter
+{
+    public function convert( DOMDocument $xmlDoc )
+    {
+        /** @var \DOMElement $customTag */
+        foreach ( $xmlDoc->getElementsByTagName( 'custom' ) as $customTag )
+        {
+            if ( $customTag->parentNode->lookupNamespaceUri( 'tmp' ) !== null )
+            {
+                $customTag->setAttribute( 'inline', 'false' );
+            }
+        }
+    }
+}

--- a/eZ/Publish/Core/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl
+++ b/eZ/Publish/Core/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl
@@ -26,7 +26,8 @@
 
     <xsl:template match="paragraph">
         <xsl:choose>
-            <xsl:when test="( ul | ol | table ) or (name(..)='li')">
+            <!-- "inline" attribute is dynamically added by CustomTags pre-converter -->
+            <xsl:when test="( ul | ol | table | embed | literal | custom[@inline='false'] ) or (name(..)='li')">
                 <xsl:apply-templates/>
             </xsl:when>
             <xsl:otherwise>


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-21334

About custom tags, I made some tests and it appears that each time a custom tag needs to be _block_, surrounding paragraph tag always declare a local `tmp` namespace.
