### PR TITLE
Fix EZP-21776: Simple FieldValue Criterion handler does not escape value when used with CONTAINS operator

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Search/Gateway/CriterionHandler/FieldValue/Handler/Simple.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Search/Gateway/CriterionHandler/FieldValue/Handler/Simple.php
@@ -37,7 +37,7 @@ class Simple extends Handler
             case Criterion\Operator::CONTAINS:
                 $filter = $query->expr->eq(
                     $this->dbHandler->quoteColumn( $column ),
-                    $this->lowerCase( $criterion->value )
+                    $query->bindValue( $this->lowerCase( $criterion->value ) )
                 );
                 break;
 


### PR DESCRIPTION
This PR resolves issue https://jira.ez.no/browse/EZP-21776

Simple bug where Criterion value was not escaped.

This is needed to unblock testing of another issue, also needs backporting to 5.2.
