### PR TITLE
Fix for EZP-22880: Use semantic HTML tags <strong> and <em>

### DIFF
--- a/eZ/Publish/Core/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl
+++ b/eZ/Publish/Core/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl
@@ -132,17 +132,17 @@
     </xsl:template>
 
     <xsl:template match="strong">
-        <b>
+        <strong>
             <xsl:copy-of select="@*"/>
             <xsl:apply-templates/>
-        </b>
+        </strong>
     </xsl:template>
 
     <xsl:template match="emphasize">
-        <i>
+        <em>
             <xsl:copy-of select="@*"/>
             <xsl:apply-templates/>
-        </i>
+        </em>
     </xsl:template>
 
     <xsl:template match="ol | ul | li">


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22880

The eZ XML tags <strong> and <emphasize> should use the more semantic <strong> and <em> HTML tags as output instead of <b> and <i>.
