### PR TITLE
Fix EZP-22958: invalid values in subtree criterion handler

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Regression/EZP21906SearchOneContentMultipleLocationsTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP21906SearchOneContentMultipleLocationsTest.php
@@ -79,7 +79,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
                     array(
                         'criterion' => new Criterion\LogicalAnd(
                             array(
-                                new Criterion\Subtree( '/1/2' ),
+                                new Criterion\Subtree( '/1/2/' ),
                                 new Criterion\ContentTypeIdentifier( 'feedback_form' ),
                                 new Criterion\Visibility( Criterion\Visibility::VISIBLE )
                             )
@@ -93,7 +93,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
                     array(
                         'criterion' => new Criterion\LogicalAnd(
                             array(
-                                new Criterion\Subtree( '/1/2' ),
+                                new Criterion\Subtree( '/1/2/' ),
                                 new Criterion\ContentTypeIdentifier( 'feedback_form' ),
                                 new Criterion\Visibility( Criterion\Visibility::VISIBLE )
                             )
@@ -108,7 +108,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
                     array(
                         'criterion' => new Criterion\LogicalAnd(
                             array(
-                                new Criterion\Subtree( '/1/2' ),
+                                new Criterion\Subtree( '/1/2/' ),
                                 new Criterion\ContentTypeIdentifier( 'feedback_form' ),
                                 new Criterion\Visibility( Criterion\Visibility::VISIBLE )
                             )
@@ -123,7 +123,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
                     array(
                         'criterion' => new Criterion\LogicalAnd(
                             array(
-                                new Criterion\Subtree( '/1/2' ),
+                                new Criterion\Subtree( '/1/2/' ),
                                 new Criterion\ContentTypeIdentifier( 'feedback_form' ),
                                 new Criterion\Visibility( Criterion\Visibility::VISIBLE )
                             )
@@ -138,7 +138,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
                     array(
                         'criterion' => new Criterion\LogicalAnd(
                             array(
-                                new Criterion\Subtree( '/1/2' ),
+                                new Criterion\Subtree( '/1/2/' ),
                                 new Criterion\ContentTypeIdentifier( 'feedback_form' ),
                                 new Criterion\Visibility( Criterion\Visibility::VISIBLE )
                             )
@@ -153,7 +153,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
                     array(
                         'criterion' => new Criterion\LogicalAnd(
                             array(
-                                new Criterion\Subtree( '/1/2' ),
+                                new Criterion\Subtree( '/1/2/' ),
                                 new Criterion\ContentTypeIdentifier( 'folder' ),
                                 new Criterion\Visibility( Criterion\Visibility::VISIBLE )
                             )
@@ -168,7 +168,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
                     array(
                         'criterion' => new Criterion\LogicalAnd(
                             array(
-                                new Criterion\Subtree( '/1/2' ),
+                                new Criterion\Subtree( '/1/2/' ),
                                 new Criterion\ContentTypeIdentifier( 'folder' ),
                                 new Criterion\Visibility( Criterion\Visibility::VISIBLE )
                             )
@@ -183,7 +183,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
                     array(
                         'criterion' => new Criterion\LogicalAnd(
                             array(
-                                new Criterion\Subtree( '/1/2' ),
+                                new Criterion\Subtree( '/1/2/' ),
                                 new Criterion\ContentTypeIdentifier( 'folder' ),
                                 new Criterion\Visibility( Criterion\Visibility::VISIBLE )
                             )
@@ -198,7 +198,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
                     array(
                         'criterion' => new Criterion\LogicalAnd(
                             array(
-                                new Criterion\Subtree( '/1/2' ),
+                                new Criterion\Subtree( '/1/2/' ),
                                 new Criterion\ContentTypeIdentifier( 'folder' ),
                                 new Criterion\Visibility( Criterion\Visibility::VISIBLE )
                             )
@@ -213,7 +213,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
                     array(
                         'criterion' => new Criterion\LogicalAnd(
                             array(
-                                new Criterion\Subtree( '/1/2' ),
+                                new Criterion\Subtree( '/1/2/' ),
                                 new Criterion\ContentTypeIdentifier( 'product' ),
                                 new Criterion\Visibility( Criterion\Visibility::VISIBLE )
                             )

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP22958SearchSubtreePathstringFormatTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP22958SearchSubtreePathstringFormatTest.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * File containing the EZP22958SearchSubtreePathstringFormatTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\API\Repository\Tests\Regression;
+
+use eZ\Publish\API\Repository\Tests\BaseTest;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+
+/**
+ * @issue EZP-21906
+ */
+class EZP22958SearchSubtreePathstringFormatTest extends BaseTest
+{
+    protected function setUp()
+    {
+        parent::setUp();
+    }
+
+    /**
+     * Tests that path string provided for subtree criterion is valid
+     *
+     * @dataProvider searchContentQueryProvider
+     */
+    public function testSearchContentSubtree( $pathString, $expectedException = null )
+    {
+        if ( $expectedException )
+        {
+            $this->setExpectedException( $expectedException );
+        }
+
+        $query = new Query(
+            array(
+                'criterion' => new Criterion\Subtree( $pathString )
+            )
+        );
+
+        $result = $this->getRepository()->getSearchService()->findContent( $query );
+    }
+
+    public function searchContentQueryProvider()
+    {
+        return array(
+            array(
+                '/1/2/',
+                null
+            ),
+            array(
+                array( '/1/2/', '/1/2/4/' ),
+                null
+            ),
+            array(
+                '/1/2',
+                'InvalidArgumentException'
+            ),
+            array(
+                array( '/1/2/', '/1/2/4' ),
+                'InvalidArgumentException'
+            ),
+            array(
+                '/1/id0/',
+                null
+            ),
+            array(
+                '/1/id0',
+                'InvalidArgumentException'
+            ),
+        );
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Subtree.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Subtree.php
@@ -31,14 +31,10 @@ class Subtree extends Criterion implements CriterionInterface
      */
     public function __construct( $value )
     {
-        if ( is_array( $value ) )
+        foreach ( (array)$value as $pathString )
         {
-            if ( !isset( $value[0][0] ) || $value[0][0] !== '/' )
-                throw new InvalidArgumentException( "\$value array values must follow the pathString format, eg /1/2/" );
-        }
-        else if ( !isset( $value[0] ) || $value[0] !== '/' )
-        {
-            throw new InvalidArgumentException( "\$value array values must follow the pathString format, eg /1/2/" );
+            if ( preg_match( '/^(\/\w+)+\/$/', $pathString ) !== 1 )
+                throw new InvalidArgumentException( "value '$pathString' must follow the pathString format, eg /1/2/" );
         }
 
         parent::__construct( null, null, $value );

--- a/eZ/Publish/Core/Limitation/Tests/SubtreeLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/SubtreeLimitationTypeTest.php
@@ -100,6 +100,7 @@ class SubtreeLimitationTypeTest extends Base
             array( new SubtreeLimitation( array( 'limitationValues' => array( true ) ) ) ),
             array( new SubtreeLimitation( array( 'limitationValues' => array( 1 ) ) ) ),
             array( new SubtreeLimitation( array( 'limitationValues' => array( 0 ) ) ) ),
+            array( new SubtreeLimitation( array( 'limitationValues' => '/1/2/' ) ) ),
         );
     }
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22958

Add proper validation of subtree format (`/1/2/3/`) for all elements in the array $value passed to the Subtree criterion.

Note that this does force the pathString to end with a forward-slash (`/`).
