### PR TITLE
Implement EZP-21044: REST OPTIONS

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -112,6 +112,27 @@ situation, the prefix /api/ezp/v2 is used in all REST hrefs.
 Remember in any case that URIs to REST resources should never be generated manually, but obtained from earlier REST
  calls.
 
+OPTIONS requests
+----------------
+
+Any resource URI the REST API responds to will respond to an OPTIONS request.
+
+The Response will contain an Allow header, that as specified in chapter 14.7 of RFC 2616 will list the methods
+accepted by the resource.
+
+Example
+~~~~~~~
+
+.. code:: http
+
+    OPTIONS /content/objects/1 HTTP/1.1
+    Host: api.example.net
+
+.. code:: http
+
+    HTTP/1.1 200 OK
+    Allow: PATCH,GET,DELETE,COPY
+
 Authentication
 ==============
 

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
@@ -1069,10 +1069,3 @@ ezpublish_rest_deleteURLAlias:
     defaults:
         _controller: ezpublish_rest.controller.url_alias:deleteURLAlias
     methods: [DELETE]
-
-ezpublis_rest_catchAll:
-    path: /{requestUri}
-    defaults:
-        _controller: ezpublish_rest.controller.root:catchAll
-    requirements:
-        requestUri: ".*"

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
@@ -1,4 +1,8 @@
 parameters:
+    ezpublish_rest.routing.options_loader.class: eZ\Bundle\EzPublishRestBundle\Routing\OptionsLoader
+    ezpublish_rest.routing.options_loader.route_collection_mapper.class: eZ\Bundle\EzPublishRestBundle\Routing\OptionsLoader\RouteCollectionMapper
+    ezpublish_rest.routing.options_loader.mapper.class: eZ\Bundle\EzPublishRestBundle\Routing\OptionsLoader\Mapper
+
     ezpublish_rest.controller.base.class: eZ\Publish\Core\REST\Server\Controller
     ezpublish_rest.controller.binary_content.class: eZ\Publish\Core\REST\Server\Controller\BinaryContent
     ezpublish_rest.controller.content.class: eZ\Publish\Core\REST\Server\Controller\Content
@@ -12,6 +16,7 @@ parameters:
     ezpublish_rest.controller.user.class: eZ\Publish\Core\REST\Server\Controller\User
     ezpublish_rest.controller.url_wildcard.class: eZ\Publish\Core\REST\Server\Controller\URLWildcard
     ezpublish_rest.controller.url_alias.class: eZ\Publish\Core\REST\Server\Controller\URLAlias
+    ezpublish_rest.controller.options.class: eZ\Publish\Core\REST\Server\Controller\Options
 
     ezpublish_rest.factory.class: eZ\Bundle\EzPublishRestBundle\ApiLoader\Factory
     ezpublish_rest.request_parser.class: eZ\Bundle\EzPublishRestBundle\RequestParser\Router
@@ -59,6 +64,21 @@ parameters:
     ezpublish_rest.input.handler.xml.class: eZ\Publish\Core\REST\Common\Input\Handler\Xml
 
 services:
+    ezpublish_rest.routing.options_loader:
+        class: %ezpublish_rest.routing.options_loader.class%
+        arguments:
+            - @ezpublish_rest.routing.options_loader.route_collection_mapper
+        tags:
+            - { name: routing.loader }
+
+    ezpublish_rest.routing.options_loader.route_collection_mapper:
+        class: %ezpublish_rest.routing.options_loader.route_collection_mapper.class%
+        arguments:
+            - @ezpublish_rest.routing.options_loader.mapper
+
+    ezpublish_rest.routing.options_loader.mapper:
+        class: %ezpublish_rest.routing.options_loader.mapper.class%
+
     ezpublish_rest.field_type_serializer:
         class: %ezpublish_rest.field_type_serializer.class%
         arguments:
@@ -200,6 +220,10 @@ services:
             - %ezpublish_rest.csrf_token_intention%
         tags:
             - { name: kernel.event_subscriber }
+
+    ezpublish_rest.controller.options:
+        class: %ezpublish_rest.controller.options.class%
+        parent: ezpublish_rest.controller.base
 
     ezpublish_rest.field_type_processor_registry:
         class: %ezpublish_rest.field_type_processor_registry.class%

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -111,6 +111,7 @@ parameters:
     ezpublish_rest.output.value_object_visitor.ResourceCreated.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\ResourceCreated
     ezpublish_rest.output.value_object_visitor.PermanentRedirect.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\PermanentRedirect
     ezpublish_rest.output.value_object_visitor.TemporaryRedirect.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\TemporaryRedirect
