### PR TITLE
removed an unneeded param in the publishContentTypeDraft call

### DIFF
--- a/eZ/Publish/Core/REST/Server/Controller/ContentType.php
+++ b/eZ/Publish/Core/REST/Server/Controller/ContentType.php
@@ -334,7 +334,7 @@ class ContentType extends RestController
 
         if ( $publish )
         {
-            $this->contentTypeService->publishContentTypeDraft( $contentTypeDraft, 'bla' );
+            $this->contentTypeService->publishContentTypeDraft( $contentTypeDraft );
 
             $contentType = $this->contentTypeService->loadContentType( $contentTypeDraft->id );
             return new Values\CreatedContentType(


### PR DESCRIPTION
It seems that param was left behind there. Not needed acording to the publishContentTypeDraft definition. 

Let me know if you need an issue for this. 
