### PR TITLE
Fixed: EZP-23313 Yaml ParseException after symfony udpate to 2.3.19

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
@@ -58,4 +58,4 @@ services:
         class: %ezpublish.signalslot.event_converter_slot.class%
         arguments: [@event_dispatcher]
         tags:
-            - { name: ezpublish.api.slot, signal: * }
+            - { name: ezpublish.api.slot, signal: '*' }


### PR DESCRIPTION
Fixes https://jira.ez.no/browse/EZP-23313

There is another pr to solve that but is suggested not to ignore this symfony update cause is a security one

https://github.com/ezsystems/ezpublish-community/pull/180
