### PR TITLE
EZP-21804 : always copy from right translation when creating new versions

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldHandler.php
@@ -186,14 +186,13 @@ class FieldHandler
                 if ( !$fieldDefinition->isTranslatable && $languageCode != $mainLanguageCode )
                 {
                     $createInNewLanguageCode = $languageCode;
-                    $field = $contentFieldMap[$fieldDefinition->id][$mainLanguageCode];
                 }
                 else
                 {
                     $createInNewLanguageCode = null;
-                    $field = $contentFieldMap[$fieldDefinition->id][$languageCode];
                 }
 
+                $field = $contentFieldMap[$fieldDefinition->id][$languageCode];
                 $content->fields[] = $this->createExistingFieldInNewVersion(
                     $field,
                     $content,


### PR DESCRIPTION
I'm not sure it's the right move here but it removes my duplicate key SQL error when creating a new draft from a content containing a non translatable attribute. 

It seems that a field is created for each translation, the actual value being copied from the main language at creation time. If I'm not wrong, that means we can safely copy from translation field when creating new version.
