### PR TITLE
Fix EZP-21847 fatal error in ezpublish:legacy:script command if ezxFormToken isn't found

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/LegacyMapper/Configuration.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/LegacyMapper/Configuration.php
@@ -153,19 +153,22 @@ class Configuration implements EventSubscriberInterface
             $settings + (array)$event->getParameters()->get( "injected-settings" )
         );
 
-        // Inject csrf protection settings to make sure legacy & symfony stack work together
-        if (
-            $this->container->hasParameter( 'form.type_extension.csrf.enabled' ) &&
-            $this->container->getParameter( 'form.type_extension.csrf.enabled' )
-        )
+        if ( class_exists( 'ezxFormToken' ) )
         {
-            ezxFormToken::setSecret( $this->container->getParameter( 'kernel.secret' ) );
-            ezxFormToken::setFormField( $this->container->getParameter( 'form.type_extension.csrf.field_name' ) );
-        }
-        // csrf protection is disabled, disable it in legacy extension as well.
-        else
-        {
-            ezxFormToken::setIsEnabled( false );
+            // Inject csrf protection settings to make sure legacy & symfony stack work together
+            if (
+                $this->container->hasParameter( 'form.type_extension.csrf.enabled' ) &&
+                $this->container->getParameter( 'form.type_extension.csrf.enabled' )
+            )
+            {
+                ezxFormToken::setSecret( $this->container->getParameter( 'kernel.secret' ) );
+                ezxFormToken::setFormField( $this->container->getParameter( 'form.type_extension.csrf.field_name' ) );
+            }
+            // csrf protection is disabled, disable it in legacy extension as well.
+            else
+            {
+                ezxFormToken::setIsEnabled( false );
+            }
         }
 
         // Register http cache content/cache event listener


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-21847

if the ezxFormToken is not present in the legacy extension autoloads, running any script through ezpublish:legacy:script command will fail with a fatal error.

This makes it impossible to run the ezpgenerateautoloads script through this command (in order to fix the problem).

This commit checks if the class has been loaded before attempting to use it's static methods.
