### PR TITLE
EZP-21893: Handle LanguageCode criterion $matchAlwaysAvailable parameter in Solr storage visitor

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SetupFactory/LegacySolr.php
+++ b/eZ/Publish/API/Repository/Tests/SetupFactory/LegacySolr.php
@@ -203,6 +203,7 @@ class LegacySolr extends Legacy
                         new FieldValueMapper\IntegerMapper(),
                         new FieldValueMapper\DateMapper(),
                         new FieldValueMapper\PriceMapper(),
+                        new FieldValueMapper\BooleanMapper(),
                         new FieldValueMapper\MultipleBooleanMapper(),
                         new FieldValueMapper\GeoLocationMapper(),
                     )

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/LanguageCode.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/LanguageCode.php
@@ -1,0 +1,36 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(
+    array(
+        'facets' => array(),
+        'searchHits' => array(
+            0 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+                array(
+                    'valueObject' => array(
+                        'id' => 57,
+                        'title' => 'Home',
+                    ),
+                    'score' => 2.7917593,
+                    'index' => NULL,
+                    'highlight' => NULL,
+                )
+            ),
+            1 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+                array(
+                    'valueObject' => array(
+                        'id' => 58,
+                        'title' => 'Contact Us',
+                    ),
+                    'score' => 2.7917593,
+                    'index' => NULL,
+                    'highlight' => NULL,
+                )
+            ),
+        ),
+        'spellSuggestion' => NULL,
+        'time' => 1,
+        'timedOut' => NULL,
+        'maxScore' => 2.7917593,
+        'totalCount' => 2,
+    )
+);

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/LanguageCodeAlwaysAvailable.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/LanguageCodeAlwaysAvailable.php
@@ -1,0 +1,80 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(
+    array(
+        'facets' => array(),
+        'searchHits' => array(
+            0 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+                array(
+                    'valueObject' => array(
+                        'id' => 50,
+                        'title' => 'Files',
+                    ),
+                    'score' => 0.20774001,
+                    'index' => NULL,
+                    'highlight' => NULL,
+                )
+            ),
+            1 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+                array(
+                    'valueObject' => array(
+                        'id' => 51,
+                        'title' => 'Multimedia',
+                    ),
+                    'score' => 0.20774001,
+                    'index' => NULL,
+                    'highlight' => NULL,
+                )
+            ),
+            2 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+                array(
+                    'valueObject' => array(
+                        'id' => 56,
+                        'title' => 'Design',
+                    ),
+                    'score' => 0.20774001,
+                    'index' => NULL,
+                    'highlight' => NULL,
+                )
+            ),
+            3 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+                array(
+                    'valueObject' => array(
+                        'id' => 57,
+                        'title' => 'Home',
+                    ),
+                    'score' => 3.007218,
+                    'index' => NULL,
+                    'highlight' => NULL,
+                )
+            ),
+            4 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+                array(
+                    'valueObject' => array(
+                        'id' => 58,
+                        'title' => 'Contact Us',
+                    ),
+                    'score' => 1.295869,
+                    'index' => NULL,
+                    'highlight' => NULL,
+                )
+            ),
+            5 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+                array(
+                    'valueObject' => array(
+                        'id' => 59,
+                        'title' => 'Partners',
+                    ),
+                    'score' => 0.20774001,
+                    'index' => NULL,
+                    'highlight' => NULL,
+                )
+            ),
+        ),
+        'spellSuggestion' => NULL,
+        'time' => 1,
+        'timedOut' => NULL,
+        'maxScore' => 3.007218,
+        'totalCount' => 16,
+    )
+);

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/LanguageCodeIn.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/LanguageCodeIn.php
@@ -1,0 +1,102 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(
+    array(
+        'facets' => array(),
+        'searchHits' => array(
+            0 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+                array(
+                    'valueObject' => array(
+                        'id' => 50,
+                        'title' => 'Files',
+                    ),
+                    'score' => 0.18718657,
+                    'index' => NULL,
+                    'highlight' => NULL,
+                )
+            ),
+            1 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+                array(
+                    'valueObject' => array(
+                        'id' => 51,
+                        'title' => 'Multimedia',
+                    ),
+                    'score' => 0.18718657,
+                    'index' => NULL,
+                    'highlight' => NULL,
+                )
+            ),
+            2 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+                array(
+                    'valueObject' => array(
+                        'id' => 52,
+                        'title' => 'Common INI settings',
+                    ),
+                    'score' => 0.18718657,
+                    'index' => NULL,
+                    'highlight' => NULL,
+                )
+            ),
+            3 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+                array(
+                    'valueObject' => array(
+                        'id' => 54,
+                        'title' => 'eZ Publish Demo Design (without demo content)',
+                    ),
+                    'score' => 0.18718657,
+                    'index' => NULL,
+                    'highlight' => NULL,
+                )
+            ),
+            4 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+                array(
+                    'valueObject' => array(
+                        'id' => 56,
+                        'title' => 'Design',
+                    ),
+                    'score' => 0.18718657,
+                    'index' => NULL,
+                    'highlight' => NULL,
+                )
+            ),
+            5 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+                array(
+                    'valueObject' => array(
+                        'id' => 57,
+                        'title' => 'Home',
+                    ),
+                    'score' => 1.3054208,
+                    'index' => NULL,
+                    'highlight' => NULL,
+                )
+            ),
+            6 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+                array(
+                    'valueObject' => array(
+                        'id' => 58,
+                        'title' => 'Contact Us',
+                    ),
+                    'score' => 1.3054208,
+                    'index' => NULL,
+                    'highlight' => NULL,
+                )
+            ),
+            7 => eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(
+                array(
+                    'valueObject' => array(
+                        'id' => 59,
+                        'title' => 'Partners',
+                    ),
+                    'score' => 0.18718657,
+                    'index' => NULL,
+                    'highlight' => NULL,
+                )
+            ),
+        ),
+        'spellSuggestion' => NULL,
+        'time' => 1,
+        'timedOut' => NULL,
+        'maxScore' => 1.3054208,
+        'totalCount' => 18,
+    )
+);

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/CriterionVisitor/LanguageCodeIn.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/CriterionVisitor/LanguageCodeIn.php
@@ -21,7 +21,7 @@ class LanguageCodeIn extends CriterionVisitor
     /**
      * CHeck if visitor is applicable to current criterion
      *
-     * @param Criterion $criterion
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      *
      * @return boolean
      */
