### PR TITLE
Fix EZP-20502: Additional check for empty fileName on field template.

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -387,7 +387,7 @@
  #}
 {% block ezimage_field %}
 {% spaceless %}
-{% if field.value %}
+{% if field.value.fileName %}
 <figure {{ block( 'field_attributes' ) }}>
     {% set imageAlias = ez_image_alias( field, versionInfo, parameters.alias|default( 'original' ) ) %}
     <img src="{{ asset( imageAlias.uri ) }}" width="{{ imageAlias.width }}" height="{{ imageAlias.height }}" alt="{{ field.value.alternativeText }}" />


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-20502

This is an additional fix that avoids calls to `ez_render_field()` with an empty image field from generating a large amount of exceptions in the logs.
