### PR TITLE
Fix EZP-23403: Fix implementation of Persistence\Solr\Slot\MoveUserGroup slot

### DIFF
--- a/eZ/Publish/Core/Persistence/Solr/Slot/MoveUserGroup.php
+++ b/eZ/Publish/Core/Persistence/Solr/Slot/MoveUserGroup.php
@@ -15,7 +15,7 @@ use eZ\Publish\Core\Persistence\Solr\Slot;
 /**
  * A Solr slot handling MoveUserGroupSignal.
  */
-class MoveUserGroup extends Slot
+class MoveUserGroup extends MoveSubtree
 {
     /**
      * Receive the given $signal and react on it
@@ -29,18 +29,8 @@ class MoveUserGroup extends Slot
 
         $userGroupContentInfo = $this->persistenceHandler->contentHandler()->loadContentInfo( $signal->userGroupId );
 
-        $this->persistenceHandler->searchHandler()->indexContent(
-            $this->persistenceHandler->contentHandler()->load(
-                $userGroupContentInfo->id,
-                $userGroupContentInfo->currentVersionNo
-            )
-        );
-
-        // TODO: buggy: fix this to be similar to MoveSubtree, they are basically the same
-        $locations = $this->persistenceHandler->locationHandler()->loadLocationsByContent( $userGroupContentInfo->id );
-        foreach ( $locations as $location )
-        {
-            $this->persistenceHandler->locationSearchHandler()->indexLocation( $location );
-        }
+        // Moving UserGroup moves its main Location, so we only need to
+        // (re)index main Location's subtree
+        $this->indexSubtree( $userGroupContentInfo->mainLocationId );
     }
 }


### PR DESCRIPTION
This PR resolves issue https://jira.ez.no/browse/EZP-23403

It turned out `MoveSubtree` slot also need to be fixed, as it was reindexing all Locations of the Content in the moved subtree, while only moved Locations needed reindexing.
`MoveUserGroup` slot is fixed by extending `MoveSubtree` slot and using its implementation.

Testing: manual testing

Followup: remove UserService::moveUserGroup() method: https://jira.ez.no/browse/EZP-23699