### PR TITLE
Fix EZP-22786: Legacy SearchHandlerTest::testStatusFilter fails on php 5.5.11

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/SearchHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/SearchHandlerTest.php
@@ -1003,7 +1003,7 @@ class SearchHandlerTest extends LanguageAwareTestCase
     {
         $this->assertSearchResults(
             array( 4, 10, 11, 12, 13, 14, 41, 42, 45, 49 ),
-            $this->getContentSearchHandler()->findContent(
+            $searchResult = $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
                         // Status criterion is gone, but this will also match all published
@@ -1017,6 +1017,11 @@ class SearchHandlerTest extends LanguageAwareTestCase
                     )
                 )
             )
+        );
+
+        $this->assertEquals(
+            185,
+            $searchResult->totalCount
         );
     }
 


### PR DESCRIPTION
The PR resolves issue https://jira.ez.no/browse/EZP-22786

Tested query is limited to 10 but has larger total count and therefore order returned for the DB can be significant.

This adds sort clause to the query and additionally asserts total count.
