### PR TITLE
FIX EZP-23080: Image/Type incorrectly checks for file existance

### DIFF
--- a/eZ/Publish/Core/FieldType/Image/Type.php
+++ b/eZ/Publish/Core/FieldType/Image/Type.php
@@ -106,11 +106,11 @@ class Type extends FieldType
     protected function checkValueStructure( BaseValue $value )
     {
         // Required parameter $path
-        if ( !isset( $value->id ) || !file_exists( $value->id ) )
+        if ( !isset( $value->id ) )
         {
             throw new InvalidArgumentValue(
-                '$value->path',
-                $value->path
+                '$value->id',
+                null
             );
         }
 


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-23080

`checkValueStructure()` is checking for existence of the image file, which may not be possible at this stage ( DFS cluster? )

AFAICT this is check is done by legacy io handler `exists()` when updating the field.
