### PR TITLE
Fix EZP-21780: Map\URI siteaccess matcher is greedy

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/URI.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/URI.php
@@ -43,7 +43,7 @@ class URI extends Map implements Matcher, URILexer
      */
     public function analyseURI( $uri )
     {
-        return str_replace( "/$this->key", '', $uri );
+        return substr( $uri, strlen( "/$this->key" ) );
     }
 
     /**
@@ -67,12 +67,7 @@ class URI extends Map implements Matcher, URILexer
             $linkUri = substr( $linkUri, 0, $qsPos );
         }
 
-        if ( strpos( $linkUri, $this->key ) === false )
-        {
-            $linkUri = "/{$this->key}{$joiningSlash}{$linkUri}";
-        }
-
-        return $linkUri . $queryString;
+        return "/{$this->key}{$joiningSlash}{$linkUri}{$queryString}";
     }
 
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterMapURITest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterMapURITest.php
@@ -51,6 +51,8 @@ class RouterMapURITest extends PHPUnit_Framework_TestCase
     {
         return array(
             array( '/my_siteaccess/foo/bar', '/foo/bar' ),
+            array( '/foo/foo/bar', '/foo/bar' ),
+            array( '/foo/foo/bar?something=foo&bar=toto', '/foo/bar?something=foo&bar=toto' ),
             array( '/vive/le/sucre', '/le/sucre' ),
             array( '/ezdemo_site/some/thing?foo=ezdemo_site&bar=toto', '/some/thing?foo=ezdemo_site&bar=toto' )
         );


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-21780

`Map\URI` is buggy when the siteaccess part appears in an URLAlias or link. 

Consider the following siteaccess match configuration:

``` yaml
        match:
            Map\URI:
                eng: eng
```

When having a content with `/eng-foo-bar` URLAlias, the Map\URI matcher, which implements `URILexer` interface will remove the `/eng` part in the content's URLAlias, resulting to `-foo-bar`, which leads to a 404.

This PR fixes it and enriches corresponding test.

This should go to 5.2 IMHO since it's a very annoying issue with no workaround.
