### PR TITLE
Fix EZP-22027 location/url alias SPI cache not updated.

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/LegacyMapper/Configuration.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/LegacyMapper/Configuration.php
@@ -186,6 +186,7 @@ class Configuration implements EventSubscriberInterface
         ezpEvent::getInstance()->attach( 'content/section/cache', array( $this->persistenceCachePurger, 'section' ) );
         ezpEvent::getInstance()->attach( 'user/cache/all', array( $this->persistenceCachePurger, 'user' ) );
         ezpEvent::getInstance()->attach( 'content/translations/cache', array( $this->persistenceCachePurger, 'languages' ) );
+        ezpEvent::getInstance()->attach( 'content/location/cache', array( $this->persistenceCachePurger, 'locations' ) );
     }
 
     private function getImageSettings()


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22027

This implements a new event/listener for clearing URL/location related cache,
see also https://github.com/ezsystems/ezpublish-legacy/pull/839
