### PR TITLE
Fix EZP-22910: Formtoken exception is thrown when logging in without debug redirection

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Controller/LegacyKernelController.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Controller/LegacyKernelController.php
@@ -98,14 +98,14 @@ class LegacyKernelController
 
         $result = $this->kernel->run();
 
-        $this->legacyHelper->loadDataFromModuleResult( $result->getAttribute( 'module_result' ) );
-
         $this->kernel->setUseExceptions( true );
 
         if ( $result instanceof ezpKernelRedirect )
         {
             return $this->legacyResponseManager->generateRedirectResponse( $result );
         }
+
+        $this->legacyHelper->loadDataFromModuleResult( $result->getAttribute( 'module_result' ) );
 
         $response = $this->legacyResponseManager->generateResponseFromModuleResult( $result );
         $this->legacyResponseManager->mapHeaders( headers_list(), $response );


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22910

Regression from [EZP-22767](https://jira.ez.no/browse/EZP-22767).

`LegacyHelper` is filled even if the result is an `ezpKernelRedirect`, triggering a form token exception when request is POST. Makes sense since `LegacyHelper` uses `runCallback()` which in this case re-triggers request parsing by the legacy kernel. As request is POST, it legitimately looks for the form token.

For some reason, the issue does not happen with XDebug on.
