### PR TITLE
Implemented EZP-15040: Support for more than 30 languages

### DIFF
--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -73,11 +73,11 @@ DROP TABLE IF EXISTS `ezcobj_state`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `ezcobj_state` (
-  `default_language_id` int(11) NOT NULL DEFAULT '0',
+  `default_language_id` bigint(20) NOT NULL DEFAULT '0',
   `group_id` int(11) NOT NULL DEFAULT '0',
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `identifier` varchar(45) NOT NULL DEFAULT '',
-  `language_mask` int(11) NOT NULL DEFAULT '0',
+  `language_mask` bigint(20) NOT NULL DEFAULT '0',
   `priority` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `ezcobj_state_identifier` (`group_id`,`identifier`),
@@ -94,10 +94,10 @@ DROP TABLE IF EXISTS `ezcobj_state_group`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `ezcobj_state_group` (
-  `default_language_id` int(11) NOT NULL DEFAULT '0',
+  `default_language_id` bigint(20) NOT NULL DEFAULT '0',
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `identifier` varchar(45) NOT NULL DEFAULT '',
-  `language_mask` int(11) NOT NULL DEFAULT '0',
+  `language_mask` bigint(20) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `ezcobj_state_group_identifier` (`identifier`),
   KEY `ezcobj_state_group_lmask` (`language_mask`)
@@ -114,9 +114,9 @@ DROP TABLE IF EXISTS `ezcobj_state_group_language`;
 CREATE TABLE `ezcobj_state_group_language` (
   `contentobject_state_group_id` int(11) NOT NULL DEFAULT '0',
   `description` longtext NOT NULL,
-  `language_id` int(11) NOT NULL DEFAULT '0',
+  `language_id` bigint(20) NOT NULL DEFAULT '0',
   `name` varchar(45) NOT NULL DEFAULT '',
-  `real_language_id` int(11) NOT NULL DEFAULT '0',
+  `real_language_id` bigint(20) NOT NULL DEFAULT '0',
   PRIMARY KEY (`contentobject_state_group_id`,`real_language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -131,7 +131,7 @@ DROP TABLE IF EXISTS `ezcobj_state_language`;
 CREATE TABLE `ezcobj_state_language` (
   `contentobject_state_id` int(11) NOT NULL DEFAULT '0',
   `description` longtext NOT NULL,
-  `language_id` int(11) NOT NULL DEFAULT '0',
+  `language_id` bigint(20) NOT NULL DEFAULT '0',
   `name` varchar(45) NOT NULL DEFAULT '',
   PRIMARY KEY (`contentobject_state_id`,`language_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -347,7 +347,7 @@ DROP TABLE IF EXISTS `ezcomment`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `ezcomment` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `language_id` int(11) NOT NULL,
+  `language_id` bigint(20) NOT NULL,
   `created` int(11) NOT NULL,
   `modified` int(11) NOT NULL,
   `user_id` int(11) NOT NULL,
@@ -377,7 +377,7 @@ DROP TABLE IF EXISTS `ezcomment_notification`;
 CREATE TABLE `ezcomment_notification` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `contentobject_id` int(11) NOT NULL,
-  `language_id` int(11) NOT NULL,
+  `language_id` bigint(20) NOT NULL,
   `send_time` int(11) NOT NULL DEFAULT '0',
   `status` int(11) NOT NULL DEFAULT '1',
   `comment_id` int(11) NOT NULL,
@@ -415,7 +415,7 @@ CREATE TABLE `ezcomment_subscription` (
   `subscriber_id` int(11) NOT NULL,
   `subscription_type` varchar(30) NOT NULL,
   `content_id` int(11) NOT NULL,
-  `language_id` int(11) NOT NULL DEFAULT '0',
+  `language_id` bigint(20) NOT NULL DEFAULT '0',
   `subscription_time` int(11) NOT NULL,
   `enabled` int(11) NOT NULL DEFAULT '1',
   `hash_string` varchar(50) DEFAULT NULL,
@@ -432,7 +432,7 @@ DROP TABLE IF EXISTS `ezcontent_language`;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `ezcontent_language` (
   `disabled` int(11) NOT NULL DEFAULT '0',
-  `id` int(11) NOT NULL DEFAULT '0',
+  `id` bigint(20) NOT NULL DEFAULT '0',
   `locale` varchar(20) NOT NULL DEFAULT '',
   `name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
@@ -489,9 +489,9 @@ CREATE TABLE `ezcontentclass` (
   `creator_id` int(11) NOT NULL DEFAULT '0',
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `identifier` varchar(50) NOT NULL DEFAULT '',
-  `initial_language_id` int(11) NOT NULL DEFAULT '0',
+  `initial_language_id` bigint(20) NOT NULL DEFAULT '0',
   `is_container` int(11) NOT NULL DEFAULT '0',
-  `language_mask` int(11) NOT NULL DEFAULT '0',
+  `language_mask` bigint(20) NOT NULL DEFAULT '0',
   `modified` int(11) NOT NULL DEFAULT '0',
   `modifier_id` int(11) NOT NULL DEFAULT '0',
   `remote_id` varchar(100) NOT NULL DEFAULT '',
@@ -573,7 +573,7 @@ DROP TABLE IF EXISTS `ezcontentclass_name`;
 CREATE TABLE `ezcontentclass_name` (
   `contentclass_id` int(11) NOT NULL DEFAULT '0',
   `contentclass_version` int(11) NOT NULL DEFAULT '0',
-  `language_id` int(11) NOT NULL DEFAULT '0',
+  `language_id` bigint(20) NOT NULL DEFAULT '0',
   `language_locale` varchar(20) NOT NULL DEFAULT '',
   `name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`contentclass_id`,`contentclass_version`,`language_id`)
@@ -609,8 +609,8 @@ CREATE TABLE `ezcontentobject` (
   `contentclass_id` int(11) NOT NULL DEFAULT '0',
   `current_version` int(11) DEFAULT NULL,
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `initial_language_id` int(11) NOT NULL DEFAULT '0',
-  `language_mask` int(11) NOT NULL DEFAULT '0',
+  `initial_language_id` bigint(20) NOT NULL DEFAULT '0',
+  `language_mask` bigint(20) NOT NULL DEFAULT '0',
   `modified` int(11) NOT NULL DEFAULT '0',
   `name` varchar(255) DEFAULT NULL,
   `owner_id` int(11) NOT NULL DEFAULT '0',
@@ -646,7 +646,7 @@ CREATE TABLE `ezcontentobject_attribute` (
   `data_type_string` varchar(50) DEFAULT '',
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `language_code` varchar(20) NOT NULL DEFAULT '',
-  `language_id` int(11) NOT NULL DEFAULT '0',
+  `language_id` bigint(20) NOT NULL DEFAULT '0',
   `sort_key_int` int(11) NOT NULL DEFAULT '0',
   `sort_key_string` varchar(255) NOT NULL DEFAULT '',
   `version` int(11) NOT NULL DEFAULT '0',
@@ -689,7 +689,7 @@ CREATE TABLE `ezcontentobject_name` (
   `content_translation` varchar(20) NOT NULL DEFAULT '',
   `content_version` int(11) NOT NULL DEFAULT '0',
   `contentobject_id` int(11) NOT NULL DEFAULT '0',
-  `language_id` int(11) NOT NULL DEFAULT '0',
+  `language_id` bigint(20) NOT NULL DEFAULT '0',
   `name` varchar(255) DEFAULT NULL,
   `real_translation` varchar(20) DEFAULT NULL,
   PRIMARY KEY (`contentobject_id`,`content_version`,`content_translation`),
@@ -779,8 +779,8 @@ CREATE TABLE `ezcontentobject_version` (
   `created` int(11) NOT NULL DEFAULT '0',
   `creator_id` int(11) NOT NULL DEFAULT '0',
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `initial_language_id` int(11) NOT NULL DEFAULT '0',
-  `language_mask` int(11) NOT NULL DEFAULT '0',
+  `initial_language_id` bigint(20) NOT NULL DEFAULT '0',
+  `language_mask` bigint(20) NOT NULL DEFAULT '0',
   `modified` int(11) NOT NULL DEFAULT '0',
   `status` int(11) NOT NULL DEFAULT '0',
   `user_id` int(11) NOT NULL DEFAULT '0',
@@ -2180,7 +2180,7 @@ CREATE TABLE `ezurlalias_ml` (
   `id` int(11) NOT NULL DEFAULT '0',
   `is_alias` int(11) NOT NULL DEFAULT '0',
   `is_original` int(11) NOT NULL DEFAULT '0',
-  `lang_mask` int(11) NOT NULL DEFAULT '0',
+  `lang_mask` bigint(20) NOT NULL DEFAULT '0',
   `link` int(11) NOT NULL DEFAULT '0',
   `parent` int(11) NOT NULL DEFAULT '0',
   `text` longtext NOT NULL,

--- a/eZ/Publish/API/Repository/Tests/LanguageServiceMaximumSupportedLanguagesTest.php
+++ b/eZ/Publish/API/Repository/Tests/LanguageServiceMaximumSupportedLanguagesTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * File containing the LanguageServiceMaximumSupportedLanguagesTest class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\API\Repository\Tests;
+
+/**
+ * Test case for maximum number of languages supported in the LanguageService.
+ *
+ * @see eZ\Publish\API\Repository\LanguageService
+ * @group integration
+ * @group language
+ */
+class LanguageServiceMaximumSupportedLanguagesTest extends BaseTest
+{
+    /**
+     * @var \eZ\Publish\API\Repository\LanguageService
+     */
+    private $languageService;
+
+    /**
+     * @var array
+     */
+    private $createdLanguages = array();
+
+    /**
+     * Creates as much languages as possible
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->languageService = $this->getRepository()->getContentLanguageService();
+
+        $languageCreate = $this->languageService->newLanguageCreateStruct();
+        $languageCreate->enabled = true;
+
+        // Create as much languages as possible
+        for ( $i = count( $this->languageService->loadLanguages() ) + 1; $i <= 8 * PHP_INT_SIZE - 2; ++$i )
+        {
+            $languageCreate->name = "Language $i";
+            $languageCreate->languageCode = sprintf( "lan-%02d", $i );
+
+            $this->createdLanguages[] = $this->languageService->createLanguage( $languageCreate );
+        }
+    }
+
+    public function tearDown()
+    {
+        while ( ( $language = array_pop( $this->createdLanguages ) ) !== null )
+        {
+            $this->languageService->deleteLanguage( $language );
+        }
+
+        parent::tearDown();
+    }
+
+    /**
+     * Test for the number of maximum language that can be created.
+     *
+     * @see \eZ\Publish\API\Repository\LanguageService::createLanguage()
+     *
+     * @depends \eZ\Publish\API\Repository\Tests\LanguageServiceTest::testNewLanguageCreateStruct
+     *
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Maximum number of languages reached!
+     */
+    public function testCreateMaximumLanguageLimit()
+    {
+        $languageCreate = $this->languageService->newLanguageCreateStruct();
+        $languageCreate->enabled = true;
+
+        $languageCreate->name = "Bad Language";
+        $languageCreate->languageCode = "lan-ER";
+
+        $this->languageService->createLanguage( $languageCreate );
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/EzcDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/EzcDatabase.php
@@ -13,6 +13,7 @@ use eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway;
 use eZ\Publish\SPI\Persistence\Content\Language;
 use eZ\Publish\Core\Persistence\Legacy\EzcDbHandler;
 use ezcQuery;
+use RuntimeException;
 
 /**
  * ezcDatabase based Language Gateway
@@ -54,6 +55,14 @@ class EzcDatabase extends Gateway
         $statement->execute();
 
         $lastId = (int)$statement->fetchColumn();
+
+        // Legacy only supports 8 * PHP_INT_SIZE - 2 languages:
+        // One bit cannot be used because PHP uses signed integers and a second one is reserved for the
+        // "always available flag".
+        if ( $lastId == pow( 2, 8 * PHP_INT_SIZE - 2 ) )
+        {
+            throw new RuntimeException( "Maximum number of languages reached!" );
+        }
         // Next power of 2 for bit masks
         $nextId = ( $lastId !== 0 ? $lastId << 1 : 2 );
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
@@ -41,11 +41,11 @@ CREATE TABLE `ezmedia` (
 
 DROP TABLE IF EXISTS ezcobj_state;
 CREATE TABLE ezcobj_state (
-  default_language_id int(11) NOT NULL DEFAULT 0,
+  default_language_id bigint(20) NOT NULL DEFAULT 0,
   group_id int(11) NOT NULL DEFAULT 0,
   id int(11) NOT NULL auto_increment,
   identifier varchar(45) NOT NULL DEFAULT '',
-  language_mask int(11) NOT NULL DEFAULT 0,
+  language_mask bigint(20) NOT NULL DEFAULT 0,
   priority int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (id),
   UNIQUE KEY ezcobj_state_identifier ( group_id, identifier ),
@@ -56,10 +56,10 @@ CREATE TABLE ezcobj_state (
 
 DROP TABLE IF EXISTS ezcobj_state_group;
 CREATE TABLE ezcobj_state_group (
-  default_language_id int(11) NOT NULL DEFAULT 0,
+  default_language_id bigint(20) NOT NULL DEFAULT 0,
   id int(11) NOT NULL auto_increment,
   identifier varchar(45) NOT NULL DEFAULT '',
-  language_mask int(11) NOT NULL DEFAULT 0,
+  language_mask bigint(20) NOT NULL DEFAULT 0,
   PRIMARY KEY ( id ),
   UNIQUE KEY ezcobj_state_group_identifier ( identifier ),
   KEY ezcobj_state_group_lmask ( language_mask )
@@ -70,8 +70,8 @@ DROP TABLE IF EXISTS ezcobj_state_group_language;
 CREATE TABLE ezcobj_state_group_language (
   contentobject_state_group_id int(11) NOT NULL DEFAULT 0,
   description longtext NOT NULL,
-  language_id int(11) NOT NULL DEFAULT 0,
-  real_language_id int(11) NOT NULL DEFAULT 0,
+  language_id bigint(20) NOT NULL DEFAULT 0,
+  real_language_id bigint(20) NOT NULL DEFAULT 0,
   name varchar(45) NOT NULL DEFAULT '',
   PRIMARY KEY ( contentobject_state_group_id, real_language_id )
 ) ENGINE=InnoDB;
@@ -81,7 +81,7 @@ DROP TABLE IF EXISTS ezcobj_state_language;
 CREATE TABLE ezcobj_state_language (
   contentobject_state_id int(11) NOT NULL DEFAULT 0,
   description longtext NOT NULL,
-  language_id int(11) NOT NULL DEFAULT 0,
+  language_id bigint(20) NOT NULL DEFAULT 0,
   name varchar(45) NOT NULL DEFAULT '',
   PRIMARY KEY ( contentobject_state_id, language_id )
 ) ENGINE=InnoDB;
@@ -98,7 +98,7 @@ CREATE TABLE ezcobj_state_link (
 DROP TABLE IF EXISTS ezcontent_language;
 CREATE TABLE ezcontent_language (
   disabled int(11) NOT NULL default '0',
-  id int(11) NOT NULL default '0',
+  id bigint(20) NOT NULL default '0',
   locale varchar(20) NOT NULL default '',
   name varchar(255) NOT NULL default '',
   PRIMARY KEY  (id),
@@ -115,9 +115,9 @@ CREATE TABLE ezcontentclass (
   creator_id int(11) NOT NULL default '0',
   id int(11) NOT NULL auto_increment,
   identifier varchar(50) NOT NULL default '',
-  initial_language_id int(11) NOT NULL default '0',
+  initial_language_id bigint(20) NOT NULL default '0',
   is_container int(11) NOT NULL default '0',
-  language_mask int(11) NOT NULL default '0',
+  language_mask bigint(20) NOT NULL default '0',
   modified int(11) NOT NULL default '0',
   modifier_id int(11) NOT NULL default '0',
   remote_id varchar(100) NOT NULL default '',
@@ -187,7 +187,7 @@ DROP TABLE IF EXISTS ezcontentclass_name;
 CREATE TABLE ezcontentclass_name (
   contentclass_id int(11) NOT NULL default '0',
   contentclass_version int(11) NOT NULL default '0',
-  language_id int(11) NOT NULL default '0',
+  language_id bigint(20) NOT NULL default '0',
   language_locale varchar(20) NOT NULL default '',
   name varchar(255) NOT NULL default '',
   PRIMARY KEY  (contentclass_id,contentclass_version,language_id)
@@ -217,8 +217,8 @@ CREATE TABLE ezcontentobject (
   contentclass_id int(11) NOT NULL default '0',
   current_version int(11) default NULL,
   id int(11) NOT NULL auto_increment,
-  initial_language_id int(11) NOT NULL default '0',
-  language_mask int(11) NOT NULL default '0',
+  initial_language_id bigint(20) NOT NULL default '0',
+  language_mask bigint(20) NOT NULL default '0',
   modified int(11) NOT NULL default '0',
   name varchar(255) default NULL,
   owner_id int(11) NOT NULL default '0',
@@ -251,7 +251,7 @@ CREATE TABLE ezcontentobject_attribute (
   data_type_string varchar(50) default '',
   id int(11) NOT NULL auto_increment,
   language_code varchar(20) NOT NULL default '',
-  language_id int(11) NOT NULL default '0',
+  language_id bigint(20) NOT NULL default '0',
   sort_key_int int(11) NOT NULL default '0',
   sort_key_string varchar(255) NOT NULL default '',
   version int(11) NOT NULL default '0',
@@ -288,7 +288,7 @@ CREATE TABLE ezcontentobject_name (
   content_translation varchar(20) NOT NULL default '',
   content_version int(11) NOT NULL default '0',
   contentobject_id int(11) NOT NULL default '0',
-  language_id int(11) NOT NULL default '0',
+  language_id bigint(20) NOT NULL default '0',
   name varchar(255) default NULL,
   real_translation varchar(20) default NULL,
   PRIMARY KEY  (contentobject_id,content_version,content_translation),
@@ -369,8 +369,8 @@ CREATE TABLE ezcontentobject_version (
   created int(11) NOT NULL default '0',
   creator_id int(11) NOT NULL default '0',
   id int(11) NOT NULL auto_increment,
-  initial_language_id int(11) NOT NULL default '0',
-  language_mask int(11) NOT NULL default '0',
+  initial_language_id bigint(20) NOT NULL default '0',
+  language_mask bigint(20) NOT NULL default '0',
   modified int(11) NOT NULL default '0',
   status int(11) NOT NULL default '0',
   user_id int(11) NOT NULL default '0',
@@ -528,7 +528,7 @@ CREATE TABLE ezurlalias_ml (
   id int(11) NOT NULL default '0',
   is_alias int(11) NOT NULL default '0',
   is_original int(11) NOT NULL default '0',
-  lang_mask int(11) NOT NULL default '0',
+  lang_mask bigint(20) NOT NULL default '0',
   link int(11) NOT NULL default '0',
   parent int(11) NOT NULL default '0',
   text longtext NOT NULL,

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
@@ -276,21 +276,21 @@ CREATE TABLE ezgmaplocation (
 
 DROP TABLE IF EXISTS ezcobj_state;
 CREATE TABLE ezcobj_state (
-    default_language_id integer NOT NULL DEFAULT 0,
+    default_language_id bigint NOT NULL DEFAULT 0,
     group_id integer NOT NULL DEFAULT 0,
     id integer DEFAULT nextval('ezcobj_state_s'::text) NOT NULL,
     identifier character varying(45) NOT NULL DEFAULT ''::character varying,
-    language_mask integer NOT NULL DEFAULT 0,
+    language_mask bigint NOT NULL DEFAULT 0,
     priority integer NOT NULL DEFAULT 0
 );
 
 
 DROP TABLE IF EXISTS ezcobj_state_group;
 CREATE TABLE ezcobj_state_group (
-    default_language_id integer NOT NULL DEFAULT 0,
+    default_language_id bigint NOT NULL DEFAULT 0,
     id integer DEFAULT nextval('ezcobj_state_group_s'::text) NOT NULL,
     identifier character varying(45) NOT NULL DEFAULT ''::character varying,
-    language_mask integer NOT NULL DEFAULT 0
+    language_mask bigint NOT NULL DEFAULT 0
 );
 
 
@@ -298,8 +298,8 @@ DROP TABLE IF EXISTS ezcobj_state_group_language;
 CREATE TABLE ezcobj_state_group_language (
     contentobject_state_group_id integer NOT NULL DEFAULT 0,
     description text NOT NULL,
-    language_id integer NOT NULL DEFAULT 0,
-    real_language_id integer NOT NULL DEFAULT 0,
+    language_id bigint NOT NULL DEFAULT 0,
+    real_language_id bigint NOT NULL DEFAULT 0,
     name character varying(45) NOT NULL DEFAULT ''::character varying
 );
 
@@ -308,7 +308,7 @@ DROP TABLE IF EXISTS ezcobj_state_language;
 CREATE TABLE ezcobj_state_language (
     contentobject_state_id integer NOT NULL DEFAULT 0,
     description text NOT NULL,
-    language_id integer NOT NULL DEFAULT 0,
+    language_id bigint NOT NULL DEFAULT 0,
     name character varying(45) NOT NULL DEFAULT ''::character varying
 );
 
@@ -321,7 +321,7 @@ CREATE TABLE ezcobj_state_link (
 DROP TABLE IF EXISTS ezcontent_language;
 CREATE TABLE ezcontent_language (
     disabled integer DEFAULT 0 NOT NULL,
-    id integer DEFAULT 0 NOT NULL,
+    id bigint DEFAULT 0 NOT NULL,
     locale character varying(20) DEFAULT ''::character varying NOT NULL,
     name character varying(255) DEFAULT ''::character varying NOT NULL
 );
@@ -334,9 +334,9 @@ CREATE TABLE ezcontentclass (
     creator_id integer DEFAULT 0 NOT NULL,
     id integer DEFAULT nextval('ezcontentclass_s'::text) NOT NULL,
     identifier character varying(50) DEFAULT ''::character varying NOT NULL,
-    initial_language_id integer DEFAULT 0 NOT NULL,
+    initial_language_id bigint DEFAULT 0 NOT NULL,
     is_container integer DEFAULT 0 NOT NULL,
-    language_mask integer DEFAULT 0 NOT NULL,
+    language_mask bigint DEFAULT 0 NOT NULL,
     modified integer DEFAULT 0 NOT NULL,
     modifier_id integer DEFAULT 0 NOT NULL,
     remote_id character varying(100) DEFAULT ''::character varying NOT NULL,
@@ -391,7 +391,7 @@ DROP TABLE IF EXISTS ezcontentclass_name;
 CREATE TABLE ezcontentclass_name (
     contentclass_id integer DEFAULT 0 NOT NULL,
     contentclass_version integer DEFAULT 0 NOT NULL,
-    language_id integer DEFAULT 0 NOT NULL,
+    language_id bigint DEFAULT 0 NOT NULL,
     language_locale character varying(20) DEFAULT ''::character varying NOT NULL,
     name character varying(255) DEFAULT ''::character varying NOT NULL
 );
@@ -411,8 +411,8 @@ CREATE TABLE ezcontentobject (
     contentclass_id integer DEFAULT 0 NOT NULL,
     current_version integer,
     id integer DEFAULT nextval('ezcontentobject_s'::text) NOT NULL,
-    initial_language_id integer DEFAULT 0 NOT NULL,
-    language_mask integer DEFAULT 0 NOT NULL,
+    initial_language_id bigint DEFAULT 0 NOT NULL,
+    language_mask bigint DEFAULT 0 NOT NULL,
     modified integer DEFAULT 0 NOT NULL,
     name character varying(255),
     owner_id integer DEFAULT 0 NOT NULL,
@@ -433,7 +433,7 @@ CREATE TABLE ezcontentobject_attribute (
     data_type_string character varying(50) DEFAULT ''::character varying,
     id integer DEFAULT nextval('ezcontentobject_attribute_s'::text) NOT NULL,
     language_code character varying(20) DEFAULT ''::character varying NOT NULL,
-    language_id integer DEFAULT 0 NOT NULL,
+    language_id bigint DEFAULT 0 NOT NULL,
     sort_key_int integer DEFAULT 0 NOT NULL,
     sort_key_string character varying(255) DEFAULT ''::character varying NOT NULL,
     "version" integer DEFAULT 0 NOT NULL
@@ -454,7 +454,7 @@ CREATE TABLE ezcontentobject_name (
     content_translation character varying(20) DEFAULT ''::character varying NOT NULL,
     content_version integer DEFAULT 0 NOT NULL,
     contentobject_id integer DEFAULT 0 NOT NULL,
-    language_id integer DEFAULT 0 NOT NULL,
+    language_id bigint DEFAULT 0 NOT NULL,
     name character varying(255),
     real_translation character varying(20)
 );
@@ -504,8 +504,8 @@ CREATE TABLE ezcontentobject_version (
     created integer DEFAULT 0 NOT NULL,
     creator_id integer DEFAULT 0 NOT NULL,
     id integer DEFAULT nextval('ezcontentobject_version_s'::text) NOT NULL,
-    initial_language_id integer DEFAULT 0 NOT NULL,
-    language_mask integer DEFAULT 0 NOT NULL,
+    initial_language_id bigint DEFAULT 0 NOT NULL,
+    language_mask bigint DEFAULT 0 NOT NULL,
     modified integer DEFAULT 0 NOT NULL,
     status integer DEFAULT 0 NOT NULL,
     user_id integer DEFAULT 0 NOT NULL,
@@ -647,7 +647,7 @@ CREATE TABLE ezurlalias_ml (
     id integer DEFAULT 0 NOT NULL,
     is_alias integer DEFAULT 0 NOT NULL,
     is_original integer DEFAULT 0 NOT NULL,
-    lang_mask integer DEFAULT 0 NOT NULL,
+    lang_mask bigint DEFAULT 0 NOT NULL,
     link integer DEFAULT 0 NOT NULL,
     parent integer DEFAULT 0 NOT NULL,
     text text NOT NULL,

--- a/phpunit-integration-legacy-solr.xml
+++ b/phpunit-integration-legacy-solr.xml
@@ -25,6 +25,7 @@
             <file>eZ/Publish/API/Repository/Tests/RepositoryTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SectionServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LanguageServiceTest.php</file>
+            <file>eZ/Publish/API/Repository/Tests/LanguageServiceMaximumSupportedLanguagesTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/ContentServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/NonRedundantFieldSetTest.php</file>

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -18,6 +18,7 @@
             <file>eZ/Publish/API/Repository/Tests/RepositoryTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SectionServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LanguageServiceTest.php</file>
+            <file>eZ/Publish/API/Repository/Tests/LanguageServiceMaximumSupportedLanguagesTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/ContentServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/NonRedundantFieldSetTest.php</file>

--- a/phpunit-integration-rest-json.xml
+++ b/phpunit-integration-rest-json.xml
@@ -17,6 +17,7 @@
             <file>eZ/Publish/API/Repository/Tests/RepositoryTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SectionServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LanguageServiceTest.php</file>
+            <file>eZ/Publish/API/Repository/Tests/LanguageServiceMaximumSupportedLanguagesTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/ContentServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LocationServiceTest.php</file>

--- a/phpunit-integration-rest-xml.xml
+++ b/phpunit-integration-rest-xml.xml
@@ -17,6 +17,7 @@
             <file>eZ/Publish/API/Repository/Tests/RepositoryTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SectionServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LanguageServiceTest.php</file>
+            <file>eZ/Publish/API/Repository/Tests/LanguageServiceMaximumSupportedLanguagesTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/ContentServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LocationServiceTest.php</file>


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-15040

Support for more than 30 (up to 62) languages thanks to the **bigint** SQL datatype.

To be reviewed together with: https://github.com/ezsystems/ezpublish-legacy/pull/746
