### PR TITLE
Fix EZP-22609: Access to /user/login should redirect to new login resource

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/routing.yml
@@ -9,3 +9,13 @@ ezpublishSetup:
     path: /ezsetup
     defaults:
         _controller: ezpublish_legacy.setup.controller:init
+
+_ezpublishLegacyLogin:
+    path: /user/login
+    defaults:
+        _controller: ezpublish_legacy.controller:loginAction
+
+_ezpublishLegacyLogout:
+    path: /user/logout
+    defaults:
+        _controller: ezpublish_legacy.controller:logoutAction

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
@@ -115,6 +115,7 @@ services:
             - @ezpublish_legacy.uri_helper
             - @ezpublish_legacy.response_manager
             - @ezpublish_legacy.templating.legacy_helper
+            - @router
         calls:
             - [setRequest, [@?request=]]
 


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-22609

This patch safely redirects a user requesting access to legacy login (`/user/login`) to the new login resource (`/login`).
Note that siteaccesses in legacy mode will not be concerned as the newly created route (`_ezpublishLegacyLogin`) is not declared as _legacy aware_.

`/user/logout` is also taken into account.
