### PR TITLE
EZP-23784: Refactored preview location handling

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
@@ -5,6 +5,7 @@ parameters:
     ezpublish.content_preview_helper.class: eZ\Publish\Core\Helper\ContentPreviewHelper
     ezpublish.config_scope_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\ConfigScopeListener
     ezpublish.dynamic_settings_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\DynamicSettingsListener
+    ezpublish.content_preview.location_provider.class: eZ\Publish\Core\Helper\PreviewLocationProvider
     ezpublish.config_resolver.resettable_services: []
     ezpublish.config_resolver.dynamic_settings_services: []
 
@@ -24,7 +25,7 @@ services:
 
     ezpublish.content_preview_helper:
         class: %ezpublish.content_preview_helper.class%
-        arguments: [@ezpublish.api.service.content, @ezpublish.api.service.location, @event_dispatcher, @ezpublish.config.resolver]
+        arguments: [@event_dispatcher]
         calls:
             - [setSiteAccess, [@ezpublish.siteaccess]]
 
@@ -45,3 +46,7 @@ services:
             - [setContainer, [@service_container]]
         tags:
             - { name: kernel.event_subscriber }
+
+    ezpublish.content_preview.location_provider:
+        class: %ezpublish.content_preview.location_provider.class%
+        arguments: [@ezpublish.api.service.location, @ezpublish.api.service.content, @ezpublish.api.persistence_handler]

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
@@ -49,4 +49,7 @@ services:
 
     ezpublish.content_preview.location_provider:
         class: %ezpublish.content_preview.location_provider.class%
-        arguments: [@ezpublish.api.service.location, @ezpublish.api.service.content, @ezpublish.api.persistence_handler]
+        arguments:
+            - @ezpublish.api.service.location
+            - @ezpublish.api.service.content
+            - @ezpublish.spi.persistence.cache.locationHandler

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -65,6 +65,7 @@ services:
             - @http_kernel
             - @ezpublish.content_preview_helper
             - @security.context
+            - @ezpublish.content_preview.location_provider
         calls:
             - [setRequest, [@?request=]]
 

--- a/eZ/Bundle/EzPublishLegacyBundle/Tests/Controller/PreviewControllerTest.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Tests/Controller/PreviewControllerTest.php
@@ -37,7 +37,8 @@ class PreviewControllerTest extends BasePreviewControllerTest
             $this->contentService,
             $this->httpKernel,
             $this->previewHelper,
-            $this->securityContext
+            $this->securityContext,
+            $this->locationProvider
         );
         $controller->setConfigResolver( $this->configResolver );
 

--- a/eZ/Publish/Core/Helper/ContentPreviewHelper.php
+++ b/eZ/Publish/Core/Helper/ContentPreviewHelper.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the ContentPreviewHelper class.
+ * This file is part of the eZ Publish Kernel package.
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -9,28 +9,14 @@
 
 namespace eZ\Publish\Core\Helper;
 
