### PR TITLE
Fix EZP-23192: Cannot define array settings in default scope

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/Contextualizer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/Contextualizer.php
@@ -74,7 +74,8 @@ class Contextualizer implements ContextualizerInterface
 
     public function mapConfigArray( $id, array $config, $options = 0 )
     {
-        $this->mapGlobalConfigArray( $id, $config );
+        $this->mapReservedScopeArray( $id, $config, ConfigResolver::SCOPE_DEFAULT );
+        $this->mapReservedScopeArray( $id, $config, ConfigResolver::SCOPE_GLOBAL );
         $defaultSettings = $this->getContainerParameter(
             $this->namespace . '.' . ConfigResolver::SCOPE_DEFAULT . '.' . $id,
             array()
@@ -248,28 +249,30 @@ class Contextualizer implements ContextualizerInterface
     }
 
     /**
-     * Ensures settings array defined in "global" scope are registered in the internal global scope.
+     * Ensures settings array defined in a given "reserved scope" are registered properly.
+     * "Reserved scope" can typically be ConfigResolver::SCOPE_DEFAULT or ConfigResolver::SCOPE_GLOBAL.
      *
      * @param string $id
      * @param array $config
+     * @param string $scope
      */
-    private function mapGlobalConfigArray( $id, array $config )
+    private function mapReservedScopeArray( $id, array $config, $scope )
     {
         if (
-            isset( $config[$this->siteAccessNodeName][ConfigResolver::SCOPE_GLOBAL][$id] )
-            && !empty( $config[$this->siteAccessNodeName][ConfigResolver::SCOPE_GLOBAL][$id] )
+            isset( $config[$this->siteAccessNodeName][$scope][$id] )
+            && !empty( $config[$this->siteAccessNodeName][$scope][$id] )
         )
         {
-            $key = $this->namespace . '.' . ConfigResolver::SCOPE_GLOBAL . '.' . $id;
-            $globalValue = $config[$this->siteAccessNodeName][ConfigResolver::SCOPE_GLOBAL][$id];
+            $key = "$this->namespace.$scope.$id";
+            $value = $config[$this->siteAccessNodeName][$scope][$id];
             if ( $this->container->hasParameter( $key ) )
             {
-                $globalValue = array_merge(
+                $value = array_merge(
                     $this->container->getParameter( $key ),
-                    $globalValue
+                    $value
                 );
             }
-            $this->container->setParameter( $key, $globalValue );
+            $this->container->setParameter( $key, $value );
         }
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/SiteAccessAware/ContextualizerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/SiteAccessAware/ContextualizerTest.php
@@ -131,10 +131,12 @@ class ContextualizerTest extends PHPUnit_Framework_TestCase
             'enabled' => false,
             'j_adore' => 'les_sushis'
         );
-        $containerBuilder->setParameter( "$this->namespace.default.foo_setting", $defaultConfig );
 
         $config = array(
             $this->saNodeName => array(
+                'default' => array(
+                    'foo_setting' => $defaultConfig
+                ),
                 'sa_group1' => array(
                     'foo_setting' => array(
                         'foo' => 'bar',
@@ -219,10 +221,12 @@ class ContextualizerTest extends PHPUnit_Framework_TestCase
             'enabled' => false,
             'j_adore' => array( 'les_sushis' )
         );
-        $containerBuilder->setParameter( "$this->namespace.default.foo_setting", $defaultConfig );
 
         $config = array(
             $this->saNodeName => array(
+                'default' => array(
+                    'foo_setting' => $defaultConfig
+                ),
                 'sa_group1' => array(
                     'foo_setting' => array(
                         'foo' => 'bar',
@@ -305,10 +309,12 @@ class ContextualizerTest extends PHPUnit_Framework_TestCase
         $containerBuilder = new ContainerBuilder();
         $this->contextualizer->setContainer( $containerBuilder );
         $defaultConfig = array( 'Earth' );
-        $containerBuilder->setParameter( "$this->namespace.default.foo_setting", $defaultConfig );
 
         $config = array(
             $this->saNodeName => array(
+                'default' => array(
+                    'foo_setting' => $defaultConfig
+                ),
                 'sa_group1' => array(
                     'foo_setting' => array( 'Mars' )
                 ),


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23192

Some array settings like custom xsl files cannot be defined in `default` scope with semantic configuration. This forces bundle developers who relies these kind of settings to provide additional installation steps (e.g. for [TagsBundle](https://github.com/netgen/TagsBundle/blob/master/Resources/doc/INSTALL.md#edit-configuration)).
Workaround is to implement a compiler pass that does the job (e.g. [EmbedTagBundle](https://github.com/lolautruche/EmbedTagBundle/blob/master/DependencyInjection/Compiler/XslRegisterPass.php), but it still doesn't use semantic config validation and proper processing/mapping.

This is due to default scope not being considered as a siteaccess when merging values across scopes).

This PR fixes it.
