### PR TITLE
Fix EZP-23364: case-correction redirects with tree_root setting

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Routing/UrlAliasRouter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Routing/UrlAliasRouter.php
@@ -21,13 +21,6 @@ class UrlAliasRouter extends BaseUrlAliasRouter
      */
     protected $configResolver;
 
-    protected $rootLocationId;
-
-    public function setRootLocationId( $rootLocationId )
-    {
-        $this->rootLocationId = $rootLocationId;
-    }
-
     /**
      * @param ConfigResolverInterface $configResolver
      */
@@ -57,11 +50,17 @@ class UrlAliasRouter extends BaseUrlAliasRouter
      */
     protected function getUrlAlias( $pathinfo )
     {
-        if ( $this->rootLocationId === null || $this->generator->isUriPrefixExcluded( $pathinfo ) )
+        $pathPrefix = $this->generator->getPathPrefixByRootLocationId( $this->rootLocationId );
+
+        if (
+            $this->rootLocationId === null ||
+            $this->generator->isUriPrefixExcluded( $pathinfo ) ||
+            $pathPrefix === "/"
+        )
         {
             return parent::getUrlAlias( $pathinfo );
         }
 
-        return $this->urlAliasService->lookup( $this->generator->getPathPrefixByRootLocationId( $this->rootLocationId ) . $pathinfo );
+        return $this->urlAliasService->lookup( $pathPrefix . $pathinfo );
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -143,15 +143,6 @@ class UrlAliasGenerator extends Generator
     }
 
     /**
-     * Returns the current root locationId
-     *
-     * @return int
-     */
-    public function getRootLocationId() {
-        return $this->rootLocationId;
-    }
-
-    /**
      * @param array $excludedUriPrefixes
      */
     public function setExcludedUriPrefixes( array $excludedUriPrefixes )


### PR DESCRIPTION
This PR resolves issue https://jira.ez.no/browse/EZP-23364

Case-correction redirect logic was not considering possible `content.tree_root.location_id` configuration option different from default content tree root. 

This is continuation of https://github.com/ezsystems/ezpublish-kernel/pull/1004 by @wizhippo, adding some additional fixes and tests.

Tests: unit test + manual integration testing.
