### PR TITLE
Fix EZP-22360: clear use role cache when moving locations from legacy

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Cache/PersistenceCachePurger.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Cache/PersistenceCachePurger.php
@@ -159,6 +159,8 @@ class PersistenceCachePurger implements CacheClearerInterface
                 $this->cache->clear( 'content', $location->contentId );
                 $this->cache->clear( 'content', 'info', $location->contentId );
                 $this->cache->clear( 'content', 'locations', $location->contentId );
+                $this->cache->clear( 'user', 'role', 'assignments', 'byGroup', $location->contentId );
+                $this->cache->clear( 'user', 'role', 'assignments', 'byGroup', 'inherited', $location->contentId );
             }
             catch ( NotFoundException $e )
             {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22360

When moving a user to a different group, in legacy stack, stash caches are not cleared, which means new permissions are not taken into account.
This clears the user role assignments for the given location when clearing it's content cache as well, 
an alternative would be to attach the 'content/cache' event to a different handler as well.
