### PR TITLE
Fix EZP-21438: Improve permission handling to use view_embed

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewControllerListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewControllerListener.php
@@ -83,8 +83,11 @@ class ViewControllerListener implements EventSubscriberInterface
             }
             else if ( $request->attributes->has( 'contentId' ) )
             {
-                $valueObject = $this->repository->getContentService()->loadContentInfo(
-                    $request->attributes->get( 'contentId' )
+                $valueObject = $this->repository->sudo(
+                    function ( $repository ) use ( $request )
+                    {
+                        return $repository->getContentService()->loadContentInfo( $request->attributes->get( 'contentId' ) );
+                    }
                 );
             }
         }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
@@ -56,7 +56,10 @@ class ViewControllerListenerTest extends PHPUnit_Framework_TestCase
         parent::setUp();
         $this->controllerResolver = $this->getMock( 'Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface' );
         $this->controllerManager = $this->getMock( 'eZ\\Publish\\Core\\MVC\\Symfony\\Controller\\ManagerInterface' );
-        $this->repository = $this->getMock( 'eZ\\Publish\\API\\Repository\\Repository' );
+        $this->repository = $this
+            ->getMockBuilder( 'eZ\\Publish\\Core\\Repository\\Repository' )
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->logger = $this->getMock( 'Psr\\Log\\LoggerInterface' );
         $this->controllerListener = new ViewControllerListener( $this->controllerResolver, $this->controllerManager, $this->repository, $this->logger );
 


### PR DESCRIPTION
### Description

Currently, load methods in contentService check for valid content/read access.
However, it is possibly that users (only) have the `view_embed` permission.

This allows for content to be rendered, from twig, using the embed viewType, if the user has view_embed permissions:

```
{{ render( controller( "ez_content:viewContent", {"contentId": 123, "viewType": "embed"} ) ) }}
```
### Tests

Manual testing
