### PR TITLE
[WIP] Integration tests via symfony

### DIFF
--- a/bootstrap_sf.php
+++ b/bootstrap_sf.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * File containing the bootstrapping of eZ Publish API for unit test use
+ *
+ * Setups class loading.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+require_once __DIR__ . '/../../../ezpublish/autoload.php';
+
+
+
+
+

--- a/eZ/Publish/Core/Persistence/Cache/CacheServiceDecorator.php
+++ b/eZ/Publish/Core/Persistence/Cache/CacheServiceDecorator.php
@@ -65,7 +65,13 @@ class CacheServiceDecorator
      */
     public function clear()
     {
-        $item = call_user_func_array( array( $this, 'getItem' ), func_get_args() );
+        $args = func_get_args();
+
+        // Do a purge, but with cache key in case of no arguments
+        if ( empty( $args ) )
+            return $this->cachePool->getDriver()->clear( array( self::SPI_CACHE_KEY_PREFIX ) );
+
+        $item = call_user_func_array( array( $this, 'getItem' ), $args );
         return $item->clear();
     }
 }

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         bootstrap="bootstrap.php"
+         bootstrap="bootstrap_sf.php"
          processIsolation="false"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"


### PR DESCRIPTION
An attempt (third one, but who is counting) towards running integration tests on symfony.
In practice SetupFactory now behaves more like [WebTestCase](https://github.com/symfony/symfony/blob/2.3/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php#L46)

NB! This requries https://github.com/ezsystems/ezpublish-community/pull/146
# How to run:

```
$ php55 bin/phpunit -c vendor/ezsystems/ezpublish-kernel/phpunit-integration-legacy.xml --stop-on-failure
```

This will not pass, locally or on travis, but at this point it no longer complains about symfony related things like missing request*, current failure:

```
PHPUnit 3.7.37 by Sebastian Bergmann.

Configuration read from /Users/andrerom/Sites/www/ezpublish/vendor/ezsystems/ezpublish-kernel/phpunit-integration-legacy.xml

E

Time: 1.77 seconds, Memory: 49.50Mb

There was 1 error:

1) eZ\Publish\API\Repository\Tests\Values\User\Limitation\ContentTypeLimitationTest::testContentTypeLimitationAllow
eZ\Publish\Core\Base\Exceptions\BadStateException: Argument '$versionInfo' has a bad state: Only versions in draft status can be published.

/Users/andrerom/Sites/www/ezpublish/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Repository/ContentService.php:1528
/Users/andrerom/Sites/www/ezpublish/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Repository/ContentService.php:1502
/Users/andrerom/Sites/www/ezpublish/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/SignalSlot/ContentService.php:416
/Users/andrerom/Sites/www/ezpublish/vendor/ezsystems/ezpublish-kernel/eZ/Publish/API/Repository/Tests/Values/User/Limitation/BaseLimitationTest.php:36
/Users/andrerom/Sites/www/ezpublish/vendor/ezsystems/ezpublish-kernel/eZ/Publish/API/Repository/Tests/Values/User/Limitation/ContentTypeLimitationTest.php:72

FAILURES!
Tests: 1, Assertions: 0, Errors: 1.
```

If it is executed without --stop-on-failure it will result in:

```
EFFE...E.E.EFE.....EF......EFE....SSSSSSSSSSSSSESSSSSSSSSSSFF   61 / 1028 (  5%)
EE.SEEEESSSESSESSSSSSSSESSSSSSSSSSSEEEEEEESE.....SSSSSSSSSSSS  122 / 1028 ( 11%)
SESSSSSSSSSSSFFEE.SE...SSSSSSSSSSSSSESSSSSSSSSSSFFFFFFFFEE.SE  183 / 1028 ( 17%)
..SSSSSSSSSSSSSESSSSSSSSSSSFEE.SE..SSSSSSSSSSSSSESSSSSSSSSSSF  244 / 1028 ( 23%)
FEE.SSE....SSSSSSSSSSSSSESSSSSSSSSSSFFFFFFFFFFFFEE.SE....SSSPHP Fatal error:  Allowed memory size of 268435456 bytes exhausted (tried to allocate 1807 bytes) in /Users/andrerom/Sites/www/ezpublish/vendor/monolog/monolog/src/Monolog/Formatter/LineFormatter.php on line 111
```

\* That went away by getting the test client and setting empty arguments.
