### PR TITLE
Fix EZP-21589: Boolean are serialized as string in JSON resp. of the REST API

### DIFF
--- a/doc/bc/changes-5.2.md
+++ b/doc/bc/changes-5.2.md
@@ -10,6 +10,9 @@ Changes affecting version compatibility with former or future versions.
   legacy pagelayout templates were improperly used to carry out tasks with side
   effects (logging, calling webservices, etc)
 
+* In the REST API JSON responses, the boolean properties are now real boolean
+  values instead of the string "true" or "false".
+
 ## Deprecations
 
 * It was incidentally possible to reference resources in REST API payloads without

--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -559,14 +559,14 @@ JSON Example
             "_href": "/content/locations/1/4/89"
           },
           "priority": "0",
-          "hidden": "false",
+          "hidden": false,
           "sortField": "PATH",
           "sortOrder": "ASC"
         }
         "Section": {
           "_href": "/content/sections/4"
         },
-        "alwaysAvailable": "true",
+        "alwaysAvailable": true,
         "remoteId": "remoteId12345678",
         "fields": {
           "field": [
@@ -698,7 +698,7 @@ JSON Example
         },
         "lastModificationDate": "2012-02-12T12:30:00",
         "mainLanguageCode": "eng-US",
-        "alwaysAvailable": "true"
+        "alwaysAvailable": true
       }
     }
 

--- a/eZ/Publish/Core/REST/Common/Output/Generator.php
+++ b/eZ/Publish/Core/REST/Common/Output/Generator.php
@@ -383,4 +383,12 @@ abstract class Generator
             );
         }
     }
+
+    /**
+     * Serializes a boolean value
+     *
+     * @param boolean $boolValue
+     * @return mixed
+     */
+    abstract public function serializeBool( $boolValue );
 }

--- a/eZ/Publish/Core/REST/Common/Output/Generator/Json.php
+++ b/eZ/Publish/Core/REST/Common/Output/Generator/Json.php
@@ -324,4 +324,15 @@ class Json extends Generator
             $hashValue
         );
     }
+
+    /**
+     * Serializes a boolean value
+     *
+     * @param boolean $boolValue
+     * @return boolean
+     */
+    public function serializeBool( $boolValue )
+    {
+        return (bool)$boolValue;
+    }
 }

--- a/eZ/Publish/Core/REST/Common/Output/Generator/Xml.php
+++ b/eZ/Publish/Core/REST/Common/Output/Generator/Xml.php
@@ -252,4 +252,15 @@ class Xml extends Generator
     {
         $this->hashGenerator->generateHashValue( $this->xmlWriter, $hashElementName, $hashValue );
     }
+
+    /**
+     * Serializes a boolean value
+     *
+     * @param boolean $boolValue
+     * @return string
+     */
+    public function serializeBool( $boolValue )
+    {
+        return ( $boolValue ? 'true' : 'false' );
+    }
 }

--- a/eZ/Publish/Core/REST/Common/Output/ValueObjectVisitor.php
+++ b/eZ/Publish/Core/REST/Common/Output/ValueObjectVisitor.php
@@ -56,13 +56,14 @@ abstract class ValueObjectVisitor
     /**
      * Returns a string representation for the given $boolValue
      *
+     * @param \eZ\Publish\Core\REST\Common\Output\Generator $generator
      * @param boolean $boolValue
      *
-     * @return string
+     * @return mixed
      */
