### PR TITLE
Fix EZP-23505: Router generates wrong URL without vhost

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator.php
@@ -103,13 +103,15 @@ abstract class Generator implements SiteAccessAware
             }
         }
 
-        $url = $requestContext->getBaseUrl() . $this->doGenerate( $urlResource, $parameters );
+        $url = $this->doGenerate( $urlResource, $parameters );
 
         // Add the SiteAccess URI back if needed.
         if ( $siteAccess && $siteAccess->matcher instanceof SiteAccess\URILexer )
         {
             $url = $siteAccess->matcher->analyseLink( $url );
         }
+
+        $url = $requestContext->getBaseUrl() . $url;
 
         if ( $absolute )
         {

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/GeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/GeneratorTest.php
@@ -79,8 +79,8 @@ class GeneratorTest extends PHPUnit_Framework_TestCase
         $matcher
             ->expects( $this->once() )
             ->method( 'analyseLink' )
-            ->with( $fullUri )
-            ->will( $this->returnValue( $fullUri ) );
+            ->with( $uri )
+            ->will( $this->returnValue( $uri ) );
 
         if ( $absolute )
         {
@@ -113,8 +113,8 @@ class GeneratorTest extends PHPUnit_Framework_TestCase
         $matcher
             ->expects( $this->once() )
             ->method( 'analyseLink' )
-            ->with( $fullUri )
-            ->will( $this->returnValue( $fullUri ) );
+            ->with( $uri )
+            ->will( $this->returnValue( $uri ) );
 
         if ( $absolute )
         {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23505
