### PR TITLE
Fix EZP-23253: XmlText Fieldtype does not respect literal tag with cla...

### DIFF
--- a/eZ/Publish/Core/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl
+++ b/eZ/Publish/Core/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl
@@ -192,10 +192,17 @@
     </xsl:template>
 
     <xsl:template match="literal">
-        <pre>
-            <xsl:copy-of select="@*"/>
-            <xsl:apply-templates/>
-        </pre>
+        <xsl:choose>
+            <xsl:when test="@class='html'">
+                <xsl:value-of select="." disable-output-escaping="yes"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <pre>
+                    <xsl:copy-of select="@*"/>
+                    <xsl:apply-templates/>
+                </pre>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 
     <xsl:template match="anchor">


### PR DESCRIPTION
...ss html

Fixes: https://jira.ez.no/browse/EZP-23253 XmlText Fieldtype doesn't respect literal tag with class html

Not an xsl expert, but i have manually tested this patch and seems to work as expected. 

Let me know if it works
