### PR TITLE
Made Legacy IO handler server URI aware

### DIFF
--- a/eZ/Publish/Core/IO/Handler/Legacy.php
+++ b/eZ/Publish/Core/IO/Handler/Legacy.php
@@ -534,6 +534,16 @@ class Legacy implements IOHandlerInterface
 
     public function getUri( $spiBinaryFileId )
     {
-        return '/' . $this->getInternalPath( $spiBinaryFileId );
+        $storagePath = $this->getStoragePath( $spiBinaryFileId );
+        $result = $this->getLegacyKernel()->runCallback(
+            function () use ( $storagePath )
+            {
+                $clusterFile = eZClusterFileHandler::instance( $storagePath );
+                return $clusterFile->applyServerUri( $storagePath );
+            },
+            false
+        );
+
+        return $result;
     }
 }


### PR DESCRIPTION
> Ready for review
> [EZP-23111](http://jira.ez.no/browse/EZP-23111)

Makes the new stack compatible with the addition of the `applyServerUri()` method recently [applied to the cluster interfaces](https://github.com/ezsystems/ezpublish-legacy/commit/f1392b4cf3db8c676db29e2868fa5d79c07850a9), making it possible to use absolute URIs on a different host for images.

Tested manually...
