### PR TITLE
EZP-23189: Remove use of zetacomponents/base

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "ext-PDO": "*",
         "ext-SPL": "*",
         "ext-xsl": "*",
-        "zetacomponents/base": "dev-master#642f63a as 1.8.1",
         "zetacomponents/mail": "1.8.*@beta",
         "zetacomponents/php-generator": "dev-master#b51935e",
         "symfony/symfony": "~2.3",

--- a/data/scripts/datadumper.php
+++ b/data/scripts/datadumper.php
@@ -15,7 +15,6 @@
  */
 
 require "./vendor/autoload.php";
-//spl_autoload_register( 'ezcBase::autoload' );
 
 if ( false === isset( $argv[1] ) || false === isset( $argv[2] ) )
 {

--- a/eZ/Publish/Core/IO/Tests/Handler/LegacyTest.php
+++ b/eZ/Publish/Core/IO/Tests/Handler/LegacyTest.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\Core\IO\Tests\Handler;
 use eZ\Publish\Core\IO\Handler\Legacy as Legacy;
 use eZ\Publish\Core\IO\Tests\Handler\Base as BaseHandlerTest;
 use eZ\Publish\Core\MVC\Legacy\Kernel;
-use ezcBaseFile;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * Handler test
@@ -49,7 +49,8 @@ class LegacyTest extends BaseHandlerTest
         chdir( $this->legacyPath );
         if ( file_exists( 'var/test' ) )
         {
-            ezcBaseFile::removeRecursive( 'var/test' );
+            $fs = new Filesystem();
+            $fs->remove( 'var/test' );
         }
         /** @var $legacyKernel Kernel */
         $legacyKernel = $_ENV['legacyKernel'];


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-23189

Only used in a unit test, changed to use Symfony FileSystem instead.