-use eZ\Publish\API\Repository\ContentService;
-use eZ\Publish\API\Repository\LocationService;
-use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
-use eZ\Publish\Core\Repository\Values\Content\Location;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ContentPreviewHelper implements SiteAccessAware
 {
-    /**
-     * @var \eZ\Publish\API\Repository\ContentService
-     */
-    protected $contentService;
-
-    /**
-     * @var \eZ\Publish\API\Repository\LocationService
-     */
-    protected $locationService;
-
     /**
      * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
      */
@@ -41,23 +27,9 @@ class ContentPreviewHelper implements SiteAccessAware
      */
     protected $originalSiteAccess;
 
-    /**
-     * @var \eZ\Publish\Core\MVC\ConfigResolverInterface
-     */
-    private $configResolver;
-
-    public function __construct(
-        ContentService $contentService,
-        LocationService $locationService,
-        EventDispatcherInterface $eventDispatcher,
-        ConfigResolverInterface $configResolver
-    )
+    public function __construct( EventDispatcherInterface $eventDispatcher )
     {
-        $this->contentService = $contentService;
-        $this->locationService = $locationService;
-
         $this->eventDispatcher = $eventDispatcher;
-        $this->configResolver = $configResolver;
     }
 
     public function setSiteAccess( SiteAccess $siteAccess = null )
@@ -101,41 +73,5 @@ class ContentPreviewHelper implements SiteAccessAware
         $this->eventDispatcher->dispatch( MVCEvents::CONFIG_SCOPE_RESTORE, $event );
 
         return $event->getSiteAccess();
-    }
-
-    /**
-     * Returns a valid Location object for $contentId.
-     * Will either load mainLocationId (if available) or build a virtual Location object.
-     *
-     * @param mixed $contentId
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\Location|null Null when content does not have location
-     */
-    public function getPreviewLocation( $contentId )
-    {
-        // contentInfo must be reloaded as content is not published yet (e.g. no mainLocationId)
-        $contentInfo = $this->contentService->loadContentInfo( $contentId );
-        // mainLocationId already exists, content has been published at least once.
-        if ( $contentInfo->mainLocationId )
-        {
-            $location = $this->locationService->loadLocation( $contentInfo->mainLocationId );
-        }
-        // New Content, never published, create a virtual location object.
-        else
-        {
-            // @todo In future releases this will be a full draft location when this feature
-            // is implemented. Or it might return null when content does not have location,
-            // but for now we can't detect that so we return a virtual draft location
-            $location = new Location(
-                array(
-                    // Faking using root locationId
-                    'id' => $this->configResolver->getParameter( 'content.tree_root.location_id' ),
-                    'contentInfo' => $contentInfo,
-                    'status' => Location::STATUS_DRAFT
-                )
-            );
-        }
-
-        return $location;
     }
 }

--- a/eZ/Publish/Core/Helper/PreviewLocationProvider.php
+++ b/eZ/Publish/Core/Helper/PreviewLocationProvider.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributd with this source code.
+ */
+namespace eZ\Publish\Core\Helper;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
+
+/**
+ * Provides location(s) for a content. Handles unpublished content that does not have an actual location yet.
+ */
+class PreviewLocationProvider
+{
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /** @var \eZ\Publish\SPI\Persistence\Content\Location\Handler */
+    private $locationHandler;
+
+    /**
+     * @param \eZ\Publish\API\Repository\LocationService $locationService
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     * @param \eZ\Publish\SPI\Persistence\Handler $persistenceHandler
+     */
+    public function __construct(
+        LocationService $locationService,
+        ContentService $contentService,
+        PersistenceHandler $persistenceHandler
+    )
+    {
+        $this->locationService = $locationService;
+        $this->contentService = $contentService;
+        $this->locationHandler = $persistenceHandler->locationHandler();
+    }
+
+    /**
+     * Loads the main location for $contentId
+     *
+     * If the content does not have a location (yet), an Location draft is returned.
+     * Location drafts do not have an id (it is set to null), and can be tested using the isDraft() method.
+     *
+     * @param mixed $contentInfo
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Location
+     */
+    public function loadMainLocation( $contentId )
+    {
+        $contentInfo = $this->contentService->loadContentInfo( $contentId );
+
+        // mainLocationId already exists, content has been published at least once.
+        if ( $contentInfo->mainLocationId )
+        {
+            $location = $this->locationService->loadLocation( $contentInfo->mainLocationId );
+        }
+        // New Content, never published, create a virtual location object.
+        else
+        {
+            // @todo In future releases this will be a full draft location when this feature
+            // is implemented. Or it might return null when content does not have location,
+            // but for now we can't detect that so we return a virtual draft location
+            $parentLocations = $this->locationHandler->loadParentLocationsForDraftContent( $contentInfo->id );
+            if ( count( $parentLocations ) === 0 )
+            {
+                return null;
+            }
+            $location = new Location(
+                array(
+                    'contentInfo' => $contentInfo,
+                    'status' => Location::STATUS_DRAFT,
+                    'parentLocationId' => $parentLocations[0]->id,
+                    'depth' => $parentLocations[0]->depth + 1
+                )
+            );
+        }
+
+        return $location;
+    }
+}

