### PR TITLE
Fix legacy cache purger when eZ is not yet installed

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Cache/LegacyCachePurger.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Cache/LegacyCachePurger.php
@@ -9,6 +9,8 @@
 
 namespace eZ\Bundle\EzPublishLegacyBundle\Cache;
 
+use eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\Configuration;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 use eZCacheHelper;
 use eZCLI;
@@ -26,9 +28,16 @@ class LegacyCachePurger implements CacheClearerInterface
      */
     private $legacyKernelClosure;
 
-    public function __construct( \Closure $legacyKernelClosure )
+    public function __construct( \Closure $legacyKernelClosure, Configuration $configurationMapper, Filesystem $fs, $legacyRootDir )
     {
         $this->legacyKernelClosure = $legacyKernelClosure;
+
+        // If ezp_extension.php doesn't exist, it means that eZ Publish is not yet installed.
+        // Hence we deactivate configuration mapper to avoid potential issues (e.g. ezxFormToken which cannot be loaded).
+        if ( !$fs->exists( "$legacyRootDir/var/autoload/ezp_extension.php" ) )
+        {
+            $configurationMapper->setIsEnabled( false );
+        }
     }
 
     /**

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
@@ -165,7 +165,7 @@ services:
 
     ezpublish_legacy.legacy_cache_purger:
         class: %ezpublish_legacy.legacy_cache_purger.class%
-        arguments: [@ezpublish_legacy.kernel]
+        arguments: [@ezpublish_legacy.kernel, @ezpublish_legacy.configuration_mapper, @filesystem, %ezpublish_legacy.root_dir%]
         tags:
             - { name: kernel.cache_clearer }
 


### PR DESCRIPTION
This PR fixes situation where `cache:clear` command is invoked while eZ Publish is not yet _installed_ (e.g. setup wizard not launched at least once).

This situation occurs when launching composer scripts.
