### PR TITLE
EZP-24047: Allow skipping count query when using SearchService against db

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -826,6 +826,110 @@ class SearchServiceTest extends BaseTest
         );
     }
 
+    public function testFindNoPerformCount()
+    {
+        $repository    = $this->getRepository();
+        $searchService = $repository->getSearchService();
+
+        $query = new Query();
+        $query->performCount = false;
+        $query->query = new Criterion\ContentTypeId(
+            array( 4 )
+        );
+
+        $searchHit = $searchService->findContent( $query );
+
+        if ( ltrim( get_class( $this->getSetupFactory() ), '\\' ) === 'eZ\Publish\API\Repository\Tests\SetupFactory\Legacy' )
+        {
+            $this->assertEquals(
+                null,
+                $searchHit->totalCount
+            );
+        }
+        else
+        {
+            $this->assertEquals(
+                2,
+                $searchHit->totalCount
+            );
+        }
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testFindNoPerformCountException()
+    {
+        if ( ltrim( get_class( $this->getSetupFactory() ), '\\' ) !== 'eZ\Publish\API\Repository\Tests\SetupFactory\Legacy' )
+        {
+            $this->markTestSkipped( "Only applicable to Legacy/DB based search" );
+        }
+
+        $repository    = $this->getRepository();
+        $searchService = $repository->getSearchService();
+
+        $query = new Query();
+        $query->performCount = false;
+        $query->limit = 0;
+        $query->query = new Criterion\ContentTypeId(
+            array( 4 )
+        );
+
+        $searchService->findContent( $query );
+    }
+
+    public function testFindLocationsNoPerformCount()
+    {
+        $repository    = $this->getRepository();
+        $searchService = $repository->getSearchService();
+
+        $query = new LocationQuery();
+        $query->performCount = false;
+        $query->query = new Criterion\ContentTypeId(
+            array( 4 )
+        );
+
+        $searchHit = $searchService->findLocations( $query );
+
+        if ( ltrim( get_class( $this->getSetupFactory() ), '\\' ) === 'eZ\Publish\API\Repository\Tests\SetupFactory\Legacy' )
+        {
+            $this->assertEquals(
+                null,
+                $searchHit->totalCount
+            );
+        }
+        else
+        {
+            $this->assertEquals(
+                2,
+                $searchHit->totalCount
+            );
+        }
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testFindLocationsNoPerformCountException()
+    {
+        if ( ltrim( get_class( $this->getSetupFactory() ), '\\' ) !== 'eZ\Publish\API\Repository\Tests\SetupFactory\Legacy' )
+        {
+            $this->markTestSkipped( "Only applicable to Legacy/DB based search" );
+        }
+
+        $repository    = $this->getRepository();
+        $searchService = $repository->getSearchService();
+
+        $query = new LocationQuery();
+        $query->performCount = false;
+        $query->limit = 0;
+        $query->query = new Criterion\ContentTypeId(
+            array( 4 )
+        );
+
+        $searchService->findLocations( $query );
+    }
+
     /**
      * Create test Content with ezcountry field having multiple countries selected.
      *

--- a/eZ/Publish/API/Repository/Values/Content/Query.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query.php
@@ -94,6 +94,13 @@ class Query extends ValueObject
     public $spellcheck;
 
     /**
+     * If true, search engine should perform count even if that means extra lookup.
+     *
+     * @var boolean
+     */
+    public $performCount = true;
+
+    /**
      * Wrapper for deprecated $criterion property
      *
      * @param string $property

--- a/eZ/Publish/API/Repository/Values/Content/Search/SearchResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/SearchResult.php
@@ -62,7 +62,9 @@ class SearchResult extends ValueObject
     /**
      * The total number of searchHits
      *
-     * @var int
+     * `null` if Query->performCount was set to false and search engine avoids search lookup.
+     *
+     * @var int|null
      */
     public $totalCount;
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway.php
@@ -27,9 +27,10 @@ abstract class Gateway
      * @param int|null $limit
      * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sort
      * @param string[] $translations
+     * @param bool $doCount
      *
      * @return mixed[][]
      */
-    abstract public function find( Criterion $criterion, $offset = 0, $limit = null, array $sort = null, array $translations = null );
+    abstract public function find( Criterion $criterion, $offset = 0, $limit = null, array $sort = null, array $translations = null, $doCount = true );
 }
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/ExceptionConversion.php
@@ -46,16 +46,17 @@ class ExceptionConversion extends Gateway
      * @param int|null $limit
      * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sort
      * @param string[] $translations
+     * @param bool $doCount
      *
      * @throws \RuntimeException
      *
      * @return mixed[][]
      */
-    public function find( Criterion $criterion, $offset = 0, $limit = null, array $sort = null, array $translations = null )
+    public function find( Criterion $criterion, $offset = 0, $limit = null, array $sort = null, array $translations = null, $doCount = true )
     {
         try
         {
-            return $this->innerGateway->find( $criterion, $offset, $limit, $sort, $translations );
+            return $this->innerGateway->find( $criterion, $offset, $limit, $sort, $translations, $doCount );
         }
         catch ( DBALException $e )
         {

--- a/eZ/Publish/Core/Search/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Handler.php
@@ -98,7 +98,7 @@ class Handler implements SearchHandlerInterface
         // combine the query with the filter
         $filter = new Criterion\LogicalAnd( array( $query->query, $query->filter ) );
 
-        $data = $this->gateway->find( $filter, $query->offset, $query->limit, $query->sortClauses, null );
+        $data = $this->gateway->find( $filter, $query->offset, $query->limit, $query->sortClauses, null, $query->performCount );
 
         $result = new SearchResult();
         $result->time = microtime( true ) - $start;
@@ -135,12 +135,13 @@ class Handler implements SearchHandlerInterface
         $searchQuery->filter = $filter;
         $searchQuery->query  = new Criterion\MatchAll();
         $searchQuery->offset = 0;
-        $searchQuery->limit  = 1;
+        $searchQuery->limit  = 2;// Because we optimize away the count query below
+        $searchQuery->performCount = true;
         $result = $this->findContent( $searchQuery, $fieldFilters );
 
-        if ( !$result->totalCount )
+        if ( empty( $result->searchHits ) )
             throw new NotFoundException( 'Content', "findSingle() found no content for given \$criterion" );
-        else if ( $result->totalCount > 1 )
+        else if ( isset( $result->searchHits[1] ) )
             throw new InvalidArgumentException( "totalCount", "findSingle() found more then one item for given \$criterion" );
 
         $first = reset( $result->searchHits );

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway.php
@@ -24,8 +24,9 @@ abstract class Gateway
      * @param int $offset
      * @param int|null $limit
      * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sortClauses
+     * @param bool $doCount
      *
      * @return mixed[][]
      */
-    abstract public function find( Criterion $criterion, $offset = 0, $limit = null, array $sortClauses = null );
+    abstract public function find( Criterion $criterion, $offset = 0, $limit = null, array $sortClauses = null, $doCount = true );
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -88,7 +88,7 @@ class DoctrineDatabase extends Gateway
     {
         $fieldMap = $this->getFieldMap( $sortClauses );
         $count = $this->getTotalCount( $criterion, $sortClauses, $fieldMap );
-        if ( $limit === 0 )
+        if ( $limit === 0 || $count <= $offset )
         {
             return array( "count" => $count, "rows" => array() );
         }

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -81,14 +81,21 @@ class DoctrineDatabase extends Gateway
      * @param int $offset
      * @param int|null $limit
      * @param null|\eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sortClauses
+     * @param bool $doCount
      *
      * @return mixed[][]
      */
-    public function find( Criterion $criterion, $offset = 0, $limit = null, array $sortClauses = null )
+    public function find( Criterion $criterion, $offset = 0, $limit = null, array $sortClauses = null, $doCount = true )
     {
         $fieldMap = $this->getFieldMap( $sortClauses );
-        $count = $this->getTotalCount( $criterion, $sortClauses, $fieldMap );
-        if ( $limit === 0 || $count <= $offset )
+        $count = $doCount ? $this->getTotalCount( $criterion, $sortClauses, $fieldMap ) : null;
+
+        if ( !$doCount && $limit === 0 )
+        {
+            throw new \RuntimeException( "Invalid query, can not disable count and request 0 items at the same time" );
+        }
+
+        if ( $limit === 0 || ( $count !== null && $count <= $offset ) )
         {
             return array( "count" => $count, "rows" => array() );
         }

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/ExceptionConversion.php
@@ -45,14 +45,17 @@ class ExceptionConversion extends Gateway
      * @param int $offset
      * @param int|null $limit
      * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sortClauses
+     * @param bool $doCount
+     *
+     * @throws \RuntimeException
      *
      * @return mixed[][]
      */
-    public function find( Criterion $criterion, $offset = 0, $limit = null, array $sortClauses = null )
+    public function find( Criterion $criterion, $offset = 0, $limit = null, array $sortClauses = null, $doCount = true )
     {
         try
         {
-            return $this->innerGateway->find( $criterion, $offset, $limit, $sortClauses );
+            return $this->innerGateway->find( $criterion, $offset, $limit, $sortClauses, $doCount );
         }
         catch ( DBALException $e )
         {

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Handler.php
@@ -70,7 +70,8 @@ class Handler implements LocationSearchHandler
             new Criterion\LogicalAnd( array( $query->query, $query->filter ) ),
             $query->offset,
             $query->limit,
-            $query->sortClauses
+            $query->sortClauses,
+            $query->performCount
         );
 
         $result = new SearchResult();


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-24047
see: http://share.ez.no/forums/ez-publish-5-platform/about-searchservice-and-count-queries

Test ping @crevillo, using  ~~$fieldFilters['perform_extra_count'] = false~~ `$query->performCount = false`