### PR TITLE
FIX EZP-23121: assignRole allows duplicate role/limitation assignments

### DIFF
--- a/eZ/Publish/API/Repository/RoleService.php
+++ b/eZ/Publish/API/Repository/RoleService.php
@@ -167,6 +167,7 @@ interface RoleService
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to assign a role
      * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if $roleLimitation is not valid
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If assignment already exists
      *
      * @param \eZ\Publish\API\Repository\Values\User\Role $role
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
@@ -190,6 +191,7 @@ interface RoleService
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to assign a role
      * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if $roleLimitation is not valid
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If assignment already exists
      *
      * @param \eZ\Publish\API\Repository\Values\User\Role $role
      * @param \eZ\Publish\API\Repository\Values\User\User $user

--- a/eZ/Publish/API/Repository/Tests/RoleServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/RoleServiceTest.php
@@ -13,6 +13,7 @@ use eZ\Publish\API\Repository\Values\User\Limitation\ContentTypeLimitation;
 use eZ\Publish\API\Repository\Values\User\Limitation\LanguageLimitation;
 use eZ\Publish\API\Repository\Values\User\Limitation\SubtreeLimitation;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use Exception;
 
 /**
  * Test case for operations in the RoleService using in memory storage.
@@ -1198,6 +1199,47 @@ class RoleServiceTest extends BaseTest
             ),
             $roleLimitation
         );
+
+        // Test again to see values being merged
+        $roleService->assignRoleToUser(
+            $role,
+            $user,
+            new SubtreeLimitation(
+                array(
+                    'limitationValues' => array( '/1/43/', '/1/2/' )
+                )
+            )
+        );
+
+        // The assignments array will contain the new role<->user assignment
+        $roleAssignments = $roleService->getRoleAssignments( $role );
+
+        // Members + Partners + Anonymous + Example User
+        $this->assertEquals( 4, count( $roleAssignments ) );
+
+        // Get the role limitation
+        $roleLimitation = null;
+        foreach ( $roleAssignments as $roleAssignment )
+        {
+            $roleLimitation = $roleAssignment->getRoleLimitation();
+            if ( $roleLimitation )
+            {
+                $this->assertInstanceOf(
+                    "\\eZ\\Publish\\API\\Repository\\Values\\User\\UserRoleAssignment",
+                    $roleAssignment
+                );
+                break;
+            }
+        }
+
+        $this->assertEquals(
+            new SubtreeLimitation(
+                array(
+                    'limitationValues' => array( '/1/43/', '/1/2/' )
+                )
+            ),
+            $roleLimitation
+        );
     }
 
     /**
@@ -1231,6 +1273,108 @@ class RoleServiceTest extends BaseTest
             new SubtreeLimitation(
                 array(
                     'limitationValues' => array( '/lorem/ipsum/42/' )
+                )
+            )
+        );
+        /* END: Use Case */
+    }
+
+    /**
+     * Test for the assignRoleToUser() method.
+     *
+     * Makes sure assigning role several times throws.
+     *
+     * @return void
+     * @see \eZ\Publish\API\Repository\RoleService::assignRoleToUser($role, $user, $roleLimitation)
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @depends eZ\Publish\API\Repository\Tests\RoleServiceTest::testAssignRoleToUser
+     * @depends eZ\Publish\API\Repository\Tests\RoleServiceTest::testLoadRoleByIdentifier
+     */
+    public function testAssignRoleToUserThrowsInvalidArgumentException()
+    {
+        $repository = $this->getRepository();
+
+        /* BEGIN: Use Case */
+        $roleService = $repository->getRoleService();
+
+        // Load the existing "Anonymous" role
+        $role = $roleService->loadRoleByIdentifier( 'Anonymous' );
+
+        // Get current user
+        $currentUser = $repository->getCurrentUser();
+
+        // Assign the "Anonymous" role to the current user
+        try
+        {
+            $roleService->assignRoleToUser(
+                $role,
+                $currentUser
+            );
+        }
+        catch ( Exception $e )
+        {
+            $this->fail( "Got exception at first valid attempt to assign role" );
+        }
+
+        // Re-Assign the "Anonymous" role to the current user
+        // This call will fail with an InvalidArgumentException, because limitation is already assigned
+        $roleService->assignRoleToUser(
+            $role,
+            $currentUser
+        );
+        /* END: Use Case */
+    }
+
+    /**
+     * Test for the assignRoleToUser() method.
+     *
+     * Makes sure assigning role several times with same limitations throws.
+     *
+     * @return void
+     * @see \eZ\Publish\API\Repository\RoleService::assignRoleToUser($role, $user, $roleLimitation)
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @depends eZ\Publish\API\Repository\Tests\RoleServiceTest::testAssignRoleToUser
+     * @depends eZ\Publish\API\Repository\Tests\RoleServiceTest::testLoadRoleByIdentifier
+     */
+    public function testAssignRoleToUserWithRoleLimitationThrowsInvalidArgumentException()
+    {
+        $repository = $this->getRepository();
+
+        /* BEGIN: Use Case */
+        $roleService = $repository->getRoleService();
+
+        // Load the existing "Anonymous" role
+        $role = $roleService->loadRoleByIdentifier( 'Anonymous' );
+
+        // Get current user
+        $currentUser = $repository->getCurrentUser();
+
+        // Assign the "Anonymous" role to the current user
+        try
+        {
+            $roleService->assignRoleToUser(
+                $role,
+                $currentUser,
+                new SubtreeLimitation(
+                    array(
+                        'limitationValues' => array( '/1/43/', '/1/2/' )
+                    )
+                )
+            );
+        }
+        catch ( Exception $e )
+        {
+            $this->fail( "Got exception at first valid attempt to assign role" );
+        }
+
+        // Re-Assign the "Anonymous" role to the current user
+        // This call will fail with an InvalidArgumentException, because limitation is already assigned
+        $roleService->assignRoleToUser(
+            $role,
+            $currentUser,
+            new SubtreeLimitation(
+                array(
+                    'limitationValues' => array( '/1/43/' )
                 )
             )
         );
@@ -1428,6 +1572,47 @@ class RoleServiceTest extends BaseTest
             ),
             $roleLimitation
         );
