### PR TITLE
Fix: suggestion Array uses 'driverOptions' as one of its key, but this o...

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
@@ -252,7 +252,7 @@ EOT
             {
                 $suggestionArray['unix_socket'] = $databaseConfig['socket'];
             }
-            $suggestionArray['driverOptions'] = $databaseConfig['options'];
+            $suggestionArray['options'] = $databaseConfig['options'];
             $suggestionArray['user'] = $databaseConfig['user'];
             $suggestionArray['password'] = $databaseConfig['password'];
         }


### PR DESCRIPTION
...ption is not recognized

If you copy past the suggestions from the doctrine change you'll get a `Unrecognized options "driverOptions" under "doctrine.dbal.connections.default"` error 

It seems that option is not recognized by doctrine and that "options" should be used instead
Ref: http://symfony.com/doc/master/reference/configuration/doctrine.html#doctrine-dbal-configuration

No jira issue added after 1:1 con Jérôme. Let me know if you need it anyway. 
