### PR TITLE
Fix EZP-23059: RichText generic template rendered tags are missing handling of semantic configuration PART 3

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
@@ -120,6 +120,9 @@ class RichText extends AbstractFieldTypeParser
                                 'MyBundle:FieldType/RichText/tag:math_equation.html.twig'
                             )
                         )
+                        ->variableNode( "config" )
+                            ->info( "Tag configuration, arbitrary configuration is allowed here." )
+                        ->end()
                     ->end()
                 ->end()
             ->end()
@@ -135,6 +138,9 @@ class RichText extends AbstractFieldTypeParser
                                     'MyBundle:FieldType/RichText/embed:content.html.twig'
                                 )
                             )
+                            ->variableNode( "config" )
+                                ->info( "Embed configuration, arbitrary configuration is allowed here." )
+                            ->end()
                         ->end()
                     ->end()
                     ->arrayNode( 'content_denied' )
@@ -146,6 +152,9 @@ class RichText extends AbstractFieldTypeParser
                                     'MyBundle:FieldType/RichText/embed:content_denied.html.twig'
                                 )
                             )
+                            ->variableNode( "config" )
+                                ->info( "Embed configuration, arbitrary configuration is allowed here." )
+                            ->end()
                         ->end()
                     ->end()
                     ->arrayNode( 'content_inline' )
@@ -157,6 +166,9 @@ class RichText extends AbstractFieldTypeParser
                                     'MyBundle:FieldType/RichText/embed:content_inline.html.twig'
                                 )
                             )
+                            ->variableNode( "config" )
+                                ->info( "Embed configuration, arbitrary configuration is allowed here." )
+                            ->end()
                         ->end()
                     ->end()
                     ->arrayNode( 'content_inline_denied' )
@@ -168,6 +180,9 @@ class RichText extends AbstractFieldTypeParser
                                     'MyBundle:FieldType/RichText/embed:content_inline_denied.html.twig'
                                 )
                             )
+                            ->variableNode( "config" )
+                                ->info( "Embed configuration, arbitrary configuration is allowed here." )
+                            ->end()
                         ->end()
                     ->end()
                     ->arrayNode( 'location' )
@@ -179,6 +194,9 @@ class RichText extends AbstractFieldTypeParser
                                     'MyBundle:FieldType/RichText/embed:location.html.twig'
                                 )
                             )
+                            ->variableNode( "config" )
+                                ->info( "Embed configuration, arbitrary configuration is allowed here." )
+                            ->end()
                         ->end()
                     ->end()
                     ->arrayNode( 'location_denied' )
@@ -190,6 +208,9 @@ class RichText extends AbstractFieldTypeParser
                                     'MyBundle:FieldType/RichText/embed:location_denied.html.twig'
                                 )
                             )
+                            ->variableNode( "config" )
+                                ->info( "Embed configuration, arbitrary configuration is allowed here." )
+                            ->end()
                         ->end()
                     ->end()
                     ->arrayNode( 'location_inline' )
@@ -201,6 +222,9 @@ class RichText extends AbstractFieldTypeParser
                                     'MyBundle:FieldType/RichText/embed:location_inline.html.twig'
                                 )
                             )
+                            ->variableNode( "config" )
+                                ->info( "Embed configuration, arbitrary configuration is allowed here." )
+                            ->end()
                         ->end()
                     ->end()
                     ->arrayNode( 'location_inline_denied' )
@@ -212,6 +236,9 @@ class RichText extends AbstractFieldTypeParser
                                     'MyBundle:FieldType/RichText/embed:location_inline_denied.html.twig'
                                 )
                             )
+                            ->variableNode( "config" )
+                                ->info( "Embed configuration, arbitrary configuration is allowed here." )
+                            ->end()
                         ->end()
                     ->end()
                 ->end()

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
@@ -156,9 +156,28 @@ class RichTextTest extends AbstractParserTestCase
                             'tags' => array(
                                 'default' => array(
                                     'template' => 'MyBundle:FieldType/RichText/tag:default.html.twig',
+                                    'config' => array(
+                                        'watch' => 'out',
+                                        'only' => 'first level',
+                                        'can' => 'be mapped to ezxml',
+                                    ),
                                 ),
                                 'math_equation' => array(
                                     'template' => 'MyBundle:FieldType/RichText/tag:math_equation.html.twig',
+                                    'config' => array(
+                                        'some' => 'arbitrary',
+                                        'hash' => array(
+                                            'structure' => 12345,
+                                            'works' => array(
+                                                'drink' => 'beer',
+                                                'explode' => false,
+                                            ),
+                                            'does not work' => array(
+                                                'drink' => 'whiskey',
+                                                'deeble' => true,
+                                            ),
+                                        ),
+                                    ),
                                 ),
                             )
                         )
@@ -167,11 +186,30 @@ class RichTextTest extends AbstractParserTestCase
                 array(
                     'fieldtypes.ezrichtext.tags.default' => array(
                         'template' => 'MyBundle:FieldType/RichText/tag:default.html.twig',
+                        'config' => array(
+                            'watch' => 'out',
+                            'only' => 'first level',
+                            'can' => 'be mapped to ezxml',
+                        ),
                     ),
                     'fieldtypes.ezrichtext.tags.math_equation' => array(
                         'template' => 'MyBundle:FieldType/RichText/tag:math_equation.html.twig',
+                        'config' => array(
+                            'some' => 'arbitrary',
+                            'hash' => array(
+                                'structure' => 12345,
+                                'works' => array(
+                                    'drink' => 'beer',
+                                    'explode' => false,
+                                ),
+                                'does not work' => array(
+                                    'drink' => 'whiskey',
+                                    'deeble' => true,
+                                ),
+                            ),
+                        ),
                     ),
-                )
+                ),
             ),
             array(
                 array(
@@ -180,9 +218,23 @@ class RichTextTest extends AbstractParserTestCase
                             'embed' => array(
                                 'content' => array(
                                     'template' => 'MyBundle:FieldType/RichText/embed:content.html.twig',
+                                    'config' => array(
+                                        'have' => array(
+                                            'spacesuit' => array(
+                                                'travel' => true,
+                                            ),
+                                        ),
+                                    ),
                                 ),
                                 'location_inline_denied' => array(
                                     'template' => 'MyBundle:FieldType/RichText/embed:location_inline_denied.html.twig',
+                                    'config' => array(
+                                        'have' => array(
+                                            'location' => array(
+                                                'index' => true,
+                                            ),
+                                        ),
+                                    ),
                                 ),
                             )
                         )
@@ -191,9 +243,23 @@ class RichTextTest extends AbstractParserTestCase
                 array(
                     'fieldtypes.ezrichtext.embed.content' => array(
                         'template' => 'MyBundle:FieldType/RichText/embed:content.html.twig',
+                        'config' => array(
+                            'have' => array(
+                                'spacesuit' => array(
+                                    'travel' => true,
+                                ),
+                            ),
+                        ),
                     ),
                     'fieldtypes.ezrichtext.embed.location_inline_denied' => array(
                         'template' => 'MyBundle:FieldType/RichText/embed:location_inline_denied.html.twig',
+                        'config' => array(
+                            'have' => array(
+                                'location' => array(
+                                    'index' => true,
+                                ),
+                            ),
+                        ),
                     ),
                 )
             ),


### PR DESCRIPTION
Additional PR to resolve https://jira.ez.no/browse/EZP-23059

Original PR #905 missed handling config for template tags and embeds, which allows arbitrary configuration.

Fixed with tests by using `VariableNode`.
