### PR TITLE
[Cache] Make sure CacheService is used for SPI Persistence cache

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/CacheServiceDecorator.php
+++ b/eZ/Publish/Core/Persistence/Cache/CacheServiceDecorator.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\Persistence\Cache;
 
-use Stash\Interfaces\PoolInterface;
+use Tedivm\StashBundle\Service\CacheService;
 
 /**
  * Class CacheServiceDecorator
@@ -28,9 +28,9 @@ class CacheServiceDecorator
     /**
      * Constructs the cache service decorator
      *
-     * @param \Stash\Interfaces\PoolInterface $cachePool
+     * @param \Tedivm\StashBundle\Service\CacheService $cachePool
      */
-    public function __construct( PoolInterface $cachePool )
+    public function __construct( CacheService $cachePool )
     {
         $this->cachePool = $cachePool;
     }

--- a/eZ/Publish/Core/Persistence/Cache/Tests/Helpers/IntegrationTestCacheServiceDecorator.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/Helpers/IntegrationTestCacheServiceDecorator.php
@@ -10,7 +10,7 @@
 namespace eZ\Publish\Core\Persistence\Cache\Tests\Helpers;
 
 use eZ\Publish\Core\Persistence\Cache\CacheServiceDecorator;
-use Stash\Pool;
+use Tedivm\StashBundle\Service\CacheService;
 use Stash\Driver\Ephemeral;
 
 /**
@@ -25,7 +25,7 @@ class IntegrationTestCacheServiceDecorator extends CacheServiceDecorator
      */
     public function __construct()
     {
-        $this->cachePool = new Pool( new Ephemeral() );
+        parent::__construct( new CacheService( 'testPool', new Ephemeral() ) );
     }
 
     /**
@@ -34,5 +34,13 @@ class IntegrationTestCacheServiceDecorator extends CacheServiceDecorator
     public function clearAllTestData()
     {
         $this->cachePool->flush();
+    }
+
+    /**
+     * @return \Tedivm\StashBundle\Service\CacheService
+     */
+    public function getPool()
+    {
+        return $this->cachePool;
     }
 }

--- a/eZ/Publish/Core/settings/storage_engines/cache.yml
+++ b/eZ/Publish/Core/settings/storage_engines/cache.yml
@@ -1,5 +1,5 @@
 parameters:
-    ezpublish.cache_pool.class: Stash\Pool
+    ezpublish.cache_pool.class: Tedivm\StashBundle\Service\CacheService
     ezpublish.cache_pool.spi.cache.decorator.class: eZ\Publish\Core\Persistence\Cache\CacheServiceDecorator
 
     ezpublish.spi.persistence.cache.class: eZ\Publish\Core\Persistence\Cache\Handler


### PR DESCRIPTION
Some reports about missing prefix of cache pools, so make sure we force use of CacheService directly which is handled this, instead of Stash\Pool which it extends.

Status: PR is for testing atm.

This reverts some of the changes done in 42df71026518da6469ff8724951d1764a60a7989.
