### PR TITLE
Fixed UrlStorage test added for EZP-23544

### DIFF
--- a/eZ/Publish/Core/FieldType/Tests/Url/UrlStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Url/UrlStorageTest.php
@@ -160,6 +160,15 @@ class UrlStorageTest extends PHPUnit_Framework_TestCase
             ->expects( $this->never() )
             ->method( "error" );
 
+        $storage = $this->getPartlyMockedStorage( array( "getGateway" ) );
+        $storage
+            ->expects( $this->any() )
+            ->method( "getGateway" )
+            ->with( $this->getContext() )
+            ->will( $this->returnValue( $gateway ) );
+
+        $storage->getFieldData( $versionInfo, $field, $this->getContext() );
+
         $this->assertEquals( null, $field->value->externalData );
     }
 


### PR DESCRIPTION
The test added in #1061 was not executing `getFieldData()`, and was only passing by chance.
