### PR TITLE
Fix EZP-21817: field copies in existing language are copied from main language instead of updated

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseNonRedundantFieldSetTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseNonRedundantFieldSetTest.php
@@ -171,8 +171,14 @@ class BaseNonRedundantFieldSetTest extends BaseTest
         $fieldValues = array(
             "field1" => array( "eng-US" => "value 1" ),
             "field2" => array( "eng-US" => "value 2" ),
-            "field3" => array( "eng-US" => "value 3" ),
-            "field4" => array( "eng-US" => "value 4" )
+            "field3" => array(
+                "eng-US" => "value 3",
+                "eng-GB" => "value 3 eng-GB"
+            ),
+            "field4" => array(
+                "eng-US" => "value 4",
+                "eng-GB" => "value 4 eng-GB"
+            )
         );
 
         return $this->createTestContent( "eng-US", $fieldValues );


### PR DESCRIPTION
This PR resolves issue https://jira.ez.no/browse/EZP-21817

When updating Content with multiple languages and containing non-translatable fields, copies of those fields in non-main language were copied instead of updated.
