### PR TITLE
EZP-23778: implement session-based auth support in BDD RestContext

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/RestClient/BuzzDriver.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/RestClient/BuzzDriver.php
@@ -63,7 +63,7 @@ class BuzzDriver implements DriverInterface
     /**
      * Get request
      *
-     * @return \Buzz\Message\Response
+     * @return \Buzz\Message\Request
      */
     protected function getRequest()
     {
@@ -165,7 +165,10 @@ class BuzzDriver implements DriverInterface
             $value = implode( ';', $value );
         }
 
-        $this->getRequest()->addHeader( "$header: $value" );
+        // Buzz can only add/append header, so we need to (re-)set all headers
+        $headers = $this->unFormatHeaders( $this->getRequest()->getHeaders() );
+        $headers[$header] = $value;
+        $this->getRequest()->setHeaders( $headers );
     }
 
     /**

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/RestContext.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/RestContext.php
@@ -28,9 +28,14 @@ class RestContext extends Context
     use SubContext\ContentTypeGroup;
     use SubContext\Exception;
 
+    const AUTHTYPE_BASICHTTP  = 'http_basic';
+    const AUTHTYPE_SESSION    = 'session';
+
     const DEFAULT_URL = 'http://localhost/';
     const DEFAULT_DRIVER = 'GuzzleDriver';
     const DEFAULT_BODY_TYPE = 'json';
+
+    const DEFAULT_AUTH_TYPE = self::AUTHTYPE_SESSION;
 
     /**
      * Rest driver for all requests and responses
@@ -40,22 +45,45 @@ class RestContext extends Context
     protected $restDriver;
 
     /**
+     * @var string
+     */
+    private $url;
+
+    /**
+     * @var string
+     */
+    private $driver;
+
+    /**
      * Initialize class
      *
      * @param string $url    Base URL for REST calls
      * @param string $driver REST Driver to be used
-     * @param string $json   
+     * @param string $json
      *
      * @return void
      */
     public function __construct(
         $url = self::DEFAULT_URL,
         $driver = self::DEFAULT_DRIVER,
-        $type = self::DEFAULT_BODY_TYPE
+        $type = self::DEFAULT_BODY_TYPE,
+        $authType = self::DEFAULT_AUTH_TYPE
     )
     {
-        $this->setRestDriver( $driver, $url );
+        $this->driver = $driver;
+        $this->url = $url;
         $this->restBodyType = $type;
+        $this->authType = $authType;
+
+        $this->setRestDriver( $this->driver, $this->url );
+    }
+
+    /**
+     * @BeforeScenario
+     */
+    private function resetDriver()
+    {
+        $this->setRestDriver( $this->driver, $this->url );
     }
 
     /**
@@ -93,6 +121,7 @@ class RestContext extends Context
         $this->restDriver->setResource(
             $this->changeMappedValuesOnUrl( $resource )
         );
+        $this->responseObject = null;
     }
 
     /**

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/Authentication.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/Authentication.php
@@ -10,9 +10,15 @@
 namespace eZ\Bundle\EzPublishRestBundle\Features\Context\SubContext;
 
 use Behat\Behat\Tester\Exception\PendingException;
+use eZ\Publish\Core\REST\Server\Values\SessionInput;
 
 trait Authentication
 {
+    /**
+     * @var eZ\Publish\Core\REST\Server\Values\UserSession
+     */
+    protected $userSession;
+
     /**
      * @Given I have :role permissions
      */
