### PR TITLE
Fix EZP-23210: Exception thrown when using alternative user provider/login handler

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Security/HttpUtils.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/HttpUtils.php
@@ -41,11 +41,27 @@ class HttpUtils extends BaseHttpUtils implements SiteAccessAware
 
     public function generateUri( $request, $path )
     {
+        if ( $this->isRouteName( $path ) )
+        {
+            // Remove siteaccess attribute to avoid triggering reverse siteaccess lookup during link generation.
+            $request->attributes->remove( 'siteaccess' );
+        }
+
         return parent::generateUri( $request, $this->analyzeLink( $path ) );
     }
 
     public function checkRequestPath( Request $request, $path )
     {
         return parent::checkRequestPath( $request, $this->analyzeLink( $path ) );
+    }
+
+    /**
+     * @param string $path Path can be URI, absolute URL or a route name.
+     *
+     * @return bool
+     */
+    private function isRouteName( $path )
+    {
+        return $path && strpos( $path, 'http' ) !== 0 && strpos( $path, '/' ) !== 0;
     }
 }


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23210

When accessing to a protected resource, Symfony Security component generates a RedirectResponse to
the configured `login_path` (default being `/login`. This path can actually be an URI, but also a _route name_.
Some authentication _extensions_ like `FOSUserBundle` use that.

Of course, when a route name is used, the UrlGenerator is called, with the route name and **all the request
attributes as parameters**. The problem is that the current SiteAccess object is stored as `siteaccess` request attribute,
which has the effect to trigger reverse SiteAccess matching, which is of course not an expected behavior.
