### PR TITLE
Fix EZP-22099: Support of legacy sso handlers to continue to work with new authentication system

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/DependencyInjection/Security/SSOFactory.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/DependencyInjection/Security/SSOFactory.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * File containing the SSOFactory class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Security;
+
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Security factory for legacy SSO handlers.
+ */
+class SSOFactory extends AbstractFactory
+{
+    protected function createAuthProvider( ContainerBuilder $container, $id, $config, $userProviderId )
+    {
+        $preAuthProviderId = 'security.authentication.provider.pre_authenticated';
+        $providerId = "$preAuthProviderId.$id";
+        $container
+            ->setDefinition( $providerId, new DefinitionDecorator( $preAuthProviderId ) )
+            ->replaceArgument( 0, new Reference( $userProviderId ) )
+            ->addArgument( $id );
+
+        return $providerId;
+    }
+
+    protected function createListener( $container, $id, $config, $userProvider )
+    {
+        $parentListenerId = $this->getListenerId();
+        $listenerId = "$parentListenerId.$id";
+        $container
+            ->setDefinition( $listenerId, new DefinitionDecorator( $parentListenerId ) )
+            ->replaceArgument( 2, $id );
+
+        return $listenerId;
+    }
+
+    protected function getListenerId()
+    {
+        return 'ezpublish_legacy.security.sso_firewall_listener';
+    }
+
+    public function getPosition()
+    {
+        return 'pre_auth';
+    }
+
+    public function getKey()
+    {
+        return 'ezpublish_legacy_sso';
+    }
+}

--- a/eZ/Bundle/EzPublishLegacyBundle/EzPublishLegacyBundle.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/EzPublishLegacyBundle.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Bundle\EzPublishLegacyBundle;
 
+use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Security\SSOFactory;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler\LegacyPass;
 use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Compiler\TwigPass;
@@ -33,5 +34,9 @@ class EzPublishLegacyBundle extends Bundle
         parent::build( $container );
         $container->addCompilerPass( new LegacyPass() );
         $container->addCompilerPass( new TwigPass() );
+
+        /** @var \Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension $securityExtension */
+        $securityExtension = $container->getExtension( 'security' );
+        $securityExtension->addSecurityListenerFactory( new SSOFactory() );
     }
 }

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/security.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/security.yml
@@ -1,6 +1,7 @@
 parameters:
     ezpublish_legacy.security.login_cleanup_listener.class: eZ\Publish\Core\MVC\Legacy\Security\Firewall\LoginCleanupListener
     ezpublish_legacy.security_mapper.class: eZ\Bundle\EzPublishLegacyBundle\LegacyMapper\Security
+    ezpublish_legacy.security.sso_firewall_listener.class: eZ\Publish\Core\MVC\Legacy\Security\Firewall\SSOListener
 
 services:
     ezpublish_legacy.security.login_cleanup_listener:
@@ -13,3 +14,16 @@ services:
         arguments: [@ezpublish.api.repository, @ezpublish.config.resolver]
         tags:
             - { name: kernel.event_subscriber }
+
+    ezpublish_legacy.security.sso_firewall_listener:
+        class: %ezpublish_legacy.security.sso_firewall_listener.class%
+        abstract: true
+        arguments:
+            - @security.context
+            - @security.authentication.manager
+            - ~     # Will be replaced at compile time by the security factory to be the right user provider
+            - @?logger
+            - @?event_dispatcher
+        calls:
+            - [setLegacyKernelClosure, [@ezpublish_legacy.kernel]]
+            - [setUserService, [@ezpublish.api.service.user]]

--- a/eZ/Publish/Core/MVC/Legacy/Security/Firewall/SSOListener.php
+++ b/eZ/Publish/Core/MVC/Legacy/Security/Firewall/SSOListener.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * File containing the SSOListener class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Legacy\Security\Firewall;
+
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\Core\MVC\Symfony\Security\User;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\Firewall\AbstractPreAuthenticatedListener;
+use eZINI;
+use eZUser;
+
+/**
+ * Firewall listener for legacy SSO handlers.
+ */
+class SSOListener extends AbstractPreAuthenticatedListener
+{
+    /**
+     * @var \Closure
+     */
+    private $legacyKernelClosure;
+
+    /**
+     * @var \eZ\Publish\API\Repository\UserService
+     */
+    private $userService;
+
+    /**
+     * @param \Closure $legacyKernelClosure
+     */
+    public function setLegacyKernelClosure( \Closure $legacyKernelClosure )
+    {
+        $this->legacyKernelClosure = $legacyKernelClosure;
+    }
+
+    /**
+     * @param mixed $userService
+     */
+    public function setUserService( UserService $userService )
+    {
+        $this->userService = $userService;
+    }
+
+    /**
+     * Iterates over legacy SSO handlers, and pre-authenticates a user if a handler returns one.
+     *
+     * @param Request $request A Request instance
+     *
+     * @return array An array composed of the user and the credentials
+     */
+    protected function getPreAuthenticatedData( Request $request )
+    {
+        $kernelClosure = $this->legacyKernelClosure;
+        /** @var \ezpKernelHandler $legacyKernel */
+        $legacyKernel = $kernelClosure();
+        $logger = $this->logger;
+
+        $legacyUser = $legacyKernel->runCallback(
+            function () use ( $logger )
+            {
+                foreach ( eZINI::instance()->variable( 'UserSettings', 'SingleSignOnHandlerArray' ) as $ssoHandlerName )
+                {
+                    $className = 'eZ' . $ssoHandlerName . 'SSOHandler';
+                    if ( !class_exists( $className ) )
+                    {
+                        if ( $logger )
+                        {
+                            $logger->error( "Undefined legacy SSOHandler class: $className" );
+                        }
+                        continue;
+                    }
+
+                    $ssoHandler = new $className();
+                    $ssoUser = $ssoHandler->handleSSOLogin();
+                    if ( !$ssoUser instanceof eZUser )
+                    {
+                        continue;
+                    }
+
+                    $logger->info( "Matched user using eZ legacy SSO Handler: $className" );
+                    return $ssoUser;
+                }
+            },
+            false
+        );
+
+        // No matched user with legacy.
+        if ( !$legacyUser instanceof eZUser )
+        {
+            return array( '', '' );
+        }
+
+        $user = new User(
+            $this->userService->loadUser( $legacyUser->attribute( 'contentobject_id' ) ),
+            array( 'ROLE_USER' )
+        );
+        return array( $user, $user->getPassword() );
+    }
+}

