### PR TITLE
Fix EZP-21924: [SensioLabsInsight] Refactor LegacyKernelController to be less than 20 lines

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Controller/LegacyKernelController.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Controller/LegacyKernelController.php
@@ -11,9 +11,9 @@ namespace eZ\Bundle\EzPublishLegacyBundle\Controller;
 
 use DateTime;
 use eZ\Bundle\EzPublishLegacyBundle\LegacyResponse;
+use eZ\Bundle\EzPublishLegacyBundle\LegacyResponse\LegacyResponseManager;
 use eZ\Publish\Core\MVC\Legacy\Kernel\URIHelper;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Templating\EngineInterface;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 
 /**
@@ -48,21 +48,17 @@ class LegacyKernelController
     private $request;
 
     /**
-     * @todo Maybe following dependencies should be mutualized in an abstract controller
-     *       Injection can be done through "parent service" feature for DIC : http://symfony.com/doc/master/components/dependency_injection/parentservices.html
-     *
-     * @param \Closure $kernelClosure
-     * @param \Symfony\Component\Templating\EngineInterface $templateEngine
-     * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
-     * @param \eZ\Publish\Core\MVC\Legacy\Kernel\URIHelper $uriHelper
+     * @var \eZ\Bundle\EzPublishLegacyBundle\LegacyResponse\LegacyResponseManager
      */
-    public function __construct( \Closure $kernelClosure, EngineInterface $templateEngine, ConfigResolverInterface $configResolver, URIHelper $uriHelper )
+    private $legacyResponseManager;
+
+    public function __construct( \Closure $kernelClosure, ConfigResolverInterface $configResolver, URIHelper $uriHelper, LegacyResponseManager $legacyResponseManager )
     {
         $this->kernel = $kernelClosure();
-        $this->templateEngine = $templateEngine;
         $this->legacyLayout = $configResolver->getParameter( 'module_default_layout', 'ezpublish_legacy' );
         $this->configResolver = $configResolver;
         $this->uriHelper = $uriHelper;
+        $this->legacyResponseManager = $legacyResponseManager;
     }
 
     public function setRequest( Request $request = null )
@@ -71,32 +67,15 @@ class LegacyKernelController
     }
 
     /**
-     * Renders a view and returns a Response.
-     *
-     * @param string $view The view name
-     * @param array $parameters An array of parameters to pass to the view
-     *
-     * @return LegacyResponse A LegacyResponse instance
-     */
-    public function render( $view, array $parameters = array() )
-    {
-        $response = new LegacyResponse();
-        $response->setContent( $this->templateEngine->render( $view, $parameters ) );
-        return $response;
-    }
-
-    /**
      * Base fallback action.
      * Will be basically used for every legacy module.
      *
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return \eZ\Bundle\EzPublishLegacyBundle\LegacyResponse
      */
     public function indexAction()
     {
         $legacyMode = $this->configResolver->getParameter( 'legacy_mode' );
-
         $this->kernel->setUseExceptions( false );
-
         // Fix up legacy URI with current request since we can be in a sub-request here.
         $this->uriHelper->updateLegacyURI( $this->request );
 
@@ -109,61 +88,8 @@ class LegacyKernelController
         $result = $this->kernel->run();
         $this->kernel->setUseExceptions( true );
 
-        $moduleResult = $result->getAttribute( 'module_result' );
-
-        if ( isset( $this->legacyLayout ) && !$legacyMode && !isset( $moduleResult['pagelayout'] ) )
-        {
-            // Replace original module_result content by filtered one
-            $moduleResult['content'] = $result->getContent();
-
-            $response = $this->render(
-                $this->legacyLayout,
-                array( 'module_result' => $moduleResult )
-            );
-
-            $response->setModuleResult( $moduleResult );
-        }
-        else
-        {
-            $response = new LegacyResponse( $result->getContent() );
-        }
-
-        // Handling error codes sent by the legacy stack
-        if ( isset( $moduleResult['errorCode'] ) )
-        {
-            $response->setStatusCode(
-                $moduleResult['errorCode'],
-                isset( $moduleResult['errorMessage'] ) ? $moduleResult['errorMessage'] : null
-            );
-        }
-
-        // Handling headers sent by the legacy stack
-        foreach ( headers_list() as $header )
-        {
-            $headerArray = explode( ": ", $header, 2 );
-            $headerName = strtolower( $headerArray[0] );
-            $headerValue = $headerArray[1];
-
-            // Removing existing header to avoid duplicate values
-            header_remove( $headerName );
-
-            switch ( $headerName )
-            {
-                // max-age and s-maxage are skipped because they are values of the cache-control header
-                case "etag":
-                    $response->setEtag( $headerValue );
-                    break;
-                case "last-modified":
-                    $response->setLastModified( new DateTime( $headerValue ) );
-                    break;
-                case "expires":
-                    $response->setExpires( new DateTime( $headerValue ) );
-                    break;
-                default;
-                    $response->headers->set( $headerName, $headerValue, true );
-                    break;
-            }
-        }
+        $response = $this->legacyResponseManager->generateResponseFromModuleResult( $result );
+        $this->legacyResponseManager->mapHeaders( headers_list(), $response );
 
         return $response;
     }

