### PR TITLE
Fix for EZP-20930: missing REST root resources

### DIFF
--- a/doc/specifications/rest/xsd/Content.xsd
+++ b/doc/specifications/rest/xsd/Content.xsd
@@ -28,6 +28,7 @@
           <xsd:element name="lastModificationDate" type="xsd:dateTime" />
           <xsd:element name="mainLanguageCode" type="xsd:string" />
           <xsd:element name="alwaysAvailable" type="xsd:boolean" />
+          <xsd:element name="ObjectStates" type="ref" />
         </xsd:all>
         <xsd:attribute name="id" type="xsd:int" />
         <xsd:attribute name="remoteId" type="xsd:string" />

--- a/doc/specifications/rest/xsd/ContentType.xsd
+++ b/doc/specifications/rest/xsd/ContentType.xsd
@@ -52,7 +52,6 @@
                 The user which created the content type
               </xsd:documentation>
             </xsd:annotation>
-
           </xsd:element>
           <xsd:element name="Modifier" type="ref">
             <xsd:annotation>
@@ -61,6 +60,20 @@
                 type
               </xsd:documentation>
             </xsd:annotation>
+          </xsd:element>
+          <xsd:element name="Groups" type="ref">
+              <xsd:annotation>
+                  <xsd:documentation>
+                      The groups this content type belongs to
+                  </xsd:documentation>
+              </xsd:annotation>
+          </xsd:element>
+          <xsd:element name="Draft" type="ref">
+              <xsd:annotation>
+                  <xsd:documentation>
+                      The draft for this content type
+                  </xsd:documentation>
+              </xsd:annotation>
           </xsd:element>
           <xsd:element name="remoteId" type="xsd:string"
             minOccurs="0">

--- a/doc/specifications/rest/xsd/Location.xsd
+++ b/doc/specifications/rest/xsd/Location.xsd
@@ -79,6 +79,13 @@
           <xsd:element name="Content" type="ref" />
           <xsd:element name="sortField" type="sortFieldType" />
           <xsd:element name="sortOrder" type="sortOrderType" />
+          <xsd:element name="UrlAliases" type="ref">
+              <xsd:annotation>
+                  <xsd:documentation>
+                      The location's URL aliases list
+                  </xsd:documentation>
+              </xsd:annotation>
+          </xsd:element>
         </xsd:all>
       </xsd:extension>
     </xsd:complexContent>

--- a/doc/specifications/rest/xsd/ObjectStateGroup.xsd
+++ b/doc/specifications/rest/xsd/ObjectStateGroup.xsd
@@ -33,6 +33,7 @@
           </xsd:element>
           <xsd:element name="names" type="multiLanguageValuesType" />
           <xsd:element name="descriptions" type="multiLanguageValuesType" />
+          <xsd:element name="ObjectStates" type="ref" />
         </xsd:all>
       </xsd:extension>
     </xsd:complexContent>

--- a/doc/specifications/rest/xsd/Root.xsd
+++ b/doc/specifications/rest/xsd/Root.xsd
@@ -6,7 +6,10 @@
   <xsd:complexType name="vnd.ez.api.Root">
     <xsd:all>
       <xsd:element name="content" type="ref" />
+      <xsd:element name="contentByRemoteId" type="ref" />
       <xsd:element name="contentTypes" type="ref" />
+      <xsd:element name="contentTypeByIdentifier" type="ref" />
+      <xsd:element name="contentTypeGroups" type="ref" />
       <xsd:element name="users" type="ref"/>
       <xsd:element name="roles" type="ref"/>
       <xsd:element name="rootLocation" type="ref"/>
@@ -15,6 +18,11 @@
       <xsd:element name="trash" type="ref"/>
       <xsd:element name="sections" type="ref"/>
       <xsd:element name="views" type="ref"/>
+      <xsd:element name="objectStateGroups" type="ref"/>
+      <xsd:element name="objectStates" type="ref"/>
+      <xsd:element name="globalUrlAliases" type="ref"/>
+      <xsd:element name="urlWildcards" type="ref"/>
+      <xsd:element name="createSession" type="ref"/>
     </xsd:all>
   </xsd:complexType>
   <xsd:element name="Root" type="vnd.ez.api.Root"/>

--- a/doc/specifications/rest/xsd/User.xsd
+++ b/doc/specifications/rest/xsd/User.xsd
@@ -14,7 +14,7 @@
           <xsd:element name="enabled" type="xsd:boolean" />
           <xsd:element name="Content" type="vnd.ez.api.Version+xml" />
           <xsd:element name="Roles" type="ref" />
-          <xsd:element name="UserGroups" type="ref" />
+          <xsd:element name="Groups" type="ref" />
         </xsd:all>
       </xsd:extension>
     </xsd:complexContent>

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
@@ -65,11 +65,14 @@ parameters:
     ezpublish_rest.input.handler.json.class: eZ\Publish\Core\REST\Common\Input\Handler\Json
     ezpublish_rest.input.handler.xml.class: eZ\Publish\Core\REST\Common\Input\Handler\Xml
 
