### PR TITLE
Fix EZP-23064: Legacy script doesn't always receive --siteaccess option

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Command/LegacyEmbedScriptCommand.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Command/LegacyEmbedScriptCommand.php
@@ -61,6 +61,13 @@ EOT
             $GLOBALS['argv'][] = '--help';
         }
 
+        $siteAccess = $input->getOption( 'siteaccess' );
+        if ( $siteAccess && !in_array( "--siteaccess=$siteAccess", $_SERVER['argv'] ) )
+        {
+            $_SERVER['argv'][] = "--siteaccess=$siteAccess";
+            $GLOBALS['argv'][] = "--siteaccess=$siteAccess";
+        }
+
         $output->writeln( "<comment>Running script '$legacyScript' in eZ Publish legacy context</comment>" );
 
         /** @var $legacyCLIHandlerClosure \Closure */


### PR DESCRIPTION
When running legacy scripts from `ezpublish/console` and specifying `--siteaccess` option, the legacy script doesn't always receive passed SiteAccess, depending on where the option is placed (before or after the script argument).

The following **does not work** (SiteAccess lost, falling back to default one):

```
php ezpublish/console ezpublish:legacy:script --env=dev --siteaccess=ezdemo_site_admin extension/ezfind/bin/php/updatesearchindexsolr.php
```

While this will work (SiteAccess option _after_ the script argument):

```
php ezpublish/console ezpublish:legacy:script --env=dev extension/ezfind/bin/php/updatesearchindexsolr.php --siteaccess=ezdemo_site_admin
```

This patch ensures that the SiteAccess option is always passed.
