### PR TITLE
Fix EZP-21379 : Output filters (CSRF) result is lost when a custom layout is set for rendering legacy module views.

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Controller/LegacyKernelController.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Controller/LegacyKernelController.php
@@ -114,7 +114,7 @@ class LegacyKernelController
         if ( isset( $this->legacyLayout ) && !$legacyMode && !isset( $moduleResult['pagelayout'] ) )
         {
             // Replace original module_result content by filtered one
-            $moduleResult['content'] =  $result->getContent() ;
+            $moduleResult['content'] = $result->getContent();
 
             $response = $this->render(
                 $this->legacyLayout,


### PR DESCRIPTION
When you set a custom layout for legacy module views, content is injected without any filters applied.
This will make any legacy view containing forms unusable (content/edit) due to the absence of the token (injected by eZ Form token output filter).
