### PR TITLE
EZP-21990: Implement Field Storage publish events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "ezsystems/ezpublish-legacy": "@dev",
         "mikey179/vfsStream": "1.1.0",
         "phpunit/phpunit": "3.7.*",
+        "mockery/mockery": "dev-fix_multiple_interfaces_mock",
         "matthiasnoback/symfony-dependency-injection-test": "0.2.*"
     },
     "replace": {
@@ -66,5 +67,11 @@
             "dev-master": "5.2.x-dev"
         },
         "ezpublish-legacy-dir": "vendor/ezsystems/ezpublish-legacy"
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/bdunogier/mockery"
+        }
+    ]
 }

--- a/eZ/Publish/Core/FieldType/NullStorage.php
+++ b/eZ/Publish/Core/FieldType/NullStorage.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType;
 
 use eZ\Publish\SPI\FieldType\FieldStorage;
+use eZ\Publish\SPI\FieldType\FieldStorageEvent;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
 

--- a/eZ/Publish/Core/Persistence/InMemory/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/InMemory/ContentHandler.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\Persistence\InMemory;
 
+use eZ\Publish\SPI\FieldType\FieldStorage\Event as FieldStorageEvent;
 use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandlerInterface;
 use eZ\Publish\Core\Persistence\FieldTypeRegistry;
 use eZ\Publish\SPI\Persistence\Content\CreateStruct;
@@ -959,6 +960,11 @@ class ContentHandler implements ContentHandlerInterface
             )
         );
 
+        return $this->load( $contentId, $versionNo );
+    }
+
+    public function sendFieldStorageEvent( $contentId, $versionNo, FieldStorageEvent $event )
+    {
         return $this->load( $contentId, $versionNo );
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/StorageHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/StorageHandler.php
@@ -9,6 +9,8 @@
 
 namespace eZ\Publish\Core\Persistence\Legacy\Content;
 
+use eZ\Publish\SPI\FieldType\FieldStorage\Event as FieldStorageEvent;
+use eZ\Publish\SPI\FieldType\FieldStorage\EventAware as EventAwareFieldStorage;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 
@@ -109,5 +111,24 @@ class StorageHandler
     {
         $this->storageRegistry->getStorage( $fieldType )
             ->deleteFieldData( $versionInfo, $ids, $this->context );
+    }
+
+    /**
+     * Sends the storage event $event
+     *
+     * The event object must reference the VersionInfo and Field it affects.
+     *
+     * @param FieldStorageEvent $fieldStorageEvent
+     *
+     * @return bool true if data was modified by the event
+     */
+    public function sendEvent( FieldStorageEvent $event )
+    {
+        $fieldStorage = $this->storageRegistry->getStorage( $event->getField()->type );
+
+        if ( !$fieldStorage instanceof EventAwareFieldStorage )
+            return false;
+
+        return $fieldStorage->handleEvent( $event, $this->context );
     }
 }

--- a/eZ/Publish/SPI/FieldType/FieldStorage/Event.php
+++ b/eZ/Publish/SPI/FieldType/FieldStorage/Event.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * File containing the Event base class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\SPI\FieldType\FieldStorage;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+
+/**
+ * Interface for FieldType events
+ *
+ * An instance of a derived class is given to {@link
+ * eZ\Publish\SPI\FieldType\EventListener::handleEvent()}. The derived class name
+ * identified the occurred event. The properties of the class give the needed
+ * event context.
+ */
+interface Event
+{
+    /**
+     * @return Field
+     */
+    public function getField();
+
+    /**
+     * @param Field $field
+     */
+    public function setField( Field $field );
+
+    /**
+     * @return VersionInfo
+     */
+    public function getVersionInfo();
+
+    /**
+     * @param VersionInfo $versionInfo
+     */
+    public function setVersionInfo( VersionInfo $versionInfo );
+}

--- a/eZ/Publish/SPI/FieldType/FieldStorage/EventAware.php
+++ b/eZ/Publish/SPI/FieldType/FieldStorage/EventAware.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * File containing the EventAware class.
+ *
+ * @copyright Copyright (C) 2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace eZ\Publish\SPI\FieldType\FieldStorage;
+
+use eZ\Publish\SPI\FieldType;
+
+/**
+ * Can be implemented by {@see eZ\Publish\SPI\FieldStorage} handlers to receive storage events.
+ *
+ *
+ */
+interface EventAware
+{
+    /**
+     * Handles storage event $event.
+     *
+     * $event provides the VersionInfo and Field objects the even is occuring on
+     *
+     * @param Event $event
+     * @param array $context
+     *
+     * @return bool True if data was modified and needs to be stored
+     */
+    public function handleEvent( Event $event, array $context );
+}

