### PR TITLE
Fix [EZP-22358]: SiteAccessRules setting doesn't work well in the Symfon...

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/LegacyMapper/Security.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/LegacyMapper/Security.php
@@ -99,18 +99,18 @@ class Security implements EventSubscriberInterface
             return;
         }
 
-        $injectedSettings = $event->getParameters()->get( 'injected-settings', array() );
+        $injectedMergeSettings = $event->getParameters()->get( 'injected-merge-settings', array() );
         $accessRules = array(
             'access;disable',
             'module;user/login',
             'module;user/logout',
         );
         // Merge existing settings with the new ones if needed.
-        if ( isset( $injectedSettings['site.ini/SiteAccessRules/Rules'] ) )
+        if ( isset( $injectedMergeSettings['site.ini/SiteAccessRules/Rules'] ) )
         {
-            $accessRules = array_merge( $injectedSettings['site.ini/SiteAccessRules/Rules'], $accessRules );
+            $accessRules = array_merge( $injectedMergeSettings['site.ini/SiteAccessRules/Rules'], $accessRules );
         }
-        $injectedSettings['site.ini/SiteAccessRules/Rules'] = $accessRules;
-        $event->getParameters()->set( 'injected-settings', $injectedSettings );
+        $injectedMergeSettings['site.ini/SiteAccessRules/Rules'] = $accessRules;
+        $event->getParameters()->set( 'injected-merge-settings', $injectedMergeSettings );
     }
 }

--- a/eZ/Bundle/EzPublishLegacyBundle/Tests/LegacyMapper/SecurityTest.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Tests/LegacyMapper/SecurityTest.php
@@ -187,7 +187,7 @@ class SecurityTest extends PHPUnit_Framework_TestCase
             array(
                 array(),
                 array(
-                    'injected-settings' => array(
+                    'injected-merge-settings' => array(
                         'site.ini/SiteAccessRules/Rules' => array(
                             'access;disable',
                             'module;user/login',
@@ -204,7 +204,7 @@ class SecurityTest extends PHPUnit_Framework_TestCase
                 array(
                     'foo' => 'bar',
                     'some' => array( 'thing' ),
-                    'injected-settings' => array(
+                    'injected-merge-settings' => array(
                         'site.ini/SiteAccessRules/Rules' => array(
                             'access;disable',
                             'module;user/login',
@@ -217,7 +217,7 @@ class SecurityTest extends PHPUnit_Framework_TestCase
                 array(
                     'foo' => 'bar',
                     'some' => array( 'thing' ),
-                    'injected-settings' => array(
+                    'injected-merge-settings' => array(
                         'Empire' => array( 'Darth Vader', 'Emperor', 'Moff Tarkin' ),
                         'Rebellion' => array( 'Luke Skywalker', 'Leïa Organa', 'Obi-Wan Kenobi', 'Han Solo' ),
                         'Chewbacca' => 'Arrrrrhhhhhh!'
@@ -226,7 +226,7 @@ class SecurityTest extends PHPUnit_Framework_TestCase
                 array(
                     'foo' => 'bar',
                     'some' => array( 'thing' ),
-                    'injected-settings' => array(
+                    'injected-merge-settings' => array(
                         'Empire' => array( 'Darth Vader', 'Emperor', 'Moff Tarkin' ),
                         'Rebellion' => array( 'Luke Skywalker', 'Leïa Organa', 'Obi-Wan Kenobi', 'Han Solo' ),
                         'Chewbacca' => 'Arrrrrhhhhhh!',
@@ -242,7 +242,7 @@ class SecurityTest extends PHPUnit_Framework_TestCase
                 array(
                     'foo' => 'bar',
                     'some' => array( 'thing' ),
-                    'injected-settings' => array(
+                    'injected-merge-settings' => array(
                         'site.ini/SiteAccessRules/Rules' => array(
                             'access;disable',
                             'module;ezinfo/about',
@@ -254,7 +254,7 @@ class SecurityTest extends PHPUnit_Framework_TestCase
                 array(
                     'foo' => 'bar',
                     'some' => array( 'thing' ),
-                    'injected-settings' => array(
+                    'injected-merge-settings' => array(
                         'site.ini/SiteAccessRules/Rules' => array(
                             'access;disable',
                             'module;ezinfo/about',
@@ -271,7 +271,7 @@ class SecurityTest extends PHPUnit_Framework_TestCase
                 array(
                     'foo' => 'bar',
                     'some' => array( 'thing' ),
-                    'injected-settings' => array(
+                    'injected-merge-settings' => array(
                         'site.ini/SiteAccessRules/Rules' => array(
                             'access;disable',
                             'module;ezinfo/about',
@@ -283,7 +283,7 @@ class SecurityTest extends PHPUnit_Framework_TestCase
                 array(
                     'foo' => 'bar',
                     'some' => array( 'thing' ),
-                    'injected-settings' => array(
+                    'injected-merge-settings' => array(
                         'site.ini/SiteAccessRules/Rules' => array(
                             'access;disable',
                             'module;ezinfo/about',


### PR DESCRIPTION
...y Stack

Fixes: https://jira.ez.no/browse/EZP-22358

I proposed the following solution without really knowing if its  the best option we can take here. 

This solution would need the merge of https://github.com/ezsystems/ezpublish-legacy/pull/884 to properly work. 

I think we could inject this setting as a merged one. If not, it will override all the rules provided by extensions as salid in the tracker. 

what the legacy pull does is just uncomment the settings in the site.ini so we can have it initialized. 
This way, we'll get a value in https://github.com/ezsystems/ezpublish-legacy/blob/master/lib/ezutils/classes/ezini.php#L1421 and so the merge with the injected settings can happen in this other if 
https://github.com/ezsystems/ezpublish-legacy/blob/master/lib/ezutils/classes/ezini.php#L1429

Please let me know if this could be solved in any other way. 
