### PR TITLE
Implemented EZP-23420: Log error if source image doesn't exist

### DIFF
--- a/eZ/Publish/API/Repository/Exceptions/SourceImageNotFoundException.php
+++ b/eZ/Publish/API/Repository/Exceptions/SourceImageNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * File containing the eZ\Publish\API\Repository\Exceptions\SourceImageNotFoundException class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\API\Repository\Exceptions;
+
+use RuntimeException;
+
+class SourceImageNotFoundException extends RuntimeException
+{
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension;
 
+use eZ\Publish\API\Repository\Exceptions\SourceImageNotFoundException;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\ValueObject;
@@ -449,6 +450,15 @@ class ContentExtension extends Twig_Extension
             if ( isset( $this->logger ) )
             {
                 $this->logger->error( "Couldn't get variation '{$variationName}' for image with id {$field->value->id}" );
+            }
+        }
+        catch ( SourceImageNotFoundException $e )
+        {
+            if ( isset( $this->logger ) )
+            {
+                $this->logger->error(
+                    "Couldn't create variation '{$variationName}' for image with id {$field->value->id} because source image can't be found"
+                );
             }
         }
     }


### PR DESCRIPTION
Implements: https://jira.ez.no/browse/EZP-23420

We can consider this as a follow up to https://github.com/ezsystems/ezpublish-kernel/pull/706

In this case, [find](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Bundle/EzPublishCoreBundle/Imagine/BinaryLoader.php#L49) function of `Imagine\BinaryLoader` throws that `NotLoadableException`

This patch catch it and just log the exception message
