### PR TITLE
[WIP] Remove references to RegEx on sentences examples in implementation

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Features/Context/SetupWizardContext.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Features/Context/SetupWizardContext.php
@@ -48,7 +48,7 @@ class SetupWizardContext extends LegacyContext
     }
 
     /**
-     * @When /^I select "([^"]*)" package version "([^"]*)"$/
+     * @When /^I select "(?P<packageName>[^"]*)" package version "(?P<version>[^"]*)"$/
      */
     public function iSelectPackage( $packageName, $version )
     {
@@ -70,7 +70,7 @@ class SetupWizardContext extends LegacyContext
     }
 
     /**
-     * @Then /^I see "([^"]*)" package version "([^"]*)" imported$/
+     * @Then /^I see "(?P<packageName>[^"]*)" package version "(?P<version>[^"]*)" imported$/
      */
     public function iSeeImported( $packageName, $version )
     {
@@ -93,7 +93,7 @@ class SetupWizardContext extends LegacyContext
     }
 
     /**
-     * @Then /^I see following packages for version "([^"]*)" imported(?:|\:)$/
+     * @Then /^I see following packages for version "(?P<version>[^"]*)" imported(?:|\:)$/
      */
     public function iSeeFollowingPackagesForVersionImported( $version, TableNode $packagesTable )
     {

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/RestContext.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/RestContext.php
@@ -262,7 +262,7 @@ class RestContext extends ApiContext implements RestSentences
     }
 
     /**
-     * When I add "<header>" header (?:to|with) "<action>" (?:an|a|for|to|the|of) "<object>"
+     * When I add "<header>" header to|with "<action>" an|a|for|to|the|of "<object>"
      *
      * Sentences examples:
      *  - I add content-type header to "Create" an "ContentType"
@@ -282,7 +282,7 @@ class RestContext extends ApiContext implements RestSentences
     }
 
     /**
-     * When I add "<header>" header (?:for|with) (?:an|a|to|the|of) "<object>"
+     * When I add "<header>" header for|with an|a|to|the|of "<object>"
      *
      * Sentences examples:
      *  - I add accept header for "ContentType"
@@ -301,7 +301,7 @@ class RestContext extends ApiContext implements RestSentences
     }
 
     /**
-     * When I make (?:an |a |)"<objectType>" object
+     * When I make an|a "<objectType>" object
      *
      * This will create an object of the type passed for step by step be filled
      */
