### PR TITLE
DFS: Fixed wrong scope in stream file listener

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -238,6 +238,8 @@ services:
             - @ezpublish.fieldType.ezimage.io_service.published
             - @ezpublish.fieldType.ezimage.io_service.draft
             - @ezpublish.fieldType.ezimage.io_service.options_provider
+        # Required by ezpublish.core.io.stream_file_listener. Request listeners are initialized very early.
+        lazy: true
 
     ezpublish.fieldType.ezimage.io_service.options_provider:
         class: %ezpublish.fieldType.ezimage.io_service.options_provider.class%

--- a/eZ/Bundle/EzPublishIOBundle/EventListener/StreamFileListener.php
+++ b/eZ/Bundle/EzPublishIOBundle/EventListener/StreamFileListener.php
@@ -26,14 +26,10 @@ class StreamFileListener implements EventSubscriberInterface
     /** @var ConfigResolverInterface */
     private $configResolver;
 
-    public function __construct( IOServiceInterface $ioService )
+    public function __construct( IOServiceInterface $ioService, ConfigResolverInterface $configResolver )
     {
         $this->ioService = $ioService;
-    }
-
-    public function setIoPrefix( $ioPrefix )
-    {
-        $this->ioPrefix = $ioPrefix;
+        $this->configResolver = $configResolver;
     }
 
     public static function getSubscribedEvents()
@@ -76,7 +72,6 @@ class StreamFileListener implements EventSubscriberInterface
      */
     private function isIoUri( $uri )
     {
-        $uri = ltrim( $uri, '/' );
-        return ( strpos( $uri, $this->ioPrefix ) === 0 );
+        return ( strpos( ltrim( $uri, '/' ), $this->configResolver->getParameter( 'io.url_prefix' ) ) === 0 );
     }
 }

--- a/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
+++ b/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
@@ -77,7 +77,5 @@ services:
         arguments:
             - @ezpublish.fieldtype.ezimage.io_service
             - @ezpublish.config.resolver
-        calls:
-            - [setIoPrefix, ["$io.url_prefix"]]
         tags:
             - { name: kernel.event_subscriber }

--- a/eZ/Bundle/EzPublishIOBundle/Tests/EventListener/StreamFileListenerTest.php
+++ b/eZ/Bundle/EzPublishIOBundle/Tests/EventListener/StreamFileListenerTest.php
@@ -26,12 +26,21 @@ class StreamFileListenerTest extends PHPUnit_Framework_TestCase
 
     private $ioUriPrefix = 'var/test/storage';
 
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface|\PHPUnit_Framework_MockObject_MockObject */
+    private $configResolverMock;
+
     public function setUp(  )
     {
         $this->ioServiceMock = $this->getMock( 'eZ\Publish\Core\IO\IOServiceInterface' );
 
-        $this->eventListener = new StreamFileListener( $this->ioServiceMock );
-        $this->eventListener->setIoPrefix( $this->ioUriPrefix );
+        $this->configResolverMock = $this->getMock( 'eZ\Publish\Core\MVC\ConfigResolverInterface' );
+        $this->configResolverMock
+            ->expects( $this->any() )
+            ->method( 'getParameter' )
+            ->with( 'io.url_prefix' )
+            ->will( $this->returnValue( $this->ioUriPrefix ) );
+
+        $this->eventListener = new StreamFileListener( $this->ioServiceMock, $this->configResolverMock );
     }
 
     public function testDoesNotRespondToNonIoUri()


### PR DESCRIPTION
Request listeners are all initialized at the same time, and the siteaccess listener is one of them. This means that we can't rely on dynamic parameters, and must use the ConfigResolver directly
to get the io url_prefix.

Furthermore, the image legacy io service has to be made lazy, or else the prefixes it uses will be reset before the ConfigResolver is configured.
