### PR TITLE
Fix EZP-21804: Duplicate key in ezcontentobject_attribute when creating new draft with untranslatable field

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseNonRedundantFieldSetTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseNonRedundantFieldSetTest.php
@@ -148,6 +148,24 @@ class BaseNonRedundantFieldSetTest extends BaseTest
         return $content;
     }
 
+    protected function createMultilingualTestContent()
+    {
+        $fieldValues = array(
+            "field1" => array( "eng-US" => "value 1" ),
+            "field2" => array( "eng-US" => "value 2" ),
+            "field3" => array(
+                "eng-US" => "value 3",
+                "eng-GB" => "value 3 eng-GB"
+            ),
+            "field4" => array(
+                "eng-US" => "value 4",
+                "eng-GB" => "value 4 eng-GB"
+            )
+        );
+
+        return $this->createTestContent( "eng-US", $fieldValues );
+    }
+
     protected function createTestContentForUpdate()
     {
         $fieldValues = array(
@@ -157,9 +175,7 @@ class BaseNonRedundantFieldSetTest extends BaseTest
             "field4" => array( "eng-US" => "value 4" )
         );
 
-        $content = $this->createTestContent( "eng-US", $fieldValues );
-
-        return $content;
+        return $this->createTestContent( "eng-US", $fieldValues );
     }
 
     protected function updateTestContent( $initialLanguageCode, array $fieldValues )
@@ -180,8 +196,7 @@ class BaseNonRedundantFieldSetTest extends BaseTest
         }
 
         $content = $contentService->updateContent( $content->getVersionInfo(), $contentUpdateStruct );
-        $content = $contentService->loadContent( $content->id, null, $content->versionInfo->versionNo );
 
-        return $content;
+        return $contentService->loadContent( $content->id, null, $content->versionInfo->versionNo );
     }
 }

--- a/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage/Gateway/LegacyStorage.php
@@ -141,7 +141,7 @@ abstract class LegacyStorage extends Gateway
      *
      * @throws \RuntimeException if no connection has been set, yet.
      *
-     * @return \eZ\Publish\Core\Persistence\Legacy\EzcDbHandler
+     * @return \ezcDbHandler|\eZ\Publish\Core\Persistence\Legacy\EzcDbHandler
      */
     protected function getConnection()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldHandler.php
@@ -173,33 +173,9 @@ class FieldHandler
      */
     public function createExistingFieldsInNewVersion( Content $content )
     {
-        $languageCodes = $this->getLanguageCodes( $content->versionInfo->languageIds );
-        $contentFieldMap = $this->getFieldMap( $content->fields );
-        $content->fields = array();
-        $contentType = $this->typeHandler->load( $content->versionInfo->contentInfo->contentTypeId );
-        $mainLanguageCode = $content->versionInfo->contentInfo->mainLanguageCode;
-
-        foreach ( $contentType->fieldDefinitions as $fieldDefinition )
+        foreach ( $content->fields as $field )
         {
-            foreach ( array_keys( $languageCodes ) as $languageCode )
-            {
-                if ( !$fieldDefinition->isTranslatable && $languageCode != $mainLanguageCode )
-                {
-                    $createInNewLanguageCode = $languageCode;
-                    $field = $contentFieldMap[$fieldDefinition->id][$mainLanguageCode];
-                }
-                else
-                {
-                    $createInNewLanguageCode = null;
-                    $field = $contentFieldMap[$fieldDefinition->id][$languageCode];
-                }
-
-                $content->fields[] = $this->createExistingFieldInNewVersion(
-                    $field,
-                    $content,
-                    $createInNewLanguageCode
-                );
-            }
+            $this->createExistingFieldInNewVersion( $field, $content );
         }
     }
 
