### PR TITLE
Fix for EZP-21961: Country\Type::getName()

### DIFF
--- a/eZ/Publish/Core/FieldType/Country/Type.php
+++ b/eZ/Publish/Core/FieldType/Country/Type.php
@@ -66,16 +66,7 @@ class Type extends FieldType
      */
     public function getName( SPIValue $value )
     {
-        return implode(
-            ", ",
-            array_map(
-                function ( $countryInfo )
-                {
-                    return $countryInfo["Name"];
-                },
-                $this->countriesInfo
-            )
-        );
+        return (string)$value;
     }
 
     /**


### PR DESCRIPTION
http://jira.ez.no/browse/EZP-21961

Wasn't using the Field's value but init data. Discovered in https://github.com/ezsystems/ezpublish-kernel/pull/621, where it has coverage.
