### PR TITLE
Fix EZP-20502: IO Exception when file isn't found

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtypes.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtypes.yml
@@ -352,6 +352,7 @@ services:
             - @ezpublish.fieldType.ezbinaryfile.IOService
             - @ezpublish.fieldType.ezbinaryfile.pathGenerator
             - @ezpublish.core.io.mimeTypeDetector
+            - @?logger
         tags:
             - {name: ezpublish.fieldType.externalStorageHandler, alias: ezbinaryfile}
 
@@ -418,6 +419,7 @@ services:
             - @ezpublish.fieldType.ezimage.IOService
             - @ezpublish.fieldType.ezimage.pathGenerator
             - @ezpublish.fieldType.metadataHandler.imagesize
+            - @?logger
         tags:
             - {name: ezpublish.fieldType.externalStorageHandler, alias: ezimage}
 
@@ -451,6 +453,7 @@ services:
             - @ezpublish.fieldType.ezbinaryfile.IOService
             - @ezpublish.fieldType.ezbinaryfile.pathGenerator
             - @ezpublish.core.io.mimeTypeDetector
+            - @?logger
         tags:
             - {name: ezpublish.fieldType.externalStorageHandler, alias: ezmedia}
 

--- a/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage.php
@@ -9,18 +9,25 @@
 
 namespace eZ\Publish\Core\FieldType\BinaryBase;
 
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\FieldType\GatewayBasedStorage;
 use eZ\Publish\Core\IO\IOService;
 use eZ\Publish\SPI\FieldType\BinaryBase\PathGenerator;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\IO\MimeTypeDetector;
