### PR TITLE
Fix EZP-22836: Cache not being cleared with object state creating

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/slot.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/slot.yml
@@ -9,6 +9,13 @@ parameters:
     ezpublish_legacy.signalslot.move_subtree.class: eZ\Publish\Core\SignalSlot\Slot\LegacyMoveSubtreeSlot
     ezpublish_legacy.signalslot.publish_version.class: eZ\Publish\Core\SignalSlot\Slot\LegacyPublishVersionSlot
     ezpublish_legacy.signalslot.set_content_state.class: eZ\Publish\Core\SignalSlot\Slot\LegacySetContentStateSlot
+    ezpublish_legacy.signalslot.create_object_state.class: eZ\Publish\Core\SignalSlot\Slot\LegacyCreateObjectStateSlot
+    ezpublish_legacy.signalslot.create_object_state_group.class: eZ\Publish\Core\SignalSlot\Slot\LegacyCreateObjectStateGroupSlot
+    ezpublish_legacy.signalslot.delete_object_state.class: eZ\Publish\Core\SignalSlot\Slot\LegacyDeleteObjectStateSlot
+    ezpublish_legacy.signalslot.delete_object_state_group.class: eZ\Publish\Core\SignalSlot\Slot\LegacyDeleteObjectStateGroupSlot
+    ezpublish_legacy.signalslot.set_priority_of_object_state.class: eZ\Publish\Core\SignalSlot\Slot\LegacySetPriorityOfObjectStateSlot
+    ezpublish_legacy.signalslot.update_object_state.class: eZ\Publish\Core\SignalSlot\Slot\LegacyUpdateObjectStateSlot
+    ezpublish_legacy.signalslot.update_object_state_group.class: eZ\Publish\Core\SignalSlot\Slot\LegacyUpdateObjectStateGroupSlot
     ezpublish_legacy.signalslot.swap_location.class: eZ\Publish\Core\SignalSlot\Slot\LegacySwapLocationSlot
     ezpublish_legacy.signalslot.unhide_location.class: eZ\Publish\Core\SignalSlot\Slot\LegacyUnhideLocationSlot
     ezpublish_legacy.signalslot.update_location.class: eZ\Publish\Core\SignalSlot\Slot\LegacyUpdateLocationSlot
@@ -82,6 +89,48 @@ services:
         arguments: [@ezpublish_legacy.kernel]
         tags:
             - { name: ezpublish.api.slot, signal: ObjectStateService\SetContentStateSignal }
+
+    ezpublish_legacy.signalslot.create_object_state:
+        class: %ezpublish_legacy.signalslot.create_object_state.class%
+        arguments: [@ezpublish_legacy.kernel]
+        tags:
+            - { name: ezpublish.api.slot, signal: ObjectStateService\CreateObjectStateSignal }
+
+    ezpublish_legacy.signalslot.create_object_state_group:
+        class: %ezpublish_legacy.signalslot.create_object_state_group.class%
+        arguments: [@ezpublish_legacy.kernel]
+        tags:
+            - { name: ezpublish.api.slot, signal: ObjectStateService\CreateObjectStateGroupSignal }
+
+    ezpublish_legacy.signalslot.delete_object_state:
+        class: %ezpublish_legacy.signalslot.delete_object_state.class%
+        arguments: [@ezpublish_legacy.kernel]
+        tags:
+            - { name: ezpublish.api.slot, signal: ObjectStateService\DeleteObjectStateSignal }
+
+    ezpublish_legacy.signalslot.delete_object_state_group:
+        class: %ezpublish_legacy.signalslot.delete_object_state_group.class%
+        arguments: [@ezpublish_legacy.kernel]
+        tags:
+            - { name: ezpublish.api.slot, signal: ObjectStateService\DeleteObjectStateGroupSignal }
+
+    ezpublish_legacy.signalslot.set_priority_of_object_state:
+        class: %ezpublish_legacy.signalslot.set_priority_of_object_state.class%
+        arguments: [@ezpublish_legacy.kernel]
+        tags:
+            - { name: ezpublish.api.slot, signal: ObjectStateService\SetPriorityOfObjectStateSignal }
+
+    ezpublish_legacy.signalslot.update_object_state:
+        class: %ezpublish_legacy.signalslot.update_object_state.class%
+        arguments: [@ezpublish_legacy.kernel]
+        tags:
+            - { name: ezpublish.api.slot, signal: ObjectStateService\UpdateObjectStateSignal }
+
+    ezpublish_legacy.signalslot.update_object_state_group:
+        class: %ezpublish_legacy.signalslot.update_object_state_group.class%
+        arguments: [@ezpublish_legacy.kernel]
+        tags:
+            - { name: ezpublish.api.slot, signal: ObjectStateService\UpdateObjectStateGroupSignal }
 
     ezpublish_legacy.signalslot.swap_location:
         class: %ezpublish_legacy.signalslot.swap_location.class%

