### PR TITLE
Fix EZP-22315: Use ez_is_field_empty to do the checks in content_fields

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -71,7 +71,7 @@
 
 {% block ezdatetime_field %}
 {% spaceless %}
-    {% if field.value.value %}
+    {% if not ez_is_field_empty( content, field ) %}
         {% if fieldSettings.useSeconds %}
             {% set field_value = field.value.value|localizeddate( 'short', 'medium', parameters.locale ) %}
         {% else %}
@@ -84,7 +84,7 @@
 
 {% block ezdate_field %}
 {% spaceless %}
-    {% if field.value.date %}
+    {% if not ez_is_field_empty( content, field ) %}
         {% set field_value = field.value.date|localizeddate( 'short', 'none', parameters.locale ) %}
         {{ block( 'simple_block_field' ) }}
     {% endif %}
@@ -93,7 +93,7 @@
 
 {% block eztime_field %}
 {% spaceless %}
-    {% if field.value.time %}
+    {% if not ez_is_field_empty( content, field ) %}
         {% if fieldSettings.useSeconds %}
             {% set field_value = field.value.time|localizeddate( 'none', 'medium', parameters.locale ) %}
         {% else %}
@@ -106,7 +106,7 @@
 
 {% block ezemail_field %}
 {% spaceless %}
-    {% if field.value.email %}
+    {% if not ez_is_field_empty( content, field ) %}
         {% set field_value = field.value.email %}
         <a href="mailto:{{ field.value.email|escape( 'url' ) }}" {{ block( 'field_attributes' ) }}>{{ field.value.email }}</a>
     {% endif %}
@@ -115,7 +115,7 @@
 
 {% block ezinteger_field %}
 {% spaceless %}
-    {% if field.value %}
+    {% if not ez_is_field_empty( content, field ) %}
         {% set field_value = field.value.value %}
         {{ block( 'simple_inline_field' ) }}
     {% endif %}