+    ezpublish_rest.templated_router.class: %router.class%
+
 services:
     ezpublish_rest.routing.options_loader:
         class: %ezpublish_rest.routing.options_loader.class%
         arguments:
             - @ezpublish_rest.routing.options_loader.route_collection_mapper
+            - @ezpublish_rest.templated_router
         tags:
             - { name: routing.loader }
 
@@ -366,3 +369,9 @@ services:
         class: %ezpublish_rest.input.handler.xml.class%
         tags:
             - { name: ezpublish_rest.input.handler, format: xml }
+
+    ezpublish_rest.templated_router:
+        class: %ezpublish_rest.templated_router.class%
+        parent: hautelook.router.template
+        calls:
+            - [ setOption, [ strict_requirements, ~ ] ]

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -119,6 +119,7 @@ services:
         calls:
             - [ setRequestParser, [ @ezpublish_rest.request_parser ] ]
             - [ setRouter, [ @router ] ]
+            - [ setTemplateRouter, [ @ezpublish_rest.templated_router] ]
 
     # Errors
     ezpublish_rest.output.value_object_visitor.InvalidArgumentException:

--- a/eZ/Publish/Core/REST/Common/Output/ValueObjectVisitor.php
+++ b/eZ/Publish/Core/REST/Common/Output/ValueObjectVisitor.php
@@ -32,6 +32,11 @@ abstract class ValueObjectVisitor
     protected $router;
 
     /**
+     * @var \Symfony\Component\Routing\RouterInterface
+     */
+    protected $templateRouter;
+
+    /**
      * Visit struct returned by controllers
      *
      * @param \eZ\Publish\Core\REST\Common\Output\Visitor $visitor
@@ -46,6 +51,11 @@ abstract class ValueObjectVisitor
     public function setRouter( RouterInterface $router )
     {
         $this->router = $router;
+    }
+
+    public function setTemplateRouter( RouterInterface $templateRouter )
+    {
+        $this->templateRouter = $templateRouter;
     }
 
     public function setRequestParser( RequestParser $requestParser )

--- a/eZ/Publish/Core/REST/Common/Tests/Output/ValueObjectVisitorBaseTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Output/ValueObjectVisitorBaseTest.php
@@ -41,9 +41,15 @@ abstract class ValueObjectVisitorBaseTest extends Tests\BaseTest
     private $routerMock;
 
     /**
-     * @var int
+     * @var \Symfony\Component\Routing\RouterInterface|\PHPUnit_Framework_MockObject_MockObject
      */
+    private $templatedRouterMock;
+
+    /** @var int */
     private $routerCallIndex = 0;
+
+    /** @var int */
+    private $templatedRouterCallIndex = 0;
 
     /**
      * Gets the visitor mock
@@ -111,6 +117,7 @@ abstract class ValueObjectVisitorBaseTest extends Tests\BaseTest
         $visitor = $this->internalGetVisitor();
         $visitor->setRequestParser( $this->getRequestParser() );
         $visitor->setRouter( $this->getRouterMock() );
+        $visitor->setTemplateRouter( $this->getTemplatedRouterMock() );
         return $visitor;
     }
 
@@ -159,6 +166,38 @@ abstract class ValueObjectVisitorBaseTest extends Tests\BaseTest
     {
         $this->getRouterMock()
             ->expects( $this->at( $this->routerCallIndex++ ) )
+            ->method( 'generate' )
+            ->with(
+                $this->equalTo( $routeName ),
+                $this->equalTo( $arguments )
+            )
+            ->will( $this->returnValue( $returnValue ) );
+    }
+
+    /**
+     * @return \Symfony\Component\Routing\RouterInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getTemplatedRouterMock()
+    {
+        if ( !isset( $this->templatedRouterMock ) )
+        {
+            $this->templatedRouterMock = $this->getMock( 'Symfony\\Component\\Routing\\RouterInterface' );
+        }
+
+        return $this->templatedRouterMock;
+    }
+
+    /**
+     * Adds an expectation to the templatedRouterMock. Expectations must be added sequentially.
+     *
+     * @param string $routeName
+     * @param array $arguments
+     * @param string $returnValue
+     */
+    protected function addTemplatedRouteExpectation( $routeName, $arguments, $returnValue )
+    {
+        $this->getTemplatedRouterMock()
+            ->expects( $this->at( $this->templatedRouterCallIndex++ ) )
             ->method( 'generate' )
             ->with(
                 $this->equalTo( $routeName ),

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ObjectStateGroup.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ObjectStateGroup.php
@@ -49,6 +49,14 @@ class ObjectStateGroup extends ValueObjectVisitor
         $generator->startValueElement( 'languageCodes', implode( ',', $data->languageCodes ) );
         $generator->endValueElement( 'languageCodes' );
 
+        $generator->startObjectElement( 'ObjectStates', 'ObjectStateList' );
+        $generator->startAttribute(
+            'href',
+            $this->router->generate( 'ezpublish_rest_loadObjectStates', array( 'objectStateGroupId' => $data->id ) )
+        );
+        $generator->endAttribute( 'href' );
+        $generator->endObjectElement( 'ObjectStates' );
+
         $this->visitNamesList( $generator, $data->getNames() );
         $this->visitDescriptionsList( $generator, $data->getDescriptions() );
 

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContent.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContent.php
@@ -177,6 +177,17 @@ class RestContent extends ValueObjectVisitor
         );
         $generator->endValueElement( 'alwaysAvailable' );
 
+        $generator->startObjectElement( 'ObjectStates', 'ContentObjectStates' );
+        $generator->startAttribute(
+            'href',
+            $this->router->generate(
+                'ezpublish_rest_getObjectStatesForContent',
+                array( 'contentId' => $contentInfo->id )
+            )
+        );
+        $generator->endAttribute( 'href' );
+        $generator->endObjectElement( 'ObjectStates' );
+
         $generator->endObjectElement( 'Content' );
     }
 }

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContentType.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContentType.php
@@ -98,6 +98,28 @@ class RestContentType extends RestContentTypeBase
         $generator->endAttribute( 'href' );
         $generator->endObjectElement( 'Modifier' );
 
