### PR TITLE
Fix for EZP-22667: Response TTL should not depend on X-User-Hash

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
@@ -63,18 +63,19 @@ class ViewController extends Controller
                 $response->setEtag( $etag );
             }
 
-            // Make the response vary against X-User-Hash header ensures that an HTTP
-            // reverse proxy caches the different possible variations of the
-            // response as it can depend on user role for instance.
-            if (
-                $request->headers->has( 'X-User-Hash' )
-                && $this->getParameter( 'content.ttl_cache' ) === true
-            )
+            if ( $this->getParameter( 'content.ttl_cache' ) === true )
             {
-                $response->setVary( 'X-User-Hash' );
                 $response->setSharedMaxAge(
                     $this->getParameter( 'content.default_ttl' )
                 );
+            }
+
+            // Make the response vary against X-User-Hash header ensures that an HTTP
+            // reverse proxy caches the different possible variations of the
+            // response as it can depend on user role for instance.
+            if ( $request->headers->has( 'X-User-Hash' ) )
+            {
+                $response->setVary( 'X-User-Hash' );
             }
 
             if ( $lastModified != null )


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22667

In the default view controller, setting the max age Cache-Control HTTP header is dependent on the request setting X-User-Hash. While context-aware cache and max age are related, they should be separate issues.
Some concrete reasons for treating them separately:
- In some cases the management of TTL is deferred to a separate team who is in charge of Apache or Varnish, not eZ Publish.
- For dev / debug purposes you want to see the TTL being used
- You should be able to set TTL regardless of whether your reverse proxy is setting a default X-User-Hash
