### PR TITLE
Fix EZP-22308: store in db sortkey value (as in legacy) and return it while searching

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Relation.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Relation.php
@@ -40,6 +40,7 @@ class Relation implements Converter
         $storageFieldValue->dataInt = !empty( $value->data['destinationContentId'] )
             ? $value->data['destinationContentId']
             : null;
+        $storageFieldValue->sortKeyInt = (int)$value->sortKey;
     }
 
     /**
@@ -53,7 +54,7 @@ class Relation implements Converter
         $fieldValue->data = array(
             "destinationContentId" => $value->dataInt ?: null,
         );
-        $fieldValue->sortKey = false;
+        $fieldValue->sortKey = (int)$value->sortKeyInt;
     }
 
     /**


### PR DESCRIPTION
Fix : https://jira.ez.no/browse/EZP-22308

When creating a relation using the PAPI, it never store the sort_key_string value.
Then, if you try to search for contents in relation with another content, it always return an empty result.

With this correction, sort_key_string is initialize with the value of the related content and when searching for content, it returns the good content.
