### PR TITLE
Fix EZP-22781: Preview Exception with Website Toolbar

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Controller/WebsiteToolbarController.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Controller/WebsiteToolbarController.php
@@ -11,6 +11,7 @@ namespace eZ\Bundle\EzPublishLegacyBundle\Controller;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\MVC\Symfony\Controller\Controller;
+use InvalidArgumentException;
 use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\SecurityContextInterface;
@@ -59,6 +60,12 @@ class WebsiteToolbarController extends Controller
     public function websiteToolbarAction( $locationId )
     {
         $response = new Response();
+
+        // Happens in PreviewController. See EZP-22823.
+        if ( $locationId === null )
+        {
+            return $response;
+        }
 
         $authorizationAttribute = new AuthorizationAttribute(
             'websitetoolbar',


### PR DESCRIPTION
> Fixes http://jira.ez.no/browse/EZP-22823
> Alternative to ezsystems/DemoBundle#83

If a null location id is passed, it will be ignored by the controller, and an empty response will be returned. This makes it easier for devs to integrate the toolbar, since they don't need to care about the preview context specificities.
