### PR TITLE
Simplified PHPDoc (invitation for a discussion)

### DIFF
--- a/eZ/Publish/API/Repository/RoleService.php
+++ b/eZ/Publish/API/Repository/RoleService.php
@@ -35,9 +35,9 @@ interface RoleService
      *                                                                        limitation is not allowed on module/function
      * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a policy limitation in the $roleCreateStruct is not valid
      *
-     * @param \eZ\Publish\API\Repository\Values\User\RoleCreateStruct $roleCreateStruct
+     * @param RoleCreateStruct $roleCreateStruct
      *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
+     * @return Role
      */
     public function createRole( RoleCreateStruct $roleCreateStruct );
 
@@ -47,10 +47,10 @@ interface RoleService
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a role
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists
      *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\RoleUpdateStruct $roleUpdateStruct
+     * @param Role $role
+     * @param RoleUpdateStruct $roleUpdateStruct
      *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
+     * @return Role
      */
     public function updateRole( Role $role, RoleUpdateStruct $roleUpdateStruct );
 
@@ -62,10 +62,10 @@ interface RoleService
      *                                                                        struct or if limitation is not allowed on module/function
      * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a limitation in the $policyCreateStruct is not valid
      *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct $policyCreateStruct
+     * @param Role $role
+     * @param PolicyCreateStruct $policyCreateStruct
      *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
+     * @return Role
      */
     public function addPolicy( Role $role, PolicyCreateStruct $policyCreateStruct );
 
@@ -77,10 +77,10 @@ interface RoleService
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if policy does not belong to the given role
      *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to remove from the role
+     * @param Role $role
+     * @param Policy $policy the policy to remove from the role
      *
-     * @return \eZ\Publish\API\Repository\Values\User\Role the updated role
+     * @return Role the updated role
      */
     public function removePolicy( Role $role, Policy $policy );
 
@@ -89,7 +89,7 @@ interface RoleService
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
      *
-     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to delete
+     * @param Policy $policy the policy to delete
      */
     public function deletePolicy( Policy $policy );
 
@@ -102,10 +102,10 @@ interface RoleService
      *                                                                        struct or if limitation is not allowed on module/function
      * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a limitation in the $policyUpdateStruct is not valid
      *
-     * @param \eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct $policyUpdateStruct
-     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy
+     * @param PolicyUpdateStruct $policyUpdateStruct
+     * @param Policy $policy
      *
-     * @return \eZ\Publish\API\Repository\Values\User\Policy
+     * @return Policy
      */
     public function updatePolicy( Policy $policy, PolicyUpdateStruct $policyUpdateStruct );
 
@@ -117,7 +117,7 @@ interface RoleService
      *
      * @param mixed $id
      *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
+     * @return Role
      */
     public function loadRole( $id );
 
@@ -129,7 +129,7 @@ interface RoleService
      *
      * @param string $identifier
      *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
+     * @return Role
      */
     public function loadRoleByIdentifier( $identifier );
 
@@ -138,7 +138,7 @@ interface RoleService
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the roles
      *
-     * @return \eZ\Publish\API\Repository\Values\User\Role[]
+     * @return Role[]
      */
     public function loadRoles();
 
@@ -147,7 +147,7 @@ interface RoleService
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to delete this role
      *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
+     * @param Role $role
      */
     public function deleteRole( Role $role );
 
@@ -158,7 +158,7 @@ interface RoleService
      *
      * @param mixed $userId
      *
-     * @return \eZ\Publish\API\Repository\Values\User\Policy[]
+     * @return Policy[]
      */
     public function loadPoliciesByUserId( $userId );
 
@@ -168,9 +168,9 @@ interface RoleService
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to assign a role
      * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if $roleLimitation is not valid
      *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
-     * @param \eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation $roleLimitation an optional role limitation (which is either a subtree limitation or section limitation)
+     * @param Role $role
+     * @param UserGroup $userGroup
+     * @param RoleLimitation $roleLimitation an optional role limitation (which is either a subtree limitation or section limitation)
      */
     public function assignRoleToUserGroup( Role $role, UserGroup $userGroup, RoleLimitation $roleLimitation = null );
 
@@ -180,8 +180,8 @@ interface RoleService
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a role
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException  If the role is not assigned to the given user group
      *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
+     * @param Role $role
+     * @param UserGroup $userGroup
      */
     public function unassignRoleFromUserGroup( Role $role, UserGroup $userGroup );
 
@@ -191,9 +191,9 @@ interface RoleService
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to assign a role
      * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if $roleLimitation is not valid
      *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
-     * @param \eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation $roleLimitation an optional role limitation (which is either a subtree limitation or section limitation)
+     * @param Role $role
+     * @param User $user
+     * @param RoleLimitation $roleLimitation an optional role limitation (which is either a subtree limitation or section limitation)
      */
     public function assignRoleToUser( Role $role, User $user, RoleLimitation $roleLimitation = null );
 
@@ -203,8 +203,8 @@ interface RoleService
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a role
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If the role is not assigned to the user
      *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
+     * @param Role $role
+     * @param User $user
      */
     public function unassignRoleFromUser( Role $role, User $user );
 
@@ -213,7 +213,7 @@ interface RoleService
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a role
      *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
+     * @param Role $role
      *
      * @return \eZ\Publish\API\Repository\Values\User\RoleAssignment[]
      */
@@ -224,7 +224,7 @@ interface RoleService
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a user
      *
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
+     * @param User $user
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserRoleAssignment[]
      */
@@ -235,7 +235,7 @@ interface RoleService
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a user group
      *
-     * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
+     * @param UserGroup $userGroup
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroupRoleAssignment[]
      */
@@ -246,7 +246,7 @@ interface RoleService
      *
      * @param string $name
      *
-     * @return \eZ\Publish\API\Repository\Values\User\RoleCreateStruct
+     * @return RoleCreateStruct
      */
     public function newRoleCreateStruct( $name );
 
@@ -256,21 +256,21 @@ interface RoleService
      * @param string $module
      * @param string $function
      *
