### PR TITLE
Fix EZP-23683: session is always started for legacy_mode SiteAccess

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/EventListener/RequestListener.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/EventListener/RequestListener.php
@@ -63,7 +63,7 @@ class RequestListener implements EventSubscriberInterface
         if (
             $event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST
             || !$this->configResolver->getParameter( 'legacy_mode' )
-            || !$request->getSession()->has( 'eZUserLoggedInID' )
+            || !( $request->getSession()->isStarted() && $request->getSession()->has( 'eZUserLoggedInID' ) )
         )
         {
             return;

--- a/eZ/Bundle/EzPublishLegacyBundle/Tests/EventListener/RequestListenerTest.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Tests/EventListener/RequestListenerTest.php
@@ -84,6 +84,10 @@ class RequestListenerTest extends PHPUnit_Framework_TestCase
             ->will( $this->returnValue( $session ) );
         $session
             ->expects( $this->once() )
+            ->method( 'isStarted' )
+            ->will( $this->returnValue( true ) );
+        $session
+            ->expects( $this->once() )
             ->method( 'has' )
             ->with( 'eZUserLoggedInID' )
             ->will( $this->returnValue( true ) );


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23683

Problem: a session is always started for siteaccesses in legacy_mode.

It seems `Symfony\Component\HttpFoundation\Session::has( $name )` actually starts a session if one does not yet exist, so this PR adds an additional check to see if one is already started.

Tests: manual.
