### PR TITLE
Added an API integration test on silent updates

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
@@ -708,6 +708,40 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
     }
 
     /**
+     * Tests updating the content without changing the field's value
+     * @depends testLoadFieldType
+     */
+    public function testUpdateFieldNoChange()
+    {
+        $content = $this->testPublishContent();
+
+        $repository     = $this->getRepository();
+        $contentService = $repository->getContentService();
+
+        $draft = $contentService->createContentDraft( $content->contentInfo );
+
+        $updateStruct = $contentService->newContentUpdateStruct();
+
+        $content = $contentService->updateContent( $draft->versionInfo, $updateStruct );
+
+        // testUpdateContentFieldStillAvailable
+        foreach ( $content->getFields() as $field )
+        {
+            if ( $field->fieldDefIdentifier === $this->customFieldIdentifier )
+            {
+                break;
+            }
+        }
+
+        if ( !isset( $field ) )
+        {
+            $this->fail( "Custom field not found." );
+        }
+
+        $this->assertFieldDataLoadedCorrect( $field );
+    }
+
+    /**
      * @depends testUpdateField
      */
     public function testUpdateTypeFieldStillAvailable( $content )


### PR DESCRIPTION
> **Tests fail, and it is normal**

Updates the content without changing the tested field's value, and asserts that the value was correctly copied.

it is known as failing on BinaryFile (see [EZP-22808](https://jira.ez.no/browse/EZP-22808)), and probably on others (Travis will tell).