+use Psr\Log\LoggerInterface;
 
 /**
  * Storage for binary files
  */
 class BinaryBaseStorage extends GatewayBasedStorage
 {
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
     /**
      * An instance of IOService configured to store to the images folder
      *
@@ -42,13 +49,16 @@ class BinaryBaseStorage extends GatewayBasedStorage
      * @param \eZ\Publish\Core\FieldType\StorageGateway[] $gateways
      * @param IOService $IOService
      * @param PathGenerator $pathGenerator
+     * @param MimeTypeDetector $mimeTypeDetector
+     * @param LoggerInterface $logger
      */
-    public function __construct( array $gateways, IOService $IOService, PathGenerator $pathGenerator, MimeTypeDetector $mimeTypeDetector )
+    public function __construct( array $gateways, IOService $IOService, PathGenerator $pathGenerator, MimeTypeDetector $mimeTypeDetector, LoggerInterface $logger = null )
     {
         parent::__construct( $gateways );
         $this->IOService = $IOService;
         $this->pathGenerator = $pathGenerator;
         $this->mimeTypeDetector = $mimeTypeDetector;
+        $this->logger = $logger;
     }
 
     /**
@@ -99,8 +109,7 @@ class BinaryBaseStorage extends GatewayBasedStorage
         $storagePath = $this->pathGenerator->getStoragePathForField( $field, $versionInfo );
 
         // The file referenced in externalData MAY be an existing IOService file which we can use
-        if ( ( $this->IOService->loadBinaryFile( $storedValue['id'] ) === false ) &&
-             ( $this->IOService->loadBinaryFile( $storagePath ) === false ) )
+        if ( ( !$this->IOService->exists( $storedValue['id'] ) ) && ( !$this->IOService->exists( $storagePath ) ) )
         {
             $createStruct = $this->IOService->newBinaryCreateStructFromLocalFile(
                 $storedValue['id']
@@ -116,7 +125,7 @@ class BinaryBaseStorage extends GatewayBasedStorage
 
         $this->removeOldFile( $field->id, $versionInfo->versionNo, $context );
 
-        return $this->getGateway( $context )->storeFileReference( $versionInfo, $field );
+        $this->getGateway( $context )->storeFileReference( $versionInfo, $field );
     }
 
     public function copyLegacyField( VersionInfo $versionInfo, Field $field, Field $originalField, array $context )
@@ -157,9 +166,20 @@ class BinaryBaseStorage extends GatewayBasedStorage
 
         if ( $fileCounts[$fileReference['id']] === 0 )
         {
-            $this->IOService->deleteBinaryFile(
-                $this->IOService->loadBinaryFile( $fileReference['id'] )
-            );
+            try
+            {
+                $binaryFile = $this->IOService->loadBinaryFile( $fileReference['id'] );
+                $this->IOService->deleteBinaryFile( $binaryFile );
+            }
+            catch ( NotFoundException $e )
+            {
+                if ( isset( $this->logger ) )
+                {
+                    $binaryFileId = $this->IOService->getInternalPath( $fileReference['id'] );
+                    $this->logger->error( "BinaryFile with ID $binaryFileId not found" );
+                }
+                return;
+            }
         }
     }
 
@@ -180,14 +200,20 @@ class BinaryBaseStorage extends GatewayBasedStorage
         $field->value->externalData = $this->getGateway( $context )->getFileReferenceData( $field->id, $versionInfo->versionNo );
         if ( $field->value->externalData !== null )
         {
-            if ( ( $binaryFile = $this->IOService->loadBinaryFile( $field->value->externalData['id'] ) ) !== false )
+            try
             {
+                $binaryFile = $this->IOService->loadBinaryFile( $field->value->externalData['id'] );
                 $field->value->externalData['fileSize'] = $binaryFile->size;
                 $field->value->externalData['uri'] = $binaryFile->uri;
             }
-            else
+            catch ( NotFoundException $e )
             {
-                throw new \RuntimeException( "Failed loading binary file {$field->value->externalData['id']}" );
+                if ( isset( $this->logger ) )
+                {
+                    $fileId = $this->IOService->getInternalPath( $field->value->externalData['id'] );
+                    $this->logger->error( "BinaryFile with ID $fileId not found" );
+                }
+                return;
             }
         }
     }
@@ -220,9 +246,19 @@ class BinaryBaseStorage extends GatewayBasedStorage
         {
             if ( $count === 0 )
             {
-                $this->IOService->deleteBinaryFile(
-                    $this->IOService->loadBinaryFile( $filePath )
-                );
+                try
+                {
+                    $binaryFile = $this->IOService->loadBinaryFile( $filePath );
+                    $this->IOService->deleteBinaryFile( $binaryFile );
+                }
+                catch ( NotFoundException $e )
+                {
+                    if ( isset( $this->logger ) )
+                    {
+                        $filePath = $this->IOService->getInternalPath( $filePath );
+                        $this->logger->error( "BinaryFile with ID $filePath not found" );
+                    }
+                }
             }
         }
     }
@@ -246,6 +282,5 @@ class BinaryBaseStorage extends GatewayBasedStorage
      */
     public function getIndexData( VersionInfo $versionInfo, Field $field, array $context )
     {
-
     }
 }

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/LegacyStorage.php
@@ -119,6 +119,9 @@ class LegacyStorage extends Gateway
      */
     public function storeImageReference( $path, $fieldId )
     {
+        // legacy stores the path to the image without a leading /
+        $path = ltrim( $path, '/ ' );
+
         $connection = $this->getConnection();
 
         $insertQuery = $connection->createInsertQuery();

--- a/eZ/Publish/Core/IO/Handler/Legacy.php
+++ b/eZ/Publish/Core/IO/Handler/Legacy.php
@@ -34,7 +34,7 @@ class Legacy implements IOHandlerInterface
     /**
      * File resource provider
      * @see getFileResourceProvider
-     * @var FileReso
+     * @var FileResource
      */
     private $fileResourceProvider = null;
 
@@ -63,12 +63,6 @@ class Legacy implements IOHandlerInterface
      */
     private $storageDirectory;
 
-    /**
-     * Created Legacy handler instance
-     *
-     * @param string $storageDirectory
-     * @param \eZ\Publish\Core\MVC\Legacy\Kernel $legacyKernel
-     */
     public function __construct( $storageDirectory, LegacyKernel $legacyKernel = null )
     {
         if ( $legacyKernel )
@@ -312,7 +306,7 @@ class Legacy implements IOHandlerInterface
     {
         if ( !$this->exists( $spiBinaryFileId ) )
         {
-            throw new NotFoundException( 'spiBinaryFile', $spiBinaryFileId );
+            throw new NotFoundException( 'BinaryFile', $spiBinaryFileId );
         }
 
         $storagePath = $this->getStoragePath( $spiBinaryFileId );

--- a/eZ/Publish/Core/IO/IOService.php
+++ b/eZ/Publish/Core/IO/IOService.php
@@ -183,16 +183,9 @@ class IOService
         if ( $binaryFileId[0] === '/' )
             return false;
 
-        try
-        {
-            $spiBinaryFile = $this->ioHandler->load( $this->getPrefixedUri( $binaryFileId ) );
-        }
-        catch ( NotFoundException $e )
-        {
-            return false;
-        }
-
-        return $this->buildDomainBinaryFileObject( $spiBinaryFile );
+        return $this->buildDomainBinaryFileObject(
+            $this->ioHandler->load( $this->getPrefixedUri( $binaryFileId ) )
+        );
     }
 
     /**
@@ -278,6 +271,11 @@ class IOService
             $metadataHandler,
             $this->getPrefixedUri( $binaryFile->id )
         );
+    }
+
+    public function exists( $binaryFileId )
+    {
+        return $this->ioHandler->exists( $this->getPrefixedUri( $binaryFileId ) );
     }
 
     /**

--- a/eZ/Publish/Core/IO/Tests/Handler/Base.php
+++ b/eZ/Publish/Core/IO/Tests/Handler/Base.php
@@ -266,7 +266,7 @@ abstract class Base extends PHPUnit_Framework_TestCase
 
     /**
      * @covers \eZ\Publish\Core\IO\Handler::getFileResource
-     * @expectedException eZ\Publish\Core\Base\Exceptions\NotFoundException
+     * @expectedException \eZ\Publish\Core\Base\Exceptions\NotFoundException
      */
     public function testGetFileResourceNonExistingFile()
     {
@@ -287,7 +287,7 @@ abstract class Base extends PHPUnit_Framework_TestCase
 
     /**
      * @covers \eZ\Publish\Core\IO\Handler::getFileContents
-     * @expectedException eZ\Publish\Core\Base\Exceptions\NotFoundException
+     * @expectedException \eZ\Publish\Core\Base\Exceptions\NotFoundException
      */
     public function testGetFileContentsNonExistingFile()
     {

--- a/eZ/Publish/Core/IO/Tests/IOServiceTest.php
+++ b/eZ/Publish/Core/IO/Tests/IOServiceTest.php
@@ -160,6 +160,29 @@ class IOServiceTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers \eZ\Publish\Core\IO\IOService::loadBinaryFile
+     * @expectedException \eZ\Publish\Core\Base\Exceptions\NotFoundException
+     */
+    public function testLoadBinaryFileNotFound()
+    {
+        $id = 'id.ext';
+        $prefixedUri = $this->getPrefixedUri( $id );
+        $this->getIOHandlerMock()
+            ->expects( $this->once() )
+            ->method( 'load' )
+            ->with( $prefixedUri )
+            ->will(
+                $this->throwException(
+                    new \eZ\Publish\Core\Base\Exceptions\NotFoundException(
+                        'BinaryFile', $prefixedUri
+                    )
+                )
+            );
+
+        $this->getIOService()->loadBinaryFile( $id );
+    }
+
+    /**
      * @covers \eZ\Publish\Core\IO\IOService::getFileInputStream
      * @depends testCreateBinaryFile
      */
@@ -189,6 +212,43 @@ class IOServiceTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @depends testCreateBinaryFile
+     * @covers IOService \eZ\Publish\Core\IO\IOService::exists()
+     */
+    public function testExists( BinaryFile $binaryFile)
+    {
+        $this->getIOHandlerMock()
+            ->expects( $this->once() )
+            ->method( 'exists' )
+            ->with( $this->equalTo( $this->getPrefixedUri( $binaryFile->id ) ) )
+            ->will( $this->returnValue( true ) );
+
+        self::assertTrue(
+            $this->getIOService()->exists(
+                $binaryFile->id
+            )
+        );
+    }
+
+    /**
+     * @covers IOService \eZ\Publish\Core\IO\IOService::exists()
+     */
+    public function testExistsNot()
+    {
+        $this->getIOHandlerMock()
+            ->expects( $this->once() )
+            ->method( 'exists' )
+            ->with( $this->equalTo( $this->getPrefixedUri( __METHOD__ ) ) )
+            ->will( $this->returnValue( false ) );
+
+        self::assertFalse(
+            $this->getIOService()->exists(
+                __METHOD__
+            )
+        );
+    }
+
+    /**
      * @covers \eZ\Publish\Core\IO\IOService::deleteBinaryFile
      * @depends testCreateBinaryFile
      */
@@ -198,6 +258,30 @@ class IOServiceTest extends PHPUnit_Framework_TestCase
             ->expects( $this->once() )
             ->method( 'delete' )
             ->with( $this->equalTo( $this->getPrefixedUri( $binaryFile->id ) ) );
+
+        $this->getIOService()->deleteBinaryFile( $binaryFile );
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\IO\IOService::deleteBinaryFile
+     * @expectedException \eZ\Publish\Core\Base\Exceptions\NotFoundException
+     */
+    public function testDeleteBinaryFileNotFound()
+    {
+        $binaryFile = new BinaryFile(
+            array( 'id' => __METHOD__ )
+        );
+
+        $prefixedId = $this->getPrefixedUri( $binaryFile->id );
+        $this->getIOHandlerMock()
+            ->expects( $this->once() )
+            ->method( 'delete' )
+            ->with( $this->equalTo( $prefixedId ) )
+            ->will(
+                $this->throwException(
+                    new \eZ\Publish\Core\Base\Exceptions\NotFoundException( 'BinaryFile', $prefixedId )
+                )
+            );
 
         $this->getIOService()->deleteBinaryFile( $binaryFile );
     }
@@ -252,7 +336,7 @@ class IOServiceTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return IOHandlerInterface
+     * @return IOHandlerInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private function getIOHandlerMock()
     {
@@ -264,7 +348,7 @@ class IOServiceTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return MimeTypeDetector
+     * @return MimeTypeDetector|\PHPUnit_Framework_MockObject_MockObject
      */
     private function getMimeTypeDetectorMock()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Image.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Image.php
@@ -97,7 +97,7 @@ class Image implements Converter
      */
     protected function createLegacyXml( array $data )
     {
-        $pathInfo = pathinfo( $data['uri'] );
+        $pathInfo = pathinfo( ltrim( $data['uri'], '/' ) );
         return $this->fillXml( $data, $pathInfo, time() );
     }
 
@@ -136,7 +136,7 @@ EOT;
             htmlspecialchars( $pathInfo['extension'] ), // suffix="%s"
             htmlspecialchars( $pathInfo['filename'] ), // basename="%s"
             htmlspecialchars( $pathInfo['dirname'] ), // dirpath
-            htmlspecialchars( $imageData['id'] ), // url
+            htmlspecialchars( ltrim( $imageData['uri'], '/' ) ), // url
             htmlspecialchars( $pathInfo['basename'] ), // @todo: Needs original file name, for whatever reason?
             htmlspecialchars( $imageData['mime'] ), // mime_type
             htmlspecialchars( $imageData['width'] ), // width

--- a/eZ/Publish/Core/REST/Server/Controller/BinaryContent.php
+++ b/eZ/Publish/Core/REST/Server/Controller/BinaryContent.php
@@ -72,6 +72,12 @@ class BinaryContent extends RestController
             throw new Exceptions\NotFoundException( "No image field with ID $fieldId could be found" );
         }
 
+        // check the field's value
+        if ( $field->value->uri === null )
+        {
+            throw new Exceptions\NotFoundException( "Image file {$field->value->id} doesn't exist" );
+        }
+
         $versionInfo = $this->repository->getContentService()->loadVersionInfo( $content->contentInfo );
 
         try


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-20502.

Catches the NotFound exceptions returned by the IO handlers when a file is referenced in the database but doesn't exist in storage, and logs errors instead. This is done in the various FieldTypes that use the IO Service, meaning the the IO handlers themselves will keep throwing exceptions, as a missing file _is_ an exception from their perspective.

It should degrade correctly,and shouldn't affect development anymore.
## TODO
- [x] Do the same changes to BinaryBase, if applicable
