### PR TITLE
Fix: exception messages with double single quotes (''string'')

### DIFF
--- a/eZ/Publish/Core/Base/Exceptions/InvalidArgumentValue.php
+++ b/eZ/Publish/Core/Base/Exceptions/InvalidArgumentValue.php
@@ -28,9 +28,10 @@ class InvalidArgumentValue extends InvalidArgumentException
      */
     public function __construct( $argumentName, $value, $className = null, Exception $previous = null )
     {
+        $valueStr = is_string( $value ) ? $value : var_export( $value, true );
         parent::__construct(
             $argumentName,
-            "'" . var_export( $value, true ) . "' is wrong value" . ( $className ? " in class '{$className}'" : "" ),
+            "'{$valueStr}' is wrong value" . ( $className ? " in class '{$className}'" : "" ),
             $previous
         );
     }

--- a/eZ/Publish/Core/Base/Exceptions/NotFoundException.php
+++ b/eZ/Publish/Core/Base/Exceptions/NotFoundException.php
@@ -29,10 +29,9 @@ class NotFoundException extends APINotFoundException implements Httpable
      */
     public function __construct( $what, $identifier, Exception $previous = null )
     {
+        $identifierStr = is_string( $identifier ) ? $identifier : var_export( $identifier, true );
         parent::__construct(
-            "Could not find '{$what}' with identifier '" .
-            ( is_array( $identifier ) ? var_export( $identifier, true ) : $identifier ) .
-            "'",
+            "Could not find '{$what}' with identifier '{$identifierStr}'",
             self::NOT_FOUND,
             $previous
         );


### PR DESCRIPTION
`InvalidArgumentValue` exception messages encode string values in single-quotes 2 times,
as var_export() already returns quoted strings.

Fix by not using var_export() for string types.
