### PR TITLE
EZP-22995: Additional fix for undefined variable

### DIFF
--- a/eZ/Bundle/EzPublishDebugBundle/Collector/TemplateDebugInfo.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Collector/TemplateDebugInfo.php
@@ -117,13 +117,6 @@ class TemplateDebugInfo
             }
         }
 
-        // Re-activate ezxFormToken if it was before, as we might be inside an inline sub-request.
-        // See https://jira.ez.no/browse/EZP-22643
-        if ( $formTokenWasEnabled )
-        {
-            ezxFormToken::setIsEnabled( true );
-        }
-
         return $templateList;
     }
 }


### PR DESCRIPTION
Additinal fix for #951, JIRA https://jira.ez.no/browse/EZP-22995

`$formTokenWasEnabled` var was removed but still being used on this block, causing an `Undefined variable` notice.