-     * @return \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct
+     * @return PolicyCreateStruct
      */
     public function newPolicyCreateStruct( $module, $function );
 
     /**
      * Instantiates a policy update class
      *
-     * @return \eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct
+     * @return PolicyUpdateStruct
      */
     public function newPolicyUpdateStruct();
 
     /**
      * Instantiates a policy update class
      *
-     * @return \eZ\Publish\API\Repository\Values\User\RoleUpdateStruct
+     * @return RoleUpdateStruct
      */
     public function newRoleUpdateStruct();
 

--- a/eZ/Publish/Core/REST/Client/RoleService.php
+++ b/eZ/Publish/Core/REST/Client/RoleService.php
@@ -43,36 +43,36 @@ use eZ\Publish\Core\REST\Common\Message;
 class RoleService implements APIRoleService, Sessionable
 {
     /**
-     * @var \eZ\Publish\Core\REST\Client\UserService
+     * @var UserService
      */
     private $userService;
 
     /**
-     * @var \eZ\Publish\Core\REST\Client\HttpClient
+     * @var HttpClient
      */
     private $client;
 
     /**
-     * @var \eZ\Publish\Core\REST\Common\Input\Dispatcher
+     * @var Dispatcher
      */
     private $inputDispatcher;
 
     /**
-     * @var \eZ\Publish\Core\REST\Common\Output\Visitor
+     * @var Visitor
      */
     private $outputVisitor;
 
     /**
-     * @var \eZ\Publish\Core\REST\Common\RequestParser
+     * @var RequestParser
      */
     private $requestParser;
 
     /**
-     * @param \eZ\Publish\Core\REST\Client\UserService $userService
-     * @param \eZ\Publish\Core\REST\Client\HttpClient $client
-     * @param \eZ\Publish\Core\REST\Common\Input\Dispatcher $inputDispatcher
-     * @param \eZ\Publish\Core\REST\Common\Output\Visitor $outputVisitor
-     * @param \eZ\Publish\Core\REST\Common\RequestParser $requestParser
+     * @param UserService $userService
+     * @param HttpClient $client
+     * @param Dispatcher $inputDispatcher
+     * @param Visitor $outputVisitor
+     * @param RequestParser $requestParser
      */
     public function __construct( UserService $userService, HttpClient $client, Dispatcher $inputDispatcher, Visitor $outputVisitor, RequestParser $requestParser )
     {
@@ -83,17 +83,6 @@ class RoleService implements APIRoleService, Sessionable
         $this->requestParser   = $requestParser;
     }
 
-    /**
-     * Set session ID
-     *
-     * Only for testing
-     *
-     * @param mixed $id
-     *
-     * @private
-     *
-     * @return void
-     */
     public function setSession( $id )
     {
         if ( $this->outputVisitor instanceof Sessionable )
@@ -102,19 +91,6 @@ class RoleService implements APIRoleService, Sessionable
         }
     }
 
-    /**
-     * Creates a new Role
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists or if limitation of the
-     *                                                                        same type is repeated in the policy create struct or if
-     *                                                                        limitation is not allowed on module/function
-     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a policy limitation in the $roleCreateStruct is not valid
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\RoleCreateStruct $roleCreateStruct
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
-     */
     public function createRole( APIRoleCreateStruct $roleCreateStruct )
     {
         $inputMessage = $this->outputVisitor->visit( $roleCreateStruct );
@@ -164,17 +140,6 @@ class RoleService implements APIRoleService, Sessionable
         );
     }
 
-    /**
-     * Updates the name of the role
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\RoleUpdateStruct $roleUpdateStruct
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
-     */
     public function updateRole( APIRole $role, RoleUpdateStruct $roleUpdateStruct )
     {
         $inputMessage = $this->outputVisitor->visit( $roleUpdateStruct );
@@ -190,19 +155,6 @@ class RoleService implements APIRoleService, Sessionable
         return $this->inputDispatcher->parse( $result );
     }
 
-    /**
-     * Adds a new policy to the role
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to add  a policy
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if limitation of the same type is repeated in policy create
-     *                                                                        struct or if limitation is not allowed on module/function
-     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a limitation in the $policyCreateStruct is not valid
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct $policyCreateStruct
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
-     */
     public function addPolicy( APIRole $role, APIPolicyCreateStruct $policyCreateStruct )
     {
         $values = $this->requestParser->parse( 'role', $role->id );
@@ -239,19 +191,6 @@ class RoleService implements APIRoleService, Sessionable
         );
     }
 
-    /**
-     * removes a policy from the role
-     *
-     * @deprecated since 5.3, use {@link deletePolicy()} instead.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if policy does not belong to the given role
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to remove from the role
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role the updated role
-     */
     public function removePolicy( APIRole $role, APIPolicy $policy )
     {
         $values = $this->requestParser->parse( 'role', $role->id );
@@ -279,32 +218,11 @@ class RoleService implements APIRoleService, Sessionable
         return $this->loadRole( $role->id );
     }
 
-    /**
-     * Deletes a policy
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to delete
-     */
     public function deletePolicy( APIPolicy $policy )
     {
         throw new \Exception( "@todo: Implement." );
     }
 
-    /**
-     * Updates the limitations of a policy. The module and function cannot be changed and
-     * the limitations are replaced by the ones in $roleUpdateStruct
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a policy
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if limitation of the same type is repeated in policy update
-     *                                                                        struct or if limitation is not allowed on module/function
-     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a limitation in the $policyUpdateStruct is not valid
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct $policyUpdateStruct
-     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Policy
-     */
     public function updatePolicy( APIPolicy $policy, APIPolicyUpdateStruct $policyUpdateStruct )
     {
         $values = $this->requestParser->parse( 'role', $policy->roleId );
@@ -327,16 +245,6 @@ class RoleService implements APIRoleService, Sessionable
         return $this->inputDispatcher->parse( $result );
     }
 
-    /**
-     * Loads a role for the given id
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read this role
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a role with the given name was not found
-     *
-     * @param mixed $id
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
-     */
     public function loadRole( $id )
     {
         $response = $this->client->request(
@@ -367,16 +275,6 @@ class RoleService implements APIRoleService, Sessionable
         );
     }
 
