### PR TITLE
Fix EZP-22775: Handle missing API Limitations better

### DIFF
--- a/eZ/Publish/API/Repository/Exceptions/NotFound/LimitationNotFoundException.php
+++ b/eZ/Publish/API/Repository/Exceptions/NotFound/LimitationNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * This file is part of the eZ Publish package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Publish\API\Repository\Exceptions\NotFound;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+
+/**
+ * This Exception is thrown if repository did not find the limitation.
+ *
+ * @package eZ\Publish\API\Repository\Exceptions
+ */
+abstract class LimitationNotFoundException extends NotFoundException
+{
+}

--- a/eZ/Publish/API/Repository/RoleService.php
+++ b/eZ/Publish/API/Repository/RoleService.php
@@ -114,6 +114,7 @@ interface RoleService
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read this role
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a role with the given name was not found
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFound\LimitationNotFoundException On missing Policy Limitation
      *
      * @param mixed $id
      *
@@ -126,6 +127,7 @@ interface RoleService
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read this role
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a role with the given name was not found
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFound\LimitationNotFoundException On missing Policy Limitation
      *
      * @param string $identifier
      *
@@ -137,6 +139,7 @@ interface RoleService
      * Loads all roles
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the roles
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFound\LimitationNotFoundException On missing Policy Limitation
      *
      * @return \eZ\Publish\API\Repository\Values\User\Role[]
      */
@@ -155,6 +158,7 @@ interface RoleService
      * Loads all policies from roles which are assigned to a user or to user groups to which the user belongs
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user with the given id was not found
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFound\LimitationNotFoundException On missing Policy Limitation
      *
      * @param mixed $userId
      *
@@ -212,6 +216,7 @@ interface RoleService
      * Returns the assigned user and user groups to this role
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a role
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFound\LimitationNotFoundException On missing Policy Limitation
      *
      * @param \eZ\Publish\API\Repository\Values\User\Role $role
      *
@@ -223,6 +228,7 @@ interface RoleService
      * Returns the roles assigned to the given user
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a user
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFound\LimitationNotFoundException On missing Policy Limitation
      *
      * @param \eZ\Publish\API\Repository\Values\User\User $user
      *
@@ -234,6 +240,7 @@ interface RoleService
      * Returns the roles assigned to the given user group
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read a user group
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFound\LimitationNotFoundException On missing Policy Limitation
      *
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
      *
@@ -281,7 +288,7 @@ interface RoleService
      *
      * @return \eZ\Publish\SPI\Limitation\Type
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if there is no LimitationType with $identifier
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFound\LimitationNotFoundException On missing Limitation
      */
     public function getLimitationType( $identifier );
 

