### PR TITLE
Fix EZP-23071: duplicate jquery inclusions break jquery plugins

### DIFF
--- a/eZ/Publish/Core/MVC/Legacy/Templating/LegacyHelper.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/LegacyHelper.php
@@ -61,9 +61,11 @@ class LegacyHelper extends ParameterBag
                 {
                     $that->set(
                         'css_files',
-                        ezjscPacker::buildStylesheetFiles(
-                            $moduleResult['content_info']['persistent_variable']['css_files'],
-                            0
+                        array_unique(
+                            ezjscPacker::buildStylesheetFiles(
+                                $moduleResult['content_info']['persistent_variable']['css_files'],
+                                0
+                            )
                         )
                     );
                 }
@@ -71,9 +73,11 @@ class LegacyHelper extends ParameterBag
                 {
                     $that->set(
                         'js_files',
-                        ezjscPacker::buildJavascriptFiles(
-                            $moduleResult['content_info']['persistent_variable']['js_files'],
-                            0
+                        array_unique(
+                            ezjscPacker::buildJavascriptFiles(
+                                $moduleResult['content_info']['persistent_variable']['js_files'],
+                                0
+                            )
                         )
                     );
                 }
@@ -83,16 +87,20 @@ class LegacyHelper extends ParameterBag
                 $designINI = eZINI::instance( 'design.ini' );
                 $that->set(
                     'css_files_configured',
-                    ezjscPacker::buildStylesheetFiles(
-                        $designINI->variable( 'StylesheetSettings', 'FrontendCSSFileList' ),
-                        0
+                    array_unique(
+                        ezjscPacker::buildStylesheetFiles(
+                            $designINI->variable( 'StylesheetSettings', 'FrontendCSSFileList' ),
+                            0
+                        )
                     )
                 );
                 $that->set(
                     'js_files_configured',
-                    ezjscPacker::buildJavascriptFiles(
-                        $designINI->variable( 'JavaScriptSettings', 'FrontendJavaScriptList' ),
-                        0
+                    array_unique(
+                        ezjscPacker::buildJavascriptFiles(
+                            $designINI->variable( 'JavaScriptSettings', 'FrontendJavaScriptList' ),
+                            0
+                        )
                     )
                 );
             },


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23071

This is an alternative to https://github.com/ezsystems/ezpublish-legacy/pull/1008
ezscript/ezcss_require functions do not create a unique list of files, which may break for example jquery plugins.

Handles legacy only, so problems may still exist due to assets included from twig.
