### PR TITLE
Fix EZP-22235: IO exception on windows filesystem

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/IOFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/IOFactory.php
@@ -76,7 +76,7 @@ class IOFactory
             {
                 $storageDirectoryParts[] = $this->configResolver->getParameter( $setting );
             }
-            $storageDirectory = implode( DIRECTORY_SEPARATOR, $storageDirectoryParts );
+            $storageDirectory = implode( '/', $storageDirectoryParts );
         }
         return new $handlerClass( $storageDirectory );
     }

--- a/eZ/Publish/Core/IO/Handler/Legacy.php
+++ b/eZ/Publish/Core/IO/Handler/Legacy.php
@@ -524,7 +524,7 @@ class Legacy implements IOHandlerInterface
             return $path;
         }
 
-        if ( strpos( $path, $this->storageDirectory . DIRECTORY_SEPARATOR ) !== 0 )
+        if ( strpos( $path, $this->storageDirectory . '/' ) !== 0 )
         {
             throw new InvalidArgumentException( '$path', "Storage directory '$this->storageDirectory' not found in $path" );
         }


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-22235

Under Windows, when retrieving an image field of a content object, I got this exception:
"Argument '$path' is invalid: Storage directory not found in image path

Fixed by replacing DIRECTORY_SEPARATOR by '/' (because path components for images in database are separated by '/' and not '\' (under windows).

Trace:
#0 D:\SitesSqwalEzpCanalTPEzPublishvendorezsystemsezpublish-kerneleZPublishCoreIOHandlerLegacy.php(391): eZPublishCoreIOHandlerLegacy->removeStoragePath('var/ezsqwal/sto...')
#1 D:SitesSqwalEzpCanalTPEzPublishvendorezsystemsezpublish-kerneleZPublishCoreIOIOService.php(249): eZPublishCoreIOHandlerLegacy->getExternalPath('var/ezsqwal/sto...')
#2 D:SitesSqwalEzpCanalTPEzPublishvendorezsystemsezpublish-kerneleZPublishCoreFieldTypeImageImageStorage.php(231): eZPublishCoreIOIOService->getExternalPath('var/ezsqwal/sto...')
#3 D:SitesSqwalEzpCanalTPEzPublishvendorezsystemsezpublish-kerneleZPublishCorePersistenceLegacyContentStorageHandler.php(95): eZPublishCoreFieldTypeImageImageStorage->getFieldData(Object(eZPublishSPIPersistenceContentVersionInfo), Object(eZPublishSPIPersistenceContentField), Array)
#4 D:SitesSqwalEzpCanalTPEzPublishvendorezsystemsezpublish-kerneleZPublishCorePersistenceLegacyContentFieldHandler.php(379): eZPublishCorePersistenceLegacyContentStorageHandler->getFieldData(Object(eZPublishSPIPersistenceContentVersionInfo), Object(eZPublishSPIPersistenceContentField))
#5 D:SitesSqwalEzpCanalTPEzPublishvendorezsystemsezpublish-kerneleZPublishCorePersistenceLegacyContentHandler.php(323): eZPublishCorePersistenceLegacyContentFieldHandler->loadExternalFieldData(Object(eZPublishSPIPersistenceContent))
#6 D:SitesSqwalEzpCanalTPEzPublishvendorezsystemsezpublish-kerneleZPublishCorePersistenceCacheContentHandler.php(72): eZPublishCorePersistenceLegacyContentHandler->load(178, 2)
#7 D:SitesSqwalEzpCanalTPEzPublishvendorezsystemsezpublish-kerneleZPublishCoreRepositoryContentService.php(385): eZPublishCorePersistenceCacheContentHandler->load(178, 2, NULL)
#8 D:SitesSqwalEzpCanalTPEzPublishvendorezsystemsezpublish-kerneleZPublishCoreRepositoryContentService.php(331): eZPublishCoreRepositoryContentService->internalLoadContent(178, NULL, NULL)
#9 D:SitesSqwalEzpCanalTPEzPublishvendorezsystemsezpublish-kerneleZPublishCoreSignalSlotContentService.php(191): eZPublishCoreRepositoryContentService->loadContent(178, NULL, NULL)
