### PR TITLE
Fix EZP-21747: Translated name should be accessible from a Page block

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/FieldType/Page/PageService.php
+++ b/eZ/Bundle/EzPublishCoreBundle/FieldType/Page/PageService.php
@@ -51,4 +51,23 @@ class PageService extends BasePageService implements RepositoryAwareInterface
 
         return $contentInfoObjects;
     }
+
+    /**
+     * Returns valid block items as content objects.
+     *
+     * @param \eZ\Publish\Core\FieldType\Page\Parts\Block $block
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content[]
+     */
+    public function getValidBlockItemsAsContent( Block $block )
+    {
+        $contentService = $this->repository->getContentService();
+        $contentObjects = array();
+        foreach ( $this->getValidBlockItems( $block ) as $item )
+        {
+            $contentObjects[] = $contentService->loadContent( $item->contentId );
+        }
+
+        return $contentObjects;
+    }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/FieldType/Page/PageServiceTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/FieldType/Page/PageServiceTest.php
@@ -74,4 +74,39 @@ class PageServiceTest extends BaseTest
 
         $this->assertSame( $expectedResult, $this->pageService->getValidBlockItemsAsContentInfo( $block ) );
     }
+
+    /**
+     * @covers \eZ\Bundle\EzPublishCoreBundle\FieldType\Page\PageService::getValidBlockItemsAsContent
+     */
+    public function testGetValidBlockItemsAsContent()
+    {
+        $this->pageService->setStorageGateway( $this->storageGateway );
+        $this->pageService->setRepository( $this->repository );
+        $block = $this->buildBlock();
+
+        $contentId1 = 1;
+        $contentId2 = 60;
+        $items = array(
+            new Item( array( 'contentId' => $contentId1 ) ),
+            new Item( array( 'contentId' => $contentId2 ) )
+        );
+
+        $content1 = $this->getMockForAbstractClass( 'eZ\Publish\API\Repository\Values\Content\Content' );
+        $content2 = $this->getMockForAbstractClass( 'eZ\Publish\API\Repository\Values\Content\Content' );
+        $expectedResult = array( $content1, $content2 );
+
+        $this->storageGateway
+            ->expects( $this->once() )
+            ->method( 'getValidBlockItems' )
+            ->with( $block )
+            ->will( $this->returnValue( $items ) );
+
+        $this->contentService
+            ->expects( $this->exactly( count( $items ) ) )
+            ->method( 'loadContent' )
+            ->with( $this->logicalOr( $contentId1, $contentId2 ) )
+            ->will( $this->onConsecutiveCalls( $content1, $content2 ) );
+
+        $this->assertSame( $expectedResult, $this->pageService->getValidBlockItemsAsContent( $block ) );
+    }
 }


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-21747

Alternative from #563 

With this alternative, one can get Content objects from block items and then correctly display their translated names.
