### PR TITLE
Cache composer dependencies and enable fast_finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,13 @@ env:
     - SOLR_VERSION="4.10.1" TEST_CONFIG="phpunit-integration-legacy-solr.xml"
     - ELASTICSEARCH_VERSION="1.4.1" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
 
+cache:
+  directories:
+    - vendor
+    - $HOME/.composer/cache
+
 matrix:
+  fast_finish: true
   allow_failures:
     - php: hhvm
       env: TEST_CONFIG="phpunit.xml" SYMFONY_VERSION="~2.6@beta"


### PR DESCRIPTION
The Travis-CI build process can be significantly be sped up by caching the composer dependencies between builds (see http://docs.travis-ci.com/user/caching/).

By setting `fast_finish` to true, Travis-CI will not wait for the items that are allowed to fail to mark a build as successful (see http://blog.travis-ci.com/2013-11-27-fast-finishing-builds/)

Cheers
:octocat: Jérôme