### PR TITLE
Fix EZP-23837: Impossible to set the value of a Media field

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/ApiLoader/Factory.php
+++ b/eZ/Bundle/EzPublishRestBundle/ApiLoader/Factory.php
@@ -50,6 +50,11 @@ class Factory
         return new FieldTypeProcessor\BinaryProcessor( sys_get_temp_dir(), $hostPrefix );
     }
 
+    public function getMediaFieldTypeProcessor()
+    {
+        return new FieldTypeProcessor\MediaProcessor( sys_get_temp_dir() );
+    }
+
     /**
      * Factory for ezpublish_rest.field_type_processor.ezimage
      *

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
@@ -268,6 +268,8 @@ services:
 
     ezpublish_rest.field_type_processor.ezmedia:
         class: %ezpublish_rest.field_type_processor.ezmedia.class%
+        factory_service: ezpublish_rest.factory
+        factory_method: getMediaFieldTypeProcessor
         tags:
             - { name: ezpublish_rest.field_type_processor, alias: ezmedia }
 

--- a/eZ/Publish/Core/REST/Common/FieldTypeProcessor/MediaProcessor.php
+++ b/eZ/Publish/Core/REST/Common/FieldTypeProcessor/MediaProcessor.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\Core\REST\Common\FieldTypeProcessor;
 use eZ\Publish\Core\REST\Common\FieldTypeProcessor;
 use eZ\Publish\Core\FieldType\Media\Type;
 
-class MediaProcessor extends FieldTypeProcessor
+class MediaProcessor extends BinaryInputProcessor
 {
     /**
      * {@inheritDoc}

--- a/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/BinaryInputProcessorTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/BinaryInputProcessorTest.php
@@ -79,8 +79,8 @@ abstract class BinaryInputProcessorTest extends PHPUnit_Framework_TestCase
 
         $outputHash = $processor->preProcessValueHash( $inputHash );
 
-        $this->assertFalse( isset( $outputHash['data'] ) );
-        $this->assertTrue( isset( $outputHash['path'] ) );
+        $this->assertFalse( isset( $outputHash['data'] ), "No data in output hash" );
+        $this->assertTrue( isset( $outputHash['path'] ), "No path in output hash" );
 
         $this->assertTrue(
             file_exists( $outputHash['path'] )

--- a/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/MediaProcessorTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/MediaProcessorTest.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\Core\REST\Common\Tests\FieldTypeProcessor;
 use eZ\Publish\Core\REST\Common\FieldTypeProcessor\MediaProcessor;
 use PHPUnit_Framework_TestCase;
 
-class MediaProcessorTest extends PHPUnit_Framework_TestCase
+class MediaProcessorTest extends BinaryInputProcessorTest
 {
     protected $constants = array(
         "TYPE_FLASH",
@@ -71,6 +71,6 @@ class MediaProcessorTest extends PHPUnit_Framework_TestCase
      */
     protected function getProcessor()
     {
-        return new MediaProcessor;
+        return new MediaProcessor( $this->getTempDir() );
     }
 }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23837 (discovered while implementing the Media field edit view in PlatformUI https://jira.ez.no/browse/EZP-23813)

# Description

It's impossible to update the value of a Media field using the REST API. It seems like it's because unlike for BinaryFile and Image, the Media field type processor does not extend the BinaryInputProcessor (which takes care of creating a file on the disk with the data provided in the REST update struct).

Note: for now, this is a very rough patch just to let me work on EZP-23813 and to see which tests it breaks :)

# Tests

manual for now