-    /**
-     * Loads a role for the given name
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read this role
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a role with the given name was not found
-     *
-     * @param string $name
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
-     */
     public function loadRoleByIdentifier( $name )
     {
         $response = $this->client->request(
@@ -391,13 +289,6 @@ class RoleService implements APIRoleService, Sessionable
         return reset( $result );
     }
 
-    /**
-     * Loads all roles
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the roles
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role[]
-     */
     public function loadRoles()
     {
         $response = $this->client->request(
@@ -411,13 +302,6 @@ class RoleService implements APIRoleService, Sessionable
         return $this->inputDispatcher->parse( $response );
     }
 
-    /**
-     * Deletes the given role
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to delete this role
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     */
     public function deleteRole( APIRole $role )
     {
         $response = $this->client->request(
@@ -436,15 +320,6 @@ class RoleService implements APIRoleService, Sessionable
             $this->inputDispatcher->parse( $response );
     }
 
-    /**
-     * Loads all policies from roles which are assigned to a user or to user groups to which the user belongs
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user with the given id was not found
-     *
-     * @param mixed $userId
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Policy[]
-     */
     public function loadPoliciesByUserId( $userId )
     {
         $values = $this->requestParser->parse( 'user', $userId );
@@ -459,16 +334,6 @@ class RoleService implements APIRoleService, Sessionable
         return $this->inputDispatcher->parse( $response );
     }
 
-    /**
-     * Assigns a role to the given user group
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to assign a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if $roleLimitation is not valid
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
-     * @param \eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation $roleLimitation an optional role limitation (which is either a subtree limitation or section limitation)
-     */
     public function assignRoleToUserGroup( APIRole $role, UserGroup $userGroup, RoleLimitation $roleLimitation = null )
     {
         $roleAssignment = new RoleAssignment(
@@ -490,15 +355,6 @@ class RoleService implements APIRoleService, Sessionable
         $this->inputDispatcher->parse( $result );
     }
 
-    /**
-     * removes a role from the given user group.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException  If the role is not assigned to the given user group
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
-     */
     public function unassignRoleFromUserGroup( APIRole $role, UserGroup $userGroup )
     {
         $values = $this->requestParser->parse( 'group', $userGroup->id );
@@ -524,16 +380,8 @@ class RoleService implements APIRoleService, Sessionable
     }
 
     /**
-     * Assigns a role to the given user
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to assign a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if $roleLimitation is not valid
-     *
+     * {@inheritDoc}
      * @todo add limitations
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
-     * @param \eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation $roleLimitation an optional role limitation (which is either a subtree limitation or section limitation)
      */
     public function assignRoleToUser( APIRole $role, User $user, RoleLimitation $roleLimitation = null )
     {
@@ -556,15 +404,6 @@ class RoleService implements APIRoleService, Sessionable
         $this->inputDispatcher->parse( $result );
     }
 
-    /**
-     * removes a role from the given user.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If the role is not assigned to the user
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
-     */
     public function unassignRoleFromUser( APIRole $role, User $user )
     {
         $values = $this->requestParser->parse( 'user', $user->id );
@@ -589,29 +428,11 @@ class RoleService implements APIRoleService, Sessionable
             $this->inputDispatcher->parse( $response );
     }
 
-    /**
-     * Returns the assigned user and user groups to this role
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a role
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\RoleAssignment[]
-     */
     public function getRoleAssignments( APIRole $role )
     {
         throw new \Exception( "@todo: Implement." );
     }
 
-    /**
-     * Returns the roles assigned to the given user
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a user
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\UserRoleAssignment[]
-     */
     public function getRoleAssignmentsForUser( User $user )
     {
         $response = $this->client->request(
@@ -622,6 +443,7 @@ class RoleService implements APIRoleService, Sessionable
             )
         );
 
+        /** @var RoleAssignment[] $roleAssignments */
         $roleAssignments = $this->inputDispatcher->parse( $response );
 
         $userRoleAssignments = array();
@@ -639,15 +461,6 @@ class RoleService implements APIRoleService, Sessionable
         return $userRoleAssignments;
     }
 
-    /**
-     * Returns the roles assigned to the given user group
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a user group
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\UserGroupRoleAssignment[]
-     */
     public function getRoleAssignmentsForUserGroup( UserGroup $userGroup )
     {
         $response = $this->client->request(
@@ -658,6 +471,7 @@ class RoleService implements APIRoleService, Sessionable
             )
         );
 
+        /** @var UserGroupRoleAssignment[] $roleAssignments */
         $roleAssignments = $this->inputDispatcher->parse( $response );
 
         $userGroupRoleAssignments = array();
@@ -675,80 +489,31 @@ class RoleService implements APIRoleService, Sessionable
         return $userGroupRoleAssignments;
     }
 
-    /**
-     * Instantiates a role create class
-     *
-     * @param string $name
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\RoleCreateStruct
-     */
     public function newRoleCreateStruct( $name )
     {
         return new Values\User\RoleCreateStruct( $name );
     }
 
-    /**
-     * Instantiates a policy create class
-     *
-     * @param string $module
-     * @param string $function
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct
-     */
     public function newPolicyCreateStruct( $module, $function )
     {
         return new PolicyCreateStruct( $module, $function );
     }
 
-    /**
-     * Instantiates a policy update class
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct
-     */
     public function newPolicyUpdateStruct()
     {
         return new PolicyUpdateStruct();
     }
 
-    /**
-     * Instantiates a policy update class
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\RoleUpdateStruct
-     */
     public function newRoleUpdateStruct()
     {
         return new RoleUpdateStruct();
     }
 
-    /**
-     * Returns the LimitationType registered with the given identifier
-     *
-     * @param string $identifier
-     *
-     * @return \eZ\Publish\SPI\Limitation\Type
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if there is no LimitationType with $identifier
-     */
     public function getLimitationType( $identifier )
     {
         throw new \eZ\Publish\API\Repository\Exceptions\NotImplementedException( __METHOD__ );
     }
 
-    /**
-     * Returns the LimitationType's assigned to a given module/function
-     *
-     * Typically used for:
-     *  - Internal validation limitation value use on Policies
-     *  - Role admin gui for editing policy limitations incl list limitation options via valueSchema()
-     *
-     * @param string $module Legacy name of "controller", it's a unique identifier like "content"
-     * @param string $function Legacy name of a controller "action", it's a unique within the controller like "read"
-     *
-     * @return \eZ\Publish\SPI\Limitation\Type[]
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If module/function to limitation type mapping
-     *                                                                 refers to a non existing identifier.
-     */
     public function getLimitationTypesByModuleFunction( $module, $function )
     {
         throw new \eZ\Publish\API\Repository\Exceptions\NotImplementedException( __METHOD__ );

--- a/eZ/Publish/Core/Repository/RoleService.php
+++ b/eZ/Publish/Core/Repository/RoleService.php
@@ -50,25 +50,25 @@ use Exception;
 class RoleService implements RoleServiceInterface
 {
     /**
-     * @var \eZ\Publish\API\Repository\Repository
+     * @var RepositoryInterface
      */
     protected $repository;
 
     /**
-     * @var \eZ\Publish\SPI\Persistence\User\Handler
+     * @var Handler
      */
     protected $userHandler;
 
     /**
-     * @var array
+     * @var array[]
      */
     protected $settings;
 
     /**
      * Setups service with reference to repository object that created it & corresponding handler
      *
-     * @param \eZ\Publish\API\Repository\Repository $repository
-     * @param \eZ\Publish\SPI\Persistence\User\Handler $userHandler
+     * @param RepositoryInterface $repository
+     * @param Handler $userHandler
      * @param array $settings
      */
     public function __construct( RepositoryInterface $repository, Handler $userHandler, array $settings = array() )
@@ -108,19 +108,6 @@ class RoleService implements RoleServiceInterface
         );
     }
 
-    /**
-     * Creates a new Role
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists or if limitation of the
-     *                                                                        same type is repeated in the policy create struct or if
-     *                                                                        limitation is not allowed on module/function
-     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a policy limitation in the $roleCreateStruct is not valid
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\RoleCreateStruct $roleCreateStruct
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
-     */
     public function createRole( APIRoleCreateStruct $roleCreateStruct )
     {
         if ( !is_string( $roleCreateStruct->identifier ) || empty( $roleCreateStruct->identifier ) )
@@ -163,17 +150,6 @@ class RoleService implements RoleServiceInterface
         return $this->buildDomainRoleObject( $createdRole );
     }
 
-    /**
-     * Updates the name of the role
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\RoleUpdateStruct $roleUpdateStruct
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
-     */
     public function updateRole( APIRole $role, RoleUpdateStruct $roleUpdateStruct )
     {
         if ( $roleUpdateStruct->identifier !== null && !is_string( $roleUpdateStruct->identifier ) )
@@ -226,19 +202,6 @@ class RoleService implements RoleServiceInterface
         return $this->loadRole( $loadedRole->id );
     }
 
-    /**
-     * Adds a new policy to the role
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to add  a policy
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if limitation of the same type is repeated in policy create
-     *                                                                        struct or if limitation is not allowed on module/function
-     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a limitation in the $policyCreateStruct is not valid
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct $policyCreateStruct
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
-     */
     public function addPolicy( APIRole $role, APIPolicyCreateStruct $policyCreateStruct )
     {
         if ( !is_string( $policyCreateStruct->module ) || empty( $policyCreateStruct->module ) )
@@ -287,19 +250,6 @@ class RoleService implements RoleServiceInterface
         return $this->loadRole( $loadedRole->id );
     }
 
-    /**
-     * removes a policy from the role
-     *
-     * @deprecated since 5.3, use {@link deletePolicy()} instead.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if policy does not belong to the given role
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to remove from the role
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role the updated role
-     */
     public function removePolicy( APIRole $role, APIPolicy $policy )
     {
         if ( $this->repository->hasAccess( 'role', 'update' ) !== true )
@@ -315,13 +265,6 @@ class RoleService implements RoleServiceInterface
         return $this->loadRole( $role->id );
     }
 
-    /**
-     * Deletes a policy
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to delete
-     */
     public function deletePolicy( APIPolicy $policy )
     {
         if ( $this->repository->hasAccess( 'role', 'update' ) !== true )
@@ -330,17 +273,6 @@ class RoleService implements RoleServiceInterface
         $this->internalDeletePolicy( $policy );
     }
 
-    /**
-     * Deletes a policy
-     *
-     * Used by {@link removePolicy()} and {@link deletePolicy()}
-     *
-     * @param APIPolicy $policy
-     *
-     * @throws \Exception
-     *
-     * @return void
-     */
     protected function internalDeletePolicy( APIPolicy $policy )
     {
         $this->repository->beginTransaction();
@@ -356,20 +288,6 @@ class RoleService implements RoleServiceInterface
         }
     }
 
-    /**
-     * Updates the limitations of a policy. The module and function cannot be changed and
-     * the limitations are replaced by the ones in $roleUpdateStruct
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a policy
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if limitation of the same type is repeated in policy update
-     *                                                                        struct or if limitation is not allowed on module/function
-     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a limitation in the $policyUpdateStruct is not valid
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct $policyUpdateStruct
-     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Policy
-     */
     public function updatePolicy( APIPolicy $policy, APIPolicyUpdateStruct $policyUpdateStruct )
     {
         if ( !is_string( $policy->module ) )
@@ -415,16 +333,6 @@ class RoleService implements RoleServiceInterface
         return $this->buildDomainPolicyObject( $spiPolicy );
     }
 
-    /**
-     * Loads a role for the given id
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read this role
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a role with the given id was not found
-     *
-     * @param mixed $id
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
-     */
     public function loadRole( $id )
     {
         if ( $this->repository->hasAccess( 'role', 'read' ) !== true )
@@ -434,16 +342,6 @@ class RoleService implements RoleServiceInterface
         return $this->buildDomainRoleObject( $spiRole );
     }
 
-    /**
-     * Loads a role for the given identifier
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read this role
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a role with the given name was not found
-     *
-     * @param string $identifier
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
-     */
     public function loadRoleByIdentifier( $identifier )
     {
         if ( !is_string( $identifier ) )
@@ -456,13 +354,6 @@ class RoleService implements RoleServiceInterface
         return $this->buildDomainRoleObject( $spiRole );
     }
 
-    /**
-     * Loads all roles
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the roles
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role[]
-     */
     public function loadRoles()
     {
         if ( $this->repository->hasAccess( 'role', 'read' ) !== true )
@@ -479,13 +370,6 @@ class RoleService implements RoleServiceInterface
         return $roles;
     }
 
-    /**
-     * Deletes the given role
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to delete this role
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     */
     public function deleteRole( APIRole $role )
     {
         if ( $this->repository->hasAccess( 'role', 'delete' ) !== true )
@@ -506,15 +390,6 @@ class RoleService implements RoleServiceInterface
         }
     }
 