+    ezpublish_rest.output.value_object_visitor.Options.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\Options
 
 services:
     ezpublish_rest.output.value_object_visitor.base:
@@ -609,3 +610,10 @@ services:
         arguments: [ true  ]
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Values\Conflict }
+
+    ezpublish_rest.output.value_object_visitor.Options:
+        parent: ezpublish_rest.output.value_object_visitor.base
+        class: %ezpublish_rest.output.value_object_visitor.Options.class%
+        arguments: [ true  ]
+        tags:
+            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Values\Options }

--- a/eZ/Bundle/EzPublishRestBundle/Routing/OptionsLoader.php
+++ b/eZ/Bundle/EzPublishRestBundle/Routing/OptionsLoader.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * File containing the Loader class.
+ *
+ * @copyright Copyright (C) 2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishRestBundle\Routing;
+
+use eZ\Bundle\EzPublishRestBundle\Routing\OptionsLoader\Mapper;
+use Symfony\Component\Config\Loader\Loader;
+use eZ\Bundle\EzPublishRestBundle\Routing\OptionsLoader\RouteCollectionMapper;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Goes through all REST routes, and registers new routes for all routes
+ * a new one with the OPTIONS method
+ */
+class OptionsLoader extends Loader
+{
+    /** @var RouteCollectionMapperMapper */
+    protected $routeCollectionMapper;
+
+    public function __construct( RouteCollectionMapper $mapper )
+    {
+        $this->routeCollectionMapper = $mapper;
+    }
+
+    /**
+     * @param mixed $resource
+     * @param string $type
+     *
+     * @return RouteCollection
+     */
+    public function load( $resource, $type = null )
+    {
+        return $this->routeCollectionMapper->mapCollection( $this->import( $resource ) );
+    }
+
+    public function supports( $resource, $type = null )
+    {
+        return $type === 'rest_options';
+    }
+}

--- a/eZ/Bundle/EzPublishRestBundle/Routing/OptionsLoader/Mapper.php
+++ b/eZ/Bundle/EzPublishRestBundle/Routing/OptionsLoader/Mapper.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * File containing the Mapper class.
+ *
+ * @copyright Copyright (C) 2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishRestBundle\Routing\OptionsLoader;
+
+use Symfony\Component\Routing\Route;
+
+/**
+ * Maps a standard REST route to its OPTIONS equivalent
+ */
+class Mapper
+{
+    /**
+     * @param $route Route REST route
+     * @return Route
+     */
+    public function mapRoute( Route $route )
+    {
+        $optionsRoute = clone( $route );
+        $optionsRoute->setMethods( array( 'OPTIONS' ) );
+        $optionsRoute->setDefault(
+            '_controller',
+            '_ezpublish_rest.controller.options:getRouteOptions'
+        );
+
+        $optionsRoute->setDefault(
+            'allowedMethods',
+            implode( ',', $route->getMethods() )
+        );
+
+        return $optionsRoute;
+    }
+
+    /**
+     * Merges the methods from $restRoute into the _method default of $optionsRoute
+     * @param Route $restRoute
+     * @param Route $optionsRoute
+     * @return Route $optionsRoute with the methods from $restRoute in the _methods default
+     */
+    public function mergeMethodsDefault( Route $optionsRoute, Route $restRoute )
+    {
+        $mergedRoute = clone( $optionsRoute );
+        $mergedRoute->setDefault(
+            'allowedMethods',
+            implode(
+                ',',
+                array_unique(
+                    array_merge(
+                        explode( ',', $optionsRoute->getDefault( 'allowedMethods' ) ),
+                        $restRoute->getMethods()
+                    )
+                )
+            )
+        );
+
+        return $mergedRoute;
+    }
+
+    /**
+     * Returns the OPTIONS name of a REST route
+     * @param $route Route
+     * @return string
+     */
+    public function getOptionsRouteName( Route $route )
+    {
+        $name = str_replace( '/', '_', $route->getPath() );
+        return 'ezpublish_rest_options_' . trim( $name, '_' );
+    }
+}

