### PR TITLE
Fix EZP-22198: Unhide location no longers triggers re-indexation

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/slot.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/slot.yml
@@ -93,7 +93,7 @@ services:
         class: %ezpublish_legacy.signalslot.unhide_location.class%
         arguments: [@ezpublish_legacy.kernel]
         tags:
-            - { name: ezpublish.api.slot, signal: LocationService\UpdateLocationSignal }
+            - { name: ezpublish.api.slot, signal: LocationService\LegacyUnhideLocationSlot }
 
     ezpublish_legacy.signalslot.update_location:
         class: %ezpublish_legacy.signalslot.update_location.class%


### PR DESCRIPTION
This PR resolves issue https://jira.ez.no/browse/EZP-22198

Slot configuration is fixed for correct Slor for Location unhide signal.
