### PR TITLE
Fix EZP-21734: Cleanup tests failing because of fixed ordering

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/RelationListIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/RelationListIntegrationTest.php
@@ -205,7 +205,7 @@ class RelationListFieldTypeIntegrationTest extends RelationBaseIntegrationTest
         $expectedData = array(
             'destinationContentIds' => array( 4, 49 ),
         );
-        $this->assertPropertiesCorrect(
+        $this->assertPropertiesCorrectUnsorted(
             $expectedData,
             $field->value
         );
@@ -269,7 +269,7 @@ class RelationListFieldTypeIntegrationTest extends RelationBaseIntegrationTest
         $expectedData = array(
             'destinationContentIds' => array( 4, 54 ),
         );
-        $this->assertPropertiesCorrect(
+        $this->assertPropertiesCorrectUnsorted(
             $expectedData,
             $field->value
         );
@@ -319,8 +319,7 @@ class RelationListFieldTypeIntegrationTest extends RelationBaseIntegrationTest
         $expectedData = array(
             'destinationContentIds' => array( 4, 49 )
         );
-
-        $this->assertPropertiesCorrect(
+        $this->assertPropertiesCorrectUnsorted(
             $expectedData,
             $field->value
         );

--- a/eZ/Publish/API/Repository/Tests/RoleServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/RoleServiceTest.php
@@ -818,15 +818,18 @@ class RoleServiceTest extends BaseTest
             }
         }
 
-        $this->assertEquals(
-            array(
-                new ContentTypeLimitation(
-                    array(
-                        'limitationValues' => array( 29, 30 )
-                    )
-                )
-            ),
-            $limitations
+        $this->assertCount( 1, $limitations );
+        $this->assertInstanceOf(
+            "\\eZ\\Publish\\API\\Repository\\Values\\User\\Limitation",
+            $limitations[0]
+        );
+
+        $expectedData = array(
+            'limitationValues' => array( 29, 30 )
+        );
+        $this->assertPropertiesCorrectUnsorted(
+            $expectedData,
+            $limitations[0]
         );
     }
 

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -1200,7 +1200,21 @@ class UserServiceTest extends BaseTest
         $userReloaded = $userService->loadUserByLogin( 'user' );
         /* END: Use Case */
 
-        $this->assertEquals( $user, $userReloaded );
+        $this->assertPropertiesCorrect(
+            array(
+                "login" => $user->login,
+                "email" => $user->email,
+                "passwordHash" => $user->passwordHash,
+                "hashAlgorithm" => $user->hashAlgorithm,
+                "enabled" => $user->enabled,
+                "maxLogin" => $user->maxLogin,
+                "id" => $user->id,
+                "contentInfo" => $user->contentInfo,
+                "versionInfo" => $user->versionInfo,
+                "fields" => $user->fields
+            ),
+            $userReloaded
+        );
     }
 
     /**


### PR DESCRIPTION
This PR resolves issue: https://jira.ez.no/browse/EZP-21734

This should fix some random failures appearing in a last couple of weeks.
It is awkward to account for these and hopefully we won't have to do much more of it.
