### PR TITLE
Fix EZP-23864: Fix coupling with legacy in debug bundle

### DIFF
--- a/doc/specifications/debug/data_collectors.md
+++ b/doc/specifications/debug/data_collectors.md
@@ -1,0 +1,54 @@
+# eZ data collectors
+
+Symfony profiler let any bundle register *data collectors* and displayed collected data in the web profiler toolbar
+and debug panel. eZ has its own data collector.
+
+## Extensibility
+As of v6.0, it is possible to display custom collected data under eZ toolbar / panel.
+The main data collector has been splitted into several dedicated ones and now only aggregates data collected by
+registered sub-collectors.
+
+## Native data collectors
+Following data collectors are part of `EzPublishDebugBundle`:
+
+* `PersistenceCacheCollector`: Collects information on persistence cache (aka SPI cache) efficiency (hits/miss).
+* `TemplatesDataCollector`: Collects information on loaded templates.
+
+## Custom data collector
+For data to appear under eZ toolbar / panel, it is only needed to write a service implementing
+`Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface`, or simply extending `Symfony\Component\HttpKernel\DataCollector\DataCollector`.
+
+This service, instead of being tagged as `data_collector`, needs to be tagged as `ezpublish_data_collector`.
+This service tag takes 2 additional arguments indicating which template(s) to use for displaying collected data in the
+toolbar and/or panel. Those templates will be *included* by the main eZ data collector, exposing your collector object,
+like for any regular data collector.
+
+### Example
+```yml
+parameters:
+    ezpublish_debug.persistence_collector.class: eZ\Bundle\EzPublishDebugBundle\Collector\PersistenceCacheCollector
+    ezpublish_debug.templates_collector.class: eZ\Bundle\EzPublishDebugBundle\Collector\TemplatesDataCollector
+
+services:
+    ezpublish_debug.persistence_collector:
+        class: %ezpublish_debug.persistence_collector.class%
+        arguments: [@ezpublish.spi.persistence.cache.persistenceLogger]
+        tags:
+            -
+                name: ezpublish_data_collector
+                id: "ezpublish.debug.persistence"
+                panelTemplate: "EzPublishDebugBundle:Profiler/persistence:panel.html.twig"
+                toolbarTemplate: "EzPublishDebugBundle:Profiler/persistence:toolbar.html.twig"
+
+    ezpublish_debug.templates_collector:
+        class: %ezpublish_debug.templates_collector.class%
+        tags:
+            -
+                name: ezpublish_data_collector
+                panelTemplate: "EzPublishDebugBundle:Profiler/templates:panel.html.twig"
+                toolbarTemplate: "EzPublishDebugBundle:Profiler/templates:toolbar.html.twig"
+
+```
+
+For further example, refer to [`PersistenceCacheCollector`](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Bundle/EzPublishDebugBundle/Collector/PersistenceCacheCollector.php) 
+or [`TemplatesDataCollector`](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Bundle/EzPublishDebugBundle/Collector/TemplatesDataCollector.php) implementation.

--- a/eZ/Bundle/EzPublishDebugBundle/Collector/EzPublishCoreCollector.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Collector/EzPublishCoreCollector.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * File containing the EzPublishDataCollector class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishDebugBundle\Collector;
+
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use InvalidArgumentException;
+use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
+
+class EzPublishCoreCollector extends DataCollector
+{
+    public function __construct()
+    {
+        $this->data = [
+            'collectors' => [],
+            'panelTemplates' => [],
+            'toolbarTemplates' => []
+        ];
+    }
+
+    public function collect( Request $request, Response $response, \Exception $exception = null )
+    {
+        /** @var DataCollectorInterface $innerCollector */
+        foreach ( $this->data['collectors'] as $innerCollector )
+        {
+            $innerCollector->collect( $request, $response, $exception );
+        }
+    }
+
+    public function getName()
+    {
+        return 'ezpublish.debug.toolbar';
+    }
+
+    /**
+     * @param DataCollectorInterface $collector
+     */
+    public function addCollector( DataCollectorInterface $collector, $panelTemplate = null, $toolbarTemplate = null )
+    {
+        $name = $collector->getName();
+        $this->data['collectors'][$name] = $collector;
+        $this->data['panelTemplates'][$name] = $panelTemplate;
+        $this->data['toolbarTemplates'][$name] = $toolbarTemplate;
+    }
+
+    /**
+     * @param string $name Name of the collector
+     *
+     * @return DataCollectorInterface
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function getCollector( $name )
+    {
+        if ( !isset( $this->data['collectors'][$name] ) )
+        {
+            throw new InvalidArgumentException( "Invalid debug collector '$name'" );
+        }
+
+        return $this->data['collectors'][$name];
+    }
+
+    /**
+     * @return DataCollectorInterface[]
+     */
+    public function getAllCollectors()
+    {
+        return $this->data['collectors'];
+    }
+
+    /**
+     * Returns toolbar template for given collector name.
+     *
+     * @param string $collectorName Name of corresponding collector.
+     *
+     * @return string
+     */
+    public function getToolbarTemplate( $collectorName )
+    {
+        if ( !isset( $this->data['toolbarTemplates'][$collectorName] ) )
+        {
+            return null;
+        }
+
+        return $this->data['toolbarTemplates'][$collectorName];
+    }
+
+    /**
+     * Returns panel template to use for given collector name.
+     *
+     * @param string $collectorName Name of corresponding collector.
+     *
+     * @return string
+     */
+    public function getPanelTemplate( $collectorName )
+    {
+        if ( !isset( $this->data['panelTemplates'][$collectorName] ) )
+        {
+            return null;
+        }
+
+        return $this->data['panelTemplates'][$collectorName];
+    }
+}

