### PR TITLE
Fixed REST API specifications after fixing EZP-21312

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -1894,6 +1894,7 @@ XML Example
       <Content href="/content/objects/23" media-type="application/vnd.ez.api.Content+xml"/>
       <sortField>PATH</sortField>
       <sortOrder>ASC</sortOrder>
+      <UrlAliases media-type="application/vnd.ez.api.UrlAliasRefList+xml" href="/api/ezp/v2/content/locations/1/4/73/133/urlaliases"/>
     </Location>
 
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-21312

This patch makes sure the example is up to date after the fix for EZP-21312.
