### PR TITLE
Fix EZP-22156: make CSRF provider optional again

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/EventListener/CsrfListener.php
+++ b/eZ/Bundle/EzPublishRestBundle/EventListener/CsrfListener.php
@@ -45,21 +45,25 @@ class CsrfListener implements EventSubscriberInterface
     private $csrfTokenIntention;
 
     /**
-     * @param \Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface $csrfProvider
+     * Note that CSRF provider needs to be optional as it will not be available
+     * when CSRF protection is disabled.
+     *
      * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $eventDispatcher
      * @param bool $csrfEnabled
      * @param string $csrfTokenIntention
+     * @param null|\Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface $csrfProvider
      */
     public function __construct(
-        CsrfProviderInterface $csrfProvider,
         EventDispatcherInterface $eventDispatcher,
         $csrfEnabled,
-        $csrfTokenIntention )
+        $csrfTokenIntention,
+        CsrfProviderInterface $csrfProvider = null
+    )
     {
-        $this->csrfProvider = $csrfProvider;
         $this->eventDispatcher = $eventDispatcher;
         $this->csrfEnabled = $csrfEnabled;
         $this->csrfTokenIntention = $csrfTokenIntention;
+        $this->csrfProvider = $csrfProvider;
     }
 
     /**

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
@@ -225,10 +225,10 @@ services:
     ezpublish_rest.csrf_listener:
         class: %ezpublish_rest.csrf_listener.class%
         arguments:
-            - @form.csrf_provider
             - @event_dispatcher
             - %form.type_extension.csrf.enabled%
             - %ezpublish_rest.csrf_token_intention%
+            - @?form.csrf_provider
         tags:
             - { name: kernel.event_subscriber }
 

--- a/eZ/Bundle/EzPublishRestBundle/Tests/EventListener/CsrfListenerTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/EventListener/CsrfListenerTest.php
@@ -310,8 +310,17 @@ class CsrfListenerTest extends EventListenerTest
      */
     protected function getEventListener( $csrfEnabled = true )
     {
+        if ( $csrfEnabled )
+        {
+            return new CsrfListener(
+                $this->getEventDispatcherMock(),
+                $csrfEnabled,
+                self::INTENTION,
+                $this->getCsrfProviderMock()
+            );
+        }
+
         return new CsrfListener(
-            $this->getCsrfProviderMock(),
             $this->getEventDispatcherMock(),
             $csrfEnabled,
             self::INTENTION


### PR DESCRIPTION
This PR resolves issue https://jira.ez.no/browse/EZP-22156

CSRF provider needs to be optional because it will not be available when CSRF protection is disabled.
Needed by https://github.com/ezsystems/ezpublish-kernel/pull/665.
