### PR TITLE
EZP-20418: Location Search Handler

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage_engines.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage_engines.yml
@@ -9,6 +9,7 @@ parameters:
     ezpublish.spi.persistence.cache.contentTypeHandler.class: eZ\Publish\Core\Persistence\Cache\ContentTypeHandler
     ezpublish.spi.persistence.cache.userHandler.class: eZ\Publish\Core\Persistence\Cache\UserHandler
     ezpublish.spi.persistence.cache.searchHandler.class: eZ\Publish\Core\Persistence\Cache\SearchHandler
+    ezpublish.spi.persistence.cache.locationSearchHandler.class: eZ\Publish\Core\Persistence\Cache\LocationSearchHandler
     ezpublish.spi.persistence.cache.urlAliasHandler.class: eZ\Publish\Core\Persistence\Cache\UrlAliasHandler
     ezpublish.spi.persistence.cache.persistenceLogger.class: eZ\Publish\Core\Persistence\Cache\PersistenceLogger
     # Make sure logging is only enabled for debug by default
@@ -108,6 +109,7 @@ services:
             - @ezpublish.spi.persistence.cache.contentTypeHandler
             - @ezpublish.spi.persistence.cache.userHandler
             - @ezpublish.spi.persistence.cache.searchHandler
+            - @ezpublish.spi.persistence.cache.locationSearchHandler
             - @ezpublish.spi.persistence.cache.urlAliasHandler
             - @ezpublish.spi.persistence.cache.persistenceLogger
 
@@ -156,6 +158,10 @@ services:
 
     ezpublish.spi.persistence.cache.searchHandler:
         class: %ezpublish.spi.persistence.cache.searchHandler.class%
+        parent: ezpublish.spi.persistence.cache.abstractHandler
+
+    ezpublish.spi.persistence.cache.locationSearchHandler:
+        class: %ezpublish.spi.persistence.cache.locationSearchHandler.class%
         parent: ezpublish.spi.persistence.cache.abstractHandler
 
     ezpublish.spi.persistence.cache.urlAliasHandler:

--- a/eZ/Publish/Core/Persistence/Cache/Handler.php
+++ b/eZ/Publish/Core/Persistence/Cache/Handler.php
@@ -13,6 +13,7 @@ use eZ\Publish\Core\Persistence\Factory as PersistenceFactory;
 use eZ\Publish\SPI\Persistence\Handler as PersistenceHandlerInterface;
 use eZ\Publish\Core\Persistence\Cache\SectionHandler as CacheSectionHandler;
 use eZ\Publish\Core\Persistence\Cache\LocationHandler as CacheLocationHandler;
+use eZ\Publish\Core\Persistence\Cache\LocationSearchHandler as CacheLocationSearchHandler;
 use eZ\Publish\Core\Persistence\Cache\ContentHandler as CacheContentHandler;
 use eZ\Publish\Core\Persistence\Cache\ContentLanguageHandler as CacheContentLanguageHandler;
 use eZ\Publish\Core\Persistence\Cache\ContentTypeHandler as CacheContentTypeHandler;
@@ -57,6 +58,11 @@ class Handler implements PersistenceHandlerInterface
     protected $locationHandler;
 
     /**
+     * @var LocationSearchHandler
+     */
+    protected $locationSearchHandler;
+
+    /**
      * @var UserHandler
      */
     protected $userHandler;
@@ -80,14 +86,15 @@ class Handler implements PersistenceHandlerInterface
      * Construct the class
      *
      * @param \eZ\Publish\Core\Persistence\Factory $persistenceFactory Must be factory for inner persistence, ie: legacy
-     * @param SectionHandler $sectionHandler
-     * @param LocationHandler $locationHandler
-     * @param ContentHandler $contentHandler
-     * @param ContentLanguageHandler $contentLanguageHandler
-     * @param ContentTypeHandler $contentTypeHandler
-     * @param UserHandler $userHandler
-     * @param SearchHandler $searchHandler
-     * @param UrlAliasHandler $urlAliasHandler
+     * @param \eZ\Publish\Core\Persistence\Cache\SectionHandler $sectionHandler
+     * @param \eZ\Publish\Core\Persistence\Cache\LocationHandler $locationHandler
+     * @param \eZ\Publish\Core\Persistence\Cache\ContentHandler $contentHandler
+     * @param \eZ\Publish\Core\Persistence\Cache\ContentLanguageHandler $contentLanguageHandler
+     * @param \eZ\Publish\Core\Persistence\Cache\ContentTypeHandler $contentTypeHandler
+     * @param \eZ\Publish\Core\Persistence\Cache\UserHandler $userHandler
+     * @param \eZ\Publish\Core\Persistence\Cache\SearchHandler $searchHandler
+     * @param \eZ\Publish\Core\Persistence\Cache\LocationSearchHandler $locationSearchHandler
+     * @param \eZ\Publish\Core\Persistence\Cache\UrlAliasHandler $urlAliasHandler
      * @param PersistenceLogger $logger
      */
     public function __construct(
@@ -99,6 +106,7 @@ class Handler implements PersistenceHandlerInterface
         CacheContentTypeHandler $contentTypeHandler,
         CacheUserHandler $userHandler,
         CacheSearchHandler $searchHandler,
+        CacheLocationSearchHandler $locationSearchHandler,
         CacheUrlAliasHandler $urlAliasHandler,
         PersistenceLogger $logger
     )
@@ -111,6 +119,7 @@ class Handler implements PersistenceHandlerInterface
         $this->contentTypeHandler = $contentTypeHandler;
         $this->userHandler = $userHandler;
         $this->searchHandler = $searchHandler;
+        $this->locationSearchHandler = $locationSearchHandler;
         $this->urlAliasHandler = $urlAliasHandler;
         $this->logger = $logger;
     }
@@ -153,6 +162,14 @@ class Handler implements PersistenceHandlerInterface
     public function locationHandler()
     {
         return $this->locationHandler;
+    }
+
+    /**
+     * @return \eZ\Publish\SPI\Persistence\Content\Location\Handler
+     */
+    public function locationSearchHandler()
+    {
+        return $this->locationSearchHandler;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Cache/LocationSearchHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/LocationSearchHandler.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * File containing the LocationSearchHandler implementation
+ *
+ * @copyright Copyright (C) 1999-2012 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\Cache;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\SPI\Persistence\Content\Location\Search\Handler as LocationSearchHandlerInterface;
+
+/**
+ * @see eZ\Publish\SPI\Persistence\Content\Location\Search\Handler
+ */
+class LocationSearchHandler extends AbstractHandler implements LocationSearchHandlerInterface
+{
+    /**
+     * Finds all locations given some $criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param int $offset
+     * @param int $limit
+     */
+    public function findLocations( Criterion $criterion, $offset = 0, $limit = 10 )
+    {
+        $this->logger->logCall( __METHOD__, array( 'criterion' => $criterion, 'offset' => $offset, 'limit' => $limit ) );
+        return $this->persistenceFactory->getLocationSearchHandler()->findLocations( $criterion, $offset, $limit );
+    }
+
+    /**
+     * Counts all locations given some $criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     *
+     * @return int
+     */
+    public function getLocationCount( Criterion $criterion )
+    {
+        $this->logger->logCall( __METHOD__, array( 'criterion' => $criterion ) );
+        return $this->persistenceFactory->getLocationSearchHandler()->getLocationCount( $criterion );
+    }
+}

--- a/eZ/Publish/Core/Persistence/Cache/Tests/HandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/HandlerTest.php
@@ -12,6 +12,7 @@ namespace eZ\Publish\Core\Persistence\Cache\Tests;
 use eZ\Publish\Core\Persistence\Cache\Handler as CacheHandler;
 use eZ\Publish\Core\Persistence\Cache\SectionHandler as CacheSectionHandler;
 use eZ\Publish\Core\Persistence\Cache\LocationHandler as CacheLocationHandler;
+use eZ\Publish\Core\Persistence\Cache\LocationSearchHandler as CacheLocationSearchHandler;
 use eZ\Publish\Core\Persistence\Cache\ContentHandler as CacheContentHandler;
 use eZ\Publish\Core\Persistence\Cache\ContentLanguageHandler as CacheContentLanguageHandler;
 use eZ\Publish\Core\Persistence\Cache\ContentTypeHandler as CacheContentTypeHandler;
@@ -84,6 +85,7 @@ abstract class HandlerTest extends PHPUnit_Framework_TestCase
             new CacheContentTypeHandler( $this->cacheMock, $this->persistenceFactoryMock, $this->loggerMock ),
             new CacheUserHandler( $this->cacheMock, $this->persistenceFactoryMock, $this->loggerMock ),
             new CacheSearchHandler( $this->cacheMock, $this->persistenceFactoryMock, $this->loggerMock ),
+            new CacheLocationSearchHandler( $this->cacheMock, $this->persistenceFactoryMock, $this->loggerMock ),
             new CacheUrlAliasHandler( $this->cacheMock, $this->persistenceFactoryMock, $this->loggerMock ),
             $this->loggerMock
         );

--- a/eZ/Publish/Core/Persistence/Factory.php
+++ b/eZ/Publish/Core/Persistence/Factory.php
@@ -91,6 +91,14 @@ class Factory
     }
 
     /**
+     * @return \eZ\Publish\SPI\Persistence\Content\Location\Handler
+     */
+    public function getLocationSearchHandler()
+    {
+        return $this->getPersistenceHandler()->locationSearchHandler();
+    }
+
+    /**
      * @return \eZ\Publish\SPI\Persistence\Content\ObjectState\Handler
      */
     public function getObjectStateHandler()

