### PR TITLE
Fix EZP-23413: Imagine alias generator: could not find configuration for a filter "original"

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGenerator.php
@@ -92,14 +92,15 @@ class AliasGenerator implements VariationHandler
         }
 
         $originalPath = $imageValue->id;
+        $originalBinary = $this->dataLoader->find( $originalPath );
         // Create the image alias only if it does not already exist.
-        if ( !$this->ioResolver->isStored( $originalPath, $variationName ) )
+        if ( $variationName !== IORepositoryResolver::VARIATION_ORIGINAL && !$this->ioResolver->isStored( $originalPath, $variationName ) )
         {
             if ( $this->logger )
                 $this->logger->debug( "Generating '$variationName' variation on $originalPath, field #$fieldId ($fieldDefIdentifier)" );
 
             $this->ioResolver->store(
-                $this->applyFilter( $this->dataLoader->find( $originalPath ), $variationName ),
+                $this->applyFilter( $originalBinary, $variationName ),
                 $originalPath,
                 $variationName
             );
@@ -138,7 +139,7 @@ class AliasGenerator implements VariationHandler
     {
         $filterConfig = $this->filterConfiguration->get( $variationName );
         // If the variation has a reference, we recursively call this method to apply reference's filters.
-        if ( isset( $filterConfig['reference'] ) && $filterConfig['reference'] !== 'original' )
+        if ( isset( $filterConfig['reference'] ) && $filterConfig['reference'] !== IORepositoryResolver::VARIATION_ORIGINAL )
         {
             $image = $this->applyFilter( $image, $filterConfig['reference'] );
         }

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/IORepositoryResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/IORepositoryResolver.php
@@ -21,6 +21,8 @@ use Symfony\Component\Routing\RequestContext;
  */
 class IORepositoryResolver implements ResolverInterface
 {
+    const VARIATION_ORIGINAL = 'original';
+
     /**
      * @var \eZ\Publish\Core\IO\IOServiceInterface
      */
@@ -57,7 +59,11 @@ class IORepositoryResolver implements ResolverInterface
     public function resolve( $path, $filter )
     {
         $path = $this->ioService->loadBinaryFile( $path )->uri;
-        return sprintf( '%s%s', $this->getBaseUrl(), $this->getFilePath( $path, $filter ) );
+        return sprintf(
+            '%s%s',
+            $this->getBaseUrl(),
+            $filter !== static::VARIATION_ORIGINAL ? $this->getFilePath( $path, $filter ) : $path
+        );
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/IORepositoryResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/IORepositoryResolverTest.php
@@ -130,6 +130,11 @@ class IORepositoryResolverTest extends PHPUnit_Framework_TestCase
         return array(
             array(
                 'Tardis/bigger/in-the-inside/RiverSong.jpg',
+                IORepositoryResolver::VARIATION_ORIGINAL, null,
+                'http://localhost/var/doctorwho/storage/images/Tardis/bigger/in-the-inside/RiverSong.jpg'
+            ),
+            array(
+                'Tardis/bigger/in-the-inside/RiverSong.jpg',
                 'thumbnail', null,
                 'http://localhost/var/doctorwho/storage/images/Tardis/bigger/in-the-inside/RiverSong_thumbnail.jpg'
             ),
@@ -152,6 +157,11 @@ class IORepositoryResolverTest extends PHPUnit_Framework_TestCase
                 'CultOfScaro/Dalek-fisherman.png',
                 'so_ridiculous', 'https://doctor.who:1234',
                 'https://doctor.who:1234/var/doctorwho/storage/images/CultOfScaro/Dalek-fisherman_so_ridiculous.png'
+            ),
+            array(
+                'CultOfScaro/Dalek-fisherman.png',
+                IORepositoryResolver::VARIATION_ORIGINAL, 'https://doctor.who:1234',
+                'https://doctor.who:1234/var/doctorwho/storage/images/CultOfScaro/Dalek-fisherman.png'
             ),
         );
     }


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23413

`original` variation needs a special process since it's a _virtual variation_.
Tests have been updated.
