### PR TITLE
Fix EZP-22430: Custom Location URL Alias not using redirect / 301

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
@@ -113,7 +113,10 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
 
                     $request->attributes->set( 'locationId', $urlAlias->destination );
 
-                    if ( $urlAlias->isHistory === true )
+                    // For Location alias setup 301 redirect to Location's current URL when:
+                    // 1. alias is history
+                    // 2. alias is custom with forward flag true
+                    if ( $urlAlias->isHistory === true || ( $urlAlias->isCustom === true && $urlAlias->forward === true ) )
                     {
                         $request->attributes->set(
                             'semanticPathinfo',


### PR DESCRIPTION
This PR resolves issue https://jira.ez.no/browse/EZP-22430

Custom forwarding Location URL alias was not handled for redirect.
This fixes the issue with tests.
