### PR TITLE
Fix EZP-23694: Solr: refactor FieldMap implementation for caching and multiple fields support

### DIFF
--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/CriterionVisitor/Field.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/CriterionVisitor/Field.php
@@ -12,6 +12,7 @@ namespace eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor;
 use eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor;
 use eZ\Publish\Core\Persistence\Solr\Content\Search\FieldMap;
 use eZ\Publish\API\Repository\Values\Content\Query\CustomFieldInterface;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 /**
  * Visits the Field criterion
@@ -38,13 +39,27 @@ abstract class Field extends CriterionVisitor
     }
 
     /**
-     * Get field type information
+     * Get field names
      *
-     * @param CustomFieldInterface $criterion
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param string $fieldDefinitionIdentifier
+     * @param string $fieldTypeIdentifier
+     * @param string $name
+     *
      * @return array
      */
-    protected function getFieldTypes( CustomFieldInterface $criterion )
+    protected function getFieldNames(
+        Criterion $criterion,
+        $fieldDefinitionIdentifier,
+        $fieldTypeIdentifier = null,
+        $name = null
+    )
     {
-        return $this->fieldMap->getFieldTypes( $criterion );
+        return $this->fieldMap->getFieldNames(
+            $criterion,
+            $fieldDefinitionIdentifier,
+            $fieldTypeIdentifier,
+            $name
+        );
     }
 }

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/CriterionVisitor/Field/FieldIn.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/CriterionVisitor/Field/FieldIn.php
@@ -48,11 +48,9 @@ class FieldIn extends Field
      */
     public function visit( Criterion $criterion, CriterionVisitor $subVisitor = null )
     {
-        $fieldTypes = $this->getFieldTypes( $criterion );
+        $fieldNames = $this->getFieldNames( $criterion, $criterion->target );
 
-        $criterion->value = (array)$criterion->value;
-
-        if ( !isset( $fieldTypes[$criterion->target] ) )
+        if ( empty( $fieldNames ) )
         {
             throw new InvalidArgumentException(
                 "\$criterion->target",
@@ -60,15 +58,14 @@ class FieldIn extends Field
             );
         }
 
+        $criterion->value = (array)$criterion->value;
+
         $queries = array();
         foreach ( $criterion->value as $value )
         {
-            foreach ( $fieldTypes[$criterion->target] as $names )
+            foreach ( $fieldNames as $name )
             {
-                foreach ( $names as $name )
-                {
-                    $queries[] = $name . ':"' . $value . '"';
-                }
+                $queries[] = $name . ':"' . $value . '"';
             }
         }
 

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/CriterionVisitor/Field/FieldRange.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/CriterionVisitor/Field/FieldRange.php
@@ -60,10 +60,10 @@ class FieldRange extends Field
             $start = null;
         }
 
-        $fieldTypes = $this->getFieldTypes( $criterion );
+        $fieldNames = $this->getFieldNames( $criterion, $criterion->target );
         $criterion->value = (array)$criterion->value;
 
