### PR TITLE
Fix EZP-23930: Adapt HttpCache to comply FOSHttpCacheBundle 1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "doctrine/doctrine-bundle": "~1.3",
         "liip/imagine-bundle": "~1.0",
         "oneup/flysystem-bundle": "~0.4",
-        "friendsofsymfony/http-cache-bundle": "~1.1",
+        "friendsofsymfony/http-cache-bundle": "~1.2",
         "symfony/expression-language": "~2.4",
         "sensio/framework-extra-bundle": "~3.0"
     },

--- a/eZ/Bundle/EzPublishCoreBundle/HttpCache.php
+++ b/eZ/Bundle/EzPublishCoreBundle/HttpCache.php
@@ -11,16 +11,13 @@ namespace eZ\Bundle\EzPublishCoreBundle;
 
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\LocationAwareStore;
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\RequestAwarePurger;
-use FOS\HttpCacheBundle\HttpCache as BaseHttpCache;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\SymfonyCache\UserContextSubscriber;
+use FOS\HttpCacheBundle\SymfonyCache\EventDispatchingHttpCache;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 
-abstract class HttpCache extends BaseHttpCache
+abstract class HttpCache extends EventDispatchingHttpCache
 {
-    const USER_HASH_HEADER = 'X-User-Hash';
-
-    const SESSION_NAME_PREFIX = 'eZSESSID';
-
     protected function createStore()
     {
         return new LocationAwareStore( $this->cacheDir ?: $this->kernel->getCacheDir() . '/http_cache' );
@@ -115,10 +112,8 @@ abstract class HttpCache extends BaseHttpCache
         return array( '127.0.0.1', '::1', 'fe80::1' );
     }
 
-    protected function cleanupForwardRequest( Request $forwardReq, Request $originalRequest )
+    protected function getDefaultSubscribers()
     {
-        parent::cleanupForwardRequest( $forwardReq, $originalRequest );
-        // Embed the original request as we need it to match the SiteAccess.
-        $forwardReq->attributes->set( '_ez_original_request', $originalRequest );
+        return [new UserContextSubscriber( ['user_hash_header' => 'X-User-Hash', 'session_name_prefix' => 'eZSESSID'] )];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SymfonyCache/UserContextSubscriber.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SymfonyCache/UserContextSubscriber.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\SymfonyCache;
+
+use FOS\HttpCache\SymfonyCache\UserContextSubscriber as BaseUserContextSubscriber;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Extends UserContextSubscriber from FOSHttpCache to include original request.
+ *
+ * {@inheritdoc}
+ */
+class UserContextSubscriber extends BaseUserContextSubscriber
+{
+    protected function cleanupHashLookupRequest( Request $hashLookupRequest, Request $originalRequest )
+    {
+        parent::cleanupHashLookupRequest( $hashLookupRequest, $originalRequest );
+        // Embed the original request as we need it to match the SiteAccess.
+        $hashLookupRequest->attributes->set( '_ez_original_request', $originalRequest );
+    }
+}


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23930

This PR fixes the [BC break introduced in FOSHttpCacheBundle 1.2.0](https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/blob/master/CHANGELOG.md#120).
Also bumps FOSHttpCacheBundle requirement to `~1.2` (composer update needed).

Should unblock https://github.com/ezsystems/ezpublish-community/pull/223 and https://github.com/ezsystems/ezpublish-community/pull/224

**Important**:
* Only affects Symfony reverse proxy
* New maintenance sub-releases needed: `2014.11.8`, `2015.01.1`, `5.4.1.1`