### PR TITLE
Fix EZP-23516: Language switcher and legacy module

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Routing/FallbackRouter.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Routing/FallbackRouter.php
@@ -12,10 +12,13 @@ namespace eZ\Bundle\EzPublishLegacyBundle\Routing;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 
-class FallbackRouter implements RouterInterface
+class FallbackRouter implements RouterInterface, RequestMatcherInterface
 {
     const ROUTE_NAME = 'ez_legacy';
 
@@ -117,26 +120,18 @@ class FallbackRouter implements RouterInterface
         throw new RouteNotFoundException();
     }
 
-    /**
-     * Tries to match a URL with a set of routes.
-     *
-     * If the matcher can not find information, it must throw one of the exceptions documented
-     * below.
-     *
-     * @param string $pathinfo The path info to be parsed (raw format, i.e. not urldecoded)
-     *
-     * @return array An array of parameters
-     *
-     * @throws ResourceNotFoundException If the resource could not be found
-     * @throws MethodNotAllowedException If the resource was found but the request method is not allowed
-     *
-     * @api
-     */
     public function match( $pathinfo )
     {
+        throw new RuntimeException( "The UrlAliasRouter doesn't support the match() method. Please use matchRequest() instead." );
+    }
+
+    public function matchRequest( Request $request )
+    {
+        $moduleUri = $request->attributes->get( 'semanticPathinfo' ) . '?' . $request->getQueryString();
         return array(
             "_route" => self::ROUTE_NAME,
             "_controller" => "ezpublish_legacy.controller:indexAction",
+            "module_uri" => $moduleUri
         );
     }
 }

--- a/eZ/Bundle/EzPublishLegacyBundle/Routing/UrlGenerator.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Routing/UrlGenerator.php
@@ -46,17 +46,25 @@ class UrlGenerator extends Generator
      */
     public function doGenerate( $legacyModuleUri, array $parameters )
     {
+        // Getting query string
+        $uriComponents = parse_url( $legacyModuleUri );
+        $legacyModuleUri = isset( $uriComponents['path'] ) ? $uriComponents['path'] : '';
+        $queryString = isset( $uriComponents['query'] ) ? '?' . $uriComponents['query'] : '';
+
         // Removing leading and trailing slashes
         if ( strpos( $legacyModuleUri, '/' ) === 0 )
             $legacyModuleUri = substr( $legacyModuleUri, 1 );
         if ( strrpos( $legacyModuleUri, '/' ) === ( strlen( $legacyModuleUri ) - 1 ) )
             $legacyModuleUri = substr( $legacyModuleUri, 0, -1 );
 
+        // Removing siteaccess parameter
+        if( isset( $parameters['siteaccess'] ) )
+            unset( $parameters[ 'siteaccess' ] );
+
         list( $moduleName, $viewName ) = explode( '/', $legacyModuleUri );
-        $siteAccess = $this->siteAccess;
 
         return $this->getLegacyKernel()->runCallback(
-            function () use ( $legacyModuleUri, $moduleName, $viewName, $parameters, $siteAccess )
+            function () use ( $legacyModuleUri, $moduleName, $viewName, $parameters, $queryString )
             {
                 $module = eZModule::findModule( $moduleName );
                 if ( !$module instanceof eZModule )
@@ -75,7 +83,7 @@ class UrlGenerator extends Generator
                     $unorderedParams .= "/($paramName)/$paramValue";
                 }
 
-                return "/$legacyModuleUri$unorderedParams";
+                return "/$legacyModuleUri$unorderedParams$queryString";
             },
             false,
             false


### PR DESCRIPTION
When trying to generate a route for legacy modules (languages switcher), it raised an error like 

```
An exception has been thrown during the rendering of a template ("When generating an eZ Publish legacy fallback route, "uri" parameter must be provided.") in EzConsultingBundle:Language:switcher.html.twig at line 17.
```

This modification solve issue https://jira.ez.no/browse/EZP-23516 
and generate the good url for legacy module using url twig function

```
{{ url( routeRef ) }}
```