--- a/eZ/Bundle/EzPublishDebugBundle/Collector/TemplateDebugInfo.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Collector/TemplateDebugInfo.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the DebugKernel class.
+ * This file is part of the eZ Publish Kernel package.
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -9,18 +9,8 @@
 
 namespace eZ\Bundle\EzPublishDebugBundle\Collector;
 
-use eZ\Publish\Core\MVC\Legacy\Kernel as LegacyKernel;
-use eZTemplate;
-use ezxFormToken;
-use RuntimeException;
-
 /**
- * Class TemplateDebugInfo
- * @package eZ\Bundle\EzPublishCoreBundle\Collector
- *
- *
  * Holds debug info about twig templates and exposes function to get legacy template info
- * @todo Move legacy code to LegacyBundle, and then consider moving left overs to DebugTemplate class (rename TwigDebugTemplate?)
  */
 class TemplateDebugInfo
 {
@@ -61,62 +51,5 @@ class TemplateDebugInfo
     public static function getTemplatesList()
     {
         return self::$templateList;
-    }
-
-    /**
-     * Returns array of loaded legacy templates
-     *
-     * @param \Closure $legacyKernel
-     *
-     * @return array
-     */
-    public static function getLegacyTemplatesList( \Closure $legacyKernel )
-    {
-        $templateList = array( 'compact' => array(), 'full' => array() );
-        // Only retrieve legacy templates list if the kernel has been booted at least once.
-        if ( !LegacyKernel::hasInstance() )
-        {
-            return $templateList;
-        }
-
-        try
-        {
-            $templateStats = $legacyKernel()->runCallback(
-                function ()
-                {
-                    return eZTemplate::templatesUsageStatistics();
-                },
-                false,
-                false
-            );
-        }
-        catch ( RuntimeException $e )
-        {
-            // Ignore the exception thrown by legacy kernel as this would break debug toolbar (and thus debug info display).
-            // Furthermore, some legacy kernel handlers don't support runCallback (e.g. ezpKernelTreeMenu)
-            $templateStats = array();
-        }
-
-        foreach ( $templateStats as $tplInfo )
-        {
-            $requestedTpl = $tplInfo["requested-template-name"];
-            $actualTpl    = $tplInfo["actual-template-name"];
-            $fullPath     = $tplInfo["template-filename"];
-
-            $templateList["full"][$actualTpl] = array(
-                "loaded" => $requestedTpl,
-                "fullPath" => $fullPath
-            );
-            if ( !isset( $templateList["compact"][$actualTpl] ) )
-            {
-                $templateList["compact"][$actualTpl] = 1;
-            }
-            else
-            {
-                $templateList["compact"][$actualTpl]++;
-            }
-        }
-
-        return $templateList;
     }
 }

--- a/eZ/Bundle/EzPublishDebugBundle/Collector/TemplatesDataCollector.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Collector/TemplatesDataCollector.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishDebugBundle\Collector;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+
+/**
+ * Data collector listing used Twig templates.
+ */
+class TemplatesDataCollector extends DataCollector
+{
+    public function collect( Request $request, Response $response, \Exception $exception = null )
+    {
+        $this->data = ['templates' => TemplateDebugInfo::getTemplatesList()];
+    }
+
+    public function getName()
+    {
+        return 'ezpublish.debug.templates';
+    }
+
+    /**
+     * Returns templates list
+     *
+     * @return array
+     */
+    public function getTemplates()
+    {
+        return $this->data['templates'];
+    }
+}

