### PR TITLE
EZP-23163: Improved config parsers tests

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/AbstractParserTestCase.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/AbstractParserTestCase.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * File containing the AbstractParserTestCase class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\Parser;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+
+abstract class AbstractParserTestCase extends AbstractExtensionTestCase
+{
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver
+     */
+    protected $configResolver;
+
+    protected function load( array $configurationValues = array() )
+    {
+        parent::load( $configurationValues );
+        $this->configResolver = $this->container->get( 'ezpublish.config.resolver.core' );
+    }
+
+    /**
+     * Asserts a parameter from ConfigResolver has expected value for given scope.
+     *
+     * @param string $parameterName
+     * @param mixed $expectedValue
+     * @param string $scope SiteAccess name, group, default or global
+     * @param bool $assertSame Set to false if you want to use assertEquals() instead of assertSame()
+     */
+    protected function assertConfigResolverParameterValue( $parameterName, $expectedValue, $scope, $assertSame = true )
+    {
+        $assertMethod = $assertSame ? 'assertSame' : 'assertEquals';
+        $this->$assertMethod( $expectedValue, $this->configResolver->getParameter( $parameterName, 'ezsettings', $scope ) );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/CommonTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/CommonTest.php
@@ -11,11 +11,9 @@ namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\Common;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
-use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
-use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\Yaml\Yaml;
 
-class CommonTest extends AbstractExtensionTestCase
+class CommonTest extends AbstractParserTestCase
 {
     private $minimalConfig;
 
@@ -24,12 +22,6 @@ class CommonTest extends AbstractExtensionTestCase
      */
     private $suggestionCollector;
 
-    /**
-     * Return an array of container extensions you need to be registered for each test (usually just the container
-     * extension you are testing.
-     *
-     * @return ExtensionInterface[]
-     */
     protected function getContainerExtensions()
     {
         $this->suggestionCollector = $this->getMock( 'eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Suggestion\ConfigSuggestion\SuggestionCollectorInterface' );
@@ -53,11 +45,8 @@ class CommonTest extends AbstractExtensionTestCase
         );
         $this->load( $config );
 
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.ezdemo_site.index_page' ) );
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.ezdemo_site_admin.index_page' ) );
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.global.index_page' ) );
-        $this->assertSame( $indexPage1, $this->container->getParameter( 'ezsettings.ezdemo_site.index_page' ) );
-        $this->assertSame( $indexPage2, $this->container->getParameter( 'ezsettings.ezdemo_site_admin.index_page' ) );
+        $this->assertConfigResolverParameterValue( 'index_page', $indexPage1, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'index_page', $indexPage2, 'ezdemo_site_admin' );
     }
 
     public function testDefaultPage()
@@ -72,11 +61,8 @@ class CommonTest extends AbstractExtensionTestCase
         );
         $this->load( $config );
 
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.ezdemo_site.default_page' ) );
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.ezdemo_site_admin.default_page' ) );
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.global.default_page' ) );
-        $this->assertSame( $defaultPage1, $this->container->getParameter( 'ezsettings.ezdemo_site.default_page' ) );
-        $this->assertSame( $defaultPage2, $this->container->getParameter( 'ezsettings.ezdemo_site_admin.default_page' ) );
+        $this->assertConfigResolverParameterValue( 'default_page', $defaultPage1, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'default_page', $defaultPage2, 'ezdemo_site_admin' );
     }
 
     /**
@@ -126,34 +112,30 @@ class CommonTest extends AbstractExtensionTestCase
     public function testLegacyMode()
     {
         $this->load( array( 'system' => array( 'ezdemo_site' => array( 'legacy_mode' => true ) ) ) );
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.ezdemo_site.legacy_mode' ) );
-        $this->assertTrue( $this->container->getParameter( 'ezsettings.ezdemo_site.legacy_mode' ) );
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.ezdemo_site.url_alias_router' ) );
-        $this->assertFalse( $this->container->getParameter( 'ezsettings.ezdemo_site.url_alias_router' ) );
+        $this->assertConfigResolverParameterValue( 'legacy_mode', true, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'url_alias_router', false, 'ezdemo_site' );
     }
 
     public function testNotLegacyMode()
     {
         $this->load( array( 'system' => array( 'ezdemo_site' => array( 'legacy_mode' => false ) ) ) );
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.ezdemo_site.legacy_mode' ) );
-        $this->assertFalse( $this->container->getParameter( 'ezsettings.ezdemo_site.legacy_mode' ) );
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.ezdemo_site.url_alias_router' ) );
-        $this->assertTrue( $this->container->getParameter( 'ezsettings.ezdemo_site.url_alias_router' ) );
+        $this->assertConfigResolverParameterValue( 'legacy_mode', false, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'url_alias_router', true, 'ezdemo_site' );
     }
 
     public function testNonExistentSettings()
     {
         $this->load();
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.ezdemo_site.legacy_mode' ) );
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.ezdemo_site.url_alias_router' ) );
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.ezdemo_site.cache_pool_name' ) );
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.ezdemo_site.var_dir' ) );
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.ezdemo_site.storage_dir' ) );
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.ezdemo_site.binary_dir' ) );
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.ezdemo_site.session_name' ) );
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.ezdemo_site.http_cache.purge_servers' ) );
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.ezdemo_site.anonymous_user_id' ) );
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.ezdemo_site.index_page' ) );
+        $this->assertConfigResolverParameterValue( 'legacy_mode', false, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'url_alias_router', true, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'cache_pool_name', 'default', 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'var_dir', 'var', 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'storage_dir', 'storage', 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'binary_dir', 'original', 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'session_name', '%ezpublish.session_name.default%', 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'http_cache.purge_servers', array( 'http://localhost/' ), 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'anonymous_user_id', 10, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'index_page', null, 'ezdemo_site' );
     }
 
     public function testMiscSettings()
@@ -189,14 +171,14 @@ class CommonTest extends AbstractExtensionTestCase
             )
         );
 
-        $this->assertSame( $cachePoolName, $this->container->getParameter( 'ezsettings.ezdemo_site.cache_pool_name' ) );
-        $this->assertSame( $varDir, $this->container->getParameter( 'ezsettings.ezdemo_site.var_dir' ) );
-        $this->assertSame( $storageDir, $this->container->getParameter( 'ezsettings.ezdemo_site.storage_dir' ) );
-        $this->assertSame( $binaryDir, $this->container->getParameter( 'ezsettings.ezdemo_site.binary_dir' ) );
-        $this->assertSame( $sessionName, $this->container->getParameter( 'ezsettings.ezdemo_site.session_name' ) );
-        $this->assertSame( $indexPage, $this->container->getParameter( 'ezsettings.ezdemo_site.index_page' ) );
-        $this->assertSame( $cachePurgeServers, $this->container->getParameter( 'ezsettings.ezdemo_site.http_cache.purge_servers' ) );
-        $this->assertSame( $anonymousUserId, $this->container->getParameter( 'ezsettings.ezdemo_site.anonymous_user_id' ) );
+        $this->assertConfigResolverParameterValue( 'cache_pool_name', $cachePoolName, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'var_dir', $varDir, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'storage_dir', $storageDir, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'binary_dir', $binaryDir, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'session_name', $sessionName, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'index_page', $indexPage, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'http_cache.purge_servers', $cachePurgeServers, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'anonymous_user_id', $anonymousUserId, 'ezdemo_site' );
     }
 
     public function testUserSettings()
@@ -215,17 +197,24 @@ class CommonTest extends AbstractExtensionTestCase
                 )
             )
         );
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.ezdemo_site.security.base_layout' ) );
-        $this->assertSame( $layout, $this->container->getParameter( 'ezsettings.ezdemo_site.security.base_layout' ) );
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.ezdemo_site.security.login_template' ) );
-        $this->assertSame( $loginTemplate, $this->container->getParameter( 'ezsettings.ezdemo_site.security.login_template' ) );
+
+        $this->assertConfigResolverParameterValue( 'security.base_layout', $layout, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'security.login_template', $loginTemplate, 'ezdemo_site' );
     }
 
     public function testNoUserSettings()
     {
         $this->load();
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.ezdemo_site.security.base_layout' ) );
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.ezdemo_site.security.login_template' ) );
+        $this->assertConfigResolverParameterValue(
+            'security.base_layout',
+            '%ezpublish.content_view.viewbase_layout%',
+            'ezdemo_site'
+        );
+        $this->assertConfigResolverParameterValue(
+            'security.login_template',
+            'EzPublishCoreBundle:Security:login.html.twig',
+            'ezdemo_site'
+        );
     }
 
     /**
@@ -241,10 +230,8 @@ class CommonTest extends AbstractExtensionTestCase
             )
         );
 
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.ezdemo_site.session' ) );
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.ezdemo_site.session_name' ) );
-        $this->assertEquals( $expected['session'], $this->container->getParameter( 'ezsettings.ezdemo_site.session' ) );
-        $this->assertEquals( $expected['session_name'], $this->container->getParameter( 'ezsettings.ezdemo_site.session_name' ) );
+        $this->assertConfigResolverParameterValue( 'session', $expected['session'], 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'session_name', $expected['session_name'], 'ezdemo_site' );
     }
 
     public function sessionSettingsProvider()

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/ContentTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/ContentTest.php
@@ -10,19 +10,11 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\Parser;
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
-use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
-use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\Content as ContentConfigParser;
 use Symfony\Component\Yaml\Yaml;
 
-class ContentTest extends AbstractExtensionTestCase
+class ContentTest extends AbstractParserTestCase
 {
-    /**
-     * Return an array of container extensions you need to be registered for each test (usually just the container
-     * extension you are testing.
-     *
-     * @return ExtensionInterface[]
-     */
     protected function getContainerExtensions()
     {
         return array(
@@ -39,9 +31,9 @@ class ContentTest extends AbstractExtensionTestCase
     {
         $this->load();
 
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.ezdemo_site.content.view_cache' ) );
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.ezdemo_site.content.ttl_cache' ) );
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.ezdemo_site.content.default_ttl' ) );
+        $this->assertConfigResolverParameterValue( 'content.view_cache', true, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'content.ttl_cache', true, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'content.default_ttl', 60, 'ezdemo_site' );
     }
 
     /**
@@ -59,7 +51,7 @@ class ContentTest extends AbstractExtensionTestCase
 
         foreach ( $expected as $key => $val )
         {
-            $this->assertSame( $val, $this->container->getParameter( $key ) );
+            $this->assertConfigResolverParameterValue( $key, $val, 'ezdemo_site' );
         }
     }
 
@@ -75,9 +67,9 @@ class ContentTest extends AbstractExtensionTestCase
                     )
                 ),
                 array(
-                    'ezsettings.ezdemo_site.content.view_cache' => true,
-                    'ezsettings.ezdemo_site.content.ttl_cache' => true,
-                    'ezsettings.ezdemo_site.content.default_ttl' => 100,
+                    'content.view_cache' => true,
+                    'content.ttl_cache' => true,
+                    'content.default_ttl' => 100,
                 )
             ),
             array(
@@ -89,9 +81,9 @@ class ContentTest extends AbstractExtensionTestCase
                     )
                 ),
                 array(
-                    'ezsettings.ezdemo_site.content.view_cache' => false,
-                    'ezsettings.ezdemo_site.content.ttl_cache' => false,
-                    'ezsettings.ezdemo_site.content.default_ttl' => 123,
+                    'content.view_cache' => false,
+                    'content.ttl_cache' => false,
+                    'content.default_ttl' => 123,
                 )
             ),
             array(
@@ -101,9 +93,9 @@ class ContentTest extends AbstractExtensionTestCase
                     )
                 ),
                 array(
-                    'ezsettings.ezdemo_site.content.view_cache' => false,
-                    'ezsettings.ezdemo_site.content.ttl_cache' => true,
-                    'ezsettings.ezdemo_site.content.default_ttl' => 60,
+                    'content.view_cache' => false,
+                    'content.ttl_cache' => true,
+                    'content.default_ttl' => 60,
                 )
             ),
             array(
@@ -113,10 +105,10 @@ class ContentTest extends AbstractExtensionTestCase
                     )
                 ),
                 array(
-                    'ezsettings.ezdemo_site.content.view_cache' => true,
-                    'ezsettings.ezdemo_site.content.ttl_cache' => true,
-                    'ezsettings.ezdemo_site.content.default_ttl' => 60,
-                    'ezsettings.ezdemo_site.content.tree_root.location_id' => 123,
+                    'content.view_cache' => true,
+                    'content.ttl_cache' => true,
+                    'content.default_ttl' => 60,
+                    'content.tree_root.location_id' => 123,
                 )
             ),
             array(
@@ -129,11 +121,11 @@ class ContentTest extends AbstractExtensionTestCase
                     )
                 ),
                 array(
-                    'ezsettings.ezdemo_site.content.view_cache' => true,
-                    'ezsettings.ezdemo_site.content.ttl_cache' => true,
-                    'ezsettings.ezdemo_site.content.default_ttl' => 60,
-                    'ezsettings.ezdemo_site.content.tree_root.location_id' => 456,
-                    'ezsettings.ezdemo_site.content.tree_root.excluded_uri_prefixes' => array( '/media/images', '/products' ),
+                    'content.view_cache' => true,
+                    'content.ttl_cache' => true,
+                    'content.default_ttl' => 60,
+                    'content.tree_root.location_id' => 456,
+                    'content.tree_root.excluded_uri_prefixes' => array( '/media/images', '/products' ),
                 )
             ),
             array(
@@ -150,10 +142,10 @@ class ContentTest extends AbstractExtensionTestCase
                     )
                 ),
                 array(
-                    'ezsettings.ezdemo_site.content.view_cache' => true,
-                    'ezsettings.ezdemo_site.content.ttl_cache' => true,
-                    'ezsettings.ezdemo_site.content.default_ttl' => 60,
-                    'ezsettings.ezdemo_site.fieldtypes.ezxml.custom_xsl' => array(
+                    'content.view_cache' => true,
+                    'content.ttl_cache' => true,
+                    'content.default_ttl' => 60,
+                    'fieldtypes.ezxml.custom_xsl' => array(
                         // Default settings will be added
                         array( 'path' => '%kernel.root_dir%/../vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl', 'priority' => 0 ),
                         array( 'path' => '%kernel.root_dir%/../vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_custom.xsl', 'priority' => 0 ),

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/ImageTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/ImageTest.php
@@ -11,11 +11,9 @@ namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\Image;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
-use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
-use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\Yaml\Yaml;
 
-class ImageTest extends AbstractExtensionTestCase
+class ImageTest extends AbstractParserTestCase
 {
     private $config;
 
@@ -42,12 +40,6 @@ class ImageTest extends AbstractExtensionTestCase
         return $this->config;
     }
 
-    /**
-     * Return an array of container extensions you need to be registered for each test (usually just the container
-     * extension you are testing.
-     *
-     * @return ExtensionInterface[]
-     */
     protected function getContainerExtensions()
     {
         return array(
@@ -60,11 +52,13 @@ class ImageTest extends AbstractExtensionTestCase
         $this->load();
 
         $expected = $this->config['system']['ezdemo_group']['image_variations'] + $this->container->getParameter( 'ezsettings.default.image_variations' );
-        $this->assertEquals( $expected, $this->container->getParameter( 'ezsettings.ezdemo_site.image_variations' ) );
-        $this->assertEquals( $expected, $this->container->getParameter( 'ezsettings.ezdemo_site_admin.image_variations' ) );
-        $this->assertEquals(
+        $this->assertConfigResolverParameterValue( 'image_variations', $expected, 'ezdemo_site', false );
+        $this->assertConfigResolverParameterValue( 'image_variations', $expected, 'ezdemo_site_admin', false );
+        $this->assertConfigResolverParameterValue(
+            'image_variations',
             $expected + $this->config['system']['fre']['image_variations'],
-            $this->container->getParameter( 'ezsettings.fre.image_variations' )
+            'fre',
+            false
         );
     }
 
@@ -74,15 +68,11 @@ class ImageTest extends AbstractExtensionTestCase
     public function testPrePostParameters( array $config, array $expected )
     {
         $this->load( array( 'system' => $config ) );
-        foreach ( $expected as $name => $value )
+        foreach ( $expected as $name => $values )
         {
-            if ( $value === null )
+            foreach ( $values as $sa => $expectedValue )
             {
-                $this->assertFalse( $this->container->hasParameter( $name ) );
-            }
-            else
-            {
-                $this->assertSame( $value, $this->container->getParameter( $name ) );
+                $this->assertConfigResolverParameterValue( $name, $expectedValue, $sa );
             }
         }
     }
@@ -100,10 +90,14 @@ class ImageTest extends AbstractExtensionTestCase
                     )
                 ),
                 array(
-                    'ezsettings.ezdemo_site.imagemagick.pre_parameters' => '-foo -bar',
-                    'ezsettings.ezdemo_site.imagemagick.post_parameters' => '-baz',
-                    'ezsettings.fre.imagemagick.pre_parameters' => null,
-                    'ezsettings.fre.imagemagick.post_parameters' => null,
+                    'imagemagick.pre_parameters' => array(
+                        'ezdemo_site' => '-foo -bar',
+                        'fre' => null
+                    ),
+                    'imagemagick.post_parameters' => array(
+                        'ezdemo_site' => '-baz',
+                        'fre' => null
+                    )
                 )
             ),
             array(
@@ -115,10 +109,14 @@ class ImageTest extends AbstractExtensionTestCase
                     )
                 ),
                 array(
-                    'ezsettings.ezdemo_site.imagemagick.pre_parameters' => '-foo -bar',
-                    'ezsettings.ezdemo_site.imagemagick.post_parameters' => null,
-                    'ezsettings.fre.imagemagick.pre_parameters' => null,
-                    'ezsettings.fre.imagemagick.post_parameters' => null,
+                    'imagemagick.pre_parameters' => array(
+                        'ezdemo_site' => '-foo -bar',
+                        'fre' => null
+                    ),
+                    'imagemagick.post_parameters' => array(
+                        'ezdemo_site' => null,
+                        'fre' => null
+                    )
                 )
             ),
             array(
@@ -130,10 +128,14 @@ class ImageTest extends AbstractExtensionTestCase
                     )
                 ),
                 array(
-                    'ezsettings.ezdemo_site.imagemagick.pre_parameters' => null,
-                    'ezsettings.ezdemo_site.imagemagick.post_parameters' => '-baz',
-                    'ezsettings.fre.imagemagick.pre_parameters' => null,
-                    'ezsettings.fre.imagemagick.post_parameters' => null,
+                    'imagemagick.pre_parameters' => array(
+                        'ezdemo_site' => null,
+                        'fre' => null
+                    ),
+                    'imagemagick.post_parameters' => array(
+                        'ezdemo_site' => '-baz',
+                        'fre' => null
+                    )
                 )
             ),
             array(
@@ -146,10 +148,14 @@ class ImageTest extends AbstractExtensionTestCase
                     )
                 ),
                 array(
-                    'ezsettings.ezdemo_site.imagemagick.pre_parameters' => null,
-                    'ezsettings.ezdemo_site.imagemagick.post_parameters' => null,
-                    'ezsettings.fre.imagemagick.pre_parameters' => '-fre',
-                    'ezsettings.fre.imagemagick.post_parameters' => '-baz -fre',
+                    'imagemagick.pre_parameters' => array(
+                        'ezdemo_site' => null,
+                        'fre' => '-fre'
+                    ),
+                    'imagemagick.post_parameters' => array(
+                        'ezdemo_site' => null,
+                        'fre' => '-baz -fre'
+                    )
                 )
             ),
         );

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/LanguagesTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/LanguagesTest.php
@@ -11,18 +11,10 @@ namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\Languages;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
-use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
-use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\Yaml\Yaml;
 
