### PR TITLE
Fix EZP-21636: Hinclude sub-requests are broken since EZP-21631 fix

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/EsiFragmentRenderer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/EsiFragmentRenderer.php
@@ -28,6 +28,6 @@ class EsiFragmentRenderer extends BaseRenderer
         }
 
         $this->fragmentUriGenerator->generateFragmentUri( $reference, $request, $absolute );
-        return parent::generateFragmentUri( $reference, $request );
+        return parent::generateFragmentUri( $reference, $request, $absolute );
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/HincludeFragmentRenderer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/HincludeFragmentRenderer.php
@@ -28,6 +28,6 @@ class HincludeFragmentRenderer extends ContainerAwareHIncludeFragmentRenderer
         }
 
         $this->fragmentUriGenerator->generateFragmentUri( $reference, $request, $absolute );
-        return parent::generateFragmentUri( $reference, $request );
+        return parent::generateFragmentUri( $reference, $request, $absolute );
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/InlineFragmentRenderer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/InlineFragmentRenderer.php
@@ -28,6 +28,6 @@ class InlineFragmentRenderer extends BaseRenderer
         }
 
         $this->fragmentUriGenerator->generateFragmentUri( $reference, $request, $absolute );
-        return parent::generateFragmentUri( $reference, $request );
+        return parent::generateFragmentUri( $reference, $request, $absolute );
     }
 }


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-21636

Fixes a regression from d6e3f67

Since Symfony 2.3.5, `$absolute` has been added to `generateFragmentUri()` (see [EZP-21631](https://jira.ez.no/browse/EZP-21631) and https://github.com/symfony/symfony/issues/8458). When I fixed EZP-21631, I just forgot to pass this new argument to the parent method.

`$absolute` is a boolean indicating if we want to generate an ablsoute fragment link.