@@ -311,7 +311,7 @@ class RestContext extends ApiContext implements RestSentences
     }
 
     /**
-     * When I add (?:the |)"<value>" value to "<field>" field
+     * When I add the "<value>" value to "<field>" field
      */
     public function iAddValueToField( $value, $field )
     {
@@ -343,7 +343,7 @@ class RestContext extends ApiContext implements RestSentences
     }
 
     /**
-     * When I send (?:the |)request
+     * When I send the request
      */
     public function iSendRequest()
     {
@@ -370,7 +370,7 @@ class RestContext extends ApiContext implements RestSentences
     }
 
     /**
-     * Then I (?:don\'t|do not) see "<header>" header
+     * Then I don\'t|do not see "<header>" header
      */
     public function iDonTSeeResponseHeader( $header )
     {
@@ -393,7 +393,7 @@ class RestContext extends ApiContext implements RestSentences
     }
 
     /**
-     * Then I (?:don\'t|do not) see "<header>" header with "<value>" value
+     * Then I don't|do not see "<header>" header with "<value>" value
      */
     public function iDonTSeeResponseHeaderWithValue( $header, $value )
     {
@@ -535,7 +535,7 @@ class RestContext extends ApiContext implements RestSentences
     }
 
     /**
-     * Then I see "<header>" header (?:for|with) (?:an|a|to|the) "<object>"
+     * Then I see "<header>" header for|with an|a|to|the "<object>"
      */
     public function iSeeResponseHeaderForObject( $header, $object )
     {
@@ -559,7 +559,7 @@ class RestContext extends ApiContext implements RestSentences
     }
 
     /**
-     * Then I see <statusCode> status code$/
+     * Then I see <statusCode> status code
      */
     public function iSeeResponseStatusCode( $statusCode )
     {
@@ -571,7 +571,7 @@ class RestContext extends ApiContext implements RestSentences
     }
 
     /**
-     * Then I see "<statusMessage>" status (?:reason phrase|message)$/
+     * Then I see "<statusMessage>" status reason phrase|message
      */
     public function iSeeResponseStatusMessage( $statusMessage )
     {

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/Authentication.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/Authentication.php
@@ -14,6 +14,10 @@ use Behat\Behat\Exception\PendingException;
 
 class Authentication extends Base implements AuthenticationSentences
 {
+    /**
+     * Given I am logged in as an|a "<role>"
+     * Given I have "<role>" permissions
+     */
     public function iAmLoggedInAsAn( $role )
     {
         switch( strtolower( $role ) )
@@ -30,11 +34,19 @@ class Authentication extends Base implements AuthenticationSentences
         $this->restClient->setAuthentication( $user, $password );
     }
 
+
+    /**
+     * Given I am logged in as "<user>" with password "<password>"
+     */
     public function iAmLoggedInAsWithPassword( $user, $password )
     {
         $this->restClient->setAuthentication( $user, $password );
     }
 
+    /**
+     * Given I am not logged in
+     * Given I do not|don't have permissions
+     */
     public function iAmNotLoggedIn()
     {
         $this->restClient->setAuthentication( '', '' );

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/ContentTypeGroup.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/ContentTypeGroup.php
@@ -107,8 +107,8 @@ class ContentTypeGroup extends Base implements ContentTypeGroupSentences
     }
 
     /**
-     * Then I see (?:a |)Content Type Group with identifier "<identifier>"
-     * Then response contains (?:a |)Content Type Group with identifier "<identifier>"
+     * Then I see a Content Type Group with identifier "<identifier>"
+     * Then response contains a Content Type Group with identifier "<identifier>"
      */
     public function iSeeContentTypeGroup( $identifier )
     {

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/Exception.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/Exception.php
@@ -15,7 +15,7 @@ use Behat\Behat\Context\Step;
 class Exception extends Base implements ExceptionSentences
 {
     /**
-     * Then I see (?:an |)invalid field (?:exception|error)
+     * Then I see an invalid field exception|error
      */
     public function iSeeAnInvalidFieldError()
     {
@@ -30,7 +30,7 @@ class Exception extends Base implements ExceptionSentences
     }
 
     /**
-     * Then I see (?:a |)forbidden (?:exception|error)
+     * Then I see a forbidden exception|error
      */
     public function iSeeAForbiddenError()
     {
@@ -43,7 +43,7 @@ class Exception extends Base implements ExceptionSentences
     }
 
     /**
-     * Then I see (?:a |)forbidden (?:exception|error) with "<message>" message
+     * Then I see a forbidden exception|error with "<message>" message
      */
     public function iSeeAForbiddenErrorWithMessage( $message )
     {
@@ -57,8 +57,8 @@ class Exception extends Base implements ExceptionSentences
     }
 
     /**
-     * Then I see (?:a |)not authorized (?:exception|error)
-     * Then I see (?:an |)unauthorized (?:exception|error)
+     * Then I see a |not authorized exception|error
+     * Then I see an unauthorized exception|error
      */
     public function iSeeNotAuthorizedError()
     {
@@ -69,7 +69,7 @@ class Exception extends Base implements ExceptionSentences
     }
 
     /**
-     * Then I see (?:a |)not found (?:exception|error)
+     * Then I see a not found exception|error
      */
     public function iSeeNotFoundError()
     {


### PR DESCRIPTION
Remove most references of RegEx on example sentences.
Since these sentences are examples only, they won't be mapped by Behat then, should be simplified.
