### PR TITLE
Fix EZP-22897: Missing access to persistent variable through LegacyHelper

### DIFF
--- a/eZ/Publish/Core/MVC/Legacy/Templating/LegacyHelper.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/LegacyHelper.php
@@ -53,6 +53,7 @@ class LegacyHelper extends ParameterBag
                 {
                     $moduleResult['content_info']['persistent_variable'] = ezjscPackerTemplateFunctions::getPersistentVariable();
                 }
+                $that->set( 'persistent_variable', $moduleResult['content_info']['persistent_variable'] );
 
                 // Javascript/CSS files required with ezcss_require/ezscript_require
                 // Compression level is forced to 0 to only get the files list


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22897

Simply adds easy access to `persistent_variable` set in legacy:

``` jinja
{% set persistent_variable = ezpublish.legacy.get( "persistent_variable" ) %}
```
