### PR TITLE
EZP-215612: Fixed autoload in api & spi composer.json

### DIFF
--- a/eZ/Publish/API/composer.json
+++ b/eZ/Publish/API/composer.json
@@ -8,7 +8,7 @@
     },
     "autoload": {
         "psr-0": {
-            "eZ": ""
+            "eZ\\Publish\\API": ""
         }
     },
     "extra": {

--- a/eZ/Publish/SPI/composer.json
+++ b/eZ/Publish/SPI/composer.json
@@ -9,7 +9,7 @@
     },
     "autoload": {
         "psr-0": {
-            "eZ": ""
+            "eZ\\Publish\\SPI": ""
         }
     },
     "extra": {


### PR DESCRIPTION
Fixes the autoload key in `eZ/Publish/SPI` & `eZ/Publish/API` composer.json.
