### PR TITLE
Fix EZP-23176: Lazy sessions are not honored in 5.3

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/security.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/security.yml
@@ -11,7 +11,7 @@ services:
 
     ezpublish_legacy.security_mapper:
         class: %ezpublish_legacy.security_mapper.class%
-        arguments: [@ezpublish.api.repository, @ezpublish.config.resolver]
+        arguments: [@ezpublish.api.repository, @ezpublish.config.resolver, @security.context]
         tags:
             - { name: kernel.event_subscriber }
 


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23176

Alternative of #932 and https://github.com/ezsystems/ezpublish-legacy/pull/1033 by @joaoinacio .

In security mapper, user was injected in legacy even if the current user wasn't authenticated. Problem is that `eZUser::setLoggedInUser()` always sets a session variable, and thus starts a session.

This patch ensures user is authenticated in security context before injecting the user.
