### PR TITLE
Fix EZP-22292 - eZDemo with content broken in ezpublish-community

### DIFF
--- a/eZ/Publish/Core/FieldType/XmlText/Type.php
+++ b/eZ/Publish/Core/FieldType/XmlText/Type.php
@@ -117,7 +117,7 @@ class Type extends FieldType
      */
     public function isEmptyValue( SPIValue $value )
     {
-        if ( $value->xml === null )
+        if ( $value->xml === null || $value->xml->documentElement === null )
         {
             return true;
         }


### PR DESCRIPTION
# EZP-22292 - eZDemo with content broken in ezpublish-community

https://jira.ez.no/browse/EZP-22292

Fix for Fatal error: Call to a member function hasChildNodes() on a non-object in /var/www/html/ezpublish5/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/XmlText/Type.php on line 125 503 Service Unavailable
