### PR TITLE
EZP-22583: Made REST output indenting optional

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
@@ -339,6 +339,8 @@ services:
         class: %ezpublish_rest.output.generator.xml.class%
         arguments:
             - @ezpublish_rest.output.generator.xml.field_type_hash_generator
+        calls:
+            - [ setFormatOutput, [ %kernel.debug% ] ]
 
     ezpublish_rest.output.generator.xml.field_type_hash_generator:
         class: %ezpublish_rest.output.generator.xml.field_type_hash_generator.class%
@@ -347,6 +349,8 @@ services:
         class: %ezpublish_rest.output.generator.json.class%
         arguments:
             - @ezpublish_rest.output.generator.json.field_type_hash_generator
+        calls:
+            - [ setFormatOutput, [ %kernel.debug% ] ]
 
     ezpublish_rest.output.generator.json.field_type_hash_generator:
         class: %ezpublish_rest.output.generator.json.field_type_hash_generator.class%

--- a/eZ/Publish/Core/REST/Common/Output/Generator.php
+++ b/eZ/Publish/Core/REST/Common/Output/Generator.php
@@ -25,6 +25,17 @@ abstract class Generator
     protected $stack = array();
 
     /**
+     * If set to true, output will be formatted and indented
+     * @var bool
+     */
+    protected $formatOutput = false;
+
+    public function setFormatOutput( $formatOutput )
+    {
+        $this->formatOutput = (bool)$formatOutput;
+    }
+
+    /**
      * Reset output visitor to a virgin state
      */
     public function reset()

--- a/eZ/Publish/Core/REST/Common/Output/Generator/Json.php
+++ b/eZ/Publish/Core/REST/Common/Output/Generator/Json.php
@@ -82,8 +82,14 @@ class Json extends Generator
     {
         $this->checkEndDocument( $data );
 
+        $jsonEncodeOptions = 0;
+        if ( $this->formatOutput && defined( 'JSON_PRETTY_PRINT' ) )
+        {
+            $jsonEncodeOptions = JSON_PRETTY_PRINT;
+        }
+
         $this->json = $this->convertArrayObjects( $this->json );
-        return json_encode( $this->json );
+        return json_encode( $this->json, $jsonEncodeOptions );
     }
 
     /**

--- a/eZ/Publish/Core/REST/Common/Output/Generator/Xml.php
+++ b/eZ/Publish/Core/REST/Common/Output/Generator/Xml.php
@@ -58,7 +58,7 @@ class Xml extends Generator
 
         $this->xmlWriter = new \XMLWriter();
         $this->xmlWriter->openMemory();
-        $this->xmlWriter->setIndent( true );
+        $this->xmlWriter->setIndent( $this->formatOutput );
         $this->xmlWriter->startDocument( '1.0', 'UTF-8' );
     }
 

--- a/eZ/Publish/Core/REST/Common/Tests/Output/Generator/Xml/FieldTypeHashGeneratorTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Output/Generator/Xml/FieldTypeHashGeneratorTest.php
@@ -31,8 +31,10 @@ class FieldTypeHashGeneratorTest extends FieldTypeHashGeneratorBaseTest
      */
     protected function initializeGenerator()
     {
-        return new Common\Output\Generator\Xml(
+        $generator = new Common\Output\Generator\Xml(
             $this->getFieldTypeHashGenerator()
         );
+        $generator->setFormatOutput( true );
+        return $generator;
     }
 }

--- a/eZ/Publish/Core/REST/Common/Tests/Output/Generator/XmlTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Output/Generator/XmlTest.php
@@ -244,6 +244,7 @@ class XmlTest extends GeneratorTest
                 )
             );
         }
+        $this->generator->setFormatOutput( true );
         return $this->generator;
     }
 }


### PR DESCRIPTION
> http://jira.ez.no/browse/EZP-22583

Passes on `%kernel.debug` as an option to the JSON & XML REST output generators. If true, the produced XML/JSON will be indented. If not, it won't be.
### TODO
- [ ] Fix tests
