### PR TITLE
Fix EZP-21349: Impossible to register one slot for multiple signals

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SignalSlotPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SignalSlotPass.php
@@ -26,12 +26,15 @@ class SignalSlotPass implements CompilerPassInterface
         $signalDispatcherDef = $container->getDefinition( 'ezpublish.signalslot.signal_dispatcher' );
         foreach ( $container->findTaggedServiceIds( 'ezpublish.api.slot' ) as $id => $attributes )
         {
-            if ( !isset( $attributes[0]['signal'] ) )
+            foreach ( $attributes as $attribute )
             {
-                throw new LogicException( "Could not find 'signal' attribute on '$id' service, which is mandatory for services tagged as 'ezpublish.api.slot'" );
-            }
+                if ( !isset( $attribute['signal'] ) )
+                {
+                    throw new LogicException( "Could not find 'signal' attribute on '$id' service, which is mandatory for services tagged as 'ezpublish.api.slot'" );
+                }
 
-            $signalDispatcherDef->addMethodCall( 'attach', array( $attributes[0]['signal'], $id ) );
+                $signalDispatcherDef->addMethodCall( 'attach', array( $attribute['signal'], $id ) );
+            }
         }
     }
 }


### PR DESCRIPTION
In a compiler pass, when using `$container->findTaggedServiceIds()`, tag attributes are grouped by tag name. So to allow a service to have the multiple tags with the same name and different attributes, we need to loop against those attributes in the compiler pass.