+        $generator->startObjectElement( 'Groups', 'ContentTypeGroupRefList' );
+        $generator->startAttribute(
+            'href',
+            $this->router->generate(
+                'ezpublish_rest_loadGroupsOfContentType',
+                array( 'contentTypeId' => $contentType->id )
+            )
+        );
+        $generator->endAttribute( 'href' );
+        $generator->endObjectElement( 'Groups' );
+
+        $generator->startObjectElement( 'Draft', 'ContentType' );
+        $generator->startAttribute(
+            'href',
+            $this->router->generate(
+                'ezpublish_rest_loadContentTypeDraft',
+                array( 'contentTypeId' => $contentType->id )
+            )
+        );
+        $generator->endAttribute( 'href' );
+        $generator->endObjectElement( 'Draft' );
+
         $generator->startValueElement( 'remoteId', $contentType->remoteId );
         $generator->endValueElement( 'remoteId' );
 

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestLocation.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestLocation.php
@@ -110,6 +110,19 @@ class RestLocation extends ValueObjectVisitor
         $generator->startValueElement( 'sortOrder', $this->serializeSortOrder( $data->location->sortOrder ) );
         $generator->endValueElement( 'sortOrder' );
 
+        $generator->startObjectElement( 'UrlAliases', 'UrlAliasRefList' );
+        $generator->startAttribute(
+            'href',
+            $this->router->generate(
+                'ezpublish_rest_listLocationURLAliases',
+                array(
+                    'locationPath' => trim( $data->location->pathString, '/' )
+                )
+            )
+        );
+        $generator->endAttribute( 'href' );
+        $generator->endObjectElement( 'UrlAliases' );
+
         $generator->endObjectElement( 'Location' );
     }
 }

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestUser.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestUser.php
@@ -95,6 +95,14 @@ class RestUser extends ValueObjectVisitor
         $generator->endAttribute( 'href' );
         $generator->endObjectElement( 'Locations' );
 
