### PR TITLE
Fix EZP-23752: Strict standards error with Symfony 2.6

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Controller.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Controller.php
@@ -52,18 +52,6 @@ class Controller extends BaseController
     }
 
     /**
-     * Checks if current user has granted access to provided attribute
-     *
-     * @param \eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute $attribute
-     *
-     * @return boolean
-     */
-    public function isGranted( AuthorizationAttribute $attribute )
-    {
-        return $this->container->get( 'security.context' )->isGranted( $attribute );
-    }
-
-    /**
      * Returns the general helper service, exposed in Twig templates as "ezpublish" global variable.
      *
      * @return \eZ\Publish\Core\MVC\Legacy\Templating\GlobalHelper


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23752

Removed custom `isGranted()` method from `eZ\Bundle\EzPublishCoreBundle\Controller`.
This must go with a Symfony version bump to `~2.6` in ezpublish-community (see https://github.com/ezsystems/ezpublish-community/pull/210)
