### PR TITLE
EZP-22858: display in HTML comments the name of the used template

### DIFF
--- a/eZ/Bundle/EzPublishDebugBundle/Twig/DebugTemplate.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Twig/DebugTemplate.php
@@ -26,8 +26,21 @@ abstract class DebugTemplate extends Twig_Template
         $startTime = microtime( true );
 
         $templateListBefore = TemplateDebugInfo::getTemplatesList();
+        $templateName = $this->getTemplateName();
+        // Check if template name ends with "html.twig", indicating this is an HTML template.
+        $isHtmlTemplate = substr( $templateName, -strlen( 'html.twig' ) ) === 'html.twig';
+
+        if ( $isHtmlTemplate )
+        {
+            echo '<!-- START ' . $this->getTemplateName() . ' -->';
+        }
 
         parent::display( $context, $blocks );
+
+        if ( $isHtmlTemplate )
+        {
+            echo '<!-- STOP ' . $this->getTemplateName() . ' -->';
+        }
 
         $endTime = microtime( true );
 


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22858

In dev environment, it displays in HTML comments the name of the used template with "START" and "STOP" (as in legacy when activating "template debug" in the debugOutput).
It was one of my favorite way to debug templates in legacy.
