### PR TITLE
Fix EZP-22404: Fatal error in TransformationProcessor

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage_engines.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage_engines.yml
@@ -213,7 +213,6 @@ services:
 
     ezpublish.api.storage_engine.transformation_parser:
         class: %ezpublish.api.storage_engine.transformation_parser.class%
-        arguments: [%kernel.root_dir%]
 
     ezpublish.api.storage_engine.pcre_compiler:
         class: %ezpublish.api.storage_engine.pcre_compiler.class%
@@ -233,7 +232,6 @@ services:
 
             # Using preprocessed files:
             - @ezpublish.api.storage_engine.pcre_compiler
-            - %kernel.root_dir%
             - %ezpublish.api.storage_engine.preprocessed_transformation_rules.resources%
 
     # Field type converters for legacy

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationSearchHandlerSortTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationSearchHandlerSortTest.php
@@ -83,12 +83,6 @@ class LocationSearchHandlerSortTest extends LanguageAwareTestCase
      */
     protected function getLocationSearchHandler()
     {
-        $rules = array();
-        foreach ( glob( __DIR__ . '/../../../Tests/TransformationProcessor/_fixtures/transformations/*.tr' ) as $file )
-        {
-            $rules[] = str_replace( self::getInstallationDir(), '', $file );
-        }
-
         return new Search\Location\Handler(
             new Search\Location\Gateway\DoctrineDatabase(
                 $this->getDatabaseHandler(),

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationSearchHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationSearchHandlerTest.php
@@ -87,18 +87,12 @@ class LocationSearchHandlerTest extends LanguageAwareTestCase
      */
     protected function getLocationSearchHandler( array $fullTextSearchConfiguration = array() )
     {
-        $rules = array();
-        foreach ( glob( __DIR__ . '/../../../Tests/TransformationProcessor/_fixtures/transformations/*.tr' ) as $file )
-        {
-            $rules[] = str_replace( self::getInstallationDir(), '', $file );
-        }
-
         $transformationProcessor = new Persistence\TransformationProcessor\DefinitionBased(
-            new Persistence\TransformationProcessor\DefinitionBased\Parser( self::getInstallationDir() ),
+            new Persistence\TransformationProcessor\DefinitionBased\Parser(),
             new Persistence\TransformationProcessor\PcreCompiler(
                 new Persistence\Utf8Converter()
             ),
-            $rules
+            glob( __DIR__ . '/../../../Tests/TransformationProcessor/_fixtures/transformations/*.tr' )
         );
         $commaSeparatedCollectionValueHandler = new CommonCriterionHandler\FieldValue\Handler\Collection(
             $this->getDatabaseHandler(),

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/SearchHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/SearchHandlerTest.php
@@ -91,18 +91,12 @@ class SearchHandlerTest extends LanguageAwareTestCase
      */
     protected function getContentSearchHandler( array $fullTextSearchConfiguration = array() )
     {
-        $rules = array();
-        foreach ( glob( __DIR__ . '/../../../Tests/TransformationProcessor/_fixtures/transformations/*.tr' ) as $file )
-        {
-            $rules[] = str_replace( self::getInstallationDir(), '', $file );
-        }
-
         $transformationProcessor = new Persistence\TransformationProcessor\DefinitionBased(
-            new Persistence\TransformationProcessor\DefinitionBased\Parser( self::getInstallationDir() ),
+            new Persistence\TransformationProcessor\DefinitionBased\Parser(),
             new Persistence\TransformationProcessor\PcreCompiler(
                 new Persistence\Utf8Converter()
             ),
-            $rules
+            glob( __DIR__ . '/../../../Tests/TransformationProcessor/_fixtures/transformations/*.tr' )
         );
         $commaSeparatedCollectionValueHandler = new Content\Search\Common\Gateway\CriterionHandler\FieldValue\Handler\Collection(
             $this->getDatabaseHandler(),

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
@@ -3026,16 +3026,10 @@ class UrlAliasHandlerTest extends TestCase
      */
     public function getProcessor()
     {
-        $rules = array();
-        foreach ( glob( __DIR__ . '/../../../../Tests/TransformationProcessor/_fixtures/transformations/*.tr' ) as $file )
-        {
-            $rules[] = str_replace( self::getInstallationDir(), '', $file );
-        }
-
         return new DefinitionBased(
-            new Parser( self::getInstallationDir() ),
+            new Parser(),
             new PcreCompiler( new Utf8Converter() ),
-            $rules
+            glob( __DIR__ . '/../../../../Tests/TransformationProcessor/_fixtures/transformations/*.tr' )
         );
     }
 }

--- a/eZ/Publish/Core/Persistence/Tests/TransformationProcessor/TransformationProcessorDefinitionBasedParserTest.php
+++ b/eZ/Publish/Core/Persistence/Tests/TransformationProcessor/TransformationProcessorDefinitionBasedParserTest.php
@@ -33,12 +33,12 @@ class TransformationProcessorDefinitionBasedParserTest extends TestCase
      */
     public function testParse( $file )
     {
-        $parser = new Persistence\TransformationProcessor\DefinitionBased\Parser( self::getInstallationDir() );
+        $parser = new Persistence\TransformationProcessor\DefinitionBased\Parser();
 
         $fixture = include $file . '.result';
         $this->assertEquals(
             $fixture,
-            $parser->parse( str_replace( self::getInstallationDir(), '', $file ) )
+            $parser->parse( $file )
         );
     }
 }

--- a/eZ/Publish/Core/Persistence/Tests/TransformationProcessor/TransformationProcessorDefinitionBasedTest.php
+++ b/eZ/Publish/Core/Persistence/Tests/TransformationProcessor/TransformationProcessorDefinitionBasedTest.php
@@ -20,16 +20,10 @@ class TransformationProcessorDefinitionBasedTest extends TestCase
 {
     public function getProcessor()
     {
-        $rules = array();
-        foreach ( glob( __DIR__ . '/_fixtures/transformations/*.tr' ) as $file )
-        {
-            $rules[] = str_replace( self::getInstallationDir(), '', $file );
-        }
-
         return new DefinitionBased(
-            new Persistence\TransformationProcessor\DefinitionBased\Parser( self::getInstallationDir() ),
+            new Persistence\TransformationProcessor\DefinitionBased\Parser(),
             new Persistence\TransformationProcessor\PcreCompiler( new Persistence\Utf8Converter() ),
-            $rules
+            glob( __DIR__ . '/_fixtures/transformations/*.tr' )
         );
     }
 

--- a/eZ/Publish/Core/Persistence/Tests/TransformationProcessor/TransformationProcessorPreprocessedBasedTest.php
+++ b/eZ/Publish/Core/Persistence/Tests/TransformationProcessor/TransformationProcessorPreprocessedBasedTest.php
@@ -20,17 +20,9 @@ class TransformationProcessorPreprocessedBasedTest extends TestCase
 {
     public function getProcessor()
     {
-        $installDir = self::getInstallationDir();
-        $rules = array();
-        foreach ( glob( __DIR__ . '/_fixtures/transformations/*.tr.result' ) as $file )
-        {
-            $rules[] = str_replace( $installDir, '', $file );
-        }
-
         return new PreprocessedBased(
             new Persistence\TransformationProcessor\PcreCompiler( new Persistence\Utf8Converter() ),
-            $installDir,
-            $rules
+            glob( __DIR__ . '/_fixtures/transformations/*.tr.result' )
         );
     }
 

--- a/eZ/Publish/Core/Persistence/TransformationProcessor/DefinitionBased/Parser.php
+++ b/eZ/Publish/Core/Persistence/TransformationProcessor/DefinitionBased/Parser.php
@@ -47,23 +47,12 @@ class Parser
     protected $tokenSpecifications = null;
 
     /**
-     * Directory to load rules relative from.
-     *
-     * @var string
-     */
-    protected $installDir;
-
-    /**
      * Construct
-     *
-     * @param string $installDir Base dir for rule loading
      *
      * @return void
      */
-    public function __construct( $installDir )
+    public function __construct( )
     {
-        $this->installDir = $installDir;
-
         $character = '(?:U\\+[0-9a-fA-F]{4}|remove|keep|[0-9a-fA-F]+|"(?:[^\\\\"]+|\\\\\\\\|\\\\\'|\\\\")*?")';
 
         $this->tokenSpecifications = array(
@@ -99,9 +88,7 @@ class Parser
     public function parse( $file )
     {
         return $this->parseString(
-            file_get_contents(
-                $this->installDir . '/' . $file
-            )
+            file_get_contents( $file )
         );
     }
 

--- a/eZ/Publish/Core/Persistence/TransformationProcessor/PreprocessedBased.php
+++ b/eZ/Publish/Core/Persistence/TransformationProcessor/PreprocessedBased.php
@@ -17,23 +17,15 @@ use eZ\Publish\Core\Persistence\TransformationProcessor;
 class PreprocessedBased extends TransformationProcessor
 {
     /**
-     * Directory to load rules relative from.
-     *
-     * @var string
-     */
-    protected $installDir;
-
-    /**
      * Constructor
      *
      * @param \eZ\Publish\Core\Persistence\TransformationProcessor\PcreCompiler $compiler
      * @param string $installDir Base dir for rule loading
      * @param array $ruleFiles
      */
-    public function __construct( PcreCompiler $compiler, $installDir, array $ruleFiles = array() )
+    public function __construct( PcreCompiler $compiler, array $ruleFiles = array() )
     {
         parent::__construct( $compiler, $ruleFiles );
-        $this->installDir = $installDir;
     }
 
     /**
@@ -49,7 +41,7 @@ class PreprocessedBased extends TransformationProcessor
 
             foreach ( $this->ruleFiles as $file )
             {
-                $rules += require $this->installDir . "/" . $file;
+                $rules += require $file;
             }
 
             $this->compiledRules = $this->compiler->compile( $rules );

--- a/eZ/Publish/Core/settings/service.ini
+++ b/eZ/Publish/Core/settings/service.ini
@@ -379,7 +379,6 @@ arguments[rules][]=eZ/Publish/Core/Persistence/Tests/TransformationProcessor/_fi
 
 [transformation_parser]
 class=eZ\Publish\Core\Persistence\TransformationProcessor\DefinitionBased\Parser
-arguments[installDir]=$install_dir
 
 [transformation_pcre_compiler]
 class=eZ\Publish\Core\Persistence\TransformationProcessor\PcreCompiler

--- a/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
@@ -82,16 +82,10 @@ abstract class BaseIntegrationTest extends TestCase
     {
         if ( !isset( $this->transformationProcessor ) )
         {
-            $rules = array();
-            foreach ( glob( __DIR__ . '/../../../Core/Persistence/Tests/TransformationProcessor/_fixtures/transformations/*.tr' ) as $file )
-            {
-                $rules[] = str_replace( self::getInstallationDir(), '', $file );
-            }
-
             $this->transformationProcessor = new DefinitionBased(
                 new Persistence\TransformationProcessor\DefinitionBased\Parser( self::getInstallationDir() ),
                 new Persistence\TransformationProcessor\PcreCompiler( new Persistence\Utf8Converter() ),
-                $rules
+                glob( __DIR__ . '/../../../Core/Persistence/Tests/TransformationProcessor/_fixtures/transformations/*.tr' )
             );
         }
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22404

TransformationProcessors append the resources path to kernel root dir, so the changes introduced in PR #703 / #712 appear to be unnecessary and actually introduce a regression.
( the resulting path is `/var/www/html/ezp/ezpublish//var/www/html/ezp/ezpublish/../vendor/ezsystems` ... )

Ref:
- https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/Persistence/TransformationProcessor/PreprocessedBased.php#L52
- https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/Persistence/TransformationProcessor/DefinitionBased/Parser.php#L103
