### PR TITLE
BDD: grab rest_url passed from behat.yml

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/FeatureContext.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/FeatureContext.php
@@ -86,8 +86,12 @@ class FeatureContext extends BaseContext implements RestInternalSentences
         // set parent parameters
         parent::__construct( $parameters );
 
+        $rest_url = !empty( $parameters['rest_url'] ) ?
+            $parameters['rest_url'] :
+            null;
+
         // create a new REST Client
-        $this->restclient = new RestClient\GuzzleClient();
+        $this->restclient = new RestClient\GuzzleClient( $rest_url );
 
         // sub contexts
         $this->useContext( 'Authentication', new AuthenticationContext( $this->restclient ) );


### PR DESCRIPTION
Till now all (rest) tests were done to: `http://localhost`
This plus ezsystems/ezpublish-community#148 will allow the use of other url on the tests
