### PR TITLE
Fixed: avoid unnecessary container re-initialization

### DIFF
--- a/eZ/Publish/SPI/Tests/FieldType/BinaryFileIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BinaryFileIntegrationTest.php
@@ -48,7 +48,7 @@ class BinaryFileIntegrationTest extends FileBaseIntegrationTest
      */
     protected function getStoragePrefix()
     {
-        return $this->getContainer()->getParameter( 'binaryfile_storage_prefix' );
+        return self::$container->getParameter( 'binaryfile_storage_prefix' );
     }
 
     /**
@@ -79,7 +79,7 @@ class BinaryFileIntegrationTest extends FileBaseIntegrationTest
                 array(
                     'LegacyStorage' => new FieldType\BinaryFile\BinaryFileStorage\Gateway\LegacyStorage(),
                 ),
-                $this->getContainer()->get( "ezpublish.fieldType.ezbinaryfile.io_service" ),
+                self::$container->get( "ezpublish.fieldType.ezbinaryfile.io_service" ),
                 new FieldType\BinaryBase\PathGenerator\LegacyPathGenerator(),
                 new FileInfo()
             )

--- a/eZ/Publish/SPI/Tests/FieldType/FileBaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/FileBaseIntegrationTest.php
@@ -55,6 +55,8 @@ abstract class FileBaseIntegrationTest extends BaseIntegrationTest
             $fs->mkdir( $storageDir );
         }
 
+        self::$setUp = false;
+
         parent::setUpBeforeClass();
     }
 
@@ -171,7 +173,7 @@ abstract class FileBaseIntegrationTest extends BaseIntegrationTest
 
     protected function getStorageDir()
     {
-        return ( self::$tmpDir ? self::$tmpDir . '/' : '' ) . $this->getContainer()->getParameter( 'storage_dir' );
+        return ( self::$tmpDir ? self::$tmpDir . '/' : '' ) . self::$container->getParameter( 'storage_dir' );
     }
 
     protected function getFilesize( $binaryFileId )

--- a/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
@@ -49,7 +49,7 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
      */
     protected function getStoragePrefix()
     {
-        return $this->getContainer()->getParameter( 'image_storage_prefix' );
+        return self::$container->getParameter( 'image_storage_prefix' );
     }
 
     /**
@@ -80,7 +80,7 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
                 array(
                     'LegacyStorage' => new FieldType\Image\ImageStorage\Gateway\LegacyStorage(),
                 ),
-                $this->getContainer()->get( "ezpublish.fieldType.ezimage.io" ),
+                self::$container->get( "ezpublish.fieldType.ezimage.io" ),
                 new FieldType\Image\PathGenerator\LegacyPathGenerator(),
                 new IO\MetadataHandler\ImageSize()
             )

--- a/eZ/Publish/SPI/Tests/FieldType/MediaIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/MediaIntegrationTest.php
@@ -48,7 +48,7 @@ class MediaIntegrationTest extends FileBaseIntegrationTest
      */
     protected function getStoragePrefix()
     {
-        return $this->getContainer()->getParameter( 'binaryfile_storage_prefix' );
+        return self::$container->getParameter( 'binaryfile_storage_prefix' );
     }
 
     /**
@@ -79,7 +79,7 @@ class MediaIntegrationTest extends FileBaseIntegrationTest
                 array(
                     'LegacyStorage' => new FieldType\Media\MediaStorage\Gateway\LegacyStorage(),
                 ),
-                $this->getContainer()->get( "ezpublish.fieldType.ezbinaryfile.io_service" ),
+                self::$container->get( "ezpublish.fieldType.ezbinaryfile.io_service" ),
                 new FieldType\BinaryBase\PathGenerator\LegacyPathGenerator(),
                 new FileInfo()
             )


### PR DESCRIPTION
SPI FieldType integration tests for Image, BinaryFile and Media were unnecessary re-initializing container.
This fixes the problem, resulting in speedup from ~30 sec to ~5 sec.

Merging after travis confirms.
