### PR TITLE
Fix EZP-23872: Empty translation array in Query Builder throws exception

### DIFF
--- a/eZ/Bundle/EzPublishDebugBundle/DependencyInjection/Compiler/DataCollectorPass.php
+++ b/eZ/Bundle/EzPublishDebugBundle/DependencyInjection/Compiler/DataCollectorPass.php
@@ -28,9 +28,9 @@ class DataCollectorPass implements CompilerPassInterface
                 $dataCollectorDef->addMethodCall(
                     'addCollector',
                     [
-                        new Reference( $id ),
-                        isset( $attribute['panelTemplate'] ) ? $attribute['panelTemplate'] : null,
-                        isset( $attribute['toolbarTemplate'] ) ? $attribute['toolbarTemplate'] : null,
+                    new Reference( $id ),
+                    isset( $attribute['panelTemplate'] ) ? $attribute['panelTemplate'] : null,
+                    isset( $attribute['toolbarTemplate'] ) ? $attribute['toolbarTemplate'] : null,
                     ]
                 );
             }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase/QueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase/QueryBuilder.php
@@ -133,7 +133,7 @@ class QueryBuilder
             )
         );
 
-        if ( $translations !== null )
+        if ( !empty( $translations ) )
         {
             $query->where(
                 $query->expr->in(


### PR DESCRIPTION
When an empty array is passed in, originating from 'eZ\Publish\Core\MVC\Symfony\View\Manager::renderLocation()', the expression builder will throw the exception "At least one element is required as value".