### PR TITLE
EZP-22510: Add doc on not being able to use dynamic settings in semantic config

### DIFF
--- a/doc/specifications/config/dynamic_settings_injection.md
+++ b/doc/specifications/config/dynamic_settings_injection.md
@@ -24,6 +24,8 @@ This service has `ezpublish.config.dynamic_setting.parser` for ID and implements
 ## Limitations
 A few limitations still remain:
 
+* It is not possible to use dynamic settings in your semantic configuration (e.g. `config.yml` or `ezpublish.yml`)
+  as they are meant primarily for parameter injection in services.
 * It is not possible to concatenate a dynamic setting, either with other dynamic settings or with container parameters.
   Workaround is to use separate arguments/setters.
 * It is not possible to define an array of options having dynamic settings. They will not be parsed. Workaround is to use


### PR DESCRIPTION
This is not really clear from current docs.
