### PR TITLE
Fix EZP-23221: fatal error in RouteReferenceGenerator if there is no request route.

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/RouteReferenceGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/RouteReferenceGenerator.php
@@ -51,7 +51,7 @@ class RouteReferenceGenerator implements RouteReferenceGeneratorInterface
         if ( $resource === null )
         {
             $resource = $this->request->attributes->get( '_route' );
-            $params += $this->request->attributes->get( '_route_params' );
+            $params += $this->request->attributes->get( '_route_params', array() );
         }
 
         $event = new RouteReferenceGenerationEvent( new RouteReference( $resource, $params ), $this->request );

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/RouteReferenceGeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/RouteReferenceGeneratorTest.php
@@ -104,6 +104,25 @@ class RouteReferenceGeneratorTest extends PHPUnit_Framework_TestCase
         $this->assertSame( $params, $reference->getParams() );
     }
 
+    public function testGenerateNullResourceWithoutRoute( )
+    {
+        $currentRouteName = 'my_route';
+        $currentRouteParams = array( 'foo' => 'bar' );
+
+        $request = new Request();
+
+        $event = new RouteReferenceGenerationEvent( new RouteReference( null, array() ), $request );
+        $this->dispatcher
+            ->expects( $this->once() )
+            ->method( 'dispatch' )
+            ->with( MVCEvents::ROUTE_REFERENCE_GENERATION, $this->equalTo( $event ) );
+
+        $generator = new RouteReferenceGenerator( $this->dispatcher );
+        $generator->setRequest( $request );
+        $reference = $generator->generate();
+        $this->assertInstanceOf( 'eZ\Publish\Core\MVC\Symfony\Routing\RouteReference', $reference );
+    }
+
     public function generateGenerator()
     {
         return array(


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23221

This prevents a hard PHP Fatal error when generating a RouteReference without any resource, and the request has no actual route/route_params.
The problem is that `array() + null` will result in "Fatal Error: Unsupported operand types"

Possible TODO: Throw an Exception, since this may be an unexpected condition?
