### PR TITLE
Fix EZP-21876: Compound matcher throws fatal error after patch from EZP-21834

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
@@ -96,18 +96,30 @@ class Configuration implements ConfigurationInterface
                             ->prototype( 'array' )
                                 ->useAttributeAsKey( 'key' )
                                 ->beforeNormalization()
-                                    // Value passed to the matcher should always be an array.
-                                    // If value is not an array, we transform it to a hash, with 'value' as key.
-                                    ->ifTrue(
+                                    ->always(
                                         function ( $v )
                                         {
-                                            return !is_array( $v );
-                                        }
-                                    )
-                                    ->then(
-                                        function ( $v )
-                                        {
-                                            return array( 'value' => $v );
+                                            // Value passed to the matcher should always be an array.
+                                            // If value is not an array, we transform it to a hash, with 'value' as key.
+                                            if ( !is_array( $v ) )
+                                            {
+                                                return array( 'value' => $v );
+                                            }
+
+                                            // If passed value is a numerically indexed array, we must convert it into a hash.
+                                            // See https://jira.ez.no/browse/EZP-21876
+                                            if ( array_keys( $v ) === range( 0, count( $v ) - 1 ) )
+                                            {
+                                                $final = array();
+                                                foreach ( $v as $i => $val )
+                                                {
+                                                    $final["i$i"] = $val;
+                                                }
+
+                                                return $final;
+                                            }
+
+                                            return $v;
                                         }
                                     )
                                 ->end()


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-21876

Patch for regression introduced in #576, fixing [EZP-21834](https://jira.ez.no/browse/EZP-21834).

Tested both with Compound siteaccess matcher and regular matcher.