@@ -323,26 +299,21 @@ class FieldHandler
     /**
      * Creates an existing field in a new version, no new ID is generated.
      *
-     * If $newLanguageCode is set field will be created in it. This is used for creating non-translatable
-     * fields from field in main language.
+     * Used to insert a field with an existing ID but a new version number.
+     * $content is used for new version data, needed by Content gateway and external storage.
      *
      * External data is being copied here as some FieldTypes require original field external data.
      * By default copying falls back to storing, it is upon external storage implementation to override
      * the behaviour as needed.
      *
-     * @param Field $originalField
+     * @param Field $field
      * @param Content $content
-     * @param string|null $newLanguageCode
      *
-     * @return \eZ\Publish\SPI\Persistence\Content\Field
+     * @return void
      */
-    protected function createExistingFieldInNewVersion( Field $originalField, Content $content, $newLanguageCode = null )
+    protected function createExistingFieldInNewVersion( Field $field, Content $content )
     {
-        $field = clone $originalField;
-        if ( $newLanguageCode !== null )
-        {
-            $field->languageCode = $newLanguageCode;
-        }
+        $originalField = clone $field;
         $field->versionNo = $content->versionInfo->versionNo;
 
         $this->contentGateway->insertExistingField(
@@ -361,8 +332,6 @@ class FieldHandler
                 $this->mapper->convertToStorageValue( $field )
             );
         }
-
-        return $field;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -250,14 +250,6 @@ class Handler implements BaseContentHandler
         );
 
         // Clone fields from previous version and append them to the new one
-        $fields = $content->fields;
-        $content->fields = array();
-        foreach ( $fields as $field )
-        {
-            $newField = clone $field;
-            $newField->versionNo = $content->versionInfo->versionNo;
-            $content->fields[] = $newField;
-        }
         $this->fieldHandler->createExistingFieldsInNewVersion( $content );
 
         // Create relations for new version

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldHandlerTest.php
@@ -296,14 +296,8 @@ class FieldHandlerTest extends LanguageAwareTestCase
      */
     protected function assertCreateExistingFieldsInNewVersion( $storageHandlerUpdatesFields = false )
     {
-        $typeHandlerMock = $this->getTypeHandlerMock();
         $contentGatewayMock = $this->getContentGatewayMock();
         $storageHandlerMock = $this->getStorageHandlerMock();
-
-        $typeHandlerMock->expects( $this->once() )
-            ->method( "load" )
-            ->with( $this->equalTo( 1 ) )
-            ->will( $this->returnValue( $this->getContentTypeFixture() ) );
 
         $contentGatewayMock->expects( $this->exactly( 6 ) )
             ->method( 'insertExistingField' )
@@ -329,11 +323,6 @@ class FieldHandlerTest extends LanguageAwareTestCase
                 );
                 $originalField = clone $field;
                 $field->versionNo = 1;
-                // These fields are copied from main language
-                if ( ( $fieldDefinitionId == 2 || $fieldDefinitionId == 3 ) && $languageCode == "eng-US" )
-                {
-                    $originalField->languageCode = "eng-GB";
-                }
                 $storageHandlerMock->expects( $this->at( $callNo++ ) )
                     ->method( 'copyFieldData' )
                     ->with(
@@ -956,14 +945,13 @@ class FieldHandlerTest extends LanguageAwareTestCase
         $thirdFieldUs->fieldDefinitionId = 3;
         $thirdFieldUs->languageCode = "eng-US";
 
-        $content->fields = array_merge(
-            $content->fields,
-            array(
-                $firstFieldGb,
-                $secondFieldUs,
-                $thirdFieldGb,
-                $thirdFieldUs
-            )
+        $content->fields = array(
+            $content->fields[0],
+            $firstFieldGb,
+            $secondFieldUs,
+            $content->fields[1],
+            $thirdFieldUs,
+            $thirdFieldGb
         );
 
         return $content;


### PR DESCRIPTION
This PR resolves issue https://jira.ez.no/browse/EZP-21804

When creating Content draft, untranslatable fields were copied from main language.
This was not necessary as in Legacy Storage complete copy is stored for each language. Because ids are respected for field in a language through versions, this resulted in DB constraints violation.

This fixes the issue by copying each field from its own language and also simplifies the implementation a bit.
