### PR TITLE
EZP-22988: Repository exceptions should be more detailed

### DIFF
--- a/eZ/Publish/Core/Base/Exceptions/UnauthorizedException.php
+++ b/eZ/Publish/Core/Base/Exceptions/UnauthorizedException.php
@@ -16,18 +16,18 @@ use Exception;
  * UnauthorizedException Exception implementation
  *
  * Use:
- *   throw new UnauthorizedException( 'content', 'read', 42 );
+ *   throw new UnauthorizedException( 'content', 'read', array( 'contentId' => 42 ) );
  */
 class UnauthorizedException extends APIUnauthorizedException implements Httpable
 {
     /**
-     * Generates: User does not have access to '{$function}' '{$module}'[ with identifier '{$identifier}']
+     * Generates: User does not have access to '{$function}' '{$module}'[ with: %property.key% '%property.value%']
      *
-     * Example: User does not have access to 'read' 'content' with identifier '42'
+     * Example: User does not have access to 'read' 'content' with: id '44', type 'article'
      *
      * @param string $module The module name should be in sync with the name of the domain object in question
      * @param string $function
-     * @param string|null $identifier
+     * @param array $properties Key value pair with non sensitive data on what kind of data user does not have access to
      * @param \Exception|null $previous
      */
     public function __construct( $module, $function, array $properties = null, Exception $previous = null )
@@ -37,7 +37,7 @@ class UnauthorizedException extends APIUnauthorizedException implements Httpable
         {
             foreach ( $properties as $name => $value )
             {
-                $identificationString .= $identificationString === '' ? ' with' : ' and';
+                $identificationString .= $identificationString === '' ? ' with:' : ',';
                 $identificationString .= " {$name} '{$value}'";
             }
         }

--- a/eZ/Publish/Core/FieldType/XmlText/Converter/EmbedToHtml5.php
+++ b/eZ/Publish/Core/FieldType/XmlText/Converter/EmbedToHtml5.php
@@ -89,7 +89,7 @@ class EmbedToHtml5 implements Converter
                     && !$this->repository->canUser( 'content', 'view_embed', $content )
                 )
                 {
-                    throw new UnauthorizedException( 'content', 'read' );
+                    throw new UnauthorizedException( 'content', 'read', array( 'contentId' => $contentId ) );
                 }
 
                 // Check published status of the Content
@@ -98,7 +98,7 @@ class EmbedToHtml5 implements Converter
                     && !$this->repository->canUser( 'content', 'versionread', $content )
                 )
                 {
-                    throw new UnauthorizedException( 'content', 'versionread' );
+                    throw new UnauthorizedException( 'content', 'versionread', array( 'contentId' => $contentId ) );
                 }
 
                 $embedContent = $this->viewManager->renderContent( $content, $view, $parameters );
@@ -118,7 +118,7 @@ class EmbedToHtml5 implements Converter
                     && !$this->repository->canUser( 'content', 'view_embed', $location->getContentInfo(), $location )
                 )
                 {
-                    throw new UnauthorizedException( 'content', 'read' );
+                    throw new UnauthorizedException( 'content', 'read', array( 'locationId' => $location->id ) );
                 }
 
                 $embedContent = $this->viewManager->renderLocation( $location, $view, $parameters );

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -130,7 +130,7 @@ class ContentService implements ContentServiceInterface
     {
         $contentInfo = $this->internalLoadContentInfo( $contentId );
         if ( !$this->repository->canUser( 'content', 'read', $contentInfo ) )
-            throw new UnauthorizedException( 'content', 'read' );
+            throw new UnauthorizedException( 'content', 'read', array( 'contentId' => $contentId ) );
 
         return $contentInfo;
     }
@@ -184,7 +184,7 @@ class ContentService implements ContentServiceInterface
         $contentInfo = $this->internalLoadContentInfo( $remoteId, true );
 
         if ( !$this->repository->canUser( 'content', 'read', $contentInfo ) )
-            throw new UnauthorizedException( 'content', 'read' );
+            throw new UnauthorizedException( 'content', 'read', array( 'remoteId' => $remoteId ) );
 
         return $contentInfo;
     }