-        if ( !isset( $fieldTypes[$criterion->target] ) )
+        if ( empty( $fieldNames ) )
         {
             throw new InvalidArgumentException(
                 "\$criterion->target",
@@ -72,12 +72,9 @@ class FieldRange extends Field
         }
 
         $queries = array();
-        foreach ( $fieldTypes[$criterion->target] as $names )
+        foreach ( $fieldNames as $name )
         {
-            foreach ( $names as $name )
-            {
-                $queries[] = $name . ':' . $this->getRange( $criterion->operator, $start, $end );
-            }
+            $queries[] = $name . ':' . $this->getRange( $criterion->operator, $start, $end );
         }
 
         return '(' . implode( ' OR ', $queries ) . ')';

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/CriterionVisitor/FullText.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/CriterionVisitor/FullText.php
@@ -38,6 +38,19 @@ class FullText extends CriterionVisitor
     }
 
     /**
+     * Get field type information
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param string $fieldDefinitionIdentifier
+     *
+     * @return array
+     */
+    protected function getFieldNames( Criterion $criterion, $fieldDefinitionIdentifier )
+    {
+        return $this->fieldMap->getFieldNames( $criterion, $fieldDefinitionIdentifier );
+    }
+
+    /**
      * CHeck if visitor is applicable to current criterion
      *
      * @param Criterion $criterion
@@ -65,19 +78,11 @@ class FullText extends CriterionVisitor
 
         foreach ( $criterion->boost as $field => $boost )
         {
-            $fields = $this->fieldMap->getFieldTypes( $criterion );
+            $fieldNames = $this->getFieldNames( $criterion, $field );
 
-            if ( !isset( $fields[$field] ) )
+            foreach ( $fieldNames as $name )
             {
-                continue;
-            }
-
-            foreach ( $fields[$field] as $fieldNames )
-            {
-                foreach ( $fieldNames as $fieldName )
-                {
-                    $queries[] = $fieldName . ":" . $criterion->value . "^" . $boost;
-                }
+                $queries[] = $name . ":" . $criterion->value . "^" . $boost;
             }
         }
 

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/CriterionVisitor/MapLocation.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/CriterionVisitor/MapLocation.php
@@ -12,6 +12,7 @@ namespace eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor;
 use eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor;
 use eZ\Publish\Core\Persistence\Solr\Content\Search\FieldMap;
 use eZ\Publish\API\Repository\Values\Content\Query\CustomFieldInterface;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 /**
  * Visits the MapLocation criterion
@@ -26,30 +27,56 @@ abstract class MapLocation extends CriterionVisitor
     protected $fieldMap;
 
     /**
-     * Name of the field type that criterion can handle
+     * Identifier of the field type that criterion can handle
      *
      * @var string
      */
-    protected $typeName = "ez_geolocation";
+    protected $fieldTypeIdentifier;
 
     /**
-     * Create from content type handler and field registry
+     * Name of the field type's indexed field that criterion can handle
+     *
+     * @var string
+     */
+    protected $fieldName;
+
+    /**
+     * Create from FieldMap, FieldType identifier and field name.
      *
      * @param \eZ\Publish\Core\Persistence\Solr\Content\Search\FieldMap $fieldMap
+     * @param string $fieldTypeIdentifier
+     * @param string $fieldName
      */
-    public function __construct( FieldMap $fieldMap )
+    public function __construct( FieldMap $fieldMap, $fieldTypeIdentifier, $fieldName )
     {
+        $this->fieldTypeIdentifier = $fieldTypeIdentifier;
+        $this->fieldName = $fieldName;
+
         $this->fieldMap = $fieldMap;
     }
 
     /**
-     * Get field type information
+     * Get field names
      *
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\CustomFieldInterface $criterion
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param string $fieldDefinitionIdentifier
+     * @param string $fieldTypeIdentifier
+     * @param string $name
+     *
      * @return array
      */