--- a/eZ/Bundle/EzPublishLegacyBundle/LegacyResponse/LegacyResponseManager.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/LegacyResponse/LegacyResponseManager.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * File containing the LegacyResponseManager class.
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishLegacyBundle\LegacyResponse;
+
+use eZ\Bundle\EzPublishLegacyBundle\LegacyResponse;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Templating\EngineInterface;
+use DateTime;
+use ezpKernelResult;
+
+/**
+ * Utility class to manage Response from legacy controllers, map headers...
+ */
+class LegacyResponseManager
+{
+    /**
+     * @var \Symfony\Component\Templating\EngineInterface
+     */
+    private $templateEngine;
+
+    /**
+     * Template declaration to wrap legacy responses in a Twig pagelayout (optional)
+     * Either a template declaration string or null/false to use legacy pagelayout
+     * Default is null.
+     *
+     * @var string|null
+     */
+    private $legacyLayout;
+
+    /**
+     * Flag indicating if we're running in legacy mode or not.
+     *
+     * @var bool
+     */
+    private $legacyMode;
+
+    public function __construct( EngineInterface $templateEngine, ConfigResolverInterface $configResolver )
+    {
+        $this->templateEngine = $templateEngine;
+        $this->legacyLayout = $configResolver->getParameter( 'module_default_layout', 'ezpublish_legacy' );
+        $this->legacyMode = $configResolver->getParameter( 'legacy_mode' );
+    }
+
+    /**
+     * Generates LegacyResponse object from result returned by legacy kernel.
+     *
+     * @param \ezpKernelResult $result
+     *
+     * @return \eZ\Bundle\EzPublishLegacyBundle\LegacyResponse
+     */
+    public function generateResponseFromModuleResult( ezpKernelResult $result )
+    {
+        $moduleResult = $result->getAttribute( 'module_result' );
+
+        if ( isset( $this->legacyLayout ) && !$this->legacyMode && !isset( $moduleResult['pagelayout'] ) )
+        {
+            // Replace original module_result content by filtered one
+            $moduleResult['content'] = $result->getContent();
+
+            $response = $this->render(
+                $this->legacyLayout,
+                array( 'module_result' => $moduleResult )
+            );
+
+            $response->setModuleResult( $moduleResult );
+        }
+        else
+        {
+            $response = new LegacyResponse( $result->getContent() );
+        }
+
+        // Handling error codes sent by the legacy stack
+        if ( isset( $moduleResult['errorCode'] ) )
+        {
+            $response->setStatusCode(
+                $moduleResult['errorCode'],
+                isset( $moduleResult['errorMessage'] ) ? $moduleResult['errorMessage'] : null
+            );
+        }
+
+        return $response;
+    }
+
+    /**
+     * Renders a view and returns a Response.
+     *
+     * @param string $view The view name
+     * @param array $parameters An array of parameters to pass to the view
+     *
+     * @return \eZ\Bundle\EzPublishLegacyBundle\LegacyResponse\LegacyResponseManager A LegacyResponse instance
+     */
+    private function render( $view, array $parameters = array() )
+    {
+        $response = new LegacyResponse();
+        $response->setContent( $this->templateEngine->render( $view, $parameters ) );
+        return $response;
+    }
+
+    /**
+     * Maps headers sent by the legacy stack to $response.
+     *
+     * @param array $headers Array headers.
+     * @param \eZ\Bundle\EzPublishLegacyBundle\LegacyResponse $response
+     *
+     * @return \eZ\Bundle\EzPublishLegacyBundle\LegacyResponse
+     */
+    public function mapHeaders( array $headers, LegacyResponse $response )
+    {
+        foreach ( $headers as $header )
+        {
+            $headerArray = explode( ": ", $header, 2 );
+            $headerName = strtolower( $headerArray[0] );
+            $headerValue = $headerArray[1];
+            // Removing existing header to avoid duplicate values
+            $this->removeHeader( $headerName );
+
+            switch ( $headerName )
+            {
+                // max-age and s-maxage are skipped because they are values of the cache-control header
+                case "etag":
+                    $response->setEtag( $headerValue );
+                    break;
+                case "last-modified":
+                    $response->setLastModified( new DateTime( $headerValue ) );
+                    break;
+                case "expires":
+                    $response->setExpires( new DateTime( $headerValue ) );
+                    break;
+                default;
+                    $response->headers->set( $headerName, $headerValue, true );
+                    break;
+            }
+        }
+
+        return $response;
+    }
+
+    /**
+     * Wraps header_remove() function.
+     * This is mainly to isolate it and become testable.
+     *
+     * @param string $headerName
+     */
+    protected function removeHeader( $headerName )
+    {
+        header_remove( $headerName );
+    }
+}

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
@@ -9,6 +9,7 @@ parameters:
     ezpublish_legacy.kernel_handler.treemenu.class: ezpKernelTreeMenu
 
     ezpublish_legacy.controller.class: eZ\Bundle\EzPublishLegacyBundle\Controller\LegacyKernelController
