### PR TITLE
Fix EZP-21840: unwanted "shebang" line running ezpublish:legacy:script

### DIFF
--- a/eZ/Publish/Core/MVC/Legacy/Kernel/CLIHandler.php
+++ b/eZ/Publish/Core/MVC/Legacy/Kernel/CLIHandler.php
@@ -94,6 +94,25 @@ class CLIHandler implements ezpKernelHandler
         $this->sessionInit();
         // Exposing $argv to embedded script
         $argv = $_SERVER['argv'];
+
+        // start output buffering before including legacy script to filter unwanted output.
+        ob_start(
+            function( $buffer )
+            {
+                static $startFlag = false;
+                // remove shebang line from start of script, if any
+                if ( !$startFlag )
+                {
+                    $buffer = preg_replace( '/^\#\![\w\/]*[ ]?php[\r?\n?]/', '', $buffer );
+                    $startFlag = true;
+                }
+                return $buffer;
+            },
+            128
+        );
+
+        ob_implicit_flush( true );
+
         include $this->embeddedScriptPath;
     }
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-21840

Executing a legacy script through php ezpublish/console ezpublish:legacy:script will output the following in the first line:
`#!/usr/bin/env php`
The above should not be displayed, even more so when the scripts are given the '--quiet' option.

This fix does not touch the shebang lines in legacy script, but rather implements an output buffer that removes it.
The buffering should otherwise be "transparent", by using implicit flush.
