### PR TITLE
EZP-22283: More descriptive error for invalid DB params

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/LegacyDbHandlerFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/LegacyDbHandlerFactory.php
@@ -28,12 +28,26 @@ class LegacyDbHandlerFactory
     /**
      * Builds the DB handler used by the legacy storage engine.
      *
+     * @throws \RuntimeException
      * @return \eZ\Publish\Core\Persistence\Legacy\EzcDbHandler
      */
     public function buildLegacyDbHandler()
     {
-        return EzcDbHandler::create(
-            $this->configResolver->getParameter( 'database.params' )
-        );
+        $dbParams = $this->configResolver->getParameter( 'database.params' );
+
+        try
+        {
+            $handler = EzcDbHandler::create( $dbParams );
+        }
+        catch ( \PDOException $e )
+        {
+            $msg =
+                "Unable to create Legacy DB handler {$dbParams['type']}:host={$dbParams['host']};database={$dbParams['database']}."
+                . " Please check your database settings in ezpublish_*.yml.";
+
+            throw new \RuntimeException( $msg, null, $e );
+        }
+
+        return $handler;
     }
 }


### PR DESCRIPTION
I am currently trying to perform an upgrade of an eZ Publish 4 project to eZ Publish 5. The eZ4 project is up to date with the current Legacy master branch from github. These are the steps I performed, following the installation instructions at Github:

``` bash
$ git clone https://github.com/ezsystems/ezpublish-community.git cms
$ cp -R /path/to/old/ez cms/ezpublish_legacy
$ rm -rf cms/ezpublish/legacy/vendor
$ cd cms
$ php -dmemory_limit=-1 ../bin/composer.phar install --prefer-dist
```

This got me the following error:

```
[PDOException]
SQLSTATE[HY000] [2002] No such file or directory
```

The same occurs when executing

```
php ezpublish/console ezpublish:configure --env=prod <package> <admin_siteaccess>
```

After some heavy debugging, I became aware that the settings from app/config/ezpublish_setup.yml are being used, and thought it would be nice if the error message would hint me to this instead of giving me just a generic error message.

This PR adds an additional error message with a hint where to find and fix the database settings:

```
[RuntimeException]
Unable to create Legacy DB handler mysql:host=;database=none. Please check your database settings in ezpublish_*.yml.

[PDOException]
SQLSTATE[HY000] [2002] No such file or directory
```

Cheers
:octocat: Jérôme
