### PR TITLE
Fix EZP-23057: viewContent does not set the X-Location-Id

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
@@ -269,6 +269,7 @@ class ViewController extends Controller
                 return $response;
             }
 
+            $response->headers->set( 'X-Location-Id', $content->contentInfo->mainLocationId );
             $response->setContent(
                 $this->renderContent( $content, $viewType, $layout, $params )
             );


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23057
# Description

The view content action in the view controller does not set the X-Location-Id header preventing the cache from being purged!

(Bug reported by @pborreli)
# Tests

manual test