-    /**
-     * Loads all policies from roles which are assigned to a user or to user groups to which the user belongs
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user with the given id was not found
-     *
-     * @param mixed $userId
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Policy[]
-     */
     public function loadPoliciesByUserId( $userId )
     {
         $spiPolicies = $this->userHandler->loadPoliciesByUserId( $userId );
@@ -531,16 +406,6 @@ class RoleService implements RoleServiceInterface
         return $policies;
     }
 
-    /**
-     * Assigns a role to the given user group
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to assign a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if $roleLimitation is not valid
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
-     * @param \eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation $roleLimitation an optional role limitation (which is either a subtree limitation or section limitation)
-     */
     public function assignRoleToUserGroup( APIRole $role, UserGroup $userGroup, RoleLimitation $roleLimitation = null )
     {
         if ( $this->repository->canUser( 'role', 'assign', $userGroup, $role ) !== true )
@@ -581,15 +446,6 @@ class RoleService implements RoleServiceInterface
         }
     }
 
-    /**
-     * removes a role from the given user group.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException  If the role is not assigned to the given user group
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
-     */
     public function unassignRoleFromUserGroup( APIRole $role, UserGroup $userGroup )
     {
         if ( $this->repository->canUser( 'role', 'assign', $userGroup, $role ) !== true )
@@ -613,16 +469,6 @@ class RoleService implements RoleServiceInterface
         }
     }
 