+    ezpublish_legacy.response_manager.class: eZ\Bundle\EzPublishLegacyBundle\LegacyResponse\LegacyResponseManager
     ezpublish_legacy.treemenu.controller.class: eZ\Bundle\EzPublishLegacyBundle\Controller\LegacyTreeMenuController
     ezpublish_legacy.treemenu.controller.options: {}
     ezpublish_legacy.setup.controller.class: eZ\Bundle\EzPublishLegacyBundle\Controller\LegacySetupController
@@ -91,13 +92,17 @@ services:
     ezpublish_legacy.kernel_handler:
         alias: ezpublish_legacy.kernel_handler.web
 
+    ezpublish_legacy.response_manager:
+        class: %ezpublish_legacy.response_manager.class%
+        arguments: [@templating, @ezpublish.config.resolver]
+
     ezpublish_legacy.controller:
         class: %ezpublish_legacy.controller.class%
         arguments:
             - @ezpublish_legacy.kernel
-            - @templating
             - @ezpublish.config.resolver
             - @ezpublish_legacy.uri_helper
+            - @ezpublish_legacy.response_manager
         calls:
             - [setRequest, [@?request=]]
 

--- a/eZ/Bundle/EzPublishLegacyBundle/Tests/LegacyResponse/LegacyResponseManagerTest.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Tests/LegacyResponse/LegacyResponseManagerTest.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * File containing the LegacyResponseManagerTest class.
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishLegacyBundle\Tests\LegacyResponse;
+
+use eZ\Bundle\EzPublishLegacyBundle\LegacyResponse\LegacyResponseManager;
+use eZ\Bundle\EzPublishLegacyBundle\LegacyResponse;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Templating\EngineInterface;
+use ezpKernelResult;
+use DateTime;
+
+class LegacyResponseManagerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var EngineInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $templateEngine;
+
+    /**
+     * @var ConfigResolverInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $configResolver;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->templateEngine = $this->getMock( 'Symfony\Component\Templating\EngineInterface' );
+        $this->configResolver = $this->getMock( 'eZ\Publish\Core\MVC\ConfigResolverInterface' );
+    }
+
+    /**
+     * Tests response generation when no custom layout can be applied:
+     *  - Custom layout provided, but in legacy mode
+     *  - Custom layout provided, module_result presents a "pagelayout" entry
+     *  - Legacy mode active, no custom layout
+     *
+     * @param string|null $customLayout Custom Twig layout being used, or null if none.
+     * @param bool $legacyMode Whether legacy mode is active or not.
+     * @param bool $moduleResultLayout Whether if module_result from legacy contains a "pagelayout" entry.
+     *
+     * @dataProvider generateResponseNoCustomLayoutProvider
+     */
+    public function testGenerateResponseNoCustomLayout( $customLayout, $legacyMode, $moduleResultLayout )
+    {
+        $this->configResolver
+            ->expects( $this->any() )
+            ->method( 'getParameter' )
+            ->will(
+                $this->returnValueMap(
+                    array(
+                        array( 'module_default_layout', 'ezpublish_legacy', null, $customLayout ),
+                        array( 'legacy_mode', null, null, $legacyMode )
+                    )
+                )
+            );
+        $this->templateEngine
+            ->expects( $this->never() )
+            ->method( 'render' );
+
+        $manager = new LegacyResponseManager( $this->templateEngine, $this->configResolver );
+        $content = 'foobar';
+        $moduleResult = array(
+            'content' => $content,
+            'errorCode' => 200,
+        );
+        if ( $moduleResultLayout )
+            $moduleResult['pagelayout'] = 'design:some_page_layout.tpl';
+
+        $kernelResult = new ezpKernelResult( $content, array( 'module_result' => $moduleResult ) );
+
+        $response = $manager->generateResponseFromModuleResult( $kernelResult );
+        $this->assertInstanceOf( 'eZ\Bundle\EzPublishLegacyBundle\LegacyResponse', $response );
+        $this->assertSame( $content, $response->getContent() );
+        $this->assertSame( $moduleResult['errorCode'], $response->getStatusCode() );
+    }
+
+    public function generateResponseNoCustomLayoutProvider()
+    {
+        return array(
+            array( null, false, false ),
+            array( 'foo.html.twig', true, false ),
+            array( 'foo.html.twig', false, true ),
+            array( null, false, true ),
+            array( null, true, true ),
+        );
+    }
+
+    /**
+     * @dataProvider generateResponseWithCustomLayoutProvider
+     */
+    public function testGenerateResponseWithCustomLayout( $customLayout, $content )
+    {
+        $contentWithLayout = "<div id=\"i-am-a-twig-layout\">$content</div>";
+        $moduleResult = array(
+            'content' => $content,
+            'errorCode' => 200,
+        );
+
+        $this->configResolver
+            ->expects( $this->any() )
+            ->method( 'getParameter' )
+            ->will(
+                $this->returnValueMap(
+                    array(
+                        array( 'module_default_layout', 'ezpublish_legacy', null, $customLayout ),
+                        array( 'legacy_mode', null, null, false )
+                    )
+                )
+            );
+        $this->templateEngine
+            ->expects( $this->once() )
+            ->method( 'render' )
+            ->with( $customLayout, array( 'module_result' => $moduleResult ) )
+            ->will( $this->returnValue( $contentWithLayout ) );
+
+        $manager = new LegacyResponseManager( $this->templateEngine, $this->configResolver );
+
+        $kernelResult = new ezpKernelResult( $content, array( 'module_result' => $moduleResult ) );
+
+        $response = $manager->generateResponseFromModuleResult( $kernelResult );
+        $this->assertInstanceOf( 'eZ\Bundle\EzPublishLegacyBundle\LegacyResponse', $response );
+        $this->assertSame( $contentWithLayout, $response->getContent() );
+        $this->assertSame( $moduleResult['errorCode'], $response->getStatusCode() );
+        $this->assertSame( $moduleResult, $response->getModuleResult() );
+    }
+
+    public function generateResponseWithCustomLayoutProvider()
+    {
+        return array(
+            array( 'foo.html.twig', 'Hello world!' ),
+            array( 'foo.html.twig', 'שלום עולם!' ),
+            array( 'bar.html.twig', 'こんにちは、世界' ),
+            array( 'i_am_a_custom_layout.html.twig', 'Know what? I\'m a legacy content!' ),
+            array( 'custom.twig', 'I love content management.' ),
+            array( 'custom.twig', '私は、コンテンツ管理が大好きです。' ),
+            array( 'custom.twig', 'אני אוהב את ניהול תוכן.' ),
+        );
+    }
+
+    public function testMapHeaders()
+    {
+        $etag = '86fb269d190d2c85f6e0468ceca42a20';
+        $date = new DateTime();
+        $dateForCache = $date->format( 'D, d M Y H:i:s' ).' GMT';
+        $headers = array( 'X-Foo: Bar', "Etag: $etag", "Last-Modified: $dateForCache", "Expires: $dateForCache" );
+
+        // Partially mock the manager to simulate calls to header_remove()
+        $manager = $this->getMockBuilder( 'eZ\Bundle\EzPublishLegacyBundle\LegacyResponse\LegacyResponseManager' )
+            ->setConstructorArgs( array( $this->templateEngine, $this->configResolver ) )
+            ->setMethods( array( 'removeHeader' ) )
+            ->getMock();
+        $manager
+            ->expects( $this->exactly( count( $headers ) ) )
+            ->method( 'removeHeader' );
+        /** @var \eZ\Bundle\EzPublishLegacyBundle\LegacyResponse\LegacyResponseManager|\PHPUnit_Framework_MockObject_MockObject $manager */
+        $response = new LegacyResponse();
+        $responseMappedHeaders = $manager->mapHeaders( $headers, $response );
+        $this->assertSame( spl_object_hash( $response ), spl_object_hash( $responseMappedHeaders ) );
+        $this->assertSame( 'Bar', $responseMappedHeaders->headers->get( 'X-Foo' ) );
+        $this->assertSame( '"' . $etag . '"', $responseMappedHeaders->getEtag() );
+        $this->assertEquals( new DateTime( $dateForCache ), $responseMappedHeaders->getLastModified() );
+        $this->assertEquals( new DateTime( $dateForCache ), $responseMappedHeaders->getExpires() );
+    }
+}


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-21924

See https://insight.sensiolabs.com/projects/0885c0ce-4b9f-4b89-aa9c-e8f9f7a315e0/analyses/7#rule-24-034

This PR refactors `LegacyKernelController` to be thiner and delegates `LegacyResponse` generation to new `LegacyResponseManager` service.

Note that `mapHeaders()` cannot be tested because of [issues in PHPUnit with process isolation](https://github.com/sebastianbergmann/phpunit/issues/314) (see also [this issue on testing headers with PHPUnit](https://github.com/sebastianbergmann/phpunit/issues/720))
