### PR TITLE
EZP-21998: Implement @ParamConverter in controllers

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Converter/ContentParamConverter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Converter/ContentParamConverter.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Converter;
+
+use eZ\Publish\API\Repository\ContentService;
+
+class ContentParamConverter extends RepositoryParamConverter
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    public function __construct( ContentService $contentService )
+    {
+        $this->contentService = $contentService;
+    }
+
+    protected function getSupportedClass()
+    {
+        return 'eZ\Publish\API\Repository\Values\Content\Content';
+    }
+
+    protected function getPropertyName()
+    {
+        return 'contentId';
+    }
+
+    protected function loadValueObject( $id )
+    {
+        return $this->contentService->loadContent( $id );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Converter/LocationParamConverter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Converter/LocationParamConverter.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Converter;
+
+use eZ\Publish\API\Repository\LocationService;
+
+class LocationParamConverter extends RepositoryParamConverter
+{
+    /** @var  \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    public function __construct( LocationService $locationService )
+    {
+        $this->locationService = $locationService;
+    }
+
+    protected function getSupportedClass()
+    {
+        return 'eZ\Publish\API\Repository\Values\Content\Location';
+    }
+
+    protected function getPropertyName()
+    {
+        return 'locationId';
+    }
+
+    protected function loadValueObject( $id )
+    {
+        return $this->locationService->loadLocation( $id );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Converter/RepositoryParamConverter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Converter/RepositoryParamConverter.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Converter;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
+use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+abstract class RepositoryParamConverter implements ParamConverterInterface
+{
+    public function supports( ParamConverter $configuration )
+    {
+        return is_a( $configuration->getClass(), $this->getSupportedClass(), true );
+    }
+
+    abstract protected function getSupportedClass();
+
+    /**
+     * @return string property name used in the method of the controller needing param conversion
+     */
+    abstract protected function getPropertyName();
+
+    /**
+     * @return string classes with its namespace
+     */
+    abstract protected function loadValueObject( $id );
+
+    /**
+     * @param Request $request
+     * @param ParamConverter $configuration
+     * @throws NotFoundHttpException if value object was not found
+     * @throws AccessDeniedHttpException if user is not allowed to load the value object
+     *
+     * @return bool
+     */
+    public function apply( Request $request, ParamConverter $configuration )
+    {
+        if ( !$request->attributes->has( $this->getPropertyName() ) )
+        {
+            return false;
+        }
+
+        $valueObjectId = $request->attributes->get( $this->getPropertyName() );
+        if ( !$valueObjectId && $configuration->isOptional() )
+        {
+            return false;
+        }
+
+        try
+        {
+            $request->attributes->set( $configuration->getName(), $this->loadValueObject( $valueObjectId ) );
+            return true;
+        }
+        catch ( NotFoundException $e )
+        {
+            throw new NotFoundHttpException( 'Requested values not found', $e );
+        }
+        catch ( UnauthorizedException $e )
+        {
+            throw new AccessDeniedHttpException( 'Access to values denied', $e );
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewControllerListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewControllerListener.php
@@ -59,7 +59,7 @@ class ViewControllerListener implements EventSubscriberInterface
 
     public static function getSubscribedEvents()
     {
-        return array( KernelEvents::CONTROLLER => 'getController' );
+        return array( KernelEvents::CONTROLLER => array( 'getController', 10 ) );
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -10,6 +10,12 @@ parameters:
     ezpublish.controller.content.preview.class: eZ\Publish\Core\MVC\Symfony\Controller\Content\PreviewController
     ezpublish.controller.page.view.class: eZ\Bundle\EzPublishCoreBundle\Controller\PageController
 
+    # Param converters
+    ezpublish.param_converter.content.class: eZ\Bundle\EzPublishCoreBundle\Converter\ContentParamConverter
+    ezpublish.param_converter.content.priority: -2
+    ezpublish.param_converter.location.class: eZ\Bundle\EzPublishCoreBundle\Converter\LocationParamConverter
+    ezpublish.param_converter.location.priority: -2
+
     # FragmentRenderer overrides
     ezpublish.decorated_fragment_renderer.inline.class: eZ\Bundle\EzPublishCoreBundle\Fragment\InlineFragmentRenderer
     ezpublish.decorated_fragment_renderer.class: eZ\Bundle\EzPublishCoreBundle\Fragment\DecoratedFragmentRenderer
@@ -118,3 +124,18 @@ services:
             - [setFragmentPath, [%fragment.path%]]
             - [setSiteAccess, [@ezpublish.siteaccess]]
         abstract: true
+
+    ezpublish.param_converter.content:
+        class: %ezpublish.param_converter.content.class%
+        arguments:
+            - @ezpublish.api.service.content
+        tags:
+            - { name: request.param_converter, priority: %ezpublish.param_converter.content.priority%, converter: ez_content_converter }
+
+    ezpublish.param_converter.location:
+        class: %ezpublish.param_converter.location.class%
+        arguments:
+            - @ezpublish.api.service.location
+        tags:
+            - { name: request.param_converter, priority: %ezpublish.param_converter.location.priority%, converter: ez_location_converter }
+

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Converter/AbstractParamConverterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Converter/AbstractParamConverterTest.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Converter;
+
+abstract class AbstractParamConverterTest extends \PHPUnit_Framework_TestCase
+{
+    public function createConfiguration( $class = null, $name = null )
+    {
+        $config = $this
+            ->getMockBuilder( 'Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter' )
+            ->setMethods( ['getClass', 'getAliasName', 'getOptions', 'getName', 'allowArray', 'isOptional'] )
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        if ( $name !== null )
+        {
+            $config->expects( $this->any() )
+                ->method( 'getName' )
+                ->will( $this->returnValue( $name ) );
+        }
+        if ( $class !== null )
+        {
+            $config->expects( $this->any() )
+                ->method( 'getClass' )
+                ->will( $this->returnValue( $class ) );
+        }
+
+        return $config;
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Converter/ContentParamConverterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Converter/ContentParamConverterTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Converter;
+
+use eZ\Bundle\EzPublishCoreBundle\Converter\ContentParamConverter;
+use Symfony\Component\HttpFoundation\Request;
+use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+
+class ContentParamConverterTest extends AbstractParamConverterTest
+{
+    const PROPERTY_NAME = 'contentId';
+
+    const CONTENT_CLASS = 'eZ\Publish\API\Repository\Values\Content\Content';
+
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\Converter\ContentParamConverter
+     */
+    private $converter;
+
+    private $contentServiceMock;
+
+    public function setUp()
+    {
+        $this->contentServiceMock = $this->getMock( 'eZ\\Publish\\API\\Repository\\ContentService' );
+
+        $this->converter = new ContentParamConverter( $this->contentServiceMock );
+    }
+
+    public function testSupports()
+    {
+        $config = $this->createConfiguration( self::CONTENT_CLASS );
+        $this->assertTrue( $this->converter->supports( $config ) );
+
+        $config = $this->createConfiguration( __CLASS__ );
+        $this->assertFalse( $this->converter->supports( $config ) );
+
+        $config = $this->createConfiguration();
+        $this->assertFalse( $this->converter->supports( $config ) );
+    }
+
+    public function testApplyContent()
+    {
+        $id = 42;
+        $valueObject = $this->getMock( 'eZ\\Publish\\API\\Repository\\Values\\Content\\Content' );
+
+        $this->contentServiceMock
+            ->expects( $this->once() )
+            ->method( 'loadContent' )
+            ->with( $id )
+            ->will( $this->returnValue( $valueObject ) );
+
+        $request = new Request( [], [], [self::PROPERTY_NAME => $id] );
+        $config = $this->createConfiguration( self::CONTENT_CLASS, 'content' );
+
+        $this->converter->apply( $request, $config );
+
+        $this->assertInstanceOf( self::CONTENT_CLASS, $request->attributes->get( 'content' ) );
+    }
+
+    public function testApplyContentNotFound404Exception()
+    {
+        $id = 42;
+        $request = new Request( [], [], [self::PROPERTY_NAME => $id] );
+        $config = $this->createConfiguration( self::CONTENT_CLASS, 'content' );
+
+        $this->contentServiceMock
+            ->expects( $this->once() )
+            ->method( 'loadContent' )
+            ->with( $id )
+            ->will( $this->throwException( new NotFoundException( '', '' ) ) );
+
+        $this->setExpectedException( 'Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'Requested values not found' );
+        $this->converter->apply( $request, $config );
+    }
+
+    public function testApplyContentUnauthorized403Exception()
+    {
+        $id = 42;
+        $request = new Request( [], [], [self::PROPERTY_NAME => $id] );
+        $config = $this->createConfiguration( self::CONTENT_CLASS, 'content' );
+
+        $this->contentServiceMock
+            ->expects( $this->once() )
+            ->method( 'loadContent' )
+            ->with( $id )
+            ->will( $this->throwException( new UnauthorizedException( '', '' ) ) );
+
+        $this->setExpectedException( 'Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException', 'Access to values denied' );
+        $this->converter->apply( $request, $config );
+    }
+
+    public function testApplyContentOptionalWithEmptyAttribute()
+    {
+        $request = new Request( [], [], [self::PROPERTY_NAME => null] );
+        $config = $this->createConfiguration( self::CONTENT_CLASS, 'content' );
+
+        $config->expects( $this->once() )
+            ->method( 'isOptional' )
+            ->will( $this->returnValue( true ) );
+
+        $this->assertFalse( $this->converter->apply( $request, $config ) );
+        $this->assertNull( $request->attributes->get( 'content' ) );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Converter/LocationParamConverterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Converter/LocationParamConverterTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Converter;
+
+use eZ\Bundle\EzPublishCoreBundle\Converter\LocationParamConverter;
+use Symfony\Component\HttpFoundation\Request;
+use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+
+class LocationParamConverterTest extends AbstractParamConverterTest
+{
+    const PROPERTY_NAME = 'locationId';
+
+    const LOCATION_CLASS = 'eZ\Publish\API\Repository\Values\Content\Location';
+
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\Converter\LocationParamConverter
+     */
+    private $converter;
+
+    private $locationServiceMock;
+
+    public function setUp()
+    {
+        $this->locationServiceMock = $this->getMock( 'eZ\\Publish\\API\\Repository\\LocationService' );
+
+        $this->converter = new LocationParamConverter( $this->locationServiceMock );
+    }
+
+    public function testSupports()
+    {
+        $config = $this->createConfiguration( self::LOCATION_CLASS );
+        $this->assertTrue( $this->converter->supports( $config ) );
+
+        $config = $this->createConfiguration( __CLASS__ );
+        $this->assertFalse( $this->converter->supports( $config ) );
+
+        $config = $this->createConfiguration();
+        $this->assertFalse( $this->converter->supports( $config ) );
+    }
+
+    public function testApplyLocation()
+    {
+        $id = 42;
+        $valueObject = $this->getMock( 'eZ\\Publish\\API\\Repository\\Values\\Content\\Location' );
+
+        $this->locationServiceMock
+            ->expects( $this->once() )
+            ->method( 'loadLocation' )
+            ->with( $id )
+            ->will( $this->returnValue( $valueObject ) );
+
+        $request = new Request( [], [], [self::PROPERTY_NAME => $id] );
+        $config = $this->createConfiguration( self::LOCATION_CLASS, 'location' );
+
+        $this->converter->apply( $request, $config );
+
+        $this->assertInstanceOf( self::LOCATION_CLASS, $request->attributes->get( 'location' ) );
+    }
+
+    public function testApplyLocationNotFound404Exception()
+    {
+        $id = 42;
+        $request = new Request( [], [], [self::PROPERTY_NAME => $id] );
+        $config = $this->createConfiguration( self::LOCATION_CLASS, 'location' );
+
+        $this->locationServiceMock
+            ->expects( $this->once() )
+            ->method( 'loadLocation' )
+            ->with( $id )
+            ->will( $this->throwException( new NotFoundException( '', '' ) ) );
+
+        $this->setExpectedException( 'Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'Requested values not found' );
+        $this->converter->apply( $request, $config );
+    }
+
+    public function testApplyLocationUnauthorized403Exception()
+    {
+        $id = 42;
+        $request = new Request( [], [], [self::PROPERTY_NAME => $id] );
+        $config = $this->createConfiguration( self::LOCATION_CLASS, 'location' );
+
+        $this->locationServiceMock
+            ->expects( $this->once() )
+            ->method( 'loadLocation' )
+            ->with( $id )
+            ->will( $this->throwException( new UnauthorizedException( '', '' ) ) );
+
+        $this->setExpectedException( 'Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException', 'Access to values denied' );
+        $this->converter->apply( $request, $config );
+    }
+
+    public function testApplyLocationOptionalWithEmptyAttribute()
+    {
+        $request = new Request( [], [], [self::PROPERTY_NAME => null] );
+        $config = $this->createConfiguration( self::LOCATION_CLASS, 'location' );
+
+        $config->expects( $this->once() )
+            ->method( 'isOptional' )
+            ->will( $this->returnValue( true ) );
+
+        $this->assertFalse( $this->converter->apply( $request, $config ) );
+        $this->assertNull( $request->attributes->get( 'location' ) );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
@@ -86,7 +86,7 @@ class ViewControllerListenerTest extends PHPUnit_Framework_TestCase
     public function testGetSubscribedEvents()
     {
         $this->assertSame(
-            array( KernelEvents::CONTROLLER => 'getController' ),
+            array( KernelEvents::CONTROLLER => array( 'getController', 10 ) ),
             $this->controllerListener->getSubscribedEvents()
         );
     }


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-21998

*Please review the test carefully as I am not used to write them* :)

## Description
Implements @ParamConverter for `Location` and `Content`

See symfony doc: http://symfony.com/doc/2.3/bundles/SensioFrameworkExtraBundle/annotations/converters.html

## Tests
Unit test and manual on DemoBundle ( see https://github.com/ezsystems/DemoBundle/pull/129 )

## TODO
* [x] Create doc (cookbook): https://doc.ez.no/display/EZP/How+to+convert+request+parameters+into+API+objects
* [x] General cleanup
* [x] Update DemoBundle