### PR TITLE
Fix EZP-23495: Catch correct exception

### DIFF
--- a/eZ/Publish/Core/FieldType/Image/IO/Legacy.php
+++ b/eZ/Publish/Core/FieldType/Image/IO/Legacy.php
@@ -13,7 +13,7 @@ use eZ\Publish\Core\IO\IOServiceInterface;
 use eZ\Publish\Core\IO\MetadataHandler;
 use eZ\Publish\Core\IO\Values\BinaryFile;
 use eZ\Publish\Core\IO\Values\BinaryFileCreateStruct;
-use RuntimeException;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 /**
  * Legacy Image IOService
@@ -153,14 +153,14 @@ class Legacy implements IOServiceInterface
         {
             return $this->publishedIOService->loadBinaryFileByUri( $binaryFileUri );
         }
-        // Runtime means that the prefix didn't match, NotFound can pass through
-        catch ( RuntimeException $prefixException )
+        // InvalidArgumentException means that the prefix didn't match, NotFound can pass through
+        catch ( InvalidArgumentException $prefixException )
         {
             try
             {
                 return $this->draftIOService->loadBinaryFileByUri( $binaryFileUri );
             }
-            catch ( RuntimeException $e )
+            catch ( InvalidArgumentException $e )
             {
                 throw $prefixException;
             }

--- a/eZ/Publish/Core/FieldType/Tests/Image/IO/LegacyTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Image/IO/LegacyTest.php
@@ -12,6 +12,7 @@ use eZ\Publish\Core\FieldType\Image\IO\Legacy as LegacyIOService;
 use eZ\Publish\Core\FieldType\Image\IO\OptionsProvider;
 use eZ\Publish\Core\IO\Values\BinaryFile;
 use eZ\Publish\Core\IO\Values\BinaryFileCreateStruct;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use PHPUnit_Framework_TestCase;
 
 class LegacyTest extends PHPUnit_Framework_TestCase
@@ -224,7 +225,7 @@ class LegacyTest extends PHPUnit_Framework_TestCase
             ->expects( $this->once() )
             ->method( 'loadBinaryFileByUri' )
             ->with( $binaryFileUri )
-            ->will( $this->throwException( new \RuntimeException ) );
+            ->will( $this->throwException( new InvalidArgumentException( '$id', "Prefix not found in {$binaryFile->id}" ) ) );
 
         $this->draftIoServiceMock
             ->expects( $this->once() )


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-23495

Legacy::loadBinaryFileByUri catches RuntimeException but IOService::loadBinaryFileByUri throws eZ\Publish\Core\Base\Exceptions\InvalidArgumentException which is not a descendant of RuntimeException.
InvalidArgumentException inherits from APIInvalidArgumentException which inherits from ForbiddenException which inherits from Exception.