-    /**
-     * Assigns a role to the given user
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to assign a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if $roleLimitation is not valid
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
-     * @param \eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation $roleLimitation an optional role limitation (which is either a subtree limitation or section limitation)
-     */
     public function assignRoleToUser( APIRole $role, User $user, RoleLimitation $roleLimitation = null )
     {
         if ( $this->repository->canUser( 'role', 'assign', $user, $role ) !== true )
@@ -663,15 +509,6 @@ class RoleService implements RoleServiceInterface
         }
     }
 
-    /**
-     * removes a role from the given user.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If the role is not assigned to the user
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
-     */
     public function unassignRoleFromUser( APIRole $role, User $user )
     {
         if ( $this->repository->canUser( 'role', 'assign', $user, $role ) !== true )
@@ -695,15 +532,6 @@ class RoleService implements RoleServiceInterface
         }
     }
 
-    /**
-     * Returns the assigned user and user groups to this role
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a role
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\RoleAssignment[]
-     */
     public function getRoleAssignments( APIRole $role )
     {
         if ( $this->repository->hasAccess( 'role', 'read' ) !== true )
@@ -765,17 +593,6 @@ class RoleService implements RoleServiceInterface
         return $roleAssignments;
     }
 
-    /**
-     * Returns the roles assigned to the given user
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
-     * @param boolean $inherited
-     *
-     * @throws \eZ\Publish\Core\Base\Exceptions\UnauthorizedException If the current user is not allowed to read a role
-     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue On invalid User object
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\UserRoleAssignment[]
-     */
     public function getRoleAssignmentsForUser( User $user, $inherited = false )
     {
         if ( $this->repository->hasAccess( 'role', 'read' ) !== true )
@@ -794,15 +611,6 @@ class RoleService implements RoleServiceInterface
         return $roleAssignments;
     }
 
-    /**
-     * Returns the roles assigned to the given user group
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a role
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\UserGroupRoleAssignment[]
-     */
     public function getRoleAssignmentsForUserGroup( UserGroup $userGroup )
     {
         if ( $this->repository->hasAccess( 'role', 'read' ) !== true )
@@ -818,13 +626,6 @@ class RoleService implements RoleServiceInterface
         return $roleAssignments;
     }
 
-    /**
-     * Instantiates a role create class
-     *
-     * @param string $name
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\RoleCreateStruct
-     */
     public function newRoleCreateStruct( $name )
     {
         return new RoleCreateStruct(
@@ -835,14 +636,6 @@ class RoleService implements RoleServiceInterface
         );
     }
 
-    /**
-     * Instantiates a policy create class
-     *
-     * @param string $module
-     * @param string $function
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct
-     */
     public function newPolicyCreateStruct( $module, $function )
     {
         return new PolicyCreateStruct(
@@ -854,11 +647,6 @@ class RoleService implements RoleServiceInterface
         );
     }
 
-    /**
-     * Instantiates a policy update class
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct
-     */
     public function newPolicyUpdateStruct()
     {
         return new PolicyUpdateStruct(
@@ -868,11 +656,6 @@ class RoleService implements RoleServiceInterface
         );
     }
 
