### PR TITLE
Fix EZP-23599 legacy search location gateway not correctly quoting depth column

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Search/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Search/Location/Gateway/DoctrineDatabase.php
@@ -120,7 +120,7 @@ class DoctrineDatabase extends Gateway
                 $selectQuery->bindValue( 1, null, PDO::PARAM_INT )
             ),
             $selectQuery->expr->neq(
-                $this->handler->quoteColumn( "depth" ),
+                $this->handler->quoteColumn( "depth", "ezcontentobject_tree" ),
                 $selectQuery->bindValue( 0, null, PDO::PARAM_INT )
             )
         );
@@ -187,7 +187,7 @@ class DoctrineDatabase extends Gateway
                 $query->bindValue( 1, null, PDO::PARAM_INT )
             ),
             $query->expr->neq(
-                $this->handler->quoteColumn( "depth" ),
+                $this->handler->quoteColumn( "depth", "ezcontentobject_tree" ),
                 $query->bindValue( 0, null, PDO::PARAM_INT )
             )
         );


### PR DESCRIPTION
Jira issue: https://jira.ez.no/browse/EZP-23599

I was trying to create custom SortClauseHandler, in which I was joining external table which contained depth column.

Because legacy search location gateway was not correctly referencing the depth column from ezcontentobject_tree, I was getting an error stating that depth column was ambiguous.

This pull request fixes this. If you require me to create jira issue, please let me know.
