### PR TITLE
Fix EZP-22337: Hidden state on Locations is not taken into account in ViewController

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
@@ -106,6 +106,10 @@ class ViewController extends Controller
             else
             {
                 $location = $this->getRepository()->getLocationService()->loadLocation( $locationId );
+                if ( $location->invisible )
+                {
+                    throw new NotFoundHttpException( "Location #$locationId cannot be displayed as it is flagged as invisible." );
+                }
             }
 
             $response->headers->set( 'X-Location-Id', $locationId );


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22337

`ViewController` now throws a NotFoundHttpException if a location is invisible.
