### PR TITLE
Fix EZP-21940: delete location doesn't fully expire stash cache

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Cache/PersistenceCachePurger.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Cache/PersistenceCachePurger.php
@@ -158,6 +158,7 @@ class PersistenceCachePurger implements CacheClearerInterface
                 $location = $this->locationHandler->load( $id );
                 $this->cache->clear( 'content', $location->contentId );
                 $this->cache->clear( 'content', 'info', $location->contentId );
+                $this->cache->clear( 'content', 'locations', $location->contentId );
             }
             catch ( NotFoundException $e )
             {

--- a/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
@@ -59,8 +59,14 @@ class LocationHandler extends AbstractHandler implements LocationHandlerInterfac
      */
     public function loadLocationsByContent( $contentId, $rootLocationId = null )
     {
-        $rootKey = $rootLocationId ? '/root/' . $rootLocationId : '';
-        $cache = $this->cache->getItem( 'content', 'locations', $contentId . $rootKey );
+        if ( $rootLocationId )
+        {
+            $cache = $this->cache->getItem( 'content', 'locations', $contentId, 'root', $rootLocationId );
+        }
+        else
+        {
+            $cache = $this->cache->getItem( 'content', 'locations', $contentId );
+        }
         $locationIds = $cache->get();
         if ( $cache->isMiss() )
         {
@@ -88,7 +94,7 @@ class LocationHandler extends AbstractHandler implements LocationHandlerInterfac
      */
     public function loadParentLocationsForDraftContent( $contentId )
     {
-        $cache = $this->cache->getItem( 'content', 'locations', "{$contentId}/parentLocationsForDraftContent" );
+        $cache = $this->cache->getItem( 'content', 'locations', $contentId, 'parentLocationsForDraftContent' );
         $locationIds = $cache->get();
         if ( $cache->isMiss() )
         {
@@ -218,7 +224,7 @@ class LocationHandler extends AbstractHandler implements LocationHandlerInterfac
         $this->cache->clear( 'location', 'subtree' );
         $this->cache->clear( 'content', 'locations', $location->contentId );
         $this->cache->clear( 'user', 'role', 'assignments', 'byGroup', $location->contentId );
-        $this->cache->clear( 'user', 'role', 'assignments', 'byGroup', 'inherited/' . $location->contentId );
+        $this->cache->clear( 'user', 'role', 'assignments', 'byGroup', 'inherited', $location->contentId );
 
         return $location;
     }

--- a/eZ/Publish/Core/Persistence/Cache/Tests/LocationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/LocationHandlerTest.php
@@ -209,7 +209,7 @@ class LocationHandlerTest extends HandlerTest
         $this->cacheMock
             ->expects( $this->once() )
             ->method( 'getItem' )
-            ->with( 'content', 'locations', "44/parentLocationsForDraftContent" )
+            ->with( 'content', 'locations', '44', 'parentLocationsForDraftContent' )
             ->will( $this->returnValue( $cacheItemMock ) );
 
         $cacheItemMock
@@ -258,7 +258,7 @@ class LocationHandlerTest extends HandlerTest
         $this->cacheMock
             ->expects( $this->at( 0 ) )
             ->method( 'getItem' )
-            ->with( 'content', 'locations', "44/parentLocationsForDraftContent" )
+            ->with( 'content', 'locations', '44', 'parentLocationsForDraftContent' )
             ->will( $this->returnValue( $cacheItemMock ) );
 
         $cacheItemMock
@@ -311,7 +311,7 @@ class LocationHandlerTest extends HandlerTest
         $this->cacheMock
             ->expects( $this->once() )
             ->method( 'getItem' )
-            ->with( 'content', 'locations', '44/root/2' )
+            ->with( 'content', 'locations', '44', 'root', '2' )
             ->will( $this->returnValue( $cacheItemMock ) );
 
         $cacheItemMock
@@ -360,7 +360,7 @@ class LocationHandlerTest extends HandlerTest
         $this->cacheMock
             ->expects( $this->at( 0 ) )
             ->method( 'getItem' )
-            ->with( 'content', 'locations', '44/root/2' )
+            ->with( 'content', 'locations', '44', 'root', '2' )
             ->will( $this->returnValue( $cacheItemMock ) );
 
         $cacheItemMock
@@ -714,7 +714,7 @@ class LocationHandlerTest extends HandlerTest
         $this->cacheMock
             ->expects( $this->at( 4 ) )
             ->method( 'clear' )
-            ->with( 'user', 'role', 'assignments', 'byGroup', 'inherited/' . 2 )
+            ->with( 'user', 'role', 'assignments', 'byGroup', 'inherited', 2 )
             ->will( $this->returnValue( true ) );
 
         $handler = $this->persistenceHandler->locationHandler();

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
@@ -123,26 +123,13 @@ class UrlAliasHandlerTest extends HandlerTest
             ->will( $this->returnValue( new UrlAlias( array( 'id' => 55, 'destination' => 44 ) ) ) );
 
         $cacheItemMock = $this->getMock( 'Stash\\Item', array(), array(), '', false );
+
+        $cacheItemLocationMock = $this->getMock( 'Stash\\Item', array(), array(), '', false );
         $this->cacheMock
             ->expects( $this->at( 0 ) )
             ->method( 'getItem' )
-            ->with( 'urlAlias', 55 )
-            ->will( $this->returnValue( $cacheItemMock ) );
-
-        $cacheItemMock
-            ->expects( $this->once() )
-            ->method( 'set' )
-            ->with( $this->isInstanceOf( 'eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias' ) );
-
-        $cacheItemMock
-            ->expects( $this->never() )
-            ->method( 'get' );
-
-        $this->cacheMock
-            ->expects( $this->at( 1 ) )
-            ->method( 'clear' )
             ->with( 'urlAlias', 'location', 44, 'custom' )
-            ->will( $this->returnValue( $cacheItemMock ) );
+            ->will( $this->returnValue( $cacheItemLocationMock ) );
 
         $handler = $this->persistenceHandler->urlAliasHandler();
         $handler->createCustomUrlAlias( 44, '/path', true, 'eng-GB', true );
@@ -251,7 +238,7 @@ class UrlAliasHandlerTest extends HandlerTest
         $this->cacheMock
             ->expects( $this->once() )
             ->method( 'getItem' )
-            ->with( 'urlAlias', 'location', '44/custom' )
+            ->with( 'urlAlias', 'location', '44', 'custom' )
             ->will( $this->returnValue( $cacheItemMock ) );
 
         $cacheItemMock
@@ -384,7 +371,7 @@ class UrlAliasHandlerTest extends HandlerTest
         $this->cacheMock
             ->expects( $this->at( 0 ) )
             ->method( 'getItem' )
-            ->with( 'urlAlias', 'location', '44/custom' )
+            ->with( 'urlAlias', 'location', '44', 'custom' )
             ->will( $this->returnValue( $cacheItemMock ) );
 
         $cacheItemMock

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UserHandlerTest.php
@@ -381,7 +381,7 @@ class UserHandlerTest extends HandlerTest
         $this->cacheMock
             ->expects( $this->once() )
             ->method( 'getItem' )
-            ->with( 'user', 'role', 'assignments', 'byGroup', 'inherited/42' )
+            ->with( 'user', 'role', 'assignments', 'byGroup', 'inherited', '42' )
             ->will( $this->returnValue( $cacheItemMock ) );
 
         $cacheItemMock
@@ -432,7 +432,7 @@ class UserHandlerTest extends HandlerTest
         $this->cacheMock
             ->expects( $this->once() )
             ->method( 'getItem' )
-            ->with( 'user', 'role', 'assignments', 'byGroup', 'inherited/42' )
+            ->with( 'user', 'role', 'assignments', 'byGroup', 'inherited', '42' )
             ->will( $this->returnValue( $cacheItemMock ) );
 
         $cacheItemMock

--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -74,8 +74,16 @@ class UrlAliasHandler extends AbstractHandler implements UrlAliasHandlerInterfac
             $locationId, $path, $forwarding, $languageCode, $alwaysAvailable
         );
 
-        $this->cache->getItem( 'urlAlias', $urlAlias->id )->set( $urlAlias );
-        $this->cache->clear( 'urlAlias', 'location', $urlAlias->destination, 'custom' );
+        $cache = $this->cache->getItem( 'urlAlias', 'location', $urlAlias->destination, 'custom' );
+        $urlAliasIds = $cache->get();
+        if ( $cache->isMiss() )
+        {
+            $urlAliasIds = array();
+        }
+
+        $urlAliasIds[] = $urlAlias->id;
+        $cache->set( $urlAliasIds );
+
         return $urlAlias;
     }
 
@@ -118,7 +126,14 @@ class UrlAliasHandler extends AbstractHandler implements UrlAliasHandlerInterfac
     public function listURLAliasesForLocation( $locationId, $custom = false )
     {
         // Look for location to list of url alias id's cache
-        $cache = $this->cache->getItem( 'urlAlias', 'location', $locationId . ( $custom ? '/custom' : '' ) );
+        if ( $custom )
+        {
+            $cache = $this->cache->getItem( 'urlAlias', 'location', $locationId, 'custom' );
+        }
+        else
+        {
+            $cache = $this->cache->getItem( 'urlAlias', 'location', $locationId );
+        }
         $urlAliasIds = $cache->get();
         if ( $cache->isMiss() )
         {
@@ -156,6 +171,8 @@ class UrlAliasHandler extends AbstractHandler implements UrlAliasHandlerInterfac
             $this->cache->clear( 'urlAlias', $urlAlias->id );
             if ( $urlAlias->type === UrlAlias::LOCATION )
                 $this->cache->clear( 'urlAlias', 'location', $urlAlias->destination );
+            if ( $urlAlias->isCustom )
+                $this->cache->clear( 'urlAlias', 'location', $urlAlias->destination, 'custom' );
         }
 
         return $return;

--- a/eZ/Publish/Core/Persistence/Cache/UserHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UserHandler.php
@@ -153,8 +153,14 @@ class UserHandler extends AbstractHandler implements UserHandlerInterface
      */
     public function loadRoleAssignmentsByGroupId( $groupId, $inherit = false )
     {
-        $cacheKey = ( $inherit ? 'inherited/' : '' ) . $groupId;
-        $cache = $this->cache->getItem( 'user', 'role', 'assignments', 'byGroup', $cacheKey );
+        if ( $inherit )
+        {
+            $cache = $this->cache->getItem( 'user', 'role', 'assignments', 'byGroup', 'inherited', $groupId );
+        }
+        else
+        {
+            $cache = $this->cache->getItem( 'user', 'role', 'assignments', 'byGroup', $groupId );
+        }
         $assignments = $cache->get();
         if ( $cache->isMiss() )
         {

--- a/eZ/Publish/Core/Repository/URLAliasService.php
+++ b/eZ/Publish/Core/Repository/URLAliasService.php
@@ -562,6 +562,8 @@ class URLAliasService implements URLAliasServiceInterface
         return new SPIURLAlias(
             array(
                 "id" => $urlAlias->id,
+                "type" => $urlAlias->type,
+                "destination" => $urlAlias->destination,
                 "isCustom" => $urlAlias->isCustom
             )
         );


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-21940

Make sure to expire content/locations/<contentId> cache in legacy PersistenceCachePurger,
For the expiry to work, LocationHandler cache must also use rootLocation as a subkey of contentId.