+        $generator->startObjectElement( 'Groups', 'UserGroupRefList' );
+        $generator->startAttribute(
+            'href',
+            $this->router->generate( 'ezpublish_rest_loadUserGroupsOfUser', array( 'userId' => $contentInfo->id ) )
+        );
+        $generator->endAttribute( 'href' );
+        $generator->endObjectElement( 'Groups' );
+
         $generator->startObjectElement( 'Owner', 'User' );
         $generator->startAttribute(
             'href',

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Root.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Root.php
@@ -35,61 +35,166 @@ class Root extends ValueObjectVisitor
         $generator->startHashElement( 'content' );
         $generator->startAttribute( 'media-type', '' );
         $generator->endAttribute( 'media-type' );
-        $generator->startAttribute( 'href', $this->router->generate( 'ezpublish_rest_redirectContent' ) );
+        $generator->startAttribute(
+            'href',
+            $this->router->generate( 'ezpublish_rest_createContent' )
+        );
         $generator->endAttribute( 'href' );
         $generator->endHashElement( 'content' );
 
+        // Uses hashElement instead of objectElement as a workaround to be able to have
+        // an empty media-type, since there is no media type for list of content yet
+        $generator->startHashElement( 'contentByRemoteId' );
+        $generator->startAttribute( 'media-type', '' );
+        $generator->endAttribute( 'media-type' );
+        $generator->startAttribute(
+            'href',
+            $this->templateRouter->generate(
+                'ezpublish_rest_redirectContent',
+                array( 'remoteId' => '{remoteId}' )
+            )
+        );
+        $generator->endAttribute( 'href' );
+        $generator->endHashElement( 'contentByRemoteId' );
+
+        // Content types list
         $generator->startObjectElement( 'contentTypes', 'ContentTypeInfoList' );
         $generator->startAttribute( 'href', $this->router->generate( 'ezpublish_rest_listContentTypes' ) );
         $generator->endAttribute( 'href' );
         $generator->endObjectElement( 'contentTypes' );
 
+        // Content type by identifier
+        // See comment above regarding usage of hash element
+        $generator->startHashElement( 'contentTypeByIdentifier' );
+        $generator->startAttribute( 'media-type', '' );
+        $generator->endAttribute( 'media-type' );
+        $generator->startAttribute(
+            'href',
+            $this->templateRouter->generate(
+                'ezpublish_rest_listContentTypes',
+                array( 'identifier' => '{identifier}' )
+            )
+        );
+        $generator->endAttribute( 'href' );
+        $generator->endHashElement( 'contentTypeByIdentifier' );
+
+        // Content type groups
+        $generator->startObjectElement( 'contentTypeGroups', 'ContentTypeGroupList' );
+        $generator->startAttribute( 'href', $this->router->generate( 'ezpublish_rest_loadContentTypeGroupList' ) );
+        $generator->endAttribute( 'href' );
+        $generator->endObjectElement( 'contentTypeGroups' );
+
+        // Users
         $generator->startObjectElement( 'users', 'UserRefList' );
         $generator->startAttribute( 'href', $this->router->generate( 'ezpublish_rest_loadUsers' ) );
         $generator->endAttribute( 'href' );
         $generator->endObjectElement( 'users' );
 
+        // Roles
         $generator->startObjectElement( 'roles', 'RoleList' );
         $generator->startAttribute( 'href', $this->router->generate( 'ezpublish_rest_listRoles' ) );
         $generator->endAttribute( 'href' );
         $generator->endObjectElement( 'roles' );
 
-        // @todo Load the locations of the following three items from settings
+        // Content root location
         $generator->startObjectElement( 'rootLocation', 'Location' );
         $generator->startAttribute( 'href', $this->router->generate( 'ezpublish_rest_loadLocation', array( 'locationPath' => '1/2' ) ) );
         $generator->endAttribute( 'href' );
         $generator->endObjectElement( 'rootLocation' );
 
+        // Users root location
         $generator->startObjectElement( 'rootUserGroup', 'UserGroup' );
         $generator->startAttribute( 'href', $this->router->generate( 'ezpublish_rest_loadUserGroup', array( 'groupPath' => '1/5' ) ) );
         $generator->endAttribute( 'href' );
         $generator->endObjectElement( 'rootUserGroup' );
 
+        // Media root location
         $generator->startObjectElement( 'rootMediaFolder', 'Location' );
         $generator->startAttribute( 'href', $this->router->generate( 'ezpublish_rest_loadLocation', array( 'locationPath' => '1/43' ) ) );
         $generator->endAttribute( 'href' );
         $generator->endObjectElement( 'rootMediaFolder' );
 
+        // Location by remote ID
+        // See comment above regarding usage of hash element
+        $generator->startHashElement( 'locationByRemoteId' );
+        $generator->startAttribute( 'media-type', '' );
+        $generator->endAttribute( 'media-type' );
+        $generator->startAttribute(
+            'href',
+            $this->templateRouter->generate(
+                'ezpublish_rest_redirectLocation',
+                array( 'remoteId' => '{remoteId}' )
+            )
+        );
+        $generator->endAttribute( 'href' );
+        $generator->endHashElement( 'locationByRemoteId' );
+
+        $generator->startHashElement( 'locationByPath' );
+        $generator->startAttribute( 'media-type', '' );
+        $generator->endAttribute( 'media-type' );
+        $generator->startAttribute(
+            'href',
+            $this->templateRouter->generate(
+                'ezpublish_rest_redirectLocation',
+                array( 'locationPath' => '{locationPath}' )
+            )
+        );
+        $generator->endAttribute( 'href' );
+        $generator->endHashElement( 'locationByPath' );
+
+        // Trash
         $generator->startObjectElement( 'trash', 'Trash' );
         $generator->startAttribute( 'href', $this->router->generate( 'ezpublish_rest_loadTrashItems' ) );
         $generator->endAttribute( 'href' );
         $generator->endObjectElement( 'trash' );
 
+        // Sections list
         $generator->startObjectElement( 'sections', 'SectionList' );
         $generator->startAttribute( 'href', $this->router->generate( 'ezpublish_rest_listSections' ) );
         $generator->endAttribute( 'href' );
         $generator->endObjectElement( 'sections' );
 
+        // Content views
         $generator->startObjectElement( 'views', 'RefList' );
         $generator->startAttribute( 'href', $this->router->generate( 'ezpublish_rest_createView' ) );
         $generator->endAttribute( 'href' );
         $generator->endObjectElement( 'views' );
 
-        // @todo object states?
-        // @todo url aliases?
-        // @todo url wildcards?
-        // @todo content type groups?
-        // @todo user policies?
+        // Object states groups
+        $generator->startObjectElement( 'objectStateGroups', 'ObjectStateGroupList' );
+        $generator->startAttribute( 'href', $this->router->generate( 'ezpublish_rest_loadObjectStateGroups' ) );
+        $generator->endAttribute( 'href' );
+        $generator->endObjectElement( 'objectStateGroups' );
+
+        // Object states
+        $generator->startObjectElement( 'objectStates', 'ObjectStateList' );
+        $generator->startAttribute(
+            'href',
+            $this->templateRouter->generate(
+                'ezpublish_rest_loadObjectStates',
+                array( 'objectStateGroupId' => '{objectStateGroupId}' )
+            )
+        );
+        $generator->endAttribute( 'href' );
+        $generator->endObjectElement( 'objectStates' );
+
+        // Global URL aliases
+        $generator->startObjectElement( 'globalUrlAliases', 'UrlAliasRefList' );
+        $generator->startAttribute( 'href', $this->router->generate( 'ezpublish_rest_listGlobalURLAliases' ) );
+        $generator->endAttribute( 'href' );
+        $generator->endObjectElement( 'globalUrlAliases' );
+
+        // URL wildcards
+        $generator->startObjectElement( 'urlWildcards', 'UrlWildcardList' );
+        $generator->startAttribute( 'href', $this->router->generate( 'ezpublish_rest_listURLWildcards' ) );
+        $generator->endAttribute( 'href' );
+        $generator->endObjectElement( 'urlWildcards' );
+
+        // Create session
+        $generator->startObjectElement( 'createSession', 'UserSession' );
+        $generator->startAttribute( 'href', $this->router->generate( 'ezpublish_rest_createSession' ) );
+        $generator->endAttribute( 'href' );
+        $generator->endObjectElement( 'createSession' );
 
         $generator->endObjectElement( 'Root' );
     }

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ObjectStateGroupTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ObjectStateGroupTest.php
@@ -52,6 +52,12 @@ class ObjectStateGroupTest extends ValueObjectVisitorBaseTest
             "/content/objectstategroups/$objectStateGroup->id"
         );
 
