### PR TITLE
[WIP][Travis] Speed up travis to use containers, cache and more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 
+# hint that we don't need sudo to use container based test system
+sudo: false
+
 # execute unit tests, integration test stubs and integration tests using legacy storage engine
 env:
   global:
@@ -36,8 +39,9 @@ matrix:
       env: TEST_CONFIG="phpunit.xml"
     - php: 5.6
       env: TEST_CONFIG="phpunit-integration-legacy.xml"
-    - php: 5.6
-      env: BEHAT_PROFILE="demo" TEST="clean"
+# Disable to test containers, this should ideally be covered by dowstream build feature of travis anyway..
+#    - php: 5.6
+#      env: BEHAT_PROFILE="demo" TEST="clean"
 # hhvm-nightly
     - php: hhvm-nightly
       env: TEST_CONFIG="phpunit.xml"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ language: php
 # hint that we don't need sudo to use container based test system
 sudo: false
 
+ # cache composer cache across builds
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 # execute unit tests, integration test stubs and integration tests using legacy storage engine
 env:
   global:

--- a/bin/.travis/my.cnf
+++ b/bin/.travis/my.cnf
@@ -1,0 +1,24 @@
+# Mysql settings for unit/integration/behat testing, not safe for prod!
+
+[client]
+socket = /dev/shm/mysql/mysqld-testing.sock
+
+[mysqld_safe]
+socket = /dev/shm/mysql/mysqld-testing.sock
+
+[mysqld]
+user = travis
+pid-file = /dev/shm/mysql/mysqld-testing.pid
+socket = /dev/shm/mysql/mysqld-testing.sock
+datadir = /dev/shm/mysql
+tmpdir = /tmp
+log_error = /dev/shm/mysql/error.log
+
+innodb_file_per_table = 1
+innodb_doublewrite = 0
+innodb_checksums = 0
+innodb_file_format = Barracuda
+innodb_flush_log_at_trx_commit = 2
+innodb_flush_method = O_DIRECT
+innodb_data_home_dir = /tmp/
+innodb_log_file_size = 1048576

--- a/bin/.travis/prepare_unittest.sh
+++ b/bin/.travis/prepare_unittest.sh
@@ -6,7 +6,12 @@
 if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] ; then phpenv config-rm xdebug.ini ; fi
 
 # Setup DB
-if [ "$DB" = "mysql" ] ; then mysql -e "CREATE DATABASE IF NOT EXISTS $DB_NAME;" -uroot ; fi
+if [ "$DB" = "mysql" ] ; then
+    mkdir /dev/shm/mysql;
+    chmod 700 /dev/shm/mysql;
+    mysqld_safe --defaults-file=bin/.travis/my.cnf -uroot;
+    mysql -e "CREATE DATABASE IF NOT EXISTS $DB_NAME;" -uroot;
+fi
 if [ "$DB" = "postgresql" ] ; then psql -c "CREATE DATABASE $DB_NAME;" -U postgres ; psql -c "CREATE EXTENSION pgcrypto;" -U postgres $DB_NAME ; fi
 
 # Setup github key to avoid api rate limit


### PR DESCRIPTION
Travis recently [officially announced](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/) docker support which for now is "opt in" by setting `sudo: false` as sudo is not supported. These images should be faster and provide some new features like updated composer and support for caching.

Todo:
- [x] Use `sudo: false` and verify that we don't use sudo for anything
- [ ] Attempt to cache composer cache across build *and verify that it works*
- [ ] Find way(s) to speed up mysql again as this version does not place mysql database on memory filesystem *OR* see if recent mysql update to 5.6 on travis env helps


