### PR TITLE
Fix EZP-23176: Sessions are always started for anonymous user

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/LegacyMapper/Security.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/LegacyMapper/Security.php
@@ -16,6 +16,7 @@ use eZ\Publish\Core\MVC\Legacy\Event\PreBuildKernelWebHandlerEvent;
 use eZ\Publish\Core\MVC\Legacy\LegacyEvents;
 use ezpWebBasedKernelHandler;
 use eZUser;
+use eZSession;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -76,16 +77,16 @@ class Security implements EventSubscriberInterface
             return;
         }
 
-        $currentUser = $this->repository->getCurrentUser();
-        if ( $currentUser->id == $this->configResolver->getParameter( "anonymous_user_id" ) )
-        {
-            return;
-        }
+        $currentUserId = $this->repository->getCurrentUser()->id;
 
         $event->getLegacyKernel()->runCallback(
-            function () use ( $currentUser )
+            function () use ( $currentUserId )
             {
-                $legacyUser = eZUser::fetch( $currentUser->id );
+                if ( $currentUserId == eZUser::anonymousId() && !eZSession::hasStarted() )
+                {
+                    return;
+                }
+                $legacyUser = eZUser::fetch( $currentUserId );
                 eZUser::setCurrentlyLoggedInUser( $legacyUser, $legacyUser->attribute( 'contentobject_id' ), eZUser::NO_SESSION_REGENERATE );
             },
             false

--- a/eZ/Bundle/EzPublishLegacyBundle/Tests/LegacyMapper/SecurityTest.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Tests/LegacyMapper/SecurityTest.php
@@ -128,12 +128,21 @@ class SecurityTest extends PHPUnit_Framework_TestCase
         $event = new PostBuildKernelEvent( $legacyKernel, $kernelHandler );
 
         $userId = 123;
-        $user = $this->getMockForAbstractClass( 'eZ\Publish\API\Repository\Values\User\User' );
+        $user = $this->getMockForAbstractClass(
+            'eZ\Publish\API\Repository\Values\User\User',
+            array(),
+            '',
+            false,
+            false,
+            false,
+            array( '__get' )
+        );
         $user
             ->expects( $this->any() )
             ->method( '__get' )
             ->with( 'id' )
             ->will( $this->returnValue( $userId ) );
+
         $this->repository
             ->expects( $this->once() )
             ->method( 'getCurrentUser' )


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23176

Problem:
Legacy's `eZUser::setCurrentlyLoggedInUser()` always starts a session, to store the `eZUserLoggedInID`.

This PR skips calling this function if the current user is anonymous, as legacy will still be able to pick this user by default (@see `eZUser::instance()`)

Note:
Additional or alternate fix (in legacy) would be to make sure `eZUser::setCurrentlyLoggedInUser()` does not start a new session.
