### PR TITLE
EZP-23510: Add support for overriding ez_page controller with block override rules

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/BlockView.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/BlockView.php
@@ -35,6 +35,15 @@ class BlockView extends View
                         ->prototype( "array" )
                             ->children()
                                 ->scalarNode( "template" )->isRequired()->info( "Your template path, as MyBundle:subdir:my_template.html.twig" )->end()
+                                ->scalarNode( 'controller' )
+                                    ->info(
+<<<EOT
+Use custom controller instead of the default one to display a block matching your rules.
+You can use the controller reference notation supported by Symfony.
+EOT
+                                    )
+                                    ->example( 'MyBundle:MyControllerClass:viewBlock' )
+                                ->end()
                                 ->arrayNode( "match" )
                                     ->info( "Condition matchers configuration" )
                                     ->useAttributeAsKey( "key" )

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/PageControllerListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/PageControllerListener.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * File containing the PageControllerListener class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\EventListener;
+
+use eZ\Publish\Core\FieldType\Page\PageService;
+use eZ\Publish\Core\FieldType\Page\Parts\Block;
+use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
+use eZ\Publish\Core\MVC\Symfony\Controller\ManagerInterface as ControllerManagerInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+class PageControllerListener implements EventSubscriberInterface
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\Controller\ManagerInterface
+     */
+    private $controllerManager;
+
+    /**
+     * @var \Symfony\Component\HttpKernel\Controller\ControllerResolverInterface
+     */
+    private $controllerResolver;
+
+    /**
+     * @var \eZ\Publish\Core\FieldType\Page\PageService
+     */
+    private $pageService;
+
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        ControllerResolverInterface $controllerResolver,
+        ControllerManagerInterface $controllerManager,
+        PageService $pageService,
+        LoggerInterface $logger
+    )
+    {
+        $this->controllerManager = $controllerManager;
+        $this->controllerResolver = $controllerResolver;
+        $this->pageService = $pageService;
+        $this->logger = $logger;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array( KernelEvents::CONTROLLER => 'getController' );
+    }
+
+    /**
+     * Detects if there is a custom controller to use to render a Block.
+     *
+     * @param FilterControllerEvent $event
+     *
+     * @throws \Symfony\Component\Security\Core\Exception\AccessDeniedException
+     */
+    public function getController( FilterControllerEvent $event )
+    {
+        $request = $event->getRequest();
+        // Only taking page related controller (i.e. ez_page:viewBlock or ez_page:viewBlockById)
+        if ( strpos( $request->attributes->get( '_controller' ), 'ez_page:' ) === false )
+        {
+            return;
+        }
+        try
+        {
+            if ( $request->attributes->has( 'id' ) )
+            {
+                $valueObject = $this->pageService->loadBlock(
+                    $request->attributes->get( 'id' )
+                );
+                $request->attributes->set( 'block', $valueObject );
+            }
+            else if ( $request->attributes->get( 'block' ) instanceof Block )
+            {
+                $valueObject = $request->attributes->get( 'block' );
+                $request->attributes->set( 'id', $valueObject->id );
+            }
+        }
+        catch ( UnauthorizedException $e)
+        {
+            throw new AccessDeniedException();
+        }
+
+        if ( !isset( $valueObject ) )
+        {
+            $this->logger->error( 'Could not resolve a page controller, invalid value object to match.' );
+            return;
+        }
+
+        $controllerReference = $this->controllerManager->getControllerReference(
+            $valueObject,
+            'block'
+        );
+
+        if ( !$controllerReference instanceof ControllerReference )
+            return;
+
+        $request->attributes->set( '_controller', $controllerReference->controller );
+        $event->setController( $this->controllerResolver->getController( $request ) );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -17,6 +17,7 @@ parameters:
 
     ezpublish.controller_manager.class: eZ\Publish\Core\MVC\Symfony\Controller\Manager
     ezpublish.controller_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\ViewControllerListener
+    ezpublish.page_controller_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\PageControllerListener
 
 services:
     # Siteaccess is injected in the container at runtime
@@ -88,11 +89,17 @@ services:
 
     ezpublish.controller_manager:
         class: %ezpublish.controller_manager.class%
-        arguments: [@ezpublish.location_view.matcher_factory, @ezpublish.content_view.matcher_factory, @logger]
+        arguments: [@ezpublish.location_view.matcher_factory, @ezpublish.content_view.matcher_factory, @ezpublish.block_view.matcher_factory, @logger]
 
     ezpublish.controller_listener:
         class: %ezpublish.controller_listener.class%
         arguments: [@controller_resolver, @ezpublish.controller_manager, @ezpublish.api.repository, @logger]
+        tags:
+            - { name: kernel.event_subscriber }
+
+    ezpublish.page_controller_listener:
+        class: %ezpublish.page_controller_listener.class%
+        arguments: [@controller_resolver, @ezpublish.controller_manager, @ezpublish.fieldType.ezpage.pageService, @logger]
         tags:
             - { name: kernel.event_subscriber }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/PageControllerListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/PageControllerListenerTest.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * File containing the PageControllerListenerTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;
+
+use eZ\Bundle\EzPublishCoreBundle\EventListener\PageControllerListener;
+use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class PageControllerListenerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $controllerResolver;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $controllerManager;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $pageService;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $logger;
+
+    /**
+     * @var ViewControllerListener
+     */
+    private $controllerListener;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $event;
+
+    /**
+     * @var Request
+     */
+    private $request;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->controllerResolver = $this->getMock( 'Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface' );
+        $this->controllerManager = $this->getMock( 'eZ\\Publish\\Core\\MVC\\Symfony\\Controller\\ManagerInterface' );
+        $this->pageService = $this->
+            getMockBuilder( 'eZ\\Publish\\Core\\FieldType\\Page\\PageService' )
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->logger = $this->getMock( 'Psr\\Log\\LoggerInterface' );
+        $this->controllerListener = new PageControllerListener( $this->controllerResolver, $this->controllerManager, $this->pageService, $this->logger );
+
+        $this->request = new Request;
+        $this->event = $this
+            ->getMockBuilder( 'Symfony\\Component\\HttpKernel\\Event\\FilterControllerEvent' )
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->event
+            ->expects( $this->any() )
+            ->method( 'getRequest' )
+            ->will( $this->returnValue( $this->request ) );
+    }
+
+    public function testGetSubscribedEvents()
+    {
+        $this->assertSame(
+            array( KernelEvents::CONTROLLER => 'getController' ),
+            $this->controllerListener->getSubscribedEvents()
+        );
+    }
+
+    public function testGetControllerNonPageController()
+    {
+        $initialController = 'Foo::bar';
+        $this->request->attributes->set( '_controller', $initialController );
+        $this->pageService
+            ->expects( $this->never() )
+            ->method( 'loadBlock' );
+
+        $this->controllerResolver
+            ->expects( $this->never() )
+            ->method( 'getControllerReference' );
+
+        $this->event
+            ->expects( $this->never() )
+            ->method( 'setController' );
+
+        $this->assertNull( $this->controllerListener->getController( $this->event ) );
+    }
+
+    public function testGetControllerInvalidParams()
+    {
+        // Don't add id / block to request attributes to enforce failure
+        $this->request->attributes->set( '_controller', 'ez_page:viewBlock' );
+        $this->pageService
+            ->expects( $this->never() )
+            ->method( 'loadBlock' );
+
+        $this->controllerResolver
+            ->expects( $this->never() )
+            ->method( 'getControllerReference' );
+
+        $this->logger
+            ->expects( $this->once() )
+            ->method( 'error' );
+
+        $this->event
+            ->expects( $this->never() )
+            ->method( 'setController' );
+
+        $this->assertNull( $this->controllerListener->getController( $this->event ) );
+    }
+
+    public function testGetControllerNoMatchedController()
+    {
+        $id = 123;
+        $this->request->attributes->add(
+            array(
+                '_controller' => 'ez_page:viewBlock',
+                'id' => $id
+            )
+        );
+
+        $valueObject = $this->getMock( 'eZ\\Publish\\Core\\FieldType\\Page\\Parts\\Block' );
+        $this->pageService
+            ->expects( $this->once() )
+            ->method( 'loadBlock' )
+            ->with( $id )
+            ->will( $this->returnValue( $valueObject ) );
+        $this->controllerManager
+            ->expects( $this->once() )
+            ->method( 'getControllerReference' )
+            ->will( $this->returnValue( null ) );
+
+        $this->event
+            ->expects( $this->never() )
+            ->method( 'setController' );
+
+        $this->assertNull( $this->controllerListener->getController( $this->event ) );
+    }
+
+    public function testGetControllerBlockId()
+    {
+        $id = 123;
+        $this->request->attributes->add(
+            array(
+                '_controller' => 'ez_page:viewBlockById',
+                'id' => $id
+            )
+        );
+
+        $valueObject = $this->getMock( 'eZ\\Publish\\Core\\FieldType\\Page\\Parts\\Block' );
+        $this->pageService
+            ->expects( $this->once() )
+            ->method( 'loadBlock' )
+            ->with( $id )
+            ->will( $this->returnValue( $valueObject ) );
+
+        $controllerIdentifier = 'AcmeTestBundle:Default:foo';
+        $controllerCallable = 'DefaultController::fooAction';
+        $controllerReference = new ControllerReference( $controllerIdentifier );
+        $this->controllerManager
+            ->expects( $this->once() )
+            ->method( 'getControllerReference' )
+            ->will( $this->returnValue( $controllerReference ) );
+        $this->controllerResolver
+            ->expects( $this->once() )
+            ->method( 'getController' )
+            ->with( $this->request )
+            ->will( $this->returnValue( $controllerCallable ) );
+        $this->event
+            ->expects( $this->once() )
+            ->method( 'setController' )
+            ->with( $controllerCallable );
+
+        $this->assertNull( $this->controllerListener->getController( $this->event ) );
+        $this->assertSame( $controllerIdentifier, $this->request->attributes->get( '_controller' ) );
+        $this->assertSame( $valueObject, $this->request->attributes->get( 'block' ) );
+    }
+
+    public function testGetControllerBlock()
+    {
+        $id = 123;
+        $block = $this
+            ->getMockBuilder( 'eZ\Publish\Core\FieldType\Page\Parts\Block' )
+            ->setConstructorArgs( array( array( 'id' => $id ) ) )
+            ->getMockForAbstractClass();
+        $viewType = 'block';
+        $this->request->attributes->add(
+            array(
+                '_controller' => 'ez_page:viewBlock',
+                'block' => $block
+            )
+        );
+
+        $controllerIdentifier = 'AcmeTestBundle:Default:foo';
+        $controllerCallable = 'DefaultController::fooAction';
+        $controllerReference = new ControllerReference( $controllerIdentifier );
+        $this->controllerManager
+            ->expects( $this->once() )
+            ->method( 'getControllerReference' )
+            ->with( $block, $viewType )
+            ->will( $this->returnValue( $controllerReference ) );
+        $this->controllerResolver
+            ->expects( $this->once() )
+            ->method( 'getController' )
+            ->with( $this->request )
+            ->will( $this->returnValue( $controllerCallable ) );
+        $this->event
+            ->expects( $this->once() )
+            ->method( 'setController' )
+            ->with( $controllerCallable );
+
+        $this->assertNull( $this->controllerListener->getController( $this->event ) );
+        $this->assertSame( $controllerIdentifier, $this->request->attributes->get( '_controller' ) );
+        $this->assertSame( $id, $this->request->attributes->get( 'id' ) );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\AccessDeniedException
+     */
+    public function testGetControllerBlockUnauthorizedException()
+    {
+        $id = 123;
+        $this->request->attributes->add(
+            array(
+                '_controller' => 'ez_page:viewBlock',
+                'id' => $id
+            )
+        );
+
+        $this->pageService
+            ->expects( $this->once() )
+            ->method( 'loadBlock' )
+            ->with( $id )
+            ->will( $this->throwException( new UnauthorizedException( 'foo', 'bar' ) ) );
+
+        $this->controllerListener->getController( $this->event );
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Manager.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Manager.php
@@ -11,8 +11,10 @@ namespace eZ\Publish\Core\MVC\Symfony\Controller;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\Core\FieldType\Page\Parts\Block;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBasedMatcherFactory;
+use eZ\Publish\Core\MVC\Symfony\Matcher\BlockMatcherFactory;
 use Psr\Log\LoggerInterface;
 use InvalidArgumentException;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
@@ -34,10 +36,16 @@ class Manager implements ManagerInterface
      */
     protected $contentMatcherFactory;
 
-    public function __construct( ContentBasedMatcherFactory $locationMatcherFactory, ContentBasedMatcherFactory $contentMatcherFactory, LoggerInterface $logger )
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\Matcher\BlockMatcherFactory
+     */
+    protected $blockMatcherFactory;
+
+    public function __construct( ContentBasedMatcherFactory $locationMatcherFactory, ContentBasedMatcherFactory $contentMatcherFactory, BlockMatcherFactory $blockMatcherFactory, LoggerInterface $logger )
     {
         $this->locationMatcherFactory = $locationMatcherFactory;
         $this->contentMatcherFactory = $contentMatcherFactory;
+        $this->blockMatcherFactory = $blockMatcherFactory;
         $this->logger = $logger;
     }
 
@@ -63,6 +71,11 @@ class Manager implements ManagerInterface
         {
             $matcherProp = 'contentMatcherFactory';
             $matchedType = 'Content';
+        }
+        else if ( $valueObject instanceof Block )
+        {
+            $matcherProp = 'blockMatcherFactory';
+            $matchedType = 'Block';
         }
         else
         {


### PR DESCRIPTION
Link to JIRA issue: [EZP-23510](https://jira.ez.no/browse/EZP-23510)

Sometimes, we require a special controller action to be able to fully implement some blocks.

Considering that you can have many places where you can call subrequests to render your blocks, current situation of requiring custom controllers to be defined directly in subrequest call is quite inefficient.

This pull request adds the possiblity to specify which controller will be called for a specific block view match, much like defining custom controllers for location view or content view match.

Also, since there are two possible actions with which one can view a block: `ez_page:viewBlock` and `ez_page:viewBlockById`, this pull request also makes it possible to specify a controller action with a signature matching either one of original actions.

Example of configuration in `ezpublish/config/ezpublish.yml`:

``` yml
ezpublish:
    system:
        eng_frontend_group:
            block_view:
                ContentGrid:
                    template: NetgenSiteBundle:block:content_grid.html.twig
                    controller: NetgenSiteBundle:Block:viewContentGridBlock
                    match:
                        Type: ContentGrid
```
