### PR TITLE
EZP-22152: Fixed debug of legacy templates list when not in pure web context

### DIFF
--- a/eZ/Bundle/EzPublishDebugBundle/Collector/TemplateDebugInfo.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Collector/TemplateDebugInfo.php
@@ -11,6 +11,7 @@ namespace eZ\Bundle\EzPublishDebugBundle\Collector;
 
 use eZ\Publish\Core\MVC\Legacy\Kernel as LegacyKernel;
 use eZTemplate;
+use RuntimeException;
 
 /**
  * Class TemplateDebugInfo
@@ -77,12 +78,20 @@ class TemplateDebugInfo
             return $templateList;
         }
 
-        $templateStats = $legacyKernel()->runCallback(
-            function ()
-            {
-                return eZTemplate::templatesUsageStatistics();
-            }
-        );
+        try
+        {
+            $templateStats = $legacyKernel()->runCallback(
+                function ()
+                {
+                    return eZTemplate::templatesUsageStatistics();
+                }
+            );
+        }
+        catch ( RuntimeException $e )
+        {
+            // Ignore the exception thrown by legacy kernel as this would break debug toolbar (and thus debug info display).
+            // Furthermore, some legacy kernel handlers don't support runCallback (e.g. ezpKernelTreeMenu)
+        }
 
         foreach ( $templateStats as $tplInfo )
         {

--- a/eZ/Publish/Core/MVC/Legacy/Kernel/Loader.php
+++ b/eZ/Publish/Core/MVC/Legacy/Kernel/Loader.php
@@ -73,18 +73,19 @@ class Loader extends ContainerAware
         $eventDispatcher = $this->eventDispatcher;
         return function () use ( $legacyKernelHandler, $legacyRootDir, $webrootDir, $eventDispatcher )
         {
-            static $legacyKernel;
-            if ( !$legacyKernel instanceof LegacyKernel )
+            if ( LegacyKernel::hasInstance() )
             {
-                if ( $legacyKernelHandler instanceof \Closure )
-                    $legacyKernelHandler = $legacyKernelHandler();
-                $legacyKernel = new LegacyKernel( $legacyKernelHandler, $legacyRootDir, $webrootDir );
-
-                $eventDispatcher->dispatch(
-                    LegacyEvents::POST_BUILD_LEGACY_KERNEL,
-                    new PostBuildKernelEvent( $legacyKernel, $legacyKernelHandler )
-                );
+                return LegacyKernel::instance();
             }
+
+            if ( $legacyKernelHandler instanceof \Closure )
+                $legacyKernelHandler = $legacyKernelHandler();
+            $legacyKernel = new LegacyKernel( $legacyKernelHandler, $legacyRootDir, $webrootDir );
+
+            $eventDispatcher->dispatch(
+                LegacyEvents::POST_BUILD_LEGACY_KERNEL,
+                new PostBuildKernelEvent( $legacyKernel, $legacyKernelHandler )
+            );
 
             return $legacyKernel;
         };


### PR DESCRIPTION
When not in _pure web context_ (e.g. tree menu), the legacy kernel uses a different kernel handler, which may not support `runCallback()`.

Link: https://jira.ez.no/browse/EZP-22152
