### PR TITLE
EZP-22767: ezscript_require not taken into account on modules

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Controller/LegacyKernelController.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Controller/LegacyKernelController.php
@@ -12,6 +12,7 @@ namespace eZ\Bundle\EzPublishLegacyBundle\Controller;
 use eZ\Bundle\EzPublishLegacyBundle\LegacyResponse;
 use eZ\Bundle\EzPublishLegacyBundle\LegacyResponse\LegacyResponseManager;
 use eZ\Publish\Core\MVC\Legacy\Kernel\URIHelper;
+use eZ\Publish\Core\MVC\Legacy\Templating\LegacyHelper;
 use Symfony\Component\HttpFoundation\Request;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use ezpKernelRedirect;
@@ -52,13 +53,23 @@ class LegacyKernelController
      */
     private $legacyResponseManager;
 
-    public function __construct( \Closure $kernelClosure, ConfigResolverInterface $configResolver, URIHelper $uriHelper, LegacyResponseManager $legacyResponseManager )
+    /** @var  \eZ\Publish\Core\MVC\Legacy\Templating\LegacyHelper; */
+    private $legacyHelper;
+
+    public function __construct(
+        \Closure $kernelClosure,
+        ConfigResolverInterface $configResolver,
+        URIHelper $uriHelper,
+        LegacyResponseManager $legacyResponseManager,
+        LegacyHelper $legacyHelper
+    )
     {
         $this->kernel = $kernelClosure();
         $this->legacyLayout = $configResolver->getParameter( 'module_default_layout', 'ezpublish_legacy' );
         $this->configResolver = $configResolver;
         $this->uriHelper = $uriHelper;
         $this->legacyResponseManager = $legacyResponseManager;
+        $this->legacyHelper = $legacyHelper;
     }
 
     public function setRequest( Request $request = null )
@@ -86,6 +97,9 @@ class LegacyKernelController
         }
 
         $result = $this->kernel->run();
+
+        $this->legacyHelper->loadDataFromModuleResult( $result->getAttribute( 'module_result' ) );
+
         $this->kernel->setUseExceptions( true );
 
         if ( $result instanceof ezpKernelRedirect )

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
@@ -114,6 +114,7 @@ services:
             - @ezpublish.config.resolver
             - @ezpublish_legacy.uri_helper
             - @ezpublish_legacy.response_manager
+            - @ezpublish_legacy.templating.legacy_helper
         calls:
             - [setRequest, [@?request=]]
 

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/templating.yml
@@ -1,5 +1,7 @@
 parameters:
     ezpublish_legacy.twig.extension.class: eZ\Publish\Core\MVC\Legacy\Templating\Twig\Extension\LegacyExtension
+    ezpublish_legacy.twig.extension.template.js: 'EzPublishLegacyBundle::ez_legacy_render_js.html.twig'
+    ezpublish_legacy.twig.extension.template.css: 'EzPublishLegacyBundle::ez_legacy_render_css.html.twig'
     ezpublish_legacy.templating.api_content_converter.class: eZ\Publish\Core\MVC\Legacy\Templating\Converter\ApiContentConverter
     ezpublish_legacy.templating.pageparts_converter.class: eZ\Publish\Core\MVC\Legacy\Templating\Converter\PagePartsConverter
     ezpublish_legacy.templating.delegating_converter.class: eZ\Publish\Core\MVC\Legacy\Templating\Converter\DelegatingConverter
@@ -15,7 +17,11 @@ parameters:
 services:
     ezpublish_legacy.twig.extension:
         class: %ezpublish_legacy.twig.extension.class%
-        arguments: [@templating.engine.eztpl]
+        arguments:
+            - @templating.engine.eztpl
+            - @ezpublish_legacy.templating.legacy_helper
+            - %ezpublish_legacy.twig.extension.template.js%
+            - %ezpublish_legacy.twig.extension.template.css%
         tags:
             - {name: twig.extension}
 
@@ -44,6 +50,7 @@ services:
 
     ezpublish_legacy.templating.legacy_helper:
         class: %ezpublish_legacy.templating.legacy_helper.class%
