### PR TITLE
Fix EZP-23234: provide a default (null) locationId for _ezpublishLocation route

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -59,6 +59,7 @@ services:
             - @ezpublish.api.service.content
             - @http_kernel
             - @ezpublish.content_preview_helper
+            - @ezpublish.templating.global_helper
             - @security.context
         calls:
             - [setRequest, [@?request=]]

--- a/eZ/Bundle/EzPublishLegacyBundle/Tests/Controller/PreviewControllerTest.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Tests/Controller/PreviewControllerTest.php
@@ -37,6 +37,7 @@ class PreviewControllerTest extends BasePreviewControllerTest
             $this->contentService,
             $this->httpKernel,
             $this->previewHelper,
+            $this->globalHelper,
             $this->securityContext
         );
         $controller->setConfigResolver( $this->configResolver );

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\Helper\ContentPreviewHelper;
+use eZ\Publish\Core\MVC\Symfony\Templating\GlobalHelper;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\View\ViewManagerInterface;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
@@ -41,6 +42,11 @@ class PreviewController
     private $previewHelper;
 
     /**
+     * @var \eZ\Publish\Core\MVC\Symfony\Templating\GlobalHelper
+     */
+    private $globalHelper;
+
+    /**
      * @var \Symfony\Component\Security\Core\SecurityContextInterface
      */
     private $securityContext;
@@ -54,12 +60,14 @@ class PreviewController
         ContentService $contentService,
         HttpKernelInterface $kernel,
         ContentPreviewHelper $previewHelper,
+        GlobalHelper $globalHelper,
         SecurityContextInterface $securityContext
     )
     {
         $this->contentService = $contentService;
         $this->kernel = $kernel;
         $this->previewHelper = $previewHelper;
+        $this->globalHelper = $globalHelper;
         $this->securityContext = $securityContext;
     }
 
@@ -117,7 +125,7 @@ class PreviewController
                 // specify a route for RouteReference generator
                 '_route' => UrlAliasGenerator::INTERNAL_LOCATION_ROUTE,
                 '_route_params' => array(
-                    'locationId' => $location->id,
+                    'locationId' => $location->id ?: $this->globalHelper->getRootLocation()->id,
                 ),
                 'location' => $location,
                 'viewType' => ViewManagerInterface::VIEW_TYPE_FULL,

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Tests/Controller/Content/PreviewControllerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Tests/Controller/Content/PreviewControllerTest.php
@@ -41,6 +41,11 @@ class PreviewControllerTest extends PHPUnit_Framework_TestCase
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
+    protected $globalHelper;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
     protected $securityContext;
 
     protected function setUp()
@@ -51,6 +56,10 @@ class PreviewControllerTest extends PHPUnit_Framework_TestCase
         $this->httpKernel = $this->getMock( 'Symfony\Component\HttpKernel\HttpKernelInterface' );
         $this->previewHelper = $this
             ->getMockBuilder( 'eZ\Publish\Core\Helper\ContentPreviewHelper' )
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->globalHelper = $this
+            ->getMockBuilder( 'eZ\Publish\Core\MVC\Symfony\Templating\GlobalHelper' )
             ->disableOriginalConstructor()
             ->getMock();
         $this->securityContext = $this->getMock( 'Symfony\Component\Security\Core\SecurityContextInterface' );
@@ -65,6 +74,7 @@ class PreviewControllerTest extends PHPUnit_Framework_TestCase
             $this->contentService,
             $this->httpKernel,
             $this->previewHelper,
+            $this->globalHelper,
             $this->securityContext
         );
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23234

This makes it possible to preview content using the internal `'_ezpublishLocation'` route if there is no actual location (new content draft).
The problem comes from using the `url()` twig helper and the checks done in Symfony.

From my limited knowledge, having a `null` default for the route should pose no issues, comments welcome.
