### PR TITLE
Fix EZP-23074: Missing form token meta tags when browsing legacy modules

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/EventListener/CsrfTokenResponseListener.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/EventListener/CsrfTokenResponseListener.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * File containing the ResponseListener class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishLegacyBundle\EventListener;
+
+use eZ\Bundle\EzPublishLegacyBundle\LegacyResponse;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use ezxFormToken;
+
+/**
+ * Adds legacy CSRF Token when needed.
+ *
+ * In the case of browsing legacy modules through Symfony (i.e. NOT legacy mode), result from legacy kernel is filtered
+ * for forms, but meta tags containing the token might not be present, e.g. when using a Twig layout to render
+ * legacy modules.
+ *
+ * @see https://jira.ez.no/browse/EZP-23074
+ */
+class CsrfTokenResponseListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::RESPONSE => 'onKernelResponse'
+        );
+    }
+
+    /**
+     * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+     */
+    public function onKernelResponse( FilterResponseEvent $event )
+    {
+        $response = $event->getResponse();
+        if ( !$this->isLegacyResponse( $response ) )
+        {
+            return;
+        }
+
+        // Filter out once again to add meta tags containing CSRF token (i.e. for legacy javascripts).
+        $response->setContent( ezxFormToken::output( $response->getContent(), false ) );
+    }
+
+    /**
+     * Checks if $response coming from LegacyKernelController having a moduleResult.
+     * Presence of moduleResult in response clearly indicates that a Twig layout is used, so no CSRF meta tag is present.
+     *
+     * @see \eZ\Bundle\EzPublishLegacyBundle\LegacyResponse\LegacyResponseManager::generateResponseFromModuleResult()
+     *
+     * @param \Symfony\Component\HttpFoundation\Response $response
+     *
+     * @return bool
+     */
+    private function isLegacyResponse( Response $response )
+    {
+        return $response instanceof LegacyResponse && $response->getModuleResult();
+    }
+}

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
@@ -58,6 +58,7 @@ parameters:
     ezpublish_legacy.rest_listener.class: eZ\Bundle\EzPublishLegacyBundle\EventListener\RestListener
     ezpublish_legacy.siteaccess_listener.class: eZ\Bundle\EzPublishLegacyBundle\EventListener\SiteAccessListener
     ezpublish_legacy.request_listener.class: eZ\Bundle\EzPublishLegacyBundle\EventListener\RequestListener
+    ezpublish_legacy.response_listener.class: eZ\Bundle\EzPublishLegacyBundle\EventListener\CsrfTokenResponseListener
     ezpublish_legacy.config_scope_listener.class: eZ\Bundle\EzPublishLegacyBundle\EventListener\ConfigScopeListener
     ezpublish_legacy.legacy_kernel_listener.class: eZ\Bundle\EzPublishLegacyBundle\EventListener\LegacyKernelListener
 
@@ -283,6 +284,11 @@ services:
     ezpublish_legacy.request_listener:
         class: %ezpublish_legacy.request_listener.class%
         arguments: [@ezpublish.config.resolver, @ezpublish.api.repository, @security.context]
+        tags:
+            - { name: kernel.event_subscriber }
+
+    ezpublish_legacy.response_listener:
+        class: %ezpublish_legacy.response_listener.class%
         tags:
             - { name: kernel.event_subscriber }
 


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-23074

Alternative of https://github.com/ezsystems/ezpublish-legacy/pull/1026

This acts with a Response listener, triggering `ezxFormToken` output filtering once again, to ensure meta tags containing CSRF token are present.

Note that `ezxFormToken::output()` has been slightly modified as well (see https://github.com/ezsystems/ezpublish-legacy/pull/1029).
## About cache

There is nothing to worry about here since HTTP cache is assumed to be handled by legacy modules.
**`LegacyKernelController` does not set cache headers on its own**.

See [`LegacyResponseManager::mapHeaders()`](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ%2FBundle%2FEzPublishLegacyBundle%2FLegacyResponse%2FLegacyResponseManager.php#L141) for more insight.