-class LanguagesTest extends AbstractExtensionTestCase
+class LanguagesTest extends AbstractParserTestCase
 {
-    /**
-     * Return an array of container extensions you need to be registered for each test (usually just the container
-     * extension you are testing.
-     *
-     * @return ExtensionInterface[]
-     */
     protected function getContainerExtensions()
     {
         return array( new EzPublishCoreExtension( array( new Languages() ) ) );
@@ -49,14 +41,9 @@ class LanguagesTest extends AbstractExtensionTestCase
         );
         $this->load( $config );
 
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.ezdemo_site.languages' ) );
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.fre.languages' ) );
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.fre2.languages' ) );
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.global.languages' ) );
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.ezdemo_site_admin.languages' ) );
-        $this->assertSame( $langDemoSite, $this->container->getParameter( 'ezsettings.ezdemo_site.languages' ) );
-        $this->assertSame( $langFre, $this->container->getParameter( 'ezsettings.fre.languages' ) );
-        $this->assertSame( $langFre, $this->container->getParameter( 'ezsettings.fre2.languages' ) );
+        $this->assertConfigResolverParameterValue( 'languages', $langDemoSite, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'languages', $langFre, 'fre' );
+        $this->assertConfigResolverParameterValue( 'languages', $langFre, 'fre2' );
         $this->assertSame(
             array(
                 'eng-GB' => array( 'ezdemo_site' ),
@@ -65,7 +52,7 @@ class LanguagesTest extends AbstractExtensionTestCase
             $this->container->getParameter( 'ezpublish.siteaccesses_by_language' )
         );
         // languages for ezdemo_site_admin will take default value (empty array)
-        $this->assertEmpty( $this->container->getParameter( 'ezsettings.ezdemo_site_admin.languages' ) );
+        $this->assertConfigResolverParameterValue( 'languages', array(), 'ezdemo_site_admin' );
     }
 
     public function testLanguagesSiteaccessGroup()
@@ -80,12 +67,8 @@ class LanguagesTest extends AbstractExtensionTestCase
         );
         $this->load( $config );
 
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.ezdemo_site.languages' ) );
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.fre.languages' ) );
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.global.languages' ) );
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.ezdemo_site_admin.languages' ) );
-        $this->assertSame( $langDemoSite, $this->container->getParameter( 'ezsettings.ezdemo_site.languages' ) );
-        $this->assertSame( $langDemoSite, $this->container->getParameter( 'ezsettings.fre.languages' ) );
+        $this->assertConfigResolverParameterValue( 'languages', $langDemoSite, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'languages', $langDemoSite, 'fre' );
         $this->assertSame(
             array(
                 'eng-US' => array( 'ezdemo_site', 'fre' ),
@@ -93,7 +76,7 @@ class LanguagesTest extends AbstractExtensionTestCase
             $this->container->getParameter( 'ezpublish.siteaccesses_by_language' )
         );
         // languages for ezdemo_site_admin will take default value (empty array)
-        $this->assertEmpty( $this->container->getParameter( 'ezsettings.ezdemo_site_admin.languages' ) );
+        $this->assertConfigResolverParameterValue( 'languages', array(), 'ezdemo_site_admin' );
     }
 
     public function testTranslationSiteAccesses()
