### PR TITLE
Fix EZP-23408: use correct scope 'image' for images in legacy IO handler

### DIFF
--- a/eZ/Publish/Core/IO/Handler/Legacy.php
+++ b/eZ/Publish/Core/IO/Handler/Legacy.php
@@ -163,7 +163,7 @@ class Legacy implements IOHandlerInterface
 
         if ( $storagePrefix === 'images' )
         {
-            return 'images';
+            return 'image';
         }
 
         if ( $storagePrefix === 'original' )


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23408

Legacy IO handler is using scope `'images'` for images, where in reality it should be `'image'`.

Tests: manual