--- a/eZ/Publish/Core/Persistence/InMemory/Backend.php
+++ b/eZ/Publish/Core/Persistence/InMemory/Backend.php
@@ -173,6 +173,7 @@ class Backend
      *
      * @param string $type
      * @param array $match A multi level array with property => value to match against
+     * @param array $excludeMatch A multi level array with property => value to explicitly exclude
      * @param array $joinInfo Optional info on how to join in other objects to become part of a
      *                        aggregate where $type is root.
      *                        Format:
@@ -191,9 +192,9 @@ class Backend
      *
      * @return object[]
      */
-    public function find( $type, array $match = array(), array $joinInfo = array() )
+    public function find( $type, array $match = array(), array $excludeMatch = array(), array $joinInfo = array() )
     {
-        $items = $this->rawFind( $type, $match, $joinInfo );
+        $items = $this->rawFind( $type, $match, $excludeMatch, $joinInfo );
         foreach ( $items as $key => $item )
             $items[$key] = $this->toValue( $type, $item, $joinInfo );
 
@@ -313,15 +314,16 @@ class Backend
      *
      * @param string $type
      * @param array $match A flat array with property => value to match against
+     * @param array $excludeMatch A flat array with property => value to explicitly exclude
      * @param array $joinInfo See {@link find()}
      *
      * @uses rawFind()
      *
      * @return int
      */
-    public function count( $type, array $match = array(), array $joinInfo = array() )
+    public function count( $type, array $match = array(), array $excludeMatch = array(), array $joinInfo = array() )
     {
-        return count( $this->rawFind( $type, $match, $joinInfo ) );
+        return count( $this->rawFind( $type, $match, $excludeMatch, $joinInfo ) );
     }
 
     /**
@@ -375,13 +377,14 @@ class Backend
      *
      * @param string $type
      * @param array $match A multi level array with property => value to match against
+     * @param array $excludeMatch A multi level array with property => value to explicitly exclude
      * @param array $joinInfo See {@link find()}
      *
      * @return array[]
      * @throws InvalidArgumentValue On invalid $type
      * @throws LogicException When there is a collision between match rules in $joinInfo and $match
      */
-    protected function rawFind( $type, array $match = array(), array $joinInfo = array() )
+    protected function rawFind( $type, array $match = array(), array $excludeMatch = array(), array $joinInfo = array() )
     {
         if ( !is_scalar( $type ) || !isset( $this->data[$type] ) )
             throw new InvalidArgumentValue( 'type', $type );
@@ -400,10 +403,12 @@ class Backend
                 $item[$joinProperty] = $this->rawFind(
                     $joinItem['type'],
                     $joinItem['match'],
-                    ( isset( $joinItem['sub'] ) ? $joinItem['sub'] : array() )
+                    isset( $joinItem['excludeMatch'] ) ? $joinItem['excludeMatch'] : array(),
+                    isset( $joinItem['sub'] ) ? $joinItem['sub'] : array()
                 );
             }
-            if ( $this->match( $item, $match ) )
+
+            if ( $this->match( $item, $match ) && ( empty( $excludeMatch ) || !$this->match( $item, $excludeMatch ) ) )
                 $items[] = $item;
         }
         return $items;

--- a/eZ/Publish/Core/Persistence/InMemory/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/InMemory/ContentHandler.php
@@ -398,6 +398,7 @@ class ContentHandler implements ContentHandlerInterface
                 '_contentId' => $id,
                 'versionNo' => $version
             ),
