### PR TITLE
Fix EZP-21548: Clear role assignments cache when dealing with locations

### DIFF
--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyAssignUserToUserGroupSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyAssignUserToUserGroupSlot.php
@@ -10,7 +10,8 @@
 namespace eZ\Publish\Core\SignalSlot\Slot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
-use eZCache;
+use eZContentCacheManager;
+use eZRole;
 
 /**
  * A legacy slot handling AssignUserToUserGroupSignal.
@@ -35,7 +36,8 @@ class LegacyAssignUserToUserGroupSlot extends AbstractLegacySlot
         $kernel->runCallback(
             function ()
             {
-                eZCache::clearByID( "user_info_cache" );
+                eZContentCacheManager::clearAllContentCache();
+                eZRole::expireCache();
             },
             false
         );

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyUnassignUserFromUserGroupSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyUnassignUserFromUserGroupSlot.php
@@ -10,7 +10,8 @@
 namespace eZ\Publish\Core\SignalSlot\Slot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
-use eZCache;
+use eZContentCacheManager;
+use eZRole;
 
 /**
  * A legacy slot handling UnAssignUserFromUserGroupSignal.
@@ -35,7 +36,8 @@ class LegacyUnassignUserFromUserGroupSlot extends AbstractLegacySlot
         $kernel->runCallback(
             function ()
             {
-                eZCache::clearByID( "user_info_cache" );
+                eZContentCacheManager::clearAllContentCache();
+                eZRole::expireCache();
             },
             false
         );


### PR DESCRIPTION
This PR resolves issue https://jira.ez.no/browse/EZP-21548

This fixes clearing of caches when assigning/unassigning User to UserGroup.
Same caches are now cleared as in Legacy Stack role/assign module.
