### PR TITLE
Implement EZP-21889: ContentTypeIdentifier Criterion visitor for Solr storage

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -104,6 +104,15 @@ class SearchServiceTest extends BaseTest
             ),
             array(
                 array(
+                    'filter' => new Criterion\ContentTypeIdentifier(
+                        "user"
+                    ),
+                    'sortClauses' => array( new SortClause\ContentId() )
+                ),
+                $fixtureDir . 'ContentTypeId.php',
+            ),
+            array(
+                array(
                     'filter' => new Criterion\ContentTypeGroupId(
                         2
                     ),

--- a/eZ/Publish/API/Repository/Tests/SetupFactory/LegacySolr.php
+++ b/eZ/Publish/API/Repository/Tests/SetupFactory/LegacySolr.php
@@ -152,6 +152,7 @@ class LegacySolr extends Legacy
                         new CriterionVisitor\LogicalNot(),
                         new CriterionVisitor\SubtreeIn(),
                         new CriterionVisitor\ContentTypeIdIn(),
+                        new CriterionVisitor\ContentTypeIdentifierIn( $persistenceHandler->contentTypeHandler() ),
                         new CriterionVisitor\ContentTypeGroupIdIn(),
                         new CriterionVisitor\LocationIdIn(),
                         new CriterionVisitor\ParentLocationIdIn(),

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/CriterionVisitor/ContentTypeIdentifierIn.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/CriterionVisitor/ContentTypeIdentifierIn.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * File containing the ContentTypeIdentifier criterion visitor class
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor;
+
+use eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler;
+
+/**
+ * Visits the ContentTypeIdentifier criterion
+ */
+class ContentTypeIdentifierIn extends CriterionVisitor
+{
+    /**
+     * ContentType handler
+     *
+     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
+     */
+    protected $contentTypeHandler;
+
+    /**
+     * Create from content type handler and field registry
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
+     */
+    public function __construct( Handler $contentTypeHandler )
+    {
+        $this->contentTypeHandler = $contentTypeHandler;
+    }
+
+    /**
+     * CHeck if visitor is applicable to current criterion
+     *
+     * @param Criterion $criterion
+     *
+     * @return boolean
+     */
+    public function canVisit( Criterion $criterion )
+    {
+        return
+            $criterion instanceof Criterion\ContentTypeIdentifier
+            && (
+                ( $criterion->operator ?: Operator::IN ) === Operator::IN ||
+                $criterion->operator === Operator::EQ
+            );
+    }
+
+    /**
+     * Map field value to a proper Solr representation
+     *
+     * @param Criterion $criterion
+     * @param CriterionVisitor $subVisitor
+     *
+     * @return string
+     */
+    public function visit( Criterion $criterion, CriterionVisitor $subVisitor = null )
+    {
+        $contentTypeHandler = $this->contentTypeHandler;
+
+        return '(' .
+            implode(
+                ' OR ',
+                array_map(
+                    function ( $value ) use ( $contentTypeHandler )
+                    {
+                        return 'type_id:"' . $contentTypeHandler->loadByIdentifier( $value )->id . '"';
+                    },
+                    $criterion->value
+                )
+            ) .
+            ')';
+    }
+}


### PR DESCRIPTION
This PR resolves issue https://jira.ez.no/browse/EZP-21889

To avoid rewriting Query in service layer for an issue that is localized, implemented criterion visitor has dependency to ContentType handler. The handler is used to find id from ContentType identifier.
