### PR TITLE
FIX EZP-21104 Creating a session while already logged on with another should return a 409 error

### DIFF
--- a/eZ/Publish/Core/REST/Server/Controller/User.php
+++ b/eZ/Publish/Core/REST/Server/Controller/User.php
@@ -975,11 +975,7 @@ class User extends RestController
                     )
                 );
             }
-
-            $anonymousUser = $this->userService->loadUser(
-                $this->container->getParameter( "ezpublish.config.resolver" )->getParameter( "anonymous_user_id" )
-            );
-            if ( $currentApiUser->id != $anonymousUser->id )
+            if ( $currentApiUser->id != $this->container->get( "ezpublish.config.resolver" )->getParameter( "anonymous_user_id" ) )
             {
                 // Already logged in with another user, this will be converted to HTTP status 409
                 return new Values\Conflict();


### PR DESCRIPTION
According to the spec if an user, with an other already active session, log in with REST API the result must be a 409 error.
I did a minor change on the call of the ez.config.resolver service and it now works.

Jira link : https://jira.ez.no/browse/EZP-21104
