### PR TITLE
Fix EZP-23552: Symfony cache won't be cleaned if Legacy ViewCaching is disabled

### DIFF
--- a/doc/bc/changes-5.3.md
+++ b/doc/bc/changes-5.3.md
@@ -72,6 +72,9 @@ Changes affecting version compatibility with former or future versions.
   ezpublish.fieldType.ezbinaryfile.IOService => ezpublish.fieldType.ezbinaryfile.io_service
   ezpublish.fieldType.ezimage.IOService => ezpublish.fieldType.ezimage.io (ezpublish.fieldType.ezimage.io_service also existed, but wasn't the expected one)
 
+* 5.3.4: `ViewCaching` legacy setting is now enforced and injected in legacy kernel when booted. This is to avoid persistence/Http
+  cache clear not working when publishing content.
+
 ## Deprecations
 
 * Method `eZ\Publish\API\Repository\RoleService::removePolicy` is deprecated in

--- a/doc/bc/changes-5.4.md
+++ b/doc/bc/changes-5.4.md
@@ -84,6 +84,9 @@ Changes affecting version compatibility with former or future versions.
   returned, with fake properties: the requested id, no uri, no file size... if logging is enabled, an info message
   will still be logged.
 
+* `ViewCaching` legacy setting is now enforced and injected in legacy kernel when booted. This is to avoid persistence/Http
+  cache clear not working when publishing content.
+
 ## Deprecations
 
 * `imagemagick` siteaccess settings are now deprecated. It is mandatory to remove them.

--- a/eZ/Bundle/EzPublishLegacyBundle/LegacyMapper/Configuration.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/LegacyMapper/Configuration.php
@@ -183,6 +183,10 @@ class Configuration extends ContainerAware implements EventSubscriberInterface
         // User settings
         $settings["site.ini/UserSettings/AnonymousUserID"] = $this->configResolver->getParameter( "anonymous_user_id" );
 
+        // Cache settings
+        // Enforce ViewCaching to be enabled in order to persistence/http cache to be purged correctly.
+        $settings['site.ini/ContentSettings/ViewCaching'] = 'enabled';
+
         $event->getParameters()->set(
             "injected-settings",
             $settings + (array)$event->getParameters()->get( "injected-settings" )


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23552

This enforces `ViewCaching` to be enabled when going through Symfony.
This is mandatory for persistence/HTTP cache to be correctly cleared.

To avoid pitfalls with having ViewCaching always enabled (e.g. having to clear cache on each change in a legacy template), one might just enable `site.ini/TemplateSettings/DevelopmentMode`:

``` ini
[TemplateSettings]
DevelopmentMode=enabled
```
