### PR TITLE
Fix EZP-22437: JSON decode result is not checked in the input parser

### DIFF
--- a/eZ/Publish/Core/REST/Common/Input/Handler/Json.php
+++ b/eZ/Publish/Core/REST/Common/Input/Handler/Json.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\REST\Common\Input\Handler;
 
 use eZ\Publish\Core\REST\Common\Input\Handler;
+use eZ\Publish\Core\REST\Common\Exceptions\Parser as ParserException;
 
 /**
  * Input format handler base class
@@ -19,12 +20,49 @@ class Json extends Handler
     /**
      * Converts the given string to an array structure
      *
+     * @throw eZ\Publish\Core\REST\Common\Exceptions\Parser
      * @param string $string
      *
      * @return array
      */
     public function convert( $string )
     {
-        return json_decode( $string, true );
+        $json = json_decode( $string, true );
+        if ( JSON_ERROR_NONE !== ( $jsonErrorCode = json_last_error() ) )
+        {
+            $message = "An error occured while decoding the JSON input:\n";
+            $message .= $this->jsonDecodeErrorMessage( $jsonErrorCode );
+            $message .= "\nInput JSON:\n\n" . $string;
+            throw new ParserException( $message );
+        }
+        return $json;
+    }
+
+    /**
+     * Returns the error message associated with the $jsonErrorCode
+     *
+     * @param $jsonErrorCode
+     * @return string
+     */
+    private function jsonDecodeErrorMessage( $jsonErrorCode )
+    {
+        if ( function_exists( 'json_last_error_msg' ) )
+        {
+            return json_last_error_msg();
+        }
+        switch ( $jsonErrorCode )
+        {
+            case JSON_ERROR_DEPTH:
+                return 'Maximum stack depth exceeded';
+            case JSON_ERROR_STATE_MISMATCH:
+                return 'Underflow or the modes mismatch';
+            case JSON_ERROR_CTRL_CHAR:
+                return 'Unexpected control character found';
+            case JSON_ERROR_SYNTAX:
+                return 'Syntax error, malformed JSON';
+            case JSON_ERROR_UTF8:
+                return 'Malformed UTF-8 characters, possibly incorrectly encoded';
+        }
+        return 'Unknown JSON decode error';
     }
 }

--- a/eZ/Publish/Core/REST/Common/Tests/Input/Handler/JsonTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Input/Handler/JsonTest.php
@@ -18,6 +18,15 @@ use PHPUnit_Framework_TestCase;
 class JsonTest extends PHPUnit_Framework_TestCase
 {
     /**
+     * @expectedException \eZ\Publish\Core\REST\Common\Exceptions\Parser
+     */
+    public function testConvertInvalidJson()
+    {
+        $handler = $this->getHandler();
+        $handler->convert( '{text:"Hello world!"}' );
+    }
+
+    /**
      * Tests conversion of array to JSON
      */
     public function testConvertJson()


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22437
# Description

The current REST JSON input parser only calls the json_decode() PHP function without any further checking. As a result, if the JSON is invalid, you only get an error message due to NULL being used as an array.

This patch changes the JSON input parser to behave like [the XML one](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/REST/Common/Input/Handler/Xml.php#L102).
# Test

unit tests + manual test
