### PR TITLE
Fix EZP-21722: Error with the ez_render_field if a custom tag xsl stylesheet is not properly loaded

### DIFF
--- a/eZ/Publish/Core/FieldType/XmlText/Converter/Html5.php
+++ b/eZ/Publish/Core/FieldType/XmlText/Converter/Html5.php
@@ -13,6 +13,7 @@ use eZ\Publish\Core\FieldType\XmlText\Converter;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use DOMDocument;
 use XSLTProcessor;
+use RuntimeException;
 
 /**
  * Converts internal XmlText representation to HTML5


### PR DESCRIPTION
If a nonexistent file is listed in the ezpublish.yml, the ez_render_field will fail its render. This little checking could let the ez_render_field doing its job.
