### PR TITLE
Fix EZP-23595: delete row from ezuser_setting on deleteUser()

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
@@ -154,11 +154,23 @@ class UserHandlerTest extends TestCase
             'Expected one user to be created.'
         );
 
+        $this->assertQueryResult(
+            array( array( 1 ) ),
+            $this->handler->createSelectQuery()->select( 'COUNT( * )' )->from( 'ezuser_setting' ),
+            'Expected one user setting to be created.'
+        );
+
         $handler->delete( $user->id );
         $this->assertQueryResult(
             array( array( 0 ) ),
             $this->handler->createSelectQuery()->select( 'COUNT( * )' )->from( 'ezuser' ),
             'Expected one user to be removed.'
+        );
+
+        $this->assertQueryResult(
+            array( array( 0 ) ),
+            $this->handler->createSelectQuery()->select( 'COUNT( * )' )->from( 'ezuser_setting' ),
+            'Expected one user setting to be removed.'
         );
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
@@ -90,6 +90,17 @@ class DoctrineDatabase extends Gateway
     {
         $query = $this->handler->createDeleteQuery();
         $query
+            ->deleteFrom( $this->handler->quoteTable( 'ezuser_setting' ) )
+            ->where(
+                $query->expr->eq(
+                    $this->handler->quoteColumn( 'user_id' ),
+                    $query->bindValue( $userId, null, \PDO::PARAM_INT )
+                )
+            );
+        $query->prepare()->execute();
+
+        $query = $this->handler->createDeleteQuery();
+        $query
             ->deleteFrom( $this->handler->quoteTable( 'ezuser' ) )
             ->where(
                 $query->expr->eq(


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-23595

`UserService::createUser()` creates rows on `ezuser_setting` table, but `deleteUser()` does not.
This can lead to DB `Integrity constraint violation` errors.

Fix by removing the corresponding row from `ezuser_setting` table.

TODO:
- [x] Add/update test for deleteUser
- [x] Add cleanup SQL to legacy db update file (see [#1106](https://github.com/ezsystems/ezpublish-legacy/pull/1106) )

Closes #922
