### PR TITLE
Fix EZP-23848: [BDD] don't expect HTTP 401 in REST API with anonymous

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Features/ContentTypeGroup/list.feature
+++ b/eZ/Bundle/EzPublishRestBundle/Features/ContentTypeGroup/list.feature
@@ -22,7 +22,18 @@ Feature: Read all Content Type Groups
             | dif3rent   |
             | id_nt.fier |
 
-    Scenario: Can't read any Content Type Group without an authorized user
+    Scenario: List Content Type Groups without an authorized user
         Given I don't have permissions
+        And there are the following Content Type Groups:
+            | groups     |
+            | some       |
+            | dif3rent   |
+            | id_nt.fier |
         When I get Content Type Groups list
-        Then response has a not authorized error
+        Then response status code is 200
+        And response status message is "OK"
+        And response contains the following Content Type Groups:
+            | groups     |
+            | some       |
+            | dif3rent   |
+            | id_nt.fier |

--- a/eZ/Bundle/EzPublishRestBundle/Features/ContentTypeGroup/read.feature
+++ b/eZ/Bundle/EzPublishRestBundle/Features/ContentTypeGroup/read.feature
@@ -21,11 +21,13 @@ Feature: Read a Content Type Groups
         When I get Content Type Group with id "{id}"
         Then response has a not found exception
 
-    Scenario: Can't read a Content Type Group without an authorized user through id
-        Given I do not have permissions
+    Scenario: Read a Content Type Group through id with anonymous user
+        Given I have "anonymous" permissions
         And there is a Content Type Group with id "{id}" and identifier "some_string"
         When I get Content Type Group with id "{id}"
-        Then response has a not authorized error
+        Then response has a Content Type Group with identifier "some_string"
+        And response has a "eZ\Publish\Core\REST\Client\Values\ContentType\ContentTypeGroup" object
+        And response header "content-type" has "ContentTypeGroup"
 
     # Get Content Type Group through <identifier>
     Scenario: Read a Content Type Group through identifier
@@ -42,8 +44,10 @@ Feature: Read a Content Type Groups
         When I get Content Type Group with identifier "some_string"
         Then response has a not found exception
 
-    Scenario: Can't read a Content Type Group without an authorized user through identifier
-        Given I do not have permissions
+    Scenario: Read a Content Type Group through identifier with anonymous user
+        Given I have "anonymous" permissions
         And there is a Content Type Group with identifier "some_string"
         When I get Content Type Group with identifier "some_string"
-        Then response has a not authorized error
+        Then response has a Content Type Group with identifier "some_string"
+        And response has a "eZ\Publish\Core\REST\Client\Values\ContentType\ContentTypeGroup" object
+        And response header "content-type" has "ContentTypeGroup"

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/Authentication.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/Authentication.php
@@ -51,7 +51,7 @@ trait Authentication
         switch ( $this->authType )
         {
             case self::AUTHTYPE_BASICHTTP:
-                $this->restDriver->setAuthentication( '', '' );
+                $this->restDriver->setAuthentication( 'anonymous', '' );
                 break;
             case self::AUTHTYPE_SESSION:
                 $this->cleanupSession();


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23848

Fix failing BDD tests due to wrong expectation of `HTTP 401: Not Authorized` response with anonymous.
In fact, this is the response for any and ALL requests if http basic auth is used, and no user is provided,
however, this is outside the scope of existing tests (ContentTypeGroup read/list).

For the purpose of existing REST api tests, `anonymous` user is used. 
In this case, the queries are allowed and return valid results (ContentTypeGroup/list)

Nitpick:  
The `Given I do not have permissions` sentence actually equals `Given I have "anonymous" permissions`.