### PR TITLE
Do not depend on current working directory to find config.php in tests

### DIFF
--- a/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
@@ -64,7 +64,7 @@ abstract class BaseIntegrationTest extends TestCase
         static $installDir = null;
         if ( $installDir === null )
         {
-            $config = require 'config.php';
+            $config = require __DIR__ . '/../../../../../config.php';
             $installDir = $config['service']['parameters']['install_dir'];
         }
         return $installDir;


### PR DESCRIPTION
Unit tests for [NetgenTagsBundle](https://github.com/netgen/TagsBundle) can be ran from the root directory of eZ Publish 5. They require that the file `vendor/ezsystems/ezpublish-kernel/config.php-DEVELOPMENT` is copied to `vendor/ezsystems/ezpublish-kernel/config.php` and since `vendor/ezsystems/ezpublish-kernel/` directory is not the current working directory, some of the tests in `NetgenTagsBundle` fail.

This change makes sure that `config.php` is found by using the `__DIR__` constant rather than depending on current working directory.
