### PR TITLE
EZP-22290: Avoid PHP notice because of uninitialized variable

### DIFF
--- a/eZ/Bundle/EzPublishDebugBundle/Collector/TemplateDebugInfo.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Collector/TemplateDebugInfo.php
@@ -91,6 +91,7 @@ class TemplateDebugInfo
         {
             // Ignore the exception thrown by legacy kernel as this would break debug toolbar (and thus debug info display).
             // Furthermore, some legacy kernel handlers don't support runCallback (e.g. ezpKernelTreeMenu)
+            $templateStats = array();
         }
 
         foreach ( $templateStats as $tplInfo )


### PR DESCRIPTION
In `TemplateDebugInfo::getLegacyTemplatesList` a PHP Notice is generated when the usage statistics can not be retrieved thus leaving `$templateStats` uninitialized.

``` php
try
{
    $templateStats = $legacyKernel()->runCallback(
        function ()
        {
            return eZTemplate::templatesUsageStatistics();
        }
    );
}
catch ( RuntimeException $e )
{
    // Ignore the exception thrown by legacy kernel as this would break debug toolbar (and thus debug info display).
    // Furthermore, some legacy kernel handlers don't support runCallback (e.g. ezpKernelTreeMenu)
}

foreach ( $templateStats as $tplInfo )
{
    // ...
}
```

This PR adds the variable declaration in the `catch` block.

https://jira.ez.no/browse/EZP-22290

Cheers
:octocat: Jérôme
