### PR TITLE
Fix EZP-22858: Display in HTML Comments name of the used template

### DIFF
--- a/eZ/Bundle/EzPublishDebugBundle/Twig/DebugTemplate.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Twig/DebugTemplate.php
@@ -26,20 +26,55 @@ abstract class DebugTemplate extends Twig_Template
         $startTime = microtime( true );
 
         $templateListBefore = TemplateDebugInfo::getTemplatesList();
+
+        // Bufferize to be able to insert template name as HTML comments if applicable.
+        // Layout template name will only appear at the end, to avoid potential quirks with old browsers
+        // when comments appear before doctype declaration.
+        ob_start();
+        parent::display( $context, $blocks );
+        $templateResult = ob_get_clean();
+
         $templateName = $this->getTemplateName();
         // Check if template name ends with "html.twig", indicating this is an HTML template.
         $isHtmlTemplate = substr( $templateName, -strlen( 'html.twig' ) ) === 'html.twig';
 
+        // Display start template comment, if applicable.
         if ( $isHtmlTemplate )
         {
-            echo '<!-- START ' . $this->getTemplateName() . ' -->';
+            if ( stripos( trim( $templateResult ), '<!doctype' ) !== false )
+            {
+                $templateResult = preg_replace(
+                    '#(<!doctype[^>]+>)#im',
+                    "$1\n<!-- START " . $templateName . ' -->',
+                    $templateResult
+                );
+            }
+            else
+            {
+                echo "\n<!-- START $templateName -->\n";
+            }
         }
 
-        parent::display( $context, $blocks );
-
+        // Display stop template comment after result, if applicable.
         if ( $isHtmlTemplate )
         {
-            echo '<!-- STOP ' . $this->getTemplateName() . ' -->';
+            $bodyPos = stripos( $templateResult, '</body>' );
+            if ( $bodyPos !== false )
+            {
+                // Add layout template name before </body>, to avoid display quirks in some browsers.
+                echo substr( $templateResult, 0, $bodyPos )
+                     . "\n<!-- STOP $templateName -->\n"
+                     . substr( $templateResult, $bodyPos );
+            }
+            else
+            {
+                echo $templateResult;
+                echo "\n<!-- STOP $templateName -->\n";
+            }
+        }
+        else
+        {
+            echo $templateResult;
         }
 
         $endTime = microtime( true );


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-22858
> Replaces #860 

This PR is an enhancement of #860.
It ensures that start/stop template comments are correctly displayed for layout templates, to avoid quirks with some (old) browsers.
1. Start comment **after** DocType declaration
2. Stop comment **before** `</body>`

**This only affects HTML templates**
