### PR TITLE
EZP-22632: Made request optional in CachedValue visitor

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -647,6 +647,6 @@ services:
         arguments:
             - @ezpublish.config.resolver
         calls:
-            - [setRequest, [@request=]]
+            - [setRequest, [@?request=]]
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Values\CachedValue }


### PR DESCRIPTION
> http://jira.ez.no/browse/EZP-22632
> Required by #795 

Makes @request optional in `ezpublish_rest.output.value_object_visitor.cached_value`. Allows usage of the visitors outside of a request scope.
