### PR TITLE
Fix: EZP-22959: trailing slash in unordered params not removed (legacy)

### DIFF
--- a/eZ/Publish/Core/MVC/Legacy/Kernel/URIHelper.php
+++ b/eZ/Publish/Core/MVC/Legacy/Kernel/URIHelper.php
@@ -25,12 +25,15 @@ class URIHelper
      */
     public function updateLegacyURI( Request $request )
     {
-        $uri = eZURI::instance();
-        $uri->setURIString(
+        $viewParametersString = rtrim(
             $request->attributes->get(
                 'semanticPathinfo',
                 $request->getPathinfo()
-            ) . $request->attributes->get( 'viewParametersString' )
+            ) . $request->attributes->get( 'viewParametersString' ),
+            '/'
         );
+
+        $uri = eZURI::instance();
+        $uri->setURIString( $viewParametersString );
     }
 }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-22959

When invoking an URI with a trailing slash, legacy should not have it included in view parameters.