@@ -108,13 +91,9 @@ class LanguagesTest extends AbstractExtensionTestCase
         );
         $this->load( $config );
 
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.ezdemo_site.translation_siteaccesses' ) );
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.fre.translation_siteaccesses' ) );
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.global.translation_siteaccesses' ) );
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.ezdemo_site_admin.translation_siteaccesses' ) );
-        $this->assertSame( $translationSAsDemoSite, $this->container->getParameter( 'ezsettings.ezdemo_site.translation_siteaccesses' ) );
-        $this->assertSame( $translationSAsFre, $this->container->getParameter( 'ezsettings.fre.translation_siteaccesses' ) );
-        $this->assertEmpty( $this->container->getParameter( 'ezsettings.ezdemo_site_admin.translation_siteaccesses' ) );
+        $this->assertConfigResolverParameterValue( 'translation_siteaccesses', $translationSAsDemoSite, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'translation_siteaccesses', $translationSAsFre, 'fre' );
+        $this->assertConfigResolverParameterValue( 'translation_siteaccesses', array(), 'ezdemo_site_admin' );
     }
 
     public function testTranslationSiteAccessesWithGroup()
@@ -129,12 +108,8 @@ class LanguagesTest extends AbstractExtensionTestCase
         );
         $this->load( $config );
 
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.ezdemo_site.translation_siteaccesses' ) );
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.fre.translation_siteaccesses' ) );
-        $this->assertFalse( $this->container->hasParameter( 'ezsettings.global.translation_siteaccesses' ) );
-        $this->assertTrue( $this->container->hasParameter( 'ezsettings.ezdemo_site_admin.translation_siteaccesses' ) );
-        $this->assertSame( $translationSAsDemoSite, $this->container->getParameter( 'ezsettings.ezdemo_site.translation_siteaccesses' ) );
-        $this->assertSame( $translationSAsDemoSite, $this->container->getParameter( 'ezsettings.fre.translation_siteaccesses' ) );
-        $this->assertEmpty( $this->container->getParameter( 'ezsettings.ezdemo_site_admin.translation_siteaccesses' ) );
+        $this->assertConfigResolverParameterValue( 'translation_siteaccesses', $translationSAsDemoSite, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'translation_siteaccesses', $translationSAsDemoSite, 'fre' );
+        $this->assertConfigResolverParameterValue( 'translation_siteaccesses', array(), 'ezdemo_site_admin' );
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/PageTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/PageTest.php
@@ -11,20 +11,12 @@ namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\Page;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
-use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
-use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\Yaml\Yaml;
 
