### PR TITLE
Fix EZP-22991: Added file exists control for parse method

### DIFF
--- a/eZ/Publish/Core/Persistence/TransformationProcessor/DefinitionBased/Parser.php
+++ b/eZ/Publish/Core/Persistence/TransformationProcessor/DefinitionBased/Parser.php
@@ -87,6 +87,11 @@ class Parser
      */
     public function parse( $file )
     {
+        if( !is_file($file) )
+        {
+            return array();
+        }
+        
         return $this->parseString(
             file_get_contents( $file )
         );

--- a/eZ/Publish/Core/Persistence/TransformationProcessor/DefinitionBased/Parser.php
+++ b/eZ/Publish/Core/Persistence/TransformationProcessor/DefinitionBased/Parser.php
@@ -87,11 +87,11 @@ class Parser
      */
     public function parse( $file )
     {
-        if( !is_file($file) )
+        if ( !is_file( $file ) )
         {
             return array();
         }
-        
+
         return $this->parseString(
             file_get_contents( $file )
         );


### PR DESCRIPTION
After update to 2014.03 version, when functional tests are launched the path of tr files is wrong. This PR add a file exists check before to launch the parseString method. 

This is not the better solution but I'm not sure if I can thrown an Exception (if so which one?) and, above all, if I can fix the path directly in the parse method. I don't know if this method is used elsewhere and if in other cases the path works fine.

Any suggestions in order to fix the issue are more than welcome.