+
+        // Test again to see values being merged
+        $roleService->assignRoleToUserGroup(
+            $role,
+            $userGroup,
+            new SubtreeLimitation(
+                array(
+                    'limitationValues' => array( '/1/43/', '/1/2/' )
+                )
+            )
+        );
+
+        // The assignments array will contain the new role<->user assignment
+        $roleAssignments = $roleService->getRoleAssignments( $role );
+
+        // Members + Partners + Anonymous + Example User
+        $this->assertEquals( 4, count( $roleAssignments ) );
+
+        // Get the role limitation
+        $roleLimitation = null;
+        foreach ( $roleAssignments as $roleAssignment )
+        {
+            $roleLimitation = $roleAssignment->getRoleLimitation();
+            if ( $roleLimitation )
+            {
+                $this->assertInstanceOf(
+                    "\\eZ\\Publish\\API\\Repository\\Values\\User\\UserGroupRoleAssignment",
+                    $roleAssignment
+                );
+                break;
+            }
+        }
+
+        $this->assertEquals(
+            new SubtreeLimitation(
+                array(
+                    'limitationValues' => array( '/1/43/', '/1/2/' )
+                )
+            ),
+            $roleLimitation
+        );
     }
 
     /**
@@ -1465,6 +1650,116 @@ class RoleServiceTest extends BaseTest
             new SubtreeLimitation(
                 array(
                     'limitationValues' => array( '/lorem/ipsum/42/' )
+                )
+            )
+        );
+        /* END: Use Case */
+    }
+
+    /**
+     * Test for the assignRoleToUserGroup() method.
+     *
+     * Makes sure assigning role several times throws.
+     *
+     * @return void
+     * @see \eZ\Publish\API\Repository\RoleService::assignRoleToUserGroup($role, $userGroup, $roleLimitation)
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @depends eZ\Publish\API\Repository\Tests\UserServiceTest::testLoadUserGroup
+     * @depends eZ\Publish\API\Repository\Tests\RoleServiceTest::testLoadRoleByIdentifier
+     * @depends eZ\Publish\API\Repository\Tests\RoleServiceTest::testAssignRoleToUserGroup
+     */
+    public function testAssignRoleToUserGroupThrowsInvalidArgumentException()
+    {
+        $repository = $this->getRepository();
+
+        $mainGroupId = $this->generateId( 'group', 4 );
+        /* BEGIN: Use Case */
+        // $mainGroupId is the ID of the main "Users" group
+
+        $userService = $repository->getUserService();
+        $roleService = $repository->getRoleService();
+
+        $userGroup = $userService->loadUserGroup( $mainGroupId );
+
+        // Load the existing "Anonymous" role
+        $role = $roleService->loadRoleByIdentifier( 'Anonymous' );
+
+        // Assign the "Anonymous" role to the newly created user group
+        try
+        {
+            $roleService->assignRoleToUserGroup(
+                $role,
+                $userGroup
+            );
+        }
+        catch ( Exception $e )
+        {
+            $this->fail( "Got exception at first valid attempt to assign role" );
+        }
+
+        // Re-Assign the "Anonymous" role to the newly created user group
+        // This call will fail with an InvalidArgumentException, because role is already assigned
+        $roleService->assignRoleToUserGroup(
+            $role,
+            $userGroup
+        );
+        /* END: Use Case */
+    }
+
+    /**
+     * Test for the assignRoleToUserGroup() method.
+     *
+     * Makes sure assigning role several times with same limitations throws.
+     *
+     * @return void
+     * @see \eZ\Publish\API\Repository\RoleService::assignRoleToUserGroup($role, $userGroup, $roleLimitation)
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @depends eZ\Publish\API\Repository\Tests\UserServiceTest::testLoadUserGroup
+     * @depends eZ\Publish\API\Repository\Tests\RoleServiceTest::testLoadRoleByIdentifier
+     * @depends eZ\Publish\API\Repository\Tests\RoleServiceTest::testAssignRoleToUserGroup
+     */
+    public function testAssignRoleToUserGroupWithRoleLimitationThrowsInvalidArgumentException()
+    {
+        $repository = $this->getRepository();
+
+        $mainGroupId = $this->generateId( 'group', 4 );
+        /* BEGIN: Use Case */
+        // $mainGroupId is the ID of the main "Users" group
+
+        $userService = $repository->getUserService();
+        $roleService = $repository->getRoleService();
+
+        $userGroup = $userService->loadUserGroup( $mainGroupId );
+
+        // Load the existing "Anonymous" role
+        $role = $roleService->loadRoleByIdentifier( 'Anonymous' );
+
+        // Assign the "Anonymous" role to the newly created user group
+        try
+        {
+            $roleService->assignRoleToUserGroup(
+                $role,
+                $userGroup,
+                new SubtreeLimitation(
+                    array(
+                        'limitationValues' => array( '/1/43/', '/1/2/' )
+                    )
+                )
+            );
+        }
+        catch ( Exception $e )
+        {
+            $this->fail( "Got exception at first valid attempt to assign role" );
+        }
+
+        // Re-Assign the "Anonymous" role to the newly created user group
+        // This call will fail with an InvalidArgumentException, because limitation is already assigned
+        $roleService->assignRoleToUserGroup(
+            $role,
+            $userGroup,
+            new SubtreeLimitation(
+                array(
+                    'limitationValues' => array( '/1/43/' )
                 )
             )
         );

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/RoleTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/RoleTest.php
@@ -11,6 +11,8 @@ namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 
 use eZ\Publish\Core\Repository\Tests\Service\Mock\Base as BaseServiceMockTest;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\SPI\Persistence\User as SPIUser;
+use eZ\Publish\SPI\Persistence\User\Role as SPIRole;
 
 /**
  * Mock test case for Role service
@@ -337,16 +339,13 @@ class RoleTest extends BaseServiceMockTest
     public function testAssignRoleToUser()
     {
         $repository = $this->getRepositoryMock();
-        $roleServiceMock = $this->getPartlyMockedRoleService( array( "loadRole" ) );
+        $roleServiceMock = $this->getPartlyMockedRoleService( array( "checkAssignmentAndFilterLimitationValues" ) );
         $roleMock = $this->getMock( "eZ\\Publish\\API\\Repository\\Values\\User\\Role" );
         $userMock = $this->getMock( "eZ\\Publish\\API\\Repository\\Values\\User\\User" );
         $limitationMock = $this->getMock( "eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation" );
         $limitationTypeMock = $this->getMock( "eZ\\Publish\\SPI\\Limitation\\Type" );
-        $userServiceMock = $this->getMock( "eZ\\Publish\\API\\Repository\\UserService" );
+        $userHandlerMock = $this->getPersistenceMockHandler( "User\\Handler" );
 
-        $repository->expects( $this->once() )
-            ->method( "getUserService" )
-            ->will( $this->returnValue( $userServiceMock ) );
         $userMock->expects( $this->any() )
             ->method( "__get" )
             ->with( "id" )
@@ -382,15 +381,21 @@ class RoleTest extends BaseServiceMockTest
             ->method( "__get" )
             ->with( "id" )
             ->will( $this->returnValue( 42 ) );
-        $roleServiceMock->expects( $this->once() )
+
+        $userHandlerMock->expects( $this->once() )
             ->method( "loadRole" )
             ->with( $this->equalTo( 42 ) )
-            ->will( $this->returnValue( $roleMock ) );
+            ->will( $this->returnValue( new SPIRole( array( 'id' => 42 ) ) ) );
 
-        $userServiceMock->expects( $this->once() )
-            ->method( "loadUser" )
+        $userHandlerMock->expects( $this->once() )
+            ->method( "load" )
             ->with( $this->equalTo( 24 ) )
-            ->will( $this->returnValue( $userMock ) );
+            ->will( $this->returnValue( new SPIUser( array( 'id' => 24 ) ) ) );
+
+        $roleServiceMock->expects( $this->once() )
+            ->method( 'checkAssignmentAndFilterLimitationValues' )
+            ->with( 24, $this->isInstanceOf( '\\eZ\\Publish\\SPI\\Persistence\\User\\Role' ), array( "testIdentifier" => array() ) )
+            ->will( $this->returnValue( array( "testIdentifier" => array() ) ) );
 
         $repository->expects( $this->once() )->method( "beginTransaction" );
         $userHandlerMock = $this->getPersistenceMockHandler( "User\\Handler" );
@@ -418,14 +423,11 @@ class RoleTest extends BaseServiceMockTest
     public function testAssignRoleToUserWithNullLimitation()
     {
         $repository = $this->getRepositoryMock();
-        $roleServiceMock = $this->getPartlyMockedRoleService( array( "loadRole" ) );
+        $roleServiceMock = $this->getPartlyMockedRoleService( array( "checkAssignmentAndFilterLimitationValues" ) );
         $roleMock = $this->getMock( "eZ\\Publish\\API\\Repository\\Values\\User\\Role" );
         $userMock = $this->getMock( "eZ\\Publish\\API\\Repository\\Values\\User\\User" );
-        $userServiceMock = $this->getMock( "eZ\\Publish\\API\\Repository\\UserService" );
+        $userHandlerMock = $this->getPersistenceMockHandler( "User\\Handler" );
 
-        $repository->expects( $this->once() )
-            ->method( "getUserService" )
-            ->will( $this->returnValue( $userServiceMock ) );
         $userMock->expects( $this->any() )
             ->method( "__get" )
             ->with( "id" )
@@ -444,15 +446,21 @@ class RoleTest extends BaseServiceMockTest
             ->method( "__get" )
             ->with( "id" )
             ->will( $this->returnValue( 42 ) );
-        $roleServiceMock->expects( $this->once() )
+
+        $userHandlerMock->expects( $this->once() )
             ->method( "loadRole" )
             ->with( $this->equalTo( 42 ) )
-            ->will( $this->returnValue( $roleMock ) );
+            ->will( $this->returnValue( new SPIRole( array( 'id' => 42 ) ) ) );
 
-        $userServiceMock->expects( $this->once() )
-            ->method( "loadUser" )
+        $userHandlerMock->expects( $this->once() )
+            ->method( "load" )
             ->with( $this->equalTo( 24 ) )
-            ->will( $this->returnValue( $userMock ) );
+            ->will( $this->returnValue( new SPIUser( array( 'id' => 24 ) ) ) );
+
+        $roleServiceMock->expects( $this->once() )
+            ->method( 'checkAssignmentAndFilterLimitationValues' )
+            ->with( 24, $this->isInstanceOf( '\\eZ\\Publish\\SPI\\Persistence\\User\\Role' ), null )
+            ->will( $this->returnValue( null ) );
 
         $repository->expects( $this->once() )->method( "beginTransaction" );
         $userHandlerMock = $this->getPersistenceMockHandler( "User\\Handler" );
@@ -480,14 +488,11 @@ class RoleTest extends BaseServiceMockTest
     public function testAssignRoleToUserWithRollback()
     {
         $repository = $this->getRepositoryMock();
-        $roleServiceMock = $this->getPartlyMockedRoleService( array( "loadRole" ) );
+        $roleServiceMock = $this->getPartlyMockedRoleService( array( "checkAssignmentAndFilterLimitationValues" ) );
         $roleMock = $this->getMock( "eZ\\Publish\\API\\Repository\\Values\\User\\Role" );
         $userMock = $this->getMock( "eZ\\Publish\\API\\Repository\\Values\\User\\User" );
-        $userServiceMock = $this->getMock( "eZ\\Publish\\API\\Repository\\UserService" );
+        $userHandlerMock = $this->getPersistenceMockHandler( "User\\Handler" );
 
-        $repository->expects( $this->once() )
-            ->method( "getUserService" )
-            ->will( $this->returnValue( $userServiceMock ) );
         $userMock->expects( $this->any() )
             ->method( "__get" )
             ->with( "id" )
@@ -506,15 +511,21 @@ class RoleTest extends BaseServiceMockTest
             ->method( "__get" )
             ->with( "id" )
             ->will( $this->returnValue( 42 ) );
-        $roleServiceMock->expects( $this->once() )
+
+        $userHandlerMock->expects( $this->once() )
             ->method( "loadRole" )
             ->with( $this->equalTo( 42 ) )
-            ->will( $this->returnValue( $roleMock ) );
+            ->will( $this->returnValue( new SPIRole( array( 'id' => 42 ) ) ) );
 
-        $userServiceMock->expects( $this->once() )
-            ->method( "loadUser" )
+        $userHandlerMock->expects( $this->once() )
+            ->method( "load" )
             ->with( $this->equalTo( 24 ) )
-            ->will( $this->returnValue( $userMock ) );
+            ->will( $this->returnValue( new SPIUser( array( 'id' => 24 ) ) ) );
+
+        $roleServiceMock->expects( $this->once() )
+            ->method( 'checkAssignmentAndFilterLimitationValues' )
+            ->with( 24, $this->isInstanceOf( '\\eZ\\Publish\\SPI\\Persistence\\User\\Role' ), null )
+            ->will( $this->returnValue( null ) );
 
         $repository->expects( $this->once() )->method( "beginTransaction" );
         $userHandlerMock = $this->getPersistenceMockHandler( "User\\Handler" );
@@ -650,12 +661,13 @@ class RoleTest extends BaseServiceMockTest
     public function testAssignRoleToUserGroup()
     {
         $repository = $this->getRepositoryMock();
-        $roleServiceMock = $this->getPartlyMockedRoleService( array( "loadRole" ) );
+        $roleServiceMock = $this->getPartlyMockedRoleService( array( "checkAssignmentAndFilterLimitationValues" ) );
         $roleMock = $this->getMock( "eZ\\Publish\\API\\Repository\\Values\\User\\Role" );
         $userGroupMock = $this->getMock( "eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup" );
         $limitationMock = $this->getMock( "eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation" );
         $limitationTypeMock = $this->getMock( "eZ\\Publish\\SPI\\Limitation\\Type" );
         $userServiceMock = $this->getMock( "eZ\\Publish\\API\\Repository\\UserService" );
+        $userHandlerMock = $this->getPersistenceMockHandler( "User\\Handler" );
 
         $repository->expects( $this->once() )
             ->method( "getUserService" )
@@ -695,15 +707,21 @@ class RoleTest extends BaseServiceMockTest
             ->method( "__get" )
             ->with( "id" )
             ->will( $this->returnValue( 42 ) );
-        $roleServiceMock->expects( $this->once() )
+
+        $userHandlerMock->expects( $this->once() )
             ->method( "loadRole" )
             ->with( $this->equalTo( 42 ) )
-            ->will( $this->returnValue( $roleMock ) );
+            ->will( $this->returnValue( new SPIRole( array( 'id' => 42 ) ) ) );
 
         $userServiceMock->expects( $this->once() )
             ->method( "loadUserGroup" )
             ->with( $this->equalTo( 24 ) )
             ->will( $this->returnValue( $userGroupMock ) );
+
+        $roleServiceMock->expects( $this->once() )
+            ->method( 'checkAssignmentAndFilterLimitationValues' )
+            ->with( 24, $this->isInstanceOf( '\\eZ\\Publish\\SPI\\Persistence\\User\\Role' ), array( "testIdentifier" => array() ) )
+            ->will( $this->returnValue( array( "testIdentifier" => array() ) ) );
 
         $repository->expects( $this->once() )->method( "beginTransaction" );
         $userHandlerMock = $this->getPersistenceMockHandler( "User\\Handler" );
@@ -731,10 +749,11 @@ class RoleTest extends BaseServiceMockTest
     public function testAssignRoleToUserGroupWithNullLimitation()
     {
         $repository = $this->getRepositoryMock();
-        $roleServiceMock = $this->getPartlyMockedRoleService( array( "loadRole" ) );
+        $roleServiceMock = $this->getPartlyMockedRoleService( array( "checkAssignmentAndFilterLimitationValues" ) );
         $roleMock = $this->getMock( "eZ\\Publish\\API\\Repository\\Values\\User\\Role" );
         $userGroupMock = $this->getMock( "eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup" );
         $userServiceMock = $this->getMock( "eZ\\Publish\\API\\Repository\\UserService" );
+        $userHandlerMock = $this->getPersistenceMockHandler( "User\\Handler" );
 
         $repository->expects( $this->once() )
             ->method( "getUserService" )
@@ -757,15 +776,21 @@ class RoleTest extends BaseServiceMockTest
             ->method( "__get" )
             ->with( "id" )
             ->will( $this->returnValue( 42 ) );
-        $roleServiceMock->expects( $this->once() )
+
+        $userHandlerMock->expects( $this->once() )
             ->method( "loadRole" )
             ->with( $this->equalTo( 42 ) )
-            ->will( $this->returnValue( $roleMock ) );
+            ->will( $this->returnValue( new SPIRole( array( 'id' => 42 ) ) ) );
 
         $userServiceMock->expects( $this->once() )
             ->method( "loadUserGroup" )
             ->with( $this->equalTo( 24 ) )
             ->will( $this->returnValue( $userGroupMock ) );
+
+        $roleServiceMock->expects( $this->once() )
+            ->method( 'checkAssignmentAndFilterLimitationValues' )
+            ->with( 24, $this->isInstanceOf( '\\eZ\\Publish\\SPI\\Persistence\\User\\Role' ), null )
+            ->will( $this->returnValue( null ) );
 
         $repository->expects( $this->once() )->method( "beginTransaction" );
         $userHandlerMock = $this->getPersistenceMockHandler( "User\\Handler" );
@@ -793,10 +818,11 @@ class RoleTest extends BaseServiceMockTest
     public function testAssignRoleToUserGroupWithRollback()
     {
         $repository = $this->getRepositoryMock();
-        $roleServiceMock = $this->getPartlyMockedRoleService( array( "loadRole" ) );
+        $roleServiceMock = $this->getPartlyMockedRoleService( array( "checkAssignmentAndFilterLimitationValues" ) );
         $roleMock = $this->getMock( "eZ\\Publish\\API\\Repository\\Values\\User\\Role" );
         $userGroupMock = $this->getMock( "eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup" );
         $userServiceMock = $this->getMock( "eZ\\Publish\\API\\Repository\\UserService" );
+        $userHandlerMock = $this->getPersistenceMockHandler( "User\\Handler" );
 
         $repository->expects( $this->once() )
             ->method( "getUserService" )
@@ -819,15 +845,21 @@ class RoleTest extends BaseServiceMockTest
             ->method( "__get" )
             ->with( "id" )
             ->will( $this->returnValue( 42 ) );
-        $roleServiceMock->expects( $this->once() )
+
+        $userHandlerMock->expects( $this->once() )
             ->method( "loadRole" )
             ->with( $this->equalTo( 42 ) )
-            ->will( $this->returnValue( $roleMock ) );
+            ->will( $this->returnValue( new SPIRole( array( 'id' => 42 ) ) ) );
 
         $userServiceMock->expects( $this->once() )
             ->method( "loadUserGroup" )
             ->with( $this->equalTo( 24 ) )
             ->will( $this->returnValue( $userGroupMock ) );
+
+        $roleServiceMock->expects( $this->once() )
+            ->method( 'checkAssignmentAndFilterLimitationValues' )
+            ->with( 24, $this->isInstanceOf( '\\eZ\\Publish\\SPI\\Persistence\\User\\Role' ), null )
+            ->will( $this->returnValue( null ) );
 
         $repository->expects( $this->once() )->method( "beginTransaction" );
         $userHandlerMock = $this->getPersistenceMockHandler( "User\\Handler" );


### PR DESCRIPTION
New approach for #926, issue : https://jira.ez.no/browse/EZP-23121

Description:
Role Service assignRoleToUser/Group allows creating duplicate role/limitation assignments.
This can be verified in legacy admin (after clearing cache) or in database.

Todo:
- [x] adjust unit tests
- [x] add some more integration coverage (suggestions welcome) 
