### PR TITLE
Rename RelationList criterion to FieldRelation

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage_engines/legacy/search_query_handlers.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage_engines/legacy/search_query_handlers.yml
@@ -16,7 +16,7 @@ parameters:
     ezpublish.persistence.legacy.search.gateway.criterion_handler.common.map_location_distance.class: eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\MapLocationDistance
     ezpublish.persistence.legacy.search.gateway.criterion_handler.common.match_all.class: eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\MatchAll
     ezpublish.persistence.legacy.search.gateway.criterion_handler.common.object_state_id.class: eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\ObjectStateId
-    ezpublish.persistence.legacy.search.gateway.criterion_handler.common.relation_list.class: eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\RelationList
+    ezpublish.persistence.legacy.search.gateway.criterion_handler.common.field_relation.class: eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\FieldRelation
     ezpublish.persistence.legacy.search.gateway.criterion_handler.common.remote_id.class: eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\RemoteId
     ezpublish.persistence.legacy.search.gateway.criterion_handler.common.section_id.class: eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\SectionId
     ezpublish.persistence.legacy.search.gateway.criterion_handler.common.user_metadata.class: eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\UserMetadata
@@ -215,9 +215,9 @@ services:
         tags:
             - {name: ezpublish.persistence.legacy.search.gateway.criterion_handler.common}
 
-    ezpublish.persistence.legacy.search.gateway.criterion_handler.common.relation_list:
+    ezpublish.persistence.legacy.search.gateway.criterion_handler.common.field_relation:
         parent: ezpublish.persistence.legacy.search.gateway.criterion_handler.base
-        class: %ezpublish.persistence.legacy.search.gateway.criterion_handler.common.relation_list.class%
+        class: %ezpublish.persistence.legacy.search.gateway.criterion_handler.common.field_relation.class%
         tags:
             - {name: ezpublish.persistence.legacy.search.gateway.criterion_handler.common}
 

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/FieldRelation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/FieldRelation.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\RelationList class.
+ * File containing the eZ\Publish\API\Repository\Values\Content\Query\Criterion\FieldRelation class.
  *
  * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
  * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
@@ -14,13 +14,16 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specificat
 use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 
 /**
- * A criterion that matches content based on the object relation field name
+ * A criterion that matches Content based on the relations in relation field.
+ * This includes Relation and RelationList field types in standard installation, but also any
+ * other field type storing {@link \eZ\Publish\API\Repository\Values\Content\Relation::FIELD}
+ * type relation.
  *
  * Supported operators:
- * - IN: will match from a list of Content id found in a RelationList
- * - CONTAINS: will match against one Content id or a list of Content id found in a RelationList
+ * - IN: will match if Content relates to one or more of the given ids through given relation field
+ * - CONTAINS: will match if Content relates to all of the given ids through given relation field
  */
