### PR TITLE
Fix EZP-22081: As a developer, I want to be able to seamlessly use multiple user providers

### DIFF
--- a/doc/specifications/security/authentication_symfony.md
+++ b/doc/specifications/security/authentication_symfony.md
@@ -122,8 +122,7 @@ This makes it easy to integrate any kind of login handlers, including SSO and ex
 (e.g. [FR3DLdapBundle](https://github.com/Maks3w/FR3DLdapBundle), [HWIOauthBundle](https://github.com/hwi/HWIOAuthBundle),
 [FOSUserBundle](https://github.com/FriendsOfSymfony/FOSUserBundle), [BeSimpleSsoAuthBundle](http://github.com/BeSimple/BeSimpleSsoAuthBundle)...).
 
-The only requirement, whatever user provider is used, is to inject a valid eZ user in the repository.
-This can be done by listening to `SecurityEvents::INTERACTIVE_LOGIN` event which is triggered once authentication has been made.
+Further explanation can be found in the [multiple user providers specification](multiple_user_providers.md).
 
 ### Integration with legacy
 

--- a/doc/specifications/security/multiple_user_providers.md
+++ b/doc/specifications/security/multiple_user_providers.md
@@ -1,0 +1,115 @@
+# Using multiple user providers for authentication
+
+## Description
+
+Symfony provides native support for [multiple user providers](https://github.com/ezsystems/ezpublish-kernel/pull/symfony.com/doc/2.3/book/security.html#using-multiple-user-providers).
+This makes it easy to integrate any kind of login handlers, including SSO and existing 3rd party bundles
+(e.g. [FR3DLdapBundle](https://github.com/Maks3w/FR3DLdapBundle), [HWIOauthBundle](https://github.com/hwi/HWIOAuthBundle),
+[FOSUserBundle](https://github.com/FriendsOfSymfony/FOSUserBundle), [BeSimpleSsoAuthBundle](http://github.com/BeSimple/BeSimpleSsoAuthBundle)...).
+
+However, to be able to use *external* user providers with eZ, a valid eZ user needs to be injected in the repository.
+This is mainly for the kernel to be able to manage content related permissions (but not limited to).
+
+Depending on your context, you will either want to create an eZ user `on-the-fly`, return an existing user, or even
+always use a generic user.
+
+## Solution
+
+Whenever a *external* user is matched (i.e. that does not come from eZ repository, like coming from LDAP),
+eZ kernel fires an `MVCEvents::INTERACTIVE_LOGIN` event. Every service listening to this event will receive a
+`eZ\Publish\Core\MVC\Symfony\Event\InteractiveLoginEvent` object which contains the original security token (that
+holds the matched user) and the request.
+
+It's then up to the listener to retrieve an eZ user from repository and assign it back to the event object.
+This user will be injected in the repository and used for the rest of the request.
+
+> If no eZ user is returned, the anonymous user will then be used.
+
+### User exposed and security token
+When a *external* user is matched, a different token will be injected in the security context, the `InteractiveLoginToken`.
+This token holds a `UserWrapped` instance which contains the originally matched user and the *API user* (the one
+from the eZ repository).
+
+Note that the *API user* is mainly used for permission checks against the repository and thus stays *under the hood*.
+
+### Customizing the user class
+It is possible to customize the user class used by extending `ezpublish.security.login_listener` service,
+which defaults to `eZ\Publish\Core\MVC\Symfony\Security\EventListener\SecurityListener`.
+
+You can override `getUser()` to return whatever user class you want, as long as it implements
+`eZ\Publish\Core\MVC\Symfony\Security\UserInterface`.
+
+
+## Example
+
+Here is a very simple example using the in-memory user provider.
+
+*ezpublish/config/security.yml*
+```yaml
+security:
+    providers:
+        # Chaining in_memory and ezpublish user providers
+        chain_provider:
+            chain:
+                providers: [in_memory, ezpublish]
+        ezpublish:
+            id: ezpublish.security.user_provider
+        in_memory:
+            memory:
+                users:
+                    # You will then be able to login with username "user" and password "userpass"
+                    user:  { password: userpass, roles: [ 'ROLE_USER' ] }
+```
+
+**Implementing the listener**
+
+*services.yml in AcmeTestBundle*
+```yaml
+parameters:
+    acme_test.interactive_event_listener.class: Acme\TestBundle\EventListener\InteractiveLoginListener
+
+services:
+    acme_test.interactive_event_listener:
+        class: %acme_test.interactive_event_listener.class%
+        arguments: [@ezpublish.api.service.user]
+        tags:
+            - { name: kernel.event_subscriber }
+```
+
+*InteractiveLoginListener*
+```php
+<?php
+namespace Acme\TestBundle\EventListener;
+
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\Core\MVC\Symfony\Event\InteractiveLoginEvent;
+use eZ\Publish\Core\MVC\Symfony\MVCEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class InteractiveLoginListener implements EventSubscriberInterface
+{
+    /**
+     * @var \eZ\Publish\API\Repository\UserService
+     */
+    private $userService;
+
+    public function __construct( UserService $userService )
+    {
+        $this->userService = $userService;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            MVCEvents::INTERACTIVE_LOGIN => 'onInteractiveLogin'
+        );
+    }
+
+    public function onInteractiveLogin( InteractiveLoginEvent $event )
+    {
+        // We just load a generic user and assign it back to the event.
+        // You may want to create users here, or even load predefined users depending on your own rules.
+        $event->setApiUser( $this->userService->loadUserByLogin( 'lolautruche' ) );
+    }
+}
+```

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/security.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/security.yml
@@ -5,6 +5,7 @@ parameters:
     ezpublish.security.voter.core.class: eZ\Publish\Core\MVC\Symfony\Security\Authorization\Voter\CoreVoter
     ezpublish.security.voter.value_object.class: eZ\Publish\Core\MVC\Symfony\Security\Authorization\Voter\ValueObjectVoter
     ezpublish.security.controller.class: eZ\Publish\Core\MVC\Symfony\Controller\SecurityController
+    ezpublish.security.login_listener.class: eZ\Publish\Core\MVC\Symfony\Security\EventListener\SecurityListener
     security.http_utils.class: eZ\Publish\Core\MVC\Symfony\Security\HttpUtils
     ezpublish.user.identity.class: eZ\Publish\Core\MVC\Symfony\Security\User\Identity
     ezpublish.user.hash_generator.class: eZ\Publish\Core\MVC\Symfony\Security\User\HashGenerator
@@ -34,6 +35,12 @@ services:
         arguments: [@templating, @ezpublish.config.resolver, @?form.csrf_provider]
         calls:
             - [setRequest, [@?request=]]
+
+    ezpublish.security.login_listener:
+        class: %ezpublish.security.login_listener.class%
+        arguments: [@ezpublish.api.repository, @ezpublish.config.resolver, @event_dispatcher, @security.context]
+        tags:
+            - { name: kernel.event_subscriber }
 
     ezpublish.user.identity:
         class: %ezpublish.user.identity.class%

--- a/eZ/Publish/Core/MVC/Symfony/Event/InteractiveLoginEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/InteractiveLoginEvent.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * File containing the InteractiveLoginEvent class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Symfony\Event;
+
+use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent as BaseInteractiveLoginEvent;
+
+class InteractiveLoginEvent extends BaseInteractiveLoginEvent
+{
+    /**
+     * @var \eZ\Publish\API\Repository\Values\User\User
+     */
+    private $apiUser;
+
+    /**
+     * Checks if an API user has been provided.
+     *
+     * @return bool
+     */
+    public function hasAPIUser()
+    {
+        return isset( $this->apiUser );
+    }
+
+    /**
+     * Injects an API user to be injected in the repository.
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\User $apiUser
+     */
+    public function setApiUser( APIUser $apiUser )
+    {
+        $this->apiUser = $apiUser;
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\User\User
+     */
+    public function getAPIUser()
+    {
+        return $this->apiUser;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Event/Tests/InteractiveLoginEventTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/Tests/InteractiveLoginEventTest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * File containing the InteractiveLoginEventTest class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Symfony\Event\Tests;
+
+use eZ\Publish\Core\MVC\Symfony\Event\InteractiveLoginEvent;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class InteractiveLoginEventTest extends PHPUnit_Framework_TestCase
+{
+    public function testGetSetAPIUser()
+    {
+        $event = new InteractiveLoginEvent( new Request(), $this->getMock( 'Symfony\Component\Security\Core\Authentication\Token\TokenInterface' ) );
+        $this->assertFalse( $event->hasAPIUser() );
+        $apiUser = $this->getMock( 'eZ\Publish\API\Repository\Values\User\User' );
+        $event->setApiUser( $apiUser );
+        $this->assertTrue( $event->hasAPIUser() );
+        $this->assertSame( $apiUser, $event->getAPIUser() );
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/MVCEvents.php
+++ b/eZ/Publish/Core/MVC/Symfony/MVCEvents.php
@@ -61,4 +61,12 @@ final class MVCEvents
      * The event listener method receives a eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent instance.
      */
     const CONFIG_SCOPE_RESTORE = 'ezpublish.config.scope_restore';
+
+    /**
+     * INTERACTIVE_LOGIN event occurs when a user has been authenticated by a foreign user provider.
+     * Listening to this event gives a chance to retrieve a valid API user to be injected in repository.
+     *
+     * The event listener method receives a eZ\Publish\Core\MVC\Symfony\Event\InteractiveLoginEvent instance.
+     */
+    const INTERACTIVE_LOGIN = 'ezpublish.security.interactive_login';
 }

--- a/eZ/Publish/Core/MVC/Symfony/Security/EventListener/SecurityListener.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/EventListener/SecurityListener.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * File containing the SecurityListener class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Symfony\Security\EventListener;
+
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\MVCEvents;
+use eZ\Publish\Core\MVC\Symfony\Security\InteractiveLoginToken;
+use eZ\Publish\Core\MVC\Symfony\Security\UserInterface as eZUser;
+use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\Core\MVC\Symfony\Event\InteractiveLoginEvent;
+use eZ\Publish\Core\MVC\Symfony\Security\UserWrapped;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent as BaseInteractiveLoginEvent;
+use Symfony\Component\Security\Http\SecurityEvents;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class SecurityListener implements EventSubscriberInterface
+{
+    /**
+     * @var \eZ\Publish\API\Repository\Repository
+     */
+    private $repository;
+
+    /**
+     * @var \eZ\Publish\Core\MVC\ConfigResolverInterface
+     */
+    private $configResolver;
+
+    /**
+     * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var \Symfony\Component\Security\Core\SecurityContextInterface
+     */
+    private $securityContext;
+
+    public function __construct( Repository $repository, ConfigResolverInterface $configResolver, EventDispatcherInterface $eventDispatcher, SecurityContextInterface $securityContext )
+    {
+        $this->repository = $repository;
+        $this->configResolver = $configResolver;
+        $this->eventDispatcher = $eventDispatcher;
+        $this->securityContext = $securityContext;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            SecurityEvents::INTERACTIVE_LOGIN => 'onInteractiveLogin'
+        );
+    }
+
+    /**
+     * Tries to retrieve a valid eZ user if authenticated user doesn't come from the repository (foreign user provider).
+     * Will dispatch an event allowing listeners to return a valid eZ user for current authenticated user.
+     * Will by default let the repository load the anonymous user.
+     *
+     * @param \Symfony\Component\Security\Http\Event\InteractiveLoginEvent $event
+     */
+    public function onInteractiveLogin( BaseInteractiveLoginEvent $event )
+    {
+        $token = $event->getAuthenticationToken();
+        $originalUser = $token->getUser();
+        if ( $originalUser instanceof eZUser || !$originalUser instanceof UserInterface )
+        {
+            return;
+        }
+
+        /*
+         * 1. Send the event.
+         * 2. If no eZ user is returned, load Anonymous user.
+         * 3. Inject eZ user in repository.
+         * 4. Create the UserWrapped user object (implementing eZ UserInterface) with loaded eZ user.
+         * 5. Create new token with UserWrapped user
+         * 6. Inject the new token in security context
+         */
+        $subLoginEvent = new InteractiveLoginEvent( $event->getRequest(), $token );
+        $this->eventDispatcher->dispatch( MVCEvents::INTERACTIVE_LOGIN, $subLoginEvent );
+
+        if ( $subLoginEvent->hasAPIUser() )
+        {
+            $apiUser = $subLoginEvent->getAPIUser();
+        }
+        else
+        {
+            $apiUser = $this->repository->getUserService()->loadUser(
+                $this->configResolver->getParameter( "anonymous_user_id" )
+            );
+        }
+
+        $this->repository->setCurrentUser( $apiUser );
+
+        $providerKey = method_exists( $token, 'getProviderKey' ) ? $token->getProviderKey() : __CLASS__;
+        $interactiveToken = new InteractiveLoginToken(
+            $this->getUser( $originalUser, $apiUser ),
+            get_class( $token ),
+            $token->getCredentials(),
+            $providerKey,
+            $token->getRoles()
+        );
+        $interactiveToken->setAttributes( $token->getAttributes() );
+        $this->securityContext->setToken( $interactiveToken );
+    }
+
+    /**
+     * Returns new user object based on original user and provided API user.
+     * One may want to override this method to use their own user class.
+     *
+     * @param \Symfony\Component\Security\Core\User\UserInterface $originalUser
+     * @param \eZ\Publish\API\Repository\Values\User\User $apiUser
+     *
+     * @return \eZ\Publish\Core\MVC\Symfony\Security\UserInterface
+     */
+    protected function getUser( UserInterface $originalUser, APIUser $apiUser )
+    {
+        return new UserWrapped( $originalUser, $apiUser );
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Security/InteractiveLoginToken.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/InteractiveLoginToken.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * File containing the InteractiveLoginToken class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Symfony\Security;
+
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+
+/**
+ * This token is used when a user has been matched by a foreign user provider.
+ * It is injected in SecurityContext to replace the original token as this one holds a new user.
+ */
+class InteractiveLoginToken extends UsernamePasswordToken
+{
+    /**
+     * @var string
+     */
+    private $originalTokenType;
+
+    public function __construct( UserInterface $user, $originalTokenType, $credentials, $providerKey, array $roles = array() )
+    {
+        parent::__construct( $user, $credentials, $providerKey, $roles );
+        $this->originalTokenType = $originalTokenType;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOriginalTokenType()
+    {
+        return $this->originalTokenType;
+    }
+
+    public function serialize()
+    {
+        return serialize( array( $this->originalTokenType, parent::serialize() ) );
+    }
+
+    public function unserialize( $serialized )
+    {
+        list( $this->originalTokenType, $parentStr ) = unserialize( $serialized );
+        parent::unserialize( $parentStr );
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/EventListener/SecurityListenerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/EventListener/SecurityListenerTest.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * File containing the SecurityListenerTest class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\EventListener;
+
+use eZ\Publish\Core\MVC\Symfony\Security\EventListener\SecurityListener;
+use eZ\Publish\Core\MVC\Symfony\Event\InteractiveLoginEvent;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent as BaseInteractiveLoginEvent;
+use Symfony\Component\Security\Http\SecurityEvents;
+
+class SecurityListenerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $repository;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $configResolver;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $securityContext;
+
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\Security\EventListener\SecurityListener
+     */
+    private $listener;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->repository = $this->getMock( 'eZ\Publish\API\Repository\Repository' );
+        $this->configResolver = $this->getMock( 'eZ\Publish\Core\MVC\ConfigResolverInterface' );
+        $this->eventDispatcher = $this->getMock( 'Symfony\Component\EventDispatcher\EventDispatcherInterface' );
+        $this->securityContext = $this->getMock( 'Symfony\Component\Security\Core\SecurityContextInterface' );
+        $this->listener = new SecurityListener( $this->repository, $this->configResolver, $this->eventDispatcher, $this->securityContext );
+    }
+
+    public function testGetSubscribedEvents()
+    {
+        $this->assertSame(
+            array( SecurityEvents::INTERACTIVE_LOGIN => 'onInteractiveLogin' ),
+            SecurityListener::getSubscribedEvents()
+        );
+    }
+
+    public function testOnInteractiveLoginAlreadyEzUser()
+    {
+        $user = $this->getMock( 'eZ\Publish\Core\MVC\Symfony\Security\UserInterface' );
+        $token = $this->getMock( 'Symfony\Component\Security\Core\Authentication\Token\TokenInterface' );
+        $token
+            ->expects( $this->once() )
+            ->method( 'getUser' )
+            ->will( $this->returnValue( $user ) );
+        $event = new BaseInteractiveLoginEvent( new Request(), $token );
+
+        $this->eventDispatcher
+            ->expects( $this->never() )
+            ->method( 'dispatch' );
+
+        $this->listener->onInteractiveLogin( $event );
+    }
+
+    public function testOnInteractiveLoginNotUserObject()
+    {
+        $user = 'foobar';
+        $token = $this->getMock( 'Symfony\Component\Security\Core\Authentication\Token\TokenInterface' );
+        $token
+            ->expects( $this->once() )
+            ->method( 'getUser' )
+            ->will( $this->returnValue( $user ) );
+        $event = new BaseInteractiveLoginEvent( new Request(), $token );
+
+        $this->eventDispatcher
+            ->expects( $this->never() )
+            ->method( 'dispatch' );
+
+        $this->listener->onInteractiveLogin( $event );
+    }
+
+    public function testOnInteractiveLogin()
+    {
+        $user = $this->getMock( 'Symfony\Component\Security\Core\User\UserInterface' );
+        $token = $this->getMock( 'Symfony\Component\Security\Core\Authentication\Token\TokenInterface' );
+        $token
+            ->expects( $this->once() )
+            ->method( 'getUser' )
+            ->will( $this->returnValue( $user ) );
+        $token
+            ->expects( $this->once() )
+            ->method( 'getRoles' )
+            ->will( $this->returnValue( array( 'ROLE_USER' ) ) );
+        $token
+            ->expects( $this->once() )
+            ->method( 'getAttributes' )
+            ->will( $this->returnValue( array( 'foo' => 'bar' ) ) );
+
+        $event = new BaseInteractiveLoginEvent( new Request(), $token );
+
+        $anonymousUserId = 10;
+        $this->configResolver
+            ->expects( $this->once() )
+            ->method( 'getParameter' )
+            ->with( 'anonymous_user_id' )
+            ->will( $this->returnValue( $anonymousUserId ) );
+
+        $apiUser = $this->getMock( 'eZ\Publish\API\Repository\Values\User\User' );
+        $userService = $this->getMock( 'eZ\Publish\API\Repository\UserService' );
+        $userService
+            ->expects( $this->once() )
+            ->method( 'loadUser' )
+            ->with( $anonymousUserId )
+            ->will( $this->returnValue( $apiUser ) );
+
+        $this->repository
+            ->expects( $this->once() )
+            ->method( 'getUserService' )
+            ->will( $this->returnValue( $userService ) );
+        $this->repository
+            ->expects( $this->once() )
+            ->method( 'setCurrentUser' )
+            ->with( $apiUser );
+
+        $this->securityContext
+            ->expects( $this->once() )
+            ->method( 'setToken' )
+            ->with( $this->isInstanceOf( 'eZ\Publish\Core\MVC\Symfony\Security\InteractiveLoginToken' ) );
+
+        $this->listener->onInteractiveLogin( $event );
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/InteractiveLoginTokenTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/InteractiveLoginTokenTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * File containing the InteractiveLoginTokenTest class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Symfony\Security\Tests;
+
+use eZ\Publish\Core\MVC\Symfony\Security\InteractiveLoginToken;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Security\Core\Role\Role;
+
+class InteractiveLoginTokenTest extends PHPUnit_Framework_TestCase
+{
+    public function testConstruct()
+    {
+        $user = $this->getMock( 'eZ\Publish\Core\MVC\Symfony\Security\UserInterface' );
+        $originalTokenType = 'FooBar';
+        $credentials = 'my_credentials';
+        $providerKey = 'key';
+        $roles = array( 'ROLE_USER', 'ROLE_TEST', new Role( 'ROLE_FOO' ) );
+        $expectedRoles = array();
+        foreach ( $roles as $role )
+        {
+            if ( is_string( $role ) )
+            {
+                $expectedRoles[] = new Role( $role );
+            }
+            else
+            {
+                $expectedRoles[] = $role;
+            }
+        }
+
+        $token = new InteractiveLoginToken( $user, $originalTokenType, $credentials, $providerKey, $roles );
+        $this->assertSame( $user, $token->getUser() );
+        $this->assertTrue( $token->isAuthenticated() );
+        $this->assertSame( $originalTokenType, $token->getOriginalTokenType() );
+        $this->assertSame( $credentials, $token->getCredentials() );
+        $this->assertSame( $providerKey, $token->getProviderKey() );
+        $this->assertEquals( $expectedRoles, $token->getRoles() );
+    }
+
+    public function testSerialize()
+    {
+        $user = $this->getMock( 'eZ\Publish\Core\MVC\Symfony\Security\UserInterface' );
+        $originalTokenType = 'FooBar';
+        $credentials = 'my_credentials';
+        $providerKey = 'key';
+        $roles = array( 'ROLE_USER', 'ROLE_TEST', new Role( 'ROLE_FOO' ) );
+
+        $token = new InteractiveLoginToken( $user, $originalTokenType, $credentials, $providerKey, $roles );
+        $serialized = serialize( $token );
+        $unserializedToken = unserialize( $serialized );
+        $this->assertEquals( $token, $unserializedToken );
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/User/ProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/User/ProviderTest.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * File containing the ProviderTest class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\User;
+
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\MVC\Symfony\Security\User\Provider;
+use PHPUnit_Framework_TestCase;
+
+class ProviderTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $repository;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $userService;
+
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\Security\User\Provider
+     */
+    private $userProvider;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->userService = $this->getMock( 'eZ\Publish\API\Repository\UserService' );
+        $this->repository = $this->getMock( 'eZ\Publish\API\Repository\Repository' );
+        $this->repository
+            ->expects( $this->any() )
+            ->method( 'getUserService' )
+            ->will( $this->returnValue( $this->userService ) );
+        $this->userProvider = new Provider( $this->repository );
+    }
+
+    public function testLoadUserByUsernameAlreadyUserObject()
+    {
+        $user = $this->getMock( 'eZ\Publish\Core\MVC\Symfony\Security\UserInterface' );
+        $this->assertSame( $user, $this->userProvider->loadUserByUsername( $user ) );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\UsernameNotFoundException
+     */
+    public function testLoadUserByUsernameUserNotFound()
+    {
+        $username = 'foobar';
+        $this->userService
+            ->expects( $this->once() )
+            ->method( 'loadUserByLogin' )
+            ->with( $username )
+            ->will( $this->throwException( new NotFoundException( 'user', $username ) ) );
+        $this->userProvider->loadUserByUsername( $username );
+    }
+
+    public function testLoadUserByUsername()
+    {
+        $username = 'foobar';
+        $apiUser = $this->getMock( 'eZ\Publish\API\Repository\Values\User\User' );
+        $this->userService
+            ->expects( $this->once() )
+            ->method( 'loadUserByLogin' )
+            ->with( $username )
+            ->will( $this->returnValue( $apiUser ) );
+
+        $user = $this->userProvider->loadUserByUsername( $username );
+        $this->assertInstanceOf( 'eZ\Publish\Core\MVC\Symfony\Security\UserInterface', $user );
+        $this->assertSame( $apiUser, $user->getAPIUser() );
+        $this->assertSame( array( 'ROLE_USER' ), $user->getRoles() );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\UnsupportedUserException
+     */
+    public function testRefreshUserNotSupported()
+    {
+        $user = $this->getMock( 'Symfony\Component\Security\Core\User\UserInterface' );
+        $this->userProvider->refreshUser( $user );
+    }
+
+    public function testRefreshUser()
+    {
+        $apiUser = $this->getMock( 'eZ\Publish\API\Repository\Values\User\User' );
+        $user = $this->getMock( 'eZ\Publish\Core\MVC\Symfony\Security\UserInterface' );
+        $user
+            ->expects( $this->once() )
+            ->method( 'getAPIUser' )
+            ->will( $this->returnValue( $apiUser ) );
+
+        $this->repository
+            ->expects( $this->once() )
+            ->method( 'setCurrentUser' )
+            ->with( $apiUser );
+
+        $this->assertSame( $user, $this->userProvider->refreshUser( $user ) );
+    }
+
+    /**
+     * @dataProvider supportsClassProvider
+     */
+    public function testSupportsClass( $class, $supports )
+    {
+        $this->assertSame( $supports, $this->userProvider->supportsClass( $class ) );
+    }
+
+    public function supportsClassProvider()
+    {
+        return array(
+            array( 'Symfony\Component\Security\Core\User\UserInterface', false ),
+            array( 'eZ\Publish\Core\MVC\Symfony\Security\User', true ),
+            array( get_class( $this->getMock( 'eZ\Publish\Core\MVC\Symfony\Security\User' ) ), true ),
+        );
+    }
+
+    public function testLoadUserByAPIUser()
+    {
+        $apiUser = $this->getMock( 'eZ\Publish\API\Repository\Values\User\User' );
+        $user = $this->userProvider->loadUserByAPIUser( $apiUser );
+        $this->assertInstanceOf( 'eZ\Publish\Core\MVC\Symfony\Security\User', $user );
+        $this->assertSame( $apiUser, $user->getAPIUser() );
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserWrappedTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserWrappedTest.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * File containing the UserWrappedTest class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Symfony\Security\Tests;
+
+use eZ\Publish\Core\MVC\Symfony\Security\UserWrapped;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Security\Core\User\User;
+
+class UserWrappedTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $apiUser;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->apiUser = $this->getMock( 'eZ\Publish\API\Repository\Values\User\User' );
+    }
+
+    public function testGetSetAPIUser()
+    {
+        $originalUser = $this->getMock( 'Symfony\Component\Security\Core\User\UserInterface' );
+        $userWrapped = new UserWrapped( $originalUser, $this->apiUser );
+        $this->assertSame( $this->apiUser, $userWrapped->getAPIUser() );
+
+        $newApiUser = $this->getMock( 'eZ\Publish\API\Repository\Values\User\User' );
+        $userWrapped->setAPIUser( $newApiUser );
+        $this->assertSame( $newApiUser, $userWrapped->getAPIUser() );
+    }
+
+    /**
+     * @dataProvider advancedUserProvider
+     */
+    public function testAdvancedUser( $username, $password, $roles, $enabled, $userNonExpired, $credentialsNonExpired, $userNonLocked )
+    {
+        $originalUser = new User( $username, $password, $roles, $enabled, $userNonExpired, $credentialsNonExpired, $userNonLocked );
+        $user = new UserWrapped( $originalUser, $this->apiUser );
+        $this->assertSame( $username, (string)$user );
+        $this->assertSame( $username, $user->getUsername() );
+        $this->assertSame( $password, $user->getPassword() );
+        $this->assertSame( $roles, $user->getRoles() );
+        $this->assertSame( $enabled, $user->isEnabled() );
+        $this->assertSame( $userNonExpired, $user->isAccountNonExpired() );
+        $this->assertSame( $credentialsNonExpired, $user->isCredentialsNonExpired() );
+        $this->assertSame( $userNonLocked, $user->isAccountNonLocked() );
+        $this->assertSame( $originalUser->getSalt(), $user->getSalt() );
+    }
+
+    public function advancedUserProvider()
+    {
+        return array(
+            array( 'foo', 'password', array( 'ROLE_USER' ), true, true, true, true ),
+            array( 'foo', 'password', array( 'ROLE_USER' ), true, false, true, false ),
+            array( 'foo', 'password', array( 'ROLE_USER' ), false, true, false, true ),
+            array( 'bar', 'secret', array( 'ROLE_TEST' ), true, true, true, true ),
+            array( 'bar', 'secret', array( 'ROLE_TEST' ), false, false, false, false ),
+            array( 'Jérôme', 'NoThisIsNotMyRealPassword', array( 'ROLE_ADMIN' ), true, true, true, true ),
+        );
+    }
+
+    public function testRegularUser()
+    {
+        $originalUser = $this->getMock( 'Symfony\Component\Security\Core\User\UserInterface' );
+        $user = new UserWrapped( $originalUser, $this->apiUser );
+
+        $this->assertTrue( $user->isEnabled() );
+        $this->assertTrue( $user->isAccountNonExpired() );
+        $this->assertTrue( $user->isAccountNonLocked() );
+        $this->assertTrue( $user->isCredentialsNonExpired() );
+        $this->assertTrue( $user->isEqualTo( $this->getMock( 'Symfony\Component\Security\Core\User\UserInterface' ) ) );
+
+        $originalUser
+            ->expects( $this->once() )
+            ->method( 'eraseCredentials' );
+        $user->eraseCredentials();
+
+        $username = 'lolautruche';
+        $password = 'NoThisIsNotMyRealPassword';
+        $roles = array( 'ROLE_USER', 'ROLE_TEST' );
+        $salt = md5( microtime( true ) );
+        $originalUser
+            ->expects( $this->exactly( 2 ) )
+            ->method( 'getUsername' )
+            ->will( $this->returnValue( $username ) );
+        $originalUser
+            ->expects( $this->once() )
+            ->method( 'getPassword' )
+            ->will( $this->returnValue( $password ) );
+        $originalUser
+            ->expects( $this->once() )
+            ->method( 'getRoles' )
+            ->will( $this->returnValue( $roles ) );
+        $originalUser
+            ->expects( $this->once() )
+            ->method( 'getSalt' )
+            ->will( $this->returnValue( $salt ) );
+
+        $this->assertSame( $username, $user->getUsername() );
+        $this->assertSame( $username, (string)$user );
+        $this->assertSame( $password, $user->getPassword() );
+        $this->assertSame( $roles, $user->getRoles() );
+        $this->assertSame( $salt, $user->getSalt() );
+    }
+
+    public function testIsEqualTo()
+    {
+        $originalUser = $this->getMock( 'eZ\Publish\Core\MVC\Symfony\Security\User' );
+        $user = new UserWrapped( $originalUser, $this->apiUser );
+        $otherUser = $this->getMock( 'Symfony\Component\Security\Core\User\UserInterface' );
+        $originalUser
+            ->expects( $this->once() )
+            ->method( 'isEqualTo' )
+            ->with( $otherUser )
+            ->will( $this->returnValue( false ) );
+        $this->assertFalse( $user->isEqualTo( $otherUser ) );
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Security/User.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/User.php
@@ -10,11 +10,10 @@
 namespace eZ\Publish\Core\MVC\Symfony\Security;
 
 use eZ\Publish\API\Repository\Values\User\User as APIUser;
-use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Security\Core\User\AdvancedUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface as BaseUserInterface;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 
-class User implements AdvancedUserInterface, EquatableInterface
+class User implements UserInterface, EquatableInterface
 {
     /**
      * @var \eZ\Publish\API\Repository\Values\User\User
@@ -116,21 +115,7 @@ class User implements AdvancedUserInterface, EquatableInterface
         $this->user = $user;
     }
 
-    /**
-     * The equality comparison should neither be done by referential equality
-     * nor by comparing identities (i.e. getId() === getId()).
-     *
-     * However, you do not need to compare every attribute, but only those that
-     * are relevant for assessing whether re-authentication is required.
-     *
-     * Also implementation should consider that $user instance may implement
-     * the extended user interface `AdvancedUserInterface`.
-     *
-     * @param UserInterface $user
-     *
-     * @return Boolean
-     */
-    public function isEqualTo( UserInterface $user )
+    public function isEqualTo( BaseUserInterface $user )
     {
         if ( $user instanceof User && $this->user instanceof APIUser )
         {

--- a/eZ/Publish/Core/MVC/Symfony/Security/UserInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * File containing the UserInterface class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Symfony\Security;
+
+use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use Symfony\Component\Security\Core\User\AdvancedUserInterface;
+
+/**
+ * Interface for Repository based users.
+ */
+interface UserInterface extends AdvancedUserInterface
+{
+    /**
+     * @return \eZ\Publish\API\Repository\Values\User\User
+     */
+    public function getAPIUser();
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\User\User $apiUser
+     */
+    public function setAPIUser( APIUser $apiUser );
+}

--- a/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * File containing the UserWrapped class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Symfony\Security;
+
+use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use Symfony\Component\Security\Core\User\AdvancedUserInterface;
+use Symfony\Component\Security\Core\User\EquatableInterface;
+use Symfony\Component\Security\Core\User\UserInterface as CoreUserInterface;
+
+class UserWrapped implements UserInterface, EquatableInterface
+{
+    /**
+     * @var \Symfony\Component\Security\Core\User\UserInterface
+     */
+    private $wrappedUser;
+
+    /**
+     * @var \eZ\Publish\API\Repository\Values\User\User
+     */
+    private $apiUser;
+
+    public function __construct( CoreUserInterface $wrappedUser, APIUser $apiUser )
+    {
+        $this->wrappedUser = $wrappedUser;
+        $this->apiUser = $apiUser;
+    }
+
+    public function __toString()
+    {
+        return $this->wrappedUser->getUsername();
+    }
+
+    public function isAccountNonExpired()
+    {
+        return $this->wrappedUser instanceof AdvancedUserInterface ? $this->wrappedUser->isAccountNonExpired() : true;
+    }
+
+    public function isAccountNonLocked()
+    {
+        return $this->wrappedUser instanceof AdvancedUserInterface ? $this->wrappedUser->isAccountNonLocked() : true;
+    }
+
+    public function isCredentialsNonExpired()
+    {
+        return $this->wrappedUser instanceof AdvancedUserInterface ? $this->wrappedUser->isCredentialsNonExpired() : true;
+    }
+
+    public function isEnabled()
+    {
+        return $this->wrappedUser instanceof AdvancedUserInterface ? $this->wrappedUser->isEnabled() : true;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\User\User $apiUser
+     */
+    public function setAPIUser( APIUser $apiUser )
+    {
+        $this->apiUser = $apiUser;
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\User\User
+     */
+    public function getAPIUser()
+    {
+        return $this->apiUser;
+    }
+
+    public function getRoles()
+    {
+        return $this->wrappedUser->getRoles();
+    }
+
+    public function getPassword()
+    {
+        return $this->wrappedUser->getPassword();
+    }
+
+    public function getSalt()
+    {
+        return $this->wrappedUser->getSalt();
+    }
+
+    public function getUsername()
+    {
+        return $this->wrappedUser->getUsername();
+    }
+
+    public function eraseCredentials()
+    {
+        $this->wrappedUser->eraseCredentials();
+    }
+
+    public function isEqualTo( CoreUserInterface $user )
+    {
+        return $this->wrappedUser instanceof EquatableInterface ? $this->wrappedUser->isEqualTo( $user ) : true;
+    }
+}


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22081

This PR introduces a mechanism allowing to use multiple user providers with eZ Publish.
Symfony natively supports multiple user providers, but this patch allows to match a user from a _foreign_ provider (e.g. LDAP) to an existing user in eZ repository.

It uses `SecurityEvents::INTERACTIVE_LOGIN` and sends another specific event. Listeners can eventually create and/or retrieve a user from eZ repository and return it. It will be then be used for repository specific user access.

[Specification can be found here](https://github.com/ezsystems/ezpublish-kernel/blob/c406b332546cea49438556c8db41fd7e74ba8fa1/doc/specifications/security/multiple_user_providers.md)
## TODO
- [x] Implement mechanism
- [x] Tests
- [x] Write specifications and an example
