### PR TITLE
Fix EZP-21955: Access to restricted content results in error 500

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewControllerListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewControllerListener.php
@@ -90,7 +90,7 @@ class ViewControllerListener implements EventSubscriberInterface
         }
         catch ( UnauthorizedException $e)
         {
-            throw new AccessDeniedException( 'Access Denied', $e );
+            throw new AccessDeniedException();
         }
 
         if ( !isset( $valueObject ) )

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
@@ -109,7 +109,7 @@ class ViewController extends Controller
         }
         catch ( UnauthorizedException $e )
         {
-            throw new AccessDeniedException( 'Access Denied', $e );
+            throw new AccessDeniedException();
         }
         catch ( Exception $e )
         {
@@ -153,7 +153,7 @@ class ViewController extends Controller
         }
         catch ( UnauthorizedException $e )
         {
-            throw new AccessDeniedException( 'Access Denied', $e );
+            throw new AccessDeniedException();
         }
         catch ( Exception $e )
         {


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-21955

Previous PR: https://github.com/ezsystems/ezpublish-kernel/pull/618
## Description

Giving arguments to the AccessDeniedException leads to side effects and an error 500 being sent. I opened an issue on the symfony bugtracker regarding this: https://github.com/symfony/symfony/issues/9544

Example on symfony's documentation show usage of this exception with no arguments: http://symfony.com/doc/current/cookbook/security/securing_services.html
## Test

Manual tests
