### PR TITLE
Fix EZP-23486: don't fallback to legacy on front-end preview

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
@@ -9,3 +9,7 @@ _ezpublishLocation:
 _ezpublishPreviewContent:
     path: /content/versionview/{contentId}/{versionNo}/{language}/site_access/{siteAccessName}
     defaults: { _controller: ezpublish.controller.content.preview:previewContentAction }
+
+_ezpublishPreviewContentDefaultSa:
+    path: /content/versionview/{contentId}/{versionNo}/{language}
+    defaults: { _controller: ezpublish.controller.content.preview:previewContentAction }

--- a/eZ/Publish/Core/Helper/ContentPreviewHelper.php
+++ b/eZ/Publish/Core/Helper/ContentPreviewHelper.php
@@ -66,6 +66,16 @@ class ContentPreviewHelper implements SiteAccessAware
     }
 
     /**
+     * Return original SiteAccess
+     *
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess
+     */
+    public function getOriginalSiteAccess()
+    {
+        return $this->originalSiteAccess;
+    }
+
+    /**
      * Switches configuration scope to $siteAccessName and returns the new SiteAccess to use for preview.
      *
      * @param string $siteAccessName

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
@@ -68,7 +68,7 @@ class PreviewController
         $this->request = $request;
     }
 
-    public function previewContentAction( $contentId, $versionNo, $language, $siteAccessName )
+    public function previewContentAction( $contentId, $versionNo, $language, $siteAccessName = null )
     {
         try
         {
@@ -85,10 +85,15 @@ class PreviewController
             throw new AccessDeniedException();
         }
 
-        $newSiteAccess = $this->previewHelper->changeConfigScope( $siteAccessName );
+        $siteAccess = $this->previewHelper->getOriginalSiteAccess();
+        // Only switch if $siteAccessName is set and different from original
+        if ( $siteAccessName !== null && $siteAccessName !== $siteAccess->name )
+        {
+            $siteAccess = $this->previewHelper->changeConfigScope( $siteAccessName );
+        }
 
         $response = $this->kernel->handle(
-            $this->getForwardRequest( $location, $content, $newSiteAccess ),
+            $this->getForwardRequest( $location, $content, $siteAccess ),
             HttpKernelInterface::SUB_REQUEST
         );
         $response->headers->remove( 'cache-control' );


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23486

Content preview in the frontend (using ezwt) does not use the `site_access` named parameter, hence no route was being matched.
This PR fixes it by adding an additional route, and making sure the `previewContentAction()` works as expected with a `null` `$siteAccessName`

Tests: Manual
