### PR TITLE
EZP-20930: Added ContentTypeGroupByIdentifier to REST Root

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -317,17 +317,28 @@ XML Example
 .. code:: xml
 
     <?xml version="1.0" encoding="UTF-8"?>
-    <Root>
-      <content href="/content/objects" media-type=""/>
-      <contentTypes href="/content/types" media-type="application/vnd.ez.api.ContentTypeInfoList+xml"/>
-      <users href="/user/users" media-type="application/vnd.ez.api.UserRefList+xml"/>
-      <roles href="/user/roles" media-type="application/vnd.ez.api.RoleList+xml"/>
-      <rootLocation href="/content/locations/1" media-type="application/vnd.ez.api.Location+xml"/>
-      <rootUserGroup href="/user/groups/1/3" media-type="application/vnd.ez.api.UserGroup+xml"/>
-      <rootMediaFolder href="/content/locations/1/43" media-type="application/vnd.ez.api.Location+xml"/>
-      <trash href="/content/trash" media-type="application/vnd.ez.api.LocationList+xml"/>
-      <sections href="/content/sections" media-type="application/vnd.ez.api.SectionList+xml"/>
-      <views href="/content/views" media-type="application/vnd.ez.api.RefList+xml"/>
+    <Root media-type="application/vnd.ez.api.Root+xml">
+        <content media-type="" href="/api/ezp/v2/content/objects"/>
+        <contentByRemoteId media-type="" href="/api/ezp/v2/content/objects?{&amp;remoteId}"/>
+        <contentTypes media-type="application/vnd.ez.api.ContentTypeInfoList+xml" href="/api/ezp/v2/content/types"/>
+        <contentTypeByIdentifier media-type="" href="/api/ezp/v2/content/types?{&amp;identifier}"/>
+        <contentTypeGroups media-type="application/vnd.ez.api.ContentTypeGroupList+xml" href="/api/ezp/v2/content/typegroups"/>
+        <contentTypeGroupByIdentifier media-type="" href="/api/ezp/v2/content/typegroups?{&amp;identifier}"/>
+        <users media-type="application/vnd.ez.api.UserRefList+xml" href="/api/ezp/v2/user/users"/>
+        <roles media-type="application/vnd.ez.api.RoleList+xml" href="/api/ezp/v2/user/roles"/>
+        <rootLocation media-type="application/vnd.ez.api.Location+xml" href="/api/ezp/v2/content/locations/1/2"/>
+        <rootUserGroup media-type="application/vnd.ez.api.UserGroup+xml" href="/api/ezp/v2/user/groups/1/5"/>
+        <rootMediaFolder media-type="application/vnd.ez.api.Location+xml" href="/api/ezp/v2/content/locations/1/43"/>
+        <locationByRemoteId media-type="" href="/api/ezp/v2/content/locations?{&amp;remoteId}"/>
+        <locationByPath media-type="" href="/api/ezp/v2/content/locations?{&amp;locationPath}"/>
+        <trash media-type="application/vnd.ez.api.Trash+xml" href="/api/ezp/v2/content/trash"/>
+        <sections media-type="application/vnd.ez.api.SectionList+xml" href="/api/ezp/v2/content/sections"/>
+        <views media-type="application/vnd.ez.api.RefList+xml" href="/api/ezp/v2/content/views"/>
+        <objectStateGroups media-type="application/vnd.ez.api.ObjectStateGroupList+xml" href="/api/ezp/v2/content/objectstategroups"/>
+        <objectStates media-type="application/vnd.ez.api.ObjectStateList+xml" href="/api/ezp/v2/content/objectstategroups/{objectStateGroupId}/objectstates"/>
+        <globalUrlAliases media-type="application/vnd.ez.api.UrlAliasRefList+xml" href="/api/ezp/v2/content/urlaliases"/>
+        <urlWildcards media-type="application/vnd.ez.api.UrlWildcardList+xml" href="/api/ezp/v2/content/urlwildcards"/>
+        <createSession media-type="application/vnd.ez.api.UserSession+xml" href="/api/ezp/v2/user/sessions"/>
     </Root>
 
 JSON Example
