### PR TITLE
Do not depend on current working directory to find config.php in tests

### DIFF
--- a/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
@@ -644,7 +644,7 @@ abstract class BaseIntegrationTest extends TestCase
     protected function getContainer()
     {
         // get configuration config
-        if ( !( $settings = include 'config.php' ) )
+        if ( !( $settings = include __DIR__ . '/../../../../../config.php' ) )
         {
             throw new \RuntimeException( 'Could not find config.php, please copy config.php-DEVELOPMENT to config.php customize to your needs!' );
         }


### PR DESCRIPTION
A repeat of pull request #634, again needed for [NetgenTagsBundle](https://github.com/netgen/TagsBundle) unit tests :)

Original description follows for reference:

Unit tests for [NetgenTagsBundle](https://github.com/netgen/TagsBundle) can be ran from the root directory of eZ Publish 5. They require that the file `vendor/ezsystems/ezpublish-kernel/config.php-DEVELOPMENT` is copied to `vendor/ezsystems/ezpublish-kernel/config.php` and since `vendor/ezsystems/ezpublish-kernel/` directory is not the current working directory, some of the tests in `NetgenTagsBundle` fail.

This change makes sure that `config.php` is found by using the `__DIR__` constant rather than depending on current working directory.