-    /**
-     * Instantiates a policy update class
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\RoleUpdateStruct
-     */
     public function newRoleUpdateStruct()
     {
         return new RoleUpdateStruct();
@@ -881,9 +664,9 @@ class RoleService implements RoleServiceInterface
     /**
      * Maps provided SPI Role value object to API Role value object
      *
-     * @param \eZ\Publish\SPI\Persistence\User\Role $role
+     * @param SPIRole $role
      *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
+     * @return APIRole
      */
     protected function buildDomainRoleObject( SPIRole $role )
     {
@@ -906,10 +689,10 @@ class RoleService implements RoleServiceInterface
      * Maps provided SPI Policy value object to API Policy value object
      *
      * @access private Only accessible for other services and the internals of the repository
-     * @param \eZ\Publish\SPI\Persistence\User\Policy $policy
-     * @param \eZ\Publish\SPI\Persistence\User\Role|null $role
+     * @param SPIPolicy $policy
+     * @param SPIRole|null $role
      *
-     * @return \eZ\Publish\API\Repository\Values\User\Policy
+     * @return Policy
      */
     public function buildDomainPolicyObject( SPIPolicy $policy, SPIRole $role = null )
     {
@@ -936,11 +719,11 @@ class RoleService implements RoleServiceInterface
     /**
      * Builds the API UserRoleAssignment object from provided SPI RoleAssignment object
      *
-     * @param \eZ\Publish\SPI\Persistence\User\RoleAssignment $spiRoleAssignment
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
+     * @param SPIRoleAssignment $spiRoleAssignment
+     * @param User $user
+     * @param APIRole $role
      *
-     * @return \eZ\Publish\API\Repository\Values\User\UserRoleAssignment
+     * @return UserRoleAssignment
      */
     public function buildDomainUserRoleAssignmentObject( SPIRoleAssignment $spiRoleAssignment, User $user = null, APIRole $role = null )
     {
@@ -967,11 +750,11 @@ class RoleService implements RoleServiceInterface
     /**
      * Builds the API UserGroupRoleAssignment object from provided SPI RoleAssignment object
      *
-     * @param \eZ\Publish\SPI\Persistence\User\RoleAssignment $spiRoleAssignment
-     * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
+     * @param SPIRoleAssignment $spiRoleAssignment
+     * @param UserGroup $userGroup
+     * @param APIRole $role
      *
-     * @return \eZ\Publish\API\Repository\Values\User\UserGroupRoleAssignment
+     * @return UserGroupRoleAssignment
      */
     public function buildDomainUserGroupRoleAssignmentObject( SPIRoleAssignment $spiRoleAssignment, UserGroup $userGroup = null, APIRole $role = null )
     {
@@ -996,16 +779,7 @@ class RoleService implements RoleServiceInterface
     }
 
     /**
-     * Returns the LimitationType registered with the given identifier
-     *
-     * Returns the correct implementation of API Limitation value object
-     * based on provided identifier
-     *
-     * @param string $identifier
-     *
-     * @return \eZ\Publish\SPI\Limitation\Type
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if there is no LimitationType with $identifier
+     * {@inheritDoc}
      */
     public function getLimitationType( $identifier )
     {
@@ -1015,21 +789,6 @@ class RoleService implements RoleServiceInterface
         return $this->settings['limitationTypes'][$identifier];
     }
 
-    /**
-     * Returns the LimitationType's assigned to a given module/function
-     *
-     * Typically used for:
-     *  - Internal validation limitation value use on Policies
-     *  - Role admin gui for editing policy limitations incl list limitation options via valueSchema()
-     *
-     * @param string $module Legacy name of "controller", it's a unique identifier like "content"
-     * @param string $function Legacy name of a controller "action", it's a unique within the controller like "read"
-     *
-     * @return \eZ\Publish\SPI\Limitation\Type[]
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If module/function to limitation type mapping
-     *                                                                 refers to a non existing identifier.
-     */
     public function getLimitationTypesByModuleFunction( $module, $function )
     {
         if ( empty( $this->settings['limitationMap'][$module][$function] ) )
@@ -1053,9 +812,9 @@ class RoleService implements RoleServiceInterface
     /**
      * Creates SPI Role value object from provided API role create struct
      *
-     * @param \eZ\Publish\API\Repository\Values\User\RoleCreateStruct $roleCreateStruct
+     * @param APIRoleCreateStruct $roleCreateStruct
      *
-     * @return \eZ\Publish\SPI\Persistence\User\Role
+     * @return SPIRole
      */
     protected function buildPersistenceRoleObject( APIRoleCreateStruct $roleCreateStruct )
     {
@@ -1082,9 +841,9 @@ class RoleService implements RoleServiceInterface
      *
      * @param string $module
      * @param string $function
-     * @param \eZ\Publish\API\Repository\Values\User\Limitation[] $limitations
+     * @param Limitation[] $limitations
      *
-     * @return \eZ\Publish\SPI\Persistence\User\Policy
+     * @return SPIPolicy
      */
     protected function buildPersistencePolicyObject( $module, $function, array $limitations )
     {
@@ -1112,7 +871,7 @@ class RoleService implements RoleServiceInterface
      *
      * @uses validatePolicy()
      *
-     * @param \eZ\Publish\API\Repository\Values\User\RoleCreateStruct $roleCreateStruct
+     * @param APIRoleCreateStruct $roleCreateStruct
      *
      * @return \eZ\Publish\Core\FieldType\ValidationError[][][]
      */
@@ -1141,12 +900,12 @@ class RoleService implements RoleServiceInterface
      *
      * @uses validateLimitations()
      *
-     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException If the same limitation is repeated or if
+     * @throws InvalidArgumentException If the same limitation is repeated or if
      *                                                                   limitation is not allowed on module/function
      *
      * @param string $module
      * @param string $function
-     * @param \eZ\Publish\API\Repository\Values\User\Limitation[] $limitations
+     * @param Limitation[] $limitations
      *
      * @return \eZ\Publish\Core\FieldType\ValidationError[][]
      */
@@ -1185,7 +944,7 @@ class RoleService implements RoleServiceInterface
      *
      * @uses validateLimitation()
      *
-     * @param \eZ\Publish\API\Repository\Values\User\Limitation[] $limitations
+     * @param Limitation[] $limitations
      *
      * @return \eZ\Publish\Core\FieldType\ValidationError[][]
      */
@@ -1207,9 +966,9 @@ class RoleService implements RoleServiceInterface
     /**
      * Validates single Limitation.
      *
-     * @throws \eZ\Publish\Core\Base\Exceptions\BadStateException If the Role settings is in a bad state
+     * @throws BadStateException If the Role settings is in a bad state
      *
-     * @param \eZ\Publish\API\Repository\Values\User\Limitation $limitation
+     * @param Limitation $limitation
      *
      * @return \eZ\Publish\Core\FieldType\ValidationError[]
      */

--- a/eZ/Publish/Core/SignalSlot/RoleService.php
+++ b/eZ/Publish/Core/SignalSlot/RoleService.php
@@ -39,14 +39,14 @@ class RoleService implements RoleServiceInterface
     /**
      * Aggregated service
      *
-     * @var \eZ\Publish\API\Repository\RoleService
+     * @var RoleServiceInterface
      */
     protected $service;
 
     /**
      * SignalDispatcher
      *
-     * @var \eZ\Publish\Core\SignalSlot\SignalDispatcher
+     * @var SignalDispatcher
      */
     protected $signalDispatcher;
 
@@ -56,8 +56,8 @@ class RoleService implements RoleServiceInterface
      * Construct service object from aggregated service and signal
      * dispatcher
      *
-     * @param \eZ\Publish\API\Repository\RoleService $service
-     * @param \eZ\Publish\Core\SignalSlot\SignalDispatcher $signalDispatcher
+     * @param RoleServiceInterface $service
+     * @param SignalDispatcher $signalDispatcher
      */
     public function __construct( RoleServiceInterface $service, SignalDispatcher $signalDispatcher )
     {
@@ -65,19 +65,6 @@ class RoleService implements RoleServiceInterface
         $this->signalDispatcher = $signalDispatcher;
     }
 
-    /**
-     * Creates a new Role
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists or if limitation of the
-     *                                                                        same type is repeated in the policy create struct or if
-     *                                                                        limitation is not allowed on module/function
-     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a policy limitation in the $roleCreateStruct is not valid
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\RoleCreateStruct $roleCreateStruct
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
-     */
     public function createRole( RoleCreateStruct $roleCreateStruct )
     {
         $returnValue = $this->service->createRole( $roleCreateStruct );
@@ -91,17 +78,6 @@ class RoleService implements RoleServiceInterface
         return $returnValue;
     }
 
-    /**
-     * Updates the name of the role
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\RoleUpdateStruct $roleUpdateStruct
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
-     */
     public function updateRole( Role $role, RoleUpdateStruct $roleUpdateStruct )
     {
         $returnValue = $this->service->updateRole( $role, $roleUpdateStruct );
@@ -115,19 +91,6 @@ class RoleService implements RoleServiceInterface
         return $returnValue;
     }
 
-    /**
-     * Adds a new policy to the role
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to add  a policy
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if limitation of the same type is repeated in policy create
-     *                                                                        struct or if limitation is not allowed on module/function
-     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a limitation in the $policyCreateStruct is not valid
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct $policyCreateStruct
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
-     */
     public function addPolicy( Role $role, PolicyCreateStruct $policyCreateStruct )
     {
         $returnValue = $this->service->addPolicy( $role, $policyCreateStruct );
@@ -142,19 +105,6 @@ class RoleService implements RoleServiceInterface
         return $returnValue;
     }
 
-    /**
-     * removes a policy from the role
-     *
-     * @deprecated since 5.3, use {@link deletePolicy()} instead.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if policy does not belong to the given role
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to remove from the role
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role the updated role
-     */
     public function removePolicy( Role $role, Policy $policy )
     {
         $returnValue = $this->service->removePolicy( $role, $policy );
@@ -169,13 +119,6 @@ class RoleService implements RoleServiceInterface
         return $returnValue;
     }
 
-    /**
-     * Delete a policy
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to delete
-     */
     public function deletePolicy( Policy $policy )
     {
         $returnValue = $this->service->deletePolicy( $policy );
@@ -190,20 +133,6 @@ class RoleService implements RoleServiceInterface
         return $returnValue;
     }
 
-    /**
-     * Updates the limitations of a policy. The module and function cannot be changed and
-     * the limitations are replaced by the ones in $roleUpdateStruct
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a policy
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if limitation of the same type is repeated in policy update
-     *                                                                        struct or if limitation is not allowed on module/function
-     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a limitation in the $policyUpdateStruct is not valid
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct $policyUpdateStruct
-     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Policy
-     */
     public function updatePolicy( Policy $policy, PolicyUpdateStruct $policyUpdateStruct )
     {
         $returnValue = $this->service->updatePolicy( $policy, $policyUpdateStruct );
@@ -217,55 +146,21 @@ class RoleService implements RoleServiceInterface
         return $returnValue;
     }
 
-    /**
-     * Loads a role for the given id
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read this role
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a role with the given name was not found
-     *
-     * @param mixed $id
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
-     */
     public function loadRole( $id )
     {
         return $this->service->loadRole( $id );
     }
 
-    /**
-     * Loads a role for the given identifier
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read this role
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a role with the given name was not found
-     *
-     * @param string $identifier
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
-     */
     public function loadRoleByIdentifier( $identifier )
     {
         return $this->service->loadRoleByIdentifier( $identifier );
     }
 
-    /**
-     * Loads all roles
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the roles
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role[]
-     */
     public function loadRoles()
     {
         return $this->service->loadRoles();
     }
 
-    /**
-     * Deletes the given role
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to delete this role
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     */
     public function deleteRole( Role $role )
     {
         $returnValue = $this->service->deleteRole( $role );
@@ -279,30 +174,11 @@ class RoleService implements RoleServiceInterface
         return $returnValue;
     }
 
-    /**
-     * Loads all policies from roles which are assigned to a user or to user groups to which the user belongs
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user with the given id was not found
-     *
-     * @param mixed $userId
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Policy[]
-     */
     public function loadPoliciesByUserId( $userId )
     {
         return $this->service->loadPoliciesByUserId( $userId );
     }
 
-    /**
-     * Assigns a role to the given user group
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to assign a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if $roleLimitation is not valid
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
-     * @param \eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation $roleLimitation an optional role limitation (which is either a subtree limitation or section limitation)
-     */
     public function assignRoleToUserGroup( Role $role, UserGroup $userGroup, RoleLimitation $roleLimitation = null )
     {
         $returnValue = $this->service->assignRoleToUserGroup( $role, $userGroup, $roleLimitation );
@@ -318,15 +194,6 @@ class RoleService implements RoleServiceInterface
         return $returnValue;
     }
 
-    /**
-     * removes a role from the given user group.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException  If the role is not assigned to the given user group
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
-     */
     public function unassignRoleFromUserGroup( Role $role, UserGroup $userGroup )
     {
         $returnValue = $this->service->unassignRoleFromUserGroup( $role, $userGroup );
@@ -341,16 +208,6 @@ class RoleService implements RoleServiceInterface
         return $returnValue;
     }
 
-    /**
-     * Assigns a role to the given user
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to assign a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if $roleLimitation is not valid
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
-     * @param \eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation $roleLimitation an optional role limitation (which is either a subtree limitation or section limitation)
-     */
     public function assignRoleToUser( Role $role, User $user, RoleLimitation $roleLimitation = null )
     {
         $returnValue = $this->service->assignRoleToUser( $role, $user, $roleLimitation );
@@ -366,15 +223,6 @@ class RoleService implements RoleServiceInterface
         return $returnValue;
     }
 
-    /**
-     * removes a role from the given user.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If the role is not assigned to the user
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
-     */
     public function unassignRoleFromUser( Role $role, User $user )
     {
         $returnValue = $this->service->unassignRoleFromUser( $role, $user );
@@ -389,122 +237,46 @@ class RoleService implements RoleServiceInterface
         return $returnValue;
     }
 
-    /**
-     * Returns the assigned user and user groups to this role
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a role
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\Role $role
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\RoleAssignment[]
-     */
     public function getRoleAssignments( Role $role )
     {
         return $this->service->getRoleAssignments( $role );
     }
 
-    /**
-     * Returns the roles assigned to the given user
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a user
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\UserRoleAssignment[]
-     */
     public function getRoleAssignmentsForUser( User $user )
     {
         return $this->service->getRoleAssignmentsForUser( $user );
     }
 
-    /**
-     * Returns the roles assigned to the given user group
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a user group
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\UserGroupRoleAssignment[]
-     */
     public function getRoleAssignmentsForUserGroup( UserGroup $userGroup )
     {
         return $this->service->getRoleAssignmentsForUserGroup( $userGroup );
     }
 
-    /**
-     * Instantiates a role create class
-     *
-     * @param string $name
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\RoleCreateStruct
-     */
     public function newRoleCreateStruct( $name )
     {
         return $this->service->newRoleCreateStruct( $name );
     }
 
-    /**
-     * Instantiates a policy create class
-     *
-     * @param string $module
-     * @param string $function
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct
-     */
     public function newPolicyCreateStruct( $module, $function )
     {
         return $this->service->newPolicyCreateStruct( $module, $function );
     }
 
-    /**
-     * Instantiates a policy update class
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct
-     */
     public function newPolicyUpdateStruct()
     {
         return $this->service->newPolicyUpdateStruct();
     }
 
-    /**
-     * Instantiates a policy update class
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\RoleUpdateStruct
-     */
     public function newRoleUpdateStruct()
     {
         return $this->service->newRoleUpdateStruct();
     }
 
-    /**
-     * Returns the LimitationType registered with the given identifier
-     *
-     * @param string $identifier
-     *
-     * @return \eZ\Publish\SPI\Limitation\Type
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if there is no LimitationType with $identifier
-     */
     public function getLimitationType( $identifier )
     {
         return $this->service->getLimitationType( $identifier );
     }
 
-    /**
-     * Returns the LimitationType's assigned to a given module/function
-     *
-     * Typically used for:
-     *  - Internal validation limitation value use on Policies
-     *  - Role admin gui for editing policy limitations incl list limitation options via valueSchema()
-     *
-     * @param string $module Legacy name of "controller", it's a unique identifier like "content"
-     * @param string $function Legacy name of a controller "action", it's a unique within the controller like "read"
-     *
-     * @return \eZ\Publish\SPI\Limitation\Type[]
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If module/function to limitation type mapping
-     *                                                                 refers to a non existing identifier.
-     */
     public function getLimitationTypesByModuleFunction( $module, $function )
     {
         return $this->service->getLimitationTypesByModuleFunction( $module, $function );


### PR DESCRIPTION
I was researching in the code to get a clue on https://jira.ez.no/browse/EZP-22299 (hint hint :) ) I noticed something in the code's PHPDocs:
#### Unnecessary FQNs when referring to classes

The PHPDoc comments refer to the FQNs of parameters and return values although they are (mostly) already available ~~or could be made available through the `use` statements at the top~~ (**Update:** As has been correctly pointed out by @andrerom and @lolautruche, no `use` statements should be added just for the sake of being able to shorten PHPDocs). This makes the PHPDoc quite bulky and could be simplified, so that instead of writing

``` php
use eZ\Publish\API\Repository\Values\User\Role;

/**
 * ...
 * @return \eZ\Publish\API\Repository\Values\User\Role
 **/
```

at multiple locations in the code, we could write

``` php
use eZ\Publish\API\Repository\Values\User\Role;

// ...
/**
 * ...
 * @return Role
 **/
```

This is partially already done, but not consistently.
#### Duplicated PHPDocs in derived classes

I noticed that all classes derived from the `RoleService` interface had exactly the same PHPDoc as the interface. If, some day, the documentation in the interface would change, this would require consequent changes in all derived classes. In addition to that, the files get bigger and thus not as easy to parse.

Modern IDEs and [phpdoc](http://www.phpdoc.org/) are able to display documentation of parent interfaces, classes and methods, so I see no compellent need to duplicate the PHPDoc in inherited elements. The benefits would be that we have to write less documentation and use less chars which would make the code a lot more fun to read :).

![phpdoc_defined](https://f.cloud.github.com/assets/67554/2088528/2eba5162-8e7c-11e3-95ad-daca35521db9.png)
![phpdoc_derived](https://f.cloud.github.com/assets/67554/2088547/678ad1ba-8e7c-11e3-9c8f-1297ca174d70.png)

In this PR, I applied these points to the `RoleService`interface and its derived classes so that you could have a look and I hope for a vivid discussion (or none at all, because you all agree with me :D).

Cheers
:octocat: Jérôme

PS: After having submitted the PR, I saw the stats: 145 additions and 836 deletions - and this only by changing 4 files. Imagine the savings when applying this everywhere :eyes: !
