### PR TITLE
Fix EZP-22126: Not possible to install/use ezpublish5 using git installation

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtypes.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtypes.yml
@@ -563,6 +563,7 @@ services:
         arguments: [%ezpublish.fieldType.ezpage.pageService.class%, @ezpublish.config.resolver, @ezpublish.fieldType.ezpage.storage_gateway]
         calls:
             - [setRepository, [@ezpublish.api.repository]]
+        lazy: true
 
     ezpublish.fieldType.ezpage.parameterProvider:
         class: %ezpublish.fieldType.ezpage.parameterProvider.class%


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22126

This was due to `ezpublish.fieldType.ezpage.pageService` being loaded by Twig ContentExtension. 
It has been marked as lazy.
