### PR TITLE
Fix EZP-23381: UserService::loadUserGroupsOfUser() checks wrong permissions

### DIFF
--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -900,8 +900,8 @@ class UserService implements UserServiceInterface
     {
         $locationService = $this->repository->getLocationService();
 
-        if ( !$this->repository->canUser( 'content', 'edit', $user ) )
-            throw new UnauthorizedException( 'content', 'edit' );
+        if ( !$this->repository->canUser( 'content', 'read', $user ) )
+            throw new UnauthorizedException( 'content', 'read' );
 
         $userLocations = $locationService->loadLocations(
             $user->getVersionInfo()->getContentInfo()


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23381

Loading user group of a user checks edit permission on the $user. Since loadUserGroupsOfUser is a read-only method, it is more relevant to check for check read-only permissions.

See comment on ca7f938c6ac8637cddbbfb28e6c8acf19c2c36c6
