### PR TITLE
Fix EZP-22353: Travis database error on ezpublish-community

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/TestInitDbCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/TestInitDbCommand.php
@@ -35,8 +35,14 @@ EOT
         $database = $this->getContainer()->get( 'ezpublish.config.resolver' )->getParameter( 'database.params' );
         if ( is_array( $database ) )
         {
-            $dbType = $database['type'];
-            $database = $database['database'];
+            $driverMap = array(
+                'pdo_mysql' => 'mysql',
+                'pdo_pgsql' => 'pgsql',
+                'pdo_sqlite' => 'sqlite',
+            );
+
+            $dbType = $driverMap[$database['driver']];
+            $database = $database['dbname'];
         }
         else
         {


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22353
## Description

Since Refactoring of Legacy SE to use Doctrine DBAL https://jira.ez.no/browse/EZP-22151 the travis would fail on ezpublish-community because database parameters needed to be mapped in a different way.

This is a temporary fix until the followup story is done https://jira.ez.no/browse/EZP-22279
## Test

I added a temporary commit on my ezpublish community PR to have composer.json pointing to this branch for ezpublish-kernel, and now test are passing: https://github.com/ezsystems/ezpublish-community/pull/106
