### PR TITLE
Fix EZP-23544: UrlStorage::getFieldData logs an error if URL with an empty ID is not found

### DIFF
--- a/eZ/Publish/Core/FieldType/Tests/Url/UrlStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Url/UrlStorageTest.php
@@ -144,6 +144,25 @@ class UrlStorageTest extends PHPUnit_Framework_TestCase
         $this->assertEquals( "", $field->value->externalData );
     }
 
+    public function testGetFieldDataWithEmptyUrlId()
+    {
+        $versionInfo = new VersionInfo();
+        $fieldValue = new FieldValue( array( "data" => array( "urlId" => null ) ) );
+        $field = new Field( array( "id" => 42, "value" => $fieldValue ) );
+        $gateway = $this->getGatewayMock();
+
+        $gateway
+            ->expects( $this->never() )
+            ->method( "getIdUrlMap" );
+
+        $logger = $this->getLoggerMock();
+        $logger
+            ->expects( $this->never() )
+            ->method( "error" );
+
+        $this->assertEquals( null, $field->value->externalData );
+    }
+
     public function testDeleteFieldData()
     {
         $versionInfo = new VersionInfo( array( "versionNo" => 24 ) );

--- a/eZ/Publish/Core/FieldType/Url/UrlStorage.php
+++ b/eZ/Publish/Core/FieldType/Url/UrlStorage.php
@@ -78,10 +78,15 @@ class UrlStorage extends GatewayBasedStorage
      */
     public function getFieldData( VersionInfo $versionInfo, Field $field, array $context )
     {
+        $id = $field->value->data["urlId"];
+        if ( empty( $id ) )
+        {
+            $field->value->externalData = null;
+            return;
+        }
+
         /** @var \eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway $gateway */
         $gateway = $this->getGateway( $context );
-        $id = $field->value->data["urlId"];
-
         $map = $gateway->getIdUrlMap( array( $id ) );
 
         // URL id is not in the DB


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-23544

The logger in `UrlStorage::getFieldData` should only log an error where there's an actual ID stored in the database, and not for ID which is `0` or `null`, which is the default for an `ezurl` field type which has no content.
