### PR TITLE
[WIP] EZP-20340 - Theme feature

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/TemplatingListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/TemplatingListener.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * File containing the TemplatingListener class.
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\EventListener;
+
+use eZ\Publish\Core\MVC\Symfony\Event\PostSiteAccessMatchEvent;
+use eZ\Publish\Core\MVC\Symfony\MVCEvents;
+use Liip\ThemeBundle\ActiveTheme;
+use Liip\ThemeBundle\Locator\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class TemplatingListener implements EventSubscriberInterface
+{
+    /**
+     * @var \Symfony\Component\DependencyInjection\ContainerInterface
+     */
+    private $container;
+
+    /**
+     * @var \Liip\ThemeBundle\ActiveTheme
+     */
+    private $activeTheme;
+
+    /**
+     * @var \Liip\ThemeBundle\Locator\FileLocator
+     */
+    private $themeFileLocator;
+
+    /**
+     * Bundles that are registered known to contain theme resources (templates or assets).
+     * Key is the bundle name, value is the absolute path to the bundle directory.
+     *
+     * @var array
+     */
+    private $themeBundles;
+
+    public function __construct(
+        ContainerInterface $container,
+        ActiveTheme $activeTheme,
+        FileLocator $themeFileLocator,
+        array $themeBundles = array()
+    )
+    {
+        $this->container = $container;
+        $this->activeTheme = $activeTheme;
+        $this->themeFileLocator = $themeFileLocator;
+        $this->themeBundles = $themeBundles;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            MVCEvents::SITEACCESS => array( 'onSiteAccessMatch', 200 )
+        );
+    }
+
+    public function onSiteAccessMatch( PostSiteAccessMatchEvent $event )
+    {
+        if ( $event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST )
+            return;
+
+        $configResolver = $this->container->get( 'ezpublish.config.resolver' );
+        $currentTheme = $configResolver->getParameter( 'themes.active_theme' );
+        // Skip if there is no active theme defined.
+        if ( !$currentTheme )
+            return;
+
+        $themeList = $configResolver->getParameter( 'themes.list' );
+        $this->activeTheme->setThemes( $themeList );
+        $this->activeTheme->setName( $currentTheme );
+
+        // TODO: This order is probably wrong, check with spec.
+        $bundleResource = array( '%bundle_path%/Resources/themes/%current_theme%/%template%' );
+        // Adding current theme from registered bundles
+        foreach ( $this->themeBundles as $bundlePath )
+        {
+            $bundleResource[] = "$bundlePath/Resources/views/themes/%current_theme%/%template%";
+        }
+
+        // Adding theme fallbacks from current bundle
+        foreach ( $themeList as $theme )
+        {
+            if ( $theme == $currentTheme )
+                continue;
+
+            $bundleResource[] = "%bundle_path%/Resources/themes/$theme/%template%";
+        }
+
+        // Adding fallbacks themes from registered bundles.
+        foreach ( $this->themeBundles as $bundlePath )
+        {
+            foreach ( $themeList as $theme )
+            {
+                if ( $theme == $currentTheme )
+                    continue;
+
+                $bundleResource[] = "$bundlePath/Resources/views/themes/$theme/%template%";
+            }
+        }
+
+        // Adding theme fallback paths for global application override (ezpublish/Resources/)
+        $appResource = array( '%dir%/themes/%current_theme%/%bundle_name%/%template%' );
+        foreach ( $themeList as $theme )
+        {
+            if ( $theme == $currentTheme )
+                continue;
+
+            $appResource[] = "%dir%/themes/$theme/%template%";
+        }
+        $appResource[] = '%dir%/%bundle_name%/%override_path%';
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -224,6 +224,10 @@ parameters:
         GMapItems:
             name: Google Map Items
 
+    # Themes related settings
+    ezsettings.default.themes.list: [foo, bar]
+    ezsettings.default.themes.active_theme: foo
+
     ###
     # Internal settings
     ###

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -17,6 +17,8 @@ parameters:
     ezpublish.templating.global_helper.core.class: eZ\Publish\Core\MVC\Symfony\Templating\GlobalHelper
     ezpublish.twig.extension.core.class: eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\CoreExtension
 
+    ezpublish.templating_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\TemplatingListener
+
 services:
     twig.loader.string:
         class: %twig.loader.string.class%
@@ -80,3 +82,13 @@ services:
         arguments: [@ezpublish.templating.global_helper]
         tags:
             - {name: twig.extension}
+
+    ezpublish.templating_listener:
+        class: %ezpublish.templating_listener.class%
+        arguments:
+            - @service_container
+            - @liip_theme.active_theme
+            - @liip_theme.file_locator
+            - ["%kernel.root_dir%/../src/Acme/TestBundle"]
+        tags:
+            - {name: kernel.event_subscriber}


### PR DESCRIPTION
**DO NOT MERGE**

*Themes* in eZ Publish 5 are what was known as *design* in eZ Publish 4.x and would allow the following:

* Possibility to define a main theme and a collection fallback themes for a given siteaccess.
* When loading a template, the system will check in theme provider bundles and in global directory (`ezpublish/Resources/`)if it can be loaded from each of them. Main theme will be checked first, fallback themes then.
* When loading an asset (e.g. css/js files) with `asset()` helper, the system will have the same behavior than for templates.

For implementation, we will use [LiipThemeBundle](https://github.com/liip/LiipThemeBundle), which already does most of the job for the template part. For the asset part, LiipThemeBundle needs to be extended, either by contribution or by implementation directly in EzPublishCoreBundle.

## TODO:

* [ ] Implement correct template loading order
* [ ] Add cache layer for templates path to avoid stat calls
* [ ] Add semantic configuration
* [ ] Handle priority for theme provider bundles
* [ ] Implement for assets