-class RelationList extends Criterion implements CriterionInterface
+class FieldRelation extends Criterion implements CriterionInterface
 {
     public function getSpecifications()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Search/Common/Gateway/CriterionHandler/FieldRelation.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Search/Common/Gateway/CriterionHandler/FieldRelation.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the DoctrineDatabase RelationList criterion handler class
+ * File containing the DoctrineDatabase FieldRelation criterion handler class
  *
  * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
  * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
@@ -16,9 +16,9 @@ use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use RuntimeException;
 
 /**
- * RelationList criterion handler
+ * FieldRelation criterion handler
  */
-class RelationList extends CriterionHandler
+class FieldRelation extends CriterionHandler
 {
     /**
      * Check if this criterion handler accepts to handle the given criterion.
@@ -29,7 +29,7 @@ class RelationList extends CriterionHandler
      */
     public function accept( Criterion $criterion )
     {
-        return $criterion instanceof Criterion\RelationList;
+        return $criterion instanceof Criterion\FieldRelation;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationSearchHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationSearchHandlerTest.php
@@ -176,7 +176,7 @@ class LocationSearchHandlerTest extends LanguageAwareTestCase
                         new CommonCriterionHandler\MapLocationDistance( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\MatchAll( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\ObjectStateId( $this->getDatabaseHandler() ),
-                        new CommonCriterionHandler\RelationList( $this->getDatabaseHandler() ),
+                        new CommonCriterionHandler\FieldRelation( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\RemoteId( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\SectionId( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\UserMetadata( $this->getDatabaseHandler() ),
@@ -1183,14 +1183,14 @@ class LocationSearchHandlerTest extends LanguageAwareTestCase
         );
     }
 
-    public function testRelationListFilterContainsSingle()
+    public function testFieldRelationFilterContainsSingle()
     {
         $this->assertSearchResults(
             array( 69 ),
             $this->getLocationSearchHandler()->findLocations(
                 new LocationQuery(
                     array(
-                        'filter' => new Criterion\RelationList(
+                        'filter' => new Criterion\FieldRelation(
                             'billboard',
                             Criterion\Operator::CONTAINS,
                             array( 60 )
@@ -1201,14 +1201,14 @@ class LocationSearchHandlerTest extends LanguageAwareTestCase
         );
     }
 
-    public function testRelationListFilterContainsSingleNoMatch()
+    public function testFieldRelationFilterContainsSingleNoMatch()
     {
         $this->assertSearchResults(
             array(),
             $this->getLocationSearchHandler()->findLocations(
                 new LocationQuery(
                     array(
-                        'filter' => new Criterion\RelationList(
+                        'filter' => new Criterion\FieldRelation(
                             'billboard',
                             Criterion\Operator::CONTAINS,
                             array( 4 )
@@ -1219,14 +1219,14 @@ class LocationSearchHandlerTest extends LanguageAwareTestCase
         );
     }
 
-    public function testRelationListFilterContainsArray()
+    public function testFieldRelationFilterContainsArray()
     {
         $this->assertSearchResults(
             array( 69 ),
             $this->getLocationSearchHandler()->findLocations(
                 new LocationQuery(
                     array(
-                        'filter' => new Criterion\RelationList(
+                        'filter' => new Criterion\FieldRelation(
                             'billboard',
                             Criterion\Operator::CONTAINS,
                             array( 60, 75 )
@@ -1237,14 +1237,14 @@ class LocationSearchHandlerTest extends LanguageAwareTestCase
         );
     }
 
-    public function testRelationListFilterContainsArrayNotMatch()
+    public function testFieldRelationFilterContainsArrayNotMatch()
     {
         $this->assertSearchResults(
             array(),
             $this->getLocationSearchHandler()->findLocations(
                 new LocationQuery(
                     array(
-                        'filter' => new Criterion\RelationList(
+                        'filter' => new Criterion\FieldRelation(
                             'billboard',
                             Criterion\Operator::CONTAINS,
                             array( 60, 64 )
@@ -1255,14 +1255,14 @@ class LocationSearchHandlerTest extends LanguageAwareTestCase
         );
     }
 
-    public function testRelationListFilterInArray()
+    public function testFieldRelationFilterInArray()
     {
         $this->assertSearchResults(
             array( 69, 77 ),
             $this->getLocationSearchHandler()->findLocations(
                 new LocationQuery(
                     array(
-                        'filter' => new Criterion\RelationList(
+                        'filter' => new Criterion\FieldRelation(
                             'billboard',
                             Criterion\Operator::IN,
                             array( 60, 64 )
@@ -1273,14 +1273,14 @@ class LocationSearchHandlerTest extends LanguageAwareTestCase
         );
     }
 
-    public function testRelationListFilterInArrayNotMatch()
+    public function testFieldRelationFilterInArrayNotMatch()
     {
         $this->assertSearchResults(
             array(),
             $this->getLocationSearchHandler()->findLocations(
                 new LocationQuery(
                     array(
-                        'filter' => new Criterion\RelationList(
+                        'filter' => new Criterion\FieldRelation(
                             'billboard',
                             Criterion\Operator::IN,
                             array( 4, 10 )

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/SearchHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/SearchHandlerTest.php
@@ -218,7 +218,7 @@ class SearchHandlerTest extends LanguageAwareTestCase
                         new Content\Search\Common\Gateway\CriterionHandler\UserMetadata(
                             $this->getDatabaseHandler()
                         ),
-                        new Content\Search\Common\Gateway\CriterionHandler\RelationList(
+                        new Content\Search\Common\Gateway\CriterionHandler\FieldRelation(
                             $this->getDatabaseHandler()
                         ),
                         new Content\Search\Gateway\CriterionHandler\Depth(
@@ -1542,14 +1542,14 @@ class SearchHandlerTest extends LanguageAwareTestCase
         );
     }
 
-    public function testRelationListFilterContainsSingle()
+    public function testFieldRelationFilterContainsSingle()
     {
         $this->assertSearchResults(
             array( 67 ),
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\RelationList(
+                        'criterion' => new Criterion\FieldRelation(
                             'billboard',
                             Criterion\Operator::CONTAINS,
                             array( 60 )
@@ -1560,14 +1560,14 @@ class SearchHandlerTest extends LanguageAwareTestCase
         );
     }
 
-    public function testRelationListFilterContainsSingleNoMatch()
+    public function testFieldRelationFilterContainsSingleNoMatch()
     {
         $this->assertSearchResults(
             array(),
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\RelationList(
+                        'criterion' => new Criterion\FieldRelation(
                             'billboard',
                             Criterion\Operator::CONTAINS,
                             array( 4 )
@@ -1578,14 +1578,14 @@ class SearchHandlerTest extends LanguageAwareTestCase
         );
     }
 
-    public function testRelationListFilterContainsArray()
+    public function testFieldRelationFilterContainsArray()
     {
         $this->assertSearchResults(
             array( 67 ),
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\RelationList(
+                        'criterion' => new Criterion\FieldRelation(
                             'billboard',
                             Criterion\Operator::CONTAINS,
                             array( 60, 75 )
@@ -1596,14 +1596,14 @@ class SearchHandlerTest extends LanguageAwareTestCase
         );
     }
 
-    public function testRelationListFilterContainsArrayNotMatch()
+    public function testFieldRelationFilterContainsArrayNotMatch()
     {
         $this->assertSearchResults(
             array(),
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\RelationList(
+                        'criterion' => new Criterion\FieldRelation(
                             'billboard',
                             Criterion\Operator::CONTAINS,
                             array( 60, 64 )
@@ -1614,14 +1614,14 @@ class SearchHandlerTest extends LanguageAwareTestCase
         );
     }
 
-    public function testRelationListFilterInArray()
+    public function testFieldRelationFilterInArray()
     {
         $this->assertSearchResults(
             array( 67, 75 ),
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\RelationList(
+                        'criterion' => new Criterion\FieldRelation(
                             'billboard',
                             Criterion\Operator::IN,
                             array( 60, 64 )
@@ -1632,14 +1632,14 @@ class SearchHandlerTest extends LanguageAwareTestCase
         );
     }
 
-    public function testRelationListFilterInArrayNotMatch()
+    public function testFieldRelationFilterInArrayNotMatch()
     {
         $this->assertSearchResults(
             array(),
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\RelationList(
+                        'criterion' => new Criterion\FieldRelation(
                             'billboard',
                             Criterion\Operator::IN,
                             array( 4, 10 )

--- a/eZ/Publish/Core/settings/service.ini
+++ b/eZ/Publish/Core/settings/service.ini
@@ -922,8 +922,8 @@ class=eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\Criterion
 [ezcommon_object_state_id:legacy_search_common_criterion_handler]
 class=eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\ObjectStateId
 
-[ezcommon_relation_list:legacy_search_common_criterion_handler]
-class=eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\RelationList
+[ezcommon_field_relation:legacy_search_common_criterion_handler]
+class=eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\FieldRelation
 
 [ezcommon_remote_id:legacy_search_common_criterion_handler]
 class=eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\RemoteId
@@ -1080,7 +1080,7 @@ arguments[handlers][]=@ezcommon_logical_or:legacy_search_common_criterion_handle
 arguments[handlers][]=@ezcommon_map_location_distance:legacy_search_common_criterion_handler
 arguments[handlers][]=@ezcommon_match_all:legacy_search_common_criterion_handler
 arguments[handlers][]=@ezcommon_object_state_id:legacy_search_common_criterion_handler
-arguments[handlers][]=@ezcommon_relation_list:legacy_search_common_criterion_handler
+arguments[handlers][]=@ezcommon_field_relation:legacy_search_common_criterion_handler
 arguments[handlers][]=@ezcommon_remote_id:legacy_search_common_criterion_handler
 arguments[handlers][]=@ezcommon_section_id:legacy_search_common_criterion_handler
 arguments[handlers][]=@ezcommon_user_metadata:legacy_search_common_criterion_handler
@@ -1108,7 +1108,7 @@ arguments[handlers][]=@ezcommon_logical_or:legacy_search_common_criterion_handle
 arguments[handlers][]=@ezcommon_map_location_distance:legacy_search_common_criterion_handler
 arguments[handlers][]=@ezcommon_match_all:legacy_search_common_criterion_handler
 arguments[handlers][]=@ezcommon_object_state_id:legacy_search_common_criterion_handler
-arguments[handlers][]=@ezcommon_relation_list:legacy_search_common_criterion_handler
+arguments[handlers][]=@ezcommon_field_relation:legacy_search_common_criterion_handler
 arguments[handlers][]=@ezcommon_remote_id:legacy_search_common_criterion_handler
 arguments[handlers][]=@ezcommon_section_id:legacy_search_common_criterion_handler
 arguments[handlers][]=@ezcommon_user_metadata:legacy_search_common_criterion_handler


### PR DESCRIPTION
This PR relates to https://github.com/ezsystems/ezpublish-kernel/pull/547

As this criterion is capable of handling all field relations (all field types storing `eZ\Publish\API\Repository\Values\Content\Relation::FIELD` type relations - in standard installation these are Relation and RelationList field types at the moment), it is renamed to reflect this.

Later we might want to implement ContentRelation or general Relation criterion.

Additional: small improvement to FieldRelation handler class description.
