### PR TITLE
Fix EZP-23632: Exception when running eZ Publish behind built in reverse proxy

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ConfigScopeListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ConfigScopeListener.php
@@ -14,11 +14,9 @@ use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Symfony\View\ViewManagerInterface;
-use Symfony\Component\DependencyInjection\ContainerAware;
-use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ConfigScopeListener extends ContainerAware implements EventSubscriberInterface
+class ConfigScopeListener implements EventSubscriberInterface
 {
     /**
      * @var \eZ\Publish\Core\MVC\Symfony\Configuration\VersatileScopeInterface
@@ -30,38 +28,20 @@ class ConfigScopeListener extends ContainerAware implements EventSubscriberInter
      */
     private $viewManager;
 
-    /**
-     * Array of serviceIds to reset in the container.
-     *
-     * @var array
-     */
-    private $resettableServiceIds;
-
-    /**
-     * Array of "fake" services handling dynamic settings injection.
-     *
-     * @var array
-     */
-    private $dynamicSettingsServiceIds;
-
     public function __construct(
         VersatileScopeInterface $configResolver,
-        ViewManagerInterface $viewManager,
-        array $resettableServiceIds,
-        array $dynamicSettingsServiceIds
+        ViewManagerInterface $viewManager
     )
     {
         $this->configResolver = $configResolver;
         $this->viewManager = $viewManager;
-        $this->resettableServiceIds = $resettableServiceIds;
-        $this->dynamicSettingsServiceIds = $dynamicSettingsServiceIds;
     }
 
     public static function getSubscribedEvents()
     {
         return array(
-            MVCEvents::CONFIG_SCOPE_CHANGE => 'onConfigScopeChange',
-            MVCEvents::CONFIG_SCOPE_RESTORE => 'onConfigScopeChange',
+            MVCEvents::CONFIG_SCOPE_CHANGE => array( 'onConfigScopeChange', 100 ),
+            MVCEvents::CONFIG_SCOPE_RESTORE => array( 'onConfigScopeChange', 100 )
         );
     }
 
@@ -72,20 +52,6 @@ class ConfigScopeListener extends ContainerAware implements EventSubscriberInter
         if ( $this->viewManager instanceof SiteAccessAware )
         {
             $this->viewManager->setSiteAccess( $siteAccess );
-        }
-
-        // Ensure to reset services that need to be.
-        foreach ( $this->resettableServiceIds as $serviceId )
-        {
-            $this->container->set( $serviceId, null );
-        }
-
-        // Force dynamic settings services to synchronize.
-        // This will trigger services depending on dynamic settings to update if they use setter injection.
-        foreach ( $this->dynamicSettingsServiceIds as $fakeServiceId )
-        {
-            $this->container->set( $fakeServiceId, null );
-            $this->container->set( $fakeServiceId, $this->container->get( $fakeServiceId ) );
         }
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/DynamicSettingsListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/DynamicSettingsListener.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * File containing the DynamicSettingsListener class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\EventListener;
+
+use eZ\Publish\Core\MVC\Symfony\Event\PostSiteAccessMatchEvent;
+use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
+use eZ\Publish\Core\MVC\Symfony\MVCEvents;
+use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class DynamicSettingsListener extends ContainerAware implements EventSubscriberInterface
+{
+    /**
+     * Array of serviceIds to reset in the container.
+     *
+     * @var array
+     */
+    private $resettableServiceIds;
+
+    /**
+     * Array of "fake" services handling dynamic settings injection.
+     *
+     * @var array
+     */
+    private $dynamicSettingsServiceIds;
+
+    public function __construct( array $resettableServiceIds, array $dynamicSettingsServiceIds )
+    {
+        $this->resettableServiceIds = $resettableServiceIds;
+        $this->dynamicSettingsServiceIds = $dynamicSettingsServiceIds;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            MVCEvents::SITEACCESS => array( 'onSiteAccessMatch', 254 ),
+            MVCEvents::CONFIG_SCOPE_CHANGE => array( 'onConfigScopeChange', 90 ),
+            MVCEvents::CONFIG_SCOPE_RESTORE => array( 'onConfigScopeChange', 90 )
+        );
+    }
+
+    public function onSiteAccessMatch( PostSiteAccessMatchEvent $event )
+    {
+        if ( $event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST )
+        {
+            return;
+        }
+
+        $this->resetDynamicSettings();
+    }
+
+    public function onConfigScopeChange( ScopeChangeEvent $event )
+    {
+        $this->resetDynamicSettings();
+    }
+
+    /**
+     * Ensure that dynamic settings are correctly reset,
+     * so that services that rely on those are correctly updated
+     */
+    private function resetDynamicSettings()
+    {
+        // Ensure to reset services that need to be.
+        foreach ( $this->resettableServiceIds as $serviceId )
+        {
+            $this->container->set( $serviceId, null );
+        }
+
+        // Force dynamic settings services to synchronize.
+        // This will trigger services depending on dynamic settings to update if they use setter injection.
+        foreach ( $this->dynamicSettingsServiceIds as $fakeServiceId )
+        {
+            $this->container->set( $fakeServiceId, null );
+            $this->container->set( $fakeServiceId, $this->container->get( $fakeServiceId ) );
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/OriginalRequestListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/OriginalRequestListener.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * File containing the OriginalRequestListener class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Request listener setting potential original request as current request attribute.
+ * Such situation occurs when generating user context hash from an external reverse proxy (e.g. Varnish).
+ */
+class OriginalRequestListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::REQUEST => array( 'onKernelRequest', 200 )
+        );
+    }
+
+    public function onKernelRequest( GetResponseEvent $event )
+    {
+        if ( $event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST )
+        {
+            return;
+        }
+
+        $request = $event->getRequest();
+        if ( !$request->headers->has( 'x-fos-original-url' ) )
+        {
+            return;
+        }
+
+        $originalRequest = Request::create(
+            $request->getSchemeAndHttpHost() . $request->headers->get( 'x-fos-original-url' ),
+            'GET', array(), array(), array(),
+            array( 'HTTP_ACCEPT' => $request->headers->get( 'x-fos-original-accept' ) )
+        );
+        $originalRequest->headers->set( 'user-agent', $request->headers->get( 'user-agent' ) );
+        $originalRequest->headers->set( 'accept-language', $request->headers->get( 'accept-language' ) );
+        $request->attributes->set( '_ez_original_request', $originalRequest );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/RequestEventListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/RequestEventListener.php
@@ -46,18 +46,12 @@ class RequestEventListener implements EventSubscriberInterface
      */
     private $router;
 
-    /**
-     * @var \eZ\Publish\SPI\HashGenerator
-     */
-    private $hashGenerator;
-
-    public function __construct( ConfigResolverInterface $configResolver, RouterInterface $router, $defaultSiteAccess, HashGenerator $hashGenerator, LoggerInterface $logger = null )
+    public function __construct( ConfigResolverInterface $configResolver, RouterInterface $router, $defaultSiteAccess, LoggerInterface $logger = null )
     {
         $this->configResolver = $configResolver;
         $this->defaultSiteAccess = $defaultSiteAccess;
         $this->router = $router;
         $this->logger = $logger;
-        $this->hashGenerator = $hashGenerator;
     }
 
     public static function getSubscribedEvents()

--- a/eZ/Bundle/EzPublishCoreBundle/HttpCache.php
+++ b/eZ/Bundle/EzPublishCoreBundle/HttpCache.php
@@ -114,4 +114,11 @@ abstract class HttpCache extends BaseHttpCache
     {
         return array( '127.0.0.1', '::1', 'fe80::1' );
     }
+
+    protected function cleanupForwardRequest( Request $forwardReq, Request $originalRequest )
+    {
+        parent::cleanupForwardRequest( $forwardReq, $originalRequest );
+        // Embed the original request as we need it to match the SiteAccess.
+        $forwardReq->attributes->set( '_ez_original_request', $originalRequest );
+    }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
@@ -4,6 +4,7 @@ parameters:
     ezpublish.field_helper.class: eZ\Publish\Core\Helper\FieldHelper
     ezpublish.content_preview_helper.class: eZ\Publish\Core\Helper\ContentPreviewHelper
     ezpublish.config_scope_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\ConfigScopeListener
+    ezpublish.dynamic_settings_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\DynamicSettingsListener
     ezpublish.config_resolver.resettable_services: []
     ezpublish.config_resolver.dynamic_settings_services: []
 
@@ -32,6 +33,12 @@ services:
         arguments:
             - @ezpublish.config.resolver.core
             - @ezpublish.view_manager
+        tags:
+            - { name: kernel.event_subscriber }
+
+    ezpublish.dynamic_settings_listener:
+        class: %ezpublish.dynamic_settings_listener.class%
+        arguments:
             - %ezpublish.config_resolver.resettable_services%
             - %ezpublish.config_resolver.dynamic_settings_services%
         calls:

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
@@ -16,6 +16,7 @@ parameters:
     ezpublish.siteaccess_match_listener.class: eZ\Publish\Core\MVC\Symfony\EventListener\SiteAccessMatchListener
     ezpublish.route_reference.generator.class: eZ\Publish\Core\MVC\Symfony\Routing\Generator\RouteReferenceGenerator
     ezpublish.route_reference.listener.language_switch.class: eZ\Publish\Core\MVC\Symfony\EventListener\LanguageSwitchListener
+    ezpublish.original_request_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\OriginalRequestListener
 
 services:
     ezpublish.chain_router:
@@ -92,7 +93,6 @@ services:
             - @ezpublish.config.resolver
             - @router
             - %ezpublish.siteaccess.default%
-            - @ezpublish.user.hash_generator
             - @?logger
         tags:
             - { name: kernel.event_subscriber }
@@ -106,5 +106,10 @@ services:
     ezpublish.route_reference.listener.language_switch:
         class: %ezpublish.route_reference.listener.language_switch.class%
         arguments: [@ezpublish.translation_helper]
+        tags:
+            - { name: kernel.event_subscriber }
+
+    ezpublish.original_request_listener:
+        class: %ezpublish.original_request_listener.class%
         tags:
             - { name: kernel.event_subscriber }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
@@ -13,3 +13,6 @@ _ezpublishPreviewContent:
 _ezpublishPreviewContentDefaultSa:
     path: /content/versionview/{contentId}/{versionNo}/{language}
     defaults: { _controller: ezpublish.controller.content.preview:previewContentAction }
+
+_ez_user_hash:
+    path: /_fos_user_context_hash

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ConfigScopeListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ConfigScopeListenerTest.php
@@ -27,25 +27,19 @@ class ConfigScopeListenerTest extends PHPUnit_Framework_TestCase
      */
     private $viewManager;
 
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
-     */
-    private $container;
-
     protected function setUp()
     {
         parent::setUp();
         $this->configResolver = $this->getMock( 'eZ\Publish\Core\MVC\Symfony\Configuration\VersatileScopeInterface' );
         $this->viewManager = $this->getMock( 'eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs\ViewManager' );
-        $this->container = $this->getMock( 'Symfony\Component\DependencyInjection\ContainerInterface' );
     }
 
     public function testGetSubscribedEvents()
     {
         $this->assertSame(
             array(
-                MVCEvents::CONFIG_SCOPE_CHANGE => 'onConfigScopeChange',
-                MVCEvents::CONFIG_SCOPE_RESTORE => 'onConfigScopeChange',
+                MVCEvents::CONFIG_SCOPE_CHANGE => array( 'onConfigScopeChange', 100 ),
+                MVCEvents::CONFIG_SCOPE_RESTORE => array( 'onConfigScopeChange', 100 )
             ),
             ConfigScopeListener::getSubscribedEvents()
         );
@@ -55,8 +49,6 @@ class ConfigScopeListenerTest extends PHPUnit_Framework_TestCase
     {
         $siteAccess = new SiteAccess( 'test' );
         $event = new ScopeChangeEvent( $siteAccess );
-        $resettableServices = array( 'foo', 'bar.baz' );
-        $dynamicSettingsServiceIds = array( 'something', 'something_else' );
         $this->configResolver
             ->expects( $this->once() )
             ->method( 'setDefaultScope' )
@@ -65,47 +57,8 @@ class ConfigScopeListenerTest extends PHPUnit_Framework_TestCase
             ->expects( $this->once() )
             ->method( 'setSiteAccess' )
             ->with( $siteAccess );
-        $this->container
-            ->expects( $this->at( 0 ) )
-            ->method( 'set' )
-            ->with( 'foo', null );
-        $this->container
-            ->expects( $this->at( 1 ) )
-            ->method( 'set' )
-            ->with( 'bar.baz', null );
 
-        $fakeService1 = new \stdClass;
-        $this->container
-            ->expects( $this->at( 2 ) )
-            ->method( 'set' )
-            ->with( 'something', null );
-        $this->container
-            ->expects( $this->at( 3 ) )
-            ->method( 'get' )
-            ->with( 'something' )
-            ->will( $this->returnValue( $fakeService1 ) );
-        $this->container
-            ->expects( $this->at( 4 ) )
-            ->method( 'set' )
-            ->with( 'something', $fakeService1 );
-
-        $fakeService2 = new \stdClass;
-        $this->container
-            ->expects( $this->at( 5 ) )
-            ->method( 'set' )
-            ->with( 'something_else', null );
-        $this->container
-            ->expects( $this->at( 6 ) )
-            ->method( 'get' )
-            ->with( 'something_else' )
-            ->will( $this->returnValue( $fakeService2 ) );
-        $this->container
-            ->expects( $this->at( 7 ) )
-            ->method( 'set' )
-            ->with( 'something_else', $fakeService2 );
-
-        $listener = new ConfigScopeListener( $this->configResolver, $this->viewManager, $resettableServices, $dynamicSettingsServiceIds );
-        $listener->setContainer( $this->container );
+        $listener = new ConfigScopeListener( $this->configResolver, $this->viewManager );
         $listener->onConfigScopeChange( $event );
         $this->assertSame( $siteAccess, $event->getSiteAccess() );
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/DynamicSettingsListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/DynamicSettingsListenerTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * File containing the DynamicSettingsListenerTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;
+
+use eZ\Bundle\EzPublishCoreBundle\EventListener\DynamicSettingsListener;
+use eZ\Publish\Core\MVC\Symfony\Event\PostSiteAccessMatchEvent;
+use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
+use eZ\Publish\Core\MVC\Symfony\MVCEvents;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class DynamicSettingsListenerTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $container;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->container = $this->getMock( 'Symfony\Component\DependencyInjection\ContainerInterface' );
+    }
+
+    public function testGetSubscribedEvents()
+    {
+        $this->assertSame(
+            array(
+                MVCEvents::SITEACCESS => array( 'onSiteAccessMatch', 254 ),
+                MVCEvents::CONFIG_SCOPE_CHANGE => array( 'onConfigScopeChange', 90 ),
+                MVCEvents::CONFIG_SCOPE_RESTORE => array( 'onConfigScopeChange', 90 )
+            ),
+            DynamicSettingsListener::getSubscribedEvents()
+        );
+    }
+
+    public function testOnSiteAccessMatchSubRequest()
+    {
+        $event = new PostSiteAccessMatchEvent( new SiteAccess( 'test' ), new Request(), HttpKernelInterface::SUB_REQUEST );
+        $resettableServices = array( 'foo', 'bar.baz' );
+        $dynamicSettingsServiceIds = array( 'something', 'something_else' );
+
+        $this->container
+            ->expects( $this->never() )
+            ->method( 'set' );
+        $this->container
+            ->expects( $this->never() )
+            ->method( 'get' );
+
+        $listener = new DynamicSettingsListener( $resettableServices, $dynamicSettingsServiceIds );
+        $listener->setContainer( $this->container );
+        $listener->onSiteAccessMatch( $event );
+    }
+
+    public function testOnSiteAccessMatch()
+    {
+        $event = new PostSiteAccessMatchEvent( new SiteAccess( 'test' ), new Request(), HttpKernelInterface::MASTER_REQUEST );
+        $resettableServices = array( 'foo', 'bar.baz' );
+        $dynamicSettingsServiceIds = array( 'something', 'something_else' );
+
+        $this->container
+            ->expects( $this->at( 0 ) )
+            ->method( 'set' )
+            ->with( 'foo', null );
+        $this->container
+            ->expects( $this->at( 1 ) )
+            ->method( 'set' )
+            ->with( 'bar.baz', null );
+
+        $fakeService1 = new \stdClass;
+        $this->container
+            ->expects( $this->at( 2 ) )
+            ->method( 'set' )
+            ->with( 'something', null );
+        $this->container
+            ->expects( $this->at( 3 ) )
+            ->method( 'get' )
+            ->with( 'something' )
+            ->will( $this->returnValue( $fakeService1 ) );
+        $this->container
+            ->expects( $this->at( 4 ) )
+            ->method( 'set' )
+            ->with( 'something', $fakeService1 );
+
+        $fakeService2 = new \stdClass;
+        $this->container
+            ->expects( $this->at( 5 ) )
+            ->method( 'set' )
+            ->with( 'something_else', null );
+        $this->container
+            ->expects( $this->at( 6 ) )
+            ->method( 'get' )
+            ->with( 'something_else' )
+            ->will( $this->returnValue( $fakeService2 ) );
+        $this->container
+            ->expects( $this->at( 7 ) )
+            ->method( 'set' )
+            ->with( 'something_else', $fakeService2 );
+
+        $listener = new DynamicSettingsListener( $resettableServices, $dynamicSettingsServiceIds );
+        $listener->setContainer( $this->container );
+        $listener->onSiteAccessMatch( $event );
+    }
+
+    public function testOnConfigScopeChange()
+    {
+        $siteAccess = new SiteAccess( 'test' );
+        $event = new ScopeChangeEvent( $siteAccess );
+        $resettableServices = array( 'foo', 'bar.baz' );
+        $dynamicSettingsServiceIds = array( 'something', 'something_else' );
+
+        $this->container
+            ->expects( $this->at( 0 ) )
+            ->method( 'set' )
+            ->with( 'foo', null );
+        $this->container
+            ->expects( $this->at( 1 ) )
+            ->method( 'set' )
+            ->with( 'bar.baz', null );
+
+        $fakeService1 = new \stdClass;
+        $this->container
+            ->expects( $this->at( 2 ) )
+            ->method( 'set' )
+            ->with( 'something', null );
+        $this->container
+            ->expects( $this->at( 3 ) )
+            ->method( 'get' )
+            ->with( 'something' )
+            ->will( $this->returnValue( $fakeService1 ) );
+        $this->container
+            ->expects( $this->at( 4 ) )
+            ->method( 'set' )
+            ->with( 'something', $fakeService1 );
+
+        $fakeService2 = new \stdClass;
+        $this->container
+            ->expects( $this->at( 5 ) )
+            ->method( 'set' )
+            ->with( 'something_else', null );
+        $this->container
+            ->expects( $this->at( 6 ) )
+            ->method( 'get' )
+            ->with( 'something_else' )
+            ->will( $this->returnValue( $fakeService2 ) );
+        $this->container
+            ->expects( $this->at( 7 ) )
+            ->method( 'set' )
+            ->with( 'something_else', $fakeService2 );
+
+        $listener = new DynamicSettingsListener( $resettableServices, $dynamicSettingsServiceIds );
+        $listener->setContainer( $this->container );
+        $listener->onConfigScopeChange( $event );
+        $this->assertSame( $siteAccess, $event->getSiteAccess() );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/OriginalRequestListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/OriginalRequestListenerTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * File containing the OriginalRequestListenerTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;
+
+use eZ\Bundle\EzPublishCoreBundle\EventListener\OriginalRequestListener;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class OriginalRequestListenerTest extends PHPUnit_Framework_TestCase
+{
+    public function testGetSubscribedEvents()
+    {
+        $this->assertSame(
+            array(
+                KernelEvents::REQUEST => array( 'onKernelRequest', 200 )
+            ),
+            OriginalRequestListener::getSubscribedEvents()
+        );
+    }
+
+    public function testOnKernelRequestNotMaster()
+    {
+        $request = new Request();
+        $event = new GetResponseEvent(
+            $this->getMock( '\Symfony\Component\HttpKernel\HttpKernelInterface' ),
+            $request,
+            HttpKernelInterface::SUB_REQUEST
+        );
+
+        $listener = new OriginalRequestListener();
+        $listener->onKernelRequest( $event );
+        $this->assertFalse( $request->attributes->has( '_ez_original_request' ) );
+    }
+
+    public function testOnKernelRequestNoOriginalRequest()
+    {
+        $request = new Request();
+        $event = new GetResponseEvent(
+            $this->getMock( '\Symfony\Component\HttpKernel\HttpKernelInterface' ),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST
+        );
+
+        $listener = new OriginalRequestListener();
+        $listener->onKernelRequest( $event );
+        $this->assertFalse( $request->attributes->has( '_ez_original_request' ) );
+    }
+
+    public function testOnKernelRequestWithOriginalRequest()
+    {
+        $scheme = 'http';
+        $host = 'phoenix-rises.fm';
+        $port = 1234;
+        $originalUri = '/foo/bar';
+        $originalAccept = 'blabla';
+
+        $expectedOriginalRequest = Request::create( sprintf( '%s://%s:%d%s', $scheme, $host, $port, $originalUri ) );
+        $expectedOriginalRequest->headers->set( 'accept', $originalAccept );
+        $expectedOriginalRequest->server->set( 'HTTP_ACCEPT', $originalAccept );
+
+        $request = Request::create( sprintf( '%s://%s:%d', $scheme, $host, $port ) . '/_fos_user_hash' );
+        $request->headers->set( 'x-fos-original-url', $originalUri );
+        $request->headers->set( 'x-fos-original-accept', $originalAccept );
+        $event = new GetResponseEvent(
+            $this->getMock( '\Symfony\Component\HttpKernel\HttpKernelInterface' ),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST
+        );
+
+        $listener = new OriginalRequestListener();
+        $listener->onKernelRequest( $event );
+        $this->assertEquals( $expectedOriginalRequest, $request->attributes->get( '_ez_original_request' ) );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RequestEventListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RequestEventListenerTest.php
@@ -34,11 +34,6 @@ class RequestEventListenerTest extends \PHPUnit_Framework_TestCase
     private $router;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
-     */
-    private $hashGenerator;
-
-    /**
      * @var \PHPUnit_Framework_MockObject_MockObject|LoggerInterface
      */
     private $logger;
@@ -69,10 +64,9 @@ class RequestEventListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->configResolver = $this->getMock( 'eZ\Publish\Core\MVC\ConfigResolverInterface' );
         $this->router = $this->getMock( 'Symfony\Component\Routing\RouterInterface' );
-        $this->hashGenerator = $this->getMock( 'eZ\\Publish\\SPI\\HashGenerator' );
         $this->logger = $this->getMock( 'Psr\\Log\\LoggerInterface' );
 
-        $this->requestEventListener = new RequestEventListener( $this->configResolver, $this->router, 'foobar', $this->hashGenerator, $this->logger );
+        $this->requestEventListener = new RequestEventListener( $this->configResolver, $this->router, 'foobar', $this->logger );
 
         $this->request = $this
             ->getMockBuilder( 'Symfony\\Component\\HttpFoundation\\Request' )
@@ -208,7 +202,7 @@ class RequestEventListenerTest extends \PHPUnit_Framework_TestCase
             ->method( 'getContext' )
             ->will( $this->returnValue( $this->getMock( 'Symfony\Component\Routing\RequestContext' ) ) );
 
-        $requestEventListener = new RequestEventListener( $this->configResolver, $this->router, 'setup', $this->hashGenerator, $this->logger );
+        $requestEventListener = new RequestEventListener( $this->configResolver, $this->router, 'setup', $this->logger );
         $event = new GetResponseEvent( $this->httpKernel, Request::create( '/setup' ), HttpKernelInterface::MASTER_REQUEST );
         $requestEventListener->onKernelRequestSetup( $event );
         $this->assertFalse( $event->hasResponse() );
@@ -226,7 +220,7 @@ class RequestEventListenerTest extends \PHPUnit_Framework_TestCase
             ->method( 'getContext' )
             ->will( $this->returnValue( $this->getMock( 'Symfony\Component\Routing\RequestContext' ) ) );
 
-        $requestEventListener = new RequestEventListener( $this->configResolver, $this->router, 'setup', $this->hashGenerator, $this->logger );
+        $requestEventListener = new RequestEventListener( $this->configResolver, $this->router, 'setup', $this->logger );
         $event = new GetResponseEvent( $this->httpKernel, Request::create( '/foo/bar' ), HttpKernelInterface::MASTER_REQUEST );
         $requestEventListener->onKernelRequestSetup( $event );
         $this->assertTrue( $event->hasResponse() );

--- a/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
+++ b/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
@@ -69,8 +69,8 @@ services:
 
     ezpublish.core.io.image_fieldtype.legacy_url_decorator:
         class: %ezpublish.core.io.url_decorator.prefix.class%
-        arguments:
-            - "$io.legacy_url_prefix$"
+        calls:
+            - [setPrefix, ["$io.legacy_url_prefix$"]]
 
     ezpublish.core.io.stream_file_listener:
         class: %ezpublish.core.io.stream_file_listener.class%

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -158,6 +158,11 @@ class UrlAliasGenerator extends Generator
      */
     public function getPathPrefixByRootLocationId( $rootLocationId )
     {
+        if ( !$rootLocationId )
+        {
+            return '';
+        }
+
         if ( isset( $this->pathPrefixMap[$rootLocationId] ) )
         {
             return $this->pathPrefixMap[$rootLocationId];


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23632

Fixes regression introduced by 9c31418fc70cfb898c2ff3eabd55cd90e14c7b6f (from #1067).
## Explanation

User hash is triggered by an event subscriber which occurs on `kernel.request` with priority `7`, so **after** a few other subscribers/listeners in eZ kernel (e.g. IO listener checking if current URI can be considered as a valid binary file).
Problem was that dependencies of those subscribers/listeners use dynamic settings that weren't updated.
1. User hash request now has a SiteAccess match thanks to the original request (HttpCache)
2. Ensures that user hash request coming from external reverse proxy (e.g. Varnish) also has a SiteAccess match with original request
3. Ensures `/fos_user_context_hash` URI has a route, in order not to trigger `UrlAliasRouter` or `FallbackRouter`
4. Ensures dynamic settings are reset after SiteAccess change
5. Ensures `ezpublish.core.io.image_fieldtype.legacy_url_decorator` uses setter for dynamic setting injection
