### PR TITLE
Fix EZP-23834: Cached ESI can not be shared among pages because of inner request

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Compound.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Compound.php
@@ -144,6 +144,6 @@ abstract class Compound implements CompoundInterface, URILexer
     public function __sleep()
     {
         // We don't need the whole matcher map and the matcher builder once serialized.
-        return array( 'config', 'subMatchers', 'request' );
+        return array( 'config', 'subMatchers' );
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/HostElement.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/HostElement.php
@@ -27,6 +27,13 @@ class HostElement implements VersatileMatcher
     private $elementNumber;
 
     /**
+     * Host elements used for matching as an array.
+     *
+     * @var array
+     */
+    private $hostElements;
+
+    /**
      * Constructor.
      *
      * @param int $elementNumber Number of elements to take into account.
@@ -36,6 +43,11 @@ class HostElement implements VersatileMatcher
         $this->elementNumber = (int)$elementNumber;
     }
 
+    public function __sleep()
+    {
+        return array( 'elementNumber', 'hostElements' );
+    }
+
     /**
      * Returns matching Siteaccess.
      *
@@ -43,8 +55,7 @@ class HostElement implements VersatileMatcher
      */
     public function match()
     {
-        $elements = explode( ".", $this->request->host );
-
+        $elements = $this->getHostElements();
         return isset( $elements[$this->elementNumber - 1] ) ? $elements[$this->elementNumber - 1] : false;
     }
 
@@ -80,5 +91,23 @@ class HostElement implements VersatileMatcher
         $hostElements[$elementNumber] = $siteAccessName;
         $this->request->setHost( implode( '.', $hostElements ) );
         return $this;
+    }
+
+    /**
+     * @return array
+     */
+    private function getHostElements()
+    {
+        if ( isset( $this->hostElements ) )
+        {
+            return $this->hostElements;
+        }
+        else if ( !isset( $this->request ) )
+        {
+            return array();
+        }
+
+        $elements = explode( ".", $this->request->host );
+        return $this->hostElements = $elements;
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Regex.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Regex.php
@@ -41,6 +41,11 @@ abstract class Regex implements Matcher
     protected $request;
 
     /**
+     * @var string
+     */
+    protected $matchedSiteAccess;
+
+    /**
      * Constructor.
      *
      * @param string $regex Regular Expression to use.
@@ -52,20 +57,36 @@ abstract class Regex implements Matcher
         $this->itemNumber = $itemNumber;
     }
 
-    /**
-     * Returns matching Siteaccess.
-     *
-     * @return string|false Siteaccess matched or false.
-     */
+    public function __sleep()
+    {
+        return array( 'regex', 'itemNumber', 'matchedSiteAccess' );
+    }
+
     public function match()
     {
+        return $this->getMatchedSiteAccess();
+    }
+
+    /**
+     * Returns matched SiteAccess.
+     *
+     * @return string|bool
+     */
+    protected function getMatchedSiteAccess()
+    {
+        if ( isset( $this->matchedSiteAccess ) )
+        {
+            return $this->matchedSiteAccess;
+        }
+
         preg_match(
             "@{$this->regex}@",
             $this->element,
             $match
         );
 
-        return isset( $match[$this->itemNumber] ) ? $match[$this->itemNumber] : false;
+        $this->matchedSiteAccess = isset( $match[$this->itemNumber] ) ? $match[$this->itemNumber] : false;
+        return $this->matchedSiteAccess;
     }
 
     /**

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIElement.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIElement.php
@@ -29,6 +29,13 @@ class URIElement implements VersatileMatcher, URILexer
     private $elementNumber;
 
     /**
+     * URI elements used for matching as an array.
+     *
+     * @var array
+     */
+    private $uriElements;
+
+    /**
      * Constructor.
      *
      * @param int $elementNumber Number of elements to take into account.
@@ -36,6 +43,11 @@ class URIElement implements VersatileMatcher, URILexer
     public function __construct( $elementNumber )
     {
         $this->elementNumber = (int)$elementNumber;
+    }
+
+    public function __sleep()
+    {
+        return array( 'elementNumber', 'uriElements' );
     }
 
     /**
@@ -63,6 +75,15 @@ class URIElement implements VersatileMatcher, URILexer
      */
     protected function getURIElements()
     {
+        if ( isset( $this->uriElements ) )
+        {
+            return $this->uriElements;
+        }
+        else if ( !isset( $this->request ) )
+        {
+            return array();
+        }
+
         $elements = array_slice(
             explode( "/", $this->request->pathinfo ),
             1,
@@ -79,7 +100,7 @@ class URIElement implements VersatileMatcher, URILexer
         if ( count( $elements ) !== $this->elementNumber )
             throw new LogicException( 'The number of provided elements to consider is different than the number of elements found in the URI' );
 
-        return $elements;
+        return $this->uriElements = $elements;
     }
 
     public function getName()

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Compound/CompoundAndTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Compound/CompoundAndTest.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\Compound;
 
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Compound\LogicalAnd;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Compound;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
@@ -313,5 +314,18 @@ class CompoundAndTest extends PHPUnit_Framework_TestCase
         {
             $this->assertInstanceOf( 'eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher', $subMatcher );
         }
+    }
+
+    public function testSerialize()
+    {
+        $matcher = new LogicalAnd( array() );
+        $matcher->setRequest( new SimplifiedRequest( array( 'pathinfo' => '/foo/bar' ) ) );
+        $sa = new SiteAccess( 'test', 'test', $matcher );
+        $serializedSA1 = serialize( $sa );
+
+        $matcher->setRequest( new SimplifiedRequest( array( 'pathinfo' => '/foo/bar/baz' ) ) );
+        $serializedSA2 = serialize( $sa );
+
+        $this->assertSame( $serializedSA1, $serializedSA2 );
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Compound/CompoundOrTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Compound/CompoundOrTest.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\Compound;
 
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Compound\LogicalOr;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Compound;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
@@ -319,5 +320,18 @@ class CompoundOrTest extends PHPUnit_Framework_TestCase
         {
             $this->assertInstanceOf( 'eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher', $subMatcher );
         }
+    }
+
+    public function testSerialize()
+    {
+        $matcher = new LogicalOr( array() );
+        $matcher->setRequest( new SimplifiedRequest( array( 'pathinfo' => '/foo/bar' ) ) );
+        $sa = new SiteAccess( 'test', 'test', $matcher );
+        $serializedSA1 = serialize( $sa );
+
+        $matcher->setRequest( new SimplifiedRequest( array( 'pathinfo' => '/foo/bar/baz' ) ) );
+        $serializedSA2 = serialize( $sa );
+
+        $this->assertSame( $serializedSA1, $serializedSA2 );
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostElementTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostElementTest.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\HostElement;
 use PHPUnit_Framework_TestCase;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
@@ -156,5 +157,18 @@ class RouterHostElementTest extends PHPUnit_Framework_TestCase
         $matcher = new HostElement( 3 );
         $matcher->setRequest( new SimplifiedRequest( array( 'host' => 'ez.no' ) ) );
         $this->assertNull( $matcher->reverseMatch( 'foo' ) );
+    }
+
+    public function testSerialize()
+    {
+        $matcher = new HostElement( 1 );
+        $matcher->setRequest( new SimplifiedRequest( array( 'host' => 'ez.no', 'pathinfo' => '/foo/bar' ) ) );
+        $sa = new SiteAccess( 'test', 'test', $matcher );
+        $serializedSA1 = serialize( $sa );
+
+        $matcher->setRequest( new SimplifiedRequest( array( 'host' => 'ez.no', 'pathinfo' => '/foo/bar/baz' ) ) );
+        $serializedSA2 = serialize( $sa );
+
+        $this->assertSame( $serializedSA1, $serializedSA2 );
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElement2Test.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElement2Test.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use PHPUnit_Framework_TestCase;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIElement as URIElementMatcher;
@@ -191,5 +192,18 @@ class RouterURIElement2Test extends PHPUnit_Framework_TestCase
         $matcher = new URIElementMatcher( 2 );
         $matcher->setRequest( new SimplifiedRequest( array( 'pathinfo' => "/my/siteaccess/foo/bar" ) ) );
         $this->assertNull( $matcher->reverseMatch( 'another_siteaccess_again_dont_tell_me' ) );
+    }
+
+    public function testSerialize()
+    {
+        $matcher = new URIElementMatcher( 2 );
+        $matcher->setRequest( new SimplifiedRequest( array( 'pathinfo' => '/foo/bar' ) ) );
+        $sa = new SiteAccess( 'test', 'test', $matcher );
+        $serializedSA1 = serialize( $sa );
+
+        $matcher->setRequest( new SimplifiedRequest( array( 'pathinfo' => '/foo/bar/baz' ) ) );
+        $serializedSA2 = serialize( $sa );
+
+        $this->assertSame( $serializedSA1, $serializedSA2 );
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElementTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElementTest.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use PHPUnit_Framework_TestCase;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIElement as URIElementMatcher;
@@ -179,5 +180,18 @@ class RouterURIElementTest extends PHPUnit_Framework_TestCase
             array( 'another_siteaccess', '/foo/bar' ),
             array( 'another_siteaccess_again_dont_tell_me', '/foo/bar' ),
         );
+    }
+
+    public function testSerialize()
+    {
+        $matcher = new URIElementMatcher( 1 );
+        $matcher->setRequest( new SimplifiedRequest( array( 'pathinfo' => '/foo/bar' ) ) );
+        $sa = new SiteAccess( 'test', 'test', $matcher );
+        $serializedSA1 = serialize( $sa );
+
+        $matcher->setRequest( new SimplifiedRequest( array( 'pathinfo' => '/foo/bar/baz' ) ) );
+        $serializedSA2 = serialize( $sa );
+
+        $this->assertSame( $serializedSA1, $serializedSA2 );
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIRegexTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIRegexTest.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use PHPUnit_Framework_TestCase;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Regex\URI as RegexMatcher;
@@ -125,5 +126,23 @@ class RouterURIRegexTest extends PHPUnit_Framework_TestCase
     {
         $matcher = new RegexMatcher( array(), array() );
         $this->assertSame( 'uri:regexp', $matcher->getName() );
+    }
+
+    public function testSerialize()
+    {
+        $matcher = new RegexMatcher(
+            array(
+                'regex' => '^/foo(\\w+)bar',
+                'itemNumber' => 2
+            )
+        );
+        $matcher->setRequest( new SimplifiedRequest( array( 'pathinfo' => '/foo/bar' ) ) );
+        $sa = new SiteAccess( 'test', 'test', $matcher );
+        $serializedSA1 = serialize( $sa );
+
+        $matcher->setRequest( new SimplifiedRequest( array( 'pathinfo' => '/foo/bar/baz' ) ) );
+        $serializedSA2 = serialize( $sa );
+
+        $this->assertSame( $serializedSA1, $serializedSA2 );
     }
 }


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23834

Cause of ESIs not being shareable amon pages (within the same SiteAccess) was the presence of SimplifiedRequest object, containing current `pathinfo`, which is most of the time not really needed.

This PR makes SiteAccess matchers not serializing the inner request when being serialized (done when generating ESI URL).