### PR TITLE
Fixes rendered REST API doc anchor links in TOC

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -3,8 +3,6 @@
 eZ Publish REST API V2 RFC
 ==========================
 
-.. sectnum::
-
 .. contents:: Table of Contents
 
 General considerations


### PR DESCRIPTION
The github rendering of the REST API spec breaks if section numbering is used.

This PR removes numbering: https://github.com/ezsystems/ezpublish-kernel/blob/fix-rest-api-TOC/doc/specifications/rest/REST-API-V2.rst.