+        arguments: [@ezpublish_legacy.kernel]
 
     ezpublish.templating.global_helper.legacy:
         class: %ezpublish.templating.global_helper.legacy.class%

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/views/ez_legacy_render_css.html.twig
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/views/ez_legacy_render_css.html.twig
@@ -1,0 +1,12 @@
+{# Template used by ez_legacy_render_css  #}
+{% block ez_legacy_render_css %}
+    {% for item in css_files %}
+        <link rel="stylesheet" type="text/css" href="{{ asset( item ) }}" />
+    {%endfor %}
+
+    {% for item in css_code_lines %}
+        <style type="text/css">
+            {{ item|raw }}
+        </style>
+    {%endfor %}
+{% endblock %}

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/views/ez_legacy_render_js.html.twig
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/views/ez_legacy_render_js.html.twig
@@ -1,0 +1,12 @@
+{# Template used by ez_legacy_render_js #}
+{% block ez_legacy_render_js %}
+    {% for item in js_files %}
+        <script type="text/javascript" src="{{ asset( item ) }}"></script>
+    {%endfor %}
+
+    {% for item in js_code_lines %}
+        <script type="text/javascript">
+            {{item|raw}}
+        </script>
+    {%endfor %}
+{% endblock %}

--- a/eZ/Publish/Core/MVC/Legacy/Templating/LegacyHelper.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/LegacyHelper.php
@@ -10,7 +10,92 @@
 namespace eZ\Publish\Core\MVC\Legacy\Templating;
 
 use Symfony\Component\HttpFoundation\ParameterBag;
+use ezjscPacker;
+use eZINI;
+use ezjscPackerTemplateFunctions;
 
 class LegacyHelper extends ParameterBag
 {
+    /**
+     * @var callable
+     */
+    private $legacyKernelClosure;
+
+    public function __construct( \Closure $legacyKernelClosure )
+    {
+        $this->legacyKernelClosure = $legacyKernelClosure;
+    }
+
+    /**
+     * Fills up the LegacyHelper with data from a given moduleResult
+     *
+     * @param array $moduleResult
+     */
+    public function loadDataFromModuleResult( array $moduleResult )
+    {
+        $kernelClosure = $this->legacyKernelClosure;
+        $that = $this;
+
+        $kernelClosure()->runCallback(
+            function () use ( $moduleResult, $that )
+            {
+                // Injecting all $moduleResult entries in the legacy helper
+                foreach ( $moduleResult as $key => $val )
+                {
+                    if ( $key === 'content' )
+                        continue;
+
+                    $that->set( $key, $val );
+                }
+
+                // Adding ezjscore data to module result if not present for support in legacy modules
+                if ( !isset( $moduleResult['content_info']['persistent_variable'] ) )
+                {
+                    $moduleResult['content_info']['persistent_variable'] = ezjscPackerTemplateFunctions::getPersistentVariable();
+                }
+
+                // Javascript/CSS files required with ezcss_require/ezscript_require
+                // Compression level is forced to 0 to only get the files list
+                if ( isset( $moduleResult['content_info']['persistent_variable']['css_files'] ) )
+                {
+                    $that->set(
+                        'css_files',
+                        ezjscPacker::buildStylesheetFiles(
+                            $moduleResult['content_info']['persistent_variable']['css_files'],
+                            0
+                        )
+                    );
+                }
+                if ( isset( $moduleResult['content_info']['persistent_variable']['js_files'] ) )
+                {
+                    $that->set(
+                        'js_files',
+                        ezjscPacker::buildJavascriptFiles(
+                            $moduleResult['content_info']['persistent_variable']['js_files'],
+                            0
+                        )
+                    );
+                }
+
+                // Now getting configured JS/CSS files, in design.ini
+                // Will only take FrontendCSSFileList/FrontendJavascriptList
+                $designINI = eZINI::instance( 'design.ini' );
+                $that->set(
+                    'css_files_configured',
+                    ezjscPacker::buildStylesheetFiles(
+                        $designINI->variable( 'StylesheetSettings', 'FrontendCSSFileList' ),
+                        0
+                    )
+                );
+                $that->set(
+                    'js_files_configured',
+                    ezjscPacker::buildJavascriptFiles(
+                        $designINI->variable( 'JavaScriptSettings', 'FrontendJavaScriptList' ),
+                        0
+                    )
+                );
+            },
+            false
+        );
+    }
 }

--- a/eZ/Publish/Core/MVC/Legacy/Templating/Tests/GlobalHelperTest.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/Tests/GlobalHelperTest.php
@@ -22,7 +22,15 @@ class GlobalHelperTest extends BaseGlobalHelperTest
     protected function setUp()
     {
         parent::setUp();
-        $this->legacyHelper = $this->getMock( 'eZ\\Publish\\Core\\MVC\\Legacy\\Templating\\LegacyHelper' );
+        $this->legacyHelper = $this->getMock(
+            'eZ\\Publish\\Core\\MVC\\Legacy\\Templating\\LegacyHelper',
+            array(),
+            array(
+                function ()
+                {
+                }
+            )
+        );
         // Force to use Legacy GlobalHelper
         $this->helper = new GlobalHelper( $this->configResolver, $this->locationService, $this->router, $this->translationHelper );
         $this->helper->setLegacyHelper( $this->legacyHelper );

--- a/eZ/Publish/Core/MVC/Legacy/Templating/Twig/Extension/LegacyExtension.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/Twig/Extension/LegacyExtension.php
@@ -9,9 +9,12 @@
 
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Twig\Extension;
 
+use eZ\Publish\Core\MVC\Legacy\Templating\LegacyHelper;
 use eZ\Publish\Core\MVC\Legacy\Templating\Twig\TokenParser\LegacyIncludeParser;
 use eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine;
 use Twig_Extension;
+use Twig_SimpleFunction;
+use Twig_Environment;
 
 /**
  * Twig extension for eZ Publish legacy
@@ -23,9 +26,33 @@ class LegacyExtension extends Twig_Extension
      */
     private $legacyEngine;
 
-    public function __construct( LegacyEngine $legacyEngine )
+    /** @var  \eZ\Publish\Core\MVC\Legacy\Templating\LegacyHelper */
+    private $legacyHelper;
+
+    /** @var  string */
+    private $jsTemplate;
+
+    /** @var  string */
+    private $cssTemplate;
+
+    /**
+     * The Twig environment
+     *
+     * @var \Twig_Environment
+     */
+    protected $environment;
+
+    public function __construct(
+        LegacyEngine $legacyEngine,
+        LegacyHelper $legacyHelper,
+        $jsTemplate,
+        $cssTemplate
+    )
     {
         $this->legacyEngine = $legacyEngine;
+        $this->legacyHelper = $legacyHelper;
+        $this->jsTemplate = $jsTemplate;
+        $this->cssTemplate = $cssTemplate;
     }
 
     /**
@@ -60,4 +87,122 @@ class LegacyExtension extends Twig_Extension
     {
         return 'ezpublish.legacy';
     }
+
+    /**
+     * Initializes the template runtime (aka Twig environment).
+     *
+     * @param \Twig_Environment $environment
+     */
+    public function initRuntime( Twig_Environment $environment )
+    {
+        $this->environment = $environment;
+    }
+
+    /**
+     * Returns a list of functions to add to the existing list.
+     *
+     * @return array
+     */
+    public function getFunctions()
+    {
+        return array(
+            new Twig_SimpleFunction(
+                'ez_legacy_render_js',
+                array( $this, 'renderLegacyJs' ),
+                array( 'is_safe' => array( 'html' ) )
+            ),
+            new Twig_SimpleFunction(
+                'ez_legacy_render_css',
+                array( $this, 'renderLegacyCss' ),
+                array( 'is_safe' => array( 'html' ) )
+            ),
+        );
+    }
+
+    /**
+     * Generates style tags to be embedded in the page
+     *
+     * @return string html script and style tags
+     */
+    public function renderLegacyJs()
+    {
+        $jsFiles = array();
+        $jsCodeLines = array();
+
+        foreach ( $this->legacyHelper->get( 'js_files' ) as $jsItem )
+        {
+            // List of items can contain empty elements, path to files or code
+            if ( !empty( $jsItem ) )
+            {
+                if ( isset( $jsItem[4] ) && $this->isFile( $jsItem, '.js' ) )
+                {
+                    $jsFiles[] = $jsItem;
+                }
+                else
+                {
+                    $jsCodeLines[] = $jsItem;
+                }
+            }
+        }
+
+        return $this->environment->render(
+            $this->jsTemplate,
+            array(
+                'js_files' => $jsFiles,
+                'js_code_lines' => $jsCodeLines
+            )
+        );
+    }
+
+    /**
+     * Generates script tags to be embedded in the page
+     *
+     * @return string html script and style tags
+     */
+    public function renderLegacyCss( )
+    {
+        $cssFiles = array();
+        $cssCodeLines = array();
+
+        foreach ( $this->legacyHelper->get( 'css_files' ) as $cssItem )
+        {
+            // List of items can contain empty elements, path to files or code
+            if ( !empty( $cssItem ) )
+            {
+                if ( isset( $cssItem[5] ) && $this->isFile( $cssItem, '.css' ) )
+                {
+                    $cssFiles[] = $cssItem;
+                }
+                else
+                {
+                    $cssCodeLines[] = $cssItem;
+                }
+            }
+        }
+
+        return $this->environment->render(
+            $this->cssTemplate,
+            array(
+                'css_files' => $cssFiles,
+                'css_code_lines' => $cssCodeLines
+            )
+        );
+    }
+
+    /**
+     * Is the provided item (path or link) a file or code. Based on legacy's rules (ezjscpacker.php)
+     *
+     * @param $item string to be tested
+     * @param $extension string extension of the file
+     *
+     * @return bool true if item is a file
+     */
+    private function isFile( $item, $extension )
+    {
+        return
+            strpos( $item, 'http://' ) === 0
+            || strpos( $item, 'https://' ) === 0
+            || strripos( $item, $extension ) === ( strlen( $item ) - strlen( $extension ) );
+    }
+
 }

--- a/eZ/Publish/Core/MVC/Legacy/View/Provider/Location.php
+++ b/eZ/Publish/Core/MVC/Legacy/View/Provider/Location.php
@@ -18,8 +18,6 @@ use eZ\Publish\Core\MVC\Symfony\View\ContentView;
 use eZ\Publish\Core\MVC\Symfony\View\ViewProviderMatcher;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZModule;
-use ezjscPacker;
-use eZINI;
 use ezpEvent;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -118,8 +116,11 @@ class Location extends Provider implements LocationViewProviderInterface
      */
     public function renderPublishedView( APILocation $location, $viewType, array $params, LegacyHelper $legacyHelper )
     {
-        return $this->getLegacyKernel()->runCallback(
-            function () use ( $location, $viewType, $params, $legacyHelper )
+        $moduleResult = array();
+
+        // Filling up moduleResult
+        $result = $this->getLegacyKernel()->runCallback(
+            function () use ( $location, $viewType, $params, &$moduleResult )
             {
                 $contentViewModule = eZModule::findModule( 'content' );
                 $moduleResult = $contentViewModule->run(
@@ -129,60 +130,14 @@ class Location extends Provider implements LocationViewProviderInterface
                     $params
                 );
 
-                // Injecting all $moduleResult entries in the legacy helper
-                foreach ( $moduleResult as $key => $val )
-                {
-                    if ( $key === 'content' )
-                        continue;
-
-                    $legacyHelper->set( $key, $val );
-                }
-
-                // Javascript/CSS files required with ezcss_require/ezscript_require
-                // Compression level is forced to 0 to only get the files list
-                if ( isset( $moduleResult['content_info']['persistent_variable']['css_files'] ) )
-                {
-                    $legacyHelper->set(
-                        'css_files',
-                        ezjscPacker::buildStylesheetFiles(
-                            $moduleResult['content_info']['persistent_variable']['css_files'],
-                            0
-                        )
-                    );
-                }
-                if ( isset( $moduleResult['content_info']['persistent_variable']['js_files'] ) )
-                {
-                    $legacyHelper->set(
-                        'js_files',
-                        ezjscPacker::buildJavascriptFiles(
-                            $moduleResult['content_info']['persistent_variable']['js_files'],
-                            0
-                        )
-                    );
-                }
-
-                // Now getting configured JS/CSS files, in design.ini
-                // Will only take FrontendCSSFileList/FrontendJavascriptList
-                $designINI = eZINI::instance( 'design.ini' );
-                $legacyHelper->set(
-                    'css_files_configured',
-                    ezjscPacker::buildStylesheetFiles(
-                        $designINI->variable( 'StylesheetSettings', 'FrontendCSSFileList' ),
-                        0
-                    )
-                );
-                $legacyHelper->set(
-                    'js_files_configured',
-                    ezjscPacker::buildJavascriptFiles(
-                        $designINI->variable( 'JavaScriptSettings', 'FrontendJavaScriptList' ),
-                        0
-                    )
-                );
-
                 return ezpEvent::getInstance()->filter( 'response/output', $moduleResult['content'] );
             },
             false
         );
+
+        $legacyHelper->loadDataFromModuleResult( $moduleResult );
+
+        return $result;
     }
 
     /**
@@ -198,8 +153,11 @@ class Location extends Provider implements LocationViewProviderInterface
     {
         /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess $siteAccess */
         $siteAccess = $this->request->attributes->get( 'siteaccess' );
-        return $this->getLegacyKernel()->runCallback(
-            function () use ( $content, $params, $legacyHelper, $siteAccess )
+        $moduleResult = array();
+
+        // Filling up moduleResult
+        $result = $this->getLegacyKernel()->runCallback(
+            function () use ( $content, $params, $siteAccess, &$moduleResult )
             {
                 $contentViewModule = eZModule::findModule( 'content' );
                 $moduleResult = $contentViewModule->run(
@@ -209,59 +167,13 @@ class Location extends Provider implements LocationViewProviderInterface
                     array( 'site_access' => $siteAccess->name ) + $params
                 );
 
-                // Injecting all $moduleResult entries in the legacy helper
-                foreach ( $moduleResult as $key => $val )
-                {
-                    if ( $key === 'content' )
-                        continue;
-
-                    $legacyHelper->set( $key, $val );
-                }
-
-                // Javascript/CSS files required with ezcss_require/ezscript_require
-                // Compression level is forced to 0 to only get the files list
-                if ( isset( $moduleResult['content_info']['persistent_variable']['css_files'] ) )
-                {
-                    $legacyHelper->set(
-                        'css_files',
-                        ezjscPacker::buildStylesheetFiles(
-                            $moduleResult['content_info']['persistent_variable']['css_files'],
-                            0
-                        )
-                    );
-                }
-                if ( isset( $moduleResult['content_info']['persistent_variable']['js_files'] ) )
-                {
-                    $legacyHelper->set(
-                        'js_files',
-                        ezjscPacker::buildJavascriptFiles(
-                            $moduleResult['content_info']['persistent_variable']['js_files'],
-                            0
-                        )
-                    );
-                }
-
-                // Now getting configured JS/CSS files, in design.ini
-                // Will only take FrontendCSSFileList/FrontendJavascriptList
-                $designINI = eZINI::instance( 'design.ini' );
-                $legacyHelper->set(
-                    'css_files_configured',
-                    ezjscPacker::buildStylesheetFiles(
-                        $designINI->variable( 'StylesheetSettings', 'FrontendCSSFileList' ),
-                        0
-                    )
-                );
-                $legacyHelper->set(
-                    'js_files_configured',
-                    ezjscPacker::buildJavascriptFiles(
-                        $designINI->variable( 'JavaScriptSettings', 'FrontendJavaScriptList' ),
-                        0
-                    )
-                );
-
                 return ezpEvent::getInstance()->filter( 'response/output', $moduleResult['content'] );
             },
             false
         );
+
+        $legacyHelper->loadDataFromModuleResult( $moduleResult );
+
+        return $result;
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/ContentExtensionTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/ContentExtensionTest.php
@@ -17,13 +17,8 @@ use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Field;
-use Twig_Test_IntegrationTestCase;
-use Twig_Environment;
-use Twig_Loader_Filesystem;
-use Twig_Loader_Chain;
-use Twig_Loader_Array;
 
-class ContentExtensionIntegrationTest extends Twig_Test_IntegrationTestCase
+class ContentExtensionIntegrationTest extends FileSystemTwigIntegrationTestCase
 {
     /**
      * @var \eZ\Publish\API\Repository\ContentTypeService|\PHPUnit_Framework_MockObject_MockObject
@@ -54,143 +49,6 @@ class ContentExtensionIntegrationTest extends Twig_Test_IntegrationTestCase
                 $this->fieldHelperMock
             )
         );
-    }
-
-    /**
-     * Overrides the default implementation to use the chain loader so that
-     * templates used internally by ez_render_* are correctly loaded
-     */
-    protected function doIntegrationTest( $file, $message, $condition, $templates, $exception, $outputs )
-    {
-        if ( $condition )
-        {
-            eval( '$ret = ' . $condition . ';' );
-            if ( !$ret )
-            {
-                $this->markTestSkipped( $condition );
-            }
-        }
-
-        // changes from the original is here
-        $loader = new Twig_Loader_Chain(
-            array(
-                new Twig_Loader_Array( $templates ),
-                new Twig_Loader_Filesystem( $this->getFixturesDir() )
-            )
-        );
-        // end changes
-
-        foreach ( $outputs as $match )
-        {
-            $config = array_merge(
-                array(
-                    'cache' => false,
-                    'strict_variables' => true,
-                ),
-                $match[2] ? eval( $match[2] . ';' ) : array()
-            );
-            $twig = new Twig_Environment( $loader, $config );
-            $twig->addGlobal( 'global', 'global' );
-            foreach ( $this->getExtensions() as $extension )
-            {
-                $twig->addExtension( $extension );
-            }
-
-            try
-            {
-                $template = $twig->loadTemplate( 'index.twig' );
-            }
-            catch ( Exception $e )
-            {
-                if ( false !== $exception )
-                {
-                    $this->assertEquals(
-                        trim( $exception ),
-                        trim(
-                            sprintf( '%s: %s', get_class( $e ), $e->getMessage() )
-                        )
-                    );
-
-                    return;
-                }
-
-                if ( $e instanceof Twig_Error_Syntax )
-                {
-                    $e->setTemplateFile( $file );
-
-                    throw $e;
-                }
-
-                throw new Twig_Error(
-                    sprintf( '%s: %s', get_class( $e ), $e->getMessage() ),
-                    -1, $file, $e
-                );
-            }
-
-            try
-            {
-                $output = trim(
-                    $template->render( eval( $match[1] . ';' ) ), "\n "
-                );
-            }
-            catch (Exception $e)
-            {
-                if ( false !== $exception )
-                {
-                    $this->assertEquals(
-                        trim( $exception ),
-                        trim(
-                            sprintf( '%s: %s', get_class( $e ), $e->getMessage() )
-                        )
-                    );
-
-                    return;
-                }
-
-                if ( $e instanceof Twig_Error_Syntax )
-                {
-                    $e->setTemplateFile( $file );
-                }
-                else
-                {
-                    $e = new Twig_Error(
-                        sprintf( '%s: %s', get_class( $e ), $e->getMessage() ),
-                        -1, $file, $e
-                    );
-                }
-
-                $output = trim(
-                    sprintf( '%s: %s', get_class( $e ), $e->getMessage() )
-                );
-            }
-
-            if ( false !== $exception )
-            {
-                list( $class, ) = explode( ':', $exception );
-                $this->assertThat(
-                    null, new PHPUnit_Framework_Constraint_Exception( $class )
-                );
-            }
-
-            $expected = trim( $match[3], "\n " );
-
-            if ( $expected != $output )
-            {
-                echo 'Compiled template that failed:';
-
-                foreach ( array_keys( $templates ) as $name )
-                {
-                    echo "Template: $name\n";
-                    $source = $loader->getSource( $name );
-                    echo $twig->compile(
-                        $twig->parse( $twig->tokenize( $source, $name ) )
-                    );
-                }
-            }
-            $this->assertEquals(
-                $expected, $output, $message . ' (in ' . $file . ')'
-            );
-        }
     }
 
     public function getFixturesDir()

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FileSystemTwigIntegrationTestCase.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FileSystemTwigIntegrationTestCase.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * File containing the FileSystemTwigIntegrationTestCase class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests\Twig\Extension;
+
+use Twig_Loader_Chain;
+use Twig_Loader_Array;
+use Twig_Loader_Filesystem;
+use Twig_Environment;
+use Exception;
+use Twig_Error_Syntax;
+use Twig_Error;
+use Twig_Test_IntegrationTestCase;
+use PHPUnit_Framework_Constraint_Exception;
+
+/**
+ * Class FileSystemTwigIntegrationTestCase
+ * This class adds a custom version of the doIntegrationTest from Twig_Test_IntegrationTestCase to
+ * allow loading (custom) templates located in the FixturesDir.
+ *
+ * @package eZ\Publish\Core\MVC\Symfony\Templating\Tests\Twig\Extension
+ */
+abstract class FileSystemTwigIntegrationTestCase extends Twig_Test_IntegrationTestCase
+{
+    /**
+     * Overrides the default implementation to use the chain loader so that
+     * templates used internally are correctly loaded
+     */
+    protected function doIntegrationTest( $file, $message, $condition, $templates, $exception, $outputs )
+    {
+        if ( $condition )
+        {
+            eval( '$ret = ' . $condition . ';' );
+            if ( !$ret )
+            {
+                $this->markTestSkipped( $condition );
+            }
+        }
+
+        // changes from the original is here, Twig_Loader_Filesystem has been added
+        $loader = new Twig_Loader_Chain(
+            array(
+                new Twig_Loader_Array( $templates ),
+                new Twig_Loader_Filesystem( $this->getFixturesDir() )
+            )
+        );
+        // end changes
+
+        foreach ( $outputs as $match )
+        {
+            $config = array_merge(
+                array(
+                    'cache' => false,
+                    'strict_variables' => true,
+                ),
+                $match[2] ? eval( $match[2] . ';' ) : array()
+            );
+            $twig = new Twig_Environment( $loader, $config );
+            $twig->addGlobal( 'global', 'global' );
+            foreach ( $this->getExtensions() as $extension )
+            {
+                $twig->addExtension( $extension );
+            }
+
+            try
+            {
+                $template = $twig->loadTemplate( 'index.twig' );
+            }
+            catch ( Exception $e )
+            {
+                if ( false !== $exception )
+                {
+                    $this->assertEquals(
+                        trim( $exception ),
+                        trim(
+                            sprintf( '%s: %s', get_class( $e ), $e->getMessage() )
+                        )
+                    );
+
+                    return;
+                }
+
+                if ( $e instanceof Twig_Error_Syntax )
+                {
+                    $e->setTemplateFile( $file );
+
+                    throw $e;
+                }
+
+                throw new Twig_Error(
+                    sprintf( '%s: %s', get_class( $e ), $e->getMessage() ),
+                    -1, $file, $e
+                );
+            }
+
+            try
+            {
+                $output = trim(
+                    $template->render( eval( $match[1] . ';' ) ), "\n "
+                );
+            }
+            catch (Exception $e)
+            {
+                if ( false !== $exception )
+                {
+                    $this->assertEquals(
+                        trim( $exception ),
+                        trim(
+                            sprintf( '%s: %s', get_class( $e ), $e->getMessage() )
+                        )
+                    );
+
+                    return;
+                }
+
+                if ( $e instanceof Twig_Error_Syntax )
+                {
+                    $e->setTemplateFile( $file );
+                }
+                else
+                {
+                    $e = new Twig_Error(
+                        sprintf( '%s: %s', get_class( $e ), $e->getMessage() ),
+                        -1, $file, $e
+                    );
+                }
+
+                $output = trim(
+                    sprintf( '%s: %s', get_class( $e ), $e->getMessage() )
+                );
+            }
+
+            if ( false !== $exception )
+            {
+                list( $class, ) = explode( ':', $exception );
+                $this->assertThat(
+                    null,
+                    new PHPUnit_Framework_Constraint_Exception( $class )
+                );
+            }
+
+            $expected = trim( $match[3], "\n " );
+
+            if ( $expected != $output )
+            {
+                echo 'Compiled template that failed:';
+
+                foreach ( array_keys( $templates ) as $name )
+                {
+                    echo "Template: $name\n";
+                    $source = $loader->getSource( $name );
+                    echo $twig->compile(
+                        $twig->parse( $twig->tokenize( $source, $name ) )
+                    );
+                }
+            }
+            $this->assertEquals(
+                $expected, $output, $message . ' (in ' . $file . ')'
+            );
+        }
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/LegacyRenderCssJsTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/LegacyRenderCssJsTest.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * File containing the LegacyRenderCssJsTest class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests\Twig\Extension;
+
+use eZ\Publish\Core\MVC\Legacy\Templating\Twig\Extension\LegacyExtension;
+
+/**
+ * Class LegacyRenderCssJsTest
+ *
+ * @package eZ\Publish\Core\MVC\Symfony\Templating\Tests\Twig\Extension
+ */
+class LegacyRenderCssJsTest extends FileSystemTwigIntegrationTestCase
+{
+    /**
+     * @param array $jsFiles
+     */
+    protected $jsFiles;
+
+    /**
+     * @param array $cssFiles
+     */
+    protected $cssFiles;
+
+    /**
+     * @return array $jsFiles
+     */
+    public function getJsFiles()
+    {
+        return $this->jsFiles;
+    }
+
+    /**
+     * @param array $jsFiles
+     */
+    public function setJsFiles( array $jsFiles )
+    {
+        $this->jsFiles = $jsFiles;
+    }
+
+    /**
+     * @return array $cssFiles
+     */
+    public function getCssFiles()
+    {
+        return $this->cssFiles;
+    }
+
+    /**
+     * @param array $cssFiles
+     */
+    public function setCssFiles( array $cssFiles )
+    {
+        $this->cssFiles = $cssFiles;
+    }
+
+    /**
+     * @return array
+     */
+    protected function getExtensions()
+    {
+        $templatesPath = 'templates/';
+
+        return array(
+            new LegacyExtension(
+                $this->getLegacyEngineMock(),
+                $this->getLegacyHelperMock(),
+                $templatesPath . 'ez_legacy_render_js.html.twig',
+                $templatesPath . 'ez_legacy_render_css.html.twig'
+            )
+        );
+    }
+
+    /**
+     * @return string
+     */
+    protected function getFixturesDir()
+    {
+        return __DIR__ . '/_fixtures/functions/ez_legacy_render_css_js/';
+    }
+
+    /**
+     * @return \eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getLegacyEngineMock()
+    {
+        $multipleObjectConverterMock = $this->getMock( 'eZ\Publish\Core\MVC\Legacy\Templating\Converter\MultipleObjectConverter' );
+
+        return $this->getMock(
+            'eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine',
+            array(),
+            array(
+                function ()
+                {
+                },
+                $multipleObjectConverterMock
+            )
+        );
+
+    }
+
+    /**
+     * @return \eZ\Publish\Core\MVC\Legacy\Templating\LegacyHelper|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getLegacyHelperMock()
+    {
+        $legacyHelperMock = $this->getMock(
+            'eZ\Publish\Core\MVC\Legacy\Templating\LegacyHelper',
+            array(),
+            array(
+                function ()
+                {
+                }
+            )
+        );
+
+        $legacyHelperMock->expects( $this->any() )
+            ->method( "get" )
+            ->with(
+                $this->logicalOr(
+                    $this->equalTo( "js_files" ),
+                    $this->equalTo( "css_files" )
+                )
+            )
+            ->will(
+                $this->returnCallback(
+                    array( $this, "legacyHelperMockCallback" )
+                )
+            );
+
+        return $legacyHelperMock;
+    }
+
+    /**
+     * Callback multiplexer for LegacyHelper::get().
+     *
+     * @param $id
+     *
+     * @return mixed
+     */
+    public function legacyHelperMockCallback( $id )
+    {
+        switch ( $id )
+        {
+            case "js_files":
+                return $this->getJsFiles();
+
+            case "css_files":
+                return $this->getCssFiles();
+        }
+
+        return null;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/functions/ez_legacy_render_css_js/ez_legacy_render_css.test
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/functions/ez_legacy_render_css_js/ez_legacy_render_css.test
@@ -1,0 +1,34 @@
+--TEST--
+"ez_legacy_render_css" function
+--TEMPLATE--
+{{ ez_legacy_render_css() }}
+
+--DATA--
+$this->setCssFiles( array( '' ) ); return array();
+--EXPECT--
+
+
+--DATA--
+$this->setCssFiles( array( 'foo' ) ); return array();
+--EXPECT--
+Code: foo
+
+--DATA--
+$this->setCssFiles( array( 'http://foo/bar' ) ); return array();
+--EXPECT--
+File: http://foo/bar
+
+--DATA--
+$this->setCssFiles( array( 'https://foo/bar' ) ); return array();
+--EXPECT--
+File: https://foo/bar
+
+--DATA--
+$this->setCssFiles( array( '/foo/bar.css' ) ); return array();
+--EXPECT--
+File: /foo/bar.css
+
+--DATA--
+$this->setCssFiles( array( 'background-color: #ffffff;' ) ); return array();
+--EXPECT--
+Code: background-color: #ffffff;

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/functions/ez_legacy_render_css_js/ez_legacy_render_js.test
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/functions/ez_legacy_render_css_js/ez_legacy_render_js.test
@@ -1,0 +1,33 @@
+--TEST--
+"ez_legacy_render_js" function
+--TEMPLATE--
+{{ ez_legacy_render_js() }}
+
+--DATA--
+$this->setJsFiles( array( '' ) ); return array();
+--EXPECT--
+
+--DATA--
+$this->setJsFiles( array( 'foo' ) ); return array();
+--EXPECT--
+Code: foo
+
+--DATA--
+$this->setJsFiles( array( 'http://foo/bar' ) ); return array();
+--EXPECT--
+File: http://foo/bar
+
+--DATA--
+$this->setJsFiles( array( 'https://foo/bar' ) ); return array();
+--EXPECT--
+File: https://foo/bar
+
+--DATA--
+$this->setJsFiles( array( '/foo/bar.js' ) ); return array();
+--EXPECT--
+File: /foo/bar.js
+
+--DATA--
+$this->setJsFiles( array( 'var foo = bar' ) ); return array();
+--EXPECT--
+Code: var foo = bar

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/functions/ez_legacy_render_css_js/templates/ez_legacy_render_css.html.twig
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/functions/ez_legacy_render_css_js/templates/ez_legacy_render_css.html.twig
@@ -1,0 +1,8 @@
+{# Template for unit testing of ez_legacy_render_css  #}
+{% for item in css_files %}
+    File: {{ item }}
+{%endfor %}
+
+{% for item in css_code_lines %}
+    Code: {{item|raw}}
+{%endfor %}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/functions/ez_legacy_render_css_js/templates/ez_legacy_render_js.html.twig
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/functions/ez_legacy_render_css_js/templates/ez_legacy_render_js.html.twig
@@ -1,0 +1,8 @@
+{# Template for unit testing of ez_legacy_render_js  #}
+{% for item in js_files %}
+    File: {{ item }}
+{%endfor %}
+
+{% for item in js_code_lines %}
+    Code: {{ item|raw }}
+{%endfor %}


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-22767
## Description

ezscript_require (legacy) not taken into account on modules. 

This PR adds two new twig operators `ez_legacy_render_js()` and `ez_legacy_render_css()`.

They are needed when using legacy templates with ezjscore requirements in module.
Including these operator in the twig template in charge of  the `<head>` of your page will generate the HTML code needed to include js and css.

Example of usage in the demobundle: https://github.com/ezsystems/DemoBundle/pull/89
## Tests

Manual and unit tests.