--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -135,6 +135,13 @@ class SearchServiceTest extends BaseTest
             ),
             array(
                 array(
+                    'filter' => new Criterion\MatchNone(),
+                    'sortClauses' => array( new SortClause\ContentId() )
+                ),
+                $fixtureDir . 'MatchNone.php',
+            ),
+            array(
+                array(
                     'filter' => new Criterion\ContentTypeGroupId(
                         2
                     ),

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/MatchNone.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/MatchNone.php
@@ -1,0 +1,16 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(array(
+   'facets' =>
+  array (
+  ),
+   'searchHits' =>
+  array (
+  ),
+   'spellSuggestion' => NULL,
+   'time' => 1,
+   'timedOut' => NULL,
+   'maxScore' => NULL,
+   'totalCount' => 0,
+));
+

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/MatchNone.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/MatchNone.php
@@ -1,0 +1,16 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(array(
+   'facets' =>
+  array (
+  ),
+   'searchHits' =>
+  array (
+  ),
+   'spellSuggestion' => NULL,
+   'time' => 1,
+   'timedOut' => NULL,
+   'maxScore' => NULL,
+   'totalCount' => 0,
+));
+

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchNone.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchNone.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This file is part of the eZ Publish package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
+
+/**
+ * A criterion that just matches nothing
+ *
+ * Useful for BlockingLimitation type, where a limitation is typically missing and needs to
+ * tell the system should block everything within the OR conditions it might be part of.
+ */
+class MatchNone extends Criterion implements CriterionInterface
+{
+    public function __construct()
+    {
+        // Do NOT call parent constructor. It tries to be too smart.
+    }
+
+    public function getSpecifications()
+    {
+        return array();
+    }
+
+    public static function createFromQueryBuilder( $target, $operator, $value )
+    {
+        return new self();
+    }
+}

--- a/eZ/Publish/API/Repository/Values/User/Limitation/BlockingLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/BlockingLimitation.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This file is part of the eZ Publish package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Publish\API\Repository\Values\User\Limitation;
+
+use eZ\Publish\API\Repository\Values\User\Limitation;
+
+/*
+ * A always blocking limitation
+ *
+ * Meant mainly for use with not implemented limitations, like legacy limitations which are not used by Platform stack.
+ */
+class BlockingLimitation extends Limitation
+{
+    /**
+     * @var string
+     */
+    protected $identifier;
+
+    /**
+     * Create new Blocking Limitation with identifier injected dynamically
+     *
+     * @throws \InvalidArgumentException If $identifier is empty
+     * @param string $identifier The identifier of the limitation
+     * @param array $limitationValues
+     */
+    public function __construct( $identifier, array $limitationValues )
+    {
+        if ( empty( $identifier ) )
+        {
+            throw new \InvalidArgumentException( 'Argument $identifier can not be empty' );
+        }
+
+        parent::__construct( array( 'identifier' => $identifier, 'limitationValues' => $limitationValues ) );
+    }
+
+    /**
+     * @see \eZ\Publish\API\Repository\Values\User\Limitation::getIdentifier()
+     *
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+}

--- a/eZ/Publish/Core/Base/Exceptions/NotFound/LimitationNotFoundException.php
+++ b/eZ/Publish/Core/Base/Exceptions/NotFound/LimitationNotFoundException.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of the eZ Publish package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Publish\Core\Base\Exceptions\NotFound;
+
+use eZ\Publish\API\Repository\Exceptions\NotFound\LimitationNotFoundException as APILimitationNotFoundException;
+use eZ\Publish\Core\Base\Exceptions\Httpable;
+use Exception;
+
+/**
+ * Limitation Not Found Exception implementation
+ */
+class LimitationNotFoundException extends APILimitationNotFoundException implements Httpable
+{
+    /**
+     * Creates a Limitation Not Found exception with info on how to fix
+     *
+     * @param string $limitation
+     * @param \Exception|null $previous
+     */
+    public function __construct( $limitation, Exception $previous = null )
+    {
+        parent::__construct(
+            "Limitation '{$limitation}' not found, needs to be implemented or configured to use "
+            . "Limitation\\BlockingLimitationType (%ezpublish.api.role.limitation_type.blocking.class%)",
+            self::INTERNAL_ERROR,
+            $previous
+        );
+    }
+}

--- a/eZ/Publish/Core/Limitation/BlockingLimitationType.php
+++ b/eZ/Publish/Core/Limitation/BlockingLimitationType.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * This file is part of the eZ Publish package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Publish\Core\Limitation;
+
+use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\Limitation as APILimitationValue;
+use eZ\Publish\API\Repository\Values\User\Limitation\BlockingLimitation as APIBlockingLimitation;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\SPI\Limitation\Type as SPILimitationTypeInterface;
+
+/**
+ * BlockingLimitationType is a limitation type that always says no to the permission system.
+ *
+ * It is for use in cases where a limitation is not implemented, or limitation is legacy specific
+ * and it is then not possible to know when to say yes, so we need to say no.
+ */
+class BlockingLimitationType implements SPILimitationTypeInterface
+{
+    /**
+     * @var string
+     */
+    private $identifier;
+
+    /**
+     * Create new Blocking Limitation with identifier injected dynamically
+     *
+     * @throws \InvalidArgumentException If $identifier is empty
+     * @param string $identifier The identifier of the limitation
+     */
+    public function __construct( $identifier )
+    {
+        if ( empty( $identifier ) )
+        {
+            throw new \InvalidArgumentException( 'Argument $identifier can not be empty' );
+        }
+
+        $this->identifier = $identifier;
+    }
+
+    /**
+     * Accepts a Blocking Limitation value and checks for structural validity.
+     *
+     * Makes sure LimitationValue object and ->limitationValues is of correct type.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If the value does not match the expected type/structure
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation $limitationValue
+     */
+    public function acceptValue( APILimitationValue $limitationValue )
+    {
+        if ( !$limitationValue instanceof APIBlockingLimitation )
+        {
+            throw new InvalidArgumentType( "\$limitationValue", "BlockingLimitation", $limitationValue );
+        }
+        else if ( !is_array( $limitationValue->limitationValues ) )
+        {
+            throw new InvalidArgumentType( "\$limitationValue->limitationValues", "array", $limitationValue->limitationValues );
+        }
+    }
+
+    /**
+     * Makes sure LimitationValue->limitationValues is valid according to valueSchema().
+     *
+     * Make sure {@link acceptValue()} is checked first!
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation $limitationValue
+     *
+     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
+     */
+    public function validate( APILimitationValue $limitationValue )
+    {
+        $validationErrors = array();
+        if ( empty( $limitationValue->limitationValues ) )
+        {
+            $validationErrors[] = new ValidationError(
+                "\$limitationValue->limitationValues => '%value%' can not be empty",
+                null,
+                array(
+                    "value" => $limitationValue->limitationValues,
+                )
+            );
+        }
+        return $validationErrors;
+    }
+
+    /**
+     * Create the Limitation Value
+     *
+     * @param mixed[] $limitationValues
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\Limitation
+     */
+    public function buildValue( array $limitationValues )
+    {
+        return new APIBlockingLimitation( $this->identifier, $limitationValues );
+    }
+
+    /**
+     * Evaluate permission against content & target(placement/parent/assignment)
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If any of the arguments are invalid
+     *         Example: If LimitationValue is instance of ContentTypeLimitationValue, and Type is SectionLimitationType.
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If value of the LimitationValue is unsupported
+     *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
+     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\ValueObject $object
+     * @param \eZ\Publish\API\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
+     *
+     * @return boolean
+     */
+    public function evaluate( APILimitationValue $value, APIUser $currentUser, ValueObject $object, array $targets = null )
+    {
+        if ( !$value instanceof APIBlockingLimitation )
+        {
+            throw new InvalidArgumentException( '$value', 'Must be of type: BlockingLimitation' );
+        }
+
+        return false;
+    }
+
+    /**
+     * Returns Criterion for use in find() query
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
+     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
+     */
+    public function getCriterion( APILimitationValue $value, APIUser $currentUser )
+    {
+        return new Criterion\MatchNone();
+    }
+
+    /**
+     * Returns info on valid $limitationValues
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException Values will need to be injected in ctor.
+     * @return mixed[]|int In case of array, a hash with key as valid limitations value and value as human readable name
+     *                     of that option, in case of int on of VALUE_SCHEMA_ constants.
+     */
+    public function valueSchema()
+    {
+        throw new NotImplementedException( __METHOD__ );
+    }
+}

--- a/eZ/Publish/Core/Limitation/Tests/BlockingLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/BlockingLimitationTypeTest.php
@@ -1,0 +1,299 @@
+<?php
+/**
+ * This file is part of the eZ Publish package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Publish\Core\Limitation\Tests;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\API\Repository\Values\User\Limitation\BlockingLimitation;
+use eZ\Publish\API\Repository\Values\User\Limitation\ObjectStateLimitation;
+use eZ\Publish\Core\Limitation\BlockingLimitationType;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+use eZ\Publish\Core\Repository\Values\Content\ContentCreateStruct;
+
+/**
+ * Test Case for LimitationType
+ */
+class BlockingLimitationTypeTest extends Base
+{
+    /**
+     * @return \eZ\Publish\Core\Limitation\BlockingLimitationType
+     */
+    public function testConstruct()
+    {
+        return new BlockingLimitationType( 'Test' );
+    }
+
+    /**
+     * @return array
+     */
+    public function providerForTestAcceptValue()
+    {
+        return array(
+            array( new BlockingLimitation( 'Test', array() ) ),
+            array( new BlockingLimitation( 'FunctionList', array() ) )
+        );
+    }
+
+    /**
+     * @dataProvider providerForTestAcceptValue
+     * @depends testConstruct
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation\BlockingLimitation $limitation
+     * @param \eZ\Publish\Core\Limitation\BlockingLimitationType $limitationType
+     */
+    public function testAcceptValue( BlockingLimitation $limitation, BlockingLimitationType $limitationType )
+    {
+        $limitationType->acceptValue( $limitation );
+    }
+
+    /**
+     * @return array
+     */
+    public function providerForTestAcceptValueException()
+    {
+        return array(
+            array( new ObjectStateLimitation() )
+        );
+    }
+
+    /**
+     * @dataProvider providerForTestAcceptValueException
+     * @depends testConstruct
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation $limitation
+     * @param \eZ\Publish\Core\Limitation\BlockingLimitationType $limitationType
+     */
+    public function testAcceptValueException( Limitation $limitation, BlockingLimitationType $limitationType )
+    {
+        $limitationType->acceptValue( $limitation );
+    }
+
+    /**
+     * @return array
+     */
+    public function providerForTestValidatePass()
+    {
+        return array(
+            array( new BlockingLimitation( 'Test', array( 'limitationValues' => array( 'ezjscore::call' ) ) ) ),
+            array( new BlockingLimitation( 'Test', array( 'limitationValues' => array( 'ezjscore::call', 'my::call' ) ) ) ),
+        );
+    }
+
+    /**
+     * @dataProvider providerForTestValidatePass
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation\BlockingLimitation $limitation
+     */
+    public function testValidatePass( BlockingLimitation $limitation )
+    {
+        // Need to create inline instead of depending on testConstruct() to get correct mock instance
+        $limitationType = $this->testConstruct();
+
+        $validationErrors = $limitationType->validate( $limitation );
+        self::assertEmpty( $validationErrors );
+    }
+
+    /**
+     * @return array
+     */
+    public function providerForTestValidateError()
+    {
+        return array(
+            array( new BlockingLimitation( 'Test', array() ), 1 ),
+            array( new BlockingLimitation( 'Test', array( 'limitationValues' => array( 0 ) ) ), 0 ),
+            array( new BlockingLimitation( 'Test', array( 'limitationValues' => array( 0, PHP_INT_MAX ) ) ), 0 ),
+        );
+    }
+
+    /**
+     * @dataProvider providerForTestValidateError
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation\BlockingLimitation $limitation
+     * @param int $errorCount
+     */
+    public function testValidateError( BlockingLimitation $limitation, $errorCount )
+    {
+        $this->getPersistenceMock()
+                ->expects( $this->never() )
+                ->method( $this->anything() );
+
+        // Need to create inline instead of depending on testConstruct() to get correct mock instance
+        $limitationType = $this->testConstruct();
+
+        $validationErrors = $limitationType->validate( $limitation );
+        self::assertCount( $errorCount, $validationErrors );
+    }
+
+    /**
+     * @depends testConstruct
+     *
+     * @param \eZ\Publish\Core\Limitation\BlockingLimitationType $limitationType
+     */
+    public function testBuildValue( BlockingLimitationType $limitationType )
+    {
+        $expected = array( 'test', 'test' => 9 );
+        $value = $limitationType->buildValue( $expected );
+
+        self::assertInstanceOf( '\eZ\Publish\API\Repository\Values\User\Limitation\BlockingLimitation', $value );
+        self::assertInternalType( 'array', $value->limitationValues );
+        self::assertEquals( $expected, $value->limitationValues );
+    }
+
+    /**
+     * @return array
+     */
+    public function providerForTestEvaluate()
+    {
+        return array(
+            // ContentInfo, no access
+            array(
+                'limitation' => new BlockingLimitation( 'Test', array() ),
+                'object' => new ContentInfo(),
+                'targets' => array()
+            ),
+            // ContentInfo, no access
+            array(
+                'limitation' => new BlockingLimitation( 'Test', array( 'limitationValues' => array( 2 ) ) ),
+                'object' => new ContentInfo(),
+                'targets' => array()
+            ),
+            // ContentInfo, with access
+            array(
+                'limitation' => new BlockingLimitation( 'Test', array( 'limitationValues' => array( 66 ) ) ),
+                'object' => new ContentInfo( array( 'contentTypeId' => 66 ) ),
+                'targets' => array()
+            ),
+            // ContentCreateStruct, no access
+            array(
+                'limitation' => new BlockingLimitation( 'Test', array( 'limitationValues' => array( 2 ) ) ),
+                'object' => new ContentCreateStruct( array( 'contentType' => ((object)array( 'id' => 22 ) ) ) ),
+                'targets' => array()
+            ),
+            // ContentCreateStruct, with access
+            array(
+                'limitation' => new BlockingLimitation( 'Test', array( 'limitationValues' => array( 2, 43 ) ) ),
+                'object' => new ContentCreateStruct( array( 'contentType' => ((object)array( 'id' => 43 ) ) ) ),
+                'targets' => array()
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider providerForTestEvaluate
+     */
+    public function testEvaluate(
+        BlockingLimitation $limitation,
+        ValueObject $object,
+        array $targets
+    )
+    {
+        // Need to create inline instead of depending on testConstruct() to get correct mock instance
+        $limitationType = $this->testConstruct();
+
+        $userMock = $this->getUserMock();
+        $userMock
+            ->expects( $this->never() )
+            ->method( $this->anything() );
+
+        $persistenceMock = $this->getPersistenceMock();
+        $persistenceMock
+            ->expects( $this->never() )
+            ->method( $this->anything() );
+
+        $value = $limitationType->evaluate(
+            $limitation,
+            $userMock,
+            $object,
+            $targets
+        );
+
+        self::assertFalse( $value );
+    }
+
+    /**
+     * @return array
+     */
+    public function providerForTestEvaluateInvalidArgument()
+    {
+        return array(
+            // invalid limitation
+            array(
+                'limitation' => new ObjectStateLimitation(),
+                'object' => new ContentInfo(),
+                'targets' => array( new Location() ),
+            )
+        );
+    }
+
+    /**
+     * @dataProvider providerForTestEvaluateInvalidArgument
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testEvaluateInvalidArgument(
+        Limitation $limitation,
+        ValueObject $object,
+        array $targets
+    )
+    {
+        // Need to create inline instead of depending on testConstruct() to get correct mock instance
+        $limitationType = $this->testConstruct();
+
+        $userMock = $this->getUserMock();
+        $userMock
+            ->expects( $this->never() )
+            ->method( $this->anything() );
+
+        $persistenceMock = $this->getPersistenceMock();
+        $persistenceMock
+            ->expects( $this->never() )
+            ->method( $this->anything() );
+
+        $v = $limitationType->evaluate(
+            $limitation,
+            $userMock,
+            $object,
+            $targets
+        );
+        var_dump( $v );// intentional, debug in case no exception above
+    }
+
+    /**
+     * @depends testConstruct
+     *
+     * @param \eZ\Publish\Core\Limitation\BlockingLimitationType $limitationType
+     */
+    public function testGetCriterion( BlockingLimitationType $limitationType )
+    {
+        $criterion = $limitationType->getCriterion(
+            new BlockingLimitation( 'Test', array() ),
+            $this->getUserMock()
+        );
+
+        self::assertInstanceOf( '\eZ\Publish\API\Repository\Values\Content\Query\Criterion\MatchNone', $criterion );
+        self::assertInternalType( 'null', $criterion->value );
+        self::assertInternalType( 'null', $criterion->operator );
+    }
+
+    /**
+     * @depends testConstruct
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\NotImplementedException
+     *
+     * @param \eZ\Publish\Core\Limitation\BlockingLimitationType $limitationType
+     */
+    public function testValueSchema( BlockingLimitationType $limitationType )
+    {
+        self::assertEquals(
+            array(),
+            $limitationType->valueSchema()
+        );
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Search/Common/Gateway/CriterionHandler/MatchNone.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Search/Common/Gateway/CriterionHandler/MatchNone.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This file is part of the eZ Publish package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler;
+
+use eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriteriaConverter;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
+
+/**
+ * MatchNone criterion handler
+ */
+class MatchNone extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     *
+     * @return boolean
+     */
+    public function accept( Criterion $criterion )
+    {
+        return $criterion instanceof Criterion\MatchNone;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriteriaConverter $converter
+     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     *
+     * @return \eZ\Publish\Core\Persistence\Database\Expression
+     */
+    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    {
+        return $query->expr->not( $query->bindValue( '1' ) );
+    }
+}
+

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/CriterionVisitor/MatchNone.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/CriterionVisitor/MatchNone.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of the eZ Publish package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor;
+
+use eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+/**
+ * Visits the MatchNone criterion
+ */
+class MatchNone extends CriterionVisitor
+{
+    /**
+     * CHeck if visitor is applicable to current criterion
+     *
+     * @param Criterion $criterion
+     *
+     * @return boolean
+     */
+    public function canVisit( Criterion $criterion )
+    {
+        return $criterion instanceof Criterion\MatchNone;
+    }
+
+    /**
+     * Map field value to a proper Solr representation
+     *
+     * @param Criterion $criterion
+     * @param CriterionVisitor $subVisitor
+     *
+     * @return string
+     */
+    public function visit( Criterion $criterion, CriterionVisitor $subVisitor = null )
+    {
+        return 'NOT (*:*)';
+    }
+}
+

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -15,7 +15,6 @@ use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\User\Limitation;
-use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use Exception;
 use RuntimeException;
@@ -354,16 +353,7 @@ class Repository implements RepositoryInterface
                 if ( $spiPolicy->limitations === '*' && $spiRoleAssignment->limitationIdentifier === null )
                     return true;
 
-                try
-                {
-                    $permissionSet['policies'][] = $roleService->buildDomainPolicyObject( $spiPolicy );
-                }
-                catch ( APINotFoundException $e )
-                {
-                    // Limitation type (and value) missing, so no access on this set, continue to next one.
-                    // @todo Introduce logging here to warn about missing limitations, and more specific exception
-                    continue;
-                }
+                $permissionSet['policies'][] = $roleService->buildDomainPolicyObject( $spiPolicy );
             }
 
             if ( !empty( $permissionSet['policies'] ) )

--- a/eZ/Publish/Core/Repository/RoleService.php
+++ b/eZ/Publish/Core/Repository/RoleService.php
@@ -36,7 +36,7 @@ use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\SPI\Persistence\User\Handler;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
-use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\Base\Exceptions\NotFound\LimitationNotFoundException;
 use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
 use eZ\Publish\Core\Base\Exceptions\BadStateException;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
@@ -1021,7 +1021,7 @@ class RoleService implements RoleServiceInterface
     public function getLimitationType( $identifier )
     {
         if ( !isset( $this->settings['limitationTypes'][$identifier] ) )
-            throw new NotFoundException( 'Limitation', $identifier );
+            throw new LimitationNotFoundException( $identifier );
 
         return $this->settings['limitationTypes'][$identifier];
     }

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/RepositoryTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/RepositoryTest.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 
-use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\Base\Exceptions\NotFound\LimitationNotFoundException;
 use eZ\Publish\Core\Repository\Tests\Service\Mock\Base as BaseServiceMockTest;
 use eZ\Publish\SPI\Persistence\User\RoleAssignment;
 use eZ\Publish\SPI\Persistence\User\Role;
@@ -221,6 +221,9 @@ class RepositoryTest extends BaseServiceMockTest
         self::assertEquals( true, $result );
     }
 
+    /**
+     * @return array
+     */
     public function providerForTestHasAccessReturnsPermissionSets()
     {
         return array(
@@ -245,13 +248,13 @@ class RepositoryTest extends BaseServiceMockTest
                 array(
                     31 => $this->createRole(
                         array(
-                            array( "test-module", "test-function", "notfound" )
+                            array( "test-module", "test-function", "test-limitation" )
                         ),
                         31
                     ),
                     32 => $this->createRole(
                         array(
-                            array( "test-module", "test-function", "test-limitation" )
+                            array( "test-module", "test-function", "test-limitation2" )
                         ),
                         32
                     ),
@@ -332,7 +335,8 @@ class RepositoryTest extends BaseServiceMockTest
                 $policyName = "policy-" . $i . "-" . $k;
                 if ( $policy->limitations === 'notfound' )
                 {
-                    $return = $this->throwException( new NotFoundException( "Limitation", "notfound" ) );
+                    $return = $this->throwException( new LimitationNotFoundException( "notfound" ) );
+                    $this->setExpectedException( 'eZ\Publish\Core\Base\Exceptions\NotFound\LimitationNotFoundException' );
                 }
                 else
                 {
@@ -355,6 +359,146 @@ class RepositoryTest extends BaseServiceMockTest
             $permissionSets,
             $repositoryMock->hasAccess( "test-module", "test-function" )
         );
+    }
+
+    /**
+     * @return array
+     */
+    public function providerForTestHasAccessReturnsException()
+    {
+        return array(
+            array(
+                array(
+                    31 => $this->createRole(
+                        array(
+                            array( "test-module", "test-function", "notfound" )
+                        ),
+                        31
+                    ),
+                ),
+                array(
+                    new RoleAssignment(
+                        array(
+                            "roleId" => 31,
+                        )
+                    )
+                ),
+            ),
+            array(
+                array(
+                    31 => $this->createRole(
+                        array(
+                            array( "test-module", "test-function", "test-limitation" )
+                        ),
+                        31
+                    ),
+                    32 => $this->createRole(
+                        array(
+                            array( "test-module", "test-function", "notfound" )
+                        ),
+                        32
+                    ),
+                ),
+                array(
+                    new RoleAssignment(
+                        array(
+                            "roleId" => 31,
+                        )
+                    ),
+                    new RoleAssignment(
+                        array(
+                            "roleId" => 32,
+                        )
+                    ),
+                ),
+            )
+        );
+    }
+
+    /**
+     * Test for the hasAccess() method.
+     *
+     * @covers \eZ\Publish\API\Repository\Repository::hasAccess
+     * @dataProvider providerForTestHasAccessReturnsException
+     * @expectedException \eZ\Publish\Core\Base\Exceptions\NotFound\LimitationNotFoundException
+     */
+    public function testHasAccessReturnsException( array $roles, array $roleAssignments )
+    {
+        /** @var $userHandlerMock \PHPUnit_Framework_MockObject_MockObject */
+        $userHandlerMock = $this->getPersistenceMock()->userHandler();
+        $roleServiceMock = $this->getMock(
+            "eZ\\Publish\\Core\\Repository\\RoleService",
+            array(),
+            array(),
+            '',
+            false
+        );
+        $repositoryMock = $this->getMock(
+            "eZ\\Publish\\Core\\Repository\\Repository",
+            array( "getRoleService", "getCurrentUser" ),
+            array(
+                $this->getPersistenceMock(),
+            )
+        );
+
+        $repositoryMock
+            ->expects( $this->once() )
+            ->method( "getRoleService" )
+            ->will( $this->returnValue( $roleServiceMock ) );
+        $repositoryMock
+            ->expects( $this->once() )
+            ->method( "getCurrentUser" )
+            ->will( $this->returnValue( $this->getStubbedUser( 14 ) ) );
+
+        $userHandlerMock
+            ->expects( $this->once() )
+            ->method( "loadRoleAssignmentsByGroupId" )
+            ->with( $this->isType( "integer" ), $this->equalTo( true ) )
+            ->will( $this->returnValue( $roleAssignments ) );
+
+        foreach ( $roleAssignments as $at => $roleAssignment )
+        {
+            $userHandlerMock
+                ->expects( $this->at( $at + 1 ) )
+                ->method( "loadRole" )
+                ->with( $roleAssignment->roleId )
+                ->will( $this->returnValue( $roles[$roleAssignment->roleId] ) );
+        }
+
+        $permissionSets = array();
+        /** @var $roleAssignments \eZ\Publish\SPI\Persistence\User\RoleAssignment[] */
+        $count = 0;
+        foreach ( $roleAssignments as $i => $roleAssignment )
+        {
+            $permissionSet = array( "limitation" => null );
+            foreach ( $roles[$roleAssignment->roleId]->policies as $k => $policy )
+            {
+                $policyName = "policy-" . $i . "-" . $k;
+                if ( $policy->limitations === 'notfound' )
+                {
+                    $return = $this->throwException( new LimitationNotFoundException( "notfound" ) );
+                }
+                else
+                {
+                    $return = $this->returnValue( $policyName );
+                    $permissionSet["policies"][] = $policyName;
+                }
+
+                $roleServiceMock
+                    ->expects( $this->at( $count++ ) )
+                    ->method( "buildDomainPolicyObject" )
+                    ->with( $policy )
+                    ->will( $return );
+
+                if ( $policy->limitations === 'notfound' )
+                {
+                    break 2;// no more execution after exception
+                }
+            }
+        }
+
+        /** @var $repositoryMock \eZ\Publish\Core\Repository\Repository */
+        $repositoryMock->hasAccess( "test-module", "test-function" );
     }
 
     public function providerForTestHasAccessReturnsPermissionSetsWithRoleLimitation()

--- a/eZ/Publish/Core/settings/roles.yml
+++ b/eZ/Publish/Core/settings/roles.yml
@@ -1,4 +1,5 @@
 parameters:
+    ezpublish.api.role.limitation_type.blocking.class: eZ\Publish\Core\Limitation\BlockingLimitationType
     ezpublish.api.role.limitation_type.content_type.class: eZ\Publish\Core\Limitation\ContentTypeLimitationType
     ezpublish.api.role.limitation_type.language.class: eZ\Publish\Core\Limitation\LanguageLimitationType
     ezpublish.api.role.limitation_type.location.class: eZ\Publish\Core\Limitation\LocationLimitationType
@@ -16,6 +17,17 @@ parameters:
     ezpublish.api.role.limitation_type.status.class: eZ\Publish\Core\Limitation\StatusLimitationType
 
 services:
+    ## Non implemented Limitations
+
+    # FunctionList is a ezjscore limitations, it only applies to ezjscore policies not used by
+    # platform stack so configuring it as blocking to avoid exceptions about missing implementation
+    ezpublish.api.role.limitation_type.function_list:
+        class: %ezpublish.api.role.limitation_type.blocking.class%
+        arguments: ['FunctionList']
+        tags:
+            - {name: ezpublish.limitationType, alias: FunctionList}
+
+    ## Implemented Limitations
     ezpublish.api.role.limitation_type.content_type:
         class: %ezpublish.api.role.limitation_type.content_type.class%
         arguments: [@ezpublish.api.persistence_handler]

--- a/eZ/Publish/Core/settings/storage_engines/legacy/search_query_handlers.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/search_query_handlers.yml
@@ -15,6 +15,7 @@ parameters:
     ezpublish.persistence.legacy.search.gateway.criterion_handler.common.logical_or.class: eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\LogicalOr
     ezpublish.persistence.legacy.search.gateway.criterion_handler.common.map_location_distance.class: eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\MapLocationDistance
     ezpublish.persistence.legacy.search.gateway.criterion_handler.common.match_all.class: eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\MatchAll
+    ezpublish.persistence.legacy.search.gateway.criterion_handler.common.match_none.class: eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\MatchNone
     ezpublish.persistence.legacy.search.gateway.criterion_handler.common.object_state_id.class: eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\ObjectStateId
     ezpublish.persistence.legacy.search.gateway.criterion_handler.common.field_relation.class: eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\FieldRelation
     ezpublish.persistence.legacy.search.gateway.criterion_handler.common.remote_id.class: eZ\Publish\Core\Persistence\Legacy\Content\Search\Common\Gateway\CriterionHandler\RemoteId
@@ -219,6 +220,13 @@ services:
     ezpublish.persistence.legacy.search.gateway.criterion_handler.common.match_all:
         parent: ezpublish.persistence.legacy.search.gateway.criterion_handler.base
         class: %ezpublish.persistence.legacy.search.gateway.criterion_handler.common.match_all.class%
+        tags:
+            - {name: ezpublish.persistence.legacy.search.gateway.criterion_handler.content}
+            - {name: ezpublish.persistence.legacy.search.gateway.criterion_handler.location}
+
+    ezpublish.persistence.legacy.search.gateway.criterion_handler.common.match_none:
+        parent: ezpublish.persistence.legacy.search.gateway.criterion_handler.base
+        class: %ezpublish.persistence.legacy.search.gateway.criterion_handler.common.match_none.class%
         tags:
             - {name: ezpublish.persistence.legacy.search.gateway.criterion_handler.content}
             - {name: ezpublish.persistence.legacy.search.gateway.criterion_handler.location}

--- a/eZ/Publish/Core/settings/storage_engines/solr/criterion_visitors.yml
+++ b/eZ/Publish/Core/settings/storage_engines/solr/criterion_visitors.yml
@@ -1,5 +1,6 @@
 parameters:
     ezpublish.persistence.solr.search.content.criterion_visitor.match_all.class: eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor\MatchAll
+    ezpublish.persistence.solr.search.content.criterion_visitor.match_none.class: eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor\MatchNone
     ezpublish.persistence.solr.search.content.criterion_visitor.content_id_in.class: eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor\ContentIdIn
     ezpublish.persistence.solr.search.content.criterion_visitor.logical_and.class: eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor\LogicalAnd
     ezpublish.persistence.solr.search.content.criterion_visitor.logical_or.class: eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor\LogicalOr
@@ -31,6 +32,11 @@ parameters:
 services:
     ezpublish.persistence.solr.search.content.criterion_visitor.match_all:
         class: %ezpublish.persistence.solr.search.content.criterion_visitor.match_all.class%
+        tags:
+            - {name: ezpublish.persistence.solr.search.content.criterion_visitor}
+
+    ezpublish.persistence.solr.search.content.criterion_visitor.match_none:
+        class: %ezpublish.persistence.solr.search.content.criterion_visitor.match_none.class%
         tags:
             - {name: ezpublish.persistence.solr.search.content.criterion_visitor}
 


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-22775
## Originally approach

In #851 there was an attempt to solve the problem by catching the exceptions in Repository->hasAccess() and assume that user does not have access under the current policy and continue iterate to the next one. However this does not benefit use of RoleService (incl userhash generation++), where the exceptions are still the case and this can't be solved by silencing it (as you then loose the whole role in question as exception is thrown instead).
## New approach

Creates:
- A Blocking Limitation(Value) & LimitationType  (think Null FieldType, but instead of doing nothing always says no)
- A MatchNone Criterion
- Sub classed NotFoundException to LimitationNotFoundException to provide more information on how to solve in the exception message (we should do the same on field types)

The idea is that you can configure missing limitations to map to BLockingLimitation, which will by design make it clear you don't have access under the given policy, also when querying using MatchNone, as we can't possible know without actually implementing the Limitation.
#### Benefit

Avoid exceptions on Limitations with no implementation that we don't really care about in New stack as they are not planned to be used. Example: ezjscore FunctionList limitation (configured out of the box here)

<del>#### Open question
I have kept the catch clause in Repository->hasAccess() as added in #851, as it benefits pure usage of API (with exception of RoleService), however on the other side it hides missing configuration so can be argued to be removed to make this behave 100% like missing FieldTypes where you need to configure NullType.</del>

<ins>Decided to remove this to make it consistent</ins>