-    protected function getFieldTypes( CustomFieldInterface $criterion )
+    protected function getFieldNames(
+        Criterion $criterion,
+        $fieldDefinitionIdentifier,
+        $fieldTypeIdentifier = null,
+        $name = null
+    )
     {
-        return $this->fieldMap->getFieldTypes( $criterion );
+        return $this->fieldMap->getFieldNames(
+            $criterion,
+            $fieldDefinitionIdentifier,
+            $fieldTypeIdentifier,
+            $name
+        );
     }
 }

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/CriterionVisitor/MapLocation/MapLocationDistanceIn.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/CriterionVisitor/MapLocation/MapLocationDistanceIn.php
@@ -49,11 +49,16 @@ class MapLocationDistanceIn extends MapLocation
     {
         /** @var \eZ\Publish\API\Repository\Values\Content\Query\Criterion\Value\MapLocationValue $location */
         $location = $criterion->valueData;
-        $fieldTypes = $this->getFieldTypes( $criterion );
         $criterion->value = (array)$criterion->value;
 
-        if ( !isset( $fieldTypes[$criterion->target][$this->typeName] ) &&
-            !isset( $fieldTypes[$criterion->target]["custom"] ) )
+        $fieldNames = $this->getFieldNames(
+            $criterion,
+            $criterion->target,
+            $this->fieldTypeIdentifier,
+            $this->fieldName
+        );
+
+        if ( empty( $fieldNames ) )
         {
             throw new InvalidArgumentException(
                 "\$criterion->target",
@@ -61,19 +66,10 @@ class MapLocationDistanceIn extends MapLocation
             );
         }
 
-        if ( isset( $fieldTypes[$criterion->target]["custom"] ) )
-        {
-            $names = $fieldTypes[$criterion->target]["custom"];
-        }
-        else
-        {
-            $names = $fieldTypes[$criterion->target][$this->typeName];
-        }
-
         $queries = array();
         foreach ( $criterion->value as $value )
         {
-            foreach ( $names as $name )
+            foreach ( $fieldNames as $name )
             {
                 $queries[] = "geodist({$name},{$location->latitude},{$location->longitude}):{$value}";
             }

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/CriterionVisitor/MapLocation/MapLocationDistanceRange.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/CriterionVisitor/MapLocation/MapLocationDistanceRange.php
@@ -62,10 +62,14 @@ class MapLocationDistanceRange extends MapLocation
             $start = null;
         }
 
-        $fieldTypes = $this->getFieldTypes( $criterion );
+        $fieldNames = $this->getFieldNames(
+            $criterion,
+            $criterion->target,
+            $this->fieldTypeIdentifier,
+            $this->fieldName
+        );
 
-        if ( !isset( $fieldTypes[$criterion->target][$this->typeName] ) &&
-            !isset( $fieldTypes[$criterion->target]["custom"] ) )
+        if ( empty( $fieldNames ) )
         {
             throw new InvalidArgumentException(
                 "\$criterion->target",
@@ -76,17 +80,8 @@ class MapLocationDistanceRange extends MapLocation
         /** @var \eZ\Publish\API\Repository\Values\Content\Query\Criterion\Value\MapLocationValue $location */
         $location = $criterion->valueData;
 
-        if ( isset( $fieldTypes[$criterion->target]["custom"] ) )
-        {
-            $names = $fieldTypes[$criterion->target]["custom"];
-        }
-        else
-        {
-            $names = $fieldTypes[$criterion->target][$this->typeName];
-        }
-
         $queries = array();
-        foreach ( $names as $name )
+        foreach ( $fieldNames as $name )
         {
             // @todo in future it should become possible to specify ranges directly on the filter (donut shape)
             $query = "{!geofilt sfield={$name} pt={$location->latitude},{$location->longitude} d={$end}}";

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/FieldMap.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/FieldMap.php
@@ -11,6 +11,9 @@ namespace eZ\Publish\Core\Persistence\Solr\Content\Search;
 
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
 use eZ\Publish\API\Repository\Values\Content\Query\CustomFieldInterface;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use RuntimeException;
 
 /**
  * Provides field mapping information
@@ -34,7 +37,7 @@ class FieldMap
     /**
      * Field name generator
      *
-     * @var \eZ\Publish\Core\Persistence\Solr\Content\Search\FieldNameGenerator
+     * @var \eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\FieldNameGenerator
      */
     protected $nameGenerator;
 
@@ -52,11 +55,15 @@ class FieldMap
      * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
      * @param \eZ\Publish\Core\Persistence\Solr\Content\Search\FieldNameGenerator $nameGenerator
      */
-    public function __construct( FieldRegistry $fieldRegistry, ContentTypeHandler $contentTypeHandler, FieldNameGenerator $nameGenerator )
+    public function __construct(
+        FieldRegistry $fieldRegistry,
+        ContentTypeHandler $contentTypeHandler,
+        FieldNameGenerator $nameGenerator
+    )
     {
-        $this->fieldRegistry      = $fieldRegistry;
+        $this->fieldRegistry = $fieldRegistry;
         $this->contentTypeHandler = $contentTypeHandler;
-        $this->nameGenerator      = $nameGenerator;
+        $this->nameGenerator = $nameGenerator;
     }
 
     /**
@@ -66,19 +73,17 @@ class FieldMap
      *
      * <code>
      *  array(
-     *      "field-identifier" => array(
-     *          "solr_field_name",
+     *      "content-type-identifier" => array(
+     *          "field-definition-identifier" => "field-type-identifier",
      *          …
      *      ),
      *      …
      *  )
      * </code>
      *
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\CustomFieldInterface $criterion
-     *
      * @return array
      */
-    public function getFieldTypes( CustomFieldInterface $criterion )
+    protected function getFieldMap()
     {
         // @TODO: temp fixed by disabling caching, see https://jira.ez.no/browse/EZP-22834
         $this->fieldTypes = array();
@@ -94,25 +99,175 @@ class FieldMap
                         continue;
                     }
 
-                    if ( $customField = $criterion->getCustomField( $contentType->identifier, $fieldDefinition->identifier ) )
-                    {
-                        $this->fieldTypes[$fieldDefinition->identifier]["custom"][] = $customField;
-                        continue;
-                    }
-
-                    $fieldType = $this->fieldRegistry->getType( $fieldDefinition->fieldType );
-                    foreach ( $fieldType->getIndexDefinition() as $name => $type )
-                    {
-                        $this->fieldTypes[$fieldDefinition->identifier][$type->type][] =
-                            $this->nameGenerator->getTypedName(
-                                $this->nameGenerator->getName( $name, $fieldDefinition->identifier, $contentType->identifier ),
-                                $type
-                            );
-                    }
+                    $this->fieldTypes[$contentType->identifier][$fieldDefinition->identifier] =
+                        $fieldDefinition->fieldType;
                 }
             }
         }
 
         return $this->fieldTypes;
+    }
+
+    /**
+     * For the given parameters returns a set of index storage field names to search on.
+     *
+     * The method will check for custom fields if given $criterion implements
+     * CustomFieldInterface. With optional parameters $fieldTypeIdentifier and
+     * $name specific field type and field from its Indexable implementation
+     * can be targeted.
+     *
+     * @see \eZ\Publish\API\Repository\Values\Content\Query\CustomFieldInterface
+     * @see \eZ\Publish\SPI\FieldType\Indexable
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param string $fieldDefinitionIdentifier
+     * @param string $fieldTypeIdentifier
+     * @param string $name
+     *
+     * @return array
+     */
+    public function getFieldNames(
+        Criterion $criterion,
+        $fieldDefinitionIdentifier,
+        $fieldTypeIdentifier = null,
+        $name = null
+    )
+    {
+        $fieldMap = $this->getFieldMap();
+        $fieldNames = array();
+
+        foreach ( $fieldMap as $contentTypeIdentifier => $fieldIdentifierMap )
+        {
+            // First check if field exists in the current ContentType, there is nothing to do if it doesn't
+            if ( !isset( $fieldIdentifierMap[$fieldDefinitionIdentifier] ) )
+            {
+                continue;
+            }
+
+            // If $fieldTypeIdentifier is given it must match current field definition
+            if (
+                $fieldTypeIdentifier !== null &&
+                $fieldTypeIdentifier !== $fieldIdentifierMap[$fieldDefinitionIdentifier]
+            )
+            {
+                continue;
+            }
+
+            $fieldNames[] = $this->getIndexFieldName(
+                $criterion,
+                $contentTypeIdentifier,
+                $fieldDefinitionIdentifier,
+                $fieldIdentifierMap[$fieldDefinitionIdentifier],
+                $name
+            );
+        }
+
+        return $fieldNames;
+    }
+
+    /**
+     * For the given parameters returns index storage field name to sort on or
+     * null if the field could not be found.
+     *
+     * The method will check for custom fields if given $sortClause implements
+     * CustomFieldInterface. With optional parameter $name specific field from
+     * field type's Indexable implementation can be targeted.
+     *
+     * Will return null if no sortable field is found.
+     *
+     * @see \eZ\Publish\API\Repository\Values\Content\Query\CustomFieldInterface
+     * @see \eZ\Publish\SPI\FieldType\Indexable
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
+     * @param string $contentTypeIdentifier
+     * @param string $fieldDefinitionIdentifier
+     * @param string $name
+     *
+     * @return null|string
+     */
+    public function getSortFieldName(
+        SortClause $sortClause,
+        $contentTypeIdentifier,
+        $fieldDefinitionIdentifier,
+        $name = null
+    )
+    {
+        $fieldMap = $this->getFieldMap();
+
+        // First check if field exists in type, there is nothing to do if it doesn't
+        if ( !isset( $fieldMap[$contentTypeIdentifier][$fieldDefinitionIdentifier] ) )
+        {
+            return null;
+        }
+
+        return $this->getIndexFieldName(
+            $sortClause,
+            $contentTypeIdentifier,
+            $fieldDefinitionIdentifier,
+            $fieldMap[$contentTypeIdentifier][$fieldDefinitionIdentifier],
+            $name
+        );
+    }
+
+    /**
+     * Returns index field name for the given parameters.
+     *
+     * @param object $criterionOrSortClause
+     * @param string $contentTypeIdentifier
+     * @param string $fieldDefinitionIdentifier
+     * @param string $fieldTypeIdentifier
+     * @param string $name
+     *
+     * @return mixed|string
+     */
+    public function getIndexFieldName(
+        $criterionOrSortClause,
+        $contentTypeIdentifier,
+        $fieldDefinitionIdentifier,
+        $fieldTypeIdentifier,
+        $name
+    )
+    {
+        // If criterion or sort clause implements CustomFieldInterface and custom field is set for
+        // ContentType/FieldDefinition, return it
+        if (
+            $criterionOrSortClause instanceof CustomFieldInterface &&
+            $customFieldName = $criterionOrSortClause->getCustomField(
+                $contentTypeIdentifier,
+                $fieldDefinitionIdentifier
+            )
+        )
+        {
+            return $customFieldName;
+        }
+
+        // Else, generate field name from field type's index definition
+
+        $indexFieldType = $this->fieldRegistry->getType( $fieldTypeIdentifier );
+
+        // If $name is not given use default search field name
+        if ( $name === null )
+        {
+            $name = $indexFieldType->getDefaultField();
+        }
+
+        $indexDefinition = $indexFieldType->getIndexDefinition();
+
+        // Should only happen by mistake, so let's throw if it does
+        if ( !isset( $indexDefinition[$name] ) )
+        {
+            throw new RuntimeException(
+                "Could not find '{$name}' field in '{$fieldTypeIdentifier}' field type's index definition"
+            );
+        }
+
+        return $this->nameGenerator->getTypedName(
+            $this->nameGenerator->getName(
+                $name,
+                $fieldDefinitionIdentifier,
+                $contentTypeIdentifier
+            ),
+            $indexDefinition[$name]
+        );
     }
 }

