### PR TITLE
Fix for empty array

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase/QueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase/QueryBuilder.php
@@ -133,7 +133,7 @@ class QueryBuilder
             )
         );
 
-        if ( $translations !== null )
+        if ( !empty( $translations ) )
         {
             $query->where(
                 $query->expr->in(


### PR DESCRIPTION
When an empty array is passed in, originating from 'eZ\Publish\Core\MVC\Symfony\View\Manager::renderLocation()', the expression builder will throw the exception "At least one element is required as value".