+        $this->addRouteExpectation(
+            'ezpublish_rest_loadObjectStates',
+            array( 'objectStateGroupId' => $objectStateGroup->id ),
+            "/content/objectstategroups/$objectStateGroup->id/objectstates"
+        );
+
         $visitor->visit(
             $this->getVisitorMock(),
             $generator,
@@ -78,7 +84,7 @@ class ObjectStateGroupTest extends ValueObjectVisitorBaseTest
             array(
                 'tag'      => 'ObjectStateGroup',
                 'children' => array(
-                    'count' => 6
+                    'count' => 7
                 )
             ),
             $result,

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestContentTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestContentTest.php
@@ -74,6 +74,11 @@ class RestContentTest extends ValueObjectVisitorBaseTest
             array( 'userId' => $restContent->contentInfo->ownerId ),
             "/user/users/{$restContent->contentInfo->ownerId}"
         );
+        $this->addRouteExpectation(
+            'ezpublish_rest_getObjectStatesForContent',
+            array( 'contentId' => $restContent->contentInfo->id ),
+            "/content/objects/{$restContent->contentInfo->id}/objectstates"
+        );
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestContentTypeTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestContentTypeTest.php
@@ -53,6 +53,16 @@ class RestContentTypeTest extends ValueObjectVisitorBaseTest
             array( 'userId' => $restContentType->contentType->modifierId ),
             "/user/users/{$restContentType->contentType->modifierId}"
         );
+        $this->addRouteExpectation(
+            'ezpublish_rest_loadGroupsOfContentType',
+            array( 'contentTypeId' => $restContentType->contentType->id ),
+            "/content/types/{$restContentType->contentType->id}/groups"
+        );
+        $this->addRouteExpectation(
+            'ezpublish_rest_loadContentTypeDraft',
+            array( 'contentTypeId' => $restContentType->contentType->id ),
+            "/content/types/{$restContentType->contentType->id}/draft"
+        );
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -117,7 +127,7 @@ class RestContentTypeTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisitDefinedType
      */
-    public function testContentTypeMediaTyp( \DOMDocument $dom )
+    public function testContentTypeMediaType( \DOMDocument $dom )
     {
         $this->assertXPath( $dom, '/ContentType[@media-type="application/vnd.ez.api.ContentType+xml"]'  );
     }
