### PR TITLE
Add integration test for EZP21289 - Test object remote id conversion to object id on XmlText

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Regression/EZP21069Test.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP21069Test.php
@@ -38,7 +38,7 @@ class EZP21069Test extends BaseTest
             $contentTypeService->loadContentTypeByIdentifier( 'folder' ),
             'eng-GB'
         );
-        $contentCreateStruct->setField ( 'name', 'TheOriginalNews' );
+        $contentCreateStruct->setField( 'name', 'TheOriginalNews' );
         $contentService->publishVersion(
             $contentService->createContent(
                 $contentCreateStruct, array( $locationService->newLocationCreateStruct( 2 ) )


### PR DESCRIPTION
This is the integration test for the issue EZP21289 - Test object remote id conversion to object id on XmlText

It's quite different from what you've on yours tests, however it needs 2 created objects for better testing.