@@ -20,10 +26,20 @@ trait Authentication
     {
         $credentials = $this->getCredentialsFor( $role );
 
-        $this->restDriver->setAuthentication(
-            $credentials['login'],
-            $credentials['password']
-        );
+        switch ( $this->authType )
+        {
+            case self::AUTHTYPE_BASICHTTP:
+                $this->restDriver->setAuthentication(
+                    $credentials['login'],
+                    $credentials['password']
+                );
+                break;
+            case self::AUTHTYPE_SESSION:
+                $this->createSession( $credentials['login'], $credentials['password'] );
+                break;
+            default:
+                throw new \Exception( "Unknown auth type: '{$this->authType}'." );
+        }
     }
 
     /**
@@ -32,6 +48,58 @@ trait Authentication
      */
     public function useAnonymousRole()
     {
-        $this->restDriver->setAuthentication( '', '' );
+        switch ( $this->authType )
+        {
+            case self::AUTHTYPE_BASICHTTP:
+                $this->restDriver->setAuthentication( '', '' );
+                break;
+            case self::AUTHTYPE_SESSION:
+                $this->cleanupSession();
+                break;
+            default:
+                throw new \Exception( "Unknown auth type: '{$this->authType}'." );
+        }
+    }
+
+    /**
+     * @When I create a (new) session with login :login and password :password
+     */
+    public function createSession( $login, $password )
+    {
+
+        $this->createRequest( 'post', '/user/sessions' );
+        $this->setHeaderWithObject( 'accept', 'Session' );
+        $this->setHeaderWithObject( 'content-type', 'SessionInput' );
+
+        $this->makeObject( 'SessionInput' );
+        $this->setFieldToValue( 'login', $login );
+        $this->setFieldToValue( 'password', $password );
+        $this->sendRequest();
+
+        $this->userSession = $this->getResponseObject();
+
+        $this->resetDriver();
+
+        // apply session/csrf token to next request
+        $this->restDriver->setHeader( 'cookie', "{$this->userSession->sessionName}={$this->userSession->sessionId}" );
+        $this->restDriver->setHeader( 'x-csrf-token', $this->userSession->csrfToken );
+    }
+
+    /**
+     * @AfterScenario
+     *
+     * Cleanup session, if applicable.
+     */
+    public function cleanupSession()
+    {
+        if ( $this->userSession )
+        {
+            $this->resetDriver();
+            $this->createRequest( 'post', "/user/sessions/{$this->userSession->sessionId}" );
+            $this->restDriver->setHeader( 'cookie', "{$this->userSession->sessionName}={$this->userSession->sessionId}" );
+            $this->restDriver->setHeader( 'x-csrf-token', $this->userSession->csrfToken );
+            $this->sendRequest();
+            $this->userSession = null;
+        }
     }
 }

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/EzRest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/EzRest.php
@@ -12,6 +12,7 @@ namespace eZ\Bundle\EzPublishRestBundle\Features\Context\SubContext;
 use EzSystems\BehatBundle\Helper\ValueObject as ValueObjectHelper;
 use eZ\Bundle\EzPublishRestBundle\Features\Context\Helper;
 use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\REST\Server\Values\SessionInput;
 use eZ\Publish\Core\REST\Common\Message;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use PHPUnit_Framework_Assert as Assertion;
@@ -322,7 +323,11 @@ trait EzRest
     {
         $repository = $this->getRepository();
 
-        switch( $objectType ) {
+        switch( $objectType )
+        {
+            case "SessionInput":
+                $this->requestObject = new SessionInput();
+                break;
             case "ContentTypeGroupCreateStruct":
                 $this->requestObject = $repository
                     ->getContentTypeService()

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
@@ -87,6 +87,7 @@ parameters:
     ezpublish_rest.input.parser.Section.class: eZ\Publish\Core\REST\Client\Input\Parser\Section
     ezpublish_rest.input.parser.SectionList.class: eZ\Publish\Core\REST\Client\Input\Parser\SectionList
     ezpublish_rest.input.parser.VersionInfo.class: eZ\Publish\Core\REST\Client\Input\Parser\VersionInfo
+    ezpublish_rest.input.parser.Session.class: eZ\Publish\Core\REST\Client\Input\Parser\Session
 
 services:
     ezpublish_rest.input.parser:
@@ -744,3 +745,12 @@ services:
             - @ezpublish.api.service.content
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.VersionInfo }
+
+    ezpublish_rest.input.parser.Session:
+        parent: ezpublish_rest.input.parser
+        class: %ezpublish_rest.input.parser.Session.class%
+        arguments:
+            - @ezpublish_rest.parser_tools
+            - @ezpublish.api.service.user
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.Session }

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -53,6 +53,7 @@ parameters:
     ezpublish_rest.output.value_object_visitor.RestUser.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\RestUser
     ezpublish_rest.output.value_object_visitor.UserSession.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\UserSession
     ezpublish_rest.output.value_object_visitor.UserSessionDeleted.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\DeletedUserSession
+    ezpublish_rest.output.value_object_visitor.SessionInput.class: eZ\Publish\Core\REST\Client\Output\ValueObjectVisitor\SessionInput
 
     # ContentType
     ezpublish_rest.output.value_object_visitor.RestContentType.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\RestContentType
@@ -395,6 +396,12 @@ services:
         class: %ezpublish_rest.output.value_object_visitor.UserSessionDeleted.class%
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Values\DeletedUserSession }
+
+    ezpublish_rest.output.value_object_visitor.SessionInput:
+        parent: ezpublish_rest.output.value_object_visitor.base
+        class: %ezpublish_rest.output.value_object_visitor.SessionInput.class%
+        tags:
+            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Values\SessionInput }
 
     # ContentType
     ezpublish_rest.output.value_object_visitor.RestContentType:

