### PR TITLE
Fix EZP-21522: wrong usage of image uri/id

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/ImageIntegrationTest.php
@@ -268,7 +268,6 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
         // Will change during storage
         unset( $expectedData['id'] );
 
-        self::assertEquals( $field->value->uri, $field->value->id );
         $expectedData['uri'] = $field->value->uri;
 
         $this->assertPropertiesCorrect(

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -128,7 +128,7 @@ class ImageStorage extends GatewayBasedStorage
             $field->value->externalData['mimeType'] = $binaryFile->mimeType;
             $field->value->externalData['imageId'] = $versionInfo->contentInfo->id . '-' . $field->id;
             $field->value->externalData['uri'] = $binaryFile->uri;
-            $field->value->externalData['id'] = $binaryFile->uri;
+            $field->value->externalData['id'] = ltrim( $binaryFile->uri, '/' );
 
             $field->value->data = array_merge(
                 $field->value->externalData,

--- a/eZ/Publish/Core/IO/Handler/Filesystem.php
+++ b/eZ/Publish/Core/IO/Handler/Filesystem.php
@@ -331,6 +331,6 @@ class Filesystem implements IOHandlerInterface
 
     public function getUri( $spiBinaryFileId )
     {
-        return ( $this->prefix ? $this->prefix . '/' : '') . $spiBinaryFileId;
+        return '/' . ( $this->prefix ? $this->prefix . '/' : '') . $spiBinaryFileId;
     }
 }


### PR DESCRIPTION
Fixes https://jira.ez.no/browse/EZP-21522 by triming the / added to the URI in a recent change (https://jira.ez.no/browse/EZP-20948).

Note: the fix might look kinda ugly, but it's not _as bad_ as it seems.

ID management in binary files aims at abstracting the storage location. The ID for a binary file would for instance  look like `application/63cd472dd7819da7b75e8e2fee507c68.pdf`. Due to implementation constraints in legacy for images, this is currently not as simple for images. For this reason, we currently use the relative path to the image as the ID.

Ideally, we would have an ID like `254-1-eng-US/Icy-Night-Flower.jpg`, but it requires quite a large refactoring due to persistence & storage engine concerns. It should be taken care of for the next major version as a follow-up task.
### Testing

Covered by API integration tests.

Without the fix:

```
phpunit -c phpunit-integration-legacy.xml eZ/Publish/API/Repository/Tests/FieldType/ImageIntegrationTest.php
E.............ESESS....SSSESSS...EE..
FAILURES!
Tests: 30, Assertions: 32, Errors: 6, Skipped: 9.
```

With the fix:

```
phpunit -c phpunit-integration-legacy.xml eZ/Publish/API/Repository/Tests/FieldType/ImageIntegrationTest.php
.......................................
OK (39 tests, 61 assertions)
```
