### PR TITLE
[WIP] SPI cache (clearing) efficieny

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -98,12 +98,18 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
      */
     public function loadContentInfoByRemoteId( $remoteId )
     {
-        $cache = $this->cache->getItem( 'content', 'info', 'remoteId', $remoteId );
-        $contentInfo = $cache->get();
+        // Using 'id' to avoid using the old key which contained the full object duplicating cache in loadContentInfo
+        $cache = $this->cache->getItem( 'content', 'info', 'remoteId', 'id', $remoteId );
+        $contentId = $cache->get();
         if ( $cache->isMiss() )
         {
             $this->logger->logCall( __METHOD__, array( 'content' => $remoteId ) );
-            $cache->set( $contentInfo = $this->persistenceHandler->contentHandler()->loadContentInfoByRemoteId( $remoteId ) );
+            $contentInfo = $this->persistenceHandler->contentHandler()->loadContentInfoByRemoteId( $remoteId );
+            $cache->set( $contentInfo->id );
+        }
+        else
+        {
+            $contentInfo = $this->loadContentInfo( $contentId );
         }
         return $contentInfo;
     }

--- a/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
@@ -263,6 +263,5 @@ class LocationHandler extends AbstractHandler implements LocationHandlerInterfac
         $this->persistenceHandler->locationHandler()->changeMainLocation( $contentId, $locationId );
         $this->cache->clear( 'content', $contentId );
         $this->cache->clear( 'content', 'info', $contentId );
-        $this->cache->clear( 'content', 'info', 'remoteId' );
     }
 }

--- a/eZ/Publish/Core/Persistence/Cache/SectionHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/SectionHandler.php
@@ -106,7 +106,6 @@ class SectionHandler extends AbstractHandler implements SectionHandlerInterface
 
         $this->cache->clear( 'content', $contentId );
         $this->cache->clear( 'content', 'info', $contentId );
-        $this->cache->clear( 'content', 'info', 'remoteId' );
 
         return $return;
     }

--- a/eZ/Publish/Core/Persistence/Cache/Tests/TrashHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/TrashHandlerTest.php
@@ -101,15 +101,10 @@ class TrashHandlerTest extends HandlerTest
         $this->cacheMock
             ->expects( $this->at( 4 ) )
             ->method( 'clear' )
-            ->with( 'content', 'info', 'remoteId' );
-
-        $this->cacheMock
-            ->expects( $this->at( 5 ) )
-            ->method( 'clear' )
             ->with( 'content', 'locations', 44 );
 
         $this->cacheMock
-            ->expects( $this->at( 6 ) )
+            ->expects( $this->at( 5 ) )
             ->method( 'clear' )
             ->with( 'user', 'role', 'assignments', 'byGroup' );
 
@@ -158,15 +153,10 @@ class TrashHandlerTest extends HandlerTest
         $this->cacheMock
             ->expects( $this->at( 3 ) )
             ->method( 'clear' )
-            ->with( 'content', 'info', 'remoteId' );
-
-        $this->cacheMock
-            ->expects( $this->at( 4 ) )
-            ->method( 'clear' )
             ->with( 'content', 'locations', 44 );
 
         $this->cacheMock
-            ->expects( $this->at( 5 ) )
+            ->expects( $this->at( 4 ) )
             ->method( 'clear' )
             ->with( 'user', 'role', 'assignments', 'byGroup' );
 

--- a/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
@@ -39,7 +39,6 @@ class TrashHandler extends AbstractHandler implements TrashHandlerInterface
         $this->cache->clear( 'location', 'subtree' );
         $this->cache->clear( 'content', $location->contentId );
         $this->cache->clear( 'content', 'info', $location->contentId );
-        $this->cache->clear( 'content', 'info', 'remoteId' );
         $this->cache->clear( 'content', 'locations', $location->contentId );
         $this->cache->clear( 'user', 'role', 'assignments', 'byGroup' );
         return $return;
