### PR TITLE
Fix EZP-22513: Exception not thrown when twig template does not exist

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -1,5 +1,5 @@
 parameters:
-    twig.loader.string.class: Twig_Loader_String
+    twig.loader.string.class: eZ\Publish\Core\MVC\Symfony\Templating\Twig\LoaderString
     twig.extension.intl.class: Twig_Extensions_Extension_Intl
 
     ezpublish.twig.extension.content.class: eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\ContentExtension

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/LoaderStringTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/LoaderStringTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: lolautruche
+ * Date: 24/03/14
+ * Time: 14:13
+ */
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests\Twig;
+
+use eZ\Publish\Core\MVC\Symfony\Templating\Twig\LoaderString;
+use PHPUnit_Framework_TestCase;
+
+class LoaderStringTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider existsProvider
+     */
+    public function testExists( $name, $expectedResult )
+    {
+        $loaderString = new LoaderString();
+        $this->assertSame( $expectedResult, $loaderString->exists( $name ) );
+    }
+
+    public function existsProvider()
+    {
+        return array(
+            array( 'foo.html.twig', false ),
+            array( 'foo/bar/baz.txt.twig', false ),
+            array( 'SOMETHING.HTML.tWiG', false ),
+            array( 'foo', true ),
+            array( 'Hey, I love twig', true ),
+            array( 'Hey, I love Twig', true ),
+        );
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/LoaderString.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/LoaderString.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * File containing the LoaderString class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating\Twig;
+
+use Twig_Loader_String;
+
+/**
+ * This loader is supposed to directly load templates as a string, not from FS.
+ *
+ * {@inheritdoc}
+ */
+class LoaderString extends Twig_Loader_String
+{
+    /**
+     * Returns true if $name is a string template, false if $name is a template name (which should be loaded by Twig_Loader_Filesystem.
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function exists( $name )
+    {
+        $suffix = '.twig';
+        $endsWithSuffix = strtolower( substr( $name, -strlen( $suffix ) ) ) === $suffix;
+
+        return !$endsWithSuffix;
+    }
+}


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22513
## Description

We use `Twig_Loader_Chain` as loader, where `Twig_Loader_Filesystem` is first checked, `Twig_Loader_String` then.
When a template fails to be loaded by `Twig_Loader_Filesystem` (method `exists()`), `Twig_Loader_String` is then checked. The problem is that `Twig_Loader_String` always returns true since passed _template name_ is supposed to be the template itself.
