### PR TITLE
Improve EZP-23333: Content object build speed using SPI Cache

### DIFF
--- a/eZ/Publish/Core/Repository/FieldTypeService.php
+++ b/eZ/Publish/Core/Repository/FieldTypeService.php
@@ -27,16 +27,6 @@ use eZ\Publish\Core\Repository\Values\ContentType\FieldType;
 class FieldTypeService implements FieldTypeServiceInterface
 {
     /**
-     * @var \eZ\Publish\API\Repository\Repository
-     */
-    protected $repository;
-
-    /**
-     * @var \eZ\Publish\SPI\Persistence\Handler
-     */
-    protected $persistenceHandler;
-
-    /**
      * @var array Hash of SPI FieldTypes or callable callbacks to generate one.
      */
     protected $settings;
@@ -51,14 +41,10 @@ class FieldTypeService implements FieldTypeServiceInterface
     /**
      * Setups service with reference to repository object that created it & corresponding handler
      *
-     * @param \eZ\Publish\API\Repository\Repository $repository
-     * @param \eZ\Publish\SPI\Persistence\Handler $handler
      * @param array $settings Hash of SPI FieldTypes or callable callbacks to generate one.
      */
-    public function __construct( RepositoryInterface $repository, Handler $handler, array $settings = array() )
+    public function __construct( array $settings = array() )
     {
-        $this->repository = $repository;
-        $this->persistenceHandler = $handler;
         $this->settings = $settings;
     }
 

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -733,7 +733,7 @@ class Repository implements RepositoryInterface
         if ( $this->fieldTypeService !== null )
             return $this->fieldTypeService;
 
-        $this->fieldTypeService = new FieldTypeService( $this, $this->persistenceHandler, $this->serviceSettings['fieldType'] );
+        $this->fieldTypeService = new FieldTypeService( $this->serviceSettings['fieldType'] );
         return $this->fieldTypeService;
     }
 
@@ -789,6 +789,7 @@ class Repository implements RepositoryInterface
 
         $this->domainMapper = new DomainMapper(
             $this,
+            $this->persistenceHandler->contentTypeHandler(),
             $this->persistenceHandler->contentLanguageHandler()
         );
         return $this->domainMapper;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/DomainMapperTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/DomainMapperTest.php
@@ -130,6 +130,7 @@ class DomainMapperTest extends BaseServiceMockTest
     {
         return new DomainMapper(
             $this->getRepositoryMock(),
+            $this->getTypeHandlerMock(),
             $this->getLanguageHandlerMock()
         );
     }
@@ -140,5 +141,13 @@ class DomainMapperTest extends BaseServiceMockTest
     protected function getLanguageHandlerMock()
     {
         return $this->getPersistenceMockHandler( 'Content\\Language\\Handler' );
+    }
+
+    /**
+     * @return \eZ\Publish\SPI\Persistence\Content\Type\Handler|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getTypeHandlerMock()
+    {
+        return $this->getPersistenceMockHandler( 'Content\\Type\\Handler' );
     }
 }


### PR DESCRIPTION
Change to get ContentType from SPI (straight from cache) instead of using API for
internal use, as API version needs lots of build and load logic and slows things down.

Todo:
- [x] create / reuse issue
