### PR TITLE
Fix EZP-21747: Translated name should be accessible from a Page block

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
@@ -7,7 +7,7 @@ services:
     # Helpers
     ezpublish.translation_helper:
         class: %ezpublish.translation_helper.class%
-        arguments: [@ezpublish.config.resolver]
+        arguments: [@ezpublish.config.resolver, @ezpublish.api.service.content]
 
     ezpublish.field_helper:
         class: %ezpublish.field_helper.class%

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/ContentExtensionTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/ContentExtensionTest.php
@@ -34,7 +34,7 @@ class ContentExtensionIntegrationTest extends Twig_Test_IntegrationTestCase
             new ContentExtension(
                 $this->getContainerMock(),
                 $configResolver,
-                new TranslationHelper( $configResolver ),
+                new TranslationHelper( $configResolver, $this->getMock( 'eZ\\Publish\\API\\Repository\\ContentService' ) ),
                 $this->getMockBuilder( 'eZ\\Publish\\Core\\Helper\\FieldHelper' )->disableOriginalConstructor()->getMock()
             )
         );

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
@@ -9,6 +9,9 @@
 
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension;
 
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\Core\Helper\FieldHelper;
 use eZ\Publish\Core\Helper\TranslationHelper;
 use eZ\Publish\Core\Repository\Values\Content\Content;
@@ -537,14 +540,25 @@ class ContentExtension extends Twig_Extension
     }
 
     /**
-     * @param \eZ\Publish\Core\Repository\Values\Content\Content $content
+     * @param \eZ\Publish\API\Repository\Values\ValueObject $content Must be a valid Content or ContentInfo object.
      * @param string $forcedLanguage Locale we want the content name translation in (e.g. "fre-FR"). Null by default (takes current locale)
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType When $content is not a valid Content or ContentInfo object.
      *
      * @return string
      */
-    public function getTranslatedContentName( Content $content, $forcedLanguage = null )
+    public function getTranslatedContentName( ValueObject $content, $forcedLanguage = null )
     {
-        return $this->translationHelper->getTranslatedName( $content, $forcedLanguage );
+        if ( $content instanceof Content )
+        {
+            return $this->translationHelper->getTranslatedContentName( $content, $forcedLanguage );
+        }
+        else if ( $content instanceof ContentInfo )
+        {
+            return $this->translationHelper->getTranslatedContentNameByContentInfo( $content, $forcedLanguage );
+        }
+
+        throw new InvalidArgumentType( '$content', 'eZ\Publish\API\Repository\Values\Content\Content or eZ\Publish\API\Repository\Values\Content\ContentInfo', $content );
     }
 
     /**


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-21747

Follow up of [EZP-21531](https://jira.ez.no/browse/EZP-21531).
In many cases you can only have ContentInfo object exposed, so
`ez_content_name()` Twig function should accept Content or ContentInfo
objects to get name from.

Open question is: Should it be in 5.2 ? My POV is that yes :octocat: 
