### PR TITLE
Fix EZP-23332: Avoid warning in LegacyEngine Templating (take 2)

### DIFF
--- a/eZ/Publish/Core/MVC/Legacy/Templating/LegacyEngine.php
+++ b/eZ/Publish/Core/MVC/Legacy/Templating/LegacyEngine.php
@@ -135,10 +135,7 @@ class LegacyEngine implements EngineInterface
      */
     public function supports( $name )
     {
-        if ( $name instanceof TemplateReference )
-        {
-            $name = $name->getLogicalName();
-        }
+        $name = (string)$name;
 
         if ( isset( $this->supportedTemplates[$name] ) )
         {


### PR DESCRIPTION
Fixes https://jira.ez.no/browse/EZP-23332

It was previously fixed with https://github.com/ezsystems/ezpublish-kernel/pull/988 but @patrickallaert suggests a better aproach
