### PR TITLE
Fix EZP-23703: Impossible to update only the name of a section

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SectionServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SectionServiceTest.php
@@ -279,6 +279,37 @@ class SectionServiceTest extends BaseTest
      * @see \eZ\Publish\API\Repository\SectionService::updateSection()
      * @depends eZ\Publish\API\Repository\Tests\SectionServiceTest::testUpdateSection
      */
+    public function testUpdateSectionWithSectionIdentifierOnNameUpdate()
+    {
+        $repository = $this->getRepository();
+
+        $standardSectionId = $this->generateId( 'section', 1 );
+        /* BEGIN: Use Case */
+        // $standardSectionId contains the ID of the "Standard" section in a eZ
+        // Publish demo installation.
+
+        $sectionService = $repository->getSectionService();
+
+        $section = $sectionService->loadSection( $standardSectionId );
+        $sectionUpdate = $sectionService->newSectionUpdateStruct();
+        $sectionUpdate->name = 'New section name';
+
+        // section identifier remains the same
+        $sectionUpdate->identifier = $section->identifier;
+
+        $updatedSection = $sectionService->updateSection( $section, $sectionUpdate );
+        /* END: Use Case */
+
+        $this->assertEquals( 'standard', $updatedSection->identifier );
+    }
+
+    /**
+     * Test for the updateSection() method.
+     *
+     * @return void
+     * @see \eZ\Publish\API\Repository\SectionService::updateSection()
+     * @depends eZ\Publish\API\Repository\Tests\SectionServiceTest::testUpdateSection
+     */
     public function testUpdateSectionKeepsSectionNameOnIdentifierUpdate()
     {
         $repository = $this->getRepository();

--- a/eZ/Publish/Core/Repository/SectionService.php
+++ b/eZ/Publish/Core/Repository/SectionService.php
@@ -141,8 +141,12 @@ class SectionService implements SectionServiceInterface
             try
             {
                 $existingSection = $this->loadSectionByIdentifier( $sectionUpdateStruct->identifier );
-                if ( $existingSection !== null )
+
+                // Allowing identifier update only for the same section
+                if ( $existingSection->id != $section->id )
+                {
                     throw new InvalidArgumentException( "sectionUpdateStruct", "section with specified identifier already exists" );
+                }
             }
             catch ( APINotFoundException $e )
             {


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-23703
## Description

If the identifier is set in `$sectionUpdateStruct` update will be impossible because the update method will think the section already exists.
## Tests

Manual test on the platform UI bundle and added integration tests