@@ -348,47 +359,94 @@ JSON Example
 .. code:: javascript
 
     {
-      "Root": {
-        "content": { "_href": "/content/objects" },
-        "contentTypes": {
-          "_href": "/content/types",
-          "_media-type": "application/vnd.ez.api.ContentTypeInfoList+json"
-        },
-        "users": {
-          "_href": "/user/users",
-          "_media-type": "application/vnd.ez.api.UserRefList+json"
-        },
-        "roles": {
-          "_href": "/user/roles",
-          "_media-type": "application/vnd.ez.api.RoleList+json"
-        },
-        "rootLocation": {
-          "_href": "/content/locations/1",
-          "_media-type": "application/vnd.ez.api.Location+json"
-        },
-        "rootUserGroup": {
-          "_href": "/user/groups/1/5",
-          "_media-type": "application/vnd.ez.api.UserGroup+json"
-        },
-        "rootMediaFolder": {
-          "_href": "/content/locations/1/43",
-          "_media-type": "application/vnd.ez.api.Location+json"
+        "Root": {
+            "_media-type": "application/vnd.ez.api.Root+json",
+            "content": {
+                "_href": "/api/ezp/v2/content/objects",
+                "_media-type": ""
+            },
+            "contentByRemoteId": {
+                "_href": "/api/ezp/v2/content/objects?{&remoteId}",
+                "_media-type": ""
+            },
+            "contentTypeByIdentifier": {
+                "_href": "/api/ezp/v2/content/types?{&identifier}",
+                "_media-type": ""
+            },
+            "contentTypeGroupByIdentifier": {
+                "_href": "/api/ezp/v2/content/typegroups?{&identifier}",
+                "_media-type": ""
+            },
+            "contentTypeGroups": {
+                "_href": "/api/ezp/v2/content/typegroups",
+                "_media-type": "application/vnd.ez.api.ContentTypeGroupList+json"
+            },
+            "contentTypes": {
+                "_href": "/api/ezp/v2/content/types",
+                "_media-type": "application/vnd.ez.api.ContentTypeInfoList+json"
+            },
+            "createSession": {
+                "_href": "/api/ezp/v2/user/sessions",
+                "_media-type": "application/vnd.ez.api.UserSession+json"
+            },
+            "globalUrlAliases": {
+                "_href": "/api/ezp/v2/content/urlaliases",
+                "_media-type": "application/vnd.ez.api.UrlAliasRefList+json"
+            },
+            "locationByPath": {
+                "_href": "/api/ezp/v2/content/locations?{&locationPath}",
+                "_media-type": ""
+            },
+            "locationByRemoteId": {
+                "_href": "/api/ezp/v2/content/locations?{&remoteId}",
+                "_media-type": ""
+            },
+            "objectStateGroups": {
+                "_href": "/api/ezp/v2/content/objectstategroups",
+                "_media-type": "application/vnd.ez.api.ObjectStateGroupList+json"
+            },
+            "objectStates": {
+                "_href": "/api/ezp/v2/content/objectstategroups/{objectStateGroupId}/objectstates",
+                "_media-type": "application/vnd.ez.api.ObjectStateList+json"
+            },
+            "roles": {
+                "_href": "/api/ezp/v2/user/roles",
+                "_media-type": "application/vnd.ez.api.RoleList+json"
+            },
+            "rootLocation": {
+                "_href": "/api/ezp/v2/content/locations/1/2",
+                "_media-type": "application/vnd.ez.api.Location+json"
+            },
+            "rootMediaFolder": {
+                "_href": "/api/ezp/v2/content/locations/1/43",
+                "_media-type": "application/vnd.ez.api.Location+json"
+            },
+            "rootUserGroup": {
+                "_href": "/api/ezp/v2/user/groups/1/5",
+                "_media-type": "application/vnd.ez.api.UserGroup+json"
+            },
+            "sections": {
+                "_href": "/api/ezp/v2/content/sections",
+                "_media-type": "application/vnd.ez.api.SectionList+json"
+            },
+            "trash": {
+                "_href": "/api/ezp/v2/content/trash",
+                "_media-type": "application/vnd.ez.api.Trash+json"
+            },
+            "urlWildcards": {
+                "_href": "/api/ezp/v2/content/urlwildcards",
+                "_media-type": "application/vnd.ez.api.UrlWildcardList+json"
+            },
+            "users": {
+                "_href": "/api/ezp/v2/user/users",
+                "_media-type": "application/vnd.ez.api.UserRefList+json"
+            },
+            "views": {
+                "_href": "/api/ezp/v2/content/views",
+                "_media-type": "application/vnd.ez.api.RefList+json"
+            }
         }
-        "trash": {
-          "_href": "/content/trash",
-          "_media-type": "application/vnd.ez.api.LocationList+json"
-        },
-        "sections": {
-          "_href": "/content/sections",
-          "_media-type": "application/vnd.ez.api.SectionList+json"
-        }
-        "sections": {
-          "_href": "/content/views",
-          "_media-type": "application/vnd.ez.api.ViewList+json"
-        }
-      }
     }
-
 
 Managing content
 ~~~~~~~~~~~~~~~~

--- a/doc/specifications/rest/xsd/Root.xsd
+++ b/doc/specifications/rest/xsd/Root.xsd
@@ -10,6 +10,7 @@
       <xsd:element name="contentTypes" type="ref" />
       <xsd:element name="contentTypeByIdentifier" type="ref" />
       <xsd:element name="contentTypeGroups" type="ref" />
+      <xsd:element name="contentTypeGroupByIdentifier" type="ref" />
       <xsd:element name="users" type="ref"/>
       <xsd:element name="roles" type="ref"/>
       <xsd:element name="rootLocation" type="ref"/>

--- a/doc/specifications/rest/xsd/xmlexamples/Root.xml
+++ b/doc/specifications/rest/xsd/xmlexamples/Root.xml
@@ -1,12 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Root>
-  <content href="/content/objects" media-type=""/>
-  <contentTypes href="/content/types" media-type="application/vnd.ez.api.ContentTypeInfoList+xml"/>
-  <users href="/user/users" media-type="application/vnd.ez.api.UserRefList+xml"/>
-  <roles href="/user/roles" media-type="application/vnd.ez.api.RoleList+xml"/>
-  <rootLocation href="/content/locations/1" media-type="application/vnd.ez.api.Location+xml"/>
-  <rootUserGroup href="/user/groups/1/3" media-type="application/vnd.ez.api.UserGroup+xml"/>
-  <rootMediaFolder href="/content/locations/1/43" media-type="application/vnd.ez.api.Location+xml"/>
-  <trash href="/content/trash" media-type="application/vnd.ez.api.LocationList+xml"/>
-  <sections href="/content/sections" media-type="application/vnd.ez.api.SectionList+xml"/>
+<Root media-type="application/vnd.ez.api.Root+xml">
+    <content media-type="" href="/api/ezp/v2/content/objects"/>
+    <contentByRemoteId media-type="" href="/api/ezp/v2/content/objects?{&amp;remoteId}"/>
+    <contentTypes media-type="application/vnd.ez.api.ContentTypeInfoList+xml" href="/api/ezp/v2/content/types"/>
+    <contentTypeByIdentifier media-type="" href="/api/ezp/v2/content/types?{&amp;identifier}"/>
+    <contentTypeGroups media-type="application/vnd.ez.api.ContentTypeGroupList+xml" href="/api/ezp/v2/content/typegroups"/>
+    <contentTypeGroupByIdentifier media-type="" href="/api/ezp/v2/content/typegroups?{&amp;identifier}"/>
+    <users media-type="application/vnd.ez.api.UserRefList+xml" href="/api/ezp/v2/user/users"/>
+    <roles media-type="application/vnd.ez.api.RoleList+xml" href="/api/ezp/v2/user/roles"/>
+    <rootLocation media-type="application/vnd.ez.api.Location+xml" href="/api/ezp/v2/content/locations/1/2"/>
+    <rootUserGroup media-type="application/vnd.ez.api.UserGroup+xml" href="/api/ezp/v2/user/groups/1/5"/>
+    <rootMediaFolder media-type="application/vnd.ez.api.Location+xml" href="/api/ezp/v2/content/locations/1/43"/>
+    <locationByRemoteId media-type="" href="/api/ezp/v2/content/locations?{&amp;remoteId}"/>
+    <locationByPath media-type="" href="/api/ezp/v2/content/locations?{&amp;locationPath}"/>
+    <trash media-type="application/vnd.ez.api.Trash+xml" href="/api/ezp/v2/content/trash"/>
+    <sections media-type="application/vnd.ez.api.SectionList+xml" href="/api/ezp/v2/content/sections"/>
+    <views media-type="application/vnd.ez.api.RefList+xml" href="/api/ezp/v2/content/views"/>
+    <objectStateGroups media-type="application/vnd.ez.api.ObjectStateGroupList+xml" href="/api/ezp/v2/content/objectstategroups"/>
+    <objectStates media-type="application/vnd.ez.api.ObjectStateList+xml" href="/api/ezp/v2/content/objectstategroups/{objectStateGroupId}/objectstates"/>
+    <globalUrlAliases media-type="application/vnd.ez.api.UrlAliasRefList+xml" href="/api/ezp/v2/content/urlaliases"/>
+    <urlWildcards media-type="application/vnd.ez.api.UrlWildcardList+xml" href="/api/ezp/v2/content/urlwildcards"/>
+    <createSession media-type="application/vnd.ez.api.UserSession+xml" href="/api/ezp/v2/user/sessions"/>
 </Root>

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Root.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Root.php
@@ -78,11 +78,26 @@ class Root extends ValueObjectVisitor
         $generator->endAttribute( 'href' );
         $generator->endHashElement( 'contentTypeByIdentifier' );
 
-        // Content type groups
+        // Creating a ContentTypeGroup
         $generator->startObjectElement( 'contentTypeGroups', 'ContentTypeGroupList' );
-        $generator->startAttribute( 'href', $this->router->generate( 'ezpublish_rest_loadContentTypeGroupList' ) );
+        $generator->startAttribute( 'href', $this->router->generate( 'ezpublish_rest_createContentTypeGroup' ) );
         $generator->endAttribute( 'href' );
         $generator->endObjectElement( 'contentTypeGroups' );
+
+        // Content type group by identifier
+        // See comment above regarding usage of hash element
+        $generator->startHashElement( 'contentTypeGroupByIdentifier' );
+        $generator->startAttribute( 'media-type', '' );
+        $generator->endAttribute( 'media-type' );
+        $generator->startAttribute(
+            'href',
+            $this->templateRouter->generate(
+                'ezpublish_rest_loadContentTypeGroupList',
+                array( 'identifier' => '{identifier}' )
+            )
+        );
+        $generator->endAttribute( 'href' );
+        $generator->endHashElement( 'contentTypeGroupByIdentifier' );
 
         // Users
         $generator->startObjectElement( 'users', 'UserRefList' );

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RootTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RootTest.php
@@ -47,7 +47,12 @@ class RootTest extends ValueObjectVisitorBaseTest
             array( 'identifier' => '{identifier}' ),
             '/content/types?{&identifier}'
         );
