### PR TITLE
EZP-22612 : URLAlias language code matching

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Regression/EZP22612URLAliasTranslations.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP22612URLAliasTranslations.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\API\Repository\Tests\Regression;
+
+use eZ\Publish\API\Repository\Tests\BaseTest;
+
+class EZP22612URLAliasTranslations extends BaseTest
+{
+    public function setUp()
+    {
+        $contentService = $this->getRepository()->getContentService();
+        $draft = $contentService->createContent(
+            $this->getFolderCreateStruct( 'common' ),
+            array(
+                $this->getRepository()->getLocationService()->newLocationCreateStruct( 2 )
+            )
+        );
+        $parentContent = $contentService->publishVersion( $draft->versionInfo );
+
+        $draft = $contentService->createContent(
+            $this->getFolderCreateStruct( 'alias' ),
+            array(
+                $this->getRepository()->getLocationService()->newLocationCreateStruct(
+                    $parentContent->contentInfo->mainLocationId
+                )
+            )
+        );
+
+        $contentService->publishVersion( $draft->versionInfo );
+    }
+
+    private function getFolderCreateStruct( $name )
+    {
+        $createStruct = $this->getRepository()->getContentService()->newContentCreateStruct(
+            $this->getRepository()->getContentTypeService()->loadContentTypeByIdentifier( 'folder' ),
+            'ger-DE'
+        );
+        $createStruct->setField( 'name', $name, 'eng-GB' );
+        $createStruct->setField( 'name', $name, 'ger-DE' );
+
+        return $createStruct;
+    }
+
+    public function testURLAliasLoadedInRightLanguage()
+    {
+        $aliasService = $this->getRepository()->getURLAliasService();
+        $alias = $aliasService->lookup( 'common/alias' );
+        $this->assertContains( 'eng-GB', $alias->languageCodes );
+    }
+}

--- a/eZ/Publish/Core/Repository/URLAliasService.php
+++ b/eZ/Publish/Core/Repository/URLAliasService.php
@@ -395,15 +395,45 @@ class URLAliasService implements URLAliasServiceInterface
      */
     protected function matchLanguageCode( array $pathElementData, $pathElement )
     {
-        foreach ( $pathElementData["translations"] as $languageCode => $translation )
+        foreach ( $this->sortTranslationsByPrioritizedLanguages( $pathElementData["translations"] ) as $translationData )
         {
-            if ( strtolower( $pathElement ) === strtolower( $translation ) )
+            if ( strtolower( $pathElement ) === strtolower( $translationData['text'] ) )
             {
-                return $languageCode;
+                return $translationData['lang'];
             }
         }
 
         return false;
+    }
+
+    /**
+     * @param array $translations
+     * @return array
+     */
+    private function sortTranslationsByPrioritizedLanguages( array $translations )
+    {
+        $sortedTranslations = array();
+        foreach ( $this->settings["prioritizedLanguageList"] as $languageCode )
+        {
+            if ( isset( $translations[$languageCode] ) )
+            {
+                $sortedTranslations[] = array(
+                    'lang' => $languageCode,
+                    'text' => $translations[$languageCode]
+                );
+                unset( $translations[$languageCode] );
+            }
+        }
+
+        foreach ( $translations as $languageCode => $translation )
+        {
+            $sortedTranslations[] = array(
+                'lang' => $languageCode,
+                'text' => $translation
+            );
+        }
+
+        return $sortedTranslations;
     }
 
     /**


### PR DESCRIPTION
See https://jira.ez.no/browse/EZP-22612

Pretty tricky one: 
- (I guess) path elements are sorted by language id in `eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Mapper::normalizePathDataRow()` 
- first matched language is returned in `eZ\Publish\Core\Repository\URLAliasService::matchLanguageCode()` 
- which causes `eZ\Publish\Core\Repository\URLAliasService::isPathLoadable()` to return false when said language is not available in current siteaccess
