### PR TITLE
SetupWizard: remove system check step

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Features/install_ezpublish_demo.feature
+++ b/eZ/Bundle/EzPublishLegacyBundle/Features/install_ezpublish_demo.feature
@@ -9,15 +9,6 @@ Feature: Install eZ Publish Demo with/withoutout content
         And I am on "Welcome to eZ Publish Community Project 5.3.0alpha1" step
         When I select "English (United Kingdom)"
         And I press "Next"
-        Then I see "System check" step
-        And I see "AcceptPathInfo disabled or running in CGI mode" message
-
-    # Since travis run on a FastCGI mode the system check will popup
-    @javascript @democontent_install @democlean_install
-    Scenario: Bypass system check for FastCGI
-        Given I am on "System check" step
-        When I check "Ignore this test" checkbox
-        And I press "Next"
         Then I see "Outgoing Email" step
 
     @javascript @democontent_install @democlean_install


### PR DESCRIPTION
Revert the https://github.com/ezsystems/ezpublish-kernel/pull/788 
Since the https://github.com/ezsystems/ezpublish-legacy/pull/934 removed the system checkup for _AcceptPathInfo_ and _FastCGI_ that step is not needed any more.