--- a/eZ/Bundle/EzPublishRestBundle/Routing/OptionsLoader/RouteCollectionMapper.php
+++ b/eZ/Bundle/EzPublishRestBundle/Routing/OptionsLoader/RouteCollectionMapper.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * File containing the OptionsRouteCollection class.
+ *
+ * @copyright Copyright (C) 2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishRestBundle\Routing\OptionsLoader;
+
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Maps a REST routes collection to the corresponding set of REST OPTIONS routes.
+ *
+ * Merges routes with the same path to a unique one, with the aggregate of merged methods in the _methods default.
+ */
+class RouteCollectionMapper
+{
+    /**
+     * @var Mapper
+     */
+    protected $mapper;
+
+    public function __construct( Mapper $mapper )
+    {
+        $this->mapper = $mapper;
+    }
+
+    /**
+     * Iterates over $restRouteCollection, and returns the corresponding RouteCollection of OPTIONS REST routes
+     *
+     * @param RouteCollection $restRouteCollection
+     * @return RouteCollection
+     */
+    public function mapCollection( RouteCollection $restRouteCollection )
+    {
+        $optionsRouteCollection = new RouteCollection();
+
+        foreach ( $restRouteCollection->all() as $restRoute )
+        {
+            $optionsRouteName = $this->mapper->getOptionsRouteName( $restRoute );
+
+            $optionsRoute = $optionsRouteCollection->get( $optionsRouteName );
+            if ( $optionsRoute === null )
+            {
+                $optionsRoute = $this->mapper->mapRoute( $restRoute );
+            }
+            else
+            {
+                $optionsRoute = $this->mapper->mergeMethodsDefault( $optionsRoute, $restRoute );
+            }
+
+            $optionsRouteCollection->add( $optionsRouteName, $optionsRoute );
+        }
+
+        return $optionsRouteCollection;
+    }
+}

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Routing/OptionsLoader/MapperTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Routing/OptionsLoader/MapperTest.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * File containing the MapperTest class.
+ *
+ * @copyright Copyright (C) 2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishRestBundle\Tests\Routing\OptionsLoader;
+
+use eZ\Bundle\EzPublishRestBundle\Routing\OptionsLoader\Mapper;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Routing\Route;
+
+class MapperTest extends PHPUnit_Framework_TestCase
+{
+    /** @var Mapper */
+    protected $mapper;
+
+    public function setUp()
+    {
+        $this->mapper = new Mapper;
+    }
+
+    public function testGetOptionsRouteName()
+    {
+        $route = new Route( '/route/{id}' );
+
+        self::assertEquals(
+            'ezpublish_rest_options_route_{id}',
+            $this->mapper->getOptionsRouteName( $route )
+        );
+    }
+
+    public function testMergeMethodsDefault()
+    {
+        $optionsRoute = new Route( '', array( 'allowedMethods' => 'PUT,DELETE' ) );
+        $restRoute = new Route( '', array(), array(), array(), '', array(), array( 'GET', 'POST' ) );
+
+        $mergedOptionsRoute = $this->mapper->mergeMethodsDefault( $optionsRoute, $restRoute );
+        self::assertEquals(
+            'PUT,DELETE,GET,POST',
+            $mergedOptionsRoute->getDefault( 'allowedMethods' )
+        );
+        self::assertEquals(
+            $optionsRoute->getMethods(),
+            $mergedOptionsRoute->getMethods()
+        );
+    }
+
+    public function testMapRoute()
+    {
+        $restRoute = new Route(
+            '/route/one/{id}',
+            array( '_controller' => 'anything' ),
+            array( 'id' => '[0-9]+' ),
+            array(),
+            '',
+            array(),
+            array( 'PUT', 'DELETE' )
+        );
+
+        $optionsRoute = $this->mapper->mapRoute( $restRoute );
+
+        self::assertEquals(
+            array( 'OPTIONS' ),
+            $optionsRoute->getMethods()
+        );
+
+        self::assertEquals(
+            $restRoute->getRequirement( 'id' ),
+            $optionsRoute->getRequirement( 'id' )
+        );
+
+        self::assertEquals(
+            'PUT,DELETE',
+            $optionsRoute->getDefault( 'allowedMethods' )
+        );
+
+        self::assertEquals(
+            '_ezpublish_rest.controller.options:getRouteOptions',
+            $optionsRoute->getDefault( '_controller' )
+        );
+    }
+}

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Routing/OptionsLoader/RouteCollectionMapperTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Routing/OptionsLoader/RouteCollectionMapperTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * File containing the OptionsRouteCollectionTest class.
+ *
+ * @copyright Copyright (C) 2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishRestBundle\Tests\Routing\OptionsLoader;
+
+use eZ\Bundle\EzPublishRestBundle\Routing\OptionsLoader\Mapper;
+use eZ\Bundle\EzPublishRestBundle\Routing\OptionsLoader\RouteCollectionMapper;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * @covers eZ\Bundle\EzPublishRestBundle\Routing\OptionsLoader\RouteCollectionMapper
+ */
+class RouteCollectionMapperTest extends PHPUnit_Framework_TestCase
+{
+    /** @var RouteCollectionMapper */
+    protected $collectionMapper;
+
+    public function setUp()
+    {
+        $this->collectionMapper = new RouteCollectionMapper(
+            new Mapper()
+        );
+    }
+
+    public function testAddRestRoutesCollection()
+    {
+        $restRoutesCollection = new RouteCollection();
+        $restRoutesCollection->add( 'ezpublish_rest_route_one_get', $this->createRoute( '/route/one', array( 'GET' ) ) );
+        $restRoutesCollection->add( 'ezpublish_rest_route_one_post', $this->createRoute( '/route/one', array( 'POST' ) ) );
+        $restRoutesCollection->add( 'ezpublish_rest_route_two_delete', $this->createRoute( '/route/two', array( 'DELETE' ) ) );
+
+        $optionsRouteCollection = $this->collectionMapper->mapCollection( $restRoutesCollection );
+
+        self::assertEquals(
+            2,
+            $optionsRouteCollection->count()
+        );
+
+        self::assertInstanceOf(
+            'Symfony\Component\Routing\Route',
+            $optionsRouteCollection->get( 'ezpublish_rest_options_route_one' )
+        );
+
+        self::assertInstanceOf(
+            'Symfony\Component\Routing\Route',
+            $optionsRouteCollection->get( 'ezpublish_rest_options_route_two' )
+        );
+
+        self::assertEquals(
+            'GET,POST',
+            $optionsRouteCollection->get( 'ezpublish_rest_options_route_one' )->getDefault( 'allowedMethods' )
+        );
+
+        self::assertEquals(
+            'DELETE',
+            $optionsRouteCollection->get( 'ezpublish_rest_options_route_two' )->getDefault( 'allowedMethods' )
+        );
+    }
+
+    /**
+     * @param string $path
+     * @param array $methods
+     * @return Route
+     */
+    private function createRoute( $path, array $methods )
+    {
+        return new Route( $path, array(), array(), array(), '', array(), $methods );
+    }
+}

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Routing/OptionsLoaderTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Routing/OptionsLoaderTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * File containing the OptionsLoaderTest class.
+ *
+ * @copyright Copyright (C) 2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishRestBundle\Tests\Routing;
+
+use eZ\Bundle\EzPublishRestBundle\Routing\OptionsLoader;
+use eZ\Bundle\EzPublishRestBundle\Routing\OptionsLoader\RouteCollectionMapper;
+use PHPUnit_Framework_MockObject_MockObject;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * @covers \eZ\Bundle\EzPublishRestBundle\Routing\OptionsLoader
+ */
+class OptionsLoaderTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $type
+     * @param bool $expected
+     * @dataProvider getResourceType
+     */
+    public function testSupportsResourceType( $type, $expected )
+    {
+        self::assertEquals(
+            $expected,
+            $this->getOptionsLoader()->supports( null, $type )
+        );
+    }
+
+    public function getResourceType()
+    {
+        return array(
+            array( 'rest_options', true ),
+            array( 'something else', false )
+        );
+    }
+
+    public function testLoad()
+    {
+        $optionsRouteCollection = new RouteCollection();
+
+        $this->getRouteCollectionMapperMock()->expects( $this->once() )
+            ->method( 'mapCollection' )
+            ->with( new RouteCollection() )
+            ->will( $this->returnValue( $optionsRouteCollection ) );
+
+        self::assertSame(
+            $optionsRouteCollection,
+            $this->getOptionsLoader()->load( 'resource', 'rest_options' )
+        );
+    }
+
+    /**
+     * Returns a partially mocked OptionsLoader, with the import method mocked
+     * @return OptionsLoader|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getOptionsLoader()
+    {
+        $mock = $this->getMockBuilder( 'eZ\Bundle\EzPublishRestBundle\Routing\OptionsLoader' )
+            ->setConstructorArgs( array( $this->getRouteCollectionMapperMock() ) )
+            ->setMethods( array( 'import' ) )
+            ->getMock();
+
+        $mock->expects( $this->any() )
+            ->method( 'import' )
+            ->with( $this->anything(), $this->anything() )
+            ->will( $this->returnValue( new RouteCollection() ) );
+
+        return $mock;
+    }
+
+    /**
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getRouteCollectionMapperMock()
+    {
+        if ( !isset( $this->routeCollectionMapperMock ) )
+        {
+            $this->routeCollectionMapperMock = $this->getMockBuilder( 'eZ\Bundle\EzPublishRestBundle\Routing\OptionsLoader\RouteCollectionMapper' )
+                ->disableOriginalConstructor()
+                ->getMock();
+        }
+
+        return $this->routeCollectionMapperMock;
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Controller/Options.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Options.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * File containing the Root controller class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\REST\Server\Controller;
+
+use eZ\Publish\Core\REST\Server\Values;
+use eZ\Publish\Core\REST\Server\Controller as RestController;
+
+/**
+ * Root controller
+ */
+class Options extends RestController
+{
+    /**
+     * Lists the verbs available for a resource
+     * @param $allowedMethods string comma separated list of supported methods. Depends on the matched OPTIONS route.
+     * @return Values\Options
+     */
+    public function getRouteOptions( $allowedMethods )
+    {
+        return new Values\Options( explode( ',', $allowedMethods ) );
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Options.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Options.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * File containing the CreatedPolicy ValueObjectVisitor class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+
+/**
+ * Options value object visitor
+ *
+ * @todo coverage add unit test
+ */
+class Options extends ValueObjectVisitor
+{
+    public function visit( Visitor $visitor, Generator $generator, $data )
+    {
+        $visitor->setHeader( 'Allow', implode( ',', $data->allowedMethods ) );
+        $visitor->setHeader( 'Content-Length', 0 );
+        $visitor->setStatus( 200 );
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/OptionsTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/OptionsTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * File containing a test class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
+
+use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
+
+use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Server\Values;
+use eZ\Publish\Core\REST\Common;
+
+class OptionsTest extends ValueObjectVisitorBaseTest
+{
+    /**
+     * Test the NoContent visitor
+     *
+     * @return string
+     */
+    public function testVisit()
+    {
+        $visitor   = $this->getVisitor();
+        $generator = $this->getGenerator();
+
+        $generator->startDocument( null );
+
+        $noContent = new Values\Options( array( 'GET', 'POST' ) );
+
+        $this->getVisitorMock()->expects( $this->once() )
+            ->method( 'setStatus' )
+            ->with( $this->equalTo( 200 ) );
+
+        $this->getVisitorMock()->expects( $this->exactly( 2 ) )
+            ->method( 'setHeader' )
+            ->will(
+                $this->returnValueMap(
+                    array( 'Allow', 'GET,POST' ),
+                    array( 'Content-Length', 0 )
+                )
+            );
+
+        $visitor->visit(
+            $this->getVisitorMock(),
+            $generator,
+            $noContent
+        );
+    }
+
+    /**
+     * Get the NoContent visitor
+     *
+     * @return \eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\NoContent
+     */
+    protected function internalGetVisitor()
+    {
+        return new ValueObjectVisitor\Options;
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Values/Options.php
+++ b/eZ/Publish/Core/REST/Server/Values/Options.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * File containing the CreatedPolicy class
+ *
+ * @copyright Copyright (C) 1999-2013 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\REST\Server\Values;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * Struct representing a resource OPTIONS response
+ */
+class Options extends ValueObject
+{
+    /**
+     * The methods allowed my the resource
+     *
+     * @var array
+     */
+    public $allowedMethods;
+
+    public function __construct( $allowedMethods )
+    {
+        $this->allowedMethods = $allowedMethods;
+    }
+}


### PR DESCRIPTION
This pull-request implements http://jira.ez.no/browse/EZP-21044, support for REST `OPTIONS` requests.
### Status

A OPTIONS requests to any REST URI will receive a response.
It will include an `Allow` header with the comma separated list of methods accepted by the URI:

```
$ curl -u "admin:publish" -X OPTIONS -i http://vm.ezpublish5/api/ezp/v2/content/objects/1

HTTP/1.1 200 OK
Allow: PATCH,GET,DELETE,COPY
Status: 200 OK
```
### Dependencies

See https://github.com/ezsystems/ezpublish-community/pull/86.
### How

Uses a custom route loader to go through REST routes, and based on those, generate a new set of routes for OPTIONS call to all declared path.

The list of supported methods is passed on via a route default, _methods.
### Testing

Unit test with 100% coverage + manual HTTP requests.
### TODO
- [x] Refactor `OptionsRouter`
- [x] Test the refactored `OptionsRouter`
- [x] Update REST specs
- [x] Add `Content-Length: 0` to the Response
- [x] Create ezpublish-community pull request for `ezpublish/config/routing.yml`
- [x] Investigate possibilities of removal of the `routing.yml`
