### PR TITLE
Move REST Input Parser to REST/Common

### DIFF
--- a/eZ/Publish/Core/REST/Client/Input/Parser/Content.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/Content.php
@@ -11,11 +11,9 @@ namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Client\ContentService;
-
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
-
 use eZ\Publish\Core\REST\Client\Values;
 use eZ\Publish\API\Repository\Values\Content\Field;
 
@@ -25,7 +23,7 @@ use eZ\Publish\API\Repository\Values\Content\Field;
  * @todo Integrate FieldType fromHash()
  * @todo Caching for extracted embedded objects
  */
-class Content extends Parser
+class Content extends BaseParser
 {
     /**
      * VersionInfo parser

--- a/eZ/Publish/Core/REST/Client/Input/Parser/ContentInfo.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/ContentInfo.php
@@ -11,16 +11,14 @@ namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Client\ContentTypeService;
-
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
-
 use eZ\Publish\Core\REST\Client\Values;
 
 /**
  * Parser for ContentInfo
  */
-class ContentInfo extends Parser
+class ContentInfo extends BaseParser
 {
     /**
      * @var \eZ\Publish\Core\REST\Common\Input\ParserTools

--- a/eZ/Publish/Core/REST/Client/Input/Parser/ContentList.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/ContentList.php
@@ -9,13 +9,13 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 /**
  * Parser for ContentList
  */
-class ContentList extends Parser
+class ContentList extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Client/Input/Parser/ContentObjectStates.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/ContentObjectStates.php
@@ -9,13 +9,13 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 /**
  * Parser for ContentObjectStates
  */
-class ContentObjectStates extends Parser
+class ContentObjectStates extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Client/Input/Parser/ContentType.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/ContentType.php
@@ -11,16 +11,14 @@ namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Client\ContentTypeService;
-
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
-
 use eZ\Publish\Core\REST\Client\Values;
 
 /**
  * Parser for ContentType
  */
-class ContentType extends Parser
+class ContentType extends BaseParser
 {
     /**
      * @var \eZ\Publish\Core\REST\Common\Input\ParserTools

--- a/eZ/Publish/Core/REST/Client/Input/Parser/ContentTypeGroup.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/ContentTypeGroup.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Client\Values;
@@ -17,7 +17,7 @@ use eZ\Publish\Core\REST\Client\Values;
 /**
  * Parser for ContentTypeGroup
  */
-class ContentTypeGroup extends Parser
+class ContentTypeGroup extends BaseParser
 {
     /**
      * @var \eZ\Publish\Core\REST\Common\Input\ParserTools

--- a/eZ/Publish/Core/REST/Client/Input/Parser/ContentTypeGroupList.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/ContentTypeGroupList.php
@@ -9,13 +9,13 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 /**
  * Parser for ContentTypeGroupList
  */
-class ContentTypeGroupList extends Parser
+class ContentTypeGroupList extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Client/Input/Parser/ContentTypeGroupRefList.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/ContentTypeGroupRefList.php
@@ -11,16 +11,14 @@ namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Client\ContentTypeService;
-
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
-
 use eZ\Publish\Core\REST\Client\Values;
 
 /**
  * Parser for ContentTypeGroupRefList
  */
-class ContentTypeGroupRefList extends Parser
+class ContentTypeGroupRefList extends BaseParser
 {
     /**
      * @var \eZ\Publish\Core\REST\Common\Input\ParserTools

--- a/eZ/Publish/Core/REST/Client/Input/Parser/ContentTypeList.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/ContentTypeList.php
@@ -9,13 +9,13 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 /**
  * Parser for ContentTypeList
  */
-class ContentTypeList extends Parser
+class ContentTypeList extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Client/Input/Parser/ErrorMessage.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/ErrorMessage.php
@@ -8,13 +8,13 @@
  */
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 /**
  * Parser for ErrorMessage
  */
-class ErrorMessage extends Parser
+class ErrorMessage extends BaseParser
 {
     /**
      * Mapping of error codes to the respective exception classes

--- a/eZ/Publish/Core/REST/Client/Input/Parser/FieldDefinition.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/FieldDefinition.php
@@ -10,11 +10,9 @@
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
-
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
-
 use eZ\Publish\Core\REST\Client\Values;
 
 /**
@@ -22,7 +20,7 @@ use eZ\Publish\Core\REST\Client\Values;
  *
  * @todo Caching for extracted embedded objects
  */
-class FieldDefinition extends Parser
+class FieldDefinition extends BaseParser
 {
     /**
      * @var \eZ\Publish\Core\REST\Common\Input\ParserTools

--- a/eZ/Publish/Core/REST/Client/Input/Parser/FieldDefinitionList.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/FieldDefinitionList.php
@@ -11,16 +11,14 @@ namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Client\ContentTypeService;
-
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
-
 use eZ\Publish\Core\REST\Client\Values;
 
 /**
  * Parser for FieldDefinitionList
  */
-class FieldDefinitionList extends Parser
+class FieldDefinitionList extends BaseParser
 {
     /**
      * @var \eZ\Publish\Core\REST\Common\Input\ParserTools

--- a/eZ/Publish/Core/REST/Client/Input/Parser/Limitation.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/Limitation.php
@@ -9,15 +9,14 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
-
 use eZ\Publish\API\Repository\Values\User\Limitation as APILimitation;
 
 /**
  * Parser for Limitation
  */
-class Limitation extends Parser
+class Limitation extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Client/Input/Parser/Location.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/Location.php
@@ -9,17 +9,16 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
-
 use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
 use eZ\Publish\Core\Repository\Values;
 
 /**
  * Parser for Location
  */
-class Location extends Parser
+class Location extends BaseParser
 {
     /**
      * @var \eZ\Publish\Core\REST\Common\Input\ParserTools

--- a/eZ/Publish/Core/REST/Client/Input/Parser/LocationList.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/LocationList.php
@@ -9,13 +9,13 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 /**
  * Parser for LocationList
  */
-class LocationList extends Parser
+class LocationList extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Client/Input/Parser/ObjectState.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/ObjectState.php
@@ -9,16 +9,15 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
-
 use eZ\Publish\Core\Repository\Values\ObjectState\ObjectState as CoreObjectState;
 
 /**
  * Parser for ObjectState
  */
-class ObjectState extends Parser
+class ObjectState extends BaseParser
 {
     /**
      * @var \eZ\Publish\Core\REST\Common\Input\ParserTools

--- a/eZ/Publish/Core/REST/Client/Input/Parser/ObjectStateGroup.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/ObjectStateGroup.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\Repository\Values\ObjectState\ObjectStateGroup as CoreObjectStateGroup;
@@ -17,7 +17,7 @@ use eZ\Publish\Core\Repository\Values\ObjectState\ObjectStateGroup as CoreObject
 /**
  * Parser for ObjectStateGroup
  */
-class ObjectStateGroup extends Parser
+class ObjectStateGroup extends BaseParser
 {
     /**
      * @var \eZ\Publish\Core\REST\Common\Input\ParserTools

--- a/eZ/Publish/Core/REST/Client/Input/Parser/ObjectStateGroupList.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/ObjectStateGroupList.php
@@ -9,13 +9,13 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 /**
  * Parser for ObjectStateGroupList
  */
-class ObjectStateGroupList extends Parser
+class ObjectStateGroupList extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Client/Input/Parser/ObjectStateList.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/ObjectStateList.php
@@ -9,13 +9,13 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 /**
  * Parser for ObjectStateList
  */
-class ObjectStateList extends Parser
+class ObjectStateList extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Client/Input/Parser/Policy.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/Policy.php
@@ -9,15 +9,14 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
-
 use eZ\Publish\Core\REST\Client;
 
 /**
  * Parser for Policy
  */
-class Policy extends Parser
+class Policy extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Client/Input/Parser/PolicyList.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/PolicyList.php
@@ -9,13 +9,13 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 /**
  * Parser for PolicyList
  */
-class PolicyList extends Parser
+class PolicyList extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Client/Input/Parser/Relation.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/Relation.php
@@ -9,16 +9,15 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
-
 use eZ\Publish\Core\REST\Client\Values;
 use eZ\Publish\Core\REST\Client\ContentService;
 
 /**
  * Parser for Relation
  */
-class Relation extends Parser
+class Relation extends BaseParser
 {
     /**
      * Content Service

--- a/eZ/Publish/Core/REST/Client/Input/Parser/RelationList.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/RelationList.php
@@ -9,13 +9,13 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 /**
  * Parser for RelationList
  */
-class RelationList extends Parser
+class RelationList extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Client/Input/Parser/Role.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/Role.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 use eZ\Publish\Core\REST\Client;
@@ -17,7 +17,7 @@ use eZ\Publish\Core\REST\Client;
 /**
  * Parser for Role
  */
-class Role extends Parser
+class Role extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Client/Input/Parser/RoleAssignment.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/RoleAssignment.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\API\Repository\Values\User\Limitation as APILimitation;
 
@@ -18,7 +18,7 @@ use eZ\Publish\Core\REST\Client;
 /**
  * Parser for RoleAssignment
  */
-class RoleAssignment extends Parser
+class RoleAssignment extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Client/Input/Parser/RoleAssignmentList.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/RoleAssignmentList.php
@@ -9,13 +9,13 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 /**
  * Parser for RoleAssignmentList
  */
-class RoleAssignmentList extends Parser
+class RoleAssignmentList extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Client/Input/Parser/RoleList.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/RoleList.php
@@ -9,13 +9,13 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 /**
  * Parser for RoleList
  */
-class RoleList extends Parser
+class RoleList extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Client/Input/Parser/Section.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/Section.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 use eZ\Publish\API\Repository\Values;
@@ -17,7 +17,7 @@ use eZ\Publish\API\Repository\Values;
 /**
  * Parser for Section
  */
-class Section extends Parser
+class Section extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Client/Input/Parser/SectionList.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/SectionList.php
@@ -9,13 +9,13 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 /**
  * Parser for SectionList
  */
-class SectionList extends Parser
+class SectionList extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Client/Input/Parser/VersionInfo.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/VersionInfo.php
@@ -9,17 +9,16 @@
 
 namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
-use eZ\Publish\Core\REST\Common\Input\Parser;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
-
 use eZ\Publish\Core\REST\Client\Values;
 use eZ\Publish\Core\REST\Client\ContentService;
 
 /**
  * Parser for VersionInfo
  */
-class VersionInfo extends Parser
+class VersionInfo extends BaseParser
 {
     /**
      * @var \eZ\Publish\Core\REST\Common\Input\ParserTools

--- a/eZ/Publish/Core/REST/Common/Input/BaseParser.php
+++ b/eZ/Publish/Core/REST/Common/Input/BaseParser.php
@@ -7,12 +7,12 @@
  * @version //autogentag//
  */
 
-namespace eZ\Publish\Core\REST\Server\Input\Parser;
+namespace eZ\Publish\Core\REST\Common\Input;
 
 use eZ\Publish\Core\REST\Common\Input\Parser;
 use eZ\Publish\Core\REST\Common\RequestParser;
 
-abstract class Base extends Parser
+abstract class BaseParser extends Parser
 {
     /**
      * URL handler

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ContentCreate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ContentCreate.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
@@ -21,7 +22,7 @@ use DateTime;
 /**
  * Parser for ContentCreate
  */
-class ContentCreate extends Base
+class ContentCreate extends BaseParser
 {
     /**
      * Content service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ContentObjectStates.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ContentObjectStates.php
@@ -9,16 +9,16 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
-
 use eZ\Publish\Core\REST\Common\Values\RestObjectState;
 use eZ\Publish\Core\Repository\Values\ObjectState\ObjectState;
 
 /**
  * Parser for ContentObjectStates
  */
-class ContentObjectStates extends Base
+class ContentObjectStates extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ContentTypeCreate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ContentTypeCreate.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Common\Exceptions;
@@ -18,7 +19,7 @@ use DateTime;
 /**
  * Parser for ContentTypeCreate
  */
-class ContentTypeCreate extends Base
+class ContentTypeCreate extends BaseParser
 {
     /**
      * ContentType service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ContentTypeGroupInput.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ContentTypeGroupInput.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Common\Exceptions;
@@ -18,7 +19,7 @@ use DateTime;
 /**
  * Parser for ContentTypeGroupInput
  */
-class ContentTypeGroupInput extends Base
+class ContentTypeGroupInput extends BaseParser
 {
     /**
      * ContentType service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ContentTypeUpdate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ContentTypeUpdate.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Common\Exceptions;
@@ -18,7 +19,7 @@ use DateTime;
 /**
  * Parser for ContentTypeUpdate
  */
-class ContentTypeUpdate extends Base
+class ContentTypeUpdate extends BaseParser
 {
     /**
      * ContentType service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ContentUpdate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ContentUpdate.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\Core\REST\Common\Values\RestContentMetadataUpdateStruct;
@@ -17,7 +18,7 @@ use Exception;
 /**
  * Parser for ContentUpdate
  */
-class ContentUpdate extends Base
+class ContentUpdate extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion.php
@@ -9,13 +9,14 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 
 /**
  * Parser for ViewInput
  */
-abstract class Criterion extends Base
+abstract class Criterion extends BaseParser
 {
     /**
      * @var array

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/ContentId.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/ContentId.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentId as ContentIdCriterion;
@@ -17,7 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentId as Conten
 /**
  * Parser for ViewInput
  */
-class ContentId extends Base
+class ContentId extends BaseParser
 {
     /**
      * Parses input structure to a Criterion object

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/ContentRemoteId.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/ContentRemoteId.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\RemoteId as ContentRemoteIdCriterion;
@@ -17,7 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\RemoteId as Content
 /**
  * Parser for RemoteId Criterion
  */
-class ContentRemoteId extends Base
+class ContentRemoteId extends BaseParser
 {
     /**
      * Parses input structure to a Criterion object

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/ContentTypeGroupId.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/ContentTypeGroupId.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeGroupId as ContentTypeGroupIdCriterion;
@@ -17,7 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeGroupId 
 /**
  * Parser for ContentTypeGroupId Criterion
  */
-class ContentTypeGroupId extends Base
+class ContentTypeGroupId extends BaseParser
 {
     /**
      * Parses input structure to a Criterion object

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/ContentTypeId.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/ContentTypeId.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeId as ContentTypeIdCriterion;
@@ -17,7 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeId as Co
 /**
  * Parser for ViewInput
  */
-class ContentTypeId extends Base
+class ContentTypeId extends BaseParser
 {
     /**
      * Parses input structure to a Criterion object

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/ContentTypeIdentifier.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/ContentTypeIdentifier.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\API\Repository\ContentTypeService;
@@ -18,7 +18,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeId as Co
 /**
  * Parser for ViewInput
  */
-class ContentTypeIdentifier extends Base
+class ContentTypeIdentifier extends BaseParser
 {
     /**
      * Content type service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/DateMetadata.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/DateMetadata.php
@@ -9,13 +9,13 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 /**
  * Parser for ViewInput Criterion
  */
-class DateMetadata extends Base
+class DateMetadata extends BaseParser
 {
     /**
      * Parses input structure to a Criterion object

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/Field.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/Field.php
@@ -9,13 +9,13 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 /**
  * Parser for Field Criterion
  */
-class Field extends Base
+class Field extends BaseParser
 {
     /**
      * Parses input structure to a Criterion object

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/FullText.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/FullText.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\FullText as FullTextCriterion;
@@ -17,7 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\FullText as FullTex
 /**
  * Parser for FullText Criterion
  */
-class FullText extends Base
+class FullText extends BaseParser
 {
     /**
      * Parses input structure to a FullText criterion

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/LanguageCode.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/LanguageCode.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LanguageCode as LanguageCodeCriterion;
@@ -17,7 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LanguageCode as Lan
 /**
  * Parser for LanguageCode Criterion
  */
-class LanguageCode extends Base
+class LanguageCode extends BaseParser
 {
     /**
      * Parses input structure to a LanguageCode Criterion object

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/LocationId.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/LocationId.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LocationId as LocationIdCriterion;
@@ -17,7 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LocationId as Locat
 /**
  * Parser for LocationId Criterion
  */
-class LocationId extends Base
+class LocationId extends BaseParser
 {
     /**
      * Parses input structure to a Criterion object

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/LocationRemoteId.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/LocationRemoteId.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LocationRemoteId as LocationRemoteIdCriterion;
@@ -17,7 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LocationRemoteId as
 /**
  * Parser for LocationRemoteId Criterion
  */
-class LocationRemoteId extends Base
+class LocationRemoteId extends BaseParser
 {
     /**
      * Parses input structure to a Criterion object

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/LogicalOperator.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/LogicalOperator.php
@@ -9,13 +9,13 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 /**
  * Parser for LogicalOperator Criterion
  */
-class LogicalOperator extends Base
+class LogicalOperator extends BaseParser
 {
     /**
      * Parses input structure to a Criterion object

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/MoreLikeThis.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/MoreLikeThis.php
@@ -9,13 +9,13 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 /**
  * Parser for MoreLikeThis Criterion
  */
-class MoreLikeThis extends Base
+class MoreLikeThis extends BaseParser
 {
     /**
      * Parses input structure to a Criterion object

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/ObjectStateId.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/ObjectStateId.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ObjectStateId as ObjectStateIdCriterion;
@@ -17,7 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ObjectStateId as Ob
 /**
  * Parser for ObjectStateId Criterion
  */
-class ObjectStateId extends Base
+class ObjectStateId extends BaseParser
 {
     /**
      * Parses input structure to a ObjectStateId Criterion object

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/Operator.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/Operator.php
@@ -9,13 +9,13 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 /**
  * Parser for Operator Criterion
  */
-class Operator extends Base
+class Operator extends BaseParser
 {
     /**
      * Parses input structure to a Criterion object

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/ParentLocationId.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/ParentLocationId.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ParentLocationId as ParentLocationIdCriterion;
@@ -17,7 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ParentLocationId as
 /**
  * Parser for LocationId Criterion
  */
-class ParentLocationId extends Base
+class ParentLocationId extends BaseParser
 {
     /**
      * Parses input structure to a ParentLocationId Criterion object

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/ParentLocationRemoteId.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/ParentLocationRemoteId.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\API\Repository\LocationService;
@@ -18,7 +18,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ParentLocationId as
 /**
  * Parser for ParentLocationId Criterion
  */
-class ParentLocationRemoteId extends Base
+class ParentLocationRemoteId extends BaseParser
 {
     /**
      * Location service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/SectionId.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/SectionId.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\SectionId as SectionIdCriterion;
@@ -17,7 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\SectionId as Sectio
 /**
  * Parser for SectionId Criterion
  */
-class SectionId extends Base
+class SectionId extends BaseParser
 {
     /**
      * Parses input structure to a SectionId Criterion object

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/SectionIdentifier.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/SectionIdentifier.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\API\Repository\SectionService;
@@ -18,7 +18,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\SectionId as Sectio
 /**
  * Parser for SectionIdentifier Criterion
  */
-class SectionIdentifier extends Base
+class SectionIdentifier extends BaseParser
 {
     /**
      * Section service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/Subtree.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/Subtree.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree as SubtreeCriterion;
@@ -17,7 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree as SubtreeC
 /**
  * Parser for Subtree Criterion
  */
-class Subtree extends Base
+class Subtree extends BaseParser
 {
     /**
      * Parses input structure to a Criterion object

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/UserMetadata.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/UserMetadata.php
@@ -9,13 +9,13 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 /**
  * Parser for ViewInput
  */
-class UserMetadata extends Base
+class UserMetadata extends BaseParser
 {
     /**
      * Parses input structure to a Criterion object

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/Visibility.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/Visibility.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
-use eZ\Publish\Core\REST\Server\Input\Parser\Base;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Visibility as VisibilityCriterion;
@@ -17,7 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Visibility as Visib
 /**
  * Parser for Visibility Criterion
  */
-class Visibility extends Base
+class Visibility extends BaseParser
 {
     /**
      * Parses input structure to a Visibility Criterion object

--- a/eZ/Publish/Core/REST/Server/Input/Parser/FieldDefinitionCreate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/FieldDefinitionCreate.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
@@ -19,7 +20,7 @@ use Exception;
 /**
  * Parser for FieldDefinitionCreate
  */
-class FieldDefinitionCreate extends Base
+class FieldDefinitionCreate extends BaseParser
 {
     /**
      * ContentType service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/FieldDefinitionUpdate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/FieldDefinitionUpdate.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
@@ -18,7 +19,7 @@ use eZ\Publish\Core\REST\Common\Exceptions;
 /**
  * Parser for FieldDefinitionUpdate
  */
-class FieldDefinitionUpdate extends Base
+class FieldDefinitionUpdate extends BaseParser
 {
     /**
      * ContentType service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/LocationCreate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/LocationCreate.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Common\Exceptions;
@@ -17,7 +18,7 @@ use eZ\Publish\API\Repository\LocationService;
 /**
  * Parser for LocationCreate
  */
-class LocationCreate extends Base
+class LocationCreate extends BaseParser
 {
     /**
      * Location service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/LocationUpdate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/LocationUpdate.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Common\Exceptions;
@@ -19,7 +20,7 @@ use eZ\Publish\Core\REST\Server\Values\RestLocationUpdateStruct;
 /**
  * Parser for LocationUpdate
  */
-class LocationUpdate extends Base
+class LocationUpdate extends BaseParser
 {
     /**
      * Location service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ObjectStateCreate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ObjectStateCreate.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Common\Exceptions;
@@ -17,7 +18,7 @@ use eZ\Publish\API\Repository\ObjectStateService;
 /**
  * Parser for ObjectStateCreate
  */
-class ObjectStateCreate extends Base
+class ObjectStateCreate extends BaseParser
 {
     /**
      * Object state service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ObjectStateGroupCreate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ObjectStateGroupCreate.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Common\Exceptions;
@@ -17,7 +18,7 @@ use eZ\Publish\API\Repository\ObjectStateService;
 /**
  * Parser for ObjectStateGroupCreate
  */
-class ObjectStateGroupCreate extends Base
+class ObjectStateGroupCreate extends BaseParser
 {
     /**
      * Object state service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ObjectStateGroupUpdate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ObjectStateGroupUpdate.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Common\Exceptions;
@@ -17,7 +18,7 @@ use eZ\Publish\API\Repository\ObjectStateService;
 /**
  * Parser for ObjectStateGroupUpdate
  */
-class ObjectStateGroupUpdate extends Base
+class ObjectStateGroupUpdate extends BaseParser
 {
     /**
      * Object state service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ObjectStateUpdate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ObjectStateUpdate.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Common\Exceptions;
@@ -17,7 +18,7 @@ use eZ\Publish\API\Repository\ObjectStateService;
 /**
  * Parser for ObjectStateUpdate
  */
-class ObjectStateUpdate extends Base
+class ObjectStateUpdate extends BaseParser
 {
     /**
      * Object state service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/PolicyCreate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/PolicyCreate.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Common\Exceptions;
@@ -17,7 +18,7 @@ use eZ\Publish\API\Repository\RoleService;
 /**
  * Parser for PolicyCreate
  */
-class PolicyCreate extends Base
+class PolicyCreate extends BaseParser
 {
     /**
      * Role service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/PolicyUpdate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/PolicyUpdate.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Common\Exceptions;
@@ -17,7 +18,7 @@ use eZ\Publish\API\Repository\RoleService;
 /**
  * Parser for PolicyUpdate
  */
-class PolicyUpdate extends Base
+class PolicyUpdate extends BaseParser
 {
     /**
      * Role service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/RelationCreate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/RelationCreate.php
@@ -9,13 +9,14 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 
 /**
  * Parser for RelationCreate
  */
-class RelationCreate extends Base
+class RelationCreate extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Server/Input/Parser/RoleAssignInput.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/RoleAssignInput.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Common\Exceptions;
@@ -18,7 +19,7 @@ use eZ\Publish\Core\REST\Server\Values\RoleAssignment;
 /**
  * Parser for RoleAssignInput
  */
-class RoleAssignInput extends Base
+class RoleAssignInput extends BaseParser
 {
     /**
      * Parser tools

--- a/eZ/Publish/Core/REST/Server/Input/Parser/RoleInput.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/RoleInput.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\API\Repository\RoleService;
@@ -16,7 +17,7 @@ use eZ\Publish\API\Repository\RoleService;
 /**
  * Parser for RoleInput
  */
-class RoleInput extends Base
+class RoleInput extends BaseParser
 {
     /**
      * Role service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/SectionInput.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/SectionInput.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\API\Repository\SectionService;
 use eZ\Publish\Core\REST\Common\Exceptions;
@@ -16,7 +17,7 @@ use eZ\Publish\Core\REST\Common\Exceptions;
 /**
  * Parser for SectionInput
  */
-class SectionInput extends Base
+class SectionInput extends BaseParser
 {
     /**
      * Section service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/SessionInput.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/SessionInput.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\Core\REST\Server\Values\SessionInput as SessionInputValue;
@@ -16,7 +17,7 @@ use eZ\Publish\Core\REST\Server\Values\SessionInput as SessionInputValue;
 /**
  * Parser for SessionInput
  */
-class SessionInput extends Base
+class SessionInput extends BaseParser
 {
     /**
      * Parse input structure

--- a/eZ/Publish/Core/REST/Server/Input/Parser/URLAliasCreate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/URLAliasCreate.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Common\Exceptions;
@@ -16,7 +17,7 @@ use eZ\Publish\Core\REST\Common\Exceptions;
 /**
  * Parser for URLAliasCreate
  */
-class URLAliasCreate extends Base
+class URLAliasCreate extends BaseParser
 {
     /**
      * Parser tools

--- a/eZ/Publish/Core/REST/Server/Input/Parser/URLWildcardCreate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/URLWildcardCreate.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\Core\REST\Common\Exceptions;
@@ -16,7 +17,7 @@ use eZ\Publish\Core\REST\Common\Exceptions;
 /**
  * Parser for URLWildcardCreate
  */
-class URLWildcardCreate extends Base
+class URLWildcardCreate extends BaseParser
 {
     /**
      * Parser tools

--- a/eZ/Publish/Core/REST/Server/Input/Parser/UserCreate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/UserCreate.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
@@ -19,7 +20,7 @@ use eZ\Publish\API\Repository\ContentTypeService;
 /**
  * Parser for UserCreate
  */
-class UserCreate extends Base
+class UserCreate extends BaseParser
 {
     /**
      * User service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/UserGroupCreate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/UserGroupCreate.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
 use eZ\Publish\Core\REST\Common\Exceptions;
@@ -18,7 +19,7 @@ use eZ\Publish\API\Repository\ContentTypeService;
 /**
  * Parser for UserGroupCreate
  */
-class UserGroupCreate extends Base
+class UserGroupCreate extends BaseParser
 {
     /**
      * User service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/UserGroupUpdate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/UserGroupUpdate.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
 use eZ\Publish\Core\REST\Common\Exceptions;
@@ -20,7 +21,7 @@ use eZ\Publish\API\Repository\LocationService;
 /**
  * Parser for UserGroupUpdate
  */
-class UserGroupUpdate extends Base
+class UserGroupUpdate extends BaseParser
 {
     /**
      * User service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/UserUpdate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/UserUpdate.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
@@ -20,7 +21,7 @@ use eZ\Publish\API\Repository\ContentService;
 /**
  * Parser for UserUpdate
  */
-class UserUpdate extends Base
+class UserUpdate extends BaseParser
 {
     /**
      * User service

--- a/eZ/Publish/Core/REST/Server/Input/Parser/VersionUpdate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/VersionUpdate.php
@@ -13,11 +13,12 @@ use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
 
 /**
  * Parser for VersionUpdate
  */
-class VersionUpdate extends Base
+class VersionUpdate extends BaseParser
 {
     /**
      * Content service


### PR DESCRIPTION
Move REST Input Parser to REST/Common

The Parser is required by the REST client as well.