@@ -36,25 +36,28 @@ class LanguageCodeIn extends CriterionVisitor
     /**
      * Map field value to a proper Solr representation
      *
-     * @param Criterion $criterion
-     * @param CriterionVisitor $subVisitor
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param \eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor $subVisitor
      *
      * @return string
      */
     public function visit( Criterion $criterion, CriterionVisitor $subVisitor = null )
     {
-        return '(' .
-            implode(
-                ' OR ',
-                array_map(
-                    function ( $value )
-                    {
-                        return 'language_code_ms:"' . $value . '"';
-                    },
-                    $criterion->value
-                )
-            ) .
-            ')';
+        $languageCodeExpressions = array_map(
+            function ( $value )
+            {
+                return 'language_code_ms:"' . $value . '"';
+            },
+            $criterion->value
+        );
+
+        /** @var Criterion\LanguageCode $criterion */
+        if ( $criterion->matchAlwaysAvailable )
+        {
+            $languageCodeExpressions[] = "always_available_b:true";
+        }
+
+        return '(' . implode( ' OR ', $languageCodeExpressions ) . ')';
     }
 }
 

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/FieldValueMapper/BooleanMapper.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/FieldValueMapper/BooleanMapper.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * File containing the BooleanMapper class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\Solr\Content\Search\FieldValueMapper;
+
+use eZ\Publish\Core\Persistence\Solr\Content\Search\FieldValueMapper;
+use eZ\Publish\SPI\Persistence\Content\Search\Field;
+use eZ\Publish\SPI\Persistence\Content\Search\FieldType;
+
+/**
+ * Maps raw document field values to something Solr can index.
+ */
+class BooleanMapper extends FieldValueMapper
+{
+    /**
+     * Check if field can be mapped
+     *
+     * @param Field $field
+     *
+     * @return boolean
+     */
+    public function canMap( Field $field )
+    {
+        return $field->type instanceof FieldType\BooleanField;
+    }
+
+    /**
+     * Map field value to a proper Solr representation
+     *
+     * @param Field $field
+     *
+     * @return mixed
+     */
+    public function map( Field $field )
+    {
+        return (boolean)$field->value;
+    }
+}
+

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/Handler.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/Handler.php
@@ -413,6 +413,11 @@ class Handler implements SearchHandlerInterface
                 ),
                 new FieldType\MultipleBooleanField()
             ),
+            new Field(
+                'always_available',
+                $content->versionInfo->contentInfo->alwaysAvailable,
+                new FieldType\BooleanField()
+            ),
         );
 
         if ( $mainLocation !== null )


### PR DESCRIPTION
This PR resolves issue https://jira.ez.no/browse/EZP-21893

Title says it all.
Different scores come from different number of content found in a single language. For example 1 of 16 content found in eng-GB makes a lower score than 1 of 2 content found in eng-US.

Sub-task of https://jira.ez.no/browse/EZP-21897.