@@ -55,7 +54,6 @@ class TrashHandler extends AbstractHandler implements TrashHandlerInterface
         $this->cache->clear( 'location', 'subtree' );
         $this->cache->clear( 'content', $trashed->contentId );
         $this->cache->clear( 'content', 'info', $trashed->contentId );
-        $this->cache->clear( 'content', 'info', 'remoteId' );
         $this->cache->clear( 'content', 'locations', $trashed->contentId );
         $this->cache->clear( 'user', 'role', 'assignments', 'byGroup' );
         return $return;

--- a/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
@@ -9,8 +9,10 @@
 
 namespace eZ\Publish\Core\Persistence\Cache;
 
-use eZ\Publish\SPI\Persistence\Content\Location\Trash\Handler as TrashHandlerInterface;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\SPI\Persistence\Content\Location\Trash\Handler as TrashHandlerInterface;
+use eZ\Publish\SPI\Persistence\Content\Location;
+use eZ\Publish\SPI\Persistence\Content\Location\Trashed;
 
 /**
  * @see eZ\Publish\SPI\Persistence\Content\Location\Trash\Handler
@@ -27,27 +29,34 @@ class TrashHandler extends AbstractHandler implements TrashHandlerInterface
     }
 
     /**
-     * @see eZ\Publish\SPI\Persistence\Content\Location\Trash\Handler
+     * @see \eZ\Publish\SPI\Persistence\Content\Location\Trash\Handler
      */
-    public function trashSubtree( $locationId )
+    public function trashSubtree( Location $location )
     {
-        $this->logger->logCall( __METHOD__, array( 'locationId' => $locationId ) );
-        $return = $this->persistenceHandler->trashHandler()->trashSubtree( $locationId );
-        $this->cache->clear( 'location' );//TIMBER!
-        $this->cache->clear( 'content' );//TIMBER!
+        $this->logger->logCall( __METHOD__, array( 'locationId' => $location->id ) );
+        $return = $this->persistenceHandler->trashHandler()->trashSubtree( $location );
+        $this->cache->clear( 'location', $location->id );
+        $this->cache->clear( 'location', 'subtree' );
+        $this->cache->clear( 'content', $location->contentId );
+        $this->cache->clear( 'content', 'info', $location->contentId );
+        $this->cache->clear( 'content', 'info', 'remoteId' );
+        $this->cache->clear( 'content', 'locations', $location->contentId );
         $this->cache->clear( 'user', 'role', 'assignments', 'byGroup' );
         return $return;
     }
 
     /**
-     * @see eZ\Publish\SPI\Persistence\Content\Location\Trash\Handler
+     * @see \eZ\Publish\SPI\Persistence\Content\Location\Trash\Handler
      */
-    public function recover( $trashedId, $newParentId )
+    public function recover( Trashed $trashed, Location $newParent )
     {
-        $this->logger->logCall( __METHOD__, array( 'id' => $trashedId, 'newParentId' => $newParentId ) );
-        $return = $this->persistenceHandler->trashHandler()->recover( $trashedId, $newParentId );
+        $this->logger->logCall( __METHOD__, array( 'id' => $trashed->id, 'newParentId' => $newParent->id ) );
+        $return = $this->persistenceHandler->trashHandler()->recover( $trashed, $newParent );
         $this->cache->clear( 'location', 'subtree' );
-        $this->cache->clear( 'content' );//TIMBER!
+        $this->cache->clear( 'content', $trashed->contentId );
+        $this->cache->clear( 'content', 'info', $trashed->contentId );
+        $this->cache->clear( 'content', 'info', 'remoteId' );
+        $this->cache->clear( 'content', 'locations', $trashed->contentId );
         $this->cache->clear( 'user', 'role', 'assignments', 'byGroup' );
         return $return;
     }
@@ -73,9 +82,13 @@ class TrashHandler extends AbstractHandler implements TrashHandlerInterface
     /**
      * @see eZ\Publish\SPI\Persistence\Content\Location\Trash\Handler
      */
