### PR TITLE
Fix EZP-22738: Fatal error in Legacy\View\Provider\Block

### DIFF
--- a/eZ/Publish/Core/MVC/Legacy/View/Provider/Block.php
+++ b/eZ/Publish/Core/MVC/Legacy/View/Provider/Block.php
@@ -55,6 +55,11 @@ class Block extends Provider implements BlockViewProviderInterface
                      * @var \eZObjectForwarder
                      */
                     $funcObject = $tpl->fetchFunctionObject( 'block_view_gui' );
+                    if ( !$funcObject )
+                    {
+                        return '';
+                    }
+
                     $children = array();
                     $funcObject->process(
                         $tpl, $children, 'block_view_gui', false,

--- a/eZ/Publish/Core/MVC/Legacy/View/Provider/Content.php
+++ b/eZ/Publish/Core/MVC/Legacy/View/Provider/Content.php
@@ -42,6 +42,10 @@ class Content extends Provider implements ContentViewProviderInterface
                      * @var \eZObjectForwarder
                      */
                     $funcObject = $tpl->fetchFunctionObject( 'content_view_gui' );
+                    if ( !$funcObject )
+                    {
+                        return '';
+                    }
 
                     // Used by XmlText field type
                     if ( isset( $params['objectParameters'] ) )


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22738

Sometimes in `Legacy\View\Provider\Block`, legacy kernel fails to return an `eZObjectForwarder` for `block_view_gui`. This happens most likely when there is a cache issue (e.g. context change when developing).
It results to a fatal error:

```
PHP Notice:  Undefined index: block_view_gui in 
/Users/lolautruche/workspace/ezsystems/ezpublish-legacy/lib/eztemplate/classes/eztemplate.php 
on line 660

PHP Fatal error:  Call to a member function process() on a non-object in 
/Users/lolautruche/workspace/ezsystems/ezpublish-kernel/
eZ/Publish/Core/MVC/Legacy/View/Provider/Block.php on line 59
```

Potentially also occurs with `Legacy\View\Provider\Content`.
