### PR TITLE
Fix EZP-22163: As a REST User I need to re authenticate existing session on login

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
@@ -1044,6 +1044,11 @@ ezpublish_rest_deleteSession:
         _controller: ezpublish_rest.controller.user:deleteSession
     methods: [DELETE]
 
+ezpublish_rest_refreshSession:
+    path: /user/sessions/{sessionId}/refresh
+    defaults:
+        _controller: ezpublish_rest.controller.user:refreshSession
+    methods: [POST]
 
 
 # URL aliases

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/UserSession.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/UserSession.php
@@ -27,12 +27,12 @@ class UserSession extends ValueObjectVisitor
      */
     public function visit( Visitor $visitor, Generator $generator, $data )
     {
-        $visitor->setStatus( 201 );
+        $status = $data->created ? 201 : 200;
+        $visitor->setStatus( $status );
 
         $visitor->setHeader( 'Content-Type', $generator->getMediaType( 'Session' ) );
 
         $sessionHref = $this->router->generate( 'ezpublish_rest_deleteSession', array( 'sessionId' => $data->sessionId ) );
-        $visitor->setHeader( 'Location', $sessionHref );
 
         //@todo Needs refactoring, disabling certain headers should not be done this way
         $visitor->setHeader( 'Accept-Patch', false );

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserSessionCreatedTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserSessionCreatedTest.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * File containing the SessionTest class
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
+
+use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
+
+use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Server\Values;
+use eZ\Publish\Core\REST\Common;
+
+class UserSessionCreatedTest extends UserSessionTest
+{
+    /**
+     * Test the Session visitor
+     *
+     * @return string
+     */
+    public function testVisit()
+    {
+        $visitor   = $this->getVisitor();
+        $generator = $this->getGenerator();
+
+        $generator->startDocument( null );
+
+        $session = new Values\UserSession(
+            $this->getUserMock(),
+            "sessionName",
+            "sessionId",
+            "csrfToken",
+            true
+        );
+
+        $this->getVisitorMock()->expects( $this->any() )
+            ->method( 'setStatus' )
+            ->with( $this->equalTo( 201  ) );
+
+        $this->getVisitorMock()->expects( $this->at( 1 ) )
+            ->method( 'setHeader' )
+            ->with( $this->equalTo( 'Content-Type' ), $this->equalTo( 'application/vnd.ez.api.Session+xml' ) );
+
+        $this->addRouteExpectation(
+            'ezpublish_rest_deleteSession',
+            array(
+                'sessionId' => $session->sessionId
+            ),
+            "/user/sessions/{$session->sessionId}"
+        );
+
+        $this->addRouteExpectation(
+            'ezpublish_rest_loadUser',
+            array( 'userId' => $session->user->id ),
+            "/user/users/{$session->user->id}"
+        );
+
+        $visitor->visit(
+            $this->getVisitorMock(),
+            $generator,
+            $session
+        );
+
+        $result = $generator->endDocument( null );
+
+        $this->assertNotNull( $result );
+
+        return $result;
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserSessionTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserSessionTest.php
@@ -33,20 +33,17 @@ class UserSessionTest extends ValueObjectVisitorBaseTest
             $this->getUserMock(),
             "sessionName",
             "sessionId",
-            "csrfToken"
+            "csrfToken",
+            false
         );
 
         $this->getVisitorMock()->expects( $this->at( 0 ) )
             ->method( 'setStatus' )
-            ->with( $this->equalTo( 201 ) );
+            ->with( $this->equalTo( 200  ) );
 
         $this->getVisitorMock()->expects( $this->at( 1 ) )
             ->method( 'setHeader' )
             ->with( $this->equalTo( 'Content-Type' ), $this->equalTo( 'application/vnd.ez.api.Session+xml' ) );
-
-        $this->getVisitorMock()->expects( $this->at( 2 ) )
-            ->method( 'setHeader' )
-            ->with( $this->equalTo( 'Location' ), $this->matchesRegularExpression( '#/user/sessions/[a-z0-9]+#i' ) );
 
         $this->addRouteExpectation(
             'ezpublish_rest_deleteSession',

--- a/eZ/Publish/Core/REST/Server/Values/UserSession.php
+++ b/eZ/Publish/Core/REST/Server/Values/UserSession.php
@@ -44,16 +44,22 @@ class UserSession extends RestValue
     public $csrfToken;
 
     /**
+     * True if session exists
+     * @var boolean
+     */
+    public $exists;
+    /**
      * @param \eZ\Publish\API\Repository\Values\User\User $user
      * @param string $sessionName
      * @param string $sessionId
      * @param string $csrfToken
      */
-    public function __construct( User $user, $sessionName, $sessionId, $csrfToken )
+    public function __construct( User $user, $sessionName, $sessionId, $csrfToken, $created )
     {
         $this->user = $user;
         $this->sessionName = $sessionName;
         $this->sessionId = $sessionId;
         $this->csrfToken = $csrfToken;
+        $this->created = $created;
     }
 }


### PR DESCRIPTION
## Link

Suggestion from : https://github.com/ezsystems/ezpublish-kernel/pull/682 
JIRA link : https://jira.ez.no/browse/EZP-22163
## Description

 The goal here is to change the existing POST /user/sessions to allow for common use case needed by session based REST clients, re authenticate a user when he comes back to application but while session cookie is still existing (session cookie might not be available to javascript for security reasons btw).

Two points :
In a first hand POST /user/sessions with a correct login / pass and with <b>session cookie</b> gives:
 <ul>   <li>    If the session differs, 201 like now (or other response code as we can't provide Location header) </li>
<li>    If the corresponding session exists, 200 with the same response as for the previous case</li> </ul>

In a second hand POST /user/sessions/<sessionId>/refresh A new resource where you can POST with <b> session cookie and csrf token</b> :

<ul>   <li> If the session is valid => 200 (204 would work if we don't provide a body)</li>
   <li> 404 if the session is not valid</li> </ul>


Specifications have also been updated.
