### PR TITLE
Fix EZP-21668: content.tree_root.location_id default value should not be null

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -26,7 +26,7 @@ parameters:
     ezsettings.default.content.view_cache: true         # Whether to use content view cache or not (Etag/Last-Modified based)
     ezsettings.default.content.ttl_cache: true          # Whether to use TTL Cache for content (i.e. Max-Age response header)
     ezsettings.default.content.default_ttl: 60          # Default TTL cache value for content
-    ezsettings.default.content.tree_root.location_id: ~ # Root locationId for routing and link generation. Useful for multisite apps with one repository.
+    ezsettings.default.content.tree_root.location_id: 2 # Root locationId for routing and link generation. Useful for multisite apps with one repository.
     ezsettings.default.content.tree_root.excluded_uri_prefixes: [] # URI prefixes that are allowed to be outside the content tree
 
     # FieldType settings

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/URI.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/URI.php
@@ -55,6 +55,9 @@ class URI extends Map implements Matcher, URILexer
      */
     public function analyseLink( $linkUri )
     {
+        // Joining slash between uriElements and actual linkUri must be present, except if $linkUri is empty.
+        $joiningSlash = empty( $linkUri ) ? '' : '/';
+        $linkUri = ltrim( $linkUri, '/' );
         // Removing query string to analyse as SiteAccess might be in it.
         $qsPos = strpos( $linkUri, '?' );
         $queryString = '';
@@ -66,7 +69,7 @@ class URI extends Map implements Matcher, URILexer
 
         if ( strpos( $linkUri, $this->key ) === false )
         {
-            $linkUri = '/' . $this->key . $linkUri;
+            $linkUri = "/{$this->key}{$joiningSlash}{$linkUri}";
         }
 
         return $linkUri . $queryString;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIElement.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIElement.php
@@ -129,7 +129,10 @@ class URIElement implements Matcher, URILexer
      */
     public function analyseLink( $linkUri )
     {
+        // Joining slash between uriElements and actual linkUri must be present, except if $linkUri is empty.
+        $joiningSlash = empty( $linkUri ) ? '' : '/';
+        $linkUri = ltrim( $linkUri, '/' );
         $uriElements = implode( '/', $this->getURIElements() );
-        return "/{$uriElements}{$linkUri}";
+        return "/{$uriElements}{$joiningSlash}{$linkUri}";
     }
 }


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-21668
