### PR TITLE
[DX] Improve assetic dump use with composer

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
@@ -24,6 +24,20 @@ class ScriptHandler extends DistributionBundleScriptHandler
         $options = self::getOptions( $event );
         $appDir = $options['symfony-app-dir'];
         $webDir = $options['symfony-web-dir'];
+        $env = isset( $options['ezpublish-asset-dump-env'] ) ? $options['ezpublish-asset-dump-env'] : "";
+
+        if ( !$env )
+        {
+            $env = $event->getIO()->ask(
+                "<question>Which environment would you like to dump production assets for?</question> (Default: 'prod', type 'none' to skip) ",
+                'prod'
+            );
+        }
+
+        if ( $env === 'none' )
+        {
+            return;
+        }
 
         if ( !is_dir( $appDir ) )
         {
@@ -37,7 +51,7 @@ class ScriptHandler extends DistributionBundleScriptHandler
             return;
         }
 
-        static::executeCommand( $event, $appDir, 'assetic:dump --env=prod ' . escapeshellarg( $webDir ) );
+        static::executeCommand( $event, $appDir, 'assetic:dump --env=' . escapeshellarg( $env ) . ' ' . escapeshellarg( $webDir ) );
     }
 
     /**


### PR DESCRIPTION
Possible approach for fixing dx issue with asset dumping and composer install/update.

https://jira.ez.no/browse/EZP-23492

Fixed:
- crashes when interfaces or something else needs to be cleared from prod cache on composer update
- control over when assets are dumped on composer install, as it is not needed on updates of most composer packages

Patch for ezpublish-community changing composer update to not dump assets:

``` diff
diff --git a/composer.json b/composer.json
index 0613899..a9d2340 100644
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::clearCache",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installAssets",
             "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installAssets",
-            "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::dumpAssets",
+            "eZ\\Bundle\\EzPublishCoreBundle\\Composer\\ScriptHandler::dumpAssetsHelpText",
             "Sensio\\Bundle\\DistributionBundle\\Composer\\ScriptHandler::installRequirementsFile",
             "eZ\\Bundle\\EzPublishLegacyBundle\\Composer\\ScriptHandler::installLegacyBundlesExtensions"
         ]
@@ -81,7 +81,9 @@
         "symfony-app-dir": "ezpublish",
         "symfony-web-dir": "web",
         "ezpublish-legacy-dir": "ezpublish_legacy",
-        "_symfony-assets-install_comment_": "One of 'symlink', 'relative' (symlinks) or 'hard'",
+        "___ezpublish-asset-dump-env": "To set environment used by dumpAssets script, like 'prod', or 'none' to skip",
+        "ezpublish-asset-dump-env": "",
+        "___symfony-assets-install": "One of 'symlink', 'relative' (symlinks) or 'hard'",
         "symfony-assets-install": "relative",
         "incenteev-parameters": {
             "file": "ezpublish/config/parameters.yml"
```

Note: this does not mean doing composer update in production is safe, such changes should still be staged as you'll often need to also clear prod cache as well and other changes like db updates.
## Screen shoots

Shows help text on composer update first, and then the question posted on composer install:
![screen shot 2014-10-21 at 14 18 07](https://cloud.githubusercontent.com/assets/289757/4718092/06baec46-591d-11e4-949d-6f92823edf74.png)
