### PR TITLE
Fix EZP-21920: do not raise exception on loadRelations

### DIFF
--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1728,17 +1728,14 @@ class ContentService implements ContentServiceInterface
         $relations = array();
         foreach ( $spiRelations as $spiRelation )
         {
-            // @todo Should relations really be loaded w/o checking permissions just because User needs to be accessible??
+            $destinationContentInfo = $this->internalLoadContentInfo( $spiRelation->destinationContentId );
+            if ( !$this->repository->canUser( 'content', 'read', $destinationContentInfo ) )
+                continue;
             $relations[] = $this->domainMapper->buildRelationDomainObject(
                 $spiRelation,
                 $contentInfo,
-                $this->internalLoadContentInfo( $spiRelation->destinationContentId )
+                $destinationContentInfo
             );
-        }
-        foreach ( $relations as $relation )
-        {
-            if ( !$this->repository->canUser( 'content', 'read', $relation->getDestinationContentInfo() ) )
-                throw new UnauthorizedException( 'content', 'read' );
         }
 
         return $relations;
@@ -1767,16 +1764,14 @@ class ContentService implements ContentServiceInterface
         $returnArray = array();
         foreach ( $spiRelations as $spiRelation )
         {
-            // @todo Should relations really be loaded w/o checking permissions just because User needs to be accessible??
-            $relation = $this->domainMapper->buildRelationDomainObject(
+            $sourceContentInfo = $this->internalLoadContentInfo( $spiRelation->sourceContentId );
+            if ( !$this->repository->canUser( 'content', 'read', $sourceContentInfo ) )
+                continue;
+            $returnArray[] = $this->domainMapper->buildRelationDomainObject(
                 $spiRelation,
-                $this->internalLoadContentInfo( $spiRelation->sourceContentId ),
+                $sourceContentInfo,
                 $contentInfo
             );
-            if ( !$this->repository->canUser( 'content', 'read', $relation->getSourceContentInfo() ) )
-                throw new UnauthorizedException( 'content', 'read' );
-
-            $returnArray[] = $relation;
         }
 
         return $returnArray;


### PR DESCRIPTION
**ContentService->loadRelations** raises an exception when the user cannot read one of the related content objects, rendering the method useless to list relations when both accessible and not accessible content exists.

If you agree with this solution, the same can be applied to loadReverseRelations

Ref: https://jira.ez.no/browse/EZP-21920
