### PR TITLE
Fix EZP-22039: ConfigResolver::hasParameter() doesn't check SiteAccess group scope

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
@@ -131,8 +131,25 @@ class ConfigResolver extends ContainerAware implements VersatileScopeInterface, 
         $defaultScopeParamName = "$namespace." . self::SCOPE_DEFAULT . ".$paramName";
         $globalScopeParamName = "$namespace." . self::SCOPE_GLOBAL . ".$paramName";
         $relativeScopeParamName = "$namespace.$scope.$paramName";
+
+        // Relative scope, siteacces group wise
+        $groupScopeHasParam = false;
+        if ( isset( $this->groupsBySiteAccess[$scope] ) )
+        {
+            foreach ( $this->groupsBySiteAccess[$scope] as $groupName )
+            {
+                $groupScopeParamName = "$namespace.$groupName.$paramName";
+                if ( $this->container->hasParameter( $groupScopeParamName ) )
+                {
+                    $groupScopeHasParam = true;
+                    break;
+                }
+            }
+        }
+
         return
             $this->container->hasParameter( $defaultScopeParamName )
+            || $groupScopeHasParam
             || $this->container->hasParameter( $relativeScopeParamName )
             || $this->container->hasParameter( $globalScopeParamName );
     }


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22039

When calling `eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver::getParameter()`, parameter is searched in the following scopes:
1. global
2. siteaccess
3. siteaccess groups
4. default

`ConfigResolver::hasParameter()` does not care for siteaccess groups.

This patch fixes this.
