### PR TITLE
fix/EZP-21207 Render input parsing errors to a 400 BadRequestException

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -156,6 +156,7 @@ services:
         arguments: [ true  ]
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Exceptions\BadRequestException }
+            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Common\Exceptions\Parser }
 
     ezpublish_rest.output.value_object_visitor.ForbiddenException:
         parent: ezpublish_rest.output.value_object_visitor.base

--- a/eZ/Publish/Core/REST/Common/Input/ParsingDispatcher.php
+++ b/eZ/Publish/Core/REST/Common/Input/ParsingDispatcher.php
@@ -28,7 +28,7 @@ class ParsingDispatcher
      *  )
      * </code>
      *
-     * @var array
+     * @var \eZ\Publish\Core\REST\Common\Input\Parser[]
      */
     protected $parsers = array();
 


### PR DESCRIPTION
The task here was to get an error 400 when having parsing errors instead of error 500.

[x] bug fixed

https://jira.ez.no/browse/EZP-21207