--- a/eZ/Publish/Core/REST/Client/Input/Parser/Session.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/Session.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * File containing the Session parser class
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\REST\Client\Input\Parser;
+
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
+use eZ\Publish\Core\REST\Common\Input\ParserTools;
+use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
+use eZ\Publish\Core\REST\Server\Values;
+use eZ\Publish\API\Repository\UserService;
+
+/**
+ * Value for Session
+ */
+class Session extends BaseParser
+{
+    /**
+     * @var \eZ\Publish\Core\REST\Common\Input\ParserTools
+     */
+    protected $parserTools;
+
+    /**
+     * User Service
+     *
+     * @var \eZ\Publish\Core\REST\Client\userService
+     */
+    protected $userService;
+
+    /**
+     * @param \eZ\Publish\Core\REST\Common\Input\ParserTools $parserTools
+     * @param \eZ\Publish\API\Repository\UserService $userService
+     */
+    public function __construct( ParserTools $parserTools, UserService $userService )
+    {
+        $this->parserTools = $parserTools;
+        $this->userService = $userService;
+    }
+
+    /**
+     * Parse input structure
+     *
+     * @param array $data
+     * @param \eZ\Publish\Core\REST\Common\Input\ParsingDispatcher $parsingDispatcher
+     *
+     * @todo Error handling
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\Role
+     */
+    public function parse( array $data, ParsingDispatcher $parsingDispatcher )
+    {
+
+        if ( !array_key_exists( '_href', $data['User'] ) )
+        {
+            throw new Exceptions\Parser( "Missing '_href' attribute for User element in Session." );
+        }
+
+        $userId = $this->requestParser->parseHref( $data['User']['_href'], 'userId' );
+
+        $user = $this->userService->loadUser( $userId );
+
+        return new Values\UserSession(
+            $user,
+            $data['name'],
+            $data['identifier'],
+            $data['csrfToken'],
+            null
+        );
+    }
+}

--- a/eZ/Publish/Core/REST/Client/Output/ValueObjectVisitor/SessionInput.php
+++ b/eZ/Publish/Core/REST/Client/Output/ValueObjectVisitor/SessionInput.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * File containing the SessionInput class
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\REST\Client\Output\ValueObjectVisitor;
+
+use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+
+/**
+ * SessionInput value object visitor
+ */
+class SessionInput extends ValueObjectVisitor
+{
+    /**
+     * Visit struct returned by controllers
+     *
+     * @param \eZ\Publish\Core\REST\Common\Output\Visitor $visitor
+     * @param \eZ\Publish\Core\REST\Common\Output\Generator $generator
+     * @param mixed $data
+     */
+    public function visit( Visitor $visitor, Generator $generator, $data )
+    {
+        $generator->startObjectElement( 'SessionInput' );
+        $visitor->setHeader( 'Content-Type', $generator->getMediaType( 'SessionInput' ) );
+
+        $generator->startValueElement( 'login', $data->login );
+        $generator->endValueElement( 'login' );
+
+        $generator->startValueElement( 'password', $data->password );
+        $generator->endValueElement( 'password' );
+
+        $generator->endObjectElement( 'SessionInput' );
+    }
+}


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23778

This adds support for session-based authentication in BDD's RestContext.
A new `authType` parameter may be added to behat.yml in REST suites to specify which method to use,
current default is "session" as per https://github.com/ezsystems/ezpublish-community/commit/8b1f227e1d84bc78