### PR TITLE
EZP-23646: docbook to ezxml conversion: preserve local tmp paragraph namespaces

### DIFF
--- a/eZ/Publish/Core/FieldType/RichText/Converter/Ezxml/FromRichTextPostNormalize.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter/Ezxml/FromRichTextPostNormalize.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * File containing the eZ\Publish\Core\FieldType\RichText\Converter\Ezxml\FromRichTextPostNormalize class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\FieldType\RichText\Converter\Ezxml;
+
+use eZ\Publish\Core\FieldType\RichText\Converter;
+use DOMDocument;
+use DOMXPath;
+
+/**
+ * Expands paragraphs and links embeds of a XML document in legacy ezxml format.
+ */
+class FromRichTextPostNormalize implements Converter
+{
+    /**
+     * Converts given $document into another \DOMDocument object
+     *
+     * @param \DOMDocument $document
+     *
+     * @return \DOMDocument
+     */
+    public function convert( DOMDocument $document )
+    {
+        $xpath = new DOMXPath( $document );
+        $temporaryParagraphs = $xpath->query( "//paragraph[@ez-temporary='1']" );
+
+        /** @var \DOMElement $paragraph */
+        foreach ( $temporaryParagraphs as $paragraph )
+        {
+            $paragraph->removeAttribute( "ez-temporary" );
+            $paragraph->setAttribute( "xmlns:tmp", "http://ez.no/namespaces/ezpublish3/temporary/" );
+        }
+
+        return $document;
+    }
+}

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Ezxml/FromRichTextPostNormalizeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Ezxml/FromRichTextPostNormalizeTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * File containing the RichText EZXML FromRichTextPostNormalize converter test
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\FieldType\Tests\RichText\Converter\Ezxml;
+
+use eZ\Publish\Core\FieldType\RichText\Converter\Ezxml\FromRichTextPostNormalize;
+use PHPUnit_Framework_TestCase;
+use DOMDocument;
+
+/**
+ * Tests the FromRichTextPostNormalize converter
+ */
+class FromRichTextPostNormalizeTest extends PHPUnit_Framework_TestCase
+{
+    public function testConvert()
+    {
+        $input = '<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:image="http://ez.no/namespaces/ezpublish3/image/">
+  <paragraph ez-temporary="1">
+    <table>
+      <tr>
+        <td>
+          <paragraph>This is a normal paragraph.</paragraph>
+          <paragraph ez-temporary="1">
+            <table>
+              <tr>
+                <td>
+                  <paragraph ez-temporary="1">
+                    <ol>
+                      <li>
+                        <paragraph ez-temporary="1">This is a list item.</paragraph>
+                      </li>
+                    </ol>
+                  </paragraph>
+                  <paragraph>This is another normal paragraph.</paragraph>
+                </td>
+              </tr>
+            </table>
+          </paragraph>
+        </td>
+      </tr>
+    </table>
+  </paragraph>
+</section>
+';
+
+        $converter = new FromRichTextPostNormalize();
+
+        $document = new DOMDocument();
+        $document->loadXML( $input );
+
+        $converterDocument = $converter->convert( $document );
+
+        $expectedOutput = '<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:image="http://ez.no/namespaces/ezpublish3/image/">
+  <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
+    <table>
+      <tr>
+        <td>
+          <paragraph>This is a normal paragraph.</paragraph>
+          <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
+            <table>
+              <tr>
+                <td>
+                  <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">
+                    <ol>
+                      <li>
+                        <paragraph xmlns:tmp="http://ez.no/namespaces/ezpublish3/temporary/">This is a list item.</paragraph>
+                      </li>
+                    </ol>
+                  </paragraph>
+                  <paragraph>This is another normal paragraph.</paragraph>
+                </td>
+              </tr>
+            </table>
+          </paragraph>
+        </td>
+      </tr>
+    </table>
+  </paragraph>
+</section>
+';
+
+        $this->assertEquals( $expectedOutput, $converterDocument->saveXML() );
+    }
+}


### PR DESCRIPTION
This PR resolves issue https://jira.ez.no/browse/EZP-23646

As local namespaces as used by legacy EZXML for temporary paragraphs are inherited by descendants, they are not preserved in XSL transformation even if explicitly added.
This needs to be handled by conversion pass that will use PHP's DOM API to add local namespace as an attribute, on paragraphs identified by temporary attribute.
#### TODOs
- [ ] adapt core conversion for needed attribute markers
