### PR TITLE
EZP-21625: loadRelations() does not check if given VersionInfo is about currently published version

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
@@ -1162,6 +1162,34 @@ class ContentServiceAuthorizationTest extends BaseContentServiceTest
     }
 
     /**
+     * Test for the loadRelations() method.
+     *
+     * @return void
+     * @see \eZ\Publish\API\Repository\ContentService::loadRelations()
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testLoadRelations
+     */
+    public function testLoadRelationsForDraftVersionThrowsUnauthorizedException()
+    {
+        $repository = $this->getRepository();
+
+        $contentService = $repository->getContentService();
+
+        /* BEGIN: Use Case */
+        $draft = $this->createContentDraftVersion1();
+
+        // Load the user service
+        $userService = $repository->getUserService();
+
+        // Set anonymous user
+        $repository->setCurrentUser( $userService->loadAnonymousUser() );
+
+        // This call will fail with a "UnauthorizedException"
+        $contentService->loadRelations( $draft->versionInfo );
+        /* END: Use Case */
+    }
+
+    /**
      * Test for the loadReverseRelations() method.
      *
      * @return void

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1704,8 +1704,19 @@ class ContentService implements ContentServiceInterface
      */
     public function loadRelations( APIVersionInfo $versionInfo )
     {
-        if ( !$this->repository->canUser( 'content', 'versionread', $versionInfo ) )
-            throw new UnauthorizedException( 'content', 'versionread' );
+        if ( $versionInfo->status === APIVersionInfo::STATUS_PUBLISHED )
+        {
+            $function = "read";
+        }
+        else
+        {
+            $function = "versionread";
+        }
+
+        if ( !$this->repository->canUser( 'content', $function, $versionInfo ) )
+        {
+            throw new UnauthorizedException( 'content', $function );
+        }
 
         $contentInfo = $versionInfo->getContentInfo();
         $spiRelations = $this->persistenceHandler->contentHandler()->loadRelations(


### PR DESCRIPTION
This PR fixes issue https://jira.ez.no/browse/EZP-21625

Added check for published version with integration test.
REST tested manually.
