### PR TITLE
Fix EZP-23516: FallbackRouter must use the whole pathinfo

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Routing/FallbackRouter.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Routing/FallbackRouter.php
@@ -127,7 +127,9 @@ class FallbackRouter implements RouterInterface, RequestMatcherInterface
 
     public function matchRequest( Request $request )
     {
-        $moduleUri = $request->attributes->get( 'semanticPathinfo' ) . '?' . $request->getQueryString();
+        $moduleUri = rtrim( $request->attributes->get( 'semanticPathinfo', $request->getPathInfo() ), '/' )
+                     . $request->attributes->get( 'viewParametersString', '' )
+                     . '?' . $request->getQueryString();
         return array(
             "_route" => self::ROUTE_NAME,
             "_controller" => "ezpublish_legacy.controller:indexAction",


### PR DESCRIPTION
Relates to #1055

For legacy, URI is fixed up in LegacyKernelController via URIHelper.
Furthermore, view parameters string must be present.
