### PR TITLE
Added string export of Query object & criteria

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Values/Content/Query/Criterion/ContentIdTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/Content/Query/Criterion/ContentIdTest.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * File containing the ContentId class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace eZ\Publish\API\Repository\Tests\Values\Content\Query\Criterion;
+
+use eZ\Publish\API\Repository\Tests\Values\Content\Query\CriterionTest;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+class ContentId extends CriterionTest
+{
+    public function providerForTestToString()
+    {
+        return array(
+            array( new Criterion\ContentId( 1 ), 'contentId = 1' ),
+            array( new Criterion\ContentId( array( 1, 2, 3 ) ), 'contentId IN (1, 2, 3)' )
+        );
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Values/Content/Query/CriterionTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/Content/Query/CriterionTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * File containing the CriterionTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace eZ\Publish\API\Repository\Tests\Values\Content\Query;
+
+use PHPUnit_Framework_TestCase;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+abstract class CriterionTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider providerForTestToString
+     * @param Criterion $criterion tested Criterion
+     * @param string $expectedString The expected string output.
+     */
+    public function testToString( Criterion $criterion, $expectedString )
+    {
+        self::assertEquals( $expectedString, (string)$criterion );
+    }
+
+    /**
+     * Provider for {@see testToString()}
+     *
+     * The methods expects as a parameter the Criterion object, and its string expectation
+     */
+    abstract public function providerForTestToString();
+}

--- a/eZ/Publish/API/Repository/Tests/Values/Content/Query/SortClauseTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/Content/Query/SortClauseTest.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * File containing the SortClauseTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+namespace eZ\Publish\API\Repository\Tests\Values\Content\Query;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Tests the abstract SortClause::__fromString() method
+ * @covers \eZ\Publish\API\Repository\Values\Content\Query\SortClause
+ */
+class SortClauseTest extends PHPUnit_Framework_TestCase
+{
+    public function testToString()
+    {
+        $sortClause = $this->getMockForAbstractClass(
+            'eZ\Publish\API\Repository\Values\Content\Query\SortClause',
+            array( 'sortTarget', 'ascending' )
+        );
+
+        self::assertEquals(
+            lcfirst( get_class( $sortClause ) ) . ' ascending',
+            (string)$sortClause
+        );
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Values/Content/QueryTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/Content/QueryTest.php
@@ -1,0 +1,68 @@
+<?php
+use eZ\Publish\API\Repository\Values\Content\Query;
+
+/**
+ * File containing the QueryTest class.
+ *
+ * @copyright Copyright (C) 2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+class QueryTest extends PHPUnit_Framework_TestCase
+{
+    public function testToString()
+    {
+        $criterion = $this->createCriterionMock( 'criterion = value AND otherCriterion in (value1, value2)' );
+
+        $sortClause = $this->createSortClauseMock( 'sortClause ASCENDING, otherSortClauseDescending' );
+
+        $query = new Query();
+        $query->filter = $criterion;
+        $query->sortClauses = array( $sortClause );
+
+        self::assertEquals(
+            'criterion = value AND otherCriterion in (value1, value2) SORT BY sortClause ASCENDING, otherSortClauseDescending',
+            (string)$query
+        );
+    }
+
+    /**
+     * Returns a SortClause object that expects __fromString() to be called once and return $toStringExpectation.
+     * @param string $toStringExpectation The string the method is expected to return on __fromString.
+     * @return Query\Criterion|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createCriterionMock( $toStringExpectation )
+    {
+        return $this->createMock( '\eZ\Publish\API\Repository\Values\Content\Query\Criterion', $toStringExpectation );
+    }
+
+    /**
+     * Returns a SortClause object that expects __fromString() to be called once and return $toStringExpectation.
+     * @param string $toStringExpectation The string the method is expected to return on __fromString.
+     * @return Query\SortClause|PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createSortClauseMock( $toStringExpectation )
+    {
+        return $this->createMock( '\eZ\Publish\API\Repository\Values\Content\Query\SortClause', $toStringExpectation );
+    }
+
+    /**
+     * Returns a mock of $class that expects __fromString() to be called once and return $toStringExpectation.
+     * @param string $toStringExpectation The string the method is expected to return on __fromString.
+     * @return PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createMock( $class, $toStringExpectation )
+    {
+        $sortClause = $this
+            ->getMockBuilder( $class, '__toString' )
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $sortClause->expects( $this->once() )
+            ->method( '__toString' )
+            ->will( $this->returnValue( $toStringExpectation ) );
+
+        return $sortClause;
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Values/Content/QueryTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/Content/QueryTest.php
@@ -11,19 +11,56 @@ use eZ\Publish\API\Repository\Values\Content\Query;
 
 class QueryTest extends PHPUnit_Framework_TestCase
 {
-    public function testToString()
+    /**
+     * @dataProvider providerForTestToString
+     */
+    public function testToString( $criterionString, $sortClauseStringArray, $expectedQueryString )
     {
-        $criterion = $this->createCriterionMock( 'criterion = value AND otherCriterion in (value1, value2)' );
-
-        $sortClause = $this->createSortClauseMock( 'sortClause ASCENDING, otherSortClauseDescending' );
-
         $query = new Query();
-        $query->filter = $criterion;
-        $query->sortClauses = array( $sortClause );
+        if ( $criterionString !== false )
+        {
+            $query->filter = $this->createCriterionMock( $criterionString );
+        }
 
-        self::assertEquals(
-            'criterion = value AND otherCriterion in (value1, value2) SORT BY sortClause ASCENDING, otherSortClauseDescending',
-            (string)$query
+        if ( $sortClauseStringArray !== false )
+        {
+            foreach ( $sortClauseStringArray as $sortClauseString )
+            {
+                $query->sortClauses[] = $this->createSortClauseMock( $sortClauseString );
+            }
+        }
+
+        self::assertEquals( $expectedQueryString, (string)$query );
+    }
+
+    public function providerForTestToString()
+    {
+        return array(
+            // both sortClause and filter
+            array(
+                'criterion = value AND otherCriterion in (value1, value2)',
+                array( 'sortClause1 ascending', 'sortClause2 descending' ),
+                'criterion = value AND otherCriterion in (value1, value2) SORT BY sortClause1 ascending, sortClause2 descending',
+            ),
+            // no filter
+            array(
+                false,
+                array( 'sortClause1 ascending', 'sortClause2 descending' ),
+                'SORT BY sortClause1 ascending, sortClause2 descending',
+            ),
+            // no sortClause
+            array(
+                'criterion = value AND otherCriterion in (value1, value2)',
+                false,
+                'criterion = value AND otherCriterion in (value1, value2)',
+            ),
+            // nothing
+            array(
+                false,
+                false,
+                '',
+            ),
+
         );
     }
 

--- a/eZ/Publish/API/Repository/Tests/Values/Content/QueryTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/Content/QueryTest.php
@@ -1,6 +1,4 @@
 <?php
-use eZ\Publish\API\Repository\Values\Content\Query;
-
 /**
  * File containing the QueryTest class.
  *
@@ -8,6 +6,10 @@ use eZ\Publish\API\Repository\Values\Content\Query;
  * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
  * @version //autogentag//
  */
+namespace eZ\Publish\API\Repository\Tests\Values\Content;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use PHPUnit_Framework_TestCase;
 
 class QueryTest extends PHPUnit_Framework_TestCase
 {
@@ -40,34 +42,33 @@ class QueryTest extends PHPUnit_Framework_TestCase
             array(
                 'criterion = value AND otherCriterion in (value1, value2)',
                 array( 'sortClause1 ascending', 'sortClause2 descending' ),
-                'criterion = value AND otherCriterion in (value1, value2) SORT BY sortClause1 ascending, sortClause2 descending',
+                'criterion = value AND otherCriterion in (value1, value2) SORT BY sortClause1 ascending, sortClause2 descending'
             ),
             // no filter
             array(
                 false,
                 array( 'sortClause1 ascending', 'sortClause2 descending' ),
-                'SORT BY sortClause1 ascending, sortClause2 descending',
+                'SORT BY sortClause1 ascending, sortClause2 descending'
             ),
             // no sortClause
             array(
                 'criterion = value AND otherCriterion in (value1, value2)',
                 false,
-                'criterion = value AND otherCriterion in (value1, value2)',
+                'criterion = value AND otherCriterion in (value1, value2)'
             ),
             // nothing
             array(
                 false,
                 false,
-                '',
-            ),
-
+                ''
+            )
         );
     }
 
     /**
      * Returns a SortClause object that expects __fromString() to be called once and return $toStringExpectation.
      * @param string $toStringExpectation The string the method is expected to return on __fromString.
-     * @return Query\Criterion|PHPUnit_Framework_MockObject_MockObject
+     * @return Query\Criterion|\PHPUnit_Framework_MockObject_MockObject
      */
     protected function createCriterionMock( $toStringExpectation )
     {
@@ -77,7 +78,7 @@ class QueryTest extends PHPUnit_Framework_TestCase
     /**
      * Returns a SortClause object that expects __fromString() to be called once and return $toStringExpectation.
      * @param string $toStringExpectation The string the method is expected to return on __fromString.
-     * @return Query\SortClause|PHPUnit_Framework_MockObject_MockObject
+     * @return Query\SortClause|\PHPUnit_Framework_MockObject_MockObject
      */
     protected function createSortClauseMock( $toStringExpectation )
     {
@@ -87,7 +88,7 @@ class QueryTest extends PHPUnit_Framework_TestCase
     /**
      * Returns a mock of $class that expects __fromString() to be called once and return $toStringExpectation.
      * @param string $toStringExpectation The string the method is expected to return on __fromString.
-     * @return PHPUnit_Framework_MockObject_MockObject
+     * @return \PHPUnit_Framework_MockObject_MockObject
      */
     protected function createMock( $class, $toStringExpectation )
     {

--- a/eZ/Publish/API/Repository/Values/Content/Query.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query.php
@@ -158,12 +158,20 @@ class Query extends ValueObject
 
         if ( $sortClauseString = $this->sortClauseToString() )
         {
-            $stringArray[] = $sortClauseString;
+            $stringArray[] = "SORT BY " . $sortClauseString;
         }
 
         return implode( ' ', $stringArray );
     }
 
+    /**
+     * Converts the query's SortClause objects to a string.
+     *
+     * Joins all SortClause objects with ", ".
+     * Example: `sortClauseA ASCENDING, sortClauseB DESCENDING`
+     *
+     * @return string
+     */
     private function sortClauseToString()
     {
         if ( count( $this->sortClauses ) == 0 )
@@ -177,6 +185,6 @@ class Query extends ValueObject
             $sortClauseStringArray[] = (string)$sortClause;
         }
 
-        return "SORT BY " . implode( ', ', $sortClauseStringArray );
+        return implode( ', ', $sortClauseStringArray );
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query.php
@@ -166,7 +166,7 @@ class Query extends ValueObject
 
     private function sortClauseToString()
     {
-        if ( count( $this->sortClauses ) == 0)
+        if ( count( $this->sortClauses ) == 0 )
         {
             return '';
         }

--- a/eZ/Publish/API/Repository/Values/Content/Query.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query.php
@@ -140,10 +140,33 @@ class Query extends ValueObject
 
     public function __toString()
     {
-        if ( $this->filter === null )
+        $stringArray = array();
+        if ( $filterString = (string)$this->filter )
+        {
+            $stringArray[] = $filterString;
+        }
+
+        if ( $sortClauseString = $this->sortClauseToString() )
+        {
+            $stringArray[] = $sortClauseString;
+        }
+
+        return implode( ' ', $stringArray );
+    }
+
+    private function sortClauseToString()
+    {
+        if ( count( $this->sortClauses ) == 0)
         {
             return '';
         }
-        return (string)$this->filter;
+
+        $sortClauseStringArray = array();
+        foreach ( $this->sortClauses as $sortClause )
+        {
+            $sortClauseStringArray[] = (string)$sortClause;
+        }
+
+        return "SORT BY " . implode( ', ', $sortClauseStringArray );
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query.php
@@ -138,6 +138,16 @@ class Query extends ValueObject
         return parent::__isset( $property );
     }
 
+    /**
+     * Returns a human readable, query language like version of the query:
+     *
+     * Example:
+     * ```
+     * contentTypeIdentifier = 'article' AND sectionId = 1 SORT BY dateModified DESCENDING
+     * ```
+     *
+     * @return string
+     */
     public function __toString()
     {
         $stringArray = array();

--- a/eZ/Publish/API/Repository/Values/Content/Query.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query.php
@@ -119,7 +119,7 @@ class Query extends ValueObject
             return;
         }
 
-        return parent::__set( $property, $value );
+        parent::__set( $property, $value );
     }
 
     /**

--- a/eZ/Publish/API/Repository/Values/Content/Query.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query.php
@@ -137,4 +137,13 @@ class Query extends ValueObject
 
         return parent::__isset( $property );
     }
+
+    public function __toString()
+    {
+        if ( $this->filter === null )
+        {
+            return '';
+        }
+        return (string)$this->filter;
+    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php
@@ -188,7 +188,7 @@ abstract class Criterion
 
     protected function getOperatorString()
     {
-        return strtoupper( $this->operator ) ?: ( is_array( $value ) ? 'IN' : 'EQ' );
+        return strtoupper( $this->operator ) ?: ( is_array( $this->value ) ? 'IN' : 'EQ' );
     }
 
     protected function getValueString()

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php
@@ -168,6 +168,12 @@ abstract class Criterion
         return new static( $target, $operator, $value );
     }
 
+    /**
+     * Exports a criterion to a human readable string, similar to a Query Language
+     * using a simple "{target} {operator} {value}" format.
+     *
+     * @return string
+     */
     public function __toString()
     {
         return sprintf(
@@ -175,6 +181,13 @@ abstract class Criterion
         );
     }
 
+    /**
+     * Returns the criterion's target as a string.
+     *
+     * Unless a target is specified (like in a Field Criterion), the string is the criterion's class name (without the NS)
+     *
+     * @return string
+     */
     protected function getTargetString()
     {
         if ( isset( $this->target ) )
@@ -186,11 +199,23 @@ abstract class Criterion
         return array_pop( $classParts );
     }
 
+    /**
+     * Returns the criterion's operator as a string
+     * @return string
+     */
     protected function getOperatorString()
     {
         return strtoupper( $this->operator ) ?: ( is_array( $this->value ) ? 'IN' : 'EQ' );
     }
 
+    /**
+     * Returns the criterion's value as a string.
+     *
+     * If the Criterion has multiple values, they are joined with ", " and nested within parenthesis.
+     * Example: `(value1, value2, value3)`
+     *
+     * @return string
+     */
     protected function getValueString()
     {
         if ( is_array( $this->value ) )

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php
@@ -167,4 +167,42 @@ abstract class Criterion
     {
         return new static( $target, $operator, $value );
     }
+
+    public function __toString()
+    {
+        return sprintf(
+            "%s %s %s", lcfirst( $this->getTargetString() ), $this->getOperatorString(), $this->getValueString()
+        );
+    }
+
+    protected function getTargetString()
+    {
+        if ( isset( $this->target ) )
+        {
+            return $this->target;
+        }
+
+        $classParts = explode( '\\', get_class( $this ) );
+        return array_pop( $classParts );
+    }
+
+    protected function getOperatorString()
+    {
+        return strtoupper( $this->operator ) ?: ( is_array( $value ) ? 'IN' : 'EQ' );
+    }
+
+    protected function getValueString()
+    {
+        if ( is_array( $this->value ) )
+        {
+            if ( count( $this->value ) == 1 )
+                return $this->value[0];
+
+            return '(' . implode( ', ', $this->value ) . ')';
+        }
+        else
+        {
+            return $this->value;
+        }
+    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Field.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Field.php
@@ -77,4 +77,9 @@ class Field extends Criterion implements CriterionInterface, CustomFieldInterfac
 
         return $this->customFields[$type][$field];
     }
+
+    protected function getTargetString()
+    {
+        return "field." . $this->target;
+    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Field.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Field.php
@@ -78,6 +78,12 @@ class Field extends Criterion implements CriterionInterface, CustomFieldInterfac
         return $this->customFields[$type][$field];
     }
 
+    /**
+     * Override of the method used by {@see Criterion::__fromString} to get the target of a criterion.
+     * For a field, we return field.{field identifier}: `field.title`, `field.body`...
+     *
+     * @return string
+     */
     protected function getTargetString()
     {
         return "field." . $this->target;

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalNot.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalNot.php
@@ -30,6 +30,11 @@ class LogicalNot extends LogicalOperator
         parent::__construct( array( $criterion ) );
     }
 
+    /**
+     * String export of a NOT criterion. NOT is prepended to the embedded criterion's string export
+     * Example: `NOT contentId = 58`
+     * @return string
+     */
     public function __toString()
     {
         return "NOT {$this->criteria[0]}";

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalNot.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalNot.php
@@ -29,4 +29,9 @@ class LogicalNot extends LogicalOperator
     {
         parent::__construct( array( $criterion ) );
     }
+
+    public function __toString()
+    {
+        return "NOT {$this->criteria[0]}";
+    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOperator.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOperator.php
@@ -54,4 +54,17 @@ abstract class LogicalOperator extends Criterion
             $this->criteria[] = $criterion;
         }
     }
+
+    public function __toString()
+    {
+        $string = strtolower( parent::getTargetString() );
+        $string = str_replace( 'logical', '', $string );
+        $logicalOperatorString = strtoupper( $string );
+
+        // join all stringified criteria with the logical operator
+        return implode(
+            " $logicalOperatorString ",
+            array_map( function ( $criterion ) { return (string)$criterion; }, $this->criteria )
+        );
+    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOperator.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOperator.php
@@ -55,6 +55,17 @@ abstract class LogicalOperator extends Criterion
         }
     }
 
+    /**
+     * Exports a Logical Criterion to a string. Done by joining  all criteria the logical one embeds with the logical
+     * operator.
+     *
+     * Example:
+     * ```
+     * criterion1 = value 1 AND criterion2 in (value2A, value2b)
+     * ```
+     *
+     * @return string
+     */
     public function __toString()
     {
         $string = strtolower( parent::getTargetString() );
@@ -64,7 +75,13 @@ abstract class LogicalOperator extends Criterion
         // join all stringified criteria with the logical operator
         return implode(
             " $logicalOperatorString ",
-            array_map( function ( $criterion ) { return (string)$criterion; }, $this->criteria )
+            array_map(
+                function ( $criterion )
+                {
+                    return (string)$criterion;
+                },
+                $this->criteria
+            )
         );
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause.php
@@ -62,4 +62,17 @@ abstract class SortClause
             $this->targetData = $targetData;
         }
     }
+
+    public function __toString()
+    {
+        return sprintf(
+            "%s %s", lcfirst( $this->getClassName() ), $this->direction
+        );
+    }
+
+    protected function getClassName()
+    {
+        $classParts = explode( '\\', get_class( $this ) );
+        return array_pop( $classParts );
+    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause.php
@@ -63,6 +63,11 @@ abstract class SortClause
         }
     }
 
+    /**
+     * Returns a string export of the SortClause object, by concatenating the sort clause target and the direction.
+     * Example: `datePublished DESCENDING`, `contentName ASCENDING`
+     * @return string
+     */
     public function __toString()
     {
         return sprintf(
@@ -70,6 +75,10 @@ abstract class SortClause
         );
     }
 
+    /**
+     * Extracts the classname (without the namespace) from the current SortClause class
+     * @return string
+     */
     protected function getClassName()
     {
         $classParts = explode( '\\', get_class( $this ) );

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause.php
@@ -65,7 +65,7 @@ abstract class SortClause
 
     /**
      * Returns a string export of the SortClause object, by concatenating the sort clause target and the direction.
-     * Example: `datePublished DESCENDING`, `contentName ASCENDING`
+     * Example: `datePublished descending`, `contentName ascending`
      * @return string
      */
     public function __toString()


### PR DESCRIPTION
> Required by ezsystems/QueryBuilderBundle#3
> (https://github.com/ezsystems/QueryBuilderBundle/tree/api_tests/eZ/Publish/API/QueryBuilder/Tests)

Offers a human readable view of a query:

``` php
$queryBuilder
    ->contentTypeIdentifier()->in( 'article', 'blog_post' )
    ->sectionId()->eq( 1 )
    ->textLineField( 'title' )->contains( 'service' )
    ->sortBy()
        ->contentName()->descending();
```

translates into:

```
contentTypeIdentifier IN (article, blog_post) AND sectionId = 1 AND title CONTAINS service
```

Implements __toString in Query and Criterion.