--- a/eZ/Publish/Core/MVC/Legacy/Tests/Security/SSOListenerTest.php
+++ b/eZ/Publish/Core/MVC/Legacy/Tests/Security/SSOListenerTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * File containing the SSOListenerTest class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Legacy\Tests\Security;
+
+use eZ\Publish\Core\MVC\Legacy\Security\Firewall\SSOListener;
+use eZ\Publish\Core\MVC\Symfony\Security\User;
+use PHPUnit_Framework_TestCase;
+use ReflectionObject;
+use Symfony\Component\HttpFoundation\Request;
+use eZUser;
+
+class SSOListenerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\Legacy\Security\Firewall\SSOListener
+     */
+    private $ssoListener;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $legacyKernel;
+
+    /**
+     * @var \Closure
+     */
+    private $legacyKernelClosure;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $userService;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->ssoListener = new SSOListener(
+            $this->getMock( 'Symfony\Component\Security\Core\SecurityContextInterface' ),
+            $this->getMock( 'Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface' ),
+            'firewall_key'
+        );
+
+        $legacyKernel = $this->legacyKernel = $this->getMock( 'ezpKernelHandler' );
+        $this->legacyKernelClosure = function () use ( $legacyKernel )
+        {
+            return $legacyKernel;
+        };
+
+        $this->userService = $this->getMock( 'eZ\Publish\API\Repository\UserService' );
+    }
+
+    public function testGetPreAuthenticatedDataNoUser()
+    {
+        $this->ssoListener->setLegacyKernelClosure( $this->legacyKernelClosure );
+        $this->ssoListener->setUserService( $this->userService );
+
+        $this->userService
+            ->expects( $this->never() )
+            ->method( 'loadUser' );
+
+        $this->legacyKernel
+            ->expects( $this->once() )
+            ->method( 'runCallback' )
+            ->with( $this->isInstanceOf( '\Closure' ), false )
+            ->will( $this->returnValue( null ) );
+
+        $refListener = new ReflectionObject( $this->ssoListener );
+        $refMethod = $refListener->getMethod( 'getPreAuthenticatedData' );
+        $refMethod->setAccessible( true );
+        $this->assertSame( array( '', '' ), $refMethod->invoke( $this->ssoListener, new Request() ) );
+    }
+
+    public function testGetPreAuthenticatedData()
+    {
+        $this->ssoListener->setLegacyKernelClosure( $this->legacyKernelClosure );
+        $this->ssoListener->setUserService( $this->userService );
+
+        $userId = 123;
+        $passwordHash = md5( 'password' );
+        $legacyUser = new eZUser( array( 'contentobject_id' => $userId ) );
+        $apiUser = $this
+            ->getMockBuilder( 'eZ\Publish\API\Repository\Values\User\User' )
+            ->setConstructorArgs( array( array( 'passwordHash' => $passwordHash ) ) )
+            ->getMockForAbstractClass();
+        $finalUser = new User( $apiUser, array( 'ROLE_USER' ) );
+
+        $this->userService
+            ->expects( $this->once() )
+            ->method( 'loadUser' )
+            ->with( $userId )
+            ->will( $this->returnValue( $apiUser ) );
+
+        $this->legacyKernel
+            ->expects( $this->once() )
+            ->method( 'runCallback' )
+            ->with( $this->isInstanceOf( '\Closure' ), false )
+            ->will( $this->returnValue( $legacyUser ) );
+
+        $refListener = new ReflectionObject( $this->ssoListener );
+        $refMethod = $refListener->getMethod( 'getPreAuthenticatedData' );
+        $refMethod->setAccessible( true );
+        $this->assertEquals( array( $finalUser, $passwordHash ), $refMethod->invoke( $this->ssoListener, new Request() ) );
+    }
+}


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22099

This PR brings support for [legacy SSO handlers](http://share.ez.no/learn/ez-publish/using-a-sso-in-ez-publish).

To be able to use your legacy SSO handlers, use the following config in your `ezpublish/config/security.yml`:

``` yaml
security:
    firewalls:
        ezpublish_front:
            pattern: ^/
            anonymous: ~
            # Adding the following entry will activate the use of old SSO handlers.
            ezpublish_legacy_sso: ~
```
## TODO
- [x] Add support for legacy SSO handlers.
