### PR TITLE
Fix EZP-23553: Checking for existence of legacy templates does not work

### DIFF
--- a/eZ/Publish/Core/MVC/Legacy/Templating/LegacyEngine.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/LegacyEngine.php
@@ -120,7 +120,8 @@ class LegacyEngine implements EngineInterface
         return $this->getLegacyKernel()->runCallback(
             function () use ( $name )
             {
-                return eZTemplate::factory()->fetch( $name ) !== false;
+                $legacyTemplate = eZTemplate::factory()->loadURIRoot( $name, false, $extraParameters );
+                return !empty( $legacyTemplate );
             }
         );
     }

--- a/eZ/Publish/Core/MVC/Legacy/Templating/Tests/Twig/EnvironmentTest.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/Tests/Twig/EnvironmentTest.php
@@ -30,6 +30,11 @@ class EnvironmentTest extends PHPUnit_Framework_TestCase
             ->with( $templateName )
             ->will( $this->returnValue( true ) );
 
+        $legacyEngine->expects( $this->any() )
+            ->method( 'exists' )
+            ->with( $templateName )
+            ->will( $this->returnValue( true ) );
+
         $twigEnv = new Environment( $this->getMock( 'Twig_LoaderInterface' ) );
         $twigEnv->setEzLegacyEngine( $legacyEngine );
         $template = $twigEnv->loadTemplate( $templateName );
@@ -38,5 +43,33 @@ class EnvironmentTest extends PHPUnit_Framework_TestCase
 
         // Calling loadTemplate a 2nd time with the same template name should return the very same Template object.
         $this->assertSame( $template, $twigEnv->loadTemplate( $templateName ) );
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\MVC\Legacy\Templating\Twig\Environment::loadTemplate
+     * @covers \eZ\Publish\Core\MVC\Legacy\Templating\Twig\Template::getTemplateName
+     *
+     * @expectedException \Twig_Error_Loader
+     */
+    public function testLoadNonExistingTemplateLegacy()
+    {
+        $legacyEngine = $this->getMockBuilder( 'eZ\\Publish\\Core\\MVC\\Legacy\\Templating\\LegacyEngine' )
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $templateName = 'design:test/helloworld.tpl';
+        $legacyEngine->expects( $this->any() )
+            ->method( 'supports' )
+            ->with( $templateName )
+            ->will( $this->returnValue( true ) );
+
+        $legacyEngine->expects( $this->any() )
+            ->method( 'exists' )
+            ->with( $templateName )
+            ->will( $this->returnValue( false ) );
+
+        $twigEnv = new Environment( $this->getMock( 'Twig_LoaderInterface' ) );
+        $twigEnv->setEzLegacyEngine( $legacyEngine );
+        $template = $twigEnv->loadTemplate( $templateName );
     }
 }

--- a/eZ/Publish/Core/MVC/Legacy/Templating/Twig/Environment.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/Twig/Environment.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\MVC\Legacy\Templating\Twig;
 
 use Twig_Environment;
+use Twig_Error_Loader;
 use eZ\Publish\Core\MVC\Legacy\Templating\LegacyEngine;
 
 class Environment extends Twig_Environment
@@ -39,6 +40,11 @@ class Environment extends Twig_Environment
 
         if ( is_string( $name ) && $this->legacyEngine->supports( $name ) )
         {
+            if ( !$this->legacyEngine->exists( $name ) )
+            {
+                throw new Twig_Error_Loader( "Unable to find the template \"$name\"" );
+            }
+
             $this->legacyTemplatesCache[$name] = new Template( $name, $this, $this->legacyEngine );
             return $this->legacyTemplatesCache[$name];
         }


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-23553

When trying to do something like this:

``` twig
{% include [
        'NetgenSiteBundle:parts:' ~ template ~ '.html.twig',
        'design:parts/' ~ template ~ '.tpl',
        'design:parts/default.tpl'
    ] ignore missing
    with {
        'location': location,
        'node': location
    }
%}
```

And first two templates do not exist, but the third one does, nothing will be rendered, while the third template should be rendered.

What happens is that legacy rendering engine does not recognize a missing legacy template properly and instead returns an empty string to be rendered.
