### PR TITLE
EZP-21548: Clear role assignments cache when dealing with locations

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/slot.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/slot.yml
@@ -19,6 +19,8 @@ parameters:
     ezpublish_legacy.signalslot.enable_language.class: eZ\Publish\Core\SignalSlot\Slot\LegacyEnableLanguageSlot
     ezpublish_legacy.signalslot.update_language_name.class: eZ\Publish\Core\SignalSlot\Slot\LegacyUpdateLanguageNameSlot
     ezpublish_legacy.signalslot.update_user.class: eZ\Publish\Core\SignalSlot\Slot\LegacyUpdateUserSlot
+    ezpublish_legacy.signalslot.assign_user_to_user_group.class: eZ\Publish\Core\SignalSlot\Slot\LegacyAssignUserToUserGroupSlot
+    ezpublish_legacy.signalslot.unassign_user_from_user_group.class: eZ\Publish\Core\SignalSlot\Slot\LegacyUnassignUserFromUserGroupSlot
 
 services:
     ezpublish_legacy.signalslot.assign_section:
@@ -140,3 +142,15 @@ services:
         arguments: [@ezpublish_legacy.kernel]
         tags:
             - { name: ezpublish.api.slot, signal: UserService\UpdateUserSignal }
+
+    ezpublish_legacy.signalslot.assign_user_to_user_group:
+        class: %ezpublish_legacy.signalslot.assign_user_to_user_group.class%
+        arguments: [@ezpublish_legacy.kernel]
+        tags:
+            - { name: ezpublish.api.slot, signal: UserService\AssignUserToUserGroupSignal }
+
+    ezpublish_legacy.signalslot.unassign_user_from_user_group:
+        class: %ezpublish_legacy.signalslot.unassign_user_from_user_group.class%
+        arguments: [@ezpublish_legacy.kernel]
+        tags:
+            - { name: ezpublish.api.slot, signal: UserService\UnAssignUserFromUserGroupSignal }

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyAssignUserToUserGroupSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyAssignUserToUserGroupSlot.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * File containing the LegacyAssignUserToUserGroupSlot class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\SignalSlot\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+use eZCache;
+
+/**
+ * A legacy slot handling AssignUserToUserGroupSignal.
+ */
+class LegacyAssignUserToUserGroupSlot extends AbstractLegacySlot
+{
+    /**
+     * Receive the given $signal and react on it
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return void
+     */
+    public function receive( Signal $signal )
+    {
+        if ( !$signal instanceof Signal\UserService\AssignUserToUserGroupSignal )
+        {
+            return;
+        }
+
+        $kernel = $this->getLegacyKernel();
+        $kernel->runCallback(
+            function ()
+            {
+                eZCache::clearByID( "user_info_cache" );
+            },
+            false
+        );
+    }
+}

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyUnassignUserFromUserGroupSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyUnassignUserFromUserGroupSlot.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * File containing the LegacyUnassignUserFromUserGroupSlot class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\SignalSlot\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+use eZCache;
+
+/**
+ * A legacy slot handling UnAssignUserFromUserGroupSignal.
+ */
+class LegacyUnassignUserFromUserGroupSlot extends AbstractLegacySlot
+{
+    /**
+     * Receive the given $signal and react on it
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return void
+     */
+    public function receive( Signal $signal )
+    {
+        if ( !$signal instanceof Signal\UserService\UnAssignUserFromUserGroupSignal )
+        {
+            return;
+        }
+
+        $kernel = $this->getLegacyKernel();
+        $kernel->runCallback(
+            function ()
+            {
+                eZCache::clearByID( "user_info_cache" );
+            },
+            false
+        );
+    }
+}

--- a/eZ/Publish/Core/settings/service.ini
+++ b/eZ/Publish/Core/settings/service.ini
@@ -90,6 +90,8 @@ arguments[mapping][eZ\Publish\Core\SignalSlot\Signal\LanguageService\DisableLang
 arguments[mapping][eZ\Publish\Core\SignalSlot\Signal\LanguageService\EnableLanguageSignal][]=enable_language:legacy
 arguments[mapping][eZ\Publish\Core\SignalSlot\Signal\LanguageService\UpdateLanguageNameSignal][]=update_language_name:legacy
 arguments[mapping][eZ\Publish\Core\SignalSlot\Signal\UserService\UpdateUserSignal][]=update_user:legacy
+arguments[mapping][eZ\Publish\Core\SignalSlot\Signal\UserService\AssignUserToUserGroupSignal][]=assign_user_to_user_group:legacy
+arguments[mapping][eZ\Publish\Core\SignalSlot\Signal\UserService\UnAssignUserFromUserGroupSignal][]=unassign_user_from_user_group:legacy
 
 
 [slot_factory]
@@ -162,6 +164,12 @@ class=eZ\Publish\Core\SignalSlot\Slot\LegacyUpdateLanguageNameSlot
 
 [update_user:legacy:slot]
 class=eZ\Publish\Core\SignalSlot\Slot\LegacyUpdateUserSlot
+
+[unassign_user_from_user_group:legacy:slot]
+class=eZ\Publish\Core\SignalSlot\Slot\LegacyUnassignUserFromUserGroupSlot
+
+[assign_user_to_user_group:legacy:slot]
+class=eZ\Publish\Core\SignalSlot\Slot\LegacyAssignUserToUserGroupSlot
 
 #### Core\Persistence Services ####
 


### PR DESCRIPTION
This PR resolves issue https://jira.ez.no/browse/EZP-21548

Second part for the issue: aside from amends to Cache storage, slots for clearing user info cache in Legacy Stack were also missing.
This implements `LegacyAssignUserToUserGroupSlot` and `LegacyUnAssignUserFromUserGroupSlot`.

Tested manually.
