### PR TITLE
Fix EZP-22272: Image alias generator throws exception if original file i...

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -40,6 +40,7 @@ services:
             - @ezpublish.fieldtype.ezimage.variation_service
             - @ezpublish.translation_helper
             - @ezpublish.field_helper
+            - @?logger
         tags:
             - {name: twig.extension}
 


### PR DESCRIPTION
...s not present

Proposed solution is based on the one added in https://github.com/ezsystems/ezpublish-kernel/pull/473, but probably can be solved somewhere else. 

What i've done is just change the throw exception part for a log error part. 
Also, i've modified the default ezimage_field template. If not, another exception is thrown telling you have no uri for imageAlias. Further more, if twig call returns false, no figure -> img tags are printed either. This will avoid things like "img src="/" .. appearing in the html

I think this exception is thrown because there's no check for the existence of the original file when you call the ezimage_alias_field twig function https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php#L431

AliasGenerator calls legacy function to create the alias and if the thing doesn't go well, it returns null. This could be because a non existent original file, and permission problem or maybe a cracks in the image converter. 

As said, this could be probably solved somewhere else, maybe checking the existence of the original file, but that will add a filestat call though... 
