### PR TITLE
EZP-23074: Legacy formToken controller, render csrf-token meta tag

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/EventListener/KernelResponseListener.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/EventListener/KernelResponseListener.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * File containing the PreContentViewListener class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishLegacyBundle\EventListener;
+
+// add the new use statement at the top of your file
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
+use ezxFormToken;
+
+class KernelResponseListener
+{
+
+    private $fieldName;
+
+    /**
+     * CSRF token
+     *
+     * @var string
+     */
+    private $csrfToken = null;
+
+    /**
+     * @param CsrfProviderInterface $csrfProvider
+     */
+    public function __construct( $fieldName, CsrfProviderInterface $csrfProvider = null )
+    {
+        $this->fieldName = $fieldName;
+        if ( $csrfProvider )
+        {
+            $this->csrfToken = $csrfProvider->generateCsrfToken( 'legacy' );
+        }
+    }
+
+    public function onKernelResponse( FilterResponseEvent $event )
+    {
+        if ( !class_exists( 'ezxFormToken' ) || !ezxFormToken::isEnabled() )
+            return;
+
+        $response = $event->getResponse();
+        foreach ( $response->headers as $header )
+        {
+            // Search for a content-type header that is NOT HTML
+            if ( is_string( $header ) &&
+                stripos( $header, 'Content-Type:' ) === 0 &&
+                strpos( $header, 'text/html' ) === false &&
+                strpos( $header, 'application/xhtml+xml' ) === false )
+            {
+               return;
+            }
+        }
+
+        $content = $response->getContent();
+
+        // If document has head tag, insert in a html5 valid and semi standard way
+        if ( strpos( $content, '<head>' ) !== false )
+        {
+            $content = str_replace(
+                '<head>',
+                "<head>\n"
+                . "<meta name=\"csrf-param\" content=\"{$this->fieldName}\" />\n"
+                . "<meta name=\"csrf-token\" id=\"{$this->fieldName}_js\" title=\"{$this->csrfToken}\" content=\"{$this->csrfToken}\" />\n",
+                $content
+            );
+        }
+
+        $response->setContent( $content );
+    }
+}

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
@@ -60,6 +60,7 @@ parameters:
     ezpublish_legacy.request_listener.class: eZ\Bundle\EzPublishLegacyBundle\EventListener\RequestListener
     ezpublish_legacy.config_scope_listener.class: eZ\Bundle\EzPublishLegacyBundle\EventListener\ConfigScopeListener
     ezpublish_legacy.legacy_kernel_listener.class: eZ\Bundle\EzPublishLegacyBundle\EventListener\LegacyKernelListener
+    ezpublish_legacy.kernel_response_listener.class: eZ\Bundle\EzPublishLegacyBundle\EventListener\KernelResponseListener
 
     ezpublish_legacy.legacy_bundles.extension_locator.class: eZ\Bundle\EzPublishLegacyBundle\LegacyBundles\LegacyExtensionsLocator
 
@@ -296,6 +297,14 @@ services:
         class: %ezpublish_legacy.legacy_kernel_listener.class%
         tags:
             - { name: kernel.event_subscriber }
+
+    ezpublish_legacy.kernel_response_listener:
+        class: %ezpublish_legacy.kernel_response_listener.class%
+        tags:
+            - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
+        arguments:
+            - %form.type_extension.csrf.field_name%
+            - @?form.csrf_provider
 
     ezpublish_legacy.legacy_bundles.extension_locator:
         class: %ezpublish_legacy.legacy_bundles.extension_locator.class%


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23074

Legacy extensions using js/jquery/ezjscore expect a 'ezxform_token_js' tag, which is not displayed without a legacy pagelayout.
This PR adds a controller method in `EzPublishLegacyBundle` to render the csrf-token meta tag.
