### PR TITLE
Fix EZP-23222: LanguageSwitcher does not work in content preview

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
@@ -17,6 +17,7 @@ use eZ\Publish\Core\Helper\ContentPreviewHelper;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\View\ViewManagerInterface;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
+use eZ\Publish\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -113,6 +114,11 @@ class PreviewController
             null, null,
             array(
                 '_controller' => 'ez_content:viewLocation',
+                // specify a route for RouteReference generator
+                '_route' => UrlAliasGenerator::INTERNAL_LOCATION_ROUTE,
+                '_route_params' => array(
+                    'locationId' => $location->id,
+                ),
                 'location' => $location,
                 'viewType' => ViewManagerInterface::VIEW_TYPE_FULL,
                 'layout' => true,


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23222

When `ez_route()` is used in content preview, the request will fail:
`RouteNotFoundException: None of the chained routers were able to generate route: Route '' not found`

This happens because PreviewController does not specify the route, only the controller.
Fix by passing the location route (`_ezpublishLocation`) and required `locationId` to the new internal request.