+            array(),
             array(
                 'contentInfo' => array(
                     'type' => 'Content\\ContentInfo',
@@ -470,6 +471,7 @@ class ContentHandler implements ContentHandlerInterface
                 '_contentId' => $contentId,
                 'versionNo' => $versionNo
             ),
+            array(),
             array(
                 'contentInfo' => array(
                     'type' => 'Content\\ContentInfo',
@@ -497,6 +499,7 @@ class ContentHandler implements ContentHandlerInterface
                 "status" => VersionInfo::STATUS_DRAFT,
                 "creatorId" => $userId
             ),
+            array(),
             array(
                 'contentInfo' => array(
                     'type' => 'Content\\ContentInfo',
@@ -764,6 +767,7 @@ class ContentHandler implements ContentHandlerInterface
             array(
                 '_contentId' => $contentId
             ),
+            array(),
             array(
                 'contentInfo' => array(
                     'type' => 'Content\\ContentInfo',

--- a/eZ/Publish/Core/Persistence/InMemory/ContentTypeHandler.php
+++ b/eZ/Publish/Core/Persistence/InMemory/ContentTypeHandler.php
@@ -130,6 +130,7 @@ class ContentTypeHandler implements ContentTypeHandlerInterface
         return $this->backend->find(
             'Content\\Type',
             array( 'groupIds' => $groupId, 'status' => $status ),
+            array(),
             array(
                 'fieldDefinitions' => array(
                     'type' => 'Content\\Type\\FieldDefinition',
@@ -154,6 +155,7 @@ class ContentTypeHandler implements ContentTypeHandlerInterface
         $type = $this->backend->find(
             'Content\\Type',
             array( 'id' => $contentTypeId, 'status' => $status ),
+            array(),
             array(
                 'fieldDefinitions' => array(
                     'type' => 'Content\\Type\\FieldDefinition',
@@ -182,6 +184,7 @@ class ContentTypeHandler implements ContentTypeHandlerInterface
         $type = $this->backend->find(
             'Content\\Type',
             array( 'identifier' => $identifier, 'status' => Type::STATUS_DEFINED ),
+            array(),
             array(
                 'fieldDefinitions' => array(
                     'type' => 'Content\\Type\\FieldDefinition',
@@ -210,6 +213,7 @@ class ContentTypeHandler implements ContentTypeHandlerInterface
         $type = $this->backend->find(
             'Content\\Type',
             array( 'remoteId' => $remoteId, 'status' => Type::STATUS_DEFINED ),
+            array(),
             array(
                 'fieldDefinitions' => array(
                     'type' => 'Content\\Type\\FieldDefinition',

--- a/eZ/Publish/Core/Persistence/InMemory/CriterionHandler.php
+++ b/eZ/Publish/Core/Persistence/InMemory/CriterionHandler.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * File containing the InMemory criterion handler class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\InMemory;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+abstract class CriterionHandler
+{
+    /**
+     * @var \eZ\Publish\Core\Persistence\InMemory\LocationHandler
+     */
+    protected $locationHandler;
+
+    /**
+     * @var \eZ\Publish\Core\Persistence\InMemory\Backend
+     */
+    protected $backend;
+
+    /**
+     * Creates a new criterion handler
+     *
+     * @param \eZ\Publish\Core\Persistence\InMemory\LocationHandler $locationHandler
+     * @param \eZ\Publish\Core\Persistence\InMemory\Backend $backend
+     */
+    public function __construct( LocationHandler $locationHandler, Backend $backend )
+    {
+        $this->locationHandler = $locationHandler;
+        $this->backend = $backend;
+    }
+
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     *
+     * @return boolean
+     */
+    abstract public function accept( Criterion $criterion );
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $match
+     * @param array $excludeMatch
+     */
+    abstract public function handle( Criterion $criterion, array &$match, array &$excludeMatch );
+}

--- a/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/ContentId.php
+++ b/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/ContentId.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * File containing the InMemory content id criterion handler class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use RuntimeException;
+
+/**
+ * Content id criterion handler
+ */
+class ContentId extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return boolean
+     */
+    public function accept( Criterion $criterion )
+    {
+        return $criterion instanceof Criterion\ContentId;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $match
+     * @param array $excludeMatch
+     */
+    public function handle( Criterion $criterion, array &$match, array &$excludeMatch )
+    {
+        if ( isset( $match["contentId"] ) )
+            throw new RuntimeException( "A content ID criterion already exists" );
+
+        $match["contentId"] = $criterion->value;
+    }
+}

--- a/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/ContentTypeGroupId.php
+++ b/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/ContentTypeGroupId.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * File containing the InMemory content type groupe id criterion handler class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+/**
+ * Content type groupe id criterion handler
+ */
+class ContentTypeGroupId extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return boolean
+     */
+    public function accept( Criterion $criterion )
+    {
+        return $criterion instanceof Criterion\ContentTypeGroupId;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $match
+     * @param array $excludeMatch
+     */
+    public function handle( Criterion $criterion, array &$match, array &$excludeMatch )
+    {
+        $contentType = $this->backend->find(
+            "Content\\Type",
+            array( "groupIds" => $criterion->value )
+        );
+        if ( empty( $contentType ) )
+        {
+            return false;
+        }
+
+        $results = $this->backend->find(
+            "Content\\ContentInfo",
+            array( "contentTypeId" => $contentType[0]->id )
+        );
+        if ( empty( $results ) )
+        {
+            return false;
+        }
+
+        $contentIds = array();
+        foreach ( $results as $result )
+        {
+            $contentIds[$result->id] = true;
+        }
+        $match["contentId"] = array_keys( $contentIds );
+    }
+}

--- a/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/ContentTypeId.php
+++ b/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/ContentTypeId.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * File containing the InMemory content type id criterion handler class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+/**
+ * Content type id criterion handler
+ */
+class ContentTypeId extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return boolean
+     */
+    public function accept( Criterion $criterion )
+    {
+        return $criterion instanceof Criterion\ContentTypeId;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $match
+     * @param array $excludeMatch
+     */
+    public function handle( Criterion $criterion, array &$match, array &$excludeMatch )
+    {
+        $results = $this->backend->find(
+            "Content\\ContentInfo",
+            array( "contentTypeId" => $criterion->value )
+        );
+        if ( empty( $results ) )
+        {
+            return false;
+        }
+
+        $contentIds = array();
+        foreach ( $results as $result )
+        {
+            $contentIds[$result->id] = true;
+        }
+        $match["contentId"] = array_keys( $contentIds );
+    }
+}

--- a/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/ContentTypeIdentifier.php
+++ b/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/ContentTypeIdentifier.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * File containing the InMemory content type identifier criterion handler class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+/**
+ * Content type identifier criterion handler
+ */
+class ContentTypeIdentifier extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return boolean
+     */
+    public function accept( Criterion $criterion )
+    {
+        return $criterion instanceof Criterion\ContentTypeIdentifier;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $match
+     * @param array $excludeMatch
+     */
+    public function handle( Criterion $criterion, array &$match, array &$excludeMatch )
+    {
+        $contentType = $this->backend->find(
+            "Content\\Type",
+            array( "identifier" => $criterion->value )
+        );
+        if ( empty( $contentType ) )
+        {
+            return false;
+        }
+
+        $results = $this->backend->find(
+            "Content\\ContentInfo",
+            array( "contentTypeId" => $contentType[0]->id )
+        );
+        if ( empty( $results ) )
+        {
+            return false;
+        }
+
+        $contentIds = array();
+        foreach ( $results as $result )
+        {
+            $contentIds[$result->id] = true;
+        }
+        $match["contentId"] = array_keys( $contentIds );
+    }
+}

--- a/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/LocationId.php
+++ b/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/LocationId.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * File containing the InMemory location id criterion handler class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use RuntimeException;
+
+/**
+ * Location id criterion handler
+ */
+class LocationId extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return boolean
+     */
+    public function accept( Criterion $criterion )
+    {
+        return $criterion instanceof Criterion\LocationId;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $match
+     * @param array $excludeMatch
+     */
+    public function handle( Criterion $criterion, array &$match, array &$excludeMatch )
+    {
+        if ( isset( $match["id"] ) )
+            throw new RuntimeException( "A location ID criterion already exists" );
+
+        $match["id"] = $criterion->value;
+    }
+}

--- a/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/LocationRemoteId.php
+++ b/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/LocationRemoteId.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * File containing the InMemory location remote id criterion handler class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use RuntimeException;
+
+/**
+ * Location remote id criterion handler
+ */
+class LocationRemoteId extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return boolean
+     */
+    public function accept( Criterion $criterion )
+    {
+        return $criterion instanceof Criterion\LocationRemoteId;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $match
+     * @param array $excludeMatch
+     */
+    public function handle( Criterion $criterion, array &$match, array &$excludeMatch )
+    {
+        if ( isset( $match["remoteId"] ) )
+            throw new RuntimeException( "A location remote ID criterion already exists" );
+
+        $match["remoteId"] = $criterion->value;
+    }
+}

--- a/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/LogicalAnd.php
+++ b/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/LogicalAnd.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * File containing the InMemory logical AND criterion handler class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+/**
+ * Logical AND criterion handler
+ */
+class LogicalAnd extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return boolean
+     */
+    public function accept( Criterion $criterion )
+    {
+        return $criterion instanceof Criterion\LogicalAnd;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $match
+     * @param array $excludeMatch
+     */
+    public function handle( Criterion $criterion, array &$match, array &$excludeMatch )
+    {
+        $results = array();
+        foreach ( $criterion->criteria as $subCriterion )
+        {
+            $innerMatch = $innerExcludeMatch = array();
+            $this->locationHandler->convertCriteria( $subCriterion, $innerMatch, $innerExcludeMatch );
+            $results[] = $result = $this->backend->find(
+                "Content\\Location",
+                $innerMatch,
+                $innerExcludeMatch
+            );
+            if ( empty( $result ) )
+            {
+                $match = false;
+                return;
+            }
+        }
+        // Transform the 2 dimensional $results array in a 2 dimensional array of ids
+        $mapping = array_map(
+            function ( $n )
+            {
+                return array_map(
+                    function ( $n )
+                    {
+                        return $n->id;
+                    },
+                    $n
+                );
+            },
+            $results
+        );
+
+        // If some location IDs have been specified, those need to be taken into account as well
+        if ( isset( $match["id"] ) )
+        {
+            $mapping[] = (array)$match["id"];
+        }
+
+        $locationIds = $mapping[0];
+
+        for ( $i = 1, $count = count( $mapping ); $i < $count; ++$i )
+        {
+            $locationIds = array_intersect( $locationIds, $mapping[$i] );
+        }
+
+        $match["id"] = $locationIds;
+    }
+}

--- a/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/LogicalNot.php
+++ b/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/LogicalNot.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * File containing the InMemory logical NOT criterion handler class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+/**
+ * Logical NOT criterion handler
+ */
+class LogicalNot extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return boolean
+     */
+    public function accept( Criterion $criterion )
+    {
+        return $criterion instanceof Criterion\LogicalNot;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $match
+     * @param array $excludeMatch
+     */
+    public function handle( Criterion $criterion, array &$match, array &$excludeMatch )
+    {
+        $results = array();
+        foreach ( $criterion->criteria as $subCriterion )
+        {
+            $innerMatch = $innerExcludeMatch = array();
+            $this->locationHandler->convertCriteria( $subCriterion, $innerMatch, $innerExcludeMatch );
+            $results[] = $result = $this->backend->find(
+                "Content\\Location",
+                $innerMatch,
+                $innerExcludeMatch
+            );
+        }
+        // Transform the 2 dimensional $results array in a 2 dimensional array of ids
+        $mapping = array_map(
+            function ( $n )
+            {
+                return array_map(
+                    function ( $n )
+                    {
+                        return $n->id;
+                    },
+                    $n
+                );
+            },
+            $results
+        );
+
+        // If some location IDs have been specified, those need to be taken into account as well
+        if ( isset( $excludeMatch["id"] ) )
+        {
+            $mapping[] = (array)$excludeMatch["id"];
+        }
+
+        $locationIds = $mapping[0];
+
+        for ( $i = 1, $count = count( $mapping ); $i < $count; ++$i )
+        {
+            $locationIds = array_intersect( $locationIds, $mapping[$i] );
+        }
+
+        $excludeMatch["id"] = $locationIds;
+    }
+}

--- a/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/LogicalOr.php
+++ b/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/LogicalOr.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * File containing the InMemory logical OR criterion handler class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+/**
+ * Logical OR criterion handler
+ */
+class LogicalOr extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return boolean
+     */
+    public function accept( Criterion $criterion )
+    {
+        return $criterion instanceof Criterion\LogicalOr;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $match
+     * @param array $excludeMatch
+     */
+    public function handle( Criterion $criterion, array &$match, array &$excludeMatch )
+    {
+        $locationIds = array();
+        foreach ( $criterion->criteria as $subCriterion )
+        {
+            $innerMatch = $innerExcludeMatch = array();
+            $this->locationHandler->convertCriteria( $subCriterion, $innerMatch, $innerExcludeMatch );
+            $results = $this->backend->find(
+                "Content\\Location",
+                $innerMatch,
+                $innerExcludeMatch
+            );
+            if ( empty( $results ) )
+            {
+                continue;
+            }
+
+            foreach ( $results as $result )
+            {
+                $locationIds[$result->id] = true;
+            }
+        }
+
+        // If some location IDs have been specified, those need to be taken into account as well
+        if ( isset( $match["id"] ) )
+        {
+            $locationIds += array_fill_keys( (array)$match["id"], true );
+        }
+
+        $match["id"] = array_keys( $locationIds );
+    }
+}

--- a/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/ParentLocationId.php
+++ b/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/ParentLocationId.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * File containing the InMemory parent location id criterion handler class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use RuntimeException;
+
+/**
+ * Parent location id criterion handler
+ */
+class ParentLocationId extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return boolean
+     */
+    public function accept( Criterion $criterion )
+    {
+        return $criterion instanceof Criterion\ParentLocationId;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $match
+     * @param array $excludeMatch
+     */
+    public function handle( Criterion $criterion, array &$match, array &$excludeMatch )
+    {
+        if ( isset( $match["parentId"] ) )
+            throw new RuntimeException( "A parent location ID criterion already exists" );
+
+        $match["parentId"] = $criterion->value;
+    }
+}

--- a/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/RemoteId.php
+++ b/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/RemoteId.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * File containing the InMemory remote id criterion handler class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+/**
+ * Remote id criterion handler
+ */
+class RemoteId extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return boolean
+     */
+    public function accept( Criterion $criterion )
+    {
+        return $criterion instanceof Criterion\RemoteId;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $match
+     * @param array $excludeMatch
+     */
+    public function handle( Criterion $criterion, array &$match, array &$excludeMatch )
+    {
+        $results = $this->backend->find(
+            "Content\\ContentInfo",
+            array( "remoteId" => $criterion->value )
+        );
+        if ( empty( $results ) )
+        {
+            return false;
+        }
+
+        $contentIds = array();
+        foreach ( $results as $result )
+        {
+            $contentIds[$result->id] = true;
+        }
+        $match["contentId"] = array_keys( $contentIds );
+    }
+}

--- a/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/SectionId.php
+++ b/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/SectionId.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * File containing the InMemory section id criterion handler class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+/**
+ * Section id criterion handler
+ */
+class SectionId extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return boolean
+     */
+    public function accept( Criterion $criterion )
+    {
+        return $criterion instanceof Criterion\SectionId;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $match
+     * @param array $excludeMatch
+     */
+    public function handle( Criterion $criterion, array &$match, array &$excludeMatch )
+    {
+        $results = $this->backend->find(
+            "Content\\ContentInfo",
+            array( "sectionId" => $criterion->value )
+        );
+        if ( empty( $results ) )
+        {
+            return false;
+        }
+
+        $contentIds = array();
+        foreach ( $results as $result )
+        {
+            $contentIds[$result->id] = true;
+        }
+        $match["contentId"] = array_keys( $contentIds );
+    }
+}

--- a/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/Subtree.php
+++ b/eZ/Publish/Core/Persistence/InMemory/CriterionHandler/Subtree.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * File containing the InMemory subtree criterion handler class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\InMemory\CriterionHandler;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use RuntimeException;
+
+/**
+ * Subtree criterion handler
+ */
+class Subtree extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return boolean
+     */
+    public function accept( Criterion $criterion )
+    {
+        return $criterion instanceof Criterion\Subtree;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $match
+     * @param array $excludeMatch
+     */
+    public function handle( Criterion $criterion, array &$match, array &$excludeMatch )
+    {
+        if ( isset( $match["pathString"] ) )
+            throw new RuntimeException( "A criterion based on pathString already exists" );
+
+        if ( count( $criterion->value ) > 1 )
+            throw new RuntimeException( "Cannot handle more than one path" );
+
+        $match["pathString"] = $criterion->value[0] . "%";
+    }
+}

--- a/eZ/Publish/Core/Persistence/InMemory/Handler.php
+++ b/eZ/Publish/Core/Persistence/InMemory/Handler.php
@@ -97,6 +97,14 @@ class Handler implements HandlerInterface
     }
 
     /**
+     * @return \eZ\Publish\SPI\Persistence\Content\Location\Search\Handler
+     */
+    public function locationSearchHandler()
+    {
+        return $this->serviceHandler( 'eZ\\Publish\\Core\\Persistence\\InMemory\\LocationSearchHandler' );
+    }
+
+    /**
      * @return \eZ\Publish\SPI\Persistence\Content\ObjectState\Handler
      */
     public function objectStateHandler()

--- a/eZ/Publish/Core/Persistence/InMemory/LocationHandler.php
+++ b/eZ/Publish/Core/Persistence/InMemory/LocationHandler.php
@@ -45,6 +45,21 @@ class LocationHandler implements LocationHandlerInterface
     {
         $this->handler = $handler;
         $this->backend = $backend;
+        $this->criterionHandlers = array(
+            new CriterionHandler\LocationId( $this, $backend ),
+            new CriterionHandler\ParentLocationId( $this, $backend ),
+            new CriterionHandler\LocationRemoteId( $this, $backend ),
+            new CriterionHandler\ContentId( $this, $backend ),
+            new CriterionHandler\SectionId( $this, $backend ),
+            new CriterionHandler\RemoteId( $this, $backend ),
+            new CriterionHandler\ContentTypeId( $this, $backend ),
+            new CriterionHandler\ContentTypeIdentifier( $this, $backend ),
+            new CriterionHandler\ContentTypeGroupId( $this, $backend ),
+            new CriterionHandler\Subtree( $this, $backend ),
+            new CriterionHandler\LogicalAnd( $this, $backend ),
+            new CriterionHandler\LogicalOr( $this, $backend ),
+            new CriterionHandler\LogicalNot( $this, $backend ),
+        );
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/InMemory/LocationSearchHandler.php
+++ b/eZ/Publish/Core/Persistence/InMemory/LocationSearchHandler.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * File containing the LocationSearchHandler implementation
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\InMemory;
+
+use eZ\Publish\SPI\Persistence\Content\Location\Search\Handler as LocationSearchHandlerInterface;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+/**
+ * @see eZ\Publish\SPI\Persistence\Content\Location\Search\Handler
+ */
+class LocationSearchHandler implements LocationSearchHandlerInterface
+{
+    /**
+     * @var \eZ\Publish\Core\Persistence\InMemory\Handler
+     */
+    protected $handler;
+
+    /**
+     * @var \eZ\Publish\Core\Persistence\InMemory\CriterionHandler[]
+     */
+    private $criterionHandlers;
+
+    /**
+     * Setups current handler instance with reference to Handler object that created it.
+     *
+     * @param \eZ\Publish\Core\Persistence\InMemory\Handler $handler
+     * @param \eZ\Publish\Core\Persistence\InMemory\Backend $backend The storage engine backend
+     */
+    public function __construct( Handler $handler, Backend $backend )
+    {
+        $this->handler = $handler;
+        $this->backend = $backend;
+        $this->criterionHandlers = array(
+            new CriterionHandler\LocationId( $this, $backend ),
+            new CriterionHandler\ParentLocationId( $this, $backend ),
+            new CriterionHandler\LocationRemoteId( $this, $backend ),
+            new CriterionHandler\ContentId( $this, $backend ),
+            new CriterionHandler\SectionId( $this, $backend ),
+            new CriterionHandler\RemoteId( $this, $backend ),
+            new CriterionHandler\ContentTypeId( $this, $backend ),
+            new CriterionHandler\ContentTypeIdentifier( $this, $backend ),
+            new CriterionHandler\ContentTypeGroupId( $this, $backend ),
+            new CriterionHandler\Subtree( $this, $backend ),
+            new CriterionHandler\LogicalAnd( $this, $backend ),
+            new CriterionHandler\LogicalOr( $this, $backend ),
+            new CriterionHandler\LogicalNot( $this, $backend ),
+        );
+    }
+
+    /**
+     * Finds all locations given some $criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param int $offset
+     * @param int $limit
+     */
+    public function findLocations( Criterion $criterion, $offset = 0, $limit = 10 )
+    {
+        $match = $excludeMatch = array();
+        $this->convertCriteria( $criterion, $match, $excludeMatch );
+
+        if ( $match === false )
+        {
+            return array();
+        }
+
+        return array_slice(
+            $this->backend->find(
+                'Content\\Location',
+                $match,
+                $excludeMatch
+            ),
+            $offset,
+            $limit
+        );
+    }
+
+    /**
+     * Counts all locations given some $criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     *
+     * @return int
+     */
+    public function getLocationCount( Criterion $criterion )
+    {
+        $match = $excludeMatch = array();
+        $this->convertCriteria( $criterion, $match, $excludeMatch );
+
+        if ( $match === false )
+        {
+            return 0;
+        }
+
+        return $this->backend->count(
+            'Content\\Location',
+            $match,
+            $excludeMatch
+        );
+    }
+
+    public function convertCriteria( Criterion $criterion, array &$match, array &$excludeMatch )
+    {
+        foreach ( $this->criterionHandlers as $criterionHandler )
+        {
+            if ( $criterionHandler->accept( $criterion ) )
+            {
+                $criterionHandler->handle( $criterion, $match, $excludeMatch );
+            }
+        }
+    }
+
+}

--- a/eZ/Publish/Core/Persistence/InMemory/SearchHandler.php
+++ b/eZ/Publish/Core/Persistence/InMemory/SearchHandler.php
@@ -106,6 +106,7 @@ class SearchHandler implements SearchHandlerInterface
         $list = $this->backend->find(
             'Content',
             $match,
+            array(),
             array(
                 'locations' => array(
                     'type' => 'Content\\Location',

--- a/eZ/Publish/Core/Persistence/InMemory/Tests/InMemory/BackendDataTest.php
+++ b/eZ/Publish/Core/Persistence/InMemory/Tests/InMemory/BackendDataTest.php
@@ -274,6 +274,7 @@ class BackendDataTest extends PHPUnit_Framework_TestCase
         $list = $this->backend->find(
             'Content',
             array( 'id' => 1 ),
+            array(),
             array(
                 'versionInfo' => array(
                     'type' => 'Content\\VersionInfo',
@@ -324,6 +325,7 @@ class BackendDataTest extends PHPUnit_Framework_TestCase
         $list = $this->backend->find(
             'Content',
             array( "versionInfo" => array( 'id' => 2 ) ),
+            array(),
             array(
                 'versionInfo' => array(
                     'type' => 'Content\\VersionInfo',
@@ -384,6 +386,7 @@ class BackendDataTest extends PHPUnit_Framework_TestCase
         $list = $this->backend->find(
             'Content',
             array( "versionInfo" => array( 'id' => 2 ) ),
+            array(),
             array(
                 'versionInfo' => array(
                     'type' => 'Content\\VersionInfo',
@@ -430,6 +433,7 @@ class BackendDataTest extends PHPUnit_Framework_TestCase
         $this->backend->find(
             'Content',
             array( "locations" => array( 'contentId' => 2 ) ),
+            array(),
             array(
                 'locations' => array(
                     'type' => 'Content\\Location',
@@ -455,6 +459,7 @@ class BackendDataTest extends PHPUnit_Framework_TestCase
             array(
                 "id" => 1,
             ),
+            array(),
             array(
                 'versionInfo' => array(
                     'type' => 'Content\\VersionInfo',
@@ -555,6 +560,7 @@ class BackendDataTest extends PHPUnit_Framework_TestCase
             $this->backend->count(
                 'Content',
                 array( "versionInfo" => array( 'id' => 2 ) ),
+                array(),
                 array(
                     'versionInfo' => array(
                         'type' => 'Content\\VersionInfo',
@@ -585,6 +591,7 @@ class BackendDataTest extends PHPUnit_Framework_TestCase
         $this->backend->count(
             'Content',
             array( "locations" => array( 'contentId' => 2 ) ),
+            array(),
             array(
                 'locations' => array(
                     'type' => 'Content\\Location',

--- a/eZ/Publish/Core/Persistence/InMemory/Tests/LocationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/InMemory/Tests/LocationHandlerTest.php
@@ -98,6 +98,7 @@ class LocationHandlerTest extends HandlerTest
                         "sectionId" => 1,
                         "typeId" => $type->id,
                         "initialLanguageId" => 2,
+                        "remoteId" => "contentRemote$i",
                         "fields" => array(
                             new Field(
                                 array(
@@ -124,6 +125,7 @@ class LocationHandlerTest extends HandlerTest
                     array(
                         "contentId" => $this->lastContentId,
                         "contentVersion" => 1,
+                        "remoteId" => "locationRemote$i",
                         "mainLocationId" => $this->lastLocationId,
                         "sortField" => Location::SORT_FIELD_NAME,
                         "sortOrder" => Location::SORT_ORDER_ASC,

--- a/eZ/Publish/Core/Persistence/InMemory/Tests/LocationSearchHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/InMemory/Tests/LocationSearchHandlerTest.php
@@ -1,0 +1,294 @@
+<?php
+/**
+ * File contains: eZ\Publish\Core\Persistence\InMemory\Tests\LocationSearchHandlerTest class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\InMemory\Tests;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+/**
+ * Test case for Location Search Handler using in memory storage.
+ */
+class LocationSearchHandlerTest extends LocationHandlerTest
+{
+    /**
+     * Test for findLocations() method.
+     *
+     * @dataProvider providerForTestFindLocations
+     * @covers \eZ\Publish\Core\Persistence\InMemory\LocationSearchHandler::findLocations
+     * @group locationSearchHandler
+     */
+    public function testFindLocations( Criterion $criterion, $results )
+    {
+        $locations = $this->persistenceHandler->locationSearchHandler()->findLocations( $criterion );
+        usort(
+            $locations,
+            function ( $a, $b )
+            {
+                if ( $a->id == $b->id )
+                    return 0;
+
+                return ( $a->id < $b->id ) ? -1 : 1;
+            }
+        );
+        $this->assertEquals( count( $results ), count( $locations ) );
+        foreach ( $results as $n => $result )
+        {
+            foreach ( $result as $key => $value )
+            {
+                $this->assertEquals( $value, $locations[$n]->$key );
+            }
+        }
+    }
+
+    public function providerForTestFindLocations()
+    {
+        return array(
+            array(
+                new Criterion\ParentLocationId( 1 ),
+                array(
+                    array( "id" => 2, "parentId" => 1 ),
+                    array( "id" => 5, "parentId" => 1 ),
+                    array( "id" => 43, "parentId" => 1 ),
+                )
+            ),
+            array(
+                new Criterion\ContentId( 54 ),
+                array( array( "id" => 56, "contentId" => 54 ) )
+            ),
+            array(
+                new Criterion\LocationRemoteId( "locationRemote1" ),
+                array( array( "id" => 55, "remoteId" => "locationRemote1" ) )
+            ),
+            array(
+                new Criterion\SectionId( 3 ),
+                array(
+                    array( "id" => 43 ),
+                    array( "id" => 53 ),
+                )
+            ),
+            array(
+                new Criterion\RemoteId( "contentRemote1" ),
+                array(
+                    array( "id" => 55, "remoteId" => "locationRemote1" ),
+                )
+            ),
+            array(
+                new Criterion\ContentTypeId( 3 ),
+                array(
+                    array( "id" => 5 ),
+                    array( "id" => 12 ),
+                    array( "id" => 13 ),
+                    array( "id" => 44 ),
+                )
+            ),
+            array(
+                new Criterion\ContentTypeIdentifier( "user_group" ),
+                array(
+                    array( "id" => 5 ),
+                    array( "id" => 12 ),
+                    array( "id" => 13 ),
+                    array( "id" => 44 ),
+                )
+            ),
+            array(
+                new Criterion\ContentTypeGroupId( 2 ),
+                array(
+                    array( "id" => 5 ),
+                    array( "id" => 12 ),
+                    array( "id" => 13 ),
+                    array( "id" => 44 ),
+                )
+            ),
+            array(
+                new Criterion\ParentLocationId( 54 ),
+                array( array( "id" => 55, "parentId" => 54 ) )
+            ),
+            array(
+                new Criterion\LocationId( 55 ),
+                array( array( "id" => 55 ) )
+            ),
+            array(
+                new Criterion\LogicalAnd(
+                    array(
+                        new Criterion\LocationRemoteId( "locationRemote1" ),
+                        new Criterion\ParentLocationId( 54 )
+                    )
+                ),
+                array( array( "id" => 55, "parentId" => 54, "remoteId" => "locationRemote1" ) )
+            ),
+            array(
+                new Criterion\LogicalAnd(
+                    array(
+                        new Criterion\LogicalAnd(
+                            array(
+                                new Criterion\LocationRemoteId( "locationRemote1" ),
+                                new Criterion\ParentLocationId( 54 )
+                            )
+                        ),
+                        new Criterion\ParentLocationId( 54 )
+                    )
+                ),
+                array( array( "id" => 55, "parentId" => 54, "remoteId" => "locationRemote1" ) )
+            ),
+            array(
+                new Criterion\LogicalAnd(
+                    array(
+                        new Criterion\LocationId( 55 ),
+                        new Criterion\LogicalAnd(
+                            array(
+                                new Criterion\LocationRemoteId( "locationRemote1" ),
+                                new Criterion\ParentLocationId( 54 )
+                            )
+                        )
+                    )
+                ),
+                array( array( "id" => 55, "parentId" => 54, "remoteId" => "locationRemote1" ) )
+            ),
+            array(
+                new Criterion\LogicalAnd(
+                    array(
+                        new Criterion\LocationId( 54 ),
+                        new Criterion\LogicalAnd(
+                            array(
+                                new Criterion\LocationRemoteId( "locationRemote1" ),
+                                new Criterion\ParentLocationId( 54 )
+                            )
+                        )
+                    )
+                ),
+                array()
+            ),
+            array(
+                new Criterion\LogicalAnd(
+                    array(
+                        new Criterion\LocationRemoteId( "locationRemote0" ),
+                        new Criterion\ParentLocationId( 54 )
+                    )
+                ),
+                array()
+            ),
+            array(
+                new Criterion\LogicalAnd(
+                    array(
+                        new Criterion\ParentLocationId( 1 ),
+                        new Criterion\LocationId( 43 ),
+                    )
+                ),
+                array(
+                    array( "id" => 43, "parentId" => 1 ),
+                )
+            ),
+            array(
+                new Criterion\LogicalAnd(
+                    array(
+                        new Criterion\ParentLocationId( 1 ),
+                        new Criterion\ParentLocationId( 1 ),
+                        new Criterion\ParentLocationId( 1 ),
+                    )
+                ),
+                array(
+                    array( "id" => 2, "parentId" => 1 ),
+                    array( "id" => 5, "parentId" => 1 ),
+                    array( "id" => 43, "parentId" => 1 ),
+                )
+            ),
+            array(
+                new Criterion\LogicalOr(
+                    array(
+                        new Criterion\LocationRemoteId( "locationRemote1" ),
+                        new Criterion\ParentLocationId( 54 ),
+                        new Criterion\LocationRemoteId( "ARemoteIdThatDoesNotExist" ),
+                    )
+                ),
+                array( array( "id" => 55, "parentId" => 54, "remoteId" => "locationRemote1" ) )
+            ),
+            array(
+                new Criterion\LogicalOr(
+                    array(
+                        new Criterion\LocationRemoteId( "locationRemote0" ),
+                        new Criterion\LogicalOr(
+                            array(
+                                new Criterion\LocationRemoteId( "locationRemote1" ),
+                                new Criterion\ParentLocationId( 54 ),
+                            )
+                        )
+                    )
+                ),
+                array(
+                    array( "id" => 54, "remoteId" => "locationRemote0" ),
+                    array( "id" => 55, "parentId" => 54, "remoteId" => "locationRemote1" )
+                )
+            ),
+            array(
+                new Criterion\LogicalOr(
+                    array(
+                        new Criterion\LocationRemoteId( "locationRemote1" ),
+                        new Criterion\LocationRemoteId( "ARemoteIdThatDoesNotExist" ),
+                    )
+                ),
+                array(
+                    array( "id" => 55, "remoteId" => "locationRemote1" ),
+                )
+            ),
+            array(
+                new Criterion\Subtree(
+                    "/1/2/"
+                ),
+                array(
+                    array( "id" => 54 ),
+                    array( "id" => 55 ),
+                    array( "id" => 56 ),
+                    array( "id" => 57 ),
+                    array( "id" => 58 ),
+                )
+            ),
+            array(
+                new Criterion\LogicalAnd(
+                    array(
+                        new Criterion\Subtree(
+                            "/1/2/"
+                        ),
+                        new Criterion\LogicalNot(
+                            new Criterion\LocationRemoteId( "locationRemote1" )
+                        ),
+                    )
+                ),
+                array(
+                    array( "id" => 54 ),
+                    array( "id" => 56 ),
+                    array( "id" => 57 ),
+                    array( "id" => 58 ),
+                )
+            ),
+            array(
+                new Criterion\LogicalAnd(
+                    array(
+                        new Criterion\LogicalNot(
+                            new Criterion\Subtree(
+                                "/1/2/"
+                            )
+                        ),
+                        new Criterion\LogicalNot(
+                            new Criterion\Subtree(
+                                "/1/5/"
+                            )
+                        ),
+                    )
+                ),
+                array(
+                    array( "id" => 1, "parentId" => 0 ),
+                    array( "id" => 2, "parentId" => 1 ),
+                    array( "id" => 5, "parentId" => 1 ),
+                    array( "id" => 43, "parentId" => 1 ),
+                    array( "id" => 53, "parentId" => 43 ),
+                )
+            ),
+        );
+    }
+}

--- a/eZ/Publish/Core/Persistence/InMemory/UserHandler.php
+++ b/eZ/Publish/Core/Persistence/InMemory/UserHandler.php
@@ -178,6 +178,7 @@ class UserHandler implements UserHandlerInterface
         $list = $this->backend->find(
             'User\\Role',
             array( 'id' => $roleId ),
+            array(),
             array(
                 'policies' => array(
                     'type' => 'User\\Policy',
@@ -205,6 +206,7 @@ class UserHandler implements UserHandlerInterface
         $list = $this->backend->find(
             'User\\Role',
             array( 'identifier' => $identifier ),
+            array(),
             array(
                 'policies' => array(
                     'type' => 'User\\Policy',
@@ -227,6 +229,7 @@ class UserHandler implements UserHandlerInterface
     {
         return $this->backend->find(
             'User\\Role',
+            array(),
             array(),
             array(
                 'policies' => array(
@@ -288,6 +291,7 @@ class UserHandler implements UserHandlerInterface
                 $list = $this->backend->find(
                     'Content',
                     array( 'id' => $location->contentId ),
+                    array(),
                     array(
                         'versionInfo' => array(
                             'type' => 'Content\\VersionInfo',
@@ -465,6 +469,7 @@ class UserHandler implements UserHandlerInterface
         $list = $this->backend->find(
             'Content',
             array( 'id' => $userId ),
+            array(),
             array(
                 'versionInfo' => array(
                     'type' => 'Content\\VersionInfo',
@@ -503,6 +508,7 @@ class UserHandler implements UserHandlerInterface
                 $list2 = $this->backend->find(
                     'Content',
                     array( 'id' => $location->contentId ),
+                    array(),
                     array(
                         'versionInfo' => array(
                             'type' => 'Content\\VersionInfo',
@@ -546,6 +552,7 @@ class UserHandler implements UserHandlerInterface
         $list = $this->backend->find(
             'User\\Role',
             array( 'groupIds' => $content->versionInfo->contentInfo->id ),
+            array(),
             array(
                 'policies' => array(
                     'type' => 'User\\Policy',

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Location;
 
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\SPI\Persistence\Content\Location\UpdateStruct;
 use eZ\Publish\SPI\Persistence\Content\Location\CreateStruct;
 
@@ -53,6 +54,22 @@ abstract class Gateway
      * @return array
      */
     abstract public function getBasicNodeDataByRemoteId( $remoteId );
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param int $offset
+     * @param int $limit
+     *
+     * @return mixed
+     */
+    abstract public function find( Criterion $criterion, $offset, $limit );
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     *
+     * @return int
+     */
+    abstract public function count( Criterion $criterion );
 
     /**
      * Loads data for all Locations for $contentId, optionally only in the

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/CriteriaConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/CriteriaConverter.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * File containing the EzcDatabase criteria converter class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use ezcQuerySelect;
+use RuntimeException;
+
+/**
+ * Content locator gateway implementation using the zeta database component.
+ */
+class CriteriaConverter
+{
+    /**
+     * Criterion handlers
+     *
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\CriterionHandler[]
+     */
+    protected $handler;
+
+    /**
+     * Construct from an optional array of Criterion handlers
+     *
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\CriterionHandler[] $handler
+     *
+     * @return void
+     */
+    public function __construct( array $handler )
+    {
+        $this->handler = $handler;
+    }
+
+    /**
+     * Generic converter of criteria into query fragments
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if Criterion is not applicable to its target
+     *
+     * @param \ezcQuerySelect $query
+     * @param Criterion $criterion
+     *
+     * @return \ezcQueryExpression
+     */
+    public function convertCriteria( ezcQuerySelect $query, Criterion $criterion )
+    {
+        foreach ( $this->handler as $handler )
+        {
+            if ( $handler->accept( $criterion ) )
+            {
+                return $handler->handle( $this, $query, $criterion );
+            }
+        }
+
+        throw new RuntimeException( 'No conversion for criterion found.' );
+    }
+}
+

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/CriterionHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/CriterionHandler.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * File containing the Legacy location criterion handler class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Persistence\Legacy\EzcDbHandler;
+use ezcQuerySelect;
+
+abstract class CriterionHandler
+{
+    /**
+     * Database handler
+     *
+     * @var \eZ\Publish\Core\Persistence\Legacy\EzcDbHandler
+     */
+    protected $dbHandler;
+
+    /**
+     * Creates a new criterion handler
+     *
+     * @param \EzcDbHandler $dbHandler
+     */
+    public function __construct( EzcDbHandler $dbHandler )
+    {
+        $this->dbHandler = $dbHandler;
+    }
+
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     *
+     * @return boolean
+     */
+    abstract public function accept( Criterion $criterion );
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\CriteriaConverter $converter
+     * @param \ezcQuerySelect $query
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     */
+    abstract public function handle( CriteriaConverter $converter, ezcQuerySelect $query, Criterion $criterion );
+}

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/CriterionHandler/LocationId.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/CriterionHandler/LocationId.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * File containing the EzcDatabase location id criterion handler class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\CriterionHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\CriteriaConverter;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use ezcQuerySelect;
+
+/**
+ * Location id criterion handler
+ */
+class LocationId extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return boolean
+     */
+    public function accept( Criterion $criterion )
+    {
+        return $criterion instanceof Criterion\LocationId;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\CriteriaConverter $converter
+     * @param \ezcQuerySelect $query
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return \ezcQueryExpression
+     */
+    public function handle( CriteriaConverter $converter, ezcQuerySelect $query, Criterion $criterion )
+    {
+        return $query->expr->in(
+            $this->dbHandler->quoteColumn( 'node_id' ),
+            $criterion->value
+        );
+    }
+}
+

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/CriterionHandler/LogicalAnd.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/CriterionHandler/LogicalAnd.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * File containing the EzcDatabase logical AND criterion handler class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\CriterionHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\CriteriaConverter;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use ezcQuerySelect;
+
+/**
+ * Logical AND criterion handler
+ */
+class LogicalAnd extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return boolean
+     */
+    public function accept( Criterion $criterion )
+    {
+        return $criterion instanceof Criterion\LogicalAnd;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\CriteriaConverter $converter
+     * @param \ezcQuerySelect $query
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return \ezcQueryExpression
+     */
+    public function handle( CriteriaConverter $converter, ezcQuerySelect $query, Criterion $criterion )
+    {
+        $subexpressions = array();
+        foreach ( $criterion->criteria as $subCriterion )
+        {
+            $subexpressions[] = $converter->convertCriteria( $query, $subCriterion );
+        }
+        return $query->expr->lAnd( $subexpressions );
+    }
+}
+

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/CriterionHandler/ParentLocationId.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/CriterionHandler/ParentLocationId.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * File containing the EzcDatabase parent location id criterion handler class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\CriterionHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\CriteriaConverter;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use ezcQuerySelect;
+
+/**
+ * Parent location id criterion handler
+ */
+class ParentLocationId extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return boolean
+     */
+    public function accept( Criterion $criterion )
+    {
+        return $criterion instanceof Criterion\ParentLocationId;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\CriteriaConverter $converter
+     * @param \ezcQuerySelect $query
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return \ezcQueryExpression
+     */
+    public function handle( CriteriaConverter $converter, ezcQuerySelect $query, Criterion $criterion )
+    {
+        return $query->expr->in(
+            $this->dbHandler->quoteColumn( 'parent_node_id' ),
+            $criterion->value
+        );
+    }
+}
+

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/CriterionHandler/Status.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/CriterionHandler/Status.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * File containing the EzcDatabase status criterion handler class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\CriterionHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\CriteriaConverter;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use ezcQuerySelect;
+
+/**
+ * Status criterion handler
+ */
+class Status extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return boolean
+     */
+    public function accept( Criterion $criterion )
+    {
+        return $criterion instanceof Criterion\Status;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\CriteriaConverter $converter
+     * @param \ezcQuerySelect $query
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     *
+     * @return \ezcQueryExpression
+     */
+    public function handle( CriteriaConverter $converter, ezcQuerySelect $query, Criterion $criterion )
+    {
+        $subSelect = $query->subSelect();
+        $subSelect
+            ->select(
+                $this->dbHandler->quoteColumn( 'id' )
+            )->from(
+                $this->dbHandler->quoteTable( 'ezcontentobject' )
+            )->where(
+                $query->expr->in(
+                    $this->dbHandler->quoteColumn( 'status'/*, 'ezcontentobject'*/ ),
+                    $criterion->value
+                )
+            );
+
+        return $query->expr->in(
+            $this->dbHandler->quoteColumn( 'contentobject_id', 'ezcontentobject_tree' ),
+            $subSelect
+        );
+    }
+}
+

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway;
 
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway;
 use eZ\Publish\SPI\Persistence\Content\Location\UpdateStruct;
 use eZ\Publish\SPI\Persistence\Content\Location\CreateStruct;
@@ -78,6 +79,50 @@ class ExceptionConversion extends Gateway
         try
         {
             return $this->innerGateway->getBasicNodeDataByRemoteId( $remoteId );
+        }
+        catch ( ezcDbException $e )
+        {
+            throw new RuntimeException( 'Database error', 0, $e );
+        }
+        catch ( PDOException $e )
+        {
+            throw new RuntimeException( 'Database error', 0, $e );
+        }
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param int $offset
+     * @param int $limit
+     *
+     * @return mixed
+     */
+    public function find( Criterion $criterion, $offset, $limit )
+    {
+        try
+        {
+            return $this->innerGateway->find( $criterion, $offset, $limit );
+        }
+        catch ( ezcDbException $e )
+        {
+            throw new RuntimeException( 'Database error', 0, $e );
+        }
+        catch ( PDOException $e )
+        {
+            throw new RuntimeException( 'Database error', 0, $e );
+        }
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     *
+     * @return int
+     */
+    public function count( Criterion $criterion )
+    {
+        try
+        {
+            return $this->innerGateway->count( $criterion );
         }
         catch ( ezcDbException $e )
         {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Search/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Search/Handler.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * File containing the Location Search Handler class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\Legacy\Content\Location\Search;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\SPI\Persistence\Content\Location\Search\Handler as BaseLocationSearchHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway as LocationGateway;
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper;
+
+/**
+ * The Location Handler interface defines operations on Location elements in the storage engine.
+ */
+class Handler implements BaseLocationSearchHandler
+{
+    /**
+     * Gateway for handling location data
+     *
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway
+     */
+    protected $locationGateway;
+
+    /**
+     * Location locationMapper
+     *
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper
+     */
+    protected $locationMapper;
+
+    /**
+     * Construct from userGateway
+     *
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway $locationGateway
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper $locationMapper
+     *
+     * @return \eZ\Publish\Core\Persistence\Legacy\Content\Location\Handler
+     */
+    public function __construct( LocationGateway $locationGateway, LocationMapper $locationMapper )
+    {
+        $this->locationGateway = $locationGateway;
+        $this->locationMapper = $locationMapper;
+    }
+
+    /**
+     * @see \eZ\Publish\SPI\Persistence\Content\Location\Search\Handler::findLocations
+     */
+    public function findLocations( Criterion $criterion, $offset = 0, $limit = 10 )
+    {
+        return $this->locationMapper->createLocationsFromRows(
+            $this->locationGateway->find( $criterion, $offset, $limit )
+        );
+    }
+
+    /**
+     * @see \eZ\Publish\SPI\Persistence\Content\Location\Search\Handler::getLocationCount
+     */
+    public function getLocationCount( Criterion $criterion )
+    {
+        return $this->locationGateway->count( $criterion );
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Handler.php
@@ -18,6 +18,7 @@ use eZ\Publish\Core\Persistence\Legacy\Content\Type\Mapper as TypeMapper;
 use eZ\Publish\Core\Persistence\Legacy\Content\Language\Mapper as LanguageMapper;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Handler as LocationHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper;
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Search\Handler as LocationSearchHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Trash\Handler as TrashHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Handler as ObjectStateHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Mapper as ObjectStateMapper;
@@ -108,6 +109,13 @@ class Handler implements HandlerInterface
      * @var \eZ\Publish\Core\Persistence\Legacy\Content\Location\Handler
      */
     protected $locationHandler;
+
+    /**
+     * Location search handler
+     *
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\Location\Search\Handler
+     */
+    protected $locationSearchHandler;
 
     /**
      * Location gateway
@@ -649,6 +657,21 @@ class Handler implements HandlerInterface
             );
         }
         return $this->locationHandler;
+    }
+
+    /**
+     * @return \eZ\Publish\SPI\Persistence\Content\Location\SearchHandler
+     */
+    public function locationSearchHandler()
+    {
+        if ( !isset( $this->locationSearchHandler ) )
+        {
+            $this->locationSearchHandler = new LocationSearchHandler(
+                $this->getLocationGateway(),
+                $this->getLocationMapper()
+            );
+        }
+        return $this->locationSearchHandler;
     }
 
     /**

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -73,12 +73,18 @@ class LocationService implements LocationServiceInterface
     protected $nameSchemaService;
 
     /**
+     * @var \eZ\Publish\Core\Repository\PermissionsCriterionHandler
+     */
+    protected $permissionsCriterionHandler;
+
+    /**
      * Setups service with reference to repository object that created it & corresponding handler
      *
      * @param \eZ\Publish\API\Repository\Repository $repository
      * @param \eZ\Publish\SPI\Persistence\Handler $handler
      * @param \eZ\Publish\Core\Repository\DomainMapper $domainMapper
      * @param \eZ\Publish\Core\Repository\NameSchemaService $nameSchemaService
+     * @param \eZ\Publish\Core\Repository\PermissionsCriterionHandler $permissionsCriterionHandler
      * @param array $settings
      */
     public function __construct(
@@ -86,6 +92,7 @@ class LocationService implements LocationServiceInterface
         Handler $handler,
         DomainMapper $domainMapper,
         NameSchemaService $nameSchemaService,
+        PermissionsCriterionHandler $permissionsCriterionHandler,
         array $settings = array()
     )
     {
@@ -97,6 +104,7 @@ class LocationService implements LocationServiceInterface
         $this->settings = $settings + array(
             //'defaultSetting' => array(),
         );
+        $this->permissionsCriterionHandler = $permissionsCriterionHandler;
     }
 
     /**
@@ -128,7 +136,7 @@ class LocationService implements LocationServiceInterface
         /** Check read access to whole source subtree
          * @var boolean|\eZ\Publish\API\Repository\Values\Content\Query\Criterion $contentReadCriterion
          */
-        $contentReadCriterion = $this->repository->getSearchService()->getPermissionsCriterion();
+        $contentReadCriterion = $this->permissionsCriterionHandler->getPermissionsCriterion();
         if ( $contentReadCriterion === false )
         {
             throw new UnauthorizedException( 'content', 'read' );
@@ -294,38 +302,28 @@ class LocationService implements LocationServiceInterface
         if ( !is_int( $limit ) )
             throw new InvalidArgumentValue( "limit", $limit );
 
-        $searchResult = $this->searchChildrenLocations(
-            $location->id,
-            $location->sortField,
-            $location->sortOrder,
-            $offset,
-            $limit
-        );
-
         $childLocations = array();
-        foreach ( $searchResult->searchHits as $spiSearchHit )
+        foreach (
+            $this->searchChildrenLocations(
+                $location->id,
+                $location->sortField,
+                $location->sortOrder,
+                $offset,
+                $limit
+            ) as $spiLocation
+        )
         {
-            $spiContentLocations = $this->persistenceHandler->locationHandler()->loadLocationsByContent(
-                $spiSearchHit->valueObject->versionInfo->contentInfo->id,
-                $location->id
-            );
-            foreach ( $spiContentLocations as $spiLocation )
+            $childLocation = $this->buildDomainLocationObject( $spiLocation );
+            if ( $this->repository->canUser( 'content', 'read', $childLocation->getContentInfo(), $childLocation ) )
             {
-                if ( $spiLocation->parentId == $location->id )
-                {
-                    $childLocation = $this->buildDomainLocationObject( $spiLocation );
-                    if ( $this->repository->canUser( 'content', 'read', $childLocation->getContentInfo(), $childLocation ) )
-                    {
-                        $childLocations[] = $childLocation;
-                    }
-                }
+                $childLocations[] = $childLocation;
             }
         }
 
         return new LocationList(
             array(
                 "locations" => $childLocations,
-                "totalCount" => (int)$searchResult->totalCount
+                "totalCount" => $this->getLocationChildCount( $location )
             )
         );
     }
@@ -339,13 +337,19 @@ class LocationService implements LocationServiceInterface
      */
     public function getLocationChildCount( APILocation $location )
     {
-        return $this->searchChildrenLocations(
-            $location->id,
-            null,
-            APILocation::SORT_ORDER_ASC,
-            0,
-            0
-        )->totalCount;
+        $criterion = new CriterionLogicalAnd(
+            array(
+                new CriterionParentLocationId( $location->id ),
+                new CriterionStatus( CriterionStatus::STATUS_PUBLISHED ),
+            )
+        );
+
+        if ( !$this->permissionsCriterionHandler->addPermissionsCriterion( $criterion ) )
+        {
+            return array();
+        }
+
+        return $this->persistenceHandler->locationSearchHandler()->getLocationCount( $criterion );
     }
 
     /**
@@ -361,28 +365,19 @@ class LocationService implements LocationServiceInterface
      */
     protected function searchChildrenLocations( $parentLocationId, $sortField = null, $sortOrder = APILocation::SORT_ORDER_ASC, $offset = 0, $limit = -1 )
     {
-        $query = new Query(
+        $criterion = new CriterionLogicalAnd(
             array(
-                'criterion' => new CriterionLogicalAnd(
-                    array(
-                        new CriterionParentLocationId( $parentLocationId ),
-                        new CriterionStatus( CriterionStatus::STATUS_PUBLISHED ),
-                    )
-                ),
-                'offset' => ( $offset >= 0 ? (int)$offset : 0 ),
-                'limit' => ( $limit >= 0 ? (int)$limit  : null )
+                new CriterionParentLocationId( $parentLocationId ),
+                new CriterionStatus( CriterionStatus::STATUS_PUBLISHED ),
             )
         );
 
-        if ( $sortField !== null )
-            $query->sortClauses = array( $this->getSortClauseBySortField( $sortField, $sortOrder ) );
-
-        if ( !$this->repository->getSearchService()->addPermissionsCriterion( $query->criterion ) )
+        if ( !$this->permissionsCriterionHandler->addPermissionsCriterion( $criterion ) )
         {
             return array();
         }
 
-        return $this->persistenceHandler->searchHandler()->findContent( $query );
+        return $this->persistenceHandler->locationSearchHandler()->findLocations( $criterion, $offset >= 0 ? (int)$offset : 0, $limit >= 0 ? (int)$limit : null );
     }
 
     /**
@@ -653,7 +648,7 @@ class LocationService implements LocationServiceInterface
         /** Check read access to whole source subtree
          * @var boolean|\eZ\Publish\API\Repository\Values\Content\Query\Criterion $contentReadCriterion
          */
-        $contentReadCriterion = $this->repository->getSearchService()->getPermissionsCriterion();
+        $contentReadCriterion = $this->permissionsCriterionHandler->getPermissionsCriterion();
         if ( $contentReadCriterion === false )
         {
             throw new UnauthorizedException( 'content', 'read' );
@@ -737,7 +732,7 @@ class LocationService implements LocationServiceInterface
         /** Check remove access to descendants
          * @var boolean|\eZ\Publish\API\Repository\Values\Content\Query\Criterion $contentReadCriterion
          */
-        $contentReadCriterion = $this->repository->getSearchService()->getPermissionsCriterion( 'content', 'remove' );
+        $contentReadCriterion = $this->permissionsCriterionHandler->getPermissionsCriterion( 'content', 'remove' );
         if ( $contentReadCriterion === false )
         {
             throw new UnauthorizedException( 'content', 'remove' );

--- a/eZ/Publish/Core/Repository/PermissionsCriterionHandler.php
+++ b/eZ/Publish/Core/Repository/PermissionsCriterionHandler.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * File containing the eZ\Publish\Core\Repository\PermissionsCriterionHandler class.
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Repository;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOr;
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\API\Repository\Repository as RepositoryInterface;
+use RuntimeException;
+
+/**
+ * Handler for permissions Criterion
+ *
+ * @package eZ\Publish\Core\Repository
+ */
+class PermissionsCriterionHandler
+{
+    /**
+     * Constructor
+     *
+     * @param \eZ\Publish\API\Repository\Repository $repository
+     */
+    public function __construct( RepositoryInterface $repository )
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * Adds content, read Permission criteria if needed and return false if no access at all
+     *
+     * @access private Temporarily made accessible until Location service stops using searchHandler()
+     * @uses getPermissionsCriterion()
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     *
+     * @return boolean|\eZ\Publish\API\Repository\Values\Content\Query\Criterion
+     */
+    public function addPermissionsCriterion( Criterion &$criterion )
+    {
+        $permissionCriterion = $this->getPermissionsCriterion();
+        if ( $permissionCriterion === true || $permissionCriterion === false )
+        {
+            return $permissionCriterion;
+        }
+
+        // Merge with original $criterion
+        if ( $criterion instanceof LogicalAnd )
+        {
+            $criterion->criteria[] = $permissionCriterion;
+        }
+        else
+        {
+            $criterion = new LogicalAnd(
+                array(
+                    $criterion,
+                    $permissionCriterion
+                )
+            );
+        }
+        return true;
+    }
+
+    /**
+     * Get content-read Permission criteria if needed and return false if no access at all
+     *
+     * @uses \eZ\Publish\API\Repository::hasAccess()
+     * @throws \RuntimeException If empty array of limitations are provided from hasAccess()
+     *
+     * @param string $module
+     * @param string $function
+     *
+     * @return boolean|\eZ\Publish\API\Repository\Values\Content\Query\Criterion
+     */
+    public function getPermissionsCriterion( $module = 'content', $function = 'read' )
+    {
+        $permissionSets = $this->repository->hasAccess( $module, $function );
+        if ( $permissionSets === false || $permissionSets === true )
+        {
+            return $permissionSets;
+        }
+
+        if ( empty( $permissionSets ) )
+            throw new RuntimeException( "Got an empty array of limitations from hasAccess( '{$module}', '{$function}' )" );
+
+        /**
+         * RoleAssignment is a OR condition, so is policy, while limitations is a AND condition
+         *
+         * If RoleAssignment has limitation then policy OR conditions are wrapped in a AND condition with the
+         * role limitation, otherwise it will be merged into RoleAssignment's OR condition.
+         */
+        $currentUser = $this->repository->getCurrentUser();
+        $roleAssignmentOrCriteria = array();
+        $roleService = $this->repository->getRoleService();
+        foreach ( $permissionSets as $permissionSet )
+        {
+            // $permissionSet is a RoleAssignment, but in the form of role limitation & role policies hash
+            $policyOrCriteria = array();
+            /**
+             * @var \eZ\Publish\API\Repository\Values\User\Policy $policy
+             */
+            foreach ( $permissionSet['policies'] as $policy )
+            {
+                $limitations = $policy->getLimitations();
+                if ( $limitations === '*' || empty( $limitations ) )
+                    continue;
+
+                $limitationsAndCriteria = array();
+                foreach ( $limitations as $limitation )
+                {
+                    $type = $roleService->getLimitationType( $limitation->getIdentifier() );
+                    $limitationsAndCriteria[] = $type->getCriterion( $limitation, $currentUser );
+                }
+
+                $policyOrCriteria[] = isset( $limitationsAndCriteria[1] ) ?
+                    new LogicalAnd( $limitationsAndCriteria ) :
+                    $limitationsAndCriteria[0];
+            }
+
+            /**
+             * Apply role limitations if there is one
+             * @var \eZ\Publish\API\Repository\Values\User\Limitation[] $permissionSet
+             */
+            if ( $permissionSet['limitation'] instanceof Limitation )
+            {
+                // We need to match both the limitation AND *one* of the policies, aka; roleLimit AND policies(OR)
+                $type = $roleService->getLimitationType( $permissionSet['limitation']->getIdentifier() );
+                if ( !empty( $policyOrCriteria ) )
+                {
+                    $roleAssignmentOrCriteria[] = new LogicalAnd(
+                        array(
+                            $type->getCriterion( $permissionSet['limitation'], $currentUser ),
+                            isset( $policyOrCriteria[1] ) ? new LogicalOr( $policyOrCriteria ) : $policyOrCriteria[0]
+                        )
+                    );
+                }
+                else
+                {
+                    $roleAssignmentOrCriteria[] = $type->getCriterion( $permissionSet['limitation'], $currentUser );
+                }
+            }
+            // Otherwise merge $policyOrCriteria into $roleAssignmentOrCriteria
+            else if ( !empty( $policyOrCriteria ) )
+            {
+                // There is no role limitation, so any of the policies can globally match in the returned OR criteria
+                $roleAssignmentOrCriteria = empty( $roleAssignmentOrCriteria ) ?
+                    $policyOrCriteria :
+                    array_merge( $roleAssignmentOrCriteria, $policyOrCriteria );
+            }
+        }
+
+        if ( empty( $roleAssignmentOrCriteria ) )
+            return false;
+
+        return isset( $roleAssignmentOrCriteria[1] ) ?
+            new LogicalOr( $roleAssignmentOrCriteria ) :
+            $roleAssignmentOrCriteria[0];
+    }
+}

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -166,6 +166,13 @@ class Repository implements RepositoryInterface
     protected $domainMapper;
 
     /**
+     * Instance of permissions criterion handler
+     *
+     * @var \eZ\Publish\Core\Repository\PermissionsCriterionHandler
+     */
+    protected $permissionsCriterionHandler;
+
+    /**
      * Array of arrays of commit events indexed by the transaction count.
      *
      * @var array
@@ -521,6 +528,7 @@ class Repository implements RepositoryInterface
             $this->persistenceHandler,
             $this->getDomainMapper(),
             $this->getNameSchemaService(),
+            $this->getPermissionsCriterionHandler(),
             $this->serviceSettings['location']
         );
         return $this->locationService;
@@ -673,6 +681,7 @@ class Repository implements RepositoryInterface
             $this,
             $this->persistenceHandler->searchHandler(),
             $this->getDomainMapper(),
+            $this->getPermissionsCriterionHandler(),
             $this->serviceSettings['search']
         );
         return $this->searchService;
@@ -747,6 +756,22 @@ class Repository implements RepositoryInterface
             $this->persistenceHandler->contentLanguageHandler()
         );
         return $this->domainMapper;
+    }
+
+    /**
+     * Get PermissionsCriterionHandler
+     *
+     * @access private Internal service for the Core Services
+     *
+     * @todo Move out from this & other repo instances when services becomes proper services in DIC terms using factory.
+     *
+     * @return \eZ\Publish\Core\Repository\PermissionsCriterionHandler
+     */
+    protected function getPermissionsCriterionHandler()
+    {
+        return $this->permissionsCriterionHandler !== null ?
+            $this->permissionsCriterionHandler :
+            $this->permissionsCriterionHandler = new PermissionsCriterionHandler( $this );
     }
 
     /**

--- a/eZ/Publish/SPI/Persistence/Content/Location/Search/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location/Search/Handler.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * File containing the Location Search Handler interface
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\SPI\Persistence\Content\Location\Search;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+/**
+ * The Location Search Handler interface defines search operations on Location elements in the storage engine.
+ */
+interface Handler
+{
+    /**
+     * Finds all locations given some $criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param int $offset
+     * @param int $limit
+     */
+    public function findLocations( Criterion $criterion, $offset = 0, $limit = 10 );
+
+    /**
+     * Counts all locations given some $criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     *
+     * @return int
+     */
+    public function getLocationCount( Criterion $criterion );
+}

--- a/eZ/Publish/SPI/Persistence/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Handler.php
@@ -40,6 +40,11 @@ interface Handler
     public function locationHandler();
 
     /**
+     * @return \eZ\Publish\SPI\Persistence\Content\Location\Search\Handler
+     */
+    public function locationSearchHandler();
+
+    /**
      * @return \eZ\Publish\SPI\Persistence\Content\ObjectState\Handler
      */
     public function objectStateHandler();


### PR DESCRIPTION
This is a reimplementation of #249, taking last comments of @docb22 into account.
- `Location\Search\Handler::findLocations( $locationCriterion, $offset, $limit )`
  - [x] Implementation in Persistence\InMemory
  - [x] Implementation in Persistence\Legacy (Missing lot of criterion handlers)
- `Location\Search\Handler::getLocationCount( $locationCriterion )`
  - [x] Implementation in Persistence\InMemory
  - [x] Implementation in Persistence\Legacy
- Refactoring:
  - [x] `LocationService::loadLocationChildren()`
  - [x] `LocationService::getLocationChildCount()`
