### PR TITLE
Fix EZP-21575: Missing Legacy signal slot cache clearing on UpdateMetaData while updating user

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/slot.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/slot.yml
@@ -18,6 +18,7 @@ parameters:
     ezpublish_legacy.signalslot.disable_language.class: eZ\Publish\Core\SignalSlot\Slot\LegacyDisableLanguageSlot
     ezpublish_legacy.signalslot.enable_language.class: eZ\Publish\Core\SignalSlot\Slot\LegacyEnableLanguageSlot
     ezpublish_legacy.signalslot.update_language_name.class: eZ\Publish\Core\SignalSlot\Slot\LegacyUpdateLanguageNameSlot
+    ezpublish_legacy.signalslot.update_user.class: eZ\Publish\Core\SignalSlot\Slot\LegacyUpdateUserSlot
 
 services:
     ezpublish_legacy.signalslot.assign_section:
@@ -133,3 +134,9 @@ services:
         arguments: [@ezpublish_legacy.kernel]
         tags:
             - { name: ezpublish.api.slot, signal: LanguageService\UpdateLanguageNameSignal }
+
+    ezpublish_legacy.signalslot.update_user:
+        class: %ezpublish_legacy.signalslot.update_user.class%
+        arguments: [@ezpublish_legacy.kernel]
+        tags:
+            - { name: ezpublish.api.slot, signal: UserService\UpdateUserSignal }

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyUpdateUserSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyUpdateUserSlot.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * File containing the LegacyUpdateUserSlot class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\SignalSlot\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+use eZContentCacheManager;
+use eZContentObject;
+use eZContentOperationCollection;
+
+/**
+ * A legacy slot handling UpdateUserSignal.
+ */
+class LegacyUpdateUserSlot extends AbstractLegacySlot
+{
+    /**
+     * Receive the given $signal and react on it
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return void
+     */
+    public function receive( Signal $signal )
+    {
+        if ( !$signal instanceof Signal\UserService\UpdateUserSignal )
+        {
+            return;
+        }
+
+        $kernel = $this->getLegacyKernel();
+        $kernel->runCallback(
+            function () use ( $signal )
+            {
+                eZContentCacheManager::clearContentCacheIfNeeded( $signal->userId );
+                eZContentOperationCollection::registerSearchObject( $signal->userId );
+                eZContentObject::clearCache();// Clear all object memory cache to free memory
+            },
+            false
+        );
+    }
+}

--- a/eZ/Publish/Core/settings/service.ini
+++ b/eZ/Publish/Core/settings/service.ini
@@ -89,6 +89,7 @@ arguments[mapping][eZ\Publish\Core\SignalSlot\Signal\LanguageService\DeleteLangu
 arguments[mapping][eZ\Publish\Core\SignalSlot\Signal\LanguageService\DisableLanguageSignal][]=disable_language:legacy
 arguments[mapping][eZ\Publish\Core\SignalSlot\Signal\LanguageService\EnableLanguageSignal][]=enable_language:legacy
 arguments[mapping][eZ\Publish\Core\SignalSlot\Signal\LanguageService\UpdateLanguageNameSignal][]=update_language_name:legacy
+arguments[mapping][eZ\Publish\Core\SignalSlot\Signal\UserService\UpdateUserSignal][]=update_user:legacy
 
 
 [slot_factory]
@@ -158,6 +159,9 @@ class=eZ\Publish\Core\SignalSlot\Slot\LegacyEnableLanguageSlot
 
 [update_language_name:legacy:slot]
 class=eZ\Publish\Core\SignalSlot\Slot\LegacyUpdateLanguageNameSlot
+
+[update_user:legacy:slot]
+class=eZ\Publish\Core\SignalSlot\Slot\LegacyUpdateUserSlot
 
 #### Core\Persistence Services ####
 


### PR DESCRIPTION
This PR resolves issue https://jira.ez.no/browse/EZP-21575

Legacy cache clearing slot for `UserService/UpdateUserSignal` is implemented.

Tested manually.
