### PR TITLE
[WIP][Solr] Impl MultipleIntegerField & MapLocation CriterionVisitors for findLocations()

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php
@@ -32,11 +32,6 @@ class SearchServiceLocationTest extends BaseTest
     protected function setUp()
     {
         $setupFactory = $this->getSetupFactory();
-        if ( $setupFactory instanceof LegacySolr )
-        {
-            $this->markTestSkipped( "Location search handler is not yet implemented for Solr storage" );
-        }
-
         if ( $setupFactory instanceof LegacyElasticsearch )
         {
             $this->markTestSkipped( "Field search is not yet implemented for Elasticsearch storage" );
@@ -102,19 +97,28 @@ class SearchServiceLocationTest extends BaseTest
     {
         $testContent = $this->createMultipleCountriesContent();
 
+        $setupFactory = $this->getSetupFactory();
+        // @todo index full contries data
+        if ( $setupFactory instanceof LegacySolr || $setupFactory instanceof LegacyElasticsearch )
+        {
+            $country = "BE";
+        }
+        else
+        {
+            $country = "Belgium";
+        }
+
         $query = new LocationQuery(
             array(
                 'criterion' => new Criterion\Field(
                     "countries",
                     Criterion\Operator::CONTAINS,
-                    "Belgium"
+                    $country
                 )
             )
         );
 
-        $repository = $this->getRepository();
-        $searchService = $repository->getSearchService();
-        $result = $searchService->findLocations( $query );
+        $result = $this->findLocationsWithSkipOnNotImplementedException( $query );
 
         $this->assertEquals( 1, $result->totalCount );
         $this->assertEquals(
@@ -127,7 +131,7 @@ class SearchServiceLocationTest extends BaseTest
      * Test for the findLocations() method.
      *
      * @see \eZ\Publish\API\Repository\SearchService::findLocations()
-     * @depends eZ\Publish\API\Repository\Tests\SearchServiceTest::testFieldCollectionContains
+     * @depends eZ\Publish\API\Repository\Tests\SearchServiceLocationTest::testFieldCollectionContains
      */
     public function testFieldCollectionContainsNoMatch()
     {
@@ -142,9 +146,7 @@ class SearchServiceLocationTest extends BaseTest
             )
         );
 
-        $repository = $this->getRepository();
-        $searchService = $repository->getSearchService();
-        $result = $searchService->findLocations( $query );
+        $result = $this->findLocationsWithSkipOnNotImplementedException( $query );
 
         $this->assertEquals( 0, $result->totalCount );
     }
@@ -154,10 +156,7 @@ class SearchServiceLocationTest extends BaseTest
      */
     public function testInvalidFieldIdentifierRange()
     {
-        $repository    = $this->getRepository();
-        $searchService = $repository->getSearchService();
-
-        $searchService->findLocations(
+        $this->findLocationsWithSkipOnNotImplementedException(
             new LocationQuery(
                 array(
                     'filter' => new Criterion\Field(
@@ -176,10 +175,7 @@ class SearchServiceLocationTest extends BaseTest
      */
     public function testInvalidFieldIdentifierIn()
     {
-        $repository    = $this->getRepository();
-        $searchService = $repository->getSearchService();
-
-        $searchService->findLocations(
+        $this->findLocationsWithSkipOnNotImplementedException(
             new LocationQuery(
                 array(
                     'filter' => new Criterion\Field(
@@ -198,10 +194,7 @@ class SearchServiceLocationTest extends BaseTest
      */
     public function testFindLocationsWithNonSearchableField()
     {
-        $repository    = $this->getRepository();
-        $searchService = $repository->getSearchService();
-
-        $searchService->findLocations(
+        $this->findLocationsWithSkipOnNotImplementedException(
             new LocationQuery(
                 array(
                     'filter' => new Criterion\Field(
@@ -319,8 +312,7 @@ class SearchServiceLocationTest extends BaseTest
             )
         );
 
-        $searchService = $repository->getSearchService();
-        $result = $searchService->findLocations( $query );
+        $result = $this->findLocationsWithSkipOnNotImplementedException( $query );
 
         $this->assertEquals( 4, $result->totalCount );
 
@@ -374,8 +366,7 @@ class SearchServiceLocationTest extends BaseTest
             )
         );
 
-        $searchService = $repository->getSearchService();
-        $result = $searchService->findLocations( $query );
+        $result = $this->findLocationsWithSkipOnNotImplementedException( $query );
 
         $this->assertEquals( 4, $result->totalCount );
 
@@ -429,8 +420,7 @@ class SearchServiceLocationTest extends BaseTest
             )
         );
 
-        $searchService = $repository->getSearchService();
-        $result = $searchService->findLocations( $query );
+        $result = $this->findLocationsWithSkipOnNotImplementedException( $query );
 
         $this->assertEquals( 4, $result->totalCount );
 
@@ -474,9 +464,7 @@ class SearchServiceLocationTest extends BaseTest
             )
         );
 
-        $repository = $this->getRepository();
-        $searchService = $repository->getSearchService();
-        $searchService->findLocations( $query );
+        $this->findLocationsWithSkipOnNotImplementedException( $query );
     }
 
     /**
@@ -500,9 +488,7 @@ class SearchServiceLocationTest extends BaseTest
             )
         );
 
-        $repository = $this->getRepository();
-        $searchService = $repository->getSearchService();
-        $searchService->findLocations( $query );
+        $this->findLocationsWithSkipOnNotImplementedException( $query );
     }
 
     /**
@@ -535,8 +521,7 @@ class SearchServiceLocationTest extends BaseTest
             )
         );
 
-        $searchService = $repository->getSearchService();
-        $result = $searchService->findLocations( $query );
+        $result = $this->findLocationsWithSkipOnNotImplementedException( $query );
 
         $this->assertEquals( 4, $result->totalCount );
 
@@ -590,8 +575,7 @@ class SearchServiceLocationTest extends BaseTest
             )
         );
 
-        $searchService = $repository->getSearchService();
-        $result = $searchService->findLocations( $query );
+        $result = $this->findLocationsWithSkipOnNotImplementedException( $query );
 
         $this->assertEquals( 4, $result->totalCount );
 
@@ -645,8 +629,7 @@ class SearchServiceLocationTest extends BaseTest
             )
         );
 
-        $searchService = $repository->getSearchService();
-        $result = $searchService->findLocations( $query );
+        $result = $this->findLocationsWithSkipOnNotImplementedException( $query );
 
         $this->assertEquals( 4, $result->totalCount );
 
@@ -700,8 +683,7 @@ class SearchServiceLocationTest extends BaseTest
             )
         );
 
-        $searchService = $repository->getSearchService();
-        $result = $searchService->findLocations( $query );
+        $result = $this->findLocationsWithSkipOnNotImplementedException( $query );
 
         $this->assertEquals( 4, $result->totalCount );
     }
@@ -710,7 +692,7 @@ class SearchServiceLocationTest extends BaseTest
      * Test for the findLocations() method.
      *
      * @see \eZ\Publish\API\Repository\SearchService::findLocations()
-     * @depends eZ\Publish\API\Repository\Tests\SearchServiceTest::testMultilingualFieldSortUnusedLanguageDoesNotFilterResultSet
+     * @depends eZ\Publish\API\Repository\Tests\SearchServiceLocationTest::testMultilingualFieldSortUnusedLanguageDoesNotFilterResultSet
      */
     public function testMultilingualFieldSortUnusedLanguageDoesNotChangeSort()
     {
@@ -739,8 +721,7 @@ class SearchServiceLocationTest extends BaseTest
             )
         );
 
-        $searchService = $repository->getSearchService();
-        $result = $searchService->findLocations( $query );
+        $result = $this->findLocationsWithSkipOnNotImplementedException( $query );
 
         $this->assertEquals( 4, $result->totalCount );
 
@@ -945,8 +926,7 @@ class SearchServiceLocationTest extends BaseTest
             )
         );
 
-        $searchService = $repository->getSearchService();
-        $result = $searchService->findLocations( $query );
+        $result = $this->findLocationsWithSkipOnNotImplementedException( $query );
 
         $this->assertEquals( 1, $result->totalCount );
         $this->assertEquals(
@@ -1024,8 +1004,7 @@ class SearchServiceLocationTest extends BaseTest
             )
         );
 
-        $searchService = $repository->getSearchService();
-        $result = $searchService->findLocations( $query );
+        $result = $this->findLocationsWithSkipOnNotImplementedException( $query );
 
         $this->assertEquals( 1, $result->totalCount );
         $this->assertEquals(
@@ -1119,8 +1098,7 @@ class SearchServiceLocationTest extends BaseTest
             )
         );
 
-        $searchService = $repository->getSearchService();
-        $result = $searchService->findLocations( $query );
+        $result = $this->findLocationsWithSkipOnNotImplementedException( $query );
 
         $this->assertEquals( 1, $result->totalCount );
         $this->assertEquals(
@@ -1227,8 +1205,7 @@ class SearchServiceLocationTest extends BaseTest
             )
         );
 
-        $searchService = $repository->getSearchService();
-        $result = $searchService->findLocations( $query );
+        $result = $this->findLocationsWithSkipOnNotImplementedException( $query );
 
         $this->assertEquals( 3, $result->totalCount );
         $this->assertEquals(
@@ -1343,8 +1320,7 @@ class SearchServiceLocationTest extends BaseTest
             )
         );
 
-        $searchService = $repository->getSearchService();
-        $result = $searchService->findLocations( $query );
+        $result = $this->findLocationsWithSkipOnNotImplementedException( $query );
 
         $this->assertEquals( 3, $result->totalCount );
         $this->assertEquals(
@@ -1433,8 +1409,7 @@ class SearchServiceLocationTest extends BaseTest
             )
         );
 
-        $searchService = $repository->getSearchService();
-        $result = $searchService->findLocations( $query );
+        $result = $this->findLocationsWithSkipOnNotImplementedException( $query );
 
         $this->assertEquals( 1, $result->totalCount );
         $this->assertEquals(
@@ -1544,8 +1519,7 @@ class SearchServiceLocationTest extends BaseTest
             )
         );
 
-        $searchService = $repository->getSearchService();
-        $result = $searchService->findLocations( $query );
+        $result = $this->findLocationsWithSkipOnNotImplementedException( $query );
 
         $this->assertEquals( 3, $result->totalCount );
         $this->assertEquals(
@@ -1563,6 +1537,30 @@ class SearchServiceLocationTest extends BaseTest
     }
 
     /**
+     * Search using $searchService->findLocations but make sure to skip if NotImplementedException
+     *
+     * @param LocationQuery $query
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
+     */
+    protected function findLocationsWithSkipOnNotImplementedException( LocationQuery $query )
+    {
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+
+        try
+        {
+            return $searchService->findLocations( $query );
+        }
+        catch ( NotImplementedException $e )
+        {
+            $this->markTestSkipped(
+                "This feature is not supported by the current search backend: " . $e->getMessage()
+            );
+        }
+    }
+
+    /**
      * Assert that query result matches the given fixture.
      *
      * @param LocationQuery $query
@@ -1571,22 +1569,10 @@ class SearchServiceLocationTest extends BaseTest
      *
      * @return void
      */
-    protected function assertQueryFixture( LocationQuery $query, $fixture, $closure = null )
+    protected function assertQueryFixture( LocationQuery $query, $fixture, $closure = null, $ignoreScore = true )
     {
-        $repository    = $this->getRepository();
-        $searchService = $repository->getSearchService();
-
-        try
-        {
-            $result = $searchService->findLocations( $query );
-            $this->simplifySearchResult( $result );
-        }
-        catch ( NotImplementedException $e )
-        {
-            $this->markTestSkipped(
-                "This feature is not supported by the current search backend: " . $e->getMessage()
-            );
-        }
+        $result = $this->findLocationsWithSkipOnNotImplementedException( $query );
+        $this->simplifySearchResult( $result );
 
         if ( !is_file( $fixture ) )
         {
@@ -1604,13 +1590,34 @@ class SearchServiceLocationTest extends BaseTest
             }
         }
 
+        $fixture = include $fixture;
+
         if ( $closure !== null )
         {
+            $closure( $fixture );
             $closure( $result );
         }
 
+        if ( $ignoreScore )
+        {
+            foreach ( array( $fixture, $result ) as $result )
+            {
+                $property = new \ReflectionProperty(get_class($result), 'maxScore');
+                $property->setAccessible( true );
+                $property->setValue( $result, 0.0 );
+
+                foreach ( $result->searchHits as $hit )
+                {
+                    $property = new \ReflectionProperty(get_class($hit), 'score');
+                    $property->setAccessible( true );
+                    $property->setValue( $hit, 0.0 );
+
+                }
+            }
+        }
+
         $this->assertEquals(
-            include $fixture,
+            $fixture,
             $result,
             "Search results do not match.",
             .1 // Be quite generous regarding delay -- most important for scores

--- a/eZ/Publish/Core/FieldType/Integer/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Integer/SearchField.php
@@ -31,7 +31,7 @@ class SearchField implements Indexable
             new Search\Field(
                 'value',
                 $field->value->data,
-                new Search\FieldType\IntegerField()
+                new Search\FieldType\MultipleIntegerField()
             ),
         );
     }
@@ -44,7 +44,7 @@ class SearchField implements Indexable
     public function getIndexDefinition()
     {
         return array(
-            'value' => new Search\FieldType\IntegerField(),
+            'value' => new Search\FieldType\MultipleIntegerField(),
         );
     }
 }

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/FieldNameGenerator.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/FieldNameGenerator.php
@@ -26,6 +26,7 @@ class FieldNameGenerator
      */
     protected $fieldNameMapping = array(
         "ez_integer"  => "i",
+        "ez_minteger"  => "mi",
         "ez_id"       => "id",
         "ez_mid"      => "mid",
         "ez_string"   => "s",

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/FieldValueMapper/MultipleIntegerMapper.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/FieldValueMapper/MultipleIntegerMapper.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * File containing the IntegerMapper class
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\Solr\Content\Search\FieldValueMapper;
+
+use eZ\Publish\Core\Persistence\Solr\Content\Search\FieldValueMapper;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Maps raw document field values to something Solr can index.
+ */
+class MultipleIntegerMapper extends FieldValueMapper
+{
+    /**
+     * Check if field can be mapped
+     *
+     * @param Field $field
+     *
+     * @return boolean
+     */
+    public function canMap( Field $field )
+    {
+        return $field->type instanceof FieldType\MultipleIntegerField;
+    }
+
+    /**
+     * Map field value to a proper Solr representation
+     *
+     * @param Field $field
+     *
+     * @return mixed
+     */
+    public function map( Field $field )
+    {
+        $values = array();
+        foreach ( (array)$field->value as $value )
+        {
+            $values[] = (int)$value;
+        }
+
+        return $values;
+    }
+}
+

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/Location/CriterionVisitor/MapLocation/MapLocationDistanceIn.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/Location/CriterionVisitor/MapLocation/MapLocationDistanceIn.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * File containing the MapLocationDistanceIn criterion visitor class for location search
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\Solr\Content\Search\Location\CriterionVisitor\MapLocation;
+
+use eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor\MapLocation\MapLocationDistanceIn as ContentMapLocationDistanceIn;
+use eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+/**
+ * Visits the MapLocationDistance criterion
+ */
+class MapLocationDistanceIn extends ContentMapLocationDistanceIn
+{
+    /**
+     * Map field value to a proper Solr representation
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException If no searchable fields are found for the given criterion target.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param \eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor $subVisitor
+     *
+     * @return string
+     */
+    public function visit( Criterion $criterion, CriterionVisitor $subVisitor = null )
+    {
+        return "{!child of='document_type_id:content' v='" . parent::visit( $criterion, $subVisitor ) . "'}";
+    }
+}
+

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/Location/CriterionVisitor/MapLocation/MapLocationDistanceRange.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/Location/CriterionVisitor/MapLocation/MapLocationDistanceRange.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * File containing the MapLocationDistanceRange criterion visitor class for location search
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\Solr\Content\Search\Location\CriterionVisitor\MapLocation;
+
+use eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor\MapLocation\MapLocationDistanceRange as ContentMapLocationDistanceRange;
+use eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+/**
+ * Visits the MapLocationDistance criterion
+ */
+class MapLocationDistanceRange extends ContentMapLocationDistanceRange
+{
+    /**
+     * Map field value to a proper Solr representation
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If no searchable fields are found for the given criterion target.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param \eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor $subVisitor
+     *
+     * @return string
+     */
+    public function visit( Criterion $criterion, CriterionVisitor $subVisitor = null )
+    {
+        return "{!child of='document_type_id:content' v='document_type_id:content AND " . parent::visit( $criterion, $subVisitor ) . "'}";
+    }
+}

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/schema.xml
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/schema.xml
@@ -99,6 +99,7 @@ should not remove or drastically change the existing definitions.
       patterns both match, the first appearing in the schema will be used.
     -->
     <dynamicField name="*_i" type="int" indexed="true" stored="true"/>
+    <dynamicField name="*_mi" type="int" indexed="true" stored="true" multiValued="true"/>
     <dynamicField name="*_id" type="identifier" indexed="true" stored="true"/>
     <dynamicField name="*_mid" type="identifier" indexed="true" stored="true" multiValued="true"/>
     <dynamicField name="*_s" type="string" indexed="true" stored="true"/>

--- a/eZ/Publish/Core/settings/storage_engines/solr/criterion_visitors.yml
+++ b/eZ/Publish/Core/settings/storage_engines/solr/criterion_visitors.yml
@@ -59,6 +59,8 @@ parameters:
     ezpublish.persistence.solr.search.location.criterion_visitor.field_in.class: eZ\Publish\Core\Persistence\Solr\Content\Search\Location\CriterionVisitor\Field\FieldIn
     ezpublish.persistence.solr.search.location.criterion_visitor.field_range.class: eZ\Publish\Core\Persistence\Solr\Content\Search\Location\CriterionVisitor\Field\FieldRange
     ezpublish.persistence.solr.search.location.criterion_visitor.full_text.class: eZ\Publish\Core\Persistence\Solr\Content\Search\Location\CriterionVisitor\FullText
+    ezpublish.persistence.solr.search.location.criterion_visitor.map_location_distance_in.class: eZ\Publish\Core\Persistence\Solr\Content\Search\Location\CriterionVisitor\MapLocation\MapLocationDistanceIn
+    ezpublish.persistence.solr.search.location.criterion_visitor.map_location_distance_range.class: eZ\Publish\Core\Persistence\Solr\Content\Search\Location\CriterionVisitor\MapLocation\MapLocationDistanceRange
 
 services:
     ezpublish.persistence.solr.search.content.criterion_visitor.match_all:
@@ -385,6 +387,20 @@ services:
 
     ezpublish.persistence.solr.search.location.criterion_visitor.full_text:
         class: %ezpublish.persistence.solr.search.location.criterion_visitor.full_text.class%
+        arguments:
+            - @ezpublish.persistence.solr.search.content.field_map
+        tags:
+            - {name: ezpublish.persistence.solr.search.location.criterion_visitor}
+
+    ezpublish.persistence.solr.search.location.criterion_visitor.map_location_distance_in:
+        class: %ezpublish.persistence.solr.search.location.criterion_visitor.map_location_distance_in.class%
+        arguments:
+            - @ezpublish.persistence.solr.search.content.field_map
+        tags:
+            - {name: ezpublish.persistence.solr.search.location.criterion_visitor}
+
+    ezpublish.persistence.solr.search.location.criterion_visitor.map_location_distance_range:
+        class: %ezpublish.persistence.solr.search.location.criterion_visitor.map_location_distance_range.class%
         arguments:
             - @ezpublish.persistence.solr.search.content.field_map
         tags:

--- a/eZ/Publish/Core/settings/storage_engines/solr/field_value_mappers.yml
+++ b/eZ/Publish/Core/settings/storage_engines/solr/field_value_mappers.yml
@@ -4,6 +4,7 @@ parameters:
     ezpublish.persistence.solr.search.content.field_value_mapper.string.class: eZ\Publish\Core\Persistence\Solr\Content\Search\FieldValueMapper\StringMapper
     ezpublish.persistence.solr.search.content.field_value_mapper.multiple_string.class: eZ\Publish\Core\Persistence\Solr\Content\Search\FieldValueMapper\MultipleStringMapper
     ezpublish.persistence.solr.search.content.field_value_mapper.integer.class: eZ\Publish\Core\Persistence\Solr\Content\Search\FieldValueMapper\IntegerMapper
+    ezpublish.persistence.solr.search.content.field_value_mapper.multiple_integer.class: eZ\Publish\Core\Persistence\Solr\Content\Search\FieldValueMapper\MultipleIntegerMapper
     ezpublish.persistence.solr.search.content.field_value_mapper.date.class: eZ\Publish\Core\Persistence\Solr\Content\Search\FieldValueMapper\DateMapper
     ezpublish.persistence.solr.search.content.field_value_mapper.price.class: eZ\Publish\Core\Persistence\Solr\Content\Search\FieldValueMapper\PriceMapper
     ezpublish.persistence.solr.search.content.field_value_mapper.boolean.class: eZ\Publish\Core\Persistence\Solr\Content\Search\FieldValueMapper\BooleanMapper
@@ -33,6 +34,11 @@ services:
 
     ezpublish.persistence.solr.search.content.field_value_mapper.integer:
         class: %ezpublish.persistence.solr.search.content.field_value_mapper.integer.class%
+        tags:
+            - {name: ezpublish.persistence.solr.search.content.field_value_mapper}
+
+    ezpublish.persistence.solr.search.content.field_value_mapper.multiple_integer:
+        class: %ezpublish.persistence.solr.search.content.field_value_mapper.multiple_integer.class%
         tags:
             - {name: ezpublish.persistence.solr.search.content.field_value_mapper}
 

--- a/eZ/Publish/SPI/Search/FieldType/MultipleIntegerField.php
+++ b/eZ/Publish/SPI/Search/FieldType/MultipleIntegerField.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * File containing the eZ\Publish\SPI\Search\FieldType\MultipleIntegerField class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Publish\SPI\Search\FieldType;
+
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Integer document field
+ */
+class MultipleIntegerField extends FieldType
+{
+    /**
+     * The type name of the facet. Has to be handled by the solr schema.
+     *
+     * @var string
+     */
+    protected $type = 'ez_minteger';
+}
+


### PR DESCRIPTION
( To be able to enable skipped tests in SearchServiceLocationTest )

Followup to https://jira.ez.no/browse/EZP-23842 and #929 

WIP since I'm not certain we should introduce MultipleIntegerField, should rather fix the modeling to not have to store fields as multiValuedField all the time as it is blocking Field sort support (afaik).

Takes down number of skips in Solr tests from 67 to 55, main remaining parts after this is:
- SortClause\Field & SortClause\MapLocationDistance
 - Content search -> missing impl, blocked by current multivalued field approach for field value languages, multivalued solr fields can not be used for sort
 - Location search -> Should probably be unsupported if it implies duplicated field indexing
- FacetBuilder\FieldFacetBuilder -> Missing impl
- LanguageAnalysis -> missing impl for anything but ElasticSearch, probably blocked by how it currently models translations using multivalued fields