### PR TITLE
EZP-21344: [REST Spec] updating doc on HTTP response

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -2122,7 +2122,8 @@ Create View
     :Content-Type:
         :application/vnd.ez.api.ViewInput+xml: the view input in xml format (see View_)
         :application/vnd.ez.api.ViewInput+json: the view input in json format (see View_)
-:Response:
+:Response: 200 OK
+           Note : when persistence will be implemented, it will change to 201 Created
 
 .. code:: http
 
@@ -2173,7 +2174,7 @@ Perform a query on images withing the media section, sorted by name, limiting re
 
 .. code:: http
 
-    HTTP/1.1 201 Created
+    HTTP/1.1 200 OK
     Location: /content/views/view1234
     Content-Type: application/vnd.ez.api.View+xml
     Content-Length: xxx


### PR DESCRIPTION
See https://jira.ez.no/browse/EZP-21344 comments

Changing the response to 200 in the POST example, according to the process described in the document.
The HTTP response is 200 OK and not 201 Created, because the storage is not implemented yet.
