### PR TITLE
SetupWizard: add choose db step since travis have mysql and postgresql

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Features/install_ezpublish_demo.feature
+++ b/eZ/Bundle/EzPublishLegacyBundle/Features/install_ezpublish_demo.feature
@@ -16,6 +16,13 @@ Feature: Install eZ Publish Demo with/withoutout content
         Given I am on "Outgoing Email" step
         When I select "Sendmail/MTA" radio button
         And I press "Next"
+        Then I see "Choose database system" step
+
+    @javascript @democontent_install @democlean_install
+    Scenario: Choose which database system to use
+        Given I am on "Choose database system" step
+        When I select "MySQL Improved" radio button
+        And I press "Next"
         Then I see "Database initialization" step
 
     @javascript @democontent_install @democlean_install


### PR DESCRIPTION
This is missing on both setup wizard installations for demo with/without content.

Since travis have both MySQL and PostgreSQL databases, this step popup.
