### PR TITLE
Add tracking of the prepended config file

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/DependencyInjection/EzPublishRestExtension.php
+++ b/eZ/Bundle/EzPublishRestBundle/DependencyInjection/EzPublishRestExtension.php
@@ -3,6 +3,7 @@ namespace eZ\Bundle\EzPublishRestBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -31,8 +32,10 @@ class EzPublishRestExtension extends Extension implements PrependExtensionInterf
     {
         if ( $container->hasExtension( 'nelmio_cors' ) )
         {
-            $config = Yaml::parse( __DIR__ . '/../Resources/config/nelmio_cors.yml' );
+            $file = __DIR__ . '/../Resources/config/nelmio_cors.yml':
+            $config = Yaml::parse( $file );
             $container->prependExtensionConfig( 'nelmio_cors', $config );
+            $container->addResource( new FileResource( $file ) )
         }
     }
 }


### PR DESCRIPTION
This allows the container to know that the file is involved in the config and so should be tracked for changes to reload the cache in debug mode.
Courtesy to @lolautruche who just listed it as an inconvenient of prependExtensionConfig during his SymfonyLive talk