--- a/eZ/Publish/Core/Persistence/Solr/Tests/Content/Search/CriterionVisitor/FullTextTest.php
+++ b/eZ/Publish/Core/Persistence/Solr/Tests/Content/Search/CriterionVisitor/FullTextTest.php
@@ -20,11 +20,11 @@ use eZ\Publish\Core\Persistence\Solr\Content\Search\CriterionVisitor;
  */
 class FullTextTest extends TestCase
 {
-    protected function getFullTextCriterionVisitor()
+    protected function getFullTextCriterionVisitor( array $fieldNames = array() )
     {
         $fieldMap = $this->getMock(
             '\\eZ\\Publish\\Core\\Persistence\\Solr\\Content\\Search\\FieldMap',
-            array( 'getFieldTypes' ),
+            array( 'getFieldNames' ),
             array(),
             '',
             false
@@ -32,13 +32,13 @@ class FullTextTest extends TestCase
 
         $fieldMap
             ->expects( $this->any() )
-            ->method( 'getFieldTypes' )
+            ->method( 'getFieldNames' )
+            ->with(
+                $this->isInstanceOf( "eZ\\Publish\\API\\Repository\\Values\\Content\\Query\\Criterion" ),
+                $this->isType( "string" )
+            )
             ->will(
-                $this->returnValue(
-                    array(
-                        'title' => array( "ez_string" => array( 'title_1_s', 'title_2_s' ) )
-                    )
-                )
+                $this->returnValue( $fieldNames )
             );
 
         return new CriterionVisitor\FullText( $fieldMap );
@@ -71,7 +71,7 @@ class FullTextTest extends TestCase
 
     public function testVisitBoost()
     {
-        $visitor = $this->getFullTextCriterionVisitor();
+        $visitor = $this->getFullTextCriterionVisitor( array( 'title_1_s', 'title_2_s' ) );
 
         $criterion = new Criterion\FullText( "Hello" );
         $criterion->boost = array( 'title' => 2 );
@@ -99,7 +99,7 @@ class FullTextTest extends TestCase
 
     public function testVisitFuzzyBoost()
     {
-        $visitor = $this->getFullTextCriterionVisitor();
+        $visitor = $this->getFullTextCriterionVisitor( array( 'title_1_s', 'title_2_s' ) );
 
         $criterion = new Criterion\FullText( "Hello" );
         $criterion->fuzziness = .5;

--- a/eZ/Publish/Core/settings/storage_engines/solr/criterion_visitors.yml
+++ b/eZ/Publish/Core/settings/storage_engines/solr/criterion_visitors.yml
@@ -190,6 +190,8 @@ services:
         class: %ezpublish.persistence.solr.search.content.criterion_visitor.map_location_distance_in.class%
         arguments:
             - @ezpublish.persistence.solr.search.content.field_map
+            - 'ezgmaplocation'
+            - 'value_location'
         tags:
             - {name: ezpublish.persistence.solr.search.content.criterion_visitor}
 
@@ -197,6 +199,8 @@ services:
         class: %ezpublish.persistence.solr.search.content.criterion_visitor.map_location_distance_range.class%
         arguments:
             - @ezpublish.persistence.solr.search.content.field_map
+            - 'ezgmaplocation'
+            - 'value_location'
         tags:
             - {name: ezpublish.persistence.solr.search.content.criterion_visitor}
 

--- a/eZ/Publish/Core/settings/storage_engines/solr/sort_clause_visitors.yml
+++ b/eZ/Publish/Core/settings/storage_engines/solr/sort_clause_visitors.yml
@@ -67,6 +67,7 @@ services:
         class: %ezpublish.persistence.solr.search.content.sort_clause_visitor.map_location_distance.class%
         arguments:
             - @ezpublish.persistence.solr.search.content.field_map
+            - 'value_location'
         tags:
             - {name: ezpublish.persistence.solr.search.content.sort_clause_visitor}
 


### PR DESCRIPTION
This PR resolves issue https://jira.ez.no/browse/EZP-23694

This is Solr counterpart of https://jira.ez.no/browse/EZP-23465 (https://github.com/ezsystems/ezpublish-kernel/pull/1046). The PR is based on https://github.com/ezsystems/ezpublish-kernel/pull/1046 and will be reopened against master when https://github.com/ezsystems/ezpublish-kernel/pull/1046 is merged.

FieldMap implementation is here updated to be identical to the Elasticsearch's one from https://github.com/ezsystems/ezpublish-kernel/pull/1046. Separate implementation is kept for easier backporting, both implementations will be merged into a common search engine FieldMap when search is decoupled from Persistence (see https://jira.ez.no/browse/EZP-23940).