### PR TITLE
Fix EZP-23037: multiple JOINs in Subtree criterion

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Search/Gateway/CriterionHandler/Subtree.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Search/Gateway/CriterionHandler/Subtree.php
@@ -44,34 +44,12 @@ class Subtree extends CriterionHandler
      */
     public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
     {
-        $table = 'contentobject_subtree';
-
         $statements = array();
         foreach ( $criterion->value as $pattern )
         {
             $statements[] = $query->expr->like(
-                $this->dbHandler->quoteColumn( 'path_string', $table ),
+                $this->dbHandler->quoteColumn( 'path_string', 'ezcontentobject_tree' ),
                 $query->bindValue( $pattern . '%' )
-            );
-        }
-
-        $joinAlias = $query->alias(
-            $this->dbHandler->quoteTable( 'ezcontentobject_tree' ),
-            $this->dbHandler->quoteTable( $table )
-        );
-
-        // only perform LEFT JOIN with ezcontentobject_tree once for this query
-        if ( !strpos( $query->getQuery(), $joinAlias ) )
-        {
-            $query->leftJoin(
-                $query->alias(
-                    $this->dbHandler->quoteTable( 'ezcontentobject_tree' ),
-                    $this->dbHandler->quoteIdentifier( $table )
-                ),
-                $query->expr->eq(
-                    $this->dbHandler->quoteColumn( 'contentobject_id', $table ),
-                    $this->dbHandler->quoteColumn( 'id', 'ezcontentobject' )
-                )
             );
         }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Search/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Search/Gateway/DoctrineDatabase.php
@@ -201,6 +201,11 @@ class DoctrineDatabase extends Gateway
                 'ezcontentobject_version',
                 'ezcontentobject.id',
                 'ezcontentobject_version.contentobject_id'
+            )
+            ->leftJoin(
+                'ezcontentobject_tree',
+                'ezcontentobject_tree.contentobject_id',
+                'ezcontentobject.id'
             );
 
         if ( $sort !== null )
@@ -234,6 +239,7 @@ class DoctrineDatabase extends Gateway
         $query = $this->handler->createSelectQuery();
 
         $query->select(
+            'DISTINCT ' .
             $this->handler->quoteColumn( 'id', 'ezcontentobject' )
         );
 
@@ -242,14 +248,20 @@ class DoctrineDatabase extends Gateway
             $this->sortClauseConverter->applySelect( $query, $sort );
         }
 
-        $query->from(
-            $this->handler->quoteTable( 'ezcontentobject' )
-        );
-        $query->innerJoin(
-            'ezcontentobject_version',
-            'ezcontentobject.id',
-            'ezcontentobject_version.contentobject_id'
-        );
+        $query
+            ->from(
+                $this->handler->quoteTable( 'ezcontentobject' )
+            )
+            ->innerJoin(
+                'ezcontentobject_version',
+                'ezcontentobject.id',
+                'ezcontentobject_version.contentobject_id'
+            )
+            ->leftJoin(
+                'ezcontentobject_tree',
+                'ezcontentobject_tree.contentobject_id',
+                'ezcontentobject.id'
+            );
 
         if ( $sort !== null )
         {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23037

Problem: 
Subtree criterion is used in content search for user roles/permissions in policy and role assignment subtree limitations.
Given enough limitations, this will cause many JOIN clauses on simple content searches.
Depending on conditions, the above can cause severe performance degradation leading to MySQL timeouts (queries not finishing).

Since it seems there is no actual need for multiple joins, and the where conditions can all be done on the same table, this PR replaces the "unique table name join" with a single join clause on the contentobject_tree table, by looking at the existing aliases in `$query`.
