### PR TITLE
Added missing TemplatedUriRouter router

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "tedivm/stash-bundle": "0.4.*",
         "sensio/distribution-bundle": "~2.3",
         "nelmio/cors-bundle": "1.3.*",
+        "hautelook/templated-uri-bundle": "~1.0 | ~2.0",
         "pagerfanta/pagerfanta": "~1.0",
         "doctrine/dbal": "2.5.*@beta",
         "ocramius/proxy-manager": "0.5.*",


### PR DESCRIPTION
This dependency is missing in ezpublish-kernel.

Related to [EZP-23392](https://jira.ez.no/browse/EZP-23392) and https://github.com/ezsystems/ezpublish-community/pull/189
