### PR TITLE
Fixed: invalid depends annotation causing skipped test

### DIFF
--- a/eZ/Publish/API/Repository/Tests/LanguageServiceMaximumSupportedLanguagesTest.php
+++ b/eZ/Publish/API/Repository/Tests/LanguageServiceMaximumSupportedLanguagesTest.php
@@ -65,7 +65,7 @@ class LanguageServiceMaximumSupportedLanguagesTest extends BaseTest
      *
      * @see \eZ\Publish\API\Repository\LanguageService::createLanguage()
      *
-     * @depends \eZ\Publish\API\Repository\Tests\LanguageServiceTest::testNewLanguageCreateStruct
+     * @depends eZ\Publish\API\Repository\Tests\LanguageServiceTest::testNewLanguageCreateStruct
      *
      * @expectedException \RuntimeException
      * @expectedExceptionMessage Maximum number of languages reached!


### PR DESCRIPTION
Minor fix, wrong `@depends` caused skipping `LanguageServiceMaximumSupportedLanguagesTest`.
Waiting for Travis to confirm.
