### PR TITLE
Add the fieldIdentifier to renderField exception message

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
@@ -380,7 +380,7 @@ class ContentExtension extends Twig_Extension
         {
             throw new InvalidArgumentException(
                 '$fieldIdentifier',
-                "Invalid for content #{$content->contentInfo->id} '{$content->contentInfo->name}'"
+                "'{$fieldIdentifier}' field not present on content #{$content->contentInfo->id} '{$content->contentInfo->name}'"
             );
         }
 


### PR DESCRIPTION
Not a bug but something that may help a bit in your dev process. 
Actually, when trying to render a field not present in a content, the exception message we get is like 

```
An exception has been thrown during the rendering of a template ("Argument '$fieldIdentifier' is invalid: Invalid for content #526...
```

This patch just change single quotes for double quotes so we can get the missed field in the Exception. 

Don't think this needs a issue in the tracker but let me know if you prefer me to do it. 