--- a/eZ/Publish/SPI/FieldType/FieldStorage/Events/BaseEvent.php
+++ b/eZ/Publish/SPI/FieldType/FieldStorage/Events/BaseEvent.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * File containing the BaseEvent class.
+ *
+ * @copyright Copyright (C) 2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace eZ\Publish\SPI\FieldType\FieldStorage\Events;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+
+/**
+ * Abstract class for FieldType storage events.
+ * Will be provided to FieldStorage handlers when applicable,
+ * and provide access to the event properties (field and versionInfo).
+ */
+abstract class BaseEvent
+{
+    /**
+     * Field the event occurred on
+     * @var Field
+     */
+    protected $field;
+
+    /**
+     * VersionInfo of the Content the affected field belongs to
+     * @var VersionInfo
+     */
+    protected $versionInfo;
+
+    /**
+     * @return Field
+     */
+    public function getField()
+    {
+        return $this->field;
+    }
+
+    /**
+     * @return VersionInfo
+     */
+    public function getVersionInfo()
+    {
+        return $this->versionInfo;
+    }
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content\Field
+     */
+    public function setField( Field $field )
+    {
+        $this->field = $field;
+    }
+
+    /**
+     * @return VersionInfo
+     */
+    public function setVersionInfo( VersionInfo $versionInfo )
+    {
+        $this->versionInfo = $versionInfo;
+    }
+}

--- a/eZ/Publish/SPI/FieldType/FieldStorage/Events/PostPublishFieldStorageEvent.php
+++ b/eZ/Publish/SPI/FieldType/FieldStorage/Events/PostPublishFieldStorageEvent.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the PostPublishEvent class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\SPI\FieldType\FieldStorage\Events;
+
+use eZ\Publish\SPI\FieldType\FieldStorage\Event as FieldStorageEvent;
+
+/**
+ * Event triggered after a field of the FieldType has been published.
+ */
+class PostPublishFieldStorageEvent extends BaseEvent implements FieldStorageEvent
+{
+}

--- a/eZ/Publish/SPI/FieldType/FieldStorage/Events/PrePublishFieldStorageEvent.php
+++ b/eZ/Publish/SPI/FieldType/FieldStorage/Events/PrePublishFieldStorageEvent.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * File containing the PrePublishEvent class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\SPI\FieldType\FieldStorage\Events;
+
+use eZ\Publish\SPI\FieldType\FieldStorage\Event as FieldStorageEvent;
+
+/**
+ * Event triggered before a field of the FieldType is published.
+ */
+class PrePublishFieldStorageEvent extends BaseEvent implements FieldStorageEvent
+{
+}

--- a/eZ/Publish/SPI/Persistence/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Handler.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\SPI\Persistence\Content;
 
 // @todo We must verify whether we want to type cast on the "Criterion" interface or abstract class
 use eZ\Publish\SPI\Persistence\Content\Relation\CreateStruct as RelationCreateStruct;
+use eZ\Publish\SPI\FieldType\FieldStorage\Event as FieldStorageEvent;
 
 /**
  * The Content Handler interface defines content operations on the storage engine.
@@ -255,4 +256,15 @@ interface Handler
      * @return \eZ\Publish\SPI\Persistence\Content The published Content
      */
     public function publish( $contentId, $versionNo, MetadataUpdateStruct $metaDataUpdateStruct );
+
+    /**
+     * Sends $event to all fields of a ContentVersion
+     *
+     * @param mixed  $contentId
+     * @param int $versionNo
+     * @param FieldStorageEvent $event
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content The modified content
+     */
+    public function sendFieldStorageEvent( $contentId, $versionNo, FieldStorageEvent $event );
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -77,4 +77,8 @@
       </exclude>
     </whitelist>
   </filter>
+
+  <listeners>
+      <listener class="\Mockery\Adapter\Phpunit\TestListener"></listener>
+  </listeners>
 </phpunit>


### PR DESCRIPTION
See https://jira.ez.no/browse/EZP-21990.

Adds Field Storage events upon content publishing (pre/post).
Required by https://jira.ez.no/browse/EZP-21213.

Should have enough coverage, but this should be tested.
# TODO
- [x] Improve coverage
- [x] Refactor events to use an optional `FieldStorage\EventAware` interface
