### PR TITLE
Updated symfony-cmf/routing dependency to 1.1.* stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "zetacomponents/system-information": "@dev",
         "zetacomponents/webdav": "1.1.*",
         "symfony/symfony": "~2.3",
-        "symfony-cmf/routing": "1.1.*@beta",
+        "symfony-cmf/routing": "1.1.*",
         "qafoo/rmf": "1.0.*",
         "kriswallsmith/buzz": ">=0.9",
         "tedivm/stash-bundle": "0.2.*",


### PR DESCRIPTION
We were already running on latest RC4 release and there is no difference in the final release (see the [diff on symfony-cmf/Routing](https://github.com/symfony-cmf/Routing/compare/1.1.0-RC4..1.1.0)).
This PR just ensures to use the stable channel.