@@ -250,6 +260,46 @@ class RestContentTypeTest extends ValueObjectVisitorBaseTest
     public function testModifierMediaType( \DOMDocument $dom )
     {
         $this->assertXPath( $dom, '/ContentType/Modifier[@media-type="application/vnd.ez.api.User+xml"]'  );
+    }
+
+    /**
+     * @param \DOMDocument $dom
+     *
+     * @depends testVisitDefinedType
+     */
+    public function testDraftHref( \DOMDocument $dom )
+    {
+        $this->assertXPath( $dom, '/ContentType/Draft[@href="/content/types/contentTypeId/draft"]'  );
+    }
+
+    /**
+     * @param \DOMDocument $dom
+     *
+     * @depends testVisitDefinedType
+     */
+    public function testDraftType( \DOMDocument $dom )
+    {
+        $this->assertXPath( $dom, '/ContentType/Draft[@media-type="application/vnd.ez.api.ContentType+xml"]'  );
+    }
+
+    /**
+     * @param \DOMDocument $dom
+     *
+     * @depends testVisitDefinedType
+     */
+    public function testGroupsHref( \DOMDocument $dom )
+    {
+        $this->assertXPath( $dom, '/ContentType/Groups[@href="/content/types/contentTypeId/groups"]'  );
+    }
+
+    /**
+     * @param \DOMDocument $dom
+     *
+     * @depends testVisitDefinedType
+     */
+    public function testGroupsType( \DOMDocument $dom )
+    {
+        $this->assertXPath( $dom, '/ContentType/Groups[@media-type="application/vnd.ez.api.ContentTypeGroupRefList+xml"]'  );
     }
 
     /**

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestLocationTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestLocationTest.php
@@ -74,6 +74,10 @@ class RestLocationTest extends ValueObjectVisitorBaseTest
             'ezpublish_rest_loadContent', array( 'contentId' => $location->location->contentId ),
             "/content/objects/{$location->location->contentId}"
         );
+        $this->addRouteExpectation(
+            'ezpublish_rest_listLocationURLAliases', array( 'locationPath' => '1/2/21/42' ),
+            "/content/objects/1/2/21/42/urlaliases"
+        );
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -101,7 +105,7 @@ class RestLocationTest extends ValueObjectVisitorBaseTest
             array(
                 'tag'      => 'Location',
                 'children' => array(
-                    'count' => 13
+                    'count' => 14
                 )
             ),
             $result,
@@ -455,6 +459,48 @@ class RestLocationTest extends ValueObjectVisitorBaseTest
             ),
             $result,
             'Invalid or non-existing <Location> childCount value element.',
+            false
+        );
+    }
+
+    /**
+     * Test if result contains Content element
+     *
+     * @param string $result
+     *
+     * @depends testVisit
+     */
+    public function testResultContainsUrlAliasesTag( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'UrlAliases'
+            ),
+            $result,
+            'Invalid <UrlAliases> element.',
+            false
+        );
+    }
+
+    /**
+     * Test if result contains Content element attributes
+     *
+     * @param string $result
+     *
+     * @depends testVisit
+     */
+    public function testResultContainsUrlAliasesTagAttributes( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'UrlAliases',
+                'attributes' => array(
+                    'media-type' => 'application/vnd.ez.api.UrlAliasRefList+xml',
+                    'href'       => '/content/objects/1/2/21/42/urlaliases',
+                )
+            ),
+            $result,
+            'Invalid <UrlAliases> attributes.',
             false
         );
     }

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestUserTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestUserTest.php
@@ -66,6 +66,11 @@ class RestUserTest extends ValueObjectVisitorBaseTest
             "/content/objects/{$restUser->contentInfo->id}/locations"
         );
         $this->addRouteExpectation(
+            'ezpublish_rest_loadUserGroupsOfUser',
+            array( 'userId' => $restUser->contentInfo->id ),
+            "/user/users/{$restUser->contentInfo->id}/groups"
+        );
+        $this->addRouteExpectation(
             'ezpublish_rest_loadUser',
             array( 'userId' => $restUser->contentInfo->ownerId ),
             "/user/users/{$restUser->contentInfo->ownerId}"

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RootTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RootTest.php
@@ -31,8 +31,23 @@ class RootTest extends ValueObjectVisitorBaseTest
 
         $role = new Root;
 
-        $this->addRouteExpectation( 'ezpublish_rest_redirectContent', array(), '/content/objects' );
+        $this->addRouteExpectation(
+            'ezpublish_rest_createContent',
+            array(),
+            '/content/objects'
+        );
+        $this->addTemplatedRouteExpectation(
+            'ezpublish_rest_redirectContent',
+            array( 'remoteId' => '{remoteId}' ),
+            '/content/objects'
+        );
         $this->addRouteExpectation( 'ezpublish_rest_listContentTypes', array(), '/content/types' );
+        $this->addTemplatedRouteExpectation(
+            'ezpublish_rest_listContentTypes',
+            array( 'identifier' => '{identifier}' ),
+            '/content/types?{&identifier}'
+        );
+        $this->addRouteExpectation( 'ezpublish_rest_loadContentTypeGroupList', array(), '/content/typegroups' );
         $this->addRouteExpectation( 'ezpublish_rest_loadUsers', array(), '/user/users' );
         $this->addRouteExpectation( 'ezpublish_rest_listRoles', array(), '/user/roles' );
         $this->addRouteExpectation(
@@ -50,9 +65,28 @@ class RootTest extends ValueObjectVisitorBaseTest
             array( 'locationPath' => '1/43' ),
             '/content/locations/1/43'
         );
+        $this->addTemplatedRouteExpectation(
+            'ezpublish_rest_redirectLocation',
+            array( 'remoteId' => '{remoteId}' ),
+            '/content/locations?{&remoteId}'
+        );
+        $this->addTemplatedRouteExpectation(
+            'ezpublish_rest_redirectLocation',
+            array( 'locationPath' => '{locationPath}' ),
+            '/content/locations?{&locationPath}'
+        );
         $this->addRouteExpectation( 'ezpublish_rest_loadTrashItems', array(), '/content/trash' );
         $this->addRouteExpectation( 'ezpublish_rest_listSections', array(), '/content/sections' );
         $this->addRouteExpectation( 'ezpublish_rest_createView', array(), '/content/views' );
+        $this->addRouteExpectation( 'ezpublish_rest_loadObjectStateGroups', array(), '/content/objectstategroups' );
+        $this->addTemplatedRouteExpectation(
+            'ezpublish_rest_loadObjectStates',
+            array( 'objectStateGroupId' => '{objectStateGroupId}' ),
+            '/content/objectstategroups/{objectStateGroupId}/objectstates'
+        );
+        $this->addRouteExpectation( 'ezpublish_rest_listGlobalURLAliases', array(), '/content/urlaliases' );
+        $this->addRouteExpectation( 'ezpublish_rest_listURLWildcards', array(), '/content/urlwildcards' );
+        $this->addRouteExpectation( 'ezpublish_rest_createSession', array(), '/user/sessions' );
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -73,12 +107,7 @@ class RootTest extends ValueObjectVisitorBaseTest
     public function testResultContainsRootElement( $result )
     {
         $this->assertTag(
-            array(
-                'tag'      => 'Root',
-                'children' => array(
-                    'count' => 10
-                )
-            ),
+            array( 'tag' => 'Root' ),
             $result,
             'Invalid <Root> element.',
             false
@@ -144,6 +173,40 @@ class RootTest extends ValueObjectVisitorBaseTest
     /**
      * @depends testVisit
      */
+    public function testResultContainsContentByRemoteIdTag( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'contentByRemoteId'
+            ),
+            $result,
+            'Missing <contentByRemoteId> element.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
+    public function testResultContainsContentByRemoteIdTagAttributes( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'contentByRemoteId',
+                'attributes' => array(
+                    'media-type' => '',
+                    'href' => '/content/objects'
+                )
+            ),
+            $result,
+            'Invalid <contentByRemoteId> tag attributes.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
     public function testResultContainsContentTypesTag( $result )
     {
         $this->assertTag(
@@ -171,6 +234,74 @@ class RootTest extends ValueObjectVisitorBaseTest
             ),
             $result,
             'Invalid <content> element.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
+    public function testResultContainsContentTypeByIdentifierTag( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'contentTypeByIdentifier'
+            ),
+            $result,
+            'Invalid <contentTypeByIdentifier> element.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
+    public function testResultContainsContentTypeByIdentifierTagAttributes( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'contentTypeByIdentifier',
+                'attributes' => array(
+                    'media-type' => '',
+                    'href' => '/content/types?{&identifier}'
+                )
+            ),
+            $result,
+            'Invalid <contentTypeByIdentifier> tag attributes.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
+    public function testResultContainsContentTypeGroupsTag( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'contentTypeGroups'
+            ),
+            $result,
+            'Missing <contentTypeGroups> element.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
+    public function testResultContainsContentTypeGroupsTagAttributes( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'contentTypeGroups',
+                'attributes' => array(
+                    'media-type' => 'application/vnd.ez.api.ContentTypeGroupList+xml',
+                    'href' => '/content/typegroups'
+                )
+            ),
+            $result,
+            'Invalid <contentTypeGroups> tag attributes.',
             false
         );
     }
@@ -348,6 +479,74 @@ class RootTest extends ValueObjectVisitorBaseTest
     /**
      * @depends testVisit
      */
+    public function testResultContainsLocationByRemoteIdTag( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'locationByRemoteId'
+            ),
+            $result,
+            'Missing <locationByRemoteId> tag.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
+    public function testResultContainsLocationByRemoteIdTagAttributes( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'locationByRemoteId',
+                'attributes' => array(
+                    'media-type' => '',
+                    'href' => '/content/locations?{&remoteId}'
+                )
+            ),
+            $result,
+            'Invalid <locationByRemoteId> tag attributes.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
+    public function testResultContainsLocationByPathTag( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'locationByPath'
+            ),
+            $result,
+            'Missing <locationByPath> tag.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
+    public function testResultContainsLocationByPathTagAttributes( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'locationByPath',
+                'attributes' => array(
+                    'media-type' => '',
+                    'href' => '/content/locations?{&locationPath}'
+                )
+            ),
+            $result,
+            'Invalid <locationByPath> tag attributes.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
     public function testResultContainsTrashTag( $result )
     {
         $this->assertTag(
@@ -443,6 +642,176 @@ class RootTest extends ValueObjectVisitorBaseTest
             ),
             $result,
             'Invalid <views> tag attributes.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
+    public function testResultContainsObjectStateGroupsTag( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'objectStateGroups'
+            ),
+            $result,
+            'Missing <objectStateGroups> tag.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
+    public function testResultContainsObjectStateGroupsTagAttributes( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'objectStateGroups',
+                'attributes' => array(
+                    'media-type' => 'application/vnd.ez.api.ObjectStateGroupList+xml',
+                    'href' => '/content/objectstategroups'
+                )
+            ),
+            $result,
+            'Invalid <objectStateGroups> tag attributes.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
+    public function testResultContainsObjectStatesTag( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'objectStates'
+            ),
+            $result,
+            'Missing <objectStates> tag.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
+    public function testResultContainsObjectStatesTagAttributes( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'objectStates',
+                'attributes' => array(
+                    'media-type' => 'application/vnd.ez.api.ObjectStateList+xml',
+                    'href' => '/content/objectstategroups/{objectStateGroupId}/objectstates'
+                )
+            ),
+            $result,
+            'Invalid <objectStates> tag attributes.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
+    public function testResultContainsGlobalUrlAliasesTag( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'globalUrlAliases'
+            ),
+            $result,
+            'Missing <globalUrlAliases> tag.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
+    public function testResultContainsGlobalUrlAliasesTagAttributes( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'globalUrlAliases',
+                'attributes' => array(
+                    'media-type' => 'application/vnd.ez.api.UrlAliasRefList+xml',
+                    'href' => '/content/urlaliases'
+                )
+            ),
+            $result,
+            'Invalid <globalUrlAliases> tag attributes.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
+    public function testResultContainsUrlWildcardsTag( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'urlWildcards'
+            ),
+            $result,
+            'Missing <urlWildcards> tag.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
+    public function testResultContainsUrlWildcardsTagAttributes( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'urlWildcards',
+                'attributes' => array(
+                    'media-type' => 'application/vnd.ez.api.UrlWildcardList+xml',
+                    'href' => '/content/urlwildcards'
+                )
+            ),
+            $result,
+            'Invalid <globalUrlAliases> tag attributes.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
+    public function testResultContainsCreateSessionTag( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'createSession'
+            ),
+            $result,
+            'Missing <createSession> tag.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
+    public function testResultContainsCreateSessionTagAttributes( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'createSession',
+                'attributes' => array(
+                    'media-type' => 'application/vnd.ez.api.UserSession+xml',
+                    'href' => '/user/sessions'
+                )
+            ),
+            $result,
+            'Invalid <createSession> tag attributes.',
             false
         );
     }


### PR DESCRIPTION
http://jira.ez.no/browse/EZP-20930

Adds the missing URLs to the REST root resource.

Adds a dependency on https://github.com/hautelook/TemplatedUriBundle that allows us to generate RFC-6570 compliant URIs through a custom router. 
## Added resources:
### Root
- `/Root/contentByRemoteId`
- `/Root/contentTypeByIdentifier`
- `/Root/contentTypeGroups`
- `/Root/rootUserGroup`
- `/Root/locationByRemoteId`,
- `/Root/locationByPath`
- `/Root/objectStateGroups`
- `/Root/objectStates`
- `/Root/globalUrlAliases`
- `/Root/createSession`
### Other
#### ObjectStateGroup
- `/ObjectStateGroup/ObjectStates`
#### Content
- `/Content/ObjectStates`
#### Location
- `/Location/UrlAliases`
#### ContentType
- `/ContentType/Draft`
- `/ContentType/Groups`
#### User
- `/User/Groups`
## Example output

``` xml
<Root media-type="application/vnd.ez.api.Root+xml">
 <contentByRemoteId media-type="" href="/api/ezp/v2/content/objects?{&amp;remoteId}"/>
 <contentTypes media-type="application/vnd.ez.api.ContentTypeInfoList+xml" href="/api/ezp/v2/content/types"/>
 <contentTypeByIdentifier media-type="" href="/api/ezp/v2/content/types?{&amp;identifier}"/>
 <contentTypeGroups media-type="application/vnd.ez.api.ContentTypeGroupList+xml" href="/api/ezp/v2/content/typegroups"/>
 <users media-type="application/vnd.ez.api.UserRefList+xml" href="/api/ezp/v2/user/users"/>
 <roles media-type="application/vnd.ez.api.RoleList+xml" href="/api/ezp/v2/user/roles"/>
 <rootLocation media-type="application/vnd.ez.api.Location+xml" href="/api/ezp/v2/content/locations/1/2"/>
 <rootUserGroup media-type="application/vnd.ez.api.UserGroup+xml" href="/api/ezp/v2/user/groups/1/5"/>
 <rootMediaFolder media-type="application/vnd.ez.api.Location+xml" href="/api/ezp/v2/content/locations/1/43"/>
 <locationByRemoteId media-type="" href="/api/ezp/v2/content/locations?{&amp;remoteId}"/>
 <locationByPath media-type="" href="/api/ezp/v2/content/locations?{&amp;locationPath}"/>
 <trash media-type="application/vnd.ez.api.Trash+xml" href="/api/ezp/v2/content/trash"/>
 <sections media-type="application/vnd.ez.api.SectionList+xml" href="/api/ezp/v2/content/sections"/>
 <views media-type="application/vnd.ez.api.RefList+xml" href="/api/ezp/v2/content/views"/>
 <objectStateGroups media-type="application/vnd.ez.api.ObjectStateGroupList+xml" href="/api/ezp/v2/content/objectstategroups"/>
 <objectStates media-type="application/vnd.ez.api.ObjectStateList+xml" href="/api/ezp/v2/content/objectstategroups/{objectStateGroupId}/objectstates"/>
 <globalUrlAliases media-type="application/vnd.ez.api.UrlAliasRefList+xml" href="/api/ezp/v2/content/urlaliases"/>
 <urlWildcards media-type="application/vnd.ez.api.UrlWildcardList+xml" href="/api/ezp/v2/content/urlwildcards"/>
 <createSession media-type="application/vnd.ez.api.UserSession+xml" href="/api/ezp/v2/user/sessions"/>
</Root>
```
## Related pull request
- https://github.com/ezsystems/ezpublish-community/pull/70
## TODO
- [x] Tests (really not a big fan of visitor tests, but well...
