### PR TITLE
New test for EZP-23288: Allow to set modifier of Content Versions & ContentType

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseContentServiceTest.php
@@ -185,6 +185,52 @@ abstract class BaseContentServiceTest extends BaseTest
     }
 
     /**
+     * Creates an updated content draft named <b>$draftVersion2</b> from
+     * a currently published content object with a user different from the
+     * creator.
+     *
+     * @return array \eZ\Publish\API\Repository\Values\Content\Content, id
+     */
+    protected function createUpdatedDraftVersion2_NotAdmin()
+    {
+        $repository = $this->getRepository();
+
+        $contentService = $repository->getContentService();
+        $userService = $repository->getUserService();
+        $mainLanguageCode = 'eng-US';
+
+        // Create a new user that belongs to the Administrator users group
+        $newUserCreateStruct = $userService->newUserCreateStruct( 'admin2', 'admin2@ez.no', "admin2", $mainLanguageCode );
+        $newUserCreateStruct->setField( 'first_name', 'Admin2', $mainLanguageCode );
+        $newUserCreateStruct->setField( 'last_name', 'Admin2', $mainLanguageCode );
+
+        // Load the Admin Group
+        $userAdminGroup = $userService->loadUserGroup( '12' );
+        
+        $userAdmin2 = $userService->createUser( $newUserCreateStruct, array ( $userAdminGroup ) );
+        
+        /* BEGIN: Inline */
+        $draftVersion2 = $this->createContentDraftVersion2();
+
+        // Create an update struct and modify some fields
+        $contentUpdate = $contentService->newContentUpdateStruct();
+        $contentUpdate->initialLanguageCode = $mainLanguageCode;
+    
+        $contentUpdate->creatorId = $this->generateId( 'user', $userAdmin2->id );
+        $contentUpdate->setField( 'name', 'An awesome forum²' );
+        $contentUpdate->setField( 'name', 'An awesome forum²³', 'eng-GB' );
+
+        // Update the content draft
+        $draftVersion2 = $contentService->updateContent(
+            $draftVersion2->getVersionInfo(),
+            $contentUpdate
+        );
+        /* END: Inline */
+
+        return array( $draftVersion2, $userAdmin2->id );
+    }
+
+    /**
      * Creates an updated content object named <b>$contentVersion2</b> from
      * a currently published content object.
      *

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -1307,6 +1307,36 @@ class ContentServiceTest extends BaseContentServiceTest
     }
 
     /**
+     * Test for the updateContent_WithDifferentUser() method.
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content
+     * @see \eZ\Publish\API\Repository\ContentService::updateContent()
+     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testNewContentUpdateStruct
+     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testCreateContentDraft
+     * @group user
+     * @group field-type
+     */
+    public function testUpdateContent_WithDifferentUser()
+    {
+        /* BEGIN: Use Case */
+        $arrayWithDraftVersion2 = $this->createUpdatedDraftVersion2_NotAdmin();
+        /* END: Use Case */
+
+        $this->assertInstanceOf(
+            '\\eZ\\Publish\\API\\Repository\\Values\\Content\\Content',
+            $arrayWithDraftVersion2[0]
+        );
+
+        $this->assertEquals(
+            $this->generateId( 'user', $arrayWithDraftVersion2[1] ),
+            $arrayWithDraftVersion2[0]->versionInfo->creatorId,
+            "creatorId is not properly set on new Version"
+        );
+
+        return $arrayWithDraftVersion2[0];
+    }
+
+    /**
      * Test for the updateContent() method.
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Content $content


### PR DESCRIPTION
#### New test for EZP-23288: Allow to set modifier of Content Versions & ContentType

This test a new user is create, inside Administrator User Group, and creates a new draft for story https://jira.ez.no/browse/EZP-23288
