### PR TITLE
Update PHPUnit to ~4.1.3

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -42,29 +42,25 @@ if ( !empty( $settings['legacy_dir'] ) )
         require_once $settings['legacy_dir'] . '/autoload.php';
     }
 
-    // Define $legacyKernelHandler to whatever you need before loading this bootstrap file.
-    // CLI handler is used by defaut, but you must use \ezpKernelWeb if not in CLI context (i.e. REST server)
-    // $legacyKernelHandler can be a closure returning the appropriate kernel handler (to avoid autoloading issues)
-    if ( isset( $legacyKernelHandler ) )
+    if ( empty( $_ENV['legacyKernel'] ) )
     {
-        $legacyKernelHandler = $legacyKernelHandler instanceof \Closure ? $legacyKernelHandler() : $legacyKernelHandler;
-    }
-    else
-    {
-        $legacyKernelHandler = new LegacyKernelCLI;
-    }
-    $legacyKernel = new LegacyKernel( $legacyKernelHandler, $settings['legacy_dir'], getcwd() );
-    set_exception_handler( null );
-    // Avoid "Fatal error" text from legacy kernel if not called
-    $legacyKernel->runCallback(
-        function ()
+        // Define $legacyKernelHandler to whatever you need before loading this bootstrap file.
+        // CLI handler is used by defaut, but you must use \ezpKernelWeb if not in CLI context (i.e. REST server)
+        // $legacyKernelHandler can be a closure returning the appropriate kernel handler (to avoid autoloading issues)
+        if ( isset( $legacyKernelHandler ) )
         {
-            eZExecution::setCleanExit();
+            $legacyKernelHandler = $legacyKernelHandler instanceof \Closure ? $legacyKernelHandler() : $legacyKernelHandler;
         }
-    );
+        else
+        {
+            $legacyKernelHandler = new LegacyKernelCLI;
+        }
+        $legacyKernel = new LegacyKernel( $legacyKernelHandler, $settings['legacy_dir'], getcwd() );
 
-    // Exposing in env variables in order be able to use them in test cases.
-    $_ENV['legacyKernel'] = $legacyKernel;
-    $_ENV['legacyPath'] = $settings['legacy_dir'];
+        // Exposing in env variables in order be able to use them in test cases.
+        $_ENV['legacyKernel'] = $legacyKernel;
+        $_ENV['legacyPath'] = $settings['legacy_dir'];
+    }
+
     $_ENV['imagemagickConvertPath'] = $settings['imagemagick_convert_path'];
 }

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "require-dev": {
         "ezsystems/ezpublish-legacy": "@dev",
         "mikey179/vfsStream": "1.1.0",
-        "phpunit/phpunit": "3.7.*",
+        "phpunit/phpunit": "~4.1.3",
         "matthiasnoback/symfony-dependency-injection-test": "0.2.*",
         "mockery/mockery": "dev-master"
     },

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/LinkTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/LinkTest.php
@@ -7,7 +7,7 @@
  * @version //autogentag//
  */
 
-namespace eZ\Publish\Core\Repository\Tests\FieldType\RichText\Converter;
+namespace eZ\Publish\Core\FieldType\Tests\RichText\Converter;
 
 use eZ\Publish\Core\FieldType\RichText\Converter\Link;
 use PHPUnit_Framework_TestCase;

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Render/EmbedTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Render/EmbedTest.php
@@ -7,7 +7,7 @@
  * @version //autogentag//
  */
 
-namespace eZ\Publish\Core\Repository\Tests\FieldType\RichText\Converter\Render;
+namespace eZ\Publish\Core\FieldType\Tests\RichText\Converter\Render;
 
 use PHPUnit_Framework_TestCase;
 use eZ\Publish\Core\FieldType\RichText\Converter\Render\Embed;

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Render/TemplateTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Render/TemplateTest.php
@@ -7,7 +7,7 @@
  * @version //autogentag//
  */
 
-namespace eZ\Publish\Core\Repository\Tests\FieldType\RichText\Converter\Render;
+namespace eZ\Publish\Core\FieldType\Tests\RichText\Converter\Render;
 
 use PHPUnit_Framework_TestCase;
 use eZ\Publish\Core\FieldType\RichText\Converter\Render\Template;

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Gateway/LegacyStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Gateway/LegacyStorageTest.php
@@ -7,7 +7,7 @@
  * @version //autogentag//
  */
 
-namespace eZ\Publish\Core\Repository\Tests\FieldType\RichText\Gateway;
+namespace eZ\Publish\Core\FieldType\Tests\RichText\Gateway;
 
 use eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\LegacyStorage;
 use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\LegacyStorage as UrlStorage;

--- a/eZ/Publish/Core/FieldType/Tests/RichText/RichTextStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/RichTextStorageTest.php
@@ -7,7 +7,7 @@
  * @version //autogentag//
  */
 
