### PR TITLE
EZP-23317 Twig Helper to get field Definition name in a template

### DIFF
--- a/eZ/Publish/Core/Helper/TranslationHelper.php
+++ b/eZ/Publish/Core/Helper/TranslationHelper.php
@@ -13,6 +13,8 @@ use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use Psr\Log\LoggerInterface;
 
@@ -141,6 +143,41 @@ class TranslationHelper
                 return $field;
             }
         }
+    }
+
+    /**
+     * Returns Field definition name in the appropriate language for a given content.
+     * By default, this method will return the field definition name in current language if translation is present. If not, main language will be used.
+     * If $forcedLanguage is provided, will return the field definition name in this language, if translation is present.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     * @param string $fieldTypeIdentifier Field definition identifier.
+     * @param string $forcedLanguage Locale we want the field definition name translated in in (e.g. "fre-FR"). Null by default (takes current locale)
+     *
+     * @return string
+     */
+    public function getTranslatedFieldDefinitionName( ContentType $contentType, $fieldTypeIdentifier, $forcedLanguage = null )
+    {
+        if ( $forcedLanguage !== null )
+        {
+            $languages = array( $forcedLanguage );
+        }
+        else
+        {
+            $languages = $this->configResolver->getParameter( 'languages' );
+        }
+
+        // Loop over prioritized languages to get the appropriate translated field definition name .
+        foreach ( $languages as $lang )
+        {
+            $fieldDefinition = $contentType->getFieldDefinition( $fieldTypeIdentifier );
+            if ( $fieldDefinition instanceof FieldDefinition && $fieldDefinition->getName( $lang ) )
+            {
+                return $fieldDefinition->getName( $lang );
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
@@ -229,6 +229,10 @@ class ContentExtension extends Twig_Extension
                 'ez_is_field_empty',
                 array( $this, 'isFieldEmpty' )
             ),
+            new Twig_SimpleFunction(
+                'ez_field_name',
+                array( $this, 'getTranslatedFieldDefinitionName' )
+            ),
         );
     }
 
@@ -646,6 +650,26 @@ class ContentExtension extends Twig_Extension
     public function getTranslatedFieldValue( Content $content, $fieldDefIdentifier, $forcedLanguage = null )
     {
         return $this->translationHelper->getTranslatedField( $content, $fieldDefIdentifier, $forcedLanguage )->value;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\ValueObject $content Must be a valid Content object.
+     * @param string $fieldIdentifier Identifier of the field to translate
+     * @param string $forcedLanguage Locale we want the content name translation in (e.g. "fre-FR"). Null by default (takes current locale)
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType When $content is not a valid Content object.
+     *
+     * @return string
+     */
+    public function getTranslatedFieldDefinitionName( ValueObject $content, $fieldIdentifier, $forcedLanguage = null )
+    {
+        if ( $content instanceof ValueObject )
+        {
+            $contentType = $this->repository->getContentTypeService()->loadContentType( $content->contentInfo->contentTypeId );
+            $fieldDefinitionName = $this->translationHelper->getTranslatedFieldDefinitionName( $contentType, $fieldIdentifier, $forcedLanguage );
+            return $fieldDefinitionName;
+        }
+        throw new InvalidArgumentType( '$content', 'eZ\Publish\API\Repository\Values\Content\Content', $content );
     }
 
     /**


### PR DESCRIPTION
# Use case

As a developper, i need a twig helper to get translated field definition name in a template using a twig function like `ez_field_name(content, 'myFieldIdentifier', [forcedLAnguage])`
This is useful when trying to display name of a field before its value.
# Usage

You can use it like this : 
`ez_field_name(content, 'fieldIdentifier', [forcedLanguage])`
And it will display the translated name of the field (extracted from the content type definition in eZ)
note: forcedLanguage is optional and eZ will use local if not defined
# Example:

An Article with 2 fields : 
name : "Name" in eng-GB and "Nom" in fre-FR
body: "Body" in eng-GB and "Corps de texte" in fre-FR

In a template, `ez_field_name(content, 'body')` will display "Body" in english and "Corps de texte" in french.

linked to https://jira.ez.no/browse/EZP-23317