-    protected function serializeBool( $boolValue )
+    protected function serializeBool( Generator $generator, $boolValue )
     {
-        return ( $boolValue ? 'true' : 'false' );
+        return $generator->serializeBool( $boolValue );
     }
 
     /**

--- a/eZ/Publish/Core/REST/Common/Tests/Output/Generator/JsonTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Output/Generator/JsonTest.php
@@ -252,6 +252,15 @@ class JsonTest extends GeneratorTest
         $generator->startObjectElement( 'stacked' );
     }
 
+    public function testSerializeBool()
+    {
+        $generator = $this->getGenerator();
+
+        $this->assertTrue( $generator->serializeBool( true ) === true );
+        $this->assertTrue( $generator->serializeBool( false ) === false );
+        $this->assertTrue( $generator->serializeBool( 'notbooleanbuttrue' ) === true );
+    }
+
     protected function getGenerator()
     {
         if ( !isset( $this->generator ) )

--- a/eZ/Publish/Core/REST/Common/Tests/Output/Generator/XmlTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Output/Generator/XmlTest.php
@@ -221,6 +221,15 @@ class XmlTest extends GeneratorTest
         );
     }
 
+    public function testSerializeBool()
+    {
+        $generator = $this->getGenerator();
+
+        $this->assertTrue( $generator->serializeBool( true ) === 'true' );
+        $this->assertTrue( $generator->serializeBool( false ) === 'false' );
+        $this->assertTrue( $generator->serializeBool( 'notbooleanbuttrue' ) === 'true' );
+    }
+
     protected function getGenerator()
     {
         if ( !isset( $this->generator ) )

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContent.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContent.php
@@ -173,7 +173,7 @@ class RestContent extends ValueObjectVisitor
 
         $generator->startValueElement(
             'alwaysAvailable',
-            ( $contentInfo->alwaysAvailable ? 'true' : 'false' )
+            $this->serializeBool( $generator, $contentInfo->alwaysAvailable )
         );
         $generator->endValueElement( 'alwaysAvailable' );
 

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContentType.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContentType.php
@@ -107,13 +107,19 @@ class RestContentType extends RestContentTypeBase
         $generator->startValueElement( 'nameSchema', $contentType->nameSchema );
         $generator->endValueElement( 'nameSchema' );
 
-        $generator->startValueElement( 'isContainer', ( $contentType->isContainer ? 'true' : 'false' ) );
+        $generator->startValueElement(
+            'isContainer',
+            $this->serializeBool( $generator, $contentType->isContainer )
+        );
         $generator->endValueElement( 'isContainer' );
 
         $generator->startValueElement( 'mainLanguageCode', $contentType->mainLanguageCode );
         $generator->endValueElement( 'mainLanguageCode' );
 
-        $generator->startValueElement( 'defaultAlwaysAvailable', ( $contentType->defaultAlwaysAvailable ? 'true' : 'false' ) );
+        $generator->startValueElement(
+            'defaultAlwaysAvailable',
+            $this->serializeBool( $generator, $contentType->defaultAlwaysAvailable )
+        );
         $generator->endValueElement( 'defaultAlwaysAvailable' );
 
         $generator->startValueElement( 'defaultSortField', $this->serializeSortField( $contentType->defaultSortField ) );

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestFieldDefinition.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestFieldDefinition.php
@@ -86,13 +86,22 @@ class RestFieldDefinition extends RestContentTypeBase
         $generator->startValueElement( 'position', $fieldDefinition->position );
         $generator->endValueElement( 'position' );
 
-        $generator->startValueElement( 'isTranslatable', $this->serializeBool( $fieldDefinition->isTranslatable ) );
+        $generator->startValueElement(
+            'isTranslatable',
+            $this->serializeBool( $generator, $fieldDefinition->isTranslatable )
+        );
         $generator->endValueElement( 'isTranslatable' );
 
-        $generator->startValueElement( 'isRequired', $this->serializeBool( $fieldDefinition->isRequired ) );
+        $generator->startValueElement(
+            'isRequired',
+            $this->serializeBool( $generator, $fieldDefinition->isRequired )
+        );
         $generator->endValueElement( 'isRequired' );
 
-        $generator->startValueElement( 'isInfoCollector', $this->serializeBool( $fieldDefinition->isInfoCollector ) );
+        $generator->startValueElement(
+            'isInfoCollector',
+            $this->serializeBool( $generator, $fieldDefinition->isInfoCollector )
+        );
         $generator->endValueElement( 'isInfoCollector' );
 
         $this->fieldTypeSerializer->serializeFieldDefaultValue(
@@ -101,7 +110,10 @@ class RestFieldDefinition extends RestContentTypeBase
             $fieldDefinition->defaultValue
         );
 
-        $generator->startValueElement( 'isSearchable', $this->serializeBool( $fieldDefinition->isSearchable ) );
+        $generator->startValueElement(
+            'isSearchable',
+            $this->serializeBool( $generator, $fieldDefinition->isSearchable )
+        );
         $generator->endValueElement( 'isSearchable' );
 
         $this->visitNamesList( $generator, $fieldDefinition->getNames() );

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestLocation.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestLocation.php
@@ -46,10 +46,16 @@ class RestLocation extends ValueObjectVisitor
         $generator->startValueElement( 'priority', $data->location->priority );
         $generator->endValueElement( 'priority' );
 
-        $generator->startValueElement( 'hidden', $data->location->hidden ? 'true' : 'false' );
+        $generator->startValueElement(
+            'hidden',
+            $this->serializeBool( $generator, $data->location->hidden )
+        );
         $generator->endValueElement( 'hidden' );
 
-        $generator->startValueElement( 'invisible', $data->location->invisible ? 'true' : 'false' );
+        $generator->startValueElement(
+            'invisible',
+            $this->serializeBool( $generator, $data->location->invisible )
+        );
         $generator->endValueElement( 'invisible' );
 
         $generator->startObjectElement( 'ParentLocation', 'Location' );

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestTrashItem.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestTrashItem.php
@@ -42,10 +42,16 @@ class RestTrashItem extends ValueObjectVisitor
         $generator->startValueElement( 'priority', $data->trashItem->priority );
         $generator->endValueElement( 'priority' );
 
-        $generator->startValueElement( 'hidden', $data->trashItem->hidden ? 'true' : 'false' );
+        $generator->startValueElement(
+            'hidden',
+            $this->serializeBool( $generator, $data->trashItem->hidden )
+        );
         $generator->endValueElement( 'hidden' );
 
-        $generator->startValueElement( 'invisible', $data->trashItem->invisible ? 'true' : 'false' );
+        $generator->startValueElement(
+            'invisible',
+            $this->serializeBool( $generator, $data->trashItem->invisible )
+        );
         $generator->endValueElement( 'invisible' );
 
         $pathStringParts = explode( '/', trim( $data->trashItem->pathString, '/' ) );

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestUser.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestUser.php
@@ -112,7 +112,10 @@ class RestUser extends ValueObjectVisitor
         $generator->startValueElement( 'mainLanguageCode', $contentInfo->mainLanguageCode );
         $generator->endValueElement( 'mainLanguageCode' );
 
-        $generator->startValueElement( 'alwaysAvailable', $contentInfo->alwaysAvailable ? 'true' : 'false' );
+        $generator->startValueElement(
+            'alwaysAvailable',
+            $this->serializeBool( $generator, $contentInfo->alwaysAvailable )
+        );
         $generator->endValueElement( 'alwaysAvailable' );
 
         $visitor->visitValueObject(
@@ -129,7 +132,10 @@ class RestUser extends ValueObjectVisitor
         $generator->startValueElement( 'email', $data->content->email );
         $generator->endValueElement( 'email' );
 
-        $generator->startValueElement( 'enabled', $data->content->enabled ? 'true' : 'false' );
+        $generator->startValueElement(
+            'enabled',
+            $this->serializeBool( $generator, $data->content->enabled )
+        );
         $generator->endValueElement( 'enabled' );
 
         $generator->startObjectElement( 'UserGroups', 'UserGroupList' );

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestUserGroup.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestUserGroup.php
@@ -117,7 +117,10 @@ class RestUserGroup extends ValueObjectVisitor
         $generator->startValueElement( 'mainLanguageCode', $contentInfo->mainLanguageCode );
         $generator->endValueElement( 'mainLanguageCode' );
 
-        $generator->startValueElement( 'alwaysAvailable', $contentInfo->alwaysAvailable ? 'true' : 'false' );
+        $generator->startValueElement(
+            'alwaysAvailable',
+            $this->serializeBool( $generator, $contentInfo->alwaysAvailable )
+        );
         $generator->endValueElement( 'alwaysAvailable' );
 
         $visitor->visitValueObject(

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/URLAlias.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/URLAlias.php
@@ -65,16 +65,28 @@ class URLAlias extends ValueObjectVisitor
         $generator->startValueElement( 'languageCodes', implode( ',', $data->languageCodes ) );
         $generator->endValueElement( 'languageCodes' );
 
-        $generator->startValueElement( 'alwaysAvailable', $this->serializeBool( $data->alwaysAvailable ) );
+        $generator->startValueElement(
+            'alwaysAvailable',
+            $this->serializeBool( $generator, $data->alwaysAvailable )
+        );
         $generator->endValueElement( 'alwaysAvailable' );
 
-        $generator->startValueElement( 'isHistory', $this->serializeBool( $data->isHistory ) );
+        $generator->startValueElement(
+            'isHistory',
+            $this->serializeBool( $generator, $data->isHistory )
+        );
         $generator->endValueElement( 'isHistory' );
 
-        $generator->startValueElement( 'forward', $this->serializeBool( $data->forward ) );
+        $generator->startValueElement(
+            'forward',
+            $this->serializeBool( $generator, $data->forward )
+        );
         $generator->endValueElement( 'forward' );
 
-        $generator->startValueElement( 'custom', $this->serializeBool( $data->isCustom ) );
+        $generator->startValueElement(
+            'custom',
+            $this->serializeBool( $generator, $data->isCustom )
+        );
         $generator->endValueElement( 'custom' );
 
         $generator->endObjectElement( 'UrlAlias' );

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/URLWildcard.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/URLWildcard.php
@@ -45,7 +45,10 @@ class URLWildcard extends ValueObjectVisitor
         $generator->startValueElement( 'destinationUrl', $data->destinationUrl );
         $generator->endValueElement( 'destinationUrl' );
 
-        $generator->startValueElement( 'forward', $data->forward ? 'true' : 'false' );
+        $generator->startValueElement(
+            'forward',
+            $this->serializeBool( $generator, $data->forward )
+        );
         $generator->endValueElement( 'forward' );
 
         $generator->endObjectElement( 'UrlWildcard' );


### PR DESCRIPTION
# Description

The boolean values in the JSON REST API responses are returned as string ("false" or "true") instead of _true_ boolean. As a result, you need to do string comparison client side to test a boolean...

This patch adds a new methods to the generator so that the boolean values are correctly serialized depending on the output type.
# Tests

unit tests + manual tests on `content/types/XX` and `content/objects/XX`
