### PR TITLE
[Travis] bump Elasticsearch to 1.4.0 final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
     - TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/$DB_NAME"
     - TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/$DB_NAME"
     - SOLR_VERSION="4.7.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml"
-    - ELASTICSEARCH_VERSION="1.4.0.Beta1" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
+    - ELASTICSEARCH_VERSION="1.4.0" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
 
 matrix:
   allow_failures:
@@ -38,7 +38,7 @@ matrix:
     - php: 5.4
       env: SOLR_VERSION="4.7.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml"
     - php: 5.4
-      env: ELASTICSEARCH_VERSION="1.4.0.Beta1" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
+      env: ELASTICSEARCH_VERSION="1.4.0" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
 # 5.5 run: unit test (Symfony 2.3) + mysql integration test + solr 4.x integration test
     - php: 5.5
       env: TEST_CONFIG="phpunit.xml"
@@ -56,7 +56,7 @@ matrix:
     - php: 5.6
       env: SOLR_VERSION="4.7.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml"
     - php: 5.6
-      env: ELASTICSEARCH_VERSION="1.4.0.Beta1" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
+      env: ELASTICSEARCH_VERSION="1.4.0" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
 # hhvm run: unit test + sqlite integration test
     - php: hhvm
       env: TEST_CONFIG="phpunit.xml"
@@ -67,7 +67,7 @@ matrix:
     - php: hhvm
       env: SOLR_VERSION="4.7.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml"
     - php: hhvm
-      env: ELASTICSEARCH_VERSION="1.4.0.Beta1" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
+      env: ELASTICSEARCH_VERSION="1.4.0" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
 
 # test only master (+ Pull requests)
 branches:

--- a/bin/.travis/init_elasticsearch.sh
+++ b/bin/.travis/init_elasticsearch.sh
@@ -53,7 +53,7 @@ download_and_run() {
 
 check_version() {
     case $1 in
-        1.2.2|1.2.3|1.3.0|1.3.1|1.3.2|1.3.3|1.3.4|1.4.0.Beta1);;
+        1.2.2|1.2.3|1.3.0|1.3.1|1.3.2|1.3.3|1.3.4|1.4.0);;
         *)
             echo "Sorry, $1 is not supported or not valid version."
             exit 1


### PR DESCRIPTION
Just bumping tested Elasticsearch version to 1.4.0 final, released yesterday.
