### PR TITLE
EZP-21914: Added set/getDbHandler to Legacy\EzcDbHandler

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/EzcDbHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/EzcDbHandler.php
@@ -41,6 +41,19 @@ class EzcDbHandler
         $this->ezcDbHandler = $ezcDbHandler;
     }
 
+    public function setDbHandler( ezcDbHandlerWrapped $ezcDbHandler )
+    {
+        $this->ezcDbHandler = $ezcDbHandler;
+    }
+
+    /**
+     * @return \ezcDbHandler
+     */
+    public function getDbHandler()
+    {
+        return $this->ezcDbHandler;
+    }
+
     /**
      * Factory for getting EzcDbHandler handler object
      *


### PR DESCRIPTION
New stack counterpart to https://github.com/ezsystems/ezpublish-legacy/pull/832.
Required for http://jira.ez.no/browse/EZP-21914

Allows us to reset the db link when required, for instance when forking.
