### PR TITLE
EZP-23355 Add a getter for wrappedUser property in UserWrapper

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserWrappedTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserWrappedTest.php
@@ -37,6 +37,17 @@ class UserWrappedTest extends PHPUnit_Framework_TestCase
         $this->assertSame( $newApiUser, $userWrapped->getAPIUser() );
     }
 
+    public function testGetSetWrappedUser()
+    {
+        $originalUser = $this->getMock( 'Symfony\Component\Security\Core\User\UserInterface' );
+        $userWrapped = new UserWrapped( $originalUser, $this->apiUser );
+        $this->assertSame( $originalUser, $userWrapped->getWrappedUser() );
+
+        $newWrappedUser = $this->getMock( 'Symfony\Component\Security\Core\User\UserInterface' );
+        $userWrapped->setWrappedUser( $newWrappedUser );
+        $this->assertSame( $newWrappedUser, $userWrapped->getWrappedUser() );
+    }
+
     /**
      * @dataProvider advancedUserProvider
      */
@@ -53,6 +64,9 @@ class UserWrappedTest extends PHPUnit_Framework_TestCase
         $this->assertSame( $credentialsNonExpired, $user->isCredentialsNonExpired() );
         $this->assertSame( $userNonLocked, $user->isAccountNonLocked() );
         $this->assertSame( $originalUser->getSalt(), $user->getSalt() );
+        $this->assertSame( $originalUser->getUsername(), $user->getWrappedUser()->getUsername() );
+        $this->assertSame( $originalUser->isEnabled(), $user->getWrappedUser()->isEnabled() );
+        $this->assertSame( $originalUser, $user->getWrappedUser() );
     }
 
     public function advancedUserProvider()
@@ -109,6 +123,7 @@ class UserWrappedTest extends PHPUnit_Framework_TestCase
         $this->assertSame( $password, $user->getPassword() );
         $this->assertSame( $roles, $user->getRoles() );
         $this->assertSame( $salt, $user->getSalt() );
+        $this->assertSame( $originalUser, $user->getWrappedUser() );
     }
 
     public function testIsEqualTo()

--- a/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
@@ -14,6 +14,15 @@ use Symfony\Component\Security\Core\User\AdvancedUserInterface;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\UserInterface as CoreUserInterface;
 
+/**
+ * This class represents a UserWrapped object.
+ *
+ * It's used when working with multiple user providers
+ *
+ * It has two properties:
+ *     - wrappedUser: containing the originally matched user.
+ *     - apiUser: containing the API User (the one from the eZ Repository )
+ */
 class UserWrapped implements UserInterface, EquatableInterface
 {
     /**
@@ -71,6 +80,22 @@ class UserWrapped implements UserInterface, EquatableInterface
     public function getAPIUser()
     {
         return $this->apiUser;
+    }
+
+    /**
+     * @param \Symfony\Component\Security\Core\User\UserInterface $wrappedUser
+     */
+    public function setWrappedUser( CoreUserInterface $wrappedUser )
+    {
+        $this->wrappedUser = $wrappedUser;
+    }
+
+    /**
+     * @return \Symfony\Component\Security\Core\User\UserInterface
+     */
+    public function getWrappedUser()
+    {
+        return $this->wrappedUser;
     }
 
     public function getRoles()


### PR DESCRIPTION
Implements https://jira.ez.no/browse/EZP-23355

This comes from a post i wrote in the forums http://share.ez.no/forums/ez-publish-5-platform/security-listener-and-userwrapper

The idea is to have access to all data in the wrappedUser so this data can be used in controllers. 
Acording  to @lolautruche this new getter won't hurt
