### PR TITLE
EZP-21994: also use TRUSTED_PROXIES by default for user-hash generation.

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Kernel.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Kernel.php
@@ -78,7 +78,7 @@ abstract class Kernel extends BaseKernel
 
     /**
      * Checks if current request is allowed to generate the user hash.
-     * Default behavior is to only accept local IP addresses:
+     * Default behavior is to accept values set in TRUSTED_PROXIES env variable and local IP addresses:
      *  - 127.0.0.1
      *  - ::1
      *  - fe80::1
@@ -89,9 +89,19 @@ abstract class Kernel extends BaseKernel
      */
     protected function canGenerateUserHash( Request $request )
     {
+        $trustedProxies = array_unique(
+            array_merge(
+                Request::getTrustedProxies(),
+                array(
+                    '127.0.0.1',
+                    '::1',
+                    'fe80::1'
+                )
+            )
+        );
         return
             $request->attributes->get( 'internalRequest' )
-            || in_array( $request->getClientIp(), array( '127.0.0.1', '::1', 'fe80::1' ) );
+            || in_array( $request->getClientIp(), $trustedProxies );
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/KernelTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/KernelTest.php
@@ -247,6 +247,43 @@ class KernelTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers eZ\Bundle\EzPublishCoreBundle\Kernel::handle
      * @covers eZ\Bundle\EzPublishCoreBundle\Kernel::isUserHashRequest
+     * @covers eZ\Bundle\EzPublishCoreBundle\Kernel::canGenerateUserHash
+     */
+    public function testHandleAuthenticateWithTrustedProxy()
+    {
+        Request::setTrustedProxies( array( '10.11.12.13' ) );
+
+        $hash = '123abc';
+        $request = new Request();
+        $request->headers->add(
+            array(
+                'X-HTTP-Override' => 'AUTHENTICATE',
+                'Accept' => Kernel::USER_HASH_ACCEPT_HEADER
+            )
+        );
+        $request->server->set( 'REMOTE_ADDR', '10.11.12.13' );
+
+        /** @var \PHPUnit_Framework_MockObject_MockObject|Kernel $kernel */
+        $kernel = $this
+            ->getMockBuilder( 'eZ\\Bundle\\EzPublishCoreBundle\\Kernel' )
+            ->disableOriginalConstructor()
+            ->setMethods( array( 'generateUserHash' ) )
+            ->getMockForAbstractClass();
+        $kernel
+            ->expects( $this->once() )
+            ->method( 'generateUserHash' )
+            ->with( $request )
+            ->will( $this->returnValue( $hash ) );
+
+        $response = $kernel->handle( $request );
+        $this->assertInstanceOf( 'Symfony\\Component\\HttpFoundation\\Response', $response );
+        $this->assertSame( 200, $response->getStatusCode() );
+        $this->assertSame( $hash, $response->headers->get( 'X-User-Hash' ) );
+    }
+
+    /**
+     * @covers eZ\Bundle\EzPublishCoreBundle\Kernel::handle
+     * @covers eZ\Bundle\EzPublishCoreBundle\Kernel::isUserHashRequest
      */
     public function testHandleRegular()
     {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-21994

For X-User-Hash generation purposes, Kernel should trust the hosts defined in `TRUSTED_PROXIES` besides local IP addresses.
This allows for customization without the need to override the kernel.
