### PR TITLE
Fix EZP-22021: legacy images naming

### DIFF
--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -118,12 +118,15 @@ class ImageStorage extends GatewayBasedStorage
         // new image
         if ( isset( $field->value->externalData ) )
         {
-            $targetPath = $this->getFieldPath(
-                $field->id,
-                $versionInfo->versionNo,
-                $field->languageCode,
-                $this->getGateway( $context )->getNodePathString( $versionInfo, $field->id )
-            ) . '/' . $field->value->externalData['fileName'];
+            $targetPath = sprintf(
+                '%s/%s',
+                $this->pathGenerator->getStoragePathForField(
+                    $field->id,
+                    $versionInfo->versionNo,
+                    $field->languageCode
+                ),
+                $field->value->externalData['fileName']
+            );
 
             if ( $this->IOService->exists( $targetPath ) )
             {
@@ -186,26 +189,6 @@ class ImageStorage extends GatewayBasedStorage
 
         // Data has been updated and needs to be stored!
         return true;
-    }
-
-    /**
-     * Returns the path where images for the defined $fieldId are stored
-     *
-     * @param mixed $fieldId
-     * @param int $versionNo
-     * @param string $languageCode
-     * @param string $nodePathString
-     *
-     * @return string
-     */
-    protected function getFieldPath( $fieldId, $versionNo, $languageCode, $nodePathString )
-    {
-        return $this->pathGenerator->getStoragePathForField(
-            $fieldId,
-            $versionNo,
-            $languageCode,
-            $nodePathString
-        );
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/Image/PathGenerator.php
+++ b/eZ/Publish/Core/FieldType/Image/PathGenerator.php
@@ -19,9 +19,8 @@ abstract class PathGenerator
      * @param mixed $fieldId
      * @param int $versionNo
      * @param string $languageCode
-     * @param string $nodePathString
      *
      * @return string
      */
-    abstract public function getStoragePathForField( $fieldId, $versionNo, $languageCode, $nodePathString );
+    abstract public function getStoragePathForField( $fieldId, $versionNo, $languageCode );
 }

--- a/eZ/Publish/Core/FieldType/Image/PathGenerator/LegacyPathGenerator.php
+++ b/eZ/Publish/Core/FieldType/Image/PathGenerator/LegacyPathGenerator.php
@@ -22,18 +22,34 @@ class LegacyPathGenerator extends PathGenerator
      * @param mixed $fieldId
      * @param int $versionNo
      * @param string $languageCode
-     * @param string $nodePathString
      *
      * @return string
      */
-    public function getStoragePathForField( $fieldId, $versionNo, $languageCode, $nodePathString )
+    public function getStoragePathForField( $fieldId, $versionNo, $languageCode )
     {
         return sprintf(
-            '%s%s-%s-%s',
-            $nodePathString, // note that $nodePathString ends with a "/"
+            '%s/%s-%s-%s',
+            $this->getDirectoryStructure( $fieldId ),
             $fieldId,
             $versionNo,
             $languageCode
+        );
+    }
+
+    /**
+     * Computes a 4 levels directory structure from $id
+     * @param string $id
+     * @return string
+     */
+    private function getDirectoryStructure( $id )
+    {
+        return trim(
+            chunk_split(
+                substr( str_pad( $id, 4, 0, STR_PAD_LEFT ), 0, 4 ),
+                1,
+                "/"
+            ),
+            "/"
         );
     }
 }

--- a/eZ/Publish/Core/FieldType/Tests/Image/PathGenerator/LegacyPathGeneratorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Image/PathGenerator/LegacyPathGeneratorTest.php
@@ -36,8 +36,7 @@ class LegacyPathGeneratorTest extends PHPUnit_Framework_TestCase
             $pathGenerator->getStoragePathForField(
                 $data['fieldId'],
                 $data['versionNo'],
-                $data['languageCode'],
-                $data['nodePathString']
+                $data['languageCode']
             )
         );
     }
@@ -47,30 +46,27 @@ class LegacyPathGeneratorTest extends PHPUnit_Framework_TestCase
         return array(
             array(
                 array(
-                    'fieldId' => 23,
+                    'fieldId' => 42,
                     'versionNo' => 1,
-                    'languageCode' => 'eng-US',
-                    'nodePathString' => 'sindelfingen/bielefeld/',
+                    'languageCode' => 'eng-US'
                 ),
-                'sindelfingen/bielefeld/23-1-eng-US',
+                '0/0/4/2/42-1-eng-US',
             ),
             array(
                 array(
                     'fieldId' => 23,
                     'versionNo' => 42,
-                    'languageCode' => 'ger-DE',
-                    'nodePathString' => 'sindelfingen/',
+                    'languageCode' => 'ger-DE'
                 ),
-                'sindelfingen/23-42-ger-DE',
+                '0/0/2/3/23-42-ger-DE',
             ),
             array(
                 array(
-                    'fieldId' => 23,
+                    'fieldId' => 123456,
                     'versionNo' => 2,
-                    'languageCode' => 'eng-GB',
-                    'nodePathString' => null,
+                    'languageCode' => 'eng-GB'
                 ),
-                '23-2-eng-GB',
+                '1/2/3/4/123456-2-eng-GB',
             ),
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
@@ -185,11 +185,8 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
             file_exists( $this->getStorageDir() . '/' . $field->value->data['uri'] ),
             "Stored file " . $field->value->data['uri'] . " doesn't exist"
         );
-
         $this->assertEquals( 'Ice-Flower.jpg', $field->value->data['fileName'] );
-
         $this->assertEquals( 'An icy flower.', $field->value->data['alternativeText'] );
-
         $this->assertNull( $field->value->externalData );
     }
 
@@ -238,17 +235,8 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
             "Stored file ".$field->value->data['uri']." exists"
         );
 
-        // Check old files not removed before update
-        // need to stay there for reference integrity
-        $this->assertEquals(
-            2,
-            count( glob( dirname( $storagePath ) . '/*' ) )
-        );
-
         $this->assertEquals( 'Blueish-Blue.jpg', $field->value->data['fileName'] );
-
         $this->assertEquals( 'This blue is so blueish.', $field->value->data['alternativeText'] );
-
         $this->assertNull( $field->value->externalData );
     }
 


### PR DESCRIPTION
See http://jira.ez.no/browse/EZP-22021

This PR prevents/limits the risk of hitting the filesystem limit on images due to the way 5.x stores images. It splits the directory structure on the field ID to a depth of 4 folders.

Should we maybe make the depth an argument, so that it can easily be increased if necessary ?
