### PR TITLE
Fix EZP-23287: empty Image FieldType triggers twig_error_runtime

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -413,7 +413,7 @@
 {% if not ez_is_field_empty( content, field ) %}
 <figure {{ block( 'field_attributes' ) }}>
     {% set imageAlias = ez_image_alias( field, versionInfo, parameters.alias|default( 'original' ) ) %}
-    {% if imageAlias %}<img src="{{ asset( imageAlias.uri ) }}"{% if imageAlias.width is defined %} width="{{ imageAlias.width }}"{% endif %}{% if imageAlias.height is defined %} height="{{ imageAlias.height }}"{% endif %} alt="{{ field.value.alternativeText }}" />{% endif %}
+    <img src="{% if imageAlias %}{{ asset( imageAlias.uri ) }}{% else %}//:0{% endif %}"{% if imageAlias.width is defined %} width="{{ imageAlias.width }}"{% endif %}{% if imageAlias.height is defined %} height="{{ imageAlias.height }}"{% endif %} alt="{{ field.value.alternativeText }}" />
 </figure>
 {% endif %}
 {% endspaceless %}


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23287

Not sure this is the best approach, but the exception has already been
made silent by [EZP-22272](https://jira.ez.no/browse/EZP-22272).

Alternative would be to add a test in `content_fields.html.twig` but I'm
not sure either.
