### PR TITLE
EZP-21976 Fix empty binary file field returning "()"

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -190,7 +190,7 @@
 {# @todo: handle the unit of the fileSize (si operator in legacy template engine) #}
 {% block ezbinaryfile_field %}
 {% spaceless %}
-    {% if field.value %}
+    {% if field.value.fileName %}
         {% set uri = 'content/download/' ~ contentInfo.id ~ '/' ~ field.id
                         ~ '/version/' ~ contentInfo.currentVersionNo ~  "/file/"
                         ~ field.value.fileName|escape( 'url' ) %}


### PR DESCRIPTION
link: https://jira.ez.no/browse/EZP-21976

Fixed "()" when we call ez_render_field() on a empty binary file.

Notice that I couldn't use ez_is_field_empty() which use for parameters a 'content' and a 'field' in 
/ezpublish-kernel/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig, 
because the template doesn't have 'content' but only 'contentInfo' .
