### PR TITLE
Fix EZP-23487: file may have already been removed

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/fieldtype_services.yml
@@ -9,4 +9,5 @@ services:
             - @ezpublish.image_alias.imagine.alias_cleaner
             - @ezpublish.fieldType.ezimage.io_service
             - @ezpublish.core.io.image_fieldtype.legacy_url_redecorator
+            - @logger
         lazy: true

--- a/eZ/Publish/Core/MVC/Legacy/Image/AliasCleaner.php
+++ b/eZ/Publish/Core/MVC/Legacy/Image/AliasCleaner.php
@@ -12,6 +12,8 @@ namespace eZ\Publish\Core\MVC\Legacy\Image;
 use eZ\Publish\Core\FieldType\Image\AliasCleanerInterface;
 use eZ\Publish\Core\IO\IOServiceInterface;
 use eZ\Publish\Core\IO\UrlRedecoratorInterface;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use Psr\Log\LoggerInterface;
 
 class AliasCleaner implements AliasCleanerInterface
 {
@@ -33,20 +35,30 @@ class AliasCleaner implements AliasCleanerInterface
     public function __construct(
         AliasCleanerInterface $innerAliasCleaner,
         IOServiceInterface $ioService,
-        UrlRedecoratorInterface $urlRedecorator
+        UrlRedecoratorInterface $urlRedecorator,
+        LoggerInterface $logger
     )
     {
         $this->innerAliasCleaner = $innerAliasCleaner;
         $this->ioService = $ioService;
         $this->urlRedecorator = $urlRedecorator;
+        $this->logger = $logger;
     }
 
     public function removeAliases( $originalPath )
     {
-        $this->innerAliasCleaner->removeAliases(
-            $this->ioService->loadBinaryFileByUri(
-                $this->urlRedecorator->redecorateFromTarget( $originalPath )
-            )
-        );
+        try
+        {
+            $this->innerAliasCleaner->removeAliases(
+                $this->ioService->loadBinaryFileByUri(
+                    $this->urlRedecorator->redecorateFromTarget( $originalPath )
+                )
+            );
+        }
+        catch( NotFoundException $e )
+        {
+            // May have already been removed by legacy eZImageAliasHandler::removeAliases()
+            $logger->debug("Image alias file not found: $originalPath");
+        }
     }
 }


### PR DESCRIPTION
The image may have already been removed before this event handler is called in `eZImageAliasHandler::removeAliases()`
