### PR TITLE
[WIP] Attempt EZP-22932: Add commit type configuration to Solr handler

### DIFF
--- a/eZ/Bundle/EzPublishSolrBundle/Command/SolrCreateIndexCommand.php
+++ b/eZ/Bundle/EzPublishSolrBundle/Command/SolrCreateIndexCommand.php
@@ -57,9 +57,9 @@ EOT
 
         /** @var \eZ\Publish\Core\Persistence\Solr\Content\Search\Handler $searchHandler */
         $searchHandler = $persistenceHandler->searchHandler();
-        $searchHandler->setCommit( false );
+        $searchHandler->setCommitType( false );
         $searchHandler->purgeIndex();
-        $searchHandler->setCommit( true );
+        $searchHandler->setCommitType( 'soft' );
 
         /** @var \Symfony\Component\Console\Helper\ProgressHelper $progress */
         $progress = $this->getHelperSet()->get( 'progress' );

--- a/eZ/Publish/API/Repository/Tests/SetupFactory/LegacySolr.php
+++ b/eZ/Publish/API/Repository/Tests/SetupFactory/LegacySolr.php
@@ -107,9 +107,9 @@ class LegacySolr extends Legacy
 
         /** @var \eZ\Publish\Core\Persistence\Solr\Content\Search\Handler $searchHandler */
         $searchHandler = $persistenceHandler->searchHandler();
-        $searchHandler->setCommit( false );
+        $searchHandler->setCommitType( false );
         $searchHandler->purgeIndex();
-        $searchHandler->setCommit( true );
+        $searchHandler->setCommitType( 'soft' );
         $searchHandler->bulkIndexContent( $contentObjects );
     }
 }

--- a/eZ/Publish/Core/Persistence/Cache/SearchHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/SearchHandler.php
@@ -117,8 +117,8 @@ class SearchHandler extends AbstractHandler implements SearchHandlerInterface
      * (also, see note on bulkIndexContent())
      * @param bool $commit
      */
-    public function setCommit( $commit )
+    public function setCommitType( $commit )
     {
-       $this->persistenceHandler->searchHandler()->setCommit( $commit );
+       $this->persistenceHandler->searchHandler()->setCommitType( $commit );
     }
 }

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/Gateway.php
@@ -66,12 +66,16 @@ abstract class Gateway
     abstract public function purgeIndex();
 
     /**
-     * Set if index/delete actions should commit or if several actions is to be expected
+     * Set how/if index/delete actions should committed
      *
-     * This should be set to false before group of actions and true before the last one
+     * Can for instance be used to disable commit when doing bulk insert, and enable afterwards.
      *
-     * @param bool $commit
+     * @param string|int|bool $commitType Specify solr commit type on updates, defaults to 'soft' one of:
+     *        'soft' Cache update, makes change instantly available, requries autoCommit to be enabled in solrconfig.xml
+     *        'hard' Full commit, for durability across hardware crashes but slow so will affect your publishing time.
+     *        bool True is hard & false is none, false requries autoCommit to be enabled in solrconfig.xml
+     *        int Use CommitWithin, time in milliseconds before at latest doing commit (hard by default in solrconfig.xml)
      */
-    abstract public function setCommit( $commit );
+    abstract public function setCommitType( $commitType );
 }
 

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/Handler.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/Handler.php
@@ -517,15 +517,20 @@ class Handler implements SearchHandlerInterface
     }
 
     /**
-     * Set if index/delete actions should commit or if several actions is to be expected
+     * Set how/if index/delete actions should committed
      *
-     * This should be set to false before group of actions and true before the last one
+     * Can for instance be used to disable commit when doing bulk insert, and enable afterwards.
+     * @todo Check with elasticsearch and consider to remove options that does not fit there.
      *
-     * @param bool $commit
+     * @param string|int|bool $commitType Specify solr commit type on updates, defaults to 'soft' one of:
+     *        'soft' Cache update, makes change instantly available, requries autoCommit to be enabled in solrconfig.xml
+     *        'hard' Full commit, for durability across hardware crashes but slow so will affect your publishing time.
+     *        bool True is hard & false is none, false requries autoCommit to be enabled in solrconfig.xml
+     *        int Use CommitWithin, time in milliseconds before at latest doing commit (hard by default in solrconfig.xml)
      */
-    public function setCommit( $commit )
+    public function setCommitType( $commit )
     {
-        $this->gateway->setCommit( $commit );
+        $this->gateway->setCommitType( $commit );
     }
 }
 

--- a/eZ/Publish/Core/Persistence/Solr/Slot.php
+++ b/eZ/Publish/Core/Persistence/Solr/Slot.php
@@ -46,7 +46,7 @@ abstract class Slot extends BaseSlot
         $this->repository->commitEvent(
             function ( $lastEvent ) use ( $searchHandler, $content )
             {
-                $searchHandler->setCommit( $lastEvent );
+                $searchHandler->setCommitType( $lastEvent ? 'soft' : false );
                 $searchHandler->indexContent( $content );
             }
         );
@@ -65,7 +65,7 @@ abstract class Slot extends BaseSlot
         $this->repository->commitEvent(
             function ( $lastEvent ) use ( $searchHandler, $contentId, $versionNo )
             {
-                $searchHandler->setCommit( $lastEvent );
+                $searchHandler->setCommitType( $lastEvent ? 'soft' : false );
                 $searchHandler->deleteContent( $contentId, $versionNo );
             }
         );
@@ -83,7 +83,7 @@ abstract class Slot extends BaseSlot
         $this->repository->commitEvent(
             function ( $lastEvent ) use ( $searchHandler, $locationId )
             {
-                $searchHandler->setCommit( $lastEvent );
+                $searchHandler->setCommitType( $lastEvent ? 'soft' : false );
                 $searchHandler->deleteLocation( $locationId );
             }
         );


### PR DESCRIPTION
Change the commit type used by solr handler to "soft" by default as hard commits in Solr 4.x seems to be handled automatically by autoCommit by default. Expose configuration so this is configurable.

Todo
- [ ] Don't expose setCommitType(), only "setCommitConfigurationEnabled()", otherwise inline hardcoding of type is encouraged while this should rather be a indexing strategy for configuration
- [ ] Discuss the needs for commit config, what needs to be exposed in a Solr 4.x env (some older options are not so relevant anymore, and hence should be skipped)
- [ ] Wire up yml config for this, in a site access/group/repo aware way
- [ ] Get feedback on other things to improve regarding indexing.
