### PR TITLE
Fix EZP-23923: ESI/Hinclude URI too long with Compound siteaccess matcher

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Compound.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Compound.php
@@ -144,6 +144,7 @@ abstract class Compound implements CompoundInterface, URILexer
     public function __sleep()
     {
         // We don't need the whole matcher map and the matcher builder once serialized.
-        return array( 'config', 'subMatchers' );
+        // config property is not needed either as it's only needed for matching.
+        return array( 'subMatchers' );
     }
 }


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23923

In compound SiteAccess matchers, it's not needed to keep defined config during serialization. Keeping it can lead to very long URLs for subrequests, potentially exceeding 2048 characters, which make Hinclude requests hardly usable.