### PR TITLE
Fix EZP-21052: Subrequests with legacy modules don't work

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/EventListener/SiteAccessListener.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/EventListener/SiteAccessListener.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * File containing the SiteAccessListener class.
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishLegacyBundle\EventListener;
+
+use eZ\Bundle\EzPublishLegacyBundle\Routing\UrlGenerator;
+use eZ\Publish\Core\MVC\Symfony\Event\PostSiteAccessMatchEvent;
+use eZ\Publish\Core\MVC\Symfony\MVCEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class SiteAccessListener implements EventSubscriberInterface
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\Routing\Generator
+     */
+    private $urlGenerator;
+
+    public function __construct( UrlGenerator $urlGenerator )
+    {
+        $this->urlGenerator = $urlGenerator;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            MVCEvents::SITEACCESS => array( 'onSiteAccessMatch', 255 )
+        );
+    }
+
+    public function onSiteAccessMatch( PostSiteAccessMatchEvent $event )
+    {
+        $this->urlGenerator->setSiteAccess( $event->getSiteAccess() );
+    }
+}

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
@@ -21,6 +21,7 @@ parameters:
     ezpublish_legacy.webconfigurator.class: Sensio\Bundle\DistributionBundle\Configurator\Configurator
 
     ezpublish_legacy.router.class: eZ\Bundle\EzPublishLegacyBundle\Routing\FallbackRouter
+    ezpublish_legacy.uri_helper.class: eZ\Publish\Core\MVC\Legacy\Kernel\URIHelper
     ezpublish_legacy.url_generator.class: eZ\Bundle\EzPublishLegacyBundle\Routing\UrlGenerator
     ezpublish_legacy.siteaccess_mapper.class: eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\SiteAccess
     ezpublish_legacy.session_mapper.class: eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\Session
@@ -49,6 +50,7 @@ parameters:
     ezpublish.fieldType.ezpage.pageService.class: eZ\Bundle\EzPublishLegacyBundle\FieldType\Page\PageService
 
     ezpublish_legacy.rest_listener.class: eZ\Bundle\EzPublishLegacyBundle\EventListener\RestListener
+    ezpublish_legacy.siteaccess_listener.class: eZ\Bundle\EzPublishLegacyBundle\EventListener\SiteAccessListener
 
 services:
     ezpublish_legacy.kernel:
@@ -65,6 +67,7 @@ services:
         arguments:
             - %ezpublish_legacy.root_dir%
             - %webroot_dir%
+            - @ezpublish_legacy.uri_helper
             - @?logger
 
     ezpublish_legacy.kernel_handler.web:
@@ -94,6 +97,9 @@ services:
             - @ezpublish_legacy.kernel
             - @templating
             - @ezpublish.config.resolver
+            - @ezpublish_legacy.uri_helper
+        calls:
+            - [setRequest, [@?request=]]
 
     ezpublish_legacy.treemenu.controller:
         class: %ezpublish_legacy.treemenu.controller.class%
@@ -118,6 +124,9 @@ services:
         arguments: [@service_container, @?request_context, @?logger]
         tags:
             - {name: router, priority: -255}
+
+    ezpublish_legacy.uri_helper:
+        class: %ezpublish_legacy.uri_helper.class%
 
     ezpublish_legacy.url_generator:
         class: %ezpublish_legacy.url_generator.class%
@@ -208,5 +217,11 @@ services:
     ezpublish_legacy.rest_listener:
         class: %ezpublish_legacy.rest_listener.class%
         arguments: [%ezpublish_rest.csrf_token_intention%]
+        tags:
+            - { name: kernel.event_subscriber }
+
+    ezpublish_legacy.siteaccess_listener:
+        class: %ezpublish_legacy.siteaccess_listener.class%
+        arguments: [@ezpublish_legacy.url_generator]
         tags:
             - { name: kernel.event_subscriber }