@@ -259,7 +259,7 @@ class ContentService implements ContentServiceInterface
 
         if ( !$this->repository->canUser( 'content', $function, $versionInfo ) )
         {
-            throw new UnauthorizedException( 'content', $function );
+            throw new UnauthorizedException( 'content', $function, array( 'contentId' => $contentId ) );
         }
 
         return $versionInfo;
@@ -343,13 +343,13 @@ class ContentService implements ContentServiceInterface
         $content = $this->internalLoadContent( $contentId, $languages, $versionNo, false, $useAlwaysAvailable );
 
         if ( !$this->repository->canUser( 'content', 'read', $content ) )
-            throw new UnauthorizedException( 'content', 'read' );
+            throw new UnauthorizedException( 'content', 'read', array( 'contentId' => $contentId ) );
 
         if (
             $content->getVersionInfo()->status !== APIVersionInfo::STATUS_PUBLISHED
             && !$this->repository->canUser( 'content', 'versionread', $content )
         )
-            throw new UnauthorizedException( 'content', 'versionread' );
+            throw new UnauthorizedException( 'content', 'versionread', array( 'contentId' => $contentId, 'versionNo' => $versionNo ) );
 
         return $content;
     }
@@ -445,13 +445,13 @@ class ContentService implements ContentServiceInterface
         $content = $this->internalLoadContent( $remoteId, $languages, $versionNo, true, $useAlwaysAvailable );
 
         if ( !$this->repository->canUser( 'content', 'read', $content ) )
-            throw new UnauthorizedException( 'content', 'read' );
+            throw new UnauthorizedException( 'content', 'read', array( 'remoteId' => $remoteId ) );
 
         if (
             $content->getVersionInfo()->status !== APIVersionInfo::STATUS_PUBLISHED
             && !$this->repository->canUser( 'content', 'versionread', $content )
         )
-            throw new UnauthorizedException( 'content', 'versionread' );
+            throw new UnauthorizedException( 'content', 'versionread', array( 'remoteId' => $remoteId, 'versionNo' => $versionNo ) );
 
         return $content;
     }
@@ -523,7 +523,17 @@ class ContentService implements ContentServiceInterface
 
         if ( !$this->repository->canUser( 'content', 'create', $contentCreateStruct, $locationCreateStructs ) )
         {
-            throw new UnauthorizedException( 'content', 'create' );
+            throw new UnauthorizedException(
+                'content',
+                'create',
+                array(
+                    'parentLocationId' =>
+                        isset( $locationCreateStructs[0] ) ?
+                            $locationCreateStructs[0]->parentLocationId :
+                            null,
+                    'sectionId' => $contentCreateStruct->sectionId
+                )
+            );
         }
 
         if ( !empty( $contentCreateStruct->remoteId ) )
@@ -906,7 +916,7 @@ class ContentService implements ContentServiceInterface
         $loadedContentInfo = $this->loadContentInfo( $contentInfo->id );
 
         if ( !$this->repository->canUser( 'content', 'edit', $loadedContentInfo ) )
-            throw new UnauthorizedException( 'content', 'edit' );
+            throw new UnauthorizedException( 'content', 'edit', array( 'contentId' => $loadedContentInfo->id ) );
 
         if ( isset( $contentMetadataUpdateStruct->remoteId ) )
         {
@@ -1028,7 +1038,7 @@ class ContentService implements ContentServiceInterface
         $contentInfo = $this->internalLoadContentInfo( $contentInfo->id );
 
         if ( !$this->repository->canUser( 'content', 'remove', $contentInfo ) )
-            throw new UnauthorizedException( 'content', 'remove' );
+            throw new UnauthorizedException( 'content', 'remove', array( 'contentId' => $contentInfo->id ) );
 
         $this->repository->beginTransaction();
         try
@@ -1120,7 +1130,7 @@ class ContentService implements ContentServiceInterface
         }
 
         if ( !$this->repository->canUser( 'content', 'edit', $contentInfo ) )
