### PR TITLE
Fix EZP-21696: new SubtreeLimitation fails w/ InvalidArgumentException

### DIFF
--- a/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
@@ -77,7 +77,7 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
         {
             try
             {
-                $pathArray = explode( '/', trim( '/', $path ) );
+                $pathArray = explode( '/', trim( $path, '/' ) );
                 $subtreeRootLocationId = end( $pathArray );
                 $this->persistence->locationHandler()->load( $subtreeRootLocationId );
             }

--- a/eZ/Publish/Core/Limitation/Tests/SubtreeLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/SubtreeLimitationTypeTest.php
@@ -147,7 +147,7 @@ class SubtreeLimitationTypeTest extends Base
 
             foreach ( $limitation->limitationValues as $key => $value )
             {
-                $pathArray = explode( '/', trim( '/', $value ) );
+                $pathArray = explode( '/', trim( $value, '/' ) );
                 $this->locationHandlerMock
                     ->expects( $this->at( $key ) )
                     ->method( "load" )
@@ -192,7 +192,7 @@ class SubtreeLimitationTypeTest extends Base
 
             foreach ( $limitation->limitationValues as $key => $value )
             {
-                $pathArray = explode( '/', trim( '/', $value ) );
+                $pathArray = explode( '/', trim( $value, '/' ) );
                 $this->locationHandlerMock
                     ->expects( $this->at( $key ) )
                     ->method( "load" )


### PR DESCRIPTION
trim's first argument should be the string to trim
