### PR TITLE
Fix EZP-23902: update multiple user providers doc security.yml example

### DIFF
--- a/doc/specifications/security/multiple_user_providers.md
+++ b/doc/specifications/security/multiple_user_providers.md
@@ -59,6 +59,9 @@ security:
                 users:
                     # You will then be able to login with username "user" and password "userpass"
                     user:  { password: userpass, roles: [ 'ROLE_USER' ] }
+    # The "in memory" provider requires an encoder for Symfony\Component\Security\Core\User\User
+    encoders:
+        Symfony\Component\Security\Core\User\User: plaintext
 ```
 
 **Implementing the listener**


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23902

With the sync with Symfony-standard 2.5 (see EZP-23494 / https://github.com/ezsystems/ezpublish-platform/commit/0cd0fc3cfac574ce9cb429772522fdc6ba835304 ) the ```encoders``` key has been removed from ```security.yml```, along with alternate providers.

The documentation/example should include the encoder as it is necessary.