-    public function deleteTrashItem( $trashedId )
+    public function deleteTrashItem( Trashed $trashed )
     {
-        $this->logger->logCall( __METHOD__, array( 'id' => $trashedId ) );
-        $this->persistenceHandler->trashHandler()->deleteTrashItem( $trashedId );
+        $this->logger->logCall( __METHOD__, array( 'id' => $trashed->id ) );
+        $this->persistenceHandler->trashHandler()->deleteTrashItem( $trashed );
+        $this->cache->clear( 'content', $trashed->contentId );
+        $this->cache->clear( 'content', 'info', $trashed->contentId );
+        $this->cache->clear( 'content', 'info', 'remoteId' );
+        $this->cache->clear( 'content', 'locations', $trashed->contentId );
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/TrashHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/TrashHandlerTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Location;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Trash\Handler;
+use eZ\Publish\SPI\Persistence\Content\Location;
 use eZ\Publish\SPI\Persistence\Content\Location\Trashed;
 
 /**
@@ -130,7 +131,7 @@ class TrashHandlerTest extends TestCase
             ->with( $array, null, new Trashed() )
             ->will( $this->returnValue( new Trashed( array( 'id' => 20 ) ) ) );
 
-        $trashedObject = $handler->trashSubtree( 20 );
+        $trashedObject = $handler->trashSubtree( new Location( array( 'id' => 20 ) ) );
         self::assertInstanceOf( 'eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Trashed', $trashedObject );
         self::assertSame( 20, $trashedObject->id );
     }
@@ -192,7 +193,7 @@ class TrashHandlerTest extends TestCase
             ->method( 'markSubtreeModified' )
             ->with( 40 );
 
-        $returnValue = $handler->trashSubtree( 20 );
+        $returnValue = $handler->trashSubtree( new Location( array( 'id' => 20 ) ) );
         self::assertNull( $returnValue );
     }
 
@@ -284,7 +285,7 @@ class TrashHandlerTest extends TestCase
             ->with( $array, null, new Trashed() )
             ->will( $this->returnValue( new Trashed( array( 'id' => 20 ) ) ) );
 
-        $trashedObject = $handler->trashSubtree( 20 );
+        $trashedObject = $handler->trashSubtree( new Location( array( 'id' => 20 ) ) );
         self::assertInstanceOf( 'eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Trashed', $trashedObject );
         self::assertSame( 20, $trashedObject->id );
     }
@@ -302,11 +303,11 @@ class TrashHandlerTest extends TestCase
             ->with( 69, 23 )
             ->will(
                 $this->returnValue(
-                    new Trashed( array( 'id' => 70 ) )
+                    new Location( array( 'id' => 70 ) )
                 )
             );
 
-        self::assertSame( 70, $handler->recover( 69, 23 ) );
+        self::assertSame( 70, $handler->recover( new Trashed( array( 'id' => 69 ) ), new Location( array( 'id' => 23 ) ) ) );
     }
 
     /**
@@ -407,33 +408,12 @@ class TrashHandlerTest extends TestCase
         $handler = $this->getTrashHandler();
 
         $this->locationGateway
-            ->expects( $this->once() )
-            ->method( 'loadTrashByLocation' )
-            ->with( 69 )
-            ->will(
-                $this->returnValue(
-                    array(
-                        'node_id' => 69,
-                        'contentobject_id' => 67,
-                        'path_string' => '/1/2/69'
-                    )
-                )
-            );
+            ->expects( $this->never() )
+            ->method( 'loadTrashByLocation' );
 
         $this->locationMapper
-            ->expects( $this->once() )
-            ->method( 'createLocationFromRow' )
-            ->will(
-                $this->returnValue(
-                    new Trashed(
-                        array(
-                            'id' => 69,
-                            'contentId' => 67,
-                            'pathString' => '/1/2/69'
-                        )
-                    )
-                )
-            );
+            ->expects( $this->never() )
+            ->method( 'createLocationFromRow' );
 
         $this->locationGateway
             ->expects( $this->once() )
@@ -451,7 +431,7 @@ class TrashHandlerTest extends TestCase
             ->method( 'deleteContent' )
             ->with( 67 );
 
-        $handler->deleteTrashItem( 69 );
+        $handler->deleteTrashItem( new Trashed( array( 'id' => 69, 'contentId' => 67 ) ) );
     }
 
     /**
@@ -462,33 +442,12 @@ class TrashHandlerTest extends TestCase
         $handler = $this->getTrashHandler();
 
         $this->locationGateway
-            ->expects( $this->once() )
-            ->method( 'loadTrashByLocation' )
-            ->with( 69 )
-            ->will(
-                $this->returnValue(
-                    array(
-                        'node_id' => 69,
-                        'contentobject_id' => 67,
-                        'path_string' => '/1/2/69'
-                    )
-                )
-            );
+            ->expects( $this->never() )
+            ->method( 'loadTrashByLocation' );
 
         $this->locationMapper
-            ->expects( $this->once() )
-            ->method( 'createLocationFromRow' )
-            ->will(
-                $this->returnValue(
-                    new Trashed(
-                        array(
-                            'id' => 69,
-                            'contentId' => 67,
-                            'pathString' => '/1/2/69'
-                        )
-                    )
-                )
-            );
+            ->expects( $this->never() )
+            ->method( 'createLocationFromRow' );
 
         $this->locationGateway
             ->expects( $this->once() )
@@ -505,6 +464,6 @@ class TrashHandlerTest extends TestCase
             ->expects( $this->never() )
             ->method( 'deleteContent' );
 
-        $handler->deleteTrashItem( 69 );
+        $handler->deleteTrashItem( new Trashed( array( 'id' => 69, 'contentId' => 67 ) ) );
     }
 }

--- a/eZ/Publish/SPI/Persistence/Content/Location/Trash/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location/Trash/Handler.php
@@ -10,6 +10,8 @@
 namespace eZ\Publish\SPI\Persistence\Content\Location\Trash;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\SPI\Persistence\Content\Location;
+use eZ\Publish\SPI\Persistence\Content\Location\Trashed;
 
 /**
  * The Trash Handler interface defines operations on Location elements in the storage engine.
@@ -35,11 +37,11 @@ interface Handler
      * Moves all locations in the subtree to the Trash. The associated content
      * objects are left untouched.
      *
-     * @param mixed $locationId
+     * @param Location $location
      *
      * @return null|\eZ\Publish\SPI\Persistence\Content\Location\Trashed null if location was deleted, otherwise Trashed object
      */
-    public function trashSubtree( $locationId );
+    public function trashSubtree( Location $location );
 
     /**
      * Returns a trashed location to normal state.
@@ -50,14 +52,14 @@ interface Handler
      *
      * Returns newly restored location Id.
      *
-     * @param mixed $trashedId
-     * @param mixed $newParentId
+     * @param Trashed $trashed
+     * @param Location $newParent
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If $newParentId is invalid
      *
      * @return int Newly restored location id
      */
-    public function recover( $trashedId, $newParentId );
+    public function recover( Trashed $trashed, Location $newParent );
 
     /**
      * Returns an array of all trashed locations satisfying the $criterion (if provided),
@@ -85,9 +87,9 @@ interface Handler
      * Removes a trashed location identified by $trashedLocationId from trash
      * Associated content has to be deleted
      *
-     * @param int $trashedId
+     * @param Trashed $trashed
      *
      * @return void
      */
-    public function deleteTrashItem( $trashedId );
+    public function deleteTrashItem( Trashed $trashed );
 }


### PR DESCRIPTION
Changes (only TrashHandler here) to avoid having to clear so much cache on operations, avoids cache wipe outs on every operation big and small.

Only thing AFAIK that speaks against doing this is if we could rather spend effort on moving cache to API, then this is unneeded and almost waste of time (well it makes it easier for storage engines if operations contain more info most likely, otherwise no value here).