--- a/eZ/Publish/Core/MVC/Legacy/Kernel/Loader.php
+++ b/eZ/Publish/Core/MVC/Legacy/Kernel/Loader.php
@@ -35,14 +35,20 @@ class Loader
     protected $webrootDir;
 
     /**
+     * @var URIHelper
+     */
+    protected $uriHelper;
+
+    /**
      * @var \Psr\Log\LoggerInterface
      */
     protected $logger;
 
-    public function __construct( $legacyRootDir, $webrootDir, LoggerInterface $logger = null )
+    public function __construct( $legacyRootDir, $webrootDir, URIHelper $uriHelper, LoggerInterface $logger = null )
     {
         $this->legacyRootDir = $legacyRootDir;
         $this->webrootDir = $webrootDir;
+        $this->uriHelper = $uriHelper;
         $this->logger = $logger;
     }
 
@@ -115,13 +121,8 @@ class Loader
                     throw new \InvalidArgumentException( 'A legacy kernel handler must be an instance of ezpKernelHandler.' );
 
                 $webHandler = new $webHandlerClass( $legacyParameters->all() );
-                $uri = eZURI::instance();
-                $uri->setURIString(
-                    $request->attributes->get(
-                        'semanticPathinfo',
-                        $request->getPathinfo()
-                    ) . $request->attributes->get( 'viewParametersString' )
-                );
+                // Fix up legacy URI for global use cases (i.e. using runCallback()).
+                $this->uriHelper->updateLegacyURI( $request );
                 chdir( $webrootDir );
             }
 

--- a/eZ/Publish/Core/MVC/Legacy/Kernel/URIHelper.php
+++ b/eZ/Publish/Core/MVC/Legacy/Kernel/URIHelper.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * File containing the WebHandler class.
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Legacy\Kernel;
+
+use Symfony\Component\HttpFoundation\Request;
+use eZURI;
+
+/**
+ * URIFixer is a helper class you can use to "align" legacy eZURI against current Symfony Request object.
+ * i.e. Inject correct Pathinfo that has been already processed within Symfony (with SiteAccess detection).
+ */
+class URIHelper
+{
+    /**
+     * Fixes up legacy eZURI against current request.
+     *
+     * @param Request $request
+     */
+    public function updateLegacyURI( Request $request )
+    {
+        $uri = eZURI::instance();
+        $uri->setURIString(
+            $request->attributes->get(
+                'semanticPathinfo',
+                $request->getPathinfo()
+            ) . $request->attributes->get( 'viewParametersString' )
+        );
+    }
+}

--- a/eZ/Publish/Core/MVC/Legacy/Tests/URIHelperTest.php
+++ b/eZ/Publish/Core/MVC/Legacy/Tests/URIHelperTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * File containing the URIFixerTest class.
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Legacy\Tests;
+
+use eZ\Publish\Core\MVC\Legacy\Kernel\URIHelper;
+use eZURI;
+use Symfony\Component\HttpFoundation\Request;
+
+class URIHelperTest extends LegacyBasedTestCase
+{
+    public function testFixUpInternalURI()
+    {
+        $initialURI = '/foo/bar/baz';
+        $modifiedURI = '/bar/baz';
+        eZURI::instance()->setURIString( $initialURI );
+        $request = Request::create( $initialURI );
+        $request->attributes->set( 'semanticPathinfo', $modifiedURI );
+
+        $helper = new URIHelper();
+        $helper->updateLegacyURI( $request );
+        $this->assertSame( $modifiedURI, eZURI::instance()->uriString( true ) );
+    }
+
+    public function testFixupInternalURIPathinfo()
+    {
+        $initialURI = '/foo/bar/baz';
+        $request = Request::create( $initialURI );
+
+        $helper = new URIHelper();
+        $helper->updateLegacyURI( $request );
+        $this->assertSame( $initialURI, eZURI::instance()->uriString( true ) );
+    }
+}


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-21052

Main problem was that `eZURI` was fixed up against current Symfony request only at legacy kernel build time.
Another problem was discovered : Link generation to legacy modules wasn't siteaccess aware (aka `URILexer` aware)
