### PR TITLE
Fix EZP-21701: ez_render_field should be able to use current template as parameter

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/functions/ez_render_field.test
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/functions/ez_render_field.test
@@ -1,6 +1,8 @@
 --TEST--
 "ez_render_field" function
 --TEMPLATE--
+{% extends 'templates/base.html.twig' %}
+{% block content %}
 {{ ez_render_field( nooverride, 'testfield' ) }}
 {{ ez_render_field( overrides, 'testfield' ) }}
 {{ ez_render_field( notdefault, 'testfield' ) }}
@@ -9,6 +11,8 @@
 {{ ez_render_field( data, 'testfield', {'parameters': { 'key1' : 1, 'key2': 2, 'key3': 3 }} ) }}
 {{ ez_render_field( data, 'testfield', {'parameters': [ 3, 2, 1]} ) }}
 {{ ez_render_field( data, 'testfield', {'parameters': [ 3, 2, 1], 'template': "templates/fields_localoverride.html.twig"} ) }}
+{{ ez_render_field( data, 'testfield', {'parameters': [ 3, 2, 1], 'template': _self} ) }}{% endblock %}
+{% block ezdata_field %}SELF OVERRIDE field id: 5 contentInfo id: 42 versionInfo versionNo: 64 attr class: ezdata-field parameters:3, 2, 1{% endblock %}
 --DATA--
 return array(
     'nooverride' => $this->getContent(
@@ -66,3 +70,4 @@ field id: 5 contentInfo id: 42 versionInfo versionNo: 64 attr class: added ezdat
 field id: 5 contentInfo id: 42 versionInfo versionNo: 64 attr class: ezdata-field parameters:1, 2, 3
 field id: 5 contentInfo id: 42 versionInfo versionNo: 64 attr class: ezdata-field parameters:3, 2, 1
 LOCAL OVERRIDE field id: 5 contentInfo id: 42 versionInfo versionNo: 64 attr class: ezdata-field parameters:3, 2, 1
+SELF OVERRIDE field id: 5 contentInfo id: 42 versionInfo versionNo: 64 attr class: ezdata-field parameters:3, 2, 1

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/templates/base.html.twig
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/templates/base.html.twig
@@ -1,0 +1,1 @@
+{% block content %}{% endblock %}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
@@ -408,7 +408,7 @@ class ContentExtension extends Twig_Extension
      *
      * @param Content $content
      * @param Field $field
-     * @param null|string $localTemplate a file where to look for the block first
+     * @param null|string|\Twig_Template $localTemplate a file where to look for the block first
      *
      * @throws \LogicException If no template block can be found for $field
      *
@@ -419,8 +419,13 @@ class ContentExtension extends Twig_Extension
         $fieldBlockName = $this->getRenderFieldBlockName( $content, $field );
         if ( $localTemplate !== null )
         {
-            $tpl = $this->environment->loadTemplate( $localTemplate );
-            $block = $this->searchBlock( $fieldBlockName, $tpl );
+            // $localTemplate might be a Twig_Template instance already (e.g. using _self Twig keyword)
+            if ( !$localTemplate instanceof Twig_Template )
+            {
+                $localTemplate = $this->environment->loadTemplate( $localTemplate );
+            }
+
+            $block = $this->searchBlock( $fieldBlockName, $localTemplate );
             if ( $block !== null )
             {
                 return array( $fieldBlockName => $block );


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-21701
## Description

Using `ez_render_field()` it is possible to specify the template that will be used using the optional parameters: 

``` jinja
{{ ez_render_field( 
       content, 
       'my_field_identifier',
       { 'template': 'AcmeTestBundle:fields:my_field_template.html.twig' }
   ) }}
```

This PR allows to specify the current template as being the source of the block.
This is useful when you want to sporadically override a field template.

``` jinja
{% extends "MyBundle::pagelayout.html.twig" %}

{% block content %}
    {# Note that "tags" is a field using ezkeyword fieldType #}
    <div class="tags">{{ ez_render_field( content, "tags" , { "template": _self } ) }}</div>
{% endblock %}

{# Here begins the inline block for my ezkeyword field #}
{% block ezkeyword_field %}
    {% spaceless %}
        {% if field.value.values|length() > 0 %}
        <ul>
            {% for keyword in field.value.values %}
            <li>{{ keyword }}</li>
            {% endfor %}

        </ul>
        {% endif %}
    {% endspaceless %}
{% endblock %}
```
## Tests

Functional test enhanced.
## Limitation

Like for [Symfony forms](http://symfony.com/doc/current/book/forms.html#global-form-theming), this will only work in templates extending another one.
