### PR TITLE
Fix EZP-21786: Using Page fieldtype, valid block items should be passed to the block templates

### DIFF
--- a/doc/bc/changes-5.2.md
+++ b/doc/bc/changes-5.2.md
@@ -42,6 +42,10 @@ Changes affecting version compatibility with former or future versions.
   As explained in API, the 'path' property for those classes is deprecated,
   and 'id' should be used instead.
 
+* PageController::viewBlock()
+
+  `pageService` injection will be removed in v6.0. See https://jira.ez.no/browse/EZP-21786.
+
 ## Removals
 
 ### API

--- a/eZ/Bundle/EzPublishCoreBundle/Controller/PageController.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Controller/PageController.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * File containing the PageController class.
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Controller;
+
+use eZ\Bundle\EzPublishCoreBundle\FieldType\Page\PageService as CoreBundlePageService;
+use eZ\Publish\Core\FieldType\Page\Parts\Block;
+use eZ\Publish\Core\MVC\Symfony\Controller\PageController as BasePageController;
+use Symfony\Component\HttpFoundation\Response;
+
+class PageController extends BasePageController
+{
+    public function viewBlock( Block $block, array $params = array(), array $cacheSettings = array() )
+    {
+        // Inject valid items as ContentInfo objects if possible.
+        if ( $this->pageService instanceof CoreBundlePageService )
+        {
+            $params += array(
+                'valid_contentinfo_items' => $this->pageService->getValidBlockItemsAsContentInfo( $block )
+            );
+        }
+
+        return parent::viewBlock( $block, $params, $cacheSettings );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -6,7 +6,7 @@ parameters:
     ezpublish.config.default_scope: ezsettings
     ezpublish.controller.base.class: eZ\Publish\Core\MVC\Symfony\Controller\Controller
     ezpublish.controller.content.view.class: eZ\Publish\Core\MVC\Symfony\Controller\Content\ViewController
-    ezpublish.controller.page.view.class: eZ\Publish\Core\MVC\Symfony\Controller\PageController
+    ezpublish.controller.page.view.class: eZ\Bundle\EzPublishCoreBundle\Controller\PageController
     ezpublish.data_collector.spi.persistence.class: eZ\Bundle\EzPublishCoreBundle\Collector\SPIPersistenceDataCollector
     ezpublish.controller.user.authentication.class: eZ\Publish\Core\MVC\Symfony\Controller\User\AuthenticationController
 

--- a/eZ/Publish/Core/MVC/Symfony/Controller/PageController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/PageController.php
@@ -24,7 +24,7 @@ class PageController extends Controller
     /**
      * @var \eZ\Publish\Core\FieldType\Page\PageService
      */
-    private $pageService;
+    protected $pageService;
 
     public function __construct( ViewManager $viewManager, PageService $pageService )
     {
@@ -67,7 +67,11 @@ class PageController extends Controller
         $response->setContent(
             $this->viewManager->renderBlock(
                 $block,
-                $params + array( 'pageService' => $this->pageService )
+                $params + array(
+                    // @deprecated pageService injection will be removed in 6.0.
+                    'pageService' => $this->pageService,
+                    'valid_items' => $this->pageService->getValidBlockItems( $block )
+                )
             )
         );
         return $response;


### PR DESCRIPTION
See [EZP-21786](https://jira.ez.no/browse/EZP-21786).
This prevents fetch function revival when designing frontpages with Page fieldtype.

Note that PageService injection in template is kept for BC sake. To be removed in v6.
