### PR TITLE
EZP-22326: [REST API] GET Content request fails when the content has no locations

### DIFF
--- a/eZ/Publish/Core/REST/Server/Controller/Content.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Content.php
@@ -67,7 +67,13 @@ class Content extends RestController
     public function loadContent( $contentId )
     {
         $contentInfo = $this->repository->getContentService()->loadContentInfo( $contentId );
-        $mainLocation = $this->repository->getLocationService()->loadLocation( $contentInfo->mainLocationId );
+
+        $mainLocation = null;
+        if ( !empty( $contentInfo->mainLocationId ) )
+        {
+            $mainLocation = $this->repository->getLocationService()->loadLocation( $contentInfo->mainLocationId );
+        }
+
         $contentType = $this->repository->getContentTypeService()->loadContentType( $contentInfo->contentTypeId );
 
         $contentVersion = null;


### PR DESCRIPTION
Fixing the exception by only loading the object's location when it is not null.