--- a/eZ/Publish/Core/SignalSlot/Slot/AbstractLegacyObjectStateSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/AbstractLegacyObjectStateSlot.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * File containing the Legacy\AbstractLegacyObjectStateSlot class
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\SignalSlot\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+use eZCache;
+
+/**
+ * An abstract legacy slot common for some ObjectStateService signals.
+ */
+abstract class AbstractLegacyObjectStateSlot extends AbstractLegacySlot
+{
+    /**
+     * Clears object state limitation cache.
+     *
+     * Concrete implementation of this class should take care of checking the type of the signal.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     */
+    public function receive( Signal $signal )
+    {
+        $kernel = $this->getLegacyKernel();
+        $kernel->runCallback(
+            function ()
+            {
+                // Passing null as $cacheItem parameter is not used by this method
+                eZCache::clearStateLimitations( null );
+            },
+            false
+        );
+    }
+}

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyCreateObjectStateGroupSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyCreateObjectStateGroupSlot.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * File containing the Legacy\LegacyCreateObjectStateGroupSlot class
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\SignalSlot\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A legacy slot handling CreateObjectStateGroupSignal.
+ */
+class LegacyCreateObjectStateGroupSlot extends AbstractLegacyObjectStateSlot
+{
+    /**
+     * Receive the given $signal and react on it
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     */
+    public function receive( Signal $signal )
+    {
+        if ( !$signal instanceof Signal\ObjectStateService\CreateObjectStateGroupSignal )
+        {
+            return;
+        }
+
+        parent::receive( $signal );
+    }
+}

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyCreateObjectStateSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyCreateObjectStateSlot.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * File containing the Legacy\LegacyCreateObjectStateSlot class
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\SignalSlot\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A legacy slot handling CreateObjectStateSignal.
+ */
+class LegacyCreateObjectStateSlot extends AbstractLegacyObjectStateSlot
+{
+    /**
+     * Receive the given $signal and react on it
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     */
+    public function receive( Signal $signal )
+    {
+        if ( !$signal instanceof Signal\ObjectStateService\CreateObjectStateSignal )
+        {
+            return;
+        }
+
+        parent::receive( $signal );
+    }
+}

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyDeleteObjectStateGroupSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyDeleteObjectStateGroupSlot.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * File containing the Legacy\LegacyDeleteObjectStateGroupSlot class
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\SignalSlot\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A legacy slot handling DeleteObjectStateGroupSignal.
+ */
+class LegacyDeleteObjectStateGroupSlot extends AbstractLegacyObjectStateSlot
+{
+    /**
+     * Receive the given $signal and react on it
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     */
+    public function receive( Signal $signal )
+    {
+        if ( !$signal instanceof Signal\ObjectStateService\DeleteObjectStateGroupSignal )
+        {
+            return;
+        }
+
+        parent::receive( $signal );
+    }
+}

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyDeleteObjectStateSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyDeleteObjectStateSlot.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * File containing the Legacy\LegacyDeleteObjectStateSlot class
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\SignalSlot\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A legacy slot handling DeleteObjectStateSignal.
+ */
+class LegacyDeleteObjectStateSlot extends AbstractLegacyObjectStateSlot
+{
+    /**
+     * Receive the given $signal and react on it
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     */
+    public function receive( Signal $signal )
+    {
+        if ( !$signal instanceof Signal\ObjectStateService\DeleteObjectStateSignal )
+        {
+            return;
+        }
+
+        parent::receive( $signal );
+    }
+}

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacySetPriorityOfObjectStateSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacySetPriorityOfObjectStateSlot.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * File containing the Legacy\LegacySetPriorityOfObjectStateSlot class
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\SignalSlot\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A legacy slot handling SetPriorityOfObjectStateSignal.
+ */
+class LegacySetPriorityOfObjectStateSlot extends AbstractLegacyObjectStateSlot
+{
+    /**
+     * Receive the given $signal and react on it
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     */
+    public function receive( Signal $signal )
+    {
+        if ( !$signal instanceof Signal\ObjectStateService\SetPriorityOfObjectStateSignal )
+        {
+            return;
+        }
+
+        parent::receive( $signal );
+    }
+}

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyUpdateObjectStateGroupSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyUpdateObjectStateGroupSlot.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * File containing the Legacy\LegacyUpdateObjectStateGroupSlot class
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\SignalSlot\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A legacy slot handling UpdateObjectStateGroupSignal.
+ */
+class LegacyUpdateObjectStateGroupSlot extends AbstractLegacyObjectStateSlot
+{
+    /**
+     * Receive the given $signal and react on it
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     */
+    public function receive( Signal $signal )
+    {
+        if ( !$signal instanceof Signal\ObjectStateService\UpdateObjectStateGroupSignal )
+        {
+            return;
+        }
+
+        parent::receive( $signal );
+    }
+}

--- a/eZ/Publish/Core/SignalSlot/Slot/LegacyUpdateObjectStateSlot.php
+++ b/eZ/Publish/Core/SignalSlot/Slot/LegacyUpdateObjectStateSlot.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * File containing the Legacy\LegacyUpdateObjectStateSlot class
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\SignalSlot\Slot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A legacy slot handling UpdateObjectStateSignal.
+ */
+class LegacyUpdateObjectStateSlot extends AbstractLegacyObjectStateSlot
+{
+    /**
+     * Receive the given $signal and react on it
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     */
+    public function receive( Signal $signal )
+    {
+        if ( !$signal instanceof Signal\ObjectStateService\UpdateObjectStateSignal )
+        {
+            return;
+        }
+
+        parent::receive( $signal );
+    }
+}


### PR DESCRIPTION
This PR resolves issue https://jira.ez.no/browse/EZP-22836

This implements slots for clearing Legacy Stack ObjectState cache.
`ezpublish-legacy` repo part of the issue is covered by https://jira.ez.no/browse/EZP-22749 and https://github.com/ezsystems/ezpublish-legacy/pull/955.