--- a/eZ/Publish/Core/Helper/PreviewLocationProvider.php
+++ b/eZ/Publish/Core/Helper/PreviewLocationProvider.php
@@ -10,7 +10,7 @@ namespace eZ\Publish\Core\Helper;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\Repository\Values\Content\Location;
-use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as PersistenceLocationHandler;
 
 /**
  * Provides location(s) for a content. Handles unpublished content that does not have an actual location yet.
@@ -29,17 +29,17 @@ class PreviewLocationProvider
     /**
      * @param \eZ\Publish\API\Repository\LocationService $locationService
      * @param \eZ\Publish\API\Repository\ContentService $contentService
-     * @param \eZ\Publish\SPI\Persistence\Handler $persistenceHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $locationHandler
      */
     public function __construct(
         LocationService $locationService,
         ContentService $contentService,
-        PersistenceHandler $persistenceHandler
+        PersistenceLocationHandler $locationHandler
     )
     {
         $this->locationService = $locationService;
         $this->contentService = $contentService;
-        $this->locationHandler = $persistenceHandler->locationHandler();
+        $this->locationHandler = $locationHandler;
     }
 
     /**

--- a/eZ/Publish/Core/Helper/PreviewLocationProvider.php
+++ b/eZ/Publish/Core/Helper/PreviewLocationProvider.php
@@ -45,12 +45,14 @@ class PreviewLocationProvider
     /**
      * Loads the main location for $contentId
      *
-     * If the content does not have a location (yet), an Location draft is returned.
+     * If the content does not have a location (yet), but has a Location draft, it is returned instead.
      * Location drafts do not have an id (it is set to null), and can be tested using the isDraft() method.
+     *
+     * If the content doesn't have a location nor a location draft, null is returned.
      *
      * @param mixed $contentInfo
      *
-     * @return \eZ\Publish\API\Repository\Values\Content\Location
+     * @return \eZ\Publish\API\Repository\Values\Content\Location|null
      */
     public function loadMainLocation( $contentId )
     {

--- a/eZ/Publish/Core/Helper/Tests/ContentPreviewHelperTest.php
+++ b/eZ/Publish/Core/Helper/Tests/ContentPreviewHelperTest.php
@@ -20,16 +20,6 @@ class ContentPreviewHelperTest extends PHPUnit_Framework_TestCase
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
      */
-    private $contentService;
-
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
-     */
-    private $locationService;
-
-    /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
-     */
     private $eventDispatcher;
 
     /**
@@ -40,8 +30,6 @@ class ContentPreviewHelperTest extends PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->contentService = $this->getMock( 'eZ\Publish\API\Repository\ContentService' );
-        $this->locationService = $this->getMock( 'eZ\Publish\API\Repository\LocationService' );
         $this->eventDispatcher = $this->getMock( 'Symfony\Component\EventDispatcher\EventDispatcherInterface' );
         $this->configResolver = $this->getMock( 'eZ\Publish\Core\MVC\ConfigResolverInterface' );
     }
@@ -58,8 +46,6 @@ class ContentPreviewHelperTest extends PHPUnit_Framework_TestCase
 
         $originalSiteAccess = new SiteAccess( 'foo', 'bar' );
         $helper = new ContentPreviewHelper(
-            $this->contentService,
-            $this->locationService,
             $this->eventDispatcher,
             $this->configResolver
         );
@@ -80,8 +66,6 @@ class ContentPreviewHelperTest extends PHPUnit_Framework_TestCase
             ->with( MVCEvents::CONFIG_SCOPE_RESTORE, $this->equalTo( $event ) );
 
         $helper = new ContentPreviewHelper(
-            $this->contentService,
-            $this->locationService,
             $this->eventDispatcher,
             $this->configResolver
         );
@@ -90,73 +74,5 @@ class ContentPreviewHelperTest extends PHPUnit_Framework_TestCase
             $originalSiteAccess,
             $helper->restoreConfigScope()
         );
-    }
-
-    public function testGetPreviewLocationNoMainLocation()
-    {
-        $contentId = 123;
-        $rootLocationId = 456;
-        $contentInfo = $this
-            ->getMockBuilder( 'eZ\Publish\API\Repository\Values\Content\ContentInfo' )
-            ->setConstructorArgs( array( array( 'id' => $contentId ) ) )
-            ->getMockForAbstractClass();
-        $this->contentService
-            ->expects( $this->once() )
-            ->method( 'loadContentInfo' )
-            ->with( $contentId )
-            ->will( $this->returnValue( $contentInfo ) );
-        $this->locationService
-            ->expects( $this->never() )
-            ->method( 'loadLocation' );
-        $this->configResolver
-            ->expects( $this->once() )
-            ->method( 'getParameter' )
-            ->with( 'content.tree_root.location_id' )
-            ->will( $this->returnValue( $rootLocationId ) );
-
-        $helper = new ContentPreviewHelper(
-            $this->contentService,
-            $this->locationService,
-            $this->eventDispatcher,
-            $this->configResolver
-        );
-        $location = $helper->getPreviewLocation( $contentId );
-        $this->assertInstanceOf( 'eZ\Publish\API\Repository\Values\Content\Location', $location );
-        $this->assertSame( $contentInfo, $location->contentInfo );
-        $this->assertSame( $rootLocationId, $location->id );
-    }
-
-    public function testGetPreviewLocation()
-    {
-        $contentId = 123;
-        $locationId = 456;
-        $contentInfo = $this
-            ->getMockBuilder( 'eZ\Publish\API\Repository\Values\Content\ContentInfo' )
-            ->setConstructorArgs( array( array( 'id' => $contentId, 'mainLocationId' => $locationId ) ) )
-            ->getMockForAbstractClass();
-        $location = $this
-            ->getMockBuilder( 'eZ\Publish\Core\Repository\Values\Content\Location' )
-            ->setConstructorArgs( array( array( 'id' => $locationId, 'contentInfo' => $contentInfo ) ) )
-            ->getMockForAbstractClass();
-        $this->contentService
-            ->expects( $this->once() )
-            ->method( 'loadContentInfo' )
-            ->with( $contentId )
-            ->will( $this->returnValue( $contentInfo ) );
-        $this->locationService
-            ->expects( $this->once() )
-            ->method( 'loadLocation' )
-            ->with( $locationId )
-            ->will( $this->returnValue( $location ) );
-
-        $helper = new ContentPreviewHelper(
-            $this->contentService,
-            $this->locationService,
-            $this->eventDispatcher,
-            $this->configResolver
-        );
-        $returnedLocation = $helper->getPreviewLocation( $contentId );
-        $this->assertSame( $location, $returnedLocation );
-        $this->assertSame( $contentInfo, $returnedLocation->contentInfo );
     }
 }

--- a/eZ/Publish/Core/Helper/Tests/PreviewLocationProviderTest.php
+++ b/eZ/Publish/Core/Helper/Tests/PreviewLocationProviderTest.php
@@ -100,4 +100,29 @@ class PreviewLocationProviderTest extends PHPUnit_Framework_TestCase
         $this->assertSame( $location, $returnedLocation );
         $this->assertSame( $contentInfo, $returnedLocation->contentInfo );
     }
+
+    public function testGetPreviewLocationNoLocation()
+    {
+        $contentId = 123;
+
+        $contentInfo = $this
+            ->getMockBuilder( 'eZ\Publish\API\Repository\Values\Content\ContentInfo' )
+            ->setConstructorArgs( array( array( 'id' => $contentId ) ) )
+            ->getMockForAbstractClass();
+        $this->contentService
+            ->expects( $this->once() )
+            ->method( 'loadContentInfo' )
+            ->with( $contentId )
+            ->will( $this->returnValue( $contentInfo ) );
+        $this->locationHandler
+            ->expects( $this->once() )
+            ->method( 'loadParentLocationsForDraftContent' )
+            ->with( $contentId )
+            ->will( $this->returnValue( array() ) );
+
+        $this->locationHandler->expects( $this->never() )->method( 'loadLocation' );
+
+        $this->assertNull( $this->provider->loadMainLocation( $contentId ) );
+    }
+
 }

--- a/eZ/Publish/Core/Helper/Tests/PreviewLocationProviderTest.php
+++ b/eZ/Publish/Core/Helper/Tests/PreviewLocationProviderTest.php
@@ -9,11 +9,7 @@
 
 namespace eZ\Publish\Core\Helper\Tests;
 
-use eZ\Publish\API\Repository\LocationService;
-use eZ\Publish\Core\Helper\ContentPreviewHelper;
 use eZ\Publish\Core\Helper\PreviewLocationProvider;
-use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
-use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use PHPUnit_Framework_TestCase;
@@ -36,15 +32,11 @@ class PreviewLocationProviderTest extends PHPUnit_Framework_TestCase
     protected function setUp()
     {
         parent::setUp();
+
         $this->contentService = $this->getMock( 'eZ\Publish\API\Repository\ContentService' );
         $this->locationService = $this->getMock( 'eZ\Publish\API\Repository\LocationService' );
-
         $this->locationHandler = $this->getMock( 'eZ\Publish\SPI\Persistence\Content\Location\Handler' );
-
-        $persistenceHandler = $this->getMock( 'eZ\Publish\SPI\Persistence\Handler' );
-        $persistenceHandler->expects( $this->any() )->method( 'locationHandler' )->will( $this->returnValue( $this->locationHandler ) );
-
-        $this->provider = new PreviewLocationProvider( $this->locationService, $this->contentService, $persistenceHandler );
+        $this->provider = new PreviewLocationProvider( $this->locationService, $this->contentService, $this->locationHandler );
     }
 
     public function testGetPreviewLocationDraft()

--- a/eZ/Publish/Core/Helper/Tests/PreviewLocationProviderTest.php
+++ b/eZ/Publish/Core/Helper/Tests/PreviewLocationProviderTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Helper\Tests;
+
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\Core\Helper\ContentPreviewHelper;
+use eZ\Publish\Core\Helper\PreviewLocationProvider;
+use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
+use eZ\Publish\Core\MVC\Symfony\MVCEvents;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+use PHPUnit_Framework_TestCase;
+
+class PreviewLocationProviderTest extends PHPUnit_Framework_TestCase
+{
+    /** @var \eZ\Publish\API\Repository\LocationService|\PHPUnit_Framework_MockObject_MockObject */
+    private $contentService;
+
+    /** @var \eZ\Publish\API\Repository\LocationService|\PHPUnit_Framework_MockObject_MockObject */
+    private $locationService;
+
+    /** @var \eZ\Publish\SPI\Persistence\Content\Location\Handler|\PHPUnit_Framework_MockObject_MockObject */
+    private $locationHandler;
+
+    /** @var \eZ\Publish\Core\Helper\PreviewLocationProvider */
+    private $provider;
+
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->contentService = $this->getMock( 'eZ\Publish\API\Repository\ContentService' );
+        $this->locationService = $this->getMock( 'eZ\Publish\API\Repository\LocationService' );
+
+        $this->locationHandler = $this->getMock( 'eZ\Publish\SPI\Persistence\Content\Location\Handler' );
+
+        $persistenceHandler = $this->getMock( 'eZ\Publish\SPI\Persistence\Handler' );
+        $persistenceHandler->expects( $this->any() )->method( 'locationHandler' )->will( $this->returnValue( $this->locationHandler ) );
+
+        $this->provider = new PreviewLocationProvider( $this->locationService, $this->contentService, $persistenceHandler );
+    }
+
+    public function testGetPreviewLocationDraft()
+    {
+        $contentId = 123;
+        $parentLocationId = 456;
+
+        $contentInfo = $this
+            ->getMockBuilder( 'eZ\Publish\API\Repository\Values\Content\ContentInfo' )
+            ->setConstructorArgs( array( array( 'id' => $contentId ) ) )
+            ->getMockForAbstractClass();
+
+        $this->contentService
+            ->expects( $this->once() )
+            ->method( 'loadContentInfo' )
+            ->with( $contentId )
+            ->will( $this->returnValue( $contentInfo ) );
+
+        $this->locationService
+            ->expects( $this->never() )
+            ->method( 'loadLocation' );
+
+        $this->locationHandler
+            ->expects( $this->once() )
+            ->method( 'loadParentLocationsForDraftContent' )
+            ->with( $contentId )
+            ->will( $this->returnValue( array( new Location( array( 'id' => $parentLocationId ) ) ) ) );
+
+        $location = $this->provider->loadMainLocation( $contentId );
+        $this->assertInstanceOf( 'eZ\Publish\API\Repository\Values\Content\Location', $location );
+        $this->assertSame( $contentInfo, $location->contentInfo );
+        $this->assertNull( $location->id );
+        $this->assertEquals( $parentLocationId, $location->parentLocationId );
+    }
+
+    public function testGetPreviewLocation()
+    {
+        $contentId = 123;
+        $locationId = 456;
+        $contentInfo = $this
+            ->getMockBuilder( 'eZ\Publish\API\Repository\Values\Content\ContentInfo' )
+            ->setConstructorArgs( array( array( 'id' => $contentId, 'mainLocationId' => $locationId ) ) )
+            ->getMockForAbstractClass();
+        $location = $this
+            ->getMockBuilder( 'eZ\Publish\Core\Repository\Values\Content\Location' )
+            ->setConstructorArgs( array( array( 'id' => $locationId, 'contentInfo' => $contentInfo ) ) )
+            ->getMockForAbstractClass();
+        $this->contentService
+            ->expects( $this->once() )
+            ->method( 'loadContentInfo' )
+            ->with( $contentId )
+            ->will( $this->returnValue( $contentInfo ) );
+        $this->locationService
+            ->expects( $this->once() )
+            ->method( 'loadLocation' )
+            ->with( $locationId )
+            ->will( $this->returnValue( $location ) );
+        $this->locationHandler->expects( $this->never() )->method( 'loadParentLocationsForDraftContent' );
+
+        $returnedLocation = $this->provider->loadMainLocation( $contentId );
+        $this->assertSame( $location, $returnedLocation );
+        $this->assertSame( $contentInfo, $returnedLocation->contentInfo );
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\Helper\ContentPreviewHelper;
+use eZ\Publish\Core\Helper\PreviewLocationProvider;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\View\ViewManagerInterface;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
@@ -50,17 +51,24 @@ class PreviewController
      */
     private $request;
 
+    /**
+     * @var \eZ\Publish\Core\Helper\PreviewLocationProvider
+     */
+    private $locationProvider;
+
     public function __construct(
         ContentService $contentService,
         HttpKernelInterface $kernel,
         ContentPreviewHelper $previewHelper,
-        SecurityContextInterface $securityContext
+        SecurityContextInterface $securityContext,
+        PreviewLocationProvider $locationProvider
     )
     {
         $this->contentService = $contentService;
         $this->kernel = $kernel;
         $this->previewHelper = $previewHelper;
         $this->securityContext = $securityContext;
+        $this->locationProvider = $locationProvider;
     }
 
     public function setRequest( Request $request = null )
@@ -73,7 +81,7 @@ class PreviewController
         try
         {
             $content = $this->contentService->loadContent( $contentId, array( $language ), $versionNo );
-            $location = $this->previewHelper->getPreviewLocation( $contentId );
+            $location = $this->locationProvider->loadMainLocation( $contentId );
         }
         catch ( UnauthorizedException $e )
         {

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Tests/Controller/Content/PreviewControllerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Tests/Controller/Content/PreviewControllerTest.php
@@ -12,6 +12,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Controller\Tests\Controller\Content;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
+use eZ\Publish\Core\Helper\PreviewLocationProvider;
 use eZ\Publish\Core\MVC\Symfony\Controller\Content\PreviewController;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\View\ViewManagerInterface;
@@ -43,6 +44,9 @@ class PreviewControllerTest extends PHPUnit_Framework_TestCase
      */
     protected $securityContext;
 
+    /** @var PreviewLocationProvider|\PHPUnit_Framework_MockObject_MockObject */
+    protected $locationProvider;
+
     protected function setUp()
     {
         parent::setUp();
@@ -54,6 +58,10 @@ class PreviewControllerTest extends PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->securityContext = $this->getMock( 'Symfony\Component\Security\Core\SecurityContextInterface' );
+        $this->locationProvider = $this
+            ->getMockBuilder( 'eZ\Publish\Core\Helper\PreviewLocationProvider' )
+            ->disableOriginalConstructor()
+            ->getMock();
     }
 
     /**
@@ -65,7 +73,8 @@ class PreviewControllerTest extends PHPUnit_Framework_TestCase
             $this->contentService,
             $this->httpKernel,
             $this->previewHelper,
-            $this->securityContext
+            $this->securityContext,
+            $this->locationProvider
         );
 
         return $controller;
@@ -102,9 +111,9 @@ class PreviewControllerTest extends PHPUnit_Framework_TestCase
             ->setConstructorArgs( array( array( 'id' => $contentId ) ) )
             ->getMockForAbstractClass();
 
-        $this->previewHelper
+        $this->locationProvider
             ->expects( $this->once() )
-            ->method( 'getPreviewLocation' )
+            ->method( 'loadMainLocation' )
             ->with( $contentId )
             ->will( $this->returnValue( $this->getMock( 'eZ\Publish\API\Repository\Values\Content\Location' ) ) );
         $this->contentService
@@ -133,9 +142,9 @@ class PreviewControllerTest extends PHPUnit_Framework_TestCase
             ->getMockForAbstractClass();
 
         // Repository expectations
-        $this->previewHelper
+        $this->locationProvider
             ->expects( $this->once() )
-            ->method( 'getPreviewLocation' )
+            ->method( 'loadMainLocation' )
             ->with( $contentId )
             ->will( $this->returnValue( $location ) );
         $this->contentService
@@ -192,7 +201,6 @@ class PreviewControllerTest extends PHPUnit_Framework_TestCase
         );
     }
 
-
     public function testPreviewDefaultSiteaccess()
     {
         $contentId = 123;
@@ -205,9 +213,9 @@ class PreviewControllerTest extends PHPUnit_Framework_TestCase
             ->getMockForAbstractClass();
 
         // Repository expectations
-        $this->previewHelper
+        $this->locationProvider
             ->expects( $this->once() )
-            ->method( 'getPreviewLocation' )
+            ->method( 'loadMainLocation' )
             ->with( $contentId )
             ->will( $this->returnValue( $location ) );
         $this->contentService


### PR DESCRIPTION
> [EZP-23784](https://jira.ez.no/browse/EZP-23784)

Improves the Location draft passed on to the preview template when previewing the first version of a Content. This draft does not have an id (it is set to null), but has the real parent location id and depth.

### Internal changes
Moved the location part out of `eZ\Publish\Core\Helpers\ContentPreviewHelper` to `eZ\Publish\Core\Helper\PreviewLocationProvider`. Using the API + SPI, the provider will either return the content's main location (API), or a fake location based on the content's parent location (SPI, uses eznodeassignment inside persistence).

### TODO
- [ ] Test on contentInfo status [instead of mainLocationId](https://github.com/ezsystems/ezpublish-kernel/pull/1113#discussion_r21676928)
- [ ] BC note