### PR TITLE
Fix capitalization in 'URLAliasService' to be consistent with API.

### DIFF
--- a/eZ/Publish/API/Repository/Tests/RepositoryTest.php
+++ b/eZ/Publish/API/Repository/Tests/RepositoryTest.php
@@ -154,11 +154,11 @@ class RepositoryTest extends BaseTest
     }
 
     /**
-     * Test for the getUrlAliasService() method.
+     * Test for the getURLAliasService() method.
      *
      * @return void
      * @group url-alias
-     * @see \eZ\Publish\API\Repository\Repository::getUrlAliasService()
+     * @see \eZ\Publish\API\Repository\Repository::getURLAliasService()
      */
     public function testGetURLAliasService()
     {

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/EzLinkToHtml5Test.php
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/EzLinkToHtml5Test.php
@@ -161,7 +161,7 @@ class EzLinkToHtml5Test extends PHPUnit_Framework_TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    protected function getMockUrlAliasService()
+    protected function getMockURLAliasService()
     {
         return $this->getMockBuilder( 'eZ\Publish\Core\Repository\URLAliasService' )
             ->disableOriginalConstructor()

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/UrlAliasTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/UrlAliasTest.php
@@ -95,7 +95,7 @@ class UrlAliasTest extends BaseTest
         $repository = $this->getRepositoryMock();
         $repository
             ->expects( $this->once() )
-            ->method( 'getUrlAliasService' )
+            ->method( 'getURLAliasService' )
             ->will( $this->returnValue( $urlAliasServiceMock ) );
 
         return $repository;

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
@@ -79,7 +79,7 @@ class UrlAliasGeneratorTest extends PHPUnit_Framework_TestCase
         $this->locationService = $this->getMock( 'eZ\\Publish\\API\\Repository\\LocationService' );
         $this->repository
             ->expects( $this->any() )
-            ->method( 'getUrlAliasService' )
+            ->method( 'getURLAliasService' )
             ->will( $this->returnValue( $this->urlAliasService ) );
         $this->repository
             ->expects( $this->any() )

--- a/eZ/Publish/Core/REST/Client/Repository.php
+++ b/eZ/Publish/Core/REST/Client/Repository.php
@@ -395,7 +395,7 @@ class Repository implements APIRepository
      *
      * @return \eZ\Publish\API\Repository\URLAliasService
      */
-    public function getUrlAliasService()
+    public function getURLAliasService()
     {
         if ( null === $this->urlAliasService )
         {

--- a/eZ/Publish/Core/SignalSlot/Repository.php
+++ b/eZ/Publish/Core/SignalSlot/Repository.php
@@ -121,7 +121,7 @@ class Repository implements RepositoryInterface
     /**
      * Instance of URL alias service
      *
-     * @var \eZ\Publish\Core\Repository\UrlAliasService
+     * @var \eZ\Publish\Core\Repository\URLAliasService
      */
     protected $urlAliasService;
 


### PR DESCRIPTION
This fixes references to `UrlAliasService` when the service/method is actually `URLAliasService`.

(Note: 
URL seems to be a cause for some disparity between api/spi/rest/ and documentation, personally and IMHO I would rather see everything in CamelCase, but I guess that's besides the point)
