### PR TITLE
Fix EZP-23387: Move image variation config for ezdemo to DemoBundle

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -140,43 +140,6 @@ parameters:
             reference: reference
             filters:
                 geometry/scaledownonly: [300, 300]
-        rss:
-            reference: reference
-            filters:
-                geometry/scale: [88, 31]
-        campaign:
-            reference: ~
-            filters:
-                geometry/scalewidthdownonly: [770]
-                geometry/crop: [770, 390, 0, 0]
-        backgroundimage:
-            reference: ~
-            filters:
-                geometry/scalewidthdownonly: [770]
-                geometry/crop: [770, 390, 0, 0]
-        highlighted:
-            reference: ~
-            filters:
-                geometry/scalewidthdownonly: [300]
-                geometry/crop: [300, 300, 0, 0]
-        galleryfull:
-            reference: ~
-            filters:
-                geometry/scalewidthdownonly: [770]
-        contentgrid:
-            reference: ~
-            filters:
-                geometry/scalewidthdownonly: [770]
-                geometry/crop: [370, 160, 0, 0]
-        gallery:
-            reference: ~
-            filters:
-                geometry/scalewidthdownonly: [770]
-                geometry/crop: [770, 390, 0, 0]
-        imagefull:
-            reference: ~
-            filters:
-                geometry/scalewidthdownonly: [770]
 
     # ImageMagick
     # TODO: Deprecated. Move this to ezpublish_legacy.

--- a/eZ/Bundle/EzPublishLegacyBundle/SetupWizard/ConfigurationConverter.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/SetupWizard/ConfigurationConverter.php
@@ -134,11 +134,15 @@ class ConfigurationConverter
             $settings['ezpublish']['imagemagick']['enabled'] = false;
         }
 
-        $variations = $this->getImageVariations( $siteList, $groupName );
-
-        foreach ( $variations as $siteaccess => $imgSettings )
+        // Dump image variations for unsupported packages only (i.e. not ezdemo)
+        // Image variations for ezdemo are defined in DemoBundle
+        if ( !isset( $this->supportedPackages[$sitePackage] ) )
         {
-            $settings['ezpublish']['system'][$siteaccess]['image_variations'] = $imgSettings;
+            $variations = $this->getImageVariations( $siteList, $groupName );
+            foreach ( $variations as $siteaccess => $imgSettings )
+            {
+                $settings['ezpublish']['system'][$siteaccess]['image_variations'] = $imgSettings;
+            }
         }
 
         foreach ( $siteList as $siteaccess )

--- a/eZ/Bundle/EzPublishLegacyBundle/Tests/SetupWizard/ConfigurationConverterTest.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Tests/SetupWizard/ConfigurationConverterTest.php
@@ -158,19 +158,6 @@ class ConfigurationConverterTest extends LegacyBasedTestCase
                     'ezdemo_group' => array(
                         'repository' => 'eng_repository',
                         'var_dir' => 'var/ezdemo_site',
-                        'image_variations' => array(
-                            'large' => array(
-                                'reference' => null, 'filters' => array(
-                                    array( 'name' => 'geometry/scaledownonly', 'params' => array( 360, 440 ) )
-                                )
-                            ),
-                            'infoboximage' => array(
-                                'reference' => null, 'filters' => array(
-                                    array( 'name' => 'geometry/scalewidth', 'params' => array( 75 ) ),
-                                    array( 'name' => 'flatten' )
-                                )
-                            ),
-                        ),
                         'languages' => array( 'eng-GB' )
                     ),
                     'eng' => array(),
@@ -342,11 +329,6 @@ class ConfigurationConverterTest extends LegacyBasedTestCase
         );
         unset( $element[IDX_MOCK_PARAMETERS]['getGroup']['infoboximage_admin'] );
 
-        $element[IDX_EXPECTED_RESULT]['ezpublish']['system']['eng']['image_variations'] = $element[IDX_EXPECTED_RESULT]['ezpublish']['system']['ezdemo_group']['image_variations'];
-        $element[IDX_EXPECTED_RESULT]['ezpublish']['system']['ezdemo_site']['image_variations'] = $element[IDX_EXPECTED_RESULT]['ezpublish']['system']['ezdemo_group']['image_variations'];
-        $element[IDX_EXPECTED_RESULT]['ezpublish']['system']['ezdemo_site_admin']['image_variations'] = $element[IDX_EXPECTED_RESULT]['ezpublish']['system']['ezdemo_group']['image_variations'];
-        unset( $element[IDX_EXPECTED_RESULT]['ezpublish']['system']['ezdemo_site_admin']['image_variations']['infoboximage'] );
-        unset( $element[IDX_EXPECTED_RESULT]['ezpublish']['system']['ezdemo_group']['image_variations'] );
         $data[] = $element;
 
         // different parameter for an alias in ezdemo_site_admin
@@ -360,11 +342,6 @@ class ConfigurationConverterTest extends LegacyBasedTestCase
             )
         );
 
-        $element[IDX_EXPECTED_RESULT]['ezpublish']['system']['eng']['image_variations'] = $element[IDX_EXPECTED_RESULT]['ezpublish']['system']['ezdemo_group']['image_variations'];
-        $element[IDX_EXPECTED_RESULT]['ezpublish']['system']['ezdemo_site']['image_variations'] = $element[IDX_EXPECTED_RESULT]['ezpublish']['system']['ezdemo_group']['image_variations'];
-        $element[IDX_EXPECTED_RESULT]['ezpublish']['system']['ezdemo_site_admin']['image_variations'] = $element[IDX_EXPECTED_RESULT]['ezpublish']['system']['ezdemo_group']['image_variations'];
-        $element[IDX_EXPECTED_RESULT]['ezpublish']['system']['ezdemo_site_admin']['image_variations']['large']['filters'][0]['params'] = array( 100, 100 );
-        unset( $element[IDX_EXPECTED_RESULT]['ezpublish']['system']['ezdemo_group']['image_variations'] );
         $data[] = $element;
 
         // several languages and same for all SA


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23387
> https://jira.ez.no/browse/EZP-23382

Tests have been updated.
Image variations are now dumped for non-ezdemo packages only.

See also [EZP-23382](https://jira.ez.no/browse/EZP-23382). Default image aliases are reduced to the minimum.
