### PR TITLE
Fix EZP-23594: It's not possible to use custom controllers for embed (inline) views in XmlText field type

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -104,16 +104,10 @@ services:
             - %ezpublish.fieldType.ezxmltext.converter.html5.resources%
             - @ezpublish.config.resolver
 
-    # Duplicating view_manager service to be sure to have a different instance for ezxmltext converter.
-    # This is to avoid circular dependecies with view_manager.
-    ezpublish.fieldtype.ezxmltext.converter.view_manager:
-        class: %ezpublish.view_manager.class%
-        parent: ezpublish.view_manager
-
     ezpublish.fieldType.ezxmltext.converter.embedToHtml5:
         class: %ezpublish.fieldType.ezxmltext.converter.embedToHtml5.class%
         arguments:
-            - @ezpublish.fieldtype.ezxmltext.converter.view_manager
+            - @fragment.handler
             - @ezpublish.api.repository
             - %ezpublish.fieldType.ezxmlText.converter.embedToHtml5.excludedAttributes%
             - @?logger

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/EmbedToHtml5Test.php
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/EmbedToHtml5Test.php
@@ -13,6 +13,7 @@ use eZ\Publish\Core\FieldType\XmlText\Converter\EmbedToHtml5;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
 use PHPUnit_Framework_TestCase;
 use DOMDocument;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
 /**
  * Tests the EmbedToHtml5 Preconverter
@@ -182,9 +183,9 @@ class EmbedToHtml5Test extends PHPUnit_Framework_TestCase
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
-    protected function getMockViewManager()
+    protected function getMockFragmentHandler()
     {
-        return $this->getMockBuilder( 'eZ\\Publish\\Core\\MVC\\Symfony\\View\\Manager' )
+        return $this->getMockBuilder( 'Symfony\\Component\\HttpKernel\\Fragment\\FragmentHandler' )
             ->disableOriginalConstructor()
             ->getMock();
     }
@@ -260,7 +261,7 @@ class EmbedToHtml5Test extends PHPUnit_Framework_TestCase
         $dom = new \DOMDocument();
         $dom->loadXML( $xmlString );
 
-        $viewManager = $this->getMockViewManager();
+        $fragmentHandler = $this->getMockFragmentHandler();
         $contentService = $this->getMockContentService();
 
         $versionInfo = $this->getMock( 'eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo' );
@@ -295,16 +296,22 @@ class EmbedToHtml5Test extends PHPUnit_Framework_TestCase
                 );
         }
 
-        $viewManager->expects( $this->once() )
-            ->method( 'renderContent' )
+        $fragmentHandler->expects( $this->once() )
+            ->method( 'render' )
             ->with(
-                $this->equalTo( $content ),
-                $this->equalTo( $view ),
-                $this->equalTo( $parameters )
+                new ControllerReference(
+                    'ez_content:embedContent',
+                    array(
+                        'contentId' => $contentId,
+                        'viewType' => $view,
+                        'layout' => false,
+                        'params' => $parameters
+                    )
+                )
             );
 
         $converter = new EmbedToHtml5(
-            $viewManager,
+            $fragmentHandler,
             $repository,
             array( 'view', 'class', 'node_id', 'object_id' )
         );
@@ -324,7 +331,7 @@ class EmbedToHtml5Test extends PHPUnit_Framework_TestCase
         $dom = new \DOMDocument();
         $dom->loadXML( $xmlString );
 
-        $viewManager = $this->getMockViewManager();
+        $fragmentHandler = $this->getMockFragmentHandler();
         $locationService = $this->getMockLocationService();
 
         $contentInfo = $this->getMock( 'eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo' );
@@ -355,16 +362,22 @@ class EmbedToHtml5Test extends PHPUnit_Framework_TestCase
                 );
         }
 
-        $viewManager->expects( $this->once() )
-            ->method( 'renderLocation' )
+        $fragmentHandler->expects( $this->once() )
+            ->method( 'render' )
             ->with(
-                $this->equalTo( $location ),
-                $this->equalTo( $view ),
-                $this->equalTo( $parameters )
+                new ControllerReference(
+                    'ez_content:embedLocation',
+                    array(
+                        'locationId' => $locationId,
+                        'viewType' => $view,
+                        'layout' => false,
+                        'params' => $parameters
+                    )
+                )
             );
 
         $converter = new EmbedToHtml5(
-            $viewManager,
+            $fragmentHandler,
             $repository,
             array( 'view', 'class', 'node_id', 'object_id' )
         );
@@ -433,7 +446,7 @@ class EmbedToHtml5Test extends PHPUnit_Framework_TestCase
         $dom = new \DOMDocument();
         $dom->loadXML( '<?xml version="1.0" encoding="utf-8"?><section xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/" xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"><paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/"><embed view="embed" object_id="42"/></paragraph></section>' );
 
-        $viewManager = $this->getMockViewManager();
+        $fragmentHandler = $this->getMockFragmentHandler();
         $contentService = $this->getMockContentService();
 
         $versionInfo = $this->getMock( 'eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo' );
@@ -469,7 +482,7 @@ class EmbedToHtml5Test extends PHPUnit_Framework_TestCase
         }
 
         $converter = new EmbedToHtml5(
-            $viewManager,
+            $fragmentHandler,
             $repository,
             array( 'view', 'class', 'node_id', 'object_id' )
         );
@@ -485,7 +498,7 @@ class EmbedToHtml5Test extends PHPUnit_Framework_TestCase
         $dom = new \DOMDocument();
         $dom->loadXML( '<?xml version="1.0" encoding="utf-8"?><section xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/" xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"><paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/"><embed view="embed" node_id="42"/></paragraph></section>' );
 
-        $viewManager = $this->getMockViewManager();
+        $fragmentHandler = $this->getMockFragmentHandler();
         $locationService = $this->getMockLocationService();
 
         $contentInfo = $this->getMock( 'eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo' );
@@ -519,7 +532,7 @@ class EmbedToHtml5Test extends PHPUnit_Framework_TestCase
             );
 
         $converter = new EmbedToHtml5(
-            $viewManager,
+            $fragmentHandler,
             $repository,
             array( 'view', 'class', 'node_id', 'object_id' )
         );
@@ -557,7 +570,7 @@ class EmbedToHtml5Test extends PHPUnit_Framework_TestCase
      */
     public function testEmbedContentNotFound( $input, $output )
     {
-        $viewManager = $this->getMockViewManager();
+        $fragmentHandler = $this->getMockFragmentHandler();
         $contentService = $this->getMockContentService();
         $repository = $this->getMockRepository( $contentService, null );
         $logger = $this->getLoggerMock();
@@ -578,7 +591,7 @@ class EmbedToHtml5Test extends PHPUnit_Framework_TestCase
             );
 
         $converter = new EmbedToHtml5(
-            $viewManager,
+            $fragmentHandler,
             $repository,
             array( "view", "class", "node_id", "object_id" ),
             $logger
@@ -625,7 +638,7 @@ class EmbedToHtml5Test extends PHPUnit_Framework_TestCase
      */
     public function testEmbedLocationNotFound( $input, $output )
     {
-        $viewManager = $this->getMockViewManager();
+        $fragmentHandler = $this->getMockFragmentHandler();
         $locationService = $this->getMockLocationService();
         $repository = $this->getMockRepository( null, $locationService );
         $logger = $this->getLoggerMock();
@@ -646,7 +659,7 @@ class EmbedToHtml5Test extends PHPUnit_Framework_TestCase
             );
 
         $converter = new EmbedToHtml5(
-            $viewManager,
+            $fragmentHandler,
             $repository,
             array( "view", "class", "node_id", "object_id" ),
             $logger

--- a/eZ/Publish/Core/FieldType/XmlText/Converter/EmbedToHtml5.php
+++ b/eZ/Publish/Core/FieldType/XmlText/Converter/EmbedToHtml5.php
@@ -14,7 +14,8 @@ use eZ\Publish\API\Repository\Repository;
 use DOMDocument;
 use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
-use eZ\Publish\Core\MVC\Symfony\View\ViewManagerInterface;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
 use Psr\Log\LoggerInterface;
 
@@ -30,9 +31,9 @@ class EmbedToHtml5 implements Converter
     protected $excludedAttributes = array();
 
     /**
-     * @var \eZ\Publish\Core\MVC\Symfony\View\ViewManagerInterface
+     * @var \Symfony\Component\HttpKernel\Fragment\FragmentHandler
      */
-    protected $viewManager;
+    protected $fragmentHandler;
 
     /**
      * @var \eZ\Publish\API\Repository\Repository
@@ -45,13 +46,13 @@ class EmbedToHtml5 implements Converter
     protected $logger;
 
     public function __construct(
-        ViewManagerInterface $viewManager,
+        FragmentHandler $fragmentHandler,
         Repository $repository,
         array $excludedAttributes,
         LoggerInterface $logger = null
     )
     {
-        $this->viewManager = $viewManager;
+        $this->fragmentHandler = $fragmentHandler;
         $this->repository = $repository;
         $this->excludedAttributes = array_fill_keys( $excludedAttributes, true );
         $this->logger = $logger;
@@ -116,7 +117,17 @@ class EmbedToHtml5 implements Converter
                         throw new UnauthorizedException( 'content', 'versionread', array( 'contentId' => $contentId ) );
                     }
 
-                    $embedContent = $this->viewManager->renderContent( $content, $view, $parameters );
+                    $embedContent = $this->fragmentHandler->render(
+                        new ControllerReference(
+                            'ez_content:embedContent',
+                            array(
+                                'contentId' => $contentId,
+                                'viewType' => $view,
+                                'layout' => false,
+                                'params' => $parameters
+                            )
+                        )
+                    );
                 }
                 catch ( APINotFoundException $e )
                 {
@@ -149,7 +160,17 @@ class EmbedToHtml5 implements Converter
                         throw new UnauthorizedException( 'content', 'read', array( 'locationId' => $location->id ) );
                     }
 
-                    $embedContent = $this->viewManager->renderLocation( $location, $view, $parameters );
+                    $embedContent = $this->fragmentHandler->render(
+                        new ControllerReference(
+                            'ez_content:embedLocation',
+                            array(
+                                'locationId' => $locationId,
+                                'viewType' => $view,
+                                'layout' => false,
+                                'params' => $parameters
+                            )
+                        )
+                    );
                 }
                 catch ( APINotFoundException $e )
                 {


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-23594

`EmbedToHtml5` `XmlText` converter directly uses the view manager to render content, while it should use subrequests to render content.

Since subrequest is not used, `ViewControllerListener` never gets triggered, which in turn means that custom controller cannot be used.

This pull request replaces view manager with Symfony fragment handler to call the subrequest on `ez_content:viewContent` or `ez_content:viewLocation`.
