### PR TITLE
Fix EZP-21581: content_view_provider.configured service uses wrong matcher factory

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -40,7 +40,7 @@ services:
 
     ezpublish.content_view_provider.configured:
         class: %ezpublish.content_view_provider.configured.class%
-        arguments: [@ezpublish.location_view.matcher_factory]
+        arguments: [@ezpublish.content_view.matcher_factory]
         tags:
             - {name: ezpublish.content_view_provider, priority: 10}
 


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-21581

Fixed content_view_provider.configured to get a content_view.matcher_factory instead of location_view.matcher_factory (so override.yml and content_view is used, not location_view)
