### PR TITLE
Fix EZP-23287: Empty Image FieldType triggers twig_error_runtime

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -413,7 +413,7 @@
 {% if not ez_is_field_empty( content, field ) %}
 <figure {{ block( 'field_attributes' ) }}>
     {% set imageAlias = ez_image_alias( field, versionInfo, parameters.alias|default( 'original' ) ) %}
-    <img src="{{ asset( imageAlias.uri ) }}" width="{{ imageAlias.width }}" height="{{ imageAlias.height }}" alt="{{ field.value.alternativeText }}" />
+    {% if imageAlias %}<img src="{{ asset( imageAlias.uri ) }}" width="{{ imageAlias.width }}" height="{{ imageAlias.height }}" alt="{{ field.value.alternativeText }}" />{% endif %}
 </figure>
 {% endif %}
 {% endspaceless %}


### PR DESCRIPTION
check if image is set, otherwise don't try to render the image
related to: http://share.ez.no/forums/ez-publish-5-platform/ez_is_field_empty-not-working-fine-with-image-fieldtype
