### PR TITLE
Moved Image Legacy IO service service class param

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -53,6 +53,7 @@ parameters:
     # Image
     ezpublish.fieldType.ezimage.pathGenerator.class: eZ\Publish\Core\FieldType\Image\PathGenerator\LegacyPathGenerator
     ezpublish.fieldType.ezimage.io_service.options_provider.class: eZ\Publish\Core\FieldType\Image\IO\OptionsProvider
+    ezpublish.fieldType.ezimage.io_legacy.class: eZ\Publish\Core\FieldType\Image\IO\Legacy
 
     # BinaryFile
     ezpublish.fieldType.ezbinaryfile.pathGenerator.class: eZ\Publish\Core\FieldType\BinaryBase\PathGenerator\LegacyPathGenerator

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/fieldtype_services.yml
@@ -1,5 +1,4 @@
 parameters:
-    ezpublish.fieldType.ezimage.io_legacy.class: eZ\Publish\Core\FieldType\Image\IO\Legacy
     ezpublish.fieldType.ezimage.io_legacy.factory.class: eZ\Bundle\EzPublishLegacyBundle\FieldType\Image\IO\IOServiceFactory
     ezpublish_legacy.image_alias.cleaner.class: eZ\Publish\Core\MVC\Legacy\Image\AliasCleaner
 


### PR DESCRIPTION
Very small one: the service class parameter for the Image Legacy IO service was in LegacyBundle, while it should really have been in CoreBundle (it's LegacyStorage, not LegacyKernel).
