### PR TITLE
Fix EZP-21548: Clear role assignments cache when dealing with locations

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
@@ -138,6 +138,7 @@ class LocationHandler extends AbstractHandler implements LocationHandlerInterfac
         $return = $this->persistenceFactory->getLocationHandler()->move( $sourceId, $destinationParentId );
 
         $this->cache->clear( 'location' );//TIMBER! (path[Identification]String)
+        $this->cache->clear( 'user', 'role', 'assignments', 'byGroup' );
 
         return $return;
     }
@@ -189,6 +190,7 @@ class LocationHandler extends AbstractHandler implements LocationHandlerInterfac
         $this->cache->clear( 'location', $locationId2 );
         $this->cache->clear( 'location', 'subtree' );
         $this->cache->clear( 'content', 'locations' );
+        $this->cache->clear( 'user', 'role', 'assignments', 'byGroup' );
 
         return $return;
     }
@@ -215,6 +217,8 @@ class LocationHandler extends AbstractHandler implements LocationHandlerInterfac
         $this->cache->getItem( 'location', $location->id )->set( $location );
         $this->cache->clear( 'location', 'subtree' );
         $this->cache->clear( 'content', 'locations', $location->contentId );
+        $this->cache->clear( 'user', 'role', 'assignments', 'byGroup', $location->contentId );
+        $this->cache->clear( 'user', 'role', 'assignments', 'byGroup', 'inherited/' . $location->contentId );
 
         return $location;
     }
@@ -229,6 +233,7 @@ class LocationHandler extends AbstractHandler implements LocationHandlerInterfac
 
         $this->cache->clear( 'location' );//TIMBER!
         $this->cache->clear( 'content' );//TIMBER!
+        $this->cache->clear( 'user', 'role', 'assignments', 'byGroup' );
 
         return $return;
     }

--- a/eZ/Publish/Core/Persistence/Cache/Tests/LocationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/LocationHandlerTest.php
@@ -462,9 +462,15 @@ class LocationHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects( $this->once() )->method( 'logCall' );
         $this->cacheMock
-            ->expects( $this->once() )
+            ->expects( $this->at( 0 ) )
             ->method( 'clear' )
             ->with( 'location' )
+            ->will( $this->returnValue( true ) );
+
+        $this->cacheMock
+            ->expects( $this->at( 1 ) )
+            ->method( 'clear' )
+            ->with( 'user', 'role', 'assignments', 'byGroup' )
             ->will( $this->returnValue( true ) );
 
         $innerHandlerMock = $this->getMock( 'eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler' );
@@ -594,6 +600,12 @@ class LocationHandlerTest extends HandlerTest
             ->with( 'content', 'locations' )
             ->will( $this->returnValue( true ) );
 
+        $this->cacheMock
+            ->expects( $this->at( 4 ) )
+            ->method( 'clear' )
+            ->with( 'user', 'role', 'assignments', 'byGroup' )
+            ->will( $this->returnValue( true ) );
+
         $innerHandlerMock = $this->getMock( 'eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler' );
         $this->persistenceFactoryMock
             ->expects( $this->once() )
@@ -693,6 +705,18 @@ class LocationHandlerTest extends HandlerTest
             ->with( 'content', 'locations', 2 )
             ->will( $this->returnValue( true ) );
 
+        $this->cacheMock
+            ->expects( $this->at( 3 ) )
+            ->method( 'clear' )
+            ->with( 'user', 'role', 'assignments', 'byGroup', 2 )
+            ->will( $this->returnValue( true ) );
+
+        $this->cacheMock
+            ->expects( $this->at( 4 ) )
+            ->method( 'clear' )
+            ->with( 'user', 'role', 'assignments', 'byGroup', 'inherited/' . 2 )
+            ->will( $this->returnValue( true ) );
+
         $handler = $this->persistenceHandler->locationHandler();
         $handler->create( new CreateStruct );
     }
@@ -713,6 +737,12 @@ class LocationHandlerTest extends HandlerTest
             ->expects( $this->at( 1 ) )
             ->method( 'clear' )
             ->with( 'content' )
+            ->will( $this->returnValue( true ) );
+
+        $this->cacheMock
+            ->expects( $this->at( 2 ) )
+            ->method( 'clear' )
+            ->with( 'user', 'role', 'assignments', 'byGroup' )
             ->will( $this->returnValue( true ) );
 
         $innerHandlerMock = $this->getMock( 'eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler' );


### PR DESCRIPTION
As UserService relies on LocationService to assign/unassign groups to users,
we must find a way to invalidate role assignments cache when creating, deleting
and moving locations.

This is a rebased version of: #534
Issue: https://jira.ez.no/browse/EZP-21548
