### PR TITLE
EZP-21861: node's path_identification_string should not have a leading /

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/EzcDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/EzcDatabase.php
@@ -1033,7 +1033,9 @@ class EzcDatabase extends Gateway
     {
         $parentData = $this->getBasicNodeData( $parentLocationId );
 
-        $newPathIdentificationString = $parentData["path_identification_string"] . "/" . $text;
+        $newPathIdentificationString = empty( $parentData["path_identification_string"] ) ?
+            $text :
+            $parentData["path_identification_string"] . "/" . $text;
 
         /** @var $query \ezcQueryUpdate */
         $query = $this->handler->createUpdateQuery();

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/EzpDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/EzpDatabaseTest.php
@@ -1202,5 +1202,39 @@ class EzpDatabaseTest extends TestCase
             // Do nothing
         }
     }
+
+    public function providerForTestUpdatePathIdentificationString()
+    {
+        return array(
+            array( 77, 2, "new_solutions", "new_solutions" ),
+            array( 75, 69, "stylesheets", "products/stylesheets" )
+        );
+    }
+
+    /**
+     * Test for the updatePathIdentificationString() method.
+     *
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway\EzcDatabase::updatePathIdentificationString
+     * @dataProvider providerForTestUpdatePathIdentificationString
+     */
+    public function testUpdatePathIdentificationString( $locationId, $parentLocationId, $text, $expected )
+    {
+        $this->insertDatabaseFixture( __DIR__ . '/_fixtures/full_example_tree.php' );
+
+        $gateway = $this->getLocationGateway();
+        $gateway->updatePathIdentificationString( $locationId, $parentLocationId, $text );
+
+        $query = $this->handler->createSelectQuery();
+        $this->assertQueryResult(
+            array( array( $expected ) ),
+            $query->select(
+                'path_identification_string'
+            )->from(
+                'ezcontentobject_tree'
+            )->where(
+                $query->expr->eq( 'node_id', $locationId )
+            )
+        );
+    }
 }
 


### PR DESCRIPTION
This PR resolves issue https://jira.ez.no/browse/EZP-21861

Location `path_identification_string` was updated with leading slash if the Location was under root.
This fixes the bug.
