### PR TITLE
Fix EZP-23264: hasParameter() of LegacyConfigResolver causes an error,

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/DependencyInjection/Configuration/LegacyConfigResolver.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/DependencyInjection/Configuration/LegacyConfigResolver.php
@@ -71,6 +71,11 @@ class LegacyConfigResolver implements ConfigResolverInterface
      */
     public function getParameter( $paramName, $namespace = null, $scope = null )
     {
+        if ( !$this->isValidParameterName( $paramName ) )
+        {
+            throw new ParameterNotFoundException( $paramName, "$namespace.ini" );
+        }
+
         $namespace = $namespace ?: $this->defaultNamespace;
         $namespace = str_replace( '.ini', '', $namespace );
         list( $iniGroup, $paramName ) = explode( '.', $paramName, 2 );
@@ -105,8 +110,6 @@ class LegacyConfigResolver implements ConfigResolverInterface
      * @param string $scope A specific siteaccess to look into. Defaults to the current siteaccess.
      *
      * @throws \eZ\Publish\Core\MVC\Exception\ParameterNotFoundException
-     *
-     * @todo Implement in ConfigResolver interface
      *
      * @return array
      */
@@ -148,6 +151,13 @@ class LegacyConfigResolver implements ConfigResolverInterface
      */
     public function hasParameter( $paramName, $namespace = null, $scope = null )
     {
+        // $paramName must have a '.' as it separates INI section and actual parameter name.
+        // e.g. DebugSettings.DebugOutput
+        if ( !$this->isValidParameterName( $paramName ) )
+        {
+            return false;
+        }
+
         $namespace = $namespace ?: $this->defaultNamespace;
         $namespace = str_replace( '.ini', '', $namespace );
         list( $iniGroup, $paramName ) = explode( '.', $paramName, 2 );
@@ -189,5 +199,19 @@ class LegacyConfigResolver implements ConfigResolverInterface
     public function getDefaultNamespace()
     {
         return $this->defaultNamespace;
+    }
+
+    /**
+     * Checks $paramName validity.
+     * $paramName must have a '.' as it separates INI section and actual parameter name.
+     * e.g. DebugSettings.DebugOutput
+     *
+     * @param string $paramName
+     *
+     * @return int
+     */
+    private function isValidParameterName( $paramName )
+    {
+        return strpos( $paramName, '.' ) !== false;
     }
 }

--- a/eZ/Bundle/EzPublishLegacyBundle/Tests/DependencyInjection/Configuration/LegacyConfigResolverTest.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Tests/DependencyInjection/Configuration/LegacyConfigResolverTest.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * File containing the LegacyConfigResolverTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishLegacyBundle\Tests\DependencyInjection\Configuration;
+
+use eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Configuration\LegacyConfigResolver;
+use PHPUnit_Framework_TestCase;
+use eZ\Publish\Core\MVC\Exception\ParameterNotFoundException;
+
+class LegacyConfigResolverTest extends PHPUnit_Framework_TestCase
+{
+    const DEFAULT_NAMESPACE = 'site';
+
+    /**
+     * @var \eZ\Bundle\EzPublishLegacyBundle\DependencyInjection\Configuration\LegacyConfigResolver
+     */
+    private $resolver;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $legacyKernel;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $legacyKernel = $this->legacyKernel = $this->getMock( 'ezpKernelHandler' );
+        $kernelClosure = function () use ( $legacyKernel )
+        {
+            return $legacyKernel;
+        };
+
+        $this->resolver = new LegacyConfigResolver( $kernelClosure, self::DEFAULT_NAMESPACE );
+    }
+
+    public function testGetSetDefaultNamespace()
+    {
+        $this->assertSame( self::DEFAULT_NAMESPACE, $this->resolver->getDefaultNamespace() );
+        $ns = 'image';
+        $this->resolver->setDefaultNamespace( $ns );
+        $this->assertSame( $ns, $this->resolver->getDefaultNamespace() );
+    }
+
+    public function testHasParameterInvalidParam()
+    {
+        $this->legacyKernel
+            ->expects( $this->never() )
+            ->method( 'runCallback' );
+        $this->assertFalse( $this->resolver->hasParameter( 'this_is_invalid' ) );
+    }
+
+    /**
+     * @dataProvider hasParameterProvider
+     */
+    public function testHasParameter( $paramName, $namespace, $expected )
+    {
+        $namespace = $namespace ?: self::DEFAULT_NAMESPACE;
+        $this->legacyKernel
+            ->expects( $this->once() )
+            ->method( 'runCallback' )
+            ->will( $this->returnValue( $expected ) );
+        $this->assertSame( $expected, $this->resolver->hasParameter( $paramName, $namespace ) );
+    }
+
+    public function hasParameterProvider()
+    {
+        return array(
+            array( 'Foo.Bar', null, true ),
+            array( 'Foo.Bar.baz', null, false ),
+            array( 'Foo.Babar', 'foo.ini', true ),
+        );
+    }
+
+    /**
+     * @expectedException \eZ\Publish\Core\MVC\Exception\ParameterNotFoundException
+     */
+    public function testGetParameterInvalidParam()
+    {
+        $this->legacyKernel
+            ->expects( $this->never() )
+            ->method( 'runCallback' );
+        $this->resolver->getParameter( 'this_is_invalid' );
+    }
+
+    /**
+     * @dataProvider getParameterProvider
+     */
+    public function testGetParameter( $paramName, $namespace, $value )
+    {
+        $this->legacyKernel
+            ->expects( $this->once() )
+            ->method( 'runCallback' )
+            ->will( $this->returnValue( $value ) );
+
+        $this->assertSame( $value, $this->resolver->getParameter( $paramName, $namespace ) );
+    }
+
+    public function getParameterProvider()
+    {
+        return array(
+            array( 'Foo.Bar', null, 'something' ),
+            array( 'Foo.Bar.baz', null, array( 'blabla' ) ),
+            array( 'Foo.Babar', 'foo.ini', 'enabled' ),
+        );
+    }
+
+    /**
+     * @expectedException \eZ\Publish\Core\MVC\Exception\ParameterNotFoundException
+     */
+    public function testGetNonExistentParameter()
+    {
+        $paramName = 'Foo.Bar';
+        $namespace = 'foo';
+        $this->legacyKernel
+            ->expects( $this->once() )
+            ->method( 'runCallback' )
+            ->will( $this->throwException( new ParameterNotFoundException( $paramName, "$namespace.ini" ) ) );
+
+        $this->resolver->getParameter( $paramName, $namespace );
+    }
+}


### PR DESCRIPTION
if the requester parameter does not exist.

> https://jira.ez.no/browse/EZP-23264

An error occurs if you want to check the existence of a specfic parameter, which is not defined.
For example:

``` php
$configResolver->hasParameter('parameter_name', 'name_space');
```

Exception message:

> ContextErrorException: Notice: Undefined offset: 1 in
> /path/to/symfony/vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishLegacyBundle/DependencyInjection/Configuration/LegacyConfigResolver.php
> line 151
