### PR TITLE
Fix EZP-21705: Wrong links generated when using Map\Host siteaccess matching

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -109,7 +109,8 @@ class UrlAliasGenerator extends Generator implements SiteAccessAware
             if ( $this->rootLocationId !== null )
             {
                 $pathPrefix = $this->getPathPrefixByRootLocationId( $this->rootLocationId );
-                if ( mb_stripos( $path, $pathPrefix ) === 0 )
+                // "/" cannot be considered as a path prefix since it's root, so we ignore it.
+                if ( $pathPrefix !== '/' && mb_stripos( $path, $pathPrefix ) === 0 )
                 {
                     $path = mb_substr( $path, mb_strlen( $pathPrefix ) );
                 }

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
@@ -236,8 +236,9 @@ class UrlAliasGeneratorTest extends PHPUnit_Framework_TestCase
      * @param URLAlias $urlAlias
      * @param $isOutsideAndNotExcluded
      * @param $expected
+     * @param $pathPrefix
      */
-    public function testDoGenerateRootLocation( URLAlias $urlAlias, $isOutsideAndNotExcluded, $expected )
+    public function testDoGenerateRootLocation( URLAlias $urlAlias, $isOutsideAndNotExcluded, $expected, $pathPrefix )
     {
         $excludedPrefixes = array( '/products', '/shared' );
         $rootLocationId = 456;
@@ -246,7 +247,6 @@ class UrlAliasGeneratorTest extends PHPUnit_Framework_TestCase
         $location = new Location( array( 'id' => 123 ) );
 
         $rootLocation = new Location( array( 'id' => $rootLocationId ) );
-        $pathPrefix = '/my/root-folder';
         $rootUrlAlias = new URLAlias( array( 'path' => $pathPrefix ) );
         $this->locationService
             ->expects( $this->once() )
@@ -281,32 +281,56 @@ class UrlAliasGeneratorTest extends PHPUnit_Framework_TestCase
             array(
                 new UrlAlias( array( 'path' => '/my/root-folder/foo/bar' ) ),
                 false,
-                '/foo/bar'
+                '/foo/bar',
+                '/my/root-folder'
             ),
             array(
                 new UrlAlias( array( 'path' => '/my/root-folder/something' ) ),
                 false,
-                '/something'
+                '/something',
+                '/my/root-folder'
             ),
             array(
                 new UrlAlias( array( 'path' => '/my/root-folder' ) ),
                 false,
+                '/',
+                '/my/root-folder'
+            ),
+            array(
+                new UrlAlias( array( 'path' => '/foo/bar' ) ),
+                false,
+                '/foo/bar',
+                '/'
+            ),
+            array(
+                new UrlAlias( array( 'path' => '/something' ) ),
+                false,
+                '/something',
+                '/'
+            ),
+            array(
+                new UrlAlias( array( 'path' => '/' ) ),
+                false,
+                '/',
                 '/'
             ),
             array(
                 new UrlAlias( array( 'path' => '/outside/tree/foo/bar' ) ),
                 true,
-                '/outside/tree/foo/bar'
+                '/outside/tree/foo/bar',
+                '/my/root-folder'
             ),
             array(
                 new UrlAlias( array( 'path' => '/products/ez-publish' ) ),
                 false,
-                '/products/ez-publish'
+                '/products/ez-publish',
+                '/my/root-folder'
             ),
             array(
                 new UrlAlias( array( 'path' => '/shared/some-content' ) ),
                 false,
-                '/shared/some-content'
+                '/shared/some-content',
+                '/my/root-folder'
             ),
         );
     }


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-21705

Regression from [EZP-21668](https://jira.ez.no/browse/EZP-21668)