-namespace eZ\Publish\Core\Repository\Tests\FieldType\RichText;
+namespace eZ\Publish\Core\FieldType\Tests\RichText;
 
 use eZ\Publish\Core\FieldType\RichText\RichTextStorage;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;

--- a/eZ/Publish/Core/FieldType/Tests/Url/Gateway/LegacyStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Url/Gateway/LegacyStorageTest.php
@@ -7,7 +7,7 @@
  * @version //autogentag//
  */
 
-namespace eZ\Publish\Core\Repository\Tests\FieldType\Url\Gateway;
+namespace eZ\Publish\Core\FieldType\Tests\Url\Gateway;
 
 use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\LegacyStorage;
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;

--- a/eZ/Publish/Core/FieldType/Tests/Url/UrlStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Url/UrlStorageTest.php
@@ -7,7 +7,7 @@
  * @version //autogentag//
  */
 
-namespace eZ\Publish\Core\Repository\Tests\FieldType\Url;
+namespace eZ\Publish\Core\FieldType\Tests\Url;
 
 use eZ\Publish\Core\FieldType\RichText\RichTextStorage;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/CustomTagsTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/CustomTagsTest.php
@@ -7,7 +7,7 @@
  * @version //autogentag//
  */
 
-namespace eZ\Publish\Core\Repository\Tests\FieldType\XmlText\Converter;
+namespace eZ\Publish\Core\FieldType\Tests\XmlText\Converter;
 
 use eZ\Publish\Core\FieldType\XmlText\Converter\CustomTags;
 use PHPUnit_Framework_TestCase;

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/EmbedToHtml5Test.php
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/EmbedToHtml5Test.php
@@ -7,7 +7,7 @@
  * @version //autogentag//
  */
 
-namespace eZ\Publish\Core\Repository\Tests\FieldType\XmlText\Converter;
+namespace eZ\Publish\Core\FieldType\Tests\XmlText\Converter;
 
 use eZ\Publish\Core\FieldType\XmlText\Converter\EmbedToHtml5;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/EzLinkToHtml5Test.php
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/EzLinkToHtml5Test.php
@@ -7,7 +7,7 @@
  * @version //autogentag//
  */
 
-namespace eZ\Publish\Core\Repository\Tests\FieldType\XmlText\Converter;
+namespace eZ\Publish\Core\FieldType\Tests\XmlText\Converter;
 
 use eZ\Publish\Core\FieldType\XmlText\Converter\EzLinkToHtml5;
 use PHPUnit_Framework_TestCase;

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/Html5Test.php
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/Html5Test.php
@@ -7,7 +7,7 @@
  * @version //autogentag//
  */
 
-namespace eZ\Publish\Core\Repository\Tests\FieldType\XmlText\Converter;
+namespace eZ\Publish\Core\FieldType\Tests\XmlText\Converter;
 
 use eZ\Publish\Core\FieldType\XmlText\Converter\Html5;
 use PHPUnit_Framework_TestCase;
@@ -20,10 +20,18 @@ use DOMXPath;
  */
 class Html5Test extends PHPUnit_Framework_TestCase
 {
+    protected $file;
 
     protected function getDefaultStylesheet()
     {
-        return __DIR__ . '../../../../XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl';
+        if ( !empty( $this->file ) )
+            return $this->file;
+
+        $file = __DIR__ . '/../../../XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl';
+        if ( !file_exists( $file ) )
+            throw new \InvalidArgumentException( "Could not find: " . $file );
+
+        return $this->file = $file;
     }
 
     protected function getPreConvertMock()
@@ -55,6 +63,7 @@ class Html5Test extends PHPUnit_Framework_TestCase
     public function testPreConverterCalled()
     {
         $dom = new DOMDocument();
+        $dom->loadXML( '<?xml version="1.0" encoding="utf-8"?><section/>' );
         $preConverterMock1 = $this->getPreConvertMock();
         $preConverterMock2 = $this->getPreConvertMock();
 

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Gateway/LegacyStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Gateway/LegacyStorageTest.php
@@ -7,7 +7,7 @@
  * @version //autogentag//
  */
 
-namespace eZ\Publish\Core\Repository\Tests\FieldType\XmlText\Gateway;
+namespace eZ\Publish\Core\FieldType\Tests\XmlText\Gateway;
 
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Input/EzXmlTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Input/EzXmlTest.php
@@ -7,7 +7,7 @@
  * @version //autogentag//
  */
 
-namespace eZ\Publish\Core\Repository\Tests\FieldType\XmlText\Input;
+namespace eZ\Publish\Core\FieldType\Tests\XmlText\Input;
 
 use eZ\Publish\Core\FieldType\XmlText\Input\EzXml;
 use PHPUnit_Framework_TestCase;


### PR DESCRIPTION
Also fix:
- boostrap.php to avoid causing out of memory issue with 256Mb memory_limit
- Empty DomDocument casuing Html5Test.php to fail
- Wrong namespace used in several FielType\Tests

Why?
Travis just updated to latests PHP version which has a BC break only fixed in latest version of PHPUnit.
