### PR TITLE
Fix EZP-23573: ez_is_field_empty does not work for a "date and time" fie...

### DIFF
--- a/eZ/Publish/Core/FieldType/DateAndTime/Type.php
+++ b/eZ/Publish/Core/FieldType/DateAndTime/Type.php
@@ -87,6 +87,26 @@ class Type extends FieldType
     }
 
     /**
+     * Returns if the given $value is considered empty by the field type
+     *
+     * Reimplemented from FieldType to let zero timestamps be considered
+     * empty, because empty DateAndTimes are stored and reloaded as zero.
+     *
+     * @param \eZ\Publish\Core\FieldType\Value $value
+     *
+     * @return boolean
+     */
+    public function isEmptyValue( SPIValue $value )
+    {
+        if ( $value->value instanceof DateTime && $value->value->getTimestamp() === 0 )
+        {
+            return true;
+        }
+
+        return parent::isEmptyValue( $value );
+    }
+
+    /**
      * Inspects given $inputValue and potentially converts it into a dedicated value object.
      *
      * @param string|int|\DateTime|\eZ\Publish\Core\FieldType\DateAndTime\Value $inputValue


### PR DESCRIPTION
...ld

Ensures that zero DateTimes are interpreted as null, so they are recognized as empty.

https://jira.ez.no/browse/EZP-23573

As I understand it, an empty DateAndTime is stored in the DB as a zero, which when loaded is initialised with a zero DateTime, and that doesn't match the null which DateAndTime/Type::getEmptyValue() produces.

Alternative solution 1: Change DateAndTime/Value::fromString() and fromTimestamp() so that if the argument is zero, return new static() instead of an instance based on the timestamp.

Alternative solution 2: Reimplement DateAndTime/Type::isEmptyValue( SPIValue $value ) and change it from
return $value === null || $value == $this->getEmptyValue();
to
return $value === null || $value == $this->getEmptyValue() || $value == new Value( new DateTime( '@0' ) );

Anyway, the consequence is that it's not possible to distinguish between "1.1.1970 00:00:00" and "empty", but that's the case now, too.
