### PR TITLE
Fix EZP-23518: Clearing image aliases with Symfony console with --purge ...

### DIFF
--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/fieldtype_services.yml
@@ -7,6 +7,5 @@ services:
         class: %ezpublish_legacy.image_alias.cleaner.class%
         arguments:
             - @ezpublish.image_alias.imagine.alias_cleaner
-            - @ezpublish.fieldType.ezimage.io_service
             - @ezpublish.core.io.image_fieldtype.legacy_url_redecorator
         lazy: true

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -239,9 +239,7 @@ class ImageStorage extends GatewayBasedStorage
 
             if ( $this->aliasCleaner )
             {
-                $this->aliasCleaner->removeAliases(
-                    $this->IOService->loadBinaryFileByUri( $storedFiles['original'] )
-                );
+                $this->aliasCleaner->removeAliases( $storedFiles['original'] );
             }
 
             foreach ( $storedFiles as $storedFilePath )

--- a/eZ/Publish/Core/MVC/Legacy/Image/AliasCleaner.php
+++ b/eZ/Publish/Core/MVC/Legacy/Image/AliasCleaner.php
@@ -21,32 +21,23 @@ class AliasCleaner implements AliasCleanerInterface
     private $innerAliasCleaner;
 
     /**
-     * @var IOServiceInterface
-     */
-    private $ioService;
-
-    /**
      * @var UrlRedecoratorInterface
      */
     private $urlRedecorator;
 
     public function __construct(
         AliasCleanerInterface $innerAliasCleaner,
-        IOServiceInterface $ioService,
         UrlRedecoratorInterface $urlRedecorator
     )
     {
         $this->innerAliasCleaner = $innerAliasCleaner;
-        $this->ioService = $ioService;
         $this->urlRedecorator = $urlRedecorator;
     }
 
     public function removeAliases( $originalPath )
     {
         $this->innerAliasCleaner->removeAliases(
-            $this->ioService->loadBinaryFileByUri(
-                $this->urlRedecorator->redecorateFromTarget( $originalPath )
-            )
+            $this->urlRedecorator->redecorateFromTarget( $originalPath )
         );
     }
 }


### PR DESCRIPTION
...option results in PHP warnings

JIRA: https://jira.ez.no/browse/EZP-23518

The removeAliases method expected a string variable. But it get a BinaryFile object.