### PR TITLE
FIX EZP-21834: overriding/extending ezpublish.siteaccess.match in config

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
@@ -94,6 +94,7 @@ class Configuration implements ConfigurationInterface
                             ->useAttributeAsKey( 'key' )
                             ->normalizeKeys( false )
                             ->prototype( 'array' )
+                                ->useAttributeAsKey( 'key' )
                                 ->beforeNormalization()
                                     // Value passed to the matcher should always be an array.
                                     // If value is not an array, we transform it to a hash, with 'value' as key.


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-21834

This allows ezpublish / siteaccess / match settings to be correctly extended/overridden in an ezpublish_{env}.yml that imports another file.
