### PR TITLE
Fix EZP-21695: Cached ESI can not be shared among pages

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/FragmentUriGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/FragmentUriGenerator.php
@@ -29,11 +29,5 @@ class FragmentUriGenerator
         // @see eZ\Publish\Core\MVC\Symfony\EventListener\SiteAccessMatchListener
         if ( $request->attributes->has( 'siteaccess' ) )
             $reference->attributes['serialized_siteaccess'] = serialize( $request->attributes->get( 'siteaccess' ) );
-
-        if ( $request->attributes->has( 'semanticPathinfo' ) )
-            $reference->attributes['semanticPathinfo'] = $request->attributes->get( 'semanticPathinfo' );
-
-        if ( $request->attributes->has( 'viewParametersString' ) )
-            $reference->attributes['viewParametersString'] = $request->attributes->get( 'viewParametersString' );
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/InlineFragmentRenderer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/InlineFragmentRenderer.php
@@ -27,7 +27,13 @@ class InlineFragmentRenderer extends BaseRenderer
             $this->fragmentUriGenerator = new FragmentUriGenerator;
         }
 
+        // Generate base fragment URI and add other needed attributes
         $this->fragmentUriGenerator->generateFragmentUri( $reference, $request, $absolute );
+        if ( $request->attributes->has( 'semanticPathinfo' ) )
+            $reference->attributes['semanticPathinfo'] = $request->attributes->get( 'semanticPathinfo' );
+        if ( $request->attributes->has( 'viewParametersString' ) )
+            $reference->attributes['viewParametersString'] = $request->attributes->get( 'viewParametersString' );
+
         return parent::generateFragmentUri( $reference, $request, $absolute );
     }
 }


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-21695

`semanticPathinfo` and `viewParametersString` should not be part of an ESI or Hinclude sub-request (but still makes sense for Inline) as it prevents caching...
