### PR TITLE
Fix EZP-21344: error in create view REST spec example

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -2060,7 +2060,7 @@ Create View
 XML Example
 '''''''''''
 
-Perform a query on articles with a specific title.
+Perform a query on images withing the media section, sorted by name, limiting results to 10.
 
 .. code:: http
 


### PR DESCRIPTION
The example for `POST /content/views` is wrong, the XML doesn't even validate.

This changes it to to an actually working example.
