### PR TITLE
[Test] Change back to mock interface

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Tests/KernelTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/KernelTest.php
@@ -157,7 +157,7 @@ class KernelTest extends \PHPUnit_Framework_TestCase
         $kernel
             ->expects( $this->once() )
             ->method( 'getCacheDriver' )
-            ->will( $this->returnValue( $this->getMock( 'Stash\\Driver\\BlackHole' ) ) );
+            ->will( $this->returnValue( $this->getMock( 'Stash\\Interfaces\\DriverInterface' ) ) );
 
         $cachePool = $kernel->getCachePool();
         $this->assertInstanceOf( 'Stash\Interfaces\PoolInterface', $cachePool );


### PR DESCRIPTION
Should be fixed now in hhvm-nightly as of:
https://github.com/facebook/hhvm/commit/8ecf23470b640067ae9daffbaa38f02828ae3996

So changing this back to how it was.
