### PR TITLE
Fix EZP-21853: Custom HTTP headers create duplicate values

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Controller/LegacyKernelController.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Controller/LegacyKernelController.php
@@ -144,6 +144,9 @@ class LegacyKernelController
             $headerName = strtolower( $headerArray[0] );
             $headerValue = $headerArray[1];
 
+            // Removing existing header to avoid duplicate values
+            header_remove( $headerName );
+
             switch ( $headerName )
             {
                 // max-age and s-maxage are skipped because they are values of the cache-control header


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-21853
## Description

The legacy kernel controller adds legacy's headers to the request . The problem is that it did not remove the existing values. That could lead to headers with duplicate values making them incoherent.

Legacy headers must have priority, so this patch clears existing headers before we set legacy ones.
## Test

Manual tests
