### PR TITLE
removed no more needed param definition

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/services.yml
@@ -56,7 +56,6 @@ parameters:
     ezpublish.fieldType.ezpage.pageService.class: eZ\Bundle\EzPublishLegacyBundle\FieldType\Page\PageService
 
     ezpublish_legacy.rest_listener.class: eZ\Bundle\EzPublishLegacyBundle\EventListener\RestListener
-    ezpublish_legacy.siteaccess_listener.class: eZ\Bundle\EzPublishLegacyBundle\EventListener\SiteAccessListener
     ezpublish_legacy.request_listener.class: eZ\Bundle\EzPublishLegacyBundle\EventListener\RequestListener
     ezpublish_legacy.response_listener.class: eZ\Bundle\EzPublishLegacyBundle\EventListener\CsrfTokenResponseListener
     ezpublish_legacy.config_scope_listener.class: eZ\Bundle\EzPublishLegacyBundle\EventListener\ConfigScopeListener


### PR DESCRIPTION
This param is not needed anymore. Class was removed in https://github.com/ezsystems/ezpublish-kernel/commit/16ace1ee1a1e87b1db08107271c68309dea3f86a and there doesn't seem to be any other occurrence of the param. 

Let me know if you need a issue for this. 