@@ -125,7 +125,7 @@
 {# @todo: handle localization #}
 {% block ezfloat_field %}
 {% spaceless %}
-    {% if field.value %}
+    {% if not ez_is_field_empty( content, field ) %}
         {% set field_value = field.value.value %}
         {{ block( 'simple_inline_field' ) }}
     {% endif %}
@@ -134,7 +134,7 @@
 
 {% block ezurl_field %}
 {% spaceless %}
-    {% if field.value %}
+    {% if not ez_is_field_empty( content, field ) %}
         <a href="{{ field.value.link }}"
             {{ block( 'field_attributes' ) }}>{{ field.value.text ? field.value.text : field.value.link }}</a>
     {% endif %}
@@ -143,7 +143,7 @@
 
 {% block ezkeyword_field %}
 {% spaceless %}
-    {% if field.value.values|length() > 0 %}
+    {% if not ez_is_field_empty( content, field ) %}
         <ul {{ block( 'field_attributes' ) }}>
         {% for keyword in field.value.values %}
             <li>{{ keyword }}</li>
@@ -190,7 +190,7 @@
 {# @todo: handle the unit of the fileSize (si operator in legacy template engine) #}
 {% block ezbinaryfile_field %}
 {% spaceless %}
-    {% if field.value.fileName %}
+    {% if not ez_is_field_empty( content, field ) %}
         {% set uri = 'content/download/' ~ contentInfo.id ~ '/' ~ field.id
                         ~ '/version/' ~ contentInfo.currentVersionNo ~  "/file/"
                         ~ field.value.fileName|escape( 'url' ) %}
@@ -201,7 +201,7 @@
 {% endblock %}
 
 {% block ezmedia_field %}
-{% if field.value %}
+{% if not ez_is_field_empty( content, field ) %}
 {% spaceless %}
     {% set type = fieldSettings.mediaType %}
     {% set value = field.value %}
@@ -260,7 +260,7 @@
 
 {% block ezobjectrelationlist_field %}
 {% spaceless %}
-    {% if field.value.destinationContentIds|length > 0 %}
+    {% if not ez_is_field_empty( content, field ) %}
     <ul {{ block( 'field_attributes' ) }}>
         {% for contentId in field.value.destinationContentIds %}
         <li>
@@ -387,7 +387,7 @@
  #}
 {% block ezimage_field %}
 {% spaceless %}
-{% if field.value.fileName %}
+{% if not ez_is_field_empty( content, field ) %}
 <figure {{ block( 'field_attributes' ) }}>
     {% set imageAlias = ez_image_alias( field, versionInfo, parameters.alias|default( 'original' ) ) %}
     <img src="{{ asset( imageAlias.uri ) }}" width="{{ imageAlias.width }}" height="{{ imageAlias.height }}" alt="{{ field.value.alternativeText }}" />
@@ -398,7 +398,7 @@
 
 {% block ezobjectrelation_field %}
 {% spaceless %}
-{% if field.value.destinationContentId %}
+{% if not ez_is_field_empty( content, field ) %}
     <div {{ block( 'field_attributes' ) }}>
         {{ render( controller( "ez_content:viewContent", {'contentId': field.value.destinationContentId, 'viewType': 'text_linked', 'noLayout': 1} ) ) }}
     </div>
@@ -409,7 +409,7 @@
 {# pageService is exposed under parameters.pageService thanks to Page\ParameterProvider #}
 {% block ezpage_field %}
 {% spaceless %}
-{% if field.value.page is not null %}
+{% if not ez_is_field_empty( content, field ) %}
     {% set layout = field.value.page.layout %}
     {% set template = parameters.pageService.getLayoutTemplate( layout ) %}
     {% include template with { 'zones': field.value.page.zones, 'zone_layout': layout, 'pageService': parameters.pageService } %}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/ContentExtensionTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/ContentExtensionTest.php
@@ -25,10 +25,16 @@ use Twig_Loader_Array;
 
 class ContentExtensionIntegrationTest extends Twig_Test_IntegrationTestCase
 {
+    /**
+     * @var \eZ\Publish\API\Repository\ContentTypeService|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $fieldHelperMock;
 
     public function getExtensions()
     {
         $configResolver = $this->getConfigResolverMock();
+        $this->fieldHelperMock = $this->getMockBuilder( 'eZ\\Publish\\Core\\Helper\\FieldHelper' )
+            ->disableOriginalConstructor()->getMock();
 
         return array(
             new ContentExtension(
@@ -40,7 +46,7 @@ class ContentExtensionIntegrationTest extends Twig_Test_IntegrationTestCase
                 $this->getMockBuilder( 'eZ\\Publish\\Core\\FieldType\\RichText\\Converter' )->disableOriginalConstructor()->getMock(),
                 $this->getMock( 'eZ\Publish\SPI\Variation\VariationHandler' ),
                 new TranslationHelper( $configResolver, $this->getMock( 'eZ\\Publish\\API\\Repository\\ContentService' ) ),
-                $this->getMockBuilder( 'eZ\\Publish\\Core\\Helper\\FieldHelper' )->disableOriginalConstructor()->getMock()
+                $this->fieldHelperMock
             )
         );
     }
@@ -236,6 +242,18 @@ class ContentExtensionIntegrationTest extends Twig_Test_IntegrationTestCase
 
         return $content;
 
+    }
+
+    protected function getField( $isEmpty )
+    {
+        $field = new Field( array( 'fieldDefIdentifier' => 'testfield', 'value' => null ) );
+
+        $this->fieldHelperMock
+            ->expects( $this->once() )
+            ->method( 'isFieldEmpty' )
+            ->will( $this->returnValue( $isEmpty ) );
+
+        return $field;
     }
 
     private function getTemplatePath( $tpl )

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/functions/ez_is_field_empty.test
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/functions/ez_is_field_empty.test
@@ -1,0 +1,80 @@
+--TEST--
+"ez_is_field_empty" function
+--TEMPLATE--
+{% if ez_is_field_empty( content, field ) %}
+    empty
+{% else %}
+    not empty
+{% endif %}
+
+--DATA--
+return array(
+    'content' => $this->getContent(
+        'data',
+        array(
+            'ezdata' => array(
+                'id' => 5,
+                'fieldDefIdentifier' => 'testfield',
+                'value' => 'foo2',
+                'languageCode' => 'fre-FR'
+            )
+        )
+    ),
+    'field' => $this->getField( false )->fieldDefIdentifier
+)
+--EXPECT--
+not empty
+
+--DATA--
+return array(
+    'content' => $this->getContent(
+        'data',
+        array(
+            'ezdata' => array(
+                'id' => 5,
+                'fieldDefIdentifier' => 'testfield',
+                'value' => 'foo2',
+                'languageCode' => 'fre-FR'
+            )
+        )
+    ),
+    'field' => $this->getField( true )->fieldDefIdentifier
+)
+--EXPECT--
+empty
+
+--DATA--
+return array(
+    'content' => $this->getContent(
+        'data',
+        array(
+            'ezdata' => array(
+                'id' => 5,
+                'fieldDefIdentifier' => 'testfield',
+                'value' => 'foo2',
+                'languageCode' => 'fre-FR'
+            )
+        )
+    ),
+    'field' => $this->getField( false )
+)
+--EXPECT--
+not empty
+
+--DATA--
+return array(
+    'content' => $this->getContent(
+        'data',
+        array(
+            'ezdata' => array(
+                'id' => 5,
+                'fieldDefIdentifier' => 'testfield',
+                'value' => 'foo2',
+                'languageCode' => 'fre-FR'
+            )
+        )
+    ),
+    'field' => $this->getField( true )
+)
+--EXPECT--
+empty

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
@@ -16,7 +16,7 @@ use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\Core\Helper\FieldHelper;
 use eZ\Publish\Core\Helper\TranslationHelper;
 use eZ\Publish\Core\MVC\Symfony\FieldType\View\ParameterProviderRegistryInterface;
-use eZ\Publish\Core\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
@@ -271,7 +271,7 @@ class ContentExtension extends Twig_Extension
     /**
      * Generates the array of parameter to pass to the field template.
      *
-     * @param \eZ\Publish\Core\Repository\Values\Content\Content $content
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
      * @param \eZ\Publish\API\Repository\Values\Content\Field $field the Field to display
      * @param array $params An array of parameters to pass to the field view
      *
@@ -295,6 +295,7 @@ class ContentExtension extends Twig_Extension
         // parameters to be passed to the template
         $params += array(
             'field' => $field,
+            'content' => $content,
             'contentInfo' => $contentInfo,
             'versionInfo' => $versionInfo,
             'fieldSettings' => $fieldDefinition->getFieldSettings()
@@ -350,7 +351,7 @@ class ContentExtension extends Twig_Extension
     /**
      * Renders the HTML for a given field.
      *
-     * @param \eZ\Publish\Core\Repository\Values\Content\Content $content
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
      * @param string $fieldIdentifier Identifier for the field we want to render
      * @param array $params An array of parameters to pass to the field view
      * @throws \InvalidArgumentException If $fieldIdentifier is invalid in $content
@@ -566,7 +567,7 @@ class ContentExtension extends Twig_Extension
     /**
      * Returns expected block name for $field, attached in $content.
      *
-     * @param \eZ\Publish\Core\Repository\Values\Content\Content $content
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
      * @param \eZ\Publish\API\Repository\Values\Content\Field $field
      *
      * @return string
@@ -591,7 +592,7 @@ class ContentExtension extends Twig_Extension
     /**
      * Returns the field type identifier for $field
      *
-     * @param \eZ\Publish\Core\Repository\Values\Content\Content $content
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
      * @param \eZ\Publish\API\Repository\Values\Content\Field $field
      *
      * @return string
@@ -636,7 +637,7 @@ class ContentExtension extends Twig_Extension
     }
 
     /**
-     * @param \eZ\Publish\Core\Repository\Values\Content\Content $content
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
      * @param string $fieldDefIdentifier Identifier for the field we want to get the value from.
      * @param string $forcedLanguage Locale we want the content name translation in (e.g. "fre-FR"). Null by default (takes current locale).
      *
@@ -649,15 +650,23 @@ class ContentExtension extends Twig_Extension
 
     /**
      * Checks if a given field is considered empty.
+     * This method accepts field as Objects or by identifiers.
      *
-     * @param \eZ\Publish\Core\Repository\Values\Content\Content $content
-     * @param string $fieldDefIdentifier Identifier for the field we want to get the value from.
-     * @param string $forcedLanguage Locale we want the content name translation in (e.g. "fre-FR"). Null by default (takes current locale).
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     * @param \eZ\Publish\API\Repository\Values\Content\Field|string $fieldDefIdentifier Field or Field Identifier to
+     *                                                                                   get the value from.
+     * @param string $forcedLanguage Locale we want the content name translation in (e.g. "fre-FR").
+     *                               Null by default (takes current locale).
      *
      * @return bool
      */
     public function isFieldEmpty( Content $content, $fieldDefIdentifier, $forcedLanguage = null )
     {
+        if ( $fieldDefIdentifier instanceof Field )
+        {
+            $fieldDefIdentifier = $fieldDefIdentifier->fieldDefIdentifier;
+        }
+
         return $this->fieldHelper->isFieldEmpty( $content, $fieldDefIdentifier, $forcedLanguage );
     }
 }


### PR DESCRIPTION
## Description

Link: https://jira.ez.no/browse/EZP-22315

Use the standard ez_is_field_empty to check the emptyness of content fields in the related twig template.
This way, the empty rule for a given field is coded only once.

To avoid setting each time `ez_is_field_empty( content, field.fieldDefIdentifier )`, ez_is_field_empty has been modified to also accept Fields.
## Test

Manual test and created unit test for ez_is_field_empty
