### PR TITLE
Fix EZP-22040 : Link title is not rendered in XMLText Field type

### DIFF
--- a/eZ/Publish/Core/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl
+++ b/eZ/Publish/Core/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl
@@ -165,9 +165,9 @@
                     <xsl:otherwise>_self</xsl:otherwise>
                 </xsl:choose>
             </xsl:attribute>
-            <xsl:if test="@title">
+            <xsl:if test="@xhtml:title">
                 <xsl:attribute name="title">
-                    <xsl:value-of select="@title"/>
+                    <xsl:value-of select="@xhtml:title"/>
                 </xsl:attribute>
             </xsl:if>
             <xsl:copy-of select="@class"/>


### PR DESCRIPTION
Yet another XmlText rendering bug...
