### PR TITLE
EZP-22481: Fix overlapped Identity name definition

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Security/User/HashGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/User/HashGenerator.php
@@ -10,7 +10,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Security\User;
 
 use eZ\Publish\SPI\HashGenerator as HashGeneratorInterface;
-use eZ\Publish\SPI\User\Identity;
+use eZ\Publish\SPI\User\Identity as IdentityInterface;
 use eZ\Publish\SPI\User\IdentityAware;
 
 /**
@@ -19,7 +19,7 @@ use eZ\Publish\SPI\User\IdentityAware;
 class HashGenerator implements HashGeneratorInterface, IdentityAware
 {
     /**
-     * @var \eZ\Publish\SPI\User\Identity
+     * @var IdentityInterface
      */
     protected $userIdentity;
 
@@ -29,7 +29,7 @@ class HashGenerator implements HashGeneratorInterface, IdentityAware
     protected $identityDefiners = array();
 
     /**
-     * @param \eZ\Publish\SPI\User\IdentityAware $identityDefiner
+     * @param IdentityAware $identityDefiner
      */
     public function setIdentityDefiner( IdentityAware $identityDefiner )
     {
@@ -37,7 +37,7 @@ class HashGenerator implements HashGeneratorInterface, IdentityAware
     }
 
     /**
-     * @return \eZ\Publish\SPI\User\IdentityAware[]
+     * @return IdentityAware[]
      */
     public function getIdentityDefiners()
     {
@@ -45,15 +45,15 @@ class HashGenerator implements HashGeneratorInterface, IdentityAware
     }
 
     /**
-     * @param Identity $identity
+     * @param IdentityInterface $identity
      */
-    public function setIdentity( Identity $identity )
+    public function setIdentity( IdentityInterface $identity )
     {
         $this->userIdentity = $identity;
     }
 
     /**
-     * @return Identity
+     * @return IdentityInterface
      */
     public function getIdentity()
     {


### PR DESCRIPTION
Fix "Cannot use eZ\Publish\SPI\User\Identity as Identity because the name is already in use in /.../vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/MVC/Symfony/Security/User/HashGenerator.php on line 13"

Identity is already defined in namespace `eZ\Publish\Core\MVC\Symfony\Security\User` see `eZ\Publish\Core\MVC\Symfony\Security\User\Identity`.
