### PR TITLE
Doc: fix minor typo in variable name

### DIFF
--- a/doc/specifications/siteaccess/language_switcher.md
+++ b/doc/specifications/siteaccess/language_switcher.md
@@ -159,7 +159,7 @@ argument to your sub-controller from the master request.
 
 ```jinja
 {# Render the language switch links in a sub-controller #}
-{{ render( controller( 'AcmeTestBundle:Default:languages', {'routeReference': ez_route()} ) ) }}
+{{ render( controller( 'AcmeTestBundle:Default:languages', {'routeRef': ez_route()} ) ) }}
 ```
 
 ```php


### PR DESCRIPTION
This is a minor fix for doc added for [EZP-22464](https://jira.ez.no/browse/EZP-22464) PR #834
