### PR TITLE
Splitted Image\Value into Base,Value and Input

### DIFF
--- a/eZ/Publish/Core/FieldType/Image/BaseValue.php
+++ b/eZ/Publish/Core/FieldType/Image/BaseValue.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of the eZ Publish Legacy package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributd with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\FieldType\Image;
+
+use eZ\Publish\Core\FieldType\Value as FieldTypeValue;
+
+/**
+ * Base Value for image. Contains user-definable attributes.
+ */
+abstract class BaseValue extends FieldTypeValue
+{
+    /**
+     * The alternative image text ("Picture of an apple")
+     *
+     * @var string|null
+     */
+    public $alternativeText;
+
+    /**
+     * Display file name of the image ("Picture-of-an-Apple.png")
+     *
+     * @var string
+     * @required
+     */
+    public $fileName;
+
+    /**
+     * Size of the image file
+     *
+     * @var int
+     */
+    public $fileSize;
+
+    public function __toString()
+    {
+        return (string)$this->fileName;
+    }
+}

--- a/eZ/Publish/Core/FieldType/Image/InputValue.php
+++ b/eZ/Publish/Core/FieldType/Image/InputValue.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributd with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\Image;
+
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+
+/**
+ * Image Field input value.
+ * Used to provide a new image file for input, using $inputUri
+ */
+class InputValue extends BaseValue
+{
+    /**
+     * The URI to the image file to be used as a source.
+     * Can only be set through the constructor or fromString.
+     * @var string
+     */
+    protected $inputUri;
+
+    /**
+     * @param array $imageData Keys: inputUri, alternativeText, fileName.
+     * @throws InvalidArgumentException If inputUri key is missing or not a valid image file
+     */
+    public function __construct( array $imageData = array() )
+    {
+        if ( !isset( $imageData['inputUri'] ) )
+        {
+            throw new InvalidArgumentException( 'imageData[inputUri]', "Missing argument" );
+        }
+
+        if ( !file_exists( $imageData['inputUri'] ) )
+        {
+            throw new InvalidArgumentException( 'imageData[inputUri]', "File not found" );
+        }
+
+        if ( !getimagesize( $imageData['inputUri'] ) )
+        {
+            throw new InvalidArgumentException( 'imageData[inputUri]', "Not a valid image" );
+        }
+
+        // set image size from provided valid file
+        $imageData['fileSize'] = filesize( $imageData['inputUri'] );
+
+        parent::__construct( $imageData );
+    }
+
+    /**
+     * Creates a value only from a file path
+     *
+     * @param string $path Path to a local file
+     *
+     * @throws InvalidArgumentType if $path doesn't refer to an existing file
+     * @return Value
+     */
+    public static function fromString( $path )
+    {
+        return new static(
+            array(
+                'inputUri' => $path,
+                'fileName' => basename( $path )
+            )
+        );
+    }
+}

--- a/eZ/Publish/Core/FieldType/Image/Value.php
+++ b/eZ/Publish/Core/FieldType/Image/Value.php
@@ -1,5 +1,5 @@
 <?php
-/**
+    /**
  * File containing the Image Value class
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
@@ -9,50 +9,21 @@
 
 namespace eZ\Publish\Core\FieldType\Image;
 
-use eZ\Publish\Core\FieldType\Value as BaseValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\API\Repository\Exceptions\PropertyNotFoundException;
 
 /**
- * Value for Image field type
+ * Repository value for Image field type, as returned when loading content.
  *
  * @property string $path Used for BC with 5.0 (EZP-20948). Equivalent to $id.
- *
- * @todo Mime type?
- * @todo Dimensions?
  */
 class Value extends BaseValue
 {
     /**
      * Image id
-     *
      * @var mixed
-     * @required
      */
     public $id;
-
-    /**
-     * The alternative image text (for example "Picture of an apple.").
-     *
-     * @var string|null
-     */
-    public $alternativeText;
-
-    /**
-     * Display file name of the image
-     *
-     * @var string
-     * @required
-     */
-    public $fileName;
-
-    /**
-     * Size of the image file
-     *
-     * @var int
-     * @required
-     */
-    public $fileSize;
 
     /**
      * The image's HTTP URI
@@ -69,7 +40,9 @@ class Value extends BaseValue
     /**
      * Construct a new Value object.
      *
-     * @param array $imageData
+     * @param array $imageData Associatinve array of properties
+     *
+     * @throws PropertyNotFoundException if the given
      */
     public function __construct( array $imageData = array() )
     {
@@ -89,58 +62,12 @@ class Value extends BaseValue
             catch ( PropertyNotFoundException $e )
             {
                 throw new InvalidArgumentType(
-                    sprintf( '$imageData->%s', $key ),
+                    sprintf( '$imageData[%s]', $key ),
                     'Property not found',
                     $value
                 );
             }
         }
-    }
-
-    /**
-     * Creates a value only from a file path
-     *
-     * @param string $path
-     *
-     * @return Value
-     */
-    public static function fromString( $path )
-    {
-        if ( !file_exists( $path ) )
-        {
-            throw new InvalidArgumentType(
-                '$path',
-                'existing file',
-                $path
-            );
-        }
-        return new static(
-            array(
-                'id' => $path,
-                'fileName' => basename( $path ),
-                'fileSize' => filesize( $path ),
-                'alternativeText' => '',
-                'uri' => '',
-            )
-        );
-    }
-
-    /**
-     * Returns the image file size in byte
-     *
-     * @return integer
-     */
-    public function getFileSize()
-    {
-        return $this->fileSize;
-    }
-
-    /**
-     * @see \eZ\Publish\Core\FieldType\Value
-     */
-    public function __toString()
-    {
-        return (string)$this->fileName;
     }
 
     public function __get( $propertyName )


### PR DESCRIPTION
> See [EZP-23080](https://jira.ez.no/browse/EZP-23080)
> Status: work in progress
### `Image\Value` changes
- `Image\BaseValue` is abstract, and holds user-defined attributes (`alternativeText` & `fileName`)
- `Value` is built only by the API, and contains `id`, `imageId`, `fileSize` and `uri`
- `InputValue` is used for inputing a new image, and adds an `imageUri` property. It checks, when given an `inputUri`, than it is a valid local image file.
