### PR TITLE
Fix EZP-23168: ESI Request URLs exceed acceptable size of 8KB

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map.php
@@ -50,6 +50,19 @@ abstract class Map implements VersatileMatcher
         $this->map = $map;
     }
 
+    /**
+     * Do not serialize the Siteaccess configuration in order to reduce ESI request URL size
+     * @see https://jira.ez.no/browse/EZP-23168
+     *
+     * @return array
+     */
+    public function __sleep()
+    {
+        $this->map = array();
+        $this->reverseMap = array();
+        return array( 'map', 'reverseMap', 'key' );
+    }
+
     public function setRequest( SimplifiedRequest $request )
     {
         $this->request = $request;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterMapURITest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterMapURITest.php
@@ -38,6 +38,9 @@ class RouterMapURITest extends PHPUnit_Framework_TestCase
             new SimplifiedRequest( array( 'pathinfo' => $uri ) )
         );
         $this->assertSame( $expectedFixedUpURI, $matcher->analyseURI( $uri ) );
+        // Unserialized matcher should have the same behavior
+        $unserializedMatcher = unserialize( serialize( $matcher ) );
+        $this->assertSame( $expectedFixedUpURI, $unserializedMatcher->analyseURI( $uri ) );
     }
 
     /**
@@ -53,6 +56,9 @@ class RouterMapURITest extends PHPUnit_Framework_TestCase
             new SimplifiedRequest( array( 'pathinfo' => $fullUri ) )
         );
         $this->assertSame( $fullUri, $matcher->analyseLink( $linkUri ) );
+        // Unserialized matcher should have the same behavior
+        $unserializedMatcher = unserialize( serialize( $matcher ) );
+        $this->assertSame( $fullUri, $unserializedMatcher->analyseLink( $linkUri ) );
     }
 
     public function fixupURIProvider()


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23168

In the ESI Request URL information about ALL site accesses is transmitted. With a larger number of site accesses the URL exceeds the size of 8192 Bytes which most servers accept. As a result, the ESI call fails.

This fix inhibits the serialization of the site access map.

It works in our case, but I'm not sure whether there are any limitations or side effects.
