### PR TITLE
EZP-23889: RestProvider must check that is_rest_request is true

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/CorsOptions/RestProvider.php
+++ b/eZ/Bundle/EzPublishRestBundle/CorsOptions/RestProvider.php
@@ -42,7 +42,7 @@ class RestProvider implements ProviderInterface
     public function getOptions( Request $request )
     {
         $return = array();
-        if ( $request->attributes->has( 'is_rest_request' ) )
+        if ( $request->attributes->has( 'is_rest_request' ) && $request->attributes->get( 'is_rest_request' ) === true )
         {
             $return['allow_methods'] = $this->getAllowedMethods( $request->getPathInfo() );
         }


### PR DESCRIPTION
Otherwise the 'allowed_methods' previously set by \Nelmio\CorsBundle\Options\ConfigProvider in \Nelmio\CorsBundle\Options\Resolver::getOptions will be overwritten with value of $return['allow_methods'] due to array_merge()
At least on my setup ;)