### PR TITLE
Fixed EZP-22552: 500 error on REST /content/views

### DIFF
--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestExecutedView.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestExecutedView.php
@@ -73,7 +73,7 @@ class RestExecutedView extends ValueObjectVisitor
 
         $generator->startAttribute(
             'href',
-            $this->router->generate( 'ezpublish_rest_loadView', array( 'viewId' => $data->identifier ) )
+            $this->router->generate( 'ezpublish_rest_getView', array( 'viewId' => $data->identifier ) )
         );
         $generator->endAttribute( 'href' );
 

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestExecutedViewTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestExecutedViewTest.php
@@ -39,7 +39,7 @@ class RestExecutedViewTest extends ValueObjectVisitorBaseTest
         );
 
         $this->addRouteExpectation(
-            'ezpublish_rest_loadView',
+            'ezpublish_rest_getView',
             array( 'viewId' => $view->identifier ),
             "/content/views/{$view->identifier}"
         );


### PR DESCRIPTION
> Fixes [EZP-22552](https://jira.ez.no/browse/EZP-22552)
> Status: ready

The RestExecutedView visitor was using a wrong route name. Weird that it showed up only now...
### TODO
- [x] Fix tests
