### PR TITLE
Fix EZP-22387: Error rendering a page block with trashed content

### DIFF
--- a/eZ/Publish/Core/FieldType/Page/PageStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Page/PageStorage/Gateway/LegacyStorage.php
@@ -75,8 +75,12 @@ class LegacyStorage extends Gateway
         $dbHandler = $this->getConnection();
         $q = $dbHandler->createSelectQuery();
         $q
-            ->select( 'object_id, node_id, priority, ts_publication, ts_visible, rotation_until, moved_to' )
+            ->select( 'object_id, ezm_pool.node_id, ezm_pool.priority, ts_publication, ts_visible, rotation_until, moved_to' )
             ->from( $dbHandler->quoteTable( 'ezm_pool' ) )
+            ->innerJoin(
+                $dbHandler->quoteTable( 'ezcontentobject_tree' ),
+                $q->expr->eq( 'ezcontentobject_tree.node_id', 'ezm_pool.node_id' )
+            )
             ->where(
                 $q->expr->eq( 'block_id', $q->bindValue( $block->id ) ),
                 $q->expr->gt( 'ts_visible', $q->bindValue( 0, null, \PDO::PARAM_INT ) ),


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22387
## Description

Items located in the trash are returned as valid content by ezpage. In order to avoid that, we are making sure items returned are available in `ezcontentobject_tree`.

It only makes it a closer match to the legacy SQL request from ezflow:
https://github.com/ezsystems/ezflow/blob/483e6ddfb13251eb2b2841edbfde14e069b27236/packages/ezflow_extension/ezextension/ezflow/classes/ezflowpool.php#L96

Invalid items will then be cleared by cronjob:

```
php ezpublish/console --env=prod ezpublish:legacy:script runcronjobs.php ezflow-cleanup
```
## Test

Manual tests.
