### PR TITLE
Fix EZP-21873 - Unable to use ez_render_field with ezgmaplocation_field

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -303,15 +303,14 @@
 
     {% set zoom = parameters.zoom|default( defaultZoom ) %}
     {% set mapType = parameters.mapType|default( defaultMapType ) %}
-    {% if parameters.width is sameas(false) %}
-        {% set mapWidth = false %}
-    {% else %}
-        {% set mapWidth = parameters.width|default( defaultWidth ) %}
+
+    {% set mapWidth, mapHeight = defaultWidth, defaultHeight %}
+    {% if parameters.width is defined %}
+        {% set mapWidth = parameters.width %}
     {% endif %}
-    {% if parameters.height is sameas(false) %}
-        {% set mapHeight = false %}
-    {% else %}
-        {% set mapHeight = parameters.height|default( defaultHeight ) %}
+
+    {% if parameters.height is defined %}
+        {% set mapHeight = parameters.height %}
     {% endif %}
 
     {% set showMap = defautShowMap %}


### PR DESCRIPTION
If you try to use

```
{{ ez_render_field( content, 'location' ) }}
```

on a gmaplocation_filed you'll get the following twig exception

```
 Key "width" for array with keys "" does not exist in EzPublishCoreBundle::content_fields.html.twig at line 306
500 Internal Server Error - Twig_Error_Runtime 
```

After investigating a bit more I found out that the problem is that the array parameters is empty