-            throw new UnauthorizedException( 'content', 'edit', array( 'name' => $contentInfo->name ) );
+            throw new UnauthorizedException( 'content', 'edit', array( 'contentId' => $contentInfo->id ) );
 
         $this->repository->beginTransaction();
         try
@@ -1170,7 +1180,7 @@ class ContentService implements ContentServiceInterface
         {
             $versionInfo = $this->domainMapper->buildVersionInfoDomainObject( $spiVersionInfo );
             if ( !$this->repository->canUser( 'content', 'versionread', $versionInfo ) )
-                throw new UnauthorizedException( 'content', 'versionread' );
+                throw new UnauthorizedException( 'content', 'versionread', array( 'contentId' => $versionInfo->contentInfo->id ) );
 
             $versionInfoList[] = $versionInfo;
         }
@@ -1235,7 +1245,7 @@ class ContentService implements ContentServiceInterface
         }
 
         if ( !$this->repository->canUser( 'content', 'edit', $content ) )
-            throw new UnauthorizedException( 'content', 'edit' );
+            throw new UnauthorizedException( 'content', 'edit', array( 'contentId' => $content->id ) );
 
         $mainLanguageCode = $content->contentInfo->mainLanguageCode;
         $languageCodes = $this->getLanguageCodesForUpdate( $contentUpdateStruct, $content );
@@ -1520,12 +1530,12 @@ class ContentService implements ContentServiceInterface
         {
             if ( !$this->repository->canUser( "content", "create", $content ) )
             {
-                throw new UnauthorizedException( 'content', 'create' );
+                throw new UnauthorizedException( 'content', 'create', array( 'contentId' => $content->id ) );
             }
         }
         else if ( !$this->repository->canUser( 'content', 'edit', $content ) )
         {
-            throw new UnauthorizedException( 'content', 'edit' );
+            throw new UnauthorizedException( 'content', 'edit', array( 'contentId' => $content->id ) );
         }
 
         $this->repository->beginTransaction();
@@ -1595,7 +1605,11 @@ class ContentService implements ContentServiceInterface
         }
 
         if ( !$this->repository->canUser( 'content', 'versionremove', $versionInfo ) )
-            throw new UnauthorizedException( 'content', 'versionremove' );
+            throw new UnauthorizedException(
+                'content',
+                'versionremove',
+                array( 'contentId' => $versionInfo->contentInfo->id, 'versionNo' => $versionInfo->versionNo )
+            );
 
         $this->repository->beginTransaction();
         try
