### PR TITLE
Fix EZP-21917: ezxml link class attribute not rendering because of wrong xsl

### DIFF
--- a/eZ/Publish/Core/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl
+++ b/eZ/Publish/Core/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl
@@ -170,7 +170,7 @@
                     <xsl:value-of select="@title"/>
                 </xsl:attribute>
             </xsl:if>
-            <xsl:value-of select="@class"/>
+            <xsl:copy-of select="@class"/>
             <xsl:apply-templates/>
         </a>
     </xsl:template>


### PR DESCRIPTION
When assigning a class to a link in ezoe the class name is rendered in the link text. This fix checks if there is a class assigned to the link and render it in the class attribute.

Thanks
