### PR TITLE
Fix EZP-23302: Update Location fails if no change is performed with the ...

### DIFF
--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -1011,6 +1011,42 @@ class LocationServiceTest extends BaseTest
     }
 
     /**
+     * Test for the updateLocation() method.
+     * Ref EZP-23302: Update Location fails if no change is performed with the update
+     *
+     * @return void
+     * @see \eZ\Publish\API\Repository\LocationService::updateLocation()
+     * @depends eZ\Publish\API\Repository\Tests\LocationServiceTest::testLoadLocation
+     */
+    public function testUpdateLocationTwice()
+    {
+        $repository = $this->getRepository();
+
+        $locationId = $this->generateId( 'location', 5 );
+        /* BEGIN: Use Case */
+        $locationService = $repository->getLocationService();
+        $repository->setCurrentUser( $repository->getUserService()->loadUser( 14 ) );
+
+        $originalLocation = $locationService->loadLocation( $locationId );
+
+        $updateStruct = $locationService->newLocationUpdateStruct();
+        $updateStruct->priority = 42;
+
+        $updatedLocation = $locationService->updateLocation(
+            $originalLocation, $updateStruct
+        );
+
+        // Repeated update with the same, unchanged struct
+        $secondUpdatedLocation = $locationService->updateLocation(
+            $updatedLocation, $updateStruct
+        );
+        /* END: Use Case */
+
+        $this->assertEquals( $updatedLocation->priority, 42 );
+        $this->assertEquals( $secondUpdatedLocation->priority, 42 );
+    }
+
+    /**
      * Test for the swapLocation() method.
      *
      * @return void

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
@@ -213,7 +213,7 @@ abstract class Gateway
     /**
      * Updates an existing location.
      *
-     * @throws \eZ\Publish\Core\Base\Exceptions\NotFoundException
+     * Will not throw anything if location id is invalid or no entries are affected.
      *
      * @param \eZ\Publish\SPI\Persistence\Content\Location\UpdateStruct $location
      * @param int $locationId

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -986,7 +986,7 @@ class DoctrineDatabase extends Gateway
     /**
      * Updates an existing location.
      *
-     * @throws \eZ\Publish\Core\Base\Exceptions\NotFoundException
+     * Will not throw anything if location id is invalid or no entries are affected.
      *
      * @param \eZ\Publish\SPI\Persistence\Content\Location\UpdateStruct $location
      * @param int $locationId
@@ -1024,10 +1024,12 @@ class DoctrineDatabase extends Gateway
         $statement = $query->prepare();
         $statement->execute();
 
-        if ( $statement->rowCount() < 1 )
+        // Commented due to EZP-23302: Update Location fails if no change is performed with the update
+        // Should be fixed with PDO::MYSQL_ATTR_FOUND_ROWS instead
+        /*if ( $statement->rowCount() < 1 )
         {
             throw new NotFound( 'location', $locationId );
-        }
+        }*/
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
@@ -482,7 +482,7 @@ class ExceptionConversion extends Gateway
     /**
      * Updates an existing location.
      *
-     * @throws \eZ\Publish\Core\Base\Exceptions\NotFoundException
+     * Will not throw anything if location id is invalid or no entries are affected.
      *
      * @param \eZ\Publish\SPI\Persistence\Content\Location\UpdateStruct $location
      * @param int $locationId


### PR DESCRIPTION
...update

@crevillo's PR #973 concludes that the exception should be commented, and wider design issue be solved separately, ref PDO::MYSQL_ATTR_FOUND_ROWS

While the exception is easy to provoke in a CLI script, I was unable to do so in a unit test. The added test passes before and after commenting the exception code :(

https://jira.ez.no/browse/EZP-23302