### PR TITLE
Fix EZP-23345: respect ezxml header level in xslt

### DIFF
--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/ezxml/docbook/core.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/ezxml/docbook/core.xsl
@@ -265,12 +265,19 @@
 
   <xsl:template match="header">
     <xsl:variable name="headingLevel">
-      <xsl:value-of select="count( ancestor-or-self::section )"/>
+      <xsl:choose>
+      <xsl:when test="@level">
+        <xsl:value-of select="@level"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="count( ancestor-or-self::section ) + 1"/>
+      </xsl:otherwise>
+      </xsl:choose>
     </xsl:variable>
     <xsl:element name="title" namespace="http://docbook.org/ns/docbook">
       <xsl:attribute name="ezxhtml:level">
         <xsl:choose>
-          <xsl:when test="$headingLevel = 1">
+          <xsl:when test="$headingLevel &lt; 2">
             <xsl:value-of select="2"/>
           </xsl:when>
           <xsl:when test="$headingLevel &gt; 6">


### PR DESCRIPTION
Fix: https://jira.ez.no/browse/EZP-23345

xslt processing for ezxml should respect header level attribute, if specified.
