### PR TITLE
Fix EZP-21631: RoutableFragmentRenderer::generateFragmentUri() not compa...

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/EsiFragmentRenderer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/EsiFragmentRenderer.php
@@ -20,14 +20,14 @@ class EsiFragmentRenderer extends BaseRenderer
      */
     private $fragmentUriGenerator;
 
-    protected function generateFragmentUri( ControllerReference $reference, Request $request )
+    protected function generateFragmentUri( ControllerReference $reference, Request $request, $absolute = false )
     {
         if ( !isset( $this->fragmentUriGenerator ) )
         {
             $this->fragmentUriGenerator = new FragmentUriGenerator;
         }
 
-        $this->fragmentUriGenerator->generateFragmentUri( $reference, $request );
+        $this->fragmentUriGenerator->generateFragmentUri( $reference, $request, $absolute );
         return parent::generateFragmentUri( $reference, $request );
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/HincludeFragmentRenderer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/HincludeFragmentRenderer.php
@@ -20,14 +20,14 @@ class HincludeFragmentRenderer extends ContainerAwareHIncludeFragmentRenderer
      */
     private $fragmentUriGenerator;
 
-    protected function generateFragmentUri( ControllerReference $reference, Request $request )
+    protected function generateFragmentUri( ControllerReference $reference, Request $request, $absolute = false )
     {
         if ( !isset( $this->fragmentUriGenerator ) )
         {
             $this->fragmentUriGenerator = new FragmentUriGenerator;
         }
 
-        $this->fragmentUriGenerator->generateFragmentUri( $reference, $request );
+        $this->fragmentUriGenerator->generateFragmentUri( $reference, $request, $absolute );
         return parent::generateFragmentUri( $reference, $request );
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/InlineFragmentRenderer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/InlineFragmentRenderer.php
@@ -20,14 +20,14 @@ class InlineFragmentRenderer extends BaseRenderer
      */
     private $fragmentUriGenerator;
 
-    protected function generateFragmentUri( ControllerReference $reference, Request $request )
+    protected function generateFragmentUri( ControllerReference $reference, Request $request, $absolute = false )
     {
         if ( !isset( $this->fragmentUriGenerator ) )
         {
             $this->fragmentUriGenerator = new FragmentUriGenerator;
         }
 
-        $this->fragmentUriGenerator->generateFragmentUri( $reference, $request );
+        $this->fragmentUriGenerator->generateFragmentUri( $reference, $request, $absolute );
         return parent::generateFragmentUri( $reference, $request );
     }
 }


### PR DESCRIPTION
...tible with Symfony 2.3.5

https://jira.ez.no/browse/EZP-21631

Related to https://github.com/symfony/symfony/commit/91234cd89aed6c5e5d6ec5947d2099ed787b6392 and https://github.com/symfony/symfony/issues/8458 .
