### PR TITLE
typo and cs changes in the defaultValues var

### DIFF
--- a/eZ/Publish/Core/FieldType/User/UserStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/User/UserStorage/Gateway/LegacyStorage.php
@@ -21,19 +21,19 @@ class LegacyStorage extends Gateway
     protected $dbHandler;
 
     /**
-     * Default values for user fielfs
+     * Default values for user fields
      *
      * @var array
      */
     protected $defaultValues = array(
-        'hasStoredLogin'   => false,
-        'contentId'   => null,
-        'login'              => null,
-        'email'              => null,
-        'passwordHash'      => null,
+        'hasStoredLogin' => false,
+        'contentId' => null,
+        'login' => null,
+        'email' => null,
+        'passwordHash' => null,
         'passwordHashType' => null,
-        'enabled'         => false,
-        'maxLogin'          => null,
+        'enabled' => false,
+        'maxLogin' => null,
     );
 
     /**


### PR DESCRIPTION
While viewing this class i found that piece of code that doesn't seem to respect our coding standards or, at least, it was indented in a weird way. Also found that typo in the phpdoc. 
I don't think we need an issue for this, but let me know if you want me to do it. 
