### PR TITLE
CS: Removed double space in the function definiton

### DIFF
--- a/eZ/Publish/API/Repository/ContentTypeService.php
+++ b/eZ/Publish/API/Repository/ContentTypeService.php
@@ -39,7 +39,7 @@ interface ContentTypeService
      *
      * @return \eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup
      */
-    public function createContentTypeGroup( ContentTypeGroupCreateStruct  $contentTypeGroupCreateStruct );
+    public function createContentTypeGroup( ContentTypeGroupCreateStruct $contentTypeGroupCreateStruct );
 
     /**
      * Get a Content Type Group object by id


### PR DESCRIPTION
A small catch in this interface. One space is enough. 