-        $this->addRouteExpectation( 'ezpublish_rest_loadContentTypeGroupList', array(), '/content/typegroups' );
+        $this->addRouteExpectation( 'ezpublish_rest_createContentTypeGroup', array(), '/content/typegroups' );
+        $this->addTemplatedRouteExpectation(
+            'ezpublish_rest_loadContentTypeGroupList',
+            array( 'identifier' => '{identifier}' ),
+            '/content/typegroups?{&identifier}'
+        );
         $this->addRouteExpectation( 'ezpublish_rest_loadUsers', array(), '/user/users' );
         $this->addRouteExpectation( 'ezpublish_rest_listRoles', array(), '/user/roles' );
         $this->addRouteExpectation(
@@ -302,6 +307,40 @@ class RootTest extends ValueObjectVisitorBaseTest
             ),
             $result,
             'Invalid <contentTypeGroups> tag attributes.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
+    public function testResultContainsContentTypeGroupByIdentifierTag( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'contentTypeGroupByIdentifier'
+            ),
+            $result,
+            'Missing <ContentTypeGroupByIdentifier> element.',
+            false
+        );
+    }
+
+    /**
+     * @depends testVisit
+     */
+    public function testResultContainsContentTypeGroupByIdentifierTagAttributes( $result )
+    {
+        $this->assertTag(
+            array(
+                'tag' => 'contentTypeGroupByIdentifier',
+                'attributes' => array(
+                    'media-type' => '',
+                    'href' => '/content/typegroups?{&identifier}'
+                )
+            ),
+            $result,
+            'Invalid <contentTypeGroupByIdentifier> tag attributes.',
             false
         );
     }


### PR DESCRIPTION
Further fix for http://jira.ez.no/browse/EZP-20930.

Adds the missing ContentTypeGroupByIdentifier link to the root REST resource.
