### PR TITLE
Improved doc for REST parameter roleId

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -4864,8 +4864,8 @@ List Users
 :Method: GET
 :Description: Load users either for a given remoteId or role
 :Parameters:
-    :roleId: lists users assigned to the given role
-    :remoteId: retrieves the user for the given remoteId
+    :roleId: lists users assigned to the given role (ex: ``GET /user/users?roleId=/user/roles/1``)
+    :remoteId: retrieves the user for the given remoteId (ex: ``GET /user/users?remoteId=55dd9713db75145f374bbd0b4f60ad29``)
 :Headers:
     :Accept:
          :application/vnd.ez.api.UserList+xml:  if set the user list returned in xml format (see User_)


### PR DESCRIPTION
> See https://jira.ez.no/browse/EZP-22162

The documentation doesn't make it clear that the `roleId` parameter  must be a REST ID and not an integer. Also added a paragraph on the REST general doc: https://doc.ez.no/display/EZP/General+REST+usage#GeneralRESTusage-Requestparameters.
