### PR TITLE
Fix EZP-22625: Circular reference on ezsettings.default.session_name

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -14,8 +14,9 @@ parameters:
     # Common settings
     ezpublish.repositories: {}
     ezsettings.default.repository: ~
-    ezsettings.default.session_name: "eZSESSID{siteaccess_hash}"    # Using "{siteaccess_hash}" in session name makes it unique per siteaccess
-    ezsettings.default.session: { name: %ezsettings.default.session_name% } # Session options that will override options from framework
+    ezpublish.session_name.default: "eZSESSID{siteaccess_hash}"
+    ezsettings.default.session_name: %ezpublish.session_name.default%    # Using "{siteaccess_hash}" in session name makes it unique per siteaccess
+    ezsettings.default.session: { name: %ezpublish.session_name.default% } # Session options that will override options from framework
     ezsettings.default.legacy_mode: false
     ezsettings.default.url_alias_router: true                       # Use UrlAliasRouter by default
     ezsettings.default.index_page: ~                    # The page to show when accessing IndexPage (/)


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22625

Just added a separate internal setting for the default session name.
