### PR TITLE
EZP-23562: Elasticsearch: make Mapper dispatchable

### DIFF
--- a/eZ/Publish/Core/Persistence/Elasticsearch/Content/Search/Handler.php
+++ b/eZ/Publish/Core/Persistence/Elasticsearch/Content/Search/Handler.php
@@ -28,7 +28,7 @@ class Handler implements SearchHandlerInterface
     protected $gateway;
 
     /**
-     * @var \eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Mapper
+     * @var \eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\MapperInterface
      */
     protected $mapper;
 
@@ -41,7 +41,7 @@ class Handler implements SearchHandlerInterface
 
     public function __construct(
         Gateway $gateway,
-        Mapper $mapper,
+        MapperInterface $mapper,
         Extractor $extractor
     )
     {

--- a/eZ/Publish/Core/Persistence/Elasticsearch/Content/Search/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Elasticsearch/Content/Search/Location/Handler.php
@@ -88,7 +88,7 @@ class Handler implements SearchHandlerInterface
      */
     public function indexLocation( Location $location )
     {
-        $document = $this->mapper->mapContentLocation( $location );
+        $document = $this->mapper->mapLocation( $location );
 
         $this->gateway->index( $document );
     }
@@ -107,7 +107,7 @@ class Handler implements SearchHandlerInterface
         $documents = array();
         foreach ( $locations as $location )
         {
-            $documents[] = $this->mapper->mapContentLocation( $location );
+            $documents[] = $this->mapper->mapLocation( $location );
         }
 
         $this->gateway->bulkIndex( $documents );

--- a/eZ/Publish/Core/Persistence/Elasticsearch/Content/Search/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Elasticsearch/Content/Search/Location/Handler.php
@@ -16,7 +16,7 @@ use eZ\Publish\SPI\Search\FieldType;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
-use eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Mapper;
+use eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\MapperInterface;
 use eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Extractor;
 use eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Gateway;
 
@@ -35,7 +35,7 @@ class Handler implements SearchHandlerInterface
     /**
      * Document mapper
      *
-     * @var \eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Mapper
+     * @var \eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\MapperInterface
      */
     protected $mapper;
 
@@ -50,12 +50,12 @@ class Handler implements SearchHandlerInterface
      * Creates a new content handler.
      *
      * @param \eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Gateway $gateway
-     * @param \eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Mapper $mapper
+     * @param \eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\MapperInterface $mapper
      * @param \eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Extractor $extractor
      */
     public function __construct(
         Gateway $gateway,
-        Mapper $mapper,
+        MapperInterface $mapper,
         Extractor $extractor
     )
     {

--- a/eZ/Publish/Core/Persistence/Elasticsearch/Content/Search/Mapper/StandardMapper.php
+++ b/eZ/Publish/Core/Persistence/Elasticsearch/Content/Search/Mapper/StandardMapper.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * File containing the Elasticsearch Mapper class
+ * This file is part of the eZ Publish Kernel package
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
 
-namespace eZ\Publish\Core\Persistence\Elasticsearch\Content\Search;
+namespace eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Mapper;
 
 use eZ\Publish\SPI\Search\Field;
 use eZ\Publish\SPI\Persistence\Content;
@@ -21,12 +21,16 @@ use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\Handler as ObjectStateHandler;
 use eZ\Publish\SPI\Persistence\Content\Section\Handler as SectionHandler;
+use eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\MapperInterface;
+use eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\FieldNameGenerator;
+use eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Document;
 
 /**
- * Mapper maps Content and Location objects to a Document object, representing a
- * document in Elasticsearch index storage.
+ * Standard Mapper implementation maps:
+ *  - Content with its fields and corresponding Locations
+ *  - Locations with Content data but without Content fields
  */
-class Mapper
+class StandardMapper implements MapperInterface
 {
     /**
      * Field name generator

--- a/eZ/Publish/Core/Persistence/Elasticsearch/Content/Search/Mapper/StandardMapper.php
+++ b/eZ/Publish/Core/Persistence/Elasticsearch/Content/Search/Mapper/StandardMapper.php
@@ -140,7 +140,7 @@ class StandardMapper implements MapperInterface
         $locationDocuments = array();
         foreach ( $locations as $location )
         {
-            $locationDocuments[] = $this->mapLocation( $location, $content );
+            $locationDocuments[] = $this->mapContentLocation( $location, $content );
         }
 
         // UserGroups and Users are Content, but permissions cascade is achieved through
@@ -369,7 +369,7 @@ class StandardMapper implements MapperInterface
      *
      * @return \eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Document
      */
-    protected function mapLocation( Location $location, Content $content )
+    protected function mapContentLocation( Location $location, Content $content )
     {
         $fields = array(
             new Field(
@@ -445,13 +445,13 @@ class StandardMapper implements MapperInterface
      *
      * @return \eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Document
      */
-    public function mapContentLocation( Location $location )
+    public function mapLocation( Location $location )
     {
         $contentInfo = $this->contentHandler->loadContentInfo( $location->contentId );
         $content = $this->contentHandler->load( $location->contentId, $contentInfo->currentVersionNo );
         $section = $this->sectionHandler->load( $content->versionInfo->contentInfo->sectionId );
 
-        $document = $this->mapLocation( $location, $content );
+        $document = $this->mapContentLocation( $location, $content );
         $document->id = $location->id;
         $document->type = "location";
 

--- a/eZ/Publish/Core/Persistence/Elasticsearch/Content/Search/MapperInterface.php
+++ b/eZ/Publish/Core/Persistence/Elasticsearch/Content/Search/MapperInterface.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\Elasticsearch\Content\Search;
+
+use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\SPI\Persistence\Content\Location;
+
+/**
+ * Mapper maps Content and Location objects to a Document object, representing a
+ * document in Elasticsearch index storage.
+ *
+ * Note that custom implementations might need to be accompanied by custom mappings.
+ */
+interface MapperInterface
+{
+    /**
+     * Maps given Content by given $contentId to a Document.
+     *
+     * @param int|string $contentId
+     *
+     * @return \eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Document
+     */
+    public function mapContentById( $contentId );
+
+    /**
+     * Maps given Content to a Document.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     *
+     * @return \eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Document
+     */
+    public function mapContent( Content $content );
+
+    /**
+     * Maps given Location to a Document.
+     *
+     * Returned Document represents a "parent" Location document searchable with Location Search.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Location $location
+     *
+     * @return \eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Document
+     */
+    public function mapLocation( Location $location );
+}

--- a/eZ/Publish/Core/settings/storage_engines/legacy_elasticsearch.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy_elasticsearch.yml
@@ -14,7 +14,7 @@ imports:
 parameters:
     ezpublish.elasticsearch_server: http://localhost:9200/
     ezpublish.persistence.elasticsearch.search.serializer.class: eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Serializer
-    ezpublish.persistence.elasticsearch.search.mapper.class: eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Mapper
+    ezpublish.persistence.elasticsearch.search.mapper.standard.class: eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Mapper\StandardMapper
     ezpublish.persistence.elasticsearch.search.gateway.native.class: eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Gateway\Native
     ezpublish.persistence.elasticsearch.search.location.gateway.native.class: eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Location\Gateway\Native
     ezpublish.spi.persistence.elasticsearch.search.handler.content.class: eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Handler
@@ -29,8 +29,8 @@ services:
             - @ezpublish.persistence.elasticsearch.search.content.field_value_mapper.aggregate
             - @ezpublish.persistence.elasticsearch.search.content.field_name_generator
 
-    ezpublish.persistence.elasticsearch.search.mapper:
-        class: %ezpublish.persistence.elasticsearch.search.mapper.class%
+    ezpublish.persistence.elasticsearch.search.mapper.standard:
+        class: %ezpublish.persistence.elasticsearch.search.mapper.standard.class%
         arguments:
             - @ezpublish.persistence.solr.search.field_registry
             - @ezpublish.persistence.elasticsearch.search.content.field_name_generator
@@ -39,6 +39,9 @@ services:
             - @ezpublish.spi.persistence.legacy.content_type.handler
             - @ezpublish.spi.persistence.legacy.object_state.handler
             - @ezpublish.spi.persistence.legacy.section.handler
+
+    ezpublish.persistence.elasticsearch.search.mapper:
+        alias: ezpublish.persistence.elasticsearch.search.mapper.standard
 
     ezpublish.persistence.legacy_elasticsearch.search.content.gateway.native:
         class: %ezpublish.persistence.elasticsearch.search.gateway.native.class%


### PR DESCRIPTION
This PR implements https://jira.ez.no/browse/EZP-23562

This breaks Mapper implementation into a abstract `Mapper` and `Standard` implementation, in order to make custom implementations dispatchable.

`mapContentLocation()` is renamed to `mapLocation()` as more appropriate.

#### TODOs
- [x] Use an interface instead of abstract class
