### PR TITLE
Fix EZP-23332: Templating Legacy Engine throws warning if TemplateRefere...

### DIFF
--- a/eZ/Publish/Core/MVC/Legacy/Templating/LegacyEngine.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/LegacyEngine.php
@@ -13,6 +13,7 @@ use Symfony\Component\Templating\EngineInterface;
 use eZ\Publish\Core\MVC\Legacy\Templating\Converter\MultipleObjectConverter;
 use eZTemplate;
 use ezpEvent;
+use Symfony\Component\Templating\TemplateReference;
 
 class LegacyEngine implements EngineInterface
 {
@@ -133,6 +134,11 @@ class LegacyEngine implements EngineInterface
      */
     public function supports( $name )
     {
+        if ( $name instanceof TemplateReference )
+        {
+            $name = $name->getLogicalName();
+        }
+
         if ( isset( $this->supportedTemplates[$name] ) )
         {
             return $this->supportedTemplates[$name];


### PR DESCRIPTION
...nce is passed as param to supports method

Fixes https://jira.ez.no/browse/EZP-23332

Found this issue when trying to add a translation webinterface to my project
http://jmsyst.com/bundles/JMSTranslationBundle/master/webinterface
Following all the steps there and pointing your browser to [your_dev]/_trans, we have a warning saying

```
ContextErrorException: Warning: Illegal offset type in isset or empty in [...]/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/MVC/Legacy/Templating/LegacyEngine.php line 136
```