@@ -1625,7 +1639,7 @@ class ContentService implements ContentServiceInterface
     public function loadVersions( ContentInfo $contentInfo )
     {
         if ( !$this->repository->canUser( 'content', 'versionread', $contentInfo ) )
-            throw new UnauthorizedException( 'content', 'versionread' );
+            throw new UnauthorizedException( 'content', 'versionread', array( 'contentId' => $contentInfo->id ) );
 
         $spiVersionInfoList = $this->persistenceHandler->contentHandler()->listVersions( $contentInfo->id );
 
@@ -1634,7 +1648,7 @@ class ContentService implements ContentServiceInterface
         {
             $versionInfo = $this->domainMapper->buildVersionInfoDomainObject( $spiVersionInfo );
             if ( !$this->repository->canUser( 'content', 'versionread', $versionInfo ) )
-                throw new UnauthorizedException( 'content', 'versionread' );
+                throw new UnauthorizedException( 'content', 'versionread', array( 'versionId' => $versionInfo->id ) );
 
             $versions[] = $versionInfo;
         }
@@ -1666,7 +1680,16 @@ class ContentService implements ContentServiceInterface
     public function copyContent( ContentInfo $contentInfo, LocationCreateStruct $destinationLocationCreateStruct, APIVersionInfo $versionInfo = null)
     {
         if ( !$this->repository->canUser( 'content', 'create', $contentInfo, $destinationLocationCreateStruct ) )
-            throw new UnauthorizedException( 'content', 'create' );
+        {
+            throw new UnauthorizedException(
+                'content',
+                'create',
+                array(
+                    'parentLocationId' => $destinationLocationCreateStruct->parentLocationId,
+                    'sectionId' => $contentInfo->sectionId
+                )
+            );
+        }
 
         $defaultObjectStates = $this->getDefaultObjectStates();
 
@@ -1770,7 +1793,7 @@ class ContentService implements ContentServiceInterface
     public function loadReverseRelations( ContentInfo $contentInfo )
     {
         if ( $this->repository->hasAccess( 'content', 'reverserelatedlist' ) !== true )
-            throw new UnauthorizedException( 'content', 'reverserelatedlist' );
+            throw new UnauthorizedException( 'content', 'reverserelatedlist', array( 'contentId' => $contentInfo->id ) );
 
         $spiRelations = $this->persistenceHandler->contentHandler()->loadReverseRelations(
             $contentInfo->id
@@ -1823,7 +1846,7 @@ class ContentService implements ContentServiceInterface
         }
 
         if ( !$this->repository->canUser( 'content', 'edit', $sourceVersion ) )
-            throw new UnauthorizedException( 'content', 'edit' );
+            throw new UnauthorizedException( 'content', 'edit', array( 'contentId' => $sourceVersion->contentInfo->id ) );
 
         $sourceContentInfo = $sourceVersion->getContentInfo();
 
@@ -1878,7 +1901,7 @@ class ContentService implements ContentServiceInterface
         }
 
         if ( !$this->repository->canUser( 'content', 'edit', $sourceVersion ) )
-            throw new UnauthorizedException( 'content', 'edit' );
+            throw new UnauthorizedException( 'content', 'edit', array( 'contentId' => $sourceVersion->contentInfo->id ) );
 
         $spiRelations = $this->persistenceHandler->contentHandler()->loadRelations(
             $sourceVersion->getContentInfo()->id,

--- a/eZ/Publish/Core/Repository/ObjectStateService.php
+++ b/eZ/Publish/Core/Repository/ObjectStateService.php
@@ -495,7 +495,7 @@ class ObjectStateService implements ObjectStateServiceInterface
     public function setContentState( ContentInfo $contentInfo, APIObjectStateGroup $objectStateGroup, APIObjectState $objectState )
     {
         if ( $this->repository->canUser( 'state', 'assign', $contentInfo, $objectState ) !== true )
-            throw new UnauthorizedException( 'state', 'assign' );
+            throw new UnauthorizedException( 'state', 'assign', array( 'contentId' => $contentInfo->id ) );
 
         $loadedObjectState = $this->loadObjectState( $objectState->id );
 

--- a/eZ/Publish/Core/Repository/SectionService.php
+++ b/eZ/Publish/Core/Repository/SectionService.php
@@ -303,7 +303,7 @@ class SectionService implements SectionServiceInterface
         $loadedSection = $this->loadSection( $section->id );
 
         if ( $this->repository->canUser( 'section', 'edit', $loadedSection ) !== true )
-            throw new UnauthorizedException( 'section', 'edit', array( 'name' => $loadedSection->name ) );
+            throw new UnauthorizedException( 'section', 'edit', array( 'sectionId' => $loadedSection->id ) );
 
         if ( $this->countAssignedContents( $loadedSection ) > 0 )
             throw new BadStateException( "section", 'section is still assigned to content' );

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -5315,7 +5315,7 @@ class ContentTest extends BaseServiceMockTest
 
         $contentInfo->expects( $this->any() )
             ->method( "__get" )
-            ->with( "id" )
+            ->with( "sectionId" )
             ->will( $this->returnValue( 42 ) );
 
         $repository->expects( $this->once() )


### PR DESCRIPTION
Like improvements to Limitation Not Found (#899) and Field Type Not Found (#901), for discussion:

```
Adds more info on UnauthorizedException as possible with $properties.
Provides object id's as it is assumed this is more safe then giving away
things like object names. Two occurances of where name where returned is
thus changed to use object id. Object id's are not very user friendly,
but it provides information for end users to provide to devloper /
adminstrator for further investigation if needed.
```

@gggeek: As your orginal source of this improvment request, is this
         within the goal you had in mind?

Review ping @crevillo