-class PageTest extends AbstractExtensionTestCase
+class PageTest extends AbstractParserTestCase
 {
     private $config;
 
-    /**
-     * Return an array of container extensions you need to be registered for each test (usually just the container
-     * extension you are testing.
-     *
-     * @return ExtensionInterface[]
-     */
     protected function getContainerExtensions()
     {
         return array(
@@ -51,8 +43,8 @@ class PageTest extends AbstractExtensionTestCase
 
         // For each siteaccess we expect to only have enabled layout/blocks
         $pageConfigForSiteaccess = $this->getPageConfigForSiteaccessFromDefaults( $defaultConfig );
-        $this->assertSame( $pageConfigForSiteaccess, $this->container->getParameter( 'ezsettings.ezdemo_site.ezpage' ) );
-        $this->assertSame( $pageConfigForSiteaccess, $this->container->getParameter( 'ezsettings.fre.ezpage' ) );
+        $this->assertConfigResolverParameterValue( 'ezpage', $pageConfigForSiteaccess, 'ezdemo_site' );
+        $this->assertConfigResolverParameterValue( 'ezpage', $pageConfigForSiteaccess, 'fre' );
     }
 
     public function testSiteaccessPageConfig()
@@ -88,7 +80,7 @@ class PageTest extends AbstractExtensionTestCase
         );
 
         $expected = $this->getPageConfigForSiteaccessFromDefaults( $defaultConfig, $siteaccessConfig );
-        $this->assertSame( $expected, $this->container->getParameter( 'ezsettings.fre.ezpage' ) );
+        $this->assertConfigResolverParameterValue( 'ezpage', $expected, 'fre' );
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/TemplatesTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/TemplatesTest.php
@@ -12,20 +12,12 @@ namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\FieldDefinitionSettingsTemplates;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\FieldTemplates;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
-use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
-use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\Yaml\Yaml;
 
-class TemplatesTest extends AbstractExtensionTestCase
+class TemplatesTest extends AbstractParserTestCase
 {
     private $config;
 
-    /**
-     * Return an array of container extensions you need to be registered for each test (usually just the container
-     * extension you are testing.
-     *
-     * @return ExtensionInterface[]
-     */
     protected function getContainerExtensions()
     {
         return array(
@@ -46,26 +38,32 @@ class TemplatesTest extends AbstractExtensionTestCase
         $fixedUpConfig = $this->getExpectedConfigFieldTemplates( $this->config );
         $groupFieldTemplates = $fixedUpConfig['system']['ezdemo_frontend_group']['field_templates'];
         $demoSiteFieldTemplates = $fixedUpConfig['system']['ezdemo_site']['field_templates'];
-        $this->assertEquals(
+        $this->assertConfigResolverParameterValue(
+            'field_templates',
             array_merge(
                 // Adding default kernel value.
                 array( array( 'template' => 'EzPublishCoreBundle::content_fields.html.twig', 'priority' => 0 ) ),
                 $groupFieldTemplates,
                 $demoSiteFieldTemplates
             ),
-            $this->container->getParameter( 'ezsettings.ezdemo_site.field_templates' )
+            'ezdemo_site',
+            false
         );
-        $this->assertEquals(
+        $this->assertConfigResolverParameterValue(
+            'field_templates',
             array_merge(
                 // Adding default kernel value.
                 array( array( 'template' => 'EzPublishCoreBundle::content_fields.html.twig', 'priority' => 0 ) ),
                 $groupFieldTemplates
             ),
-            $this->container->getParameter( 'ezsettings.fre.field_templates' )
+            'fre',
+            false
         );
-        $this->assertEquals(
+        $this->assertConfigResolverParameterValue(
+            'field_templates',
             array( array( 'template' => 'EzPublishCoreBundle::content_fields.html.twig', 'priority' => 0 ) ),
-            $this->container->getParameter( 'ezsettings.ezdemo_site_admin.field_templates' )
+            'ezdemo_site_admin',
+            false
         );
     }
 
@@ -95,26 +93,33 @@ class TemplatesTest extends AbstractExtensionTestCase
         $fixedUpConfig = $this->getExpectedConfigFieldDefinitionSettingsTemplates( $this->config );
         $groupFieldTemplates = $fixedUpConfig['system']['ezdemo_frontend_group']['fielddefinition_settings_templates'];
         $demoSiteFieldTemplates = $fixedUpConfig['system']['ezdemo_site']['fielddefinition_settings_templates'];
-        $this->assertEquals(
+
+        $this->assertConfigResolverParameterValue(
+            'fielddefinition_settings_templates',
             array_merge(
                 // Adding default kernel value.
                 array( array( 'template' => 'EzPublishCoreBundle::fielddefinition_settings.html.twig', 'priority' => 0 ) ),
                 $groupFieldTemplates,
                 $demoSiteFieldTemplates
             ),
-            $this->container->getParameter( 'ezsettings.ezdemo_site.fielddefinition_settings_templates' )
+            'ezdemo_site',
+            false
         );
-        $this->assertEquals(
+        $this->assertConfigResolverParameterValue(
+            'fielddefinition_settings_templates',
             array_merge(
                 // Adding default kernel value.
                 array( array( 'template' => 'EzPublishCoreBundle::fielddefinition_settings.html.twig', 'priority' => 0 ) ),
                 $groupFieldTemplates
             ),
-            $this->container->getParameter( 'ezsettings.fre.fielddefinition_settings_templates' )
+            'fre',
+            false
         );
-        $this->assertEquals(
+        $this->assertConfigResolverParameterValue(
+            'fielddefinition_settings_templates',
             array( array( 'template' => 'EzPublishCoreBundle::fielddefinition_settings.html.twig', 'priority' => 0 ) ),
-            $this->container->getParameter( 'ezsettings.ezdemo_site_admin.fielddefinition_settings_templates' )
+            'ezdemo_site_admin',
+            false
         );
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/ViewTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/ViewTest.php
@@ -13,20 +13,12 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\Block
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\ContentView;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\LocationView;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
-use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
-use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\Yaml\Yaml;
 
-class ViewTest extends AbstractExtensionTestCase
+class ViewTest extends AbstractParserTestCase
 {
     private $config;
 
-    /**
-     * Return an array of container extensions you need to be registered for each test (usually just the container
-     * extension you are testing.
-     *
-     * @return ExtensionInterface[]
-     */
     protected function getContainerExtensions()
     {
         return array(
@@ -53,15 +45,10 @@ class ViewTest extends AbstractExtensionTestCase
                 }
             }
         }
-        $this->assertEquals(
-            $expectedLocationView,
-            $this->container->getParameter( 'ezsettings.ezdemo_site.location_view' )
-        );
-        $this->assertEquals(
-            $expectedLocationView,
-            $this->container->getParameter( 'ezsettings.fre.location_view' )
-        );
-        $this->assertSame( array(), $this->container->getParameter( 'ezsettings.ezdemo_site_admin.location_view' ) );
+
+        $this->assertConfigResolverParameterValue( 'location_view', $expectedLocationView, 'ezdemo_site', false );
+        $this->assertConfigResolverParameterValue( 'location_view', $expectedLocationView, 'fre', false );
+        $this->assertConfigResolverParameterValue( 'location_view', array(), 'ezdemo_site_admin', false );
     }
 
     public function testContentView()
@@ -78,28 +65,32 @@ class ViewTest extends AbstractExtensionTestCase
                 }
             }
         }
-        $this->assertEquals(
-            $expectedContentView,
-            $this->container->getParameter( 'ezsettings.ezdemo_site.content_view' )
-        );
-        $this->assertEquals(
-            $expectedContentView,
-            $this->container->getParameter( 'ezsettings.fre.content_view' )
-        );
-        $this->assertSame( array(), $this->container->getParameter( 'ezsettings.ezdemo_site_admin.location_view' ) );
+
+        $this->assertConfigResolverParameterValue( 'content_view', $expectedContentView, 'ezdemo_site', false );
+        $this->assertConfigResolverParameterValue( 'content_view', $expectedContentView, 'fre', false );
+        $this->assertConfigResolverParameterValue( 'content_view', array(), 'ezdemo_site_admin', false );
     }
 
     public function testBlockView()
     {
         $this->load();
-        $this->assertEquals(
+        $this->assertConfigResolverParameterValue(
+            'block_view',
             array( 'block' => $this->config['system']['ezdemo_frontend_group']['block_view'] ),
-            $this->container->getParameter( 'ezsettings.ezdemo_site.block_view' )
+            'ezdemo_site',
+            false
         );
-        $this->assertEquals(
+        $this->assertConfigResolverParameterValue(
+            'block_view',
             array( 'block' => $this->config['system']['ezdemo_frontend_group']['block_view'] ),
-            $this->container->getParameter( 'ezsettings.fre.block_view' )
+            'fre',
+            false
         );
-        $this->assertSame( array(), $this->container->getParameter( 'ezsettings.ezdemo_site_admin.block_view' ) );
+        $this->assertConfigResolverParameterValue(
+            'block_view',
+            array(),
+            'ezdemo_site_admin',
+            false
+        );
     }
 }


### PR DESCRIPTION
> Follow up for https://jira.ez.no/browse/EZP-23163

Improved tests.
They now use a real ConfigResolver, as expected in normal life.
