### PR TITLE
Fix EZP-22225; Publishing content in a symfony command throws InactiveScopeException

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
@@ -165,6 +165,7 @@ services:
     ezpublish.signalslot.repository:
         class: %ezpublish.signalslot.repository.class%
         arguments: [@ezpublish.api.inner_repository, @ezpublish.signalslot.signal_dispatcher]
+        lazy: true
 
     ezpublish.signalslot.signal_dispatcher:
         class: %ezpublish.signalslot.signal_dispatcher.class%

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
@@ -143,6 +143,7 @@ services:
         arguments: [@ezpublish_legacy.url_generator, @?request_context, @?logger]
         tags:
             - {name: router, priority: -255}
+        lazy: true
 
     ezpublish_legacy.uri_helper:
         class: %ezpublish_legacy.uri_helper.class%


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22225

When launching a CLI command with `ezpublish/console`, some pre-checks are invoked and all registered commands are being called with `isEnabled()` method. In these cases, the router is often called (e.g. to warm up route cache) and this makes the legacy kernel being _pre-booted_ (closure is ready), but with the default kernel handler (`ezpKernelWeb` instead of `CLIHandler`). Indeed, the appropriate handler is only set when commands are being registered (not possible before for various reasons).

Considering this preamble, solution is quite simple (declaring 2 services as _lazy_), but needs some explanation:
- `ezpublish.signalslot.repository` - Actually the problem here is one of its dependency, `ezpublish.signalslot.signal_dispatcher` which is being built with all legacy aware slots, depending on the legacy kernel. This service is called when loading the router.
- `ezpublish_legacy.router` - Also called when loading the router.

When launching a CLI command, router can be loaded:
- By the cache warmer service (warm up route cache)
- By `router:dump-apache` command, when `isEnabled()` is invoked.

Declaring those 2 services as lazy should definitively solve this issue.