--- a/eZ/Bundle/EzPublishDebugBundle/DependencyInjection/Compiler/DataCollectorPass.php
+++ b/eZ/Bundle/EzPublishDebugBundle/DependencyInjection/Compiler/DataCollectorPass.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishDebugBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class DataCollectorPass implements CompilerPassInterface
+{
+    public function process( ContainerBuilder $container )
+    {
+        if ( !$container->hasDefinition( 'ezpublish_debug.data_collector' ) )
+            return;
+
+        $dataCollectorDef = $container->getDefinition( 'ezpublish_debug.data_collector' );
+        foreach ( $container->findTaggedServiceIds( 'ezpublish_data_collector' ) as $id => $attributes )
+        {
+            foreach ( $attributes as $attribute )
+            {
+                $dataCollectorDef->addMethodCall(
+                    'addCollector',
+                    [
+                        new Reference( $id ),
+                        isset( $attribute['panelTemplate'] ) ? $attribute['panelTemplate'] : null,
+                        isset( $attribute['toolbarTemplate'] ) ? $attribute['toolbarTemplate'] : null,
+                    ]
+                );
+            }
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishDebugBundle/DependencyInjection/Compiler/DataCollectorPass.php
+++ b/eZ/Bundle/EzPublishDebugBundle/DependencyInjection/Compiler/DataCollectorPass.php
@@ -26,8 +26,7 @@ class DataCollectorPass implements CompilerPassInterface
             foreach ( $attributes as $attribute )
             {
                 $dataCollectorDef->addMethodCall(
-                    'addCollector',
-                    [
+                    'addCollector', [
                         new Reference( $id ),
                         isset( $attribute['panelTemplate'] ) ? $attribute['panelTemplate'] : null,
                         isset( $attribute['toolbarTemplate'] ) ? $attribute['toolbarTemplate'] : null,

--- a/eZ/Bundle/EzPublishDebugBundle/EzPublishDebugBundle.php
+++ b/eZ/Bundle/EzPublishDebugBundle/EzPublishDebugBundle.php
@@ -9,8 +9,15 @@
 
 namespace eZ\Bundle\EzPublishDebugBundle;
 
+use eZ\Bundle\EzPublishDebugBundle\DependencyInjection\Compiler\DataCollectorPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class EzPublishDebugBundle extends Bundle
 {
+    public function build( ContainerBuilder $container )
+    {
+        parent::build( $container );
+        $container->addCompilerPass( new DataCollectorPass() );
+    }
 }

--- a/eZ/Bundle/EzPublishDebugBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishDebugBundle/Resources/config/services.yml
@@ -1,12 +1,31 @@
 parameters:
-    ezpublish.debug.data_collector.class: eZ\Bundle\EzPublishDebugBundle\Collector\EzPublishDataCollector
+    ezpublish.debug.data_collector.class: eZ\Bundle\EzPublishDebugBundle\Collector\EzPublishCoreCollector
+    ezpublish_debug.persistence_collector.class: eZ\Bundle\EzPublishDebugBundle\Collector\PersistenceCacheCollector
+    ezpublish_debug.templates_collector.class: eZ\Bundle\EzPublishDebugBundle\Collector\TemplatesDataCollector
 
 services:
-    ezpublish.debug.data_collector:
+    ezpublish_debug.data_collector:
         class: %ezpublish.debug.data_collector.class%
-        arguments: [ @ezpublish.spi.persistence.cache.persistenceLogger, @ezpublish_legacy.kernel ]
         tags:
             -
                 name: data_collector
                 template: "EzPublishDebugBundle:Profiler:layout"
                 id: "ezpublish.debug.toolbar"
+
+    ezpublish_debug.persistence_collector:
+        class: %ezpublish_debug.persistence_collector.class%
+        arguments: [@ezpublish.spi.persistence.cache.persistenceLogger]
+        tags:
+            -
+                name: ezpublish_data_collector
+                id: "ezpublish.debug.persistence"
+                panelTemplate: "EzPublishDebugBundle:Profiler/persistence:panel.html.twig"
+                toolbarTemplate: "EzPublishDebugBundle:Profiler/persistence:toolbar.html.twig"
+
+    ezpublish_debug.templates_collector:
+        class: %ezpublish_debug.templates_collector.class%
+        tags:
+            -
+                name: ezpublish_data_collector
+                panelTemplate: "EzPublishDebugBundle:Profiler/templates:panel.html.twig"
+                toolbarTemplate: "EzPublishDebugBundle:Profiler/templates:toolbar.html.twig"

--- a/eZ/Bundle/EzPublishDebugBundle/Resources/views/Profiler/layout.html.twig
+++ b/eZ/Bundle/EzPublishDebugBundle/Resources/views/Profiler/layout.html.twig
@@ -6,34 +6,16 @@
     {% endset %}
 
     {% set text %}
-        <div class="sf-toolbar-info-piece">
-            <b>SPI (persistence)</b>
-        </div>
-        <div class="sf-toolbar-info-piece">
-            <b>calls</b> <span class="sf-toolbar-status sf-toolbar-status-green">{{ collector.count }}</span>
-        </div>
-        <div class="sf-toolbar-info-piece">
-            <b>handlers</b> <span class="sf-toolbar-status sf-toolbar-status-green">{{ collector.handlerscount }}</span>
-        </div>
-        <hr />
+        {% for name, inner_collector in collector.allCollectors %}
+            {% set inner_template = collector.getToolbarTemplate( name ) %}
+            {% if inner_template %}
+                {% include inner_template with { "collector": inner_collector } %}
 
-        {% if ( collector.templates.compact|length or collector.legacytemplates.compact|length ) %}
-            <div class="sf-toolbar-info-piece">
-                <b>Templates</b>
-            </div>
-
-            {% if collector.templates.compact|length %}
-                <div class="sf-toolbar-info-piece">
-                    <b>Twig</b> <span class="sf-toolbar-status sf-toolbar-status-green">{{ collector.templates.compact|length }}</span>
-                </div>
+                {% if not loop.last %}<hr />{% endif %}
             {% endif %}
 
-            {% if collector.legacytemplates.compact|length %}
-                <div class="sf-toolbar-info-piece">
-                    <b>Legacy</b> <span class="sf-toolbar-status sf-toolbar-status-green">{{ collector.legacytemplates.compact|length }}</span>
-                </div>
-            {% endif %}
-        {% endif %}
+        {% endfor %}
+
     {% endset %}
 
     {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
@@ -43,81 +25,18 @@
 <span class="label">
     <span class="icon"><img width="20" height="24" alt="eZ Publish Info" style="vertical-align: middle;" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAYCAYAAAD6S912AAAD8GlDQ1BJQ0MgUHJvZmlsZQAAOMuNVd1v21QUP4lvXKQWP6Cxjg4Vi69VU1u5GxqtxgZJk6XpQhq5zdgqpMl1bhpT1za2021Vn/YCbwz4A4CyBx6QeEIaDMT2su0BtElTQRXVJKQ9dNpAaJP2gqpwrq9Tu13GuJGvfznndz7v0TVAx1ea45hJGWDe8l01n5GPn5iWO1YhCc9BJ/RAp6Z7TrpcLgIuxoVH1sNfIcHeNwfa6/9zdVappwMknkJsVz19HvFpgJSpO64PIN5G+fAp30Hc8TziHS4miFhheJbjLMMzHB8POFPqKGKWi6TXtSriJcT9MzH5bAzzHIK1I08t6hq6zHpRdu2aYdJYuk9Q/881bzZa8Xrx6fLmJo/iu4/VXnfH1BB/rmu5ScQvI77m+BkmfxXxvcZcJY14L0DymZp7pML5yTcW61PvIN6JuGr4halQvmjNlCa4bXJ5zj6qhpxrujeKPYMXEd+q00KR5yNAlWZzrF+Ie+uNsdC/MO4tTOZafhbroyXuR3Df08bLiHsQf+ja6gTPWVimZl7l/oUrjl8OcxDWLbNU5D6JRL2gxkDu16fGuC054OMhclsyXTOOFEL+kmMGs4i5kfNuQ62EnBuam8tzP+Q+tSqhz9SuqpZlvR1EfBiOJTSgYMMM7jpYsAEyqJCHDL4dcFFTAwNMlFDUUpQYiadhDmXteeWAw3HEmA2s15k1RmnP4RHuhBybdBOF7MfnICmSQ2SYjIBM3iRvkcMki9IRcnDTthyLz2Ld2fTzPjTQK+Mdg8y5nkZfFO+se9LQr3/09xZr+5GcaSufeAfAww60mAPx+q8u/bAr8rFCLrx7s+vqEkw8qb+p26n11Aruq6m1iJH6PbWGv1VIY25mkNE8PkaQhxfLIF7DZXx80HD/A3l2jLclYs061xNpWCfoB6WHJTjbH0mV35Q/lRXlC+W8cndbl9t2SfhU+Fb4UfhO+F74GWThknBZ+Em4InwjXIyd1ePnY/Psg3pb1TJNu15TMKWMtFt6ScpKL0ivSMXIn9QtDUlj0h7U7N48t3i8eC0GnMC91dX2sTivgloDTgUVeEGHLTizbf5Da9JLhkhh29QOs1luMcScmBXTIIt7xRFxSBxnuJWfuAd1I7jntkyd/pgKaIwVr3MgmDo2q8x6IdB5QH162mcX7ajtnHGN2bov71OU1+U0fqqoXLD0wX5ZM005UHmySz3qLtDqILDvIL+iH6jB9y2x83ok898GOPQX3lk3Itl0A+BrD6D7tUjWh3fis58BXDigN9yF8M5PJH4B8Gr79/F/XRm8m241mw/wvur4BGDj42bzn+Vmc+NL9L8GcMn8F1kAcXi1s/XUAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH3QEPFDMKCOYbNQAAAoZJREFUOMvtlE1rU0EUhp9z5jY3SaXWWkQR0RZx5UrUWtouXFTottA/Iogfq6zc+Bes+jesUDfuRbuwQjEiAdtaNW2a5ib33jkubowmxvi19cAd5jLDO/Oe85yB//HPcfbMhI0Uhg34429s9IgHkkcPH1q1Wl0CCDbelrlz+w6zc7O0mk0Q+cUVBMxQVQCWl+8TJwnOOQACgOnpKywsLPyVw5drL0iTtFuw2WoBkCRJ5+RBYWaICEmSEEXNrrUAQNo2VRURQUQwM7z3/QUz45hZ54A4il1HsCtDbTER6dj4WYRhSD7MUcjnGDkyUu0r+FWsVquxvr5OnHpEHYZlt2rvcaqIOl6X38nO7j77y4/m+wp673HOUalUuHx1nvH6LqdHINrLbPYaGj01KuX4wD8fn7g+MzV1PRiEx8njJ7g3OcbFoyEHzQYqPxbMxFmo6HbU8Defb1swCDfnlZM5ZbLgqEuQEWDd21LvpeCMohbl8CGRYFDS49QTJQkHrZhGK+6LlG/3zUEcS5rEDBQUAUVwKqgK2qeLDFABUQERBlJsPT82uCEzlvkOUO99B2bvPfKb7WftQayNTRiGWdsE3zJQKBQQEQMTfls6E4wrlQpbW1vU63UAhotFym/K6kmdqJqZSfYKCdZrXLrnweLi4tCTlRWerq5iltkPhwI2P3zkU23ba3BULWm105L21zIwBDMI5mZmSlEU0Wg0QBUz02I+tz/6fufS573aUmCbvpAvim81RUS7SiUIKRCqEYpDNf55cm7cunVtbe3V4wvvn6Xnj41roxmJqPbWHm9CTo1qIjzYaBCUSqVeFoNSqRQNqY7lA+HuBlAfgqbPgLM+vLTfs3PDIV8AeYkiNww3NXYAAAAASUVORK5CYII=" /></span>
     <strong>eZ Publish</strong>
-    <span class="count">
-        <span title="SPI calls">{{ collector.count }}</span>
-    </span>
 </span>
 {% endblock %}
 
 {% block panel %}
     <h2>eZ Publish Usage Information</h2>
 
-    {% if collector.legacytemplates.full|length > 0 %}
-    <h3>Loaded legacy templates</h3>
-    <table>
-        <tr>
-            <th>Requested</th>
-            <th><abbr title="Usage count">#</abbr></th>
-            <th>Override</th>
-            <th>Path</th>
-        </tr>
-        {% for tpl, info in collector.legacytemplates.full %}
-        <tr>
-            <td>{{ tpl }}</td>
-            <td>{{ collector.legacytemplates.compact[tpl] }}</td>
-            <td>{% if tpl != info.loaded %}{{ info.loaded }}N/A{% else %}{% endif %}</td>
-            <td>{{ info.fullPath }}</td>
-        </tr>
-        {% endfor %}
-    </table>
-    {% endif %}
+    {% for name, inner_collector in collector.allCollectors %}
+        {% set inner_template = collector.getPanelTemplate( name ) %}
+        {% if inner_template %}{% include inner_template with { "collector": inner_collector } %}{% endif %}
 
-    {% if collector.templates.full|length > 0 %}
-    <h3>Loaded twig templates</h3>
-    <table>
-        <tr>
-            <th>Loaded template</th>
-            <th><abbr title="Usage count">#</abbr></th>
-            <th><abbr title="Execution time (all occurrences, in milliseconds)">Exec. time (ms)</abbr></th>
-        </tr>
-        {% for tpl,time in collector.templates.full %}
-        <tr>
-            <td>{{ tpl }}</td>
-            <td>{{ collector.templates.compact[tpl] }}</td>
-            <td style="text-align: right">{{ time }}</td>
-        </tr>
-        {% endfor %}
-    </table>
-    {% endif %}
+        {% if not loop.last %}<hr />{% endif %}
 
-    <table>
-        <tr>
-            <th>Total Uncached SPI calls:</th>
-            <td>{{ collector.count }}</td>
-        </tr>
-        {% if collector.handlerscount %}
-        <tr>
-            <th>Uncached SPI handlers(times loaded):</th>
-            <td>{{ collector.handlers|join(', ') }}</td>
-        </tr>
-        {% endif %}
-    </table>
+    {% endfor %}
 
-    {% if collector.callsLoggingEnabled %}
-        <h3>Uncached SPI calls</h3>
-        <table>
-            <tr>
-                <th>Class</th>
-                <th>Method</th>
-                <th>Arguments</th>
-            </tr>
-            {% for call in collector.calls %}
-                <tr>
-                    <td>{{ call.class }}</td>
-                    <td>{{ call.method }}</td>
-                    <td>{{ call.arguments }}</td>
-                </tr>
-        {% endfor %}
-        </table>
-    {% endif %}
 {% endblock %}

--- a/eZ/Bundle/EzPublishDebugBundle/Resources/views/Profiler/persistence/panel.html.twig
+++ b/eZ/Bundle/EzPublishDebugBundle/Resources/views/Profiler/persistence/panel.html.twig
@@ -1,0 +1,30 @@
+<table>
+    <tr>
+        <th>Total Uncached SPI calls:</th>
+        <td>{{ collector.count }}</td>
+    </tr>
+    {% if collector.handlerscount %}
+        <tr>
+            <th>Uncached SPI handlers(times loaded):</th>
+            <td>{{ collector.handlers|join(', ') }}</td>
+        </tr>
+    {% endif %}
+</table>
+
+{% if collector.callsLoggingEnabled %}
+    <h3>Uncached SPI calls</h3>
+    <table>
+        <tr>
+            <th>Class</th>
+            <th>Method</th>
+            <th>Arguments</th>
+        </tr>
+        {% for call in collector.calls %}
+            <tr>
+                <td>{{ call.class }}</td>
+                <td>{{ call.method }}</td>
+                <td>{{ call.arguments }}</td>
+            </tr>
+        {% endfor %}
+    </table>
+{% endif %}

--- a/eZ/Bundle/EzPublishDebugBundle/Resources/views/Profiler/persistence/toolbar.html.twig
+++ b/eZ/Bundle/EzPublishDebugBundle/Resources/views/Profiler/persistence/toolbar.html.twig
@@ -1,0 +1,9 @@
+<div class="sf-toolbar-info-piece">
+    <b>SPI (persistence)</b>
+</div>
+<div class="sf-toolbar-info-piece">
+    <b>calls</b> <span class="sf-toolbar-status sf-toolbar-status-green">{{ collector.count }}</span>
+</div>
+<div class="sf-toolbar-info-piece">
+    <b>handlers</b> <span class="sf-toolbar-status sf-toolbar-status-green">{{ collector.handlerscount }}</span>
+</div>

--- a/eZ/Bundle/EzPublishDebugBundle/Resources/views/Profiler/templates/panel.html.twig
+++ b/eZ/Bundle/EzPublishDebugBundle/Resources/views/Profiler/templates/panel.html.twig
@@ -1,0 +1,17 @@
+{% if collector.templates.full|length > 0 %}
+    <h3>Loaded twig templates</h3>
+    <table>
+        <tr>
+            <th>Loaded template</th>
+            <th><abbr title="Usage count">#</abbr></th>
+            <th><abbr title="Execution time (all occurrences, in milliseconds)">Exec. time (ms)</abbr></th>
+        </tr>
+        {% for tpl, time in collector.templates.full %}
+            <tr>
+                <td>{{ tpl }}</td>
+                <td>{{ collector.templates.compact[tpl] }}</td>
+                <td style="text-align: right">{{ time }}</td>
+            </tr>
+        {% endfor %}
+    </table>
+{% endif %}

--- a/eZ/Bundle/EzPublishDebugBundle/Resources/views/Profiler/templates/toolbar.html.twig
+++ b/eZ/Bundle/EzPublishDebugBundle/Resources/views/Profiler/templates/toolbar.html.twig
@@ -1,0 +1,6 @@
+{% if collector.templates.compact|length %}
+    <div class="sf-toolbar-info-piece">
+        <b>Twig templates</b> <span class="sf-toolbar-status sf-toolbar-status-green">{{ collector.templates.compact|length }}</span>
+    </div>
+
+{% endif %}

--- a/eZ/Bundle/EzPublishDebugBundle/Tests/Collector/EzPublishCoreCollectorTest.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Tests/Collector/EzPublishCoreCollectorTest.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishDebugBundle\Tests\Collector;
+
+use eZ\Bundle\EzPublishDebugBundle\Collector\EzPublishCoreCollector;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Exception;
+
+class EzPublishCoreCollectorTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var EzPublishCoreCollector
+     */
+    private $mainCollector;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->mainCollector = new EzPublishCoreCollector();
+    }
+
+    public function testAddGetCollector()
+    {
+        $collector = $this->getMock( '\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface' );
+        $name = 'foobar';
+        $collector
+            ->expects( $this->once() )
+            ->method( 'getName' )
+            ->will( $this->returnValue( $name ) );
+
+        $this->mainCollector->addCollector( $collector );
+        $this->assertSame( $collector, $this->mainCollector->getCollector( $name ) );
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testGetInvalidCollector()
+    {
+        $collector = $this->getMock( '\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface' );
+        $this->mainCollector->addCollector( $collector );
+        $this->assertSame( $collector, $this->mainCollector->getCollector( 'foo' ) );
+    }
+
+    public function testGetAllCollectors()
+    {
+        $collector1 = $this->getMock( '\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface' );
+        $nameCollector1 = 'collector1';
+        $collector1
+            ->expects( $this->once() )
+            ->method( 'getName' )
+            ->will( $this->returnValue( $nameCollector1 ) );
+        $collector2 = $this->getMock( '\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface' );
+        $nameCollector2 = 'collector2';
+        $collector2
+            ->expects( $this->once() )
+            ->method( 'getName' )
+            ->will( $this->returnValue( $nameCollector2 ) );
+
+        $allCollectors = [
+            $nameCollector1 => $collector1,
+            $nameCollector2 => $collector2
+        ];
+
+        foreach ( $allCollectors as $name => $collector )
+        {
+            $this->mainCollector->addCollector( $collector );
+        }
+
+        $this->assertSame( $allCollectors, $this->mainCollector->getAllCollectors() );
+    }
+
+    public function testGetToolbarTemplateNothing()
+    {
+        $collector = $this->getMock( '\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface' );
+        $name = 'foobar';
+        $collector
+            ->expects( $this->once() )
+            ->method( 'getName' )
+            ->will( $this->returnValue( $name ) );
+        $this->mainCollector->addCollector( $collector );
+        $this->assertNull( $this->mainCollector->getToolbarTemplate( $name ) );
+    }
+
+    public function testGetToolbarTemplate()
+    {
+        $collector = $this->getMock( '\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface' );
+        $name = 'foobar';
+        $collector
+            ->expects( $this->once() )
+            ->method( 'getName' )
+            ->will( $this->returnValue( $name ) );
+        $toolbarTemplate = 'toolbar.html.twig';
+
+        $this->mainCollector->addCollector( $collector, 'foo', $toolbarTemplate );
+        $this->assertSame( $toolbarTemplate, $this->mainCollector->getToolbarTemplate( $name ) );
+    }
+
+    public function testGetPanelTemplateNothing()
+    {
+        $collector = $this->getMock( '\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface' );
+        $name = 'foobar';
+        $collector
+            ->expects( $this->once() )
+            ->method( 'getName' )
+            ->will( $this->returnValue( $name ) );
+        $this->mainCollector->addCollector( $collector );
+        $this->assertNull( $this->mainCollector->getPanelTemplate( $name ) );
+    }
+
+    public function testGetPanelTemplate()
+    {
+        $collector = $this->getMock( '\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface' );
+        $name = 'foobar';
+        $collector
+            ->expects( $this->once() )
+            ->method( 'getName' )
+            ->will( $this->returnValue( $name ) );
+        $panelTemplate = 'toolbar.html.twig';
+
+        $this->mainCollector->addCollector( $collector, $panelTemplate, 'foo' );
+        $this->assertSame( $panelTemplate, $this->mainCollector->getPanelTemplate( $name ) );
+    }
+
+    public function testCollect()
+    {
+        $collector1 = $this->getMock( '\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface' );
+        $nameCollector1 = 'collector1';
+        $collector1
+            ->expects( $this->once() )
+            ->method( 'getName' )
+            ->will( $this->returnValue( $nameCollector1 ) );
+        $collector2 = $this->getMock( '\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface' );
+        $nameCollector2 = 'collector2';
+        $collector2
+            ->expects( $this->once() )
+            ->method( 'getName' )
+            ->will( $this->returnValue( $nameCollector2 ) );
+
+        $allCollectors = [
+            $nameCollector1 => $collector1,
+            $nameCollector2 => $collector2
+        ];
+
+        $request = new Request();
+        $response = new Response();
+        $exception = new Exception;
+
+        /**
+         * @var \PHPUnit_Framework_MockObject_MockObject $collector
+         */
+        foreach ( $allCollectors as $name => $collector )
+        {
+            $this->mainCollector->addCollector( $collector );
+            $collector
+                ->expects( $this->once() )
+                ->method( 'collect' )
+                ->with( $request, $response, $exception );
+        }
+
+        $this->mainCollector->collect( $request, $response, $exception );
+    }
+}

--- a/eZ/Bundle/EzPublishDebugBundle/Tests/DependencyInjection/Compiler/DataCollectorPassTest.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Tests/DependencyInjection/Compiler/DataCollectorPassTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishDebugBundle\Tests\DependencyInjection\Compiler;
+
+use eZ\Bundle\EzPublishDebugBundle\DependencyInjection\Compiler\DataCollectorPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class DataCollectorPassTest extends AbstractCompilerPassTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->setDefinition( 'ezpublish_debug.data_collector', new Definition() );
+    }
+
+    protected function registerCompilerPass( ContainerBuilder $container )
+    {
+        $container->addCompilerPass( new DataCollectorPass() );
+    }
+
+    public function testAddCollector()
+    {
+        $panelTemplate = 'panel.html.twig';
+        $toolbarTemplate = 'toolbar.html.twig';
+        $definition = new Definition();
+        $definition->addTag(
+            'ezpublish_data_collector',
+            ['panelTemplate' => $panelTemplate, 'toolbarTemplate' => $toolbarTemplate]
+        );
+
+        $serviceId = 'service_id';
+        $this->setDefinition( $serviceId, $definition );
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'ezpublish_debug.data_collector',
+            'addCollector',
+            array( new Reference( $serviceId ), $panelTemplate, $toolbarTemplate )
+        );
+    }
+}

--- a/eZ/Bundle/EzPublishLegacyBundle/Collector/LegacyTemplatesCollector.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Collector/LegacyTemplatesCollector.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishLegacyBundle\Collector;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+
+/**
+ * Collects list of used legacy templates.
+ */
+class LegacyTemplatesCollector extends DataCollector
+{
+    /**
+     * @var callable
+     */
+    private $legacyKernel;
+
+    public function __construct( \Closure $legacyKernel )
+    {
+        $this->legacyKernel = $legacyKernel;
+    }
+
+    public function collect( Request $request, Response $response, \Exception $exception = null )
+    {
+        $this->data = ['legacyTemplates' => TemplateDebugInfo::getLegacyTemplatesList( $this->legacyKernel )];
+    }
+
+    public function getName()
+    {
+        return 'ezpublish_legacy.templates';
+    }
+
+    /**
+     * Returns templates list
+     *
+     * @return array
+     */
+    public function getLegacyTemplates()
+    {
+        return $this->data['legacyTemplates'];
+    }
+}

--- a/eZ/Bundle/EzPublishLegacyBundle/Collector/TemplateDebugInfo.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Collector/TemplateDebugInfo.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishLegacyBundle\Collector;
+
+use eZ\Publish\Core\MVC\Legacy\Kernel as LegacyKernel;
+use eZTemplate;
+use ezxFormToken;
+use RuntimeException;
+
+class TemplateDebugInfo
+{
+    /**
+     * Returns array of loaded legacy templates
+     *
+     * @param \Closure $legacyKernel
+     *
+     * @return array
+     */
+    public static function getLegacyTemplatesList( \Closure $legacyKernel )
+    {
+        $templateList = array( 'compact' => array(), 'full' => array() );
+        // Only retrieve legacy templates list if the kernel has been booted at least once.
+        if ( !LegacyKernel::hasInstance() )
+        {
+            return $templateList;
+        }
+
+        try
+        {
+            $templateStats = $legacyKernel()->runCallback(
+                function ()
+                {
+                    return eZTemplate::templatesUsageStatistics();
+                },
+                false,
+                false
+            );
+        }
+        catch ( RuntimeException $e )
+        {
+            // Ignore the exception thrown by legacy kernel as this would break debug toolbar (and thus debug info display).
+            // Furthermore, some legacy kernel handlers don't support runCallback (e.g. ezpKernelTreeMenu)
+            $templateStats = array();
+        }
+
+        foreach ( $templateStats as $tplInfo )
+        {
+            $requestedTpl = $tplInfo["requested-template-name"];
+            $actualTpl    = $tplInfo["actual-template-name"];
+            $fullPath     = $tplInfo["template-filename"];
+
+            $templateList["full"][$actualTpl] = array(
+                "loaded" => $requestedTpl,
+                "fullPath" => $fullPath
+            );
+            if ( !isset( $templateList["compact"][$actualTpl] ) )
+            {
+                $templateList["compact"][$actualTpl] = 1;
+            }
+            else
+            {
+                $templateList["compact"][$actualTpl]++;
+            }
+        }
+
+        return $templateList;
+    }
+}

--- a/eZ/Bundle/EzPublishLegacyBundle/Collector/TemplateDebugInfo.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/Collector/TemplateDebugInfo.php
@@ -37,7 +37,24 @@ class TemplateDebugInfo
             $templateStats = $legacyKernel()->runCallback(
                 function ()
                 {
-                    return eZTemplate::templatesUsageStatistics();
+                    if ( eZTemplate::isTemplatesUsageStatisticsEnabled() )
+                    {
+                        return eZTemplate::templatesUsageStatistics();
+                    }
+                    else
+                    {
+                        $stats = [];
+                        foreach ( eZTemplate::instance()->templateFetchList() as $tpl )
+                        {
+                            $stats[] = [
+                                'requested-template-name' => $tpl,
+                                'actual-template-name' => $tpl,
+                                'template-filename' => $tpl
+                            ];
+                        }
+
+                        return $stats;
+                    }
                 },
                 false,
                 false

--- a/eZ/Bundle/EzPublishLegacyBundle/DependencyInjection/EzPublishLegacyExtension.php
+++ b/eZ/Bundle/EzPublishLegacyBundle/DependencyInjection/EzPublishLegacyExtension.php
@@ -51,6 +51,8 @@ class EzPublishLegacyExtension extends Extension
         // SignalSlot settings
         $loader->load( 'slot.yml' );
 
+        $loader->load( 'debug.yml' );
+
         // Default settings
         $loader->load( 'default_settings.yml' );
 

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/config/debug.yml
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/config/debug.yml
@@ -1,0 +1,12 @@
+parameters:
+    ezpublish_legacy.debug.templates_collector.class: eZ\Bundle\EzPublishLegacyBundle\Collector\LegacyTemplatesCollector
+
+services:
+    ezpublish_legacy.debug.templates_collector:
+        class: %ezpublish_legacy.debug.templates_collector.class%
+        arguments: [@ezpublish_legacy.kernel]
+        tags:
+            -
+                name: ezpublish_data_collector
+                panelTemplate: "EzPublishLegacyBundle:Profiler/templates:panel.html.twig"
+                toolbarTemplate: "EzPublishLegacyBundle:Profiler/templates:toolbar.html.twig"

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/views/Profiler/templates/panel.html.twig
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/views/Profiler/templates/panel.html.twig
@@ -1,0 +1,19 @@
+{% if collector.legacytemplates.full|length > 0 %}
+    <h3>Loaded legacy templates</h3>
+    <table>
+        <tr>
+            <th>Requested</th>
+            <th><abbr title="Usage count">#</abbr></th>
+            <th>Override</th>
+            <th>Path</th>
+        </tr>
+        {% for tpl, info in collector.legacytemplates.full %}
+            <tr>
+                <td>{{ tpl }}</td>
+                <td>{{ collector.legacytemplates.compact[tpl] }}</td>
+                <td>{% if tpl != info.loaded %}{{ info.loaded }}{% else %}N/A{% endif %}</td>
+                <td>{{ info.fullPath }}</td>
+            </tr>
+        {% endfor %}
+    </table>
+{% endif %}

--- a/eZ/Bundle/EzPublishLegacyBundle/Resources/views/Profiler/templates/toolbar.html.twig
+++ b/eZ/Bundle/EzPublishLegacyBundle/Resources/views/Profiler/templates/toolbar.html.twig
@@ -1,0 +1,6 @@
+{% if collector.legacytemplates.compact|length %}
+    <div class="sf-toolbar-info-piece">
+        <b>Legacy templates</b> <span class="sf-toolbar-status sf-toolbar-status-green">{{ collector.legacytemplates.compact|length }}</span>
+    </div>
+
+{% endif %}


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23864

This patch decouples legacy data collector from core.
It adds an extension point allowing to add custom *eZ collectors* (i.e. meant to be displayed in
webprofiler under eZ toolbar/panel).

# eZ data collectors

Symfony profiler let any bundle register *data collectors* and displayed collected data in the web profiler toolbar
and debug panel. eZ has its own data collector.

## Extensibility
As of v6.0, it is possible to display custom collected data under eZ toolbar / panel.
The main data collector has been splitted into several dedicated ones and now only aggregates data collected by
registered sub-collectors.

## Native data collectors
Following data collectors are part of `EzPublishDebugBundle`:

* `PersistenceCacheCollector`: Collects information on persistence cache (aka SPI cache) efficiency (hits/miss).
* `TemplatesDataCollector`: Collects information on loaded templates.

## Custom data collector
For data to appear under eZ toolbar / panel, it is only needed to write a service implementing
`Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface`, or simply extending `Symfony\Component\HttpKernel\DataCollector\DataCollector`.

This service, instead of being tagged as `data_collector`, needs to be tagged as `ezpublish_data_collector`.
This service tag takes 2 additional arguments indicating which template(s) to use for displaying collected data in the
toolbar and/or panel. Those templates will be *included* by the main eZ data collector, exposing your collector object,
like for any regular data collector.

### Example
```yml
parameters:
    ezpublish_debug.persistence_collector.class: eZ\Bundle\EzPublishDebugBundle\Collector\PersistenceCacheCollector
    ezpublish_debug.templates_collector.class: eZ\Bundle\EzPublishDebugBundle\Collector\TemplatesDataCollector

services:
    ezpublish_debug.persistence_collector:
        class: %ezpublish_debug.persistence_collector.class%
        arguments: [@ezpublish.spi.persistence.cache.persistenceLogger]
        tags:
            -
                name: ezpublish_data_collector
                id: "ezpublish.debug.persistence"
                panelTemplate: "EzPublishDebugBundle:Profiler/persistence:panel.html.twig"
                toolbarTemplate: "EzPublishDebugBundle:Profiler/persistence:toolbar.html.twig"

    ezpublish_debug.templates_collector:
        class: %ezpublish_debug.templates_collector.class%
        tags:
            -
                name: ezpublish_data_collector
                panelTemplate: "EzPublishDebugBundle:Profiler/templates:panel.html.twig"
                toolbarTemplate: "EzPublishDebugBundle:Profiler/templates:toolbar.html.twig"

```

For further example, refer to [`PersistenceCacheCollector`](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Bundle/EzPublishDebugBundle/Collector/PersistenceCacheCollector.php) 
or [`TemplatesDataCollector`](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Bundle/EzPublishDebugBundle/Collector/TemplatesDataCollector.php) implementation.