### PR TITLE
Fix EZP-22228: NotFoundException thrown when not all requested languages are present

### DIFF
--- a/eZ/Publish/Core/Persistence/InMemory/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/InMemory/ContentHandler.php
@@ -419,6 +419,13 @@ class ContentHandler implements ContentHandlerInterface
         if ( isset( $translations ) )
             $fieldMatch["languageCode"] = $translations;
         $content->fields = $this->backend->find( 'Content\\Field', $fieldMatch );
+        if ( empty( $content->fields ) )
+        {
+            throw new NotFoundException(
+                'Content',
+                "contentId:{$id}, versionNo:{$version}" . ( $translations ? ', ' . implode( ',', $translations ) : '' )
+            );
+        }
 
         $content->versionInfo = $versions[0];
         return $content;

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -393,29 +393,6 @@ class ContentService implements ContentServiceInterface
             );
         }
 
-        if ( !empty( $languages ) )
-        {
-            foreach ( $languages as $languageCode )
-            {
-                if (
-                    !in_array(
-                        $this->persistenceHandler->contentLanguageHandler()->loadByLanguageCode( $languageCode )->id,
-                        $spiContent->versionInfo->languageIds
-                    )
-                )
-                {
-                    throw new NotFoundException(
-                        "Content",
-                        array(
-                            $isRemoteId ? "remoteId" : "id" => $id,
-                            "languages" => $languages,
-                            "versionNo" => $versionNo
-                        )
-                    );
-                }
-            }
-        }
-
         return $this->domainMapper->buildContentDomainObject( $spiContent );
     }
 

--- a/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentBase.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentBase.php
@@ -382,8 +382,10 @@ abstract class ContentBase extends BaseServiceTest
         return array(
             array( 4, null, null ),
             array( 4, array( "eng-US" ), null ),
+            array( 4, array( "eng-US", "fre-FR" ), null ),
             array( 4, null, 1 ),
-            array( 4, array( "eng-US" ), 1 )
+            array( 4, array( "eng-US", "fre-FR", "nor-NO", "eng-DE" ), 1 ),
+            array( 4, array( "eng-US" ), 1 ),
         );
     }
 
@@ -524,7 +526,7 @@ abstract class ContentBase extends BaseServiceTest
         $contentService = $this->repository->getContentService();
 
         // Throws an exception because content does not exists in "eng-GB" language
-        $content = $contentService->loadContent( 4, array( "eng-GB" ) );
+        $content = $contentService->loadContent( 4, array( "fre-FR" ) );
         /* END: Use Case */
     }
 
@@ -532,15 +534,19 @@ abstract class ContentBase extends BaseServiceTest
      * Test for the loadContent() method.
      *
      * @covers \eZ\Publish\Core\Repository\ContentService::loadContent
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     public function testLoadContentThrowsNotFoundExceptionLanguageNotFoundVariation()
     {
         /* BEGIN: Use Case */
         $contentService = $this->repository->getContentService();
 
-        // Throws an exception because content does not exists in "eng-GB" language
+        // Content only exists in eng-US, so we should only have it in eng-US.
         $content = $contentService->loadContent( 4, array( "eng-US", "eng-GB" ) );
+        $this->assertInstanceOf(
+            "eZ\\Publish\\API\\Repository\\Values\\Content\\Content",
+            $content
+        );
+        $this->assertContentValues( $content, array( "eng-US" ) );
         /* END: Use Case */
     }
 


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22228

When passing a language filter to `ContentService::loadContent()`, and requested content isn't translated in one of the passed languages, `ContentService` will throw a `NotFoundException`, even if the content exists in at least one of the passed language.
This is a blocker when using prioritized languages. It should not throw an exception for this since the `ContentHandler` (SPI) is already reponsible of throwing a `NotFoundException` if there is no result.

This issue appeared after merging #686 
