### PR TITLE
Fix EZP-23126: do not redirect to /login when in legacy_mode

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/LegacyResponse/LegacyResponseManager.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/LegacyResponse/LegacyResponseManager.php
@@ -84,9 +84,9 @@ class LegacyResponseManager
         // Handling error codes sent by the legacy stack
         if ( isset( $moduleResult['errorCode'] ) )
         {
-            // If having an "Unauthorized" or "Forbidden" error code, we send an AccessDeniedException
-            // to be able to trigger redirection to login in Symfony stack.
-            if ( $moduleResult['errorCode'] == 401 || $moduleResult['errorCode'] == 403 )
+            // If having an "Unauthorized" or "Forbidden" error code in non-legacy mode,
+            // we send an AccessDeniedException to be able to trigger redirection to login in Symfony stack.
+            if ( !$this->legacyMode && ( $moduleResult['errorCode'] == 401 || $moduleResult['errorCode'] == 403 ) )
             {
                 $errorMessage = isset( $moduleResult['errorMessage'] ) ? $moduleResult['errorMessage'] : 'Access denied';
                 throw new AccessDeniedException( $errorMessage );


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23126

Problem:
When in legacy mode, accessing a restricted content will cause a redirect to /login, instead of displaying the embed login (by default).

Solution:
Do not throw `AccessDeniedException` in SF when using legacy_mode

Note: This was not observed in admin siteaccess as the login page returns a HTTP 200 status code, unlike accessing restricted content.
