### PR TITLE
Fixed: EZP-23302: Update Location fails if no change is performed with t...

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -1022,9 +1022,8 @@ class DoctrineDatabase extends Gateway
                 )
             );
         $statement = $query->prepare();
-        $statement->execute();
 
-        if ( $statement->rowCount() < 1 )
+        if ( $statement->execute() === false )
         {
             throw new NotFound( 'location', $locationId );
         }


### PR DESCRIPTION
...he update

Fixes: https://jira.ez.no/browse/EZP-23302

If you use the api to update a Location and pass a LocationStruct which values are identicals to the Location ones, update process will throw an exception saying your location is not found anymore

Steps to reproduce:
-------------------------
You can try this cli command from one of your bundles (apply your namespace and bundle name accordingly )
```php
class TestCommand extends ContainerAwareCommand
{
    protected function configure()
    {
        $this->setName( 'namespace:bundle:test' )->setDefinition(array());
    }

    protected function execute( InputInterface $input, OutputInterface $output )
    {
        $repository = $this->getContainer()->get( 'ezpublish.api.repository' );
        $locationService = $repository->getLocationService();
        $repository->setCurrentUser( $repository->getUserService()->loadUser( 14 ) );

        $rootLocation = $locationService->loadLocation( 2 );
        $locationUpdateStruct = $locationService->newLocationUpdateStruct();
        $locationUpdateStruct->priority = 100;
        // first will be ok
        $output->writeln( 'First attempt should be ok...');
        $locationService->updateLocation( $rootLocation, $locationUpdateStruct );

        $output->writeln( 'Second attempt will fail...' );
        $locationService->updateLocation( $rootLocation, $locationUpdateStruct );
    }
}
```

Fix
----

I think problem is because the check performed after DoctrineDatabase Gateway [performs the update]
(https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php#L1027)

See third note here http://php.net//manual/en/pdostatement.rowcount.php

rowCount returns number of rows affected by the update op. but it seems that is no change produced in the row, that row doesn't count to return this rowCount number.
In our case, while the first option will change the priority of our root node, second one won't change anything and thats cause we have a rowCount less than 1.