### PR TITLE
[Tests] More info on MaximumSupportedLanguagesTest failure when 32bit column on 64bit

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SetupFactory/Legacy.php
+++ b/eZ/Publish/API/Repository/Tests/SetupFactory/Legacy.php
@@ -407,4 +407,14 @@ class Legacy extends SetupFactory
 
         return self::$serviceContainer;
     }
+
+    /**
+     * Get the Database name
+     *
+     * @return string
+     */
+    public function getDB()
+    {
+        return self::$db;
+    }
 }


### PR DESCRIPTION
Just testing why this test fails on PHP 5.3 and hhvm, unsure why it seems to try to generate language number 32, when only 30 is supposed to be supported on 32-bit.
