### PR TITLE
Fix EZP-23424: clear content/info/remoteId persistence cache

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Cache/PersistenceCachePurger.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Cache/PersistenceCachePurger.php
@@ -158,6 +158,7 @@ class PersistenceCachePurger implements CacheClearerInterface
                 $location = $this->locationHandler->load( $id );
                 $this->cache->clear( 'content', $location->contentId );
                 $this->cache->clear( 'content', 'info', $location->contentId );
+                $this->cache->clear( 'content', 'info', 'remoteId' );
                 $this->cache->clear( 'content', 'locations', $location->contentId );
                 $this->cache->clear( 'user', 'role', 'assignments', 'byGroup', $location->contentId );
                 $this->cache->clear( 'user', 'role', 'assignments', 'byGroup', 'inherited', $location->contentId );

--- a/eZ/Bundle/EzPublishLegacyBundle/Tests/Cache/PersistenceCachePurgerTest.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Tests/Cache/PersistenceCachePurgerTest.php
@@ -233,6 +233,7 @@ class PersistenceCachePurgerTest extends PHPUnit_Framework_TestCase
                     array(
                         array( 'content', $contentId, null ),
                         array( 'content', 'info', $contentId, null ),
+                        array( 'content', 'info', 'remoteId', null ),
                         array( 'urlAlias', null ),
                         array( 'location', null ),
                     )


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23424

When persistence cache is cleared (from legacy, through the `content/cache` event),
 cache for `'content', 'info', 'remoteId'` was not being cleared.

Tests: manual

TODO:
- [x] Update / add tests
