### PR TITLE
Fix EZP-23966: SPI: Introduce main handler for Search Engines

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/Handler.php
+++ b/eZ/Publish/Core/Persistence/Cache/Handler.php
@@ -158,7 +158,7 @@ class Handler implements PersistenceHandlerInterface
     }
 
     /**
-     * @return \eZ\Publish\SPI\Search\Handler
+     * @return \eZ\Publish\SPI\Search\Content\Handler
      */
     public function searchHandler()
     {

--- a/eZ/Publish/Core/Persistence/Cache/LocationSearchHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/LocationSearchHandler.php
@@ -11,7 +11,7 @@ namespace eZ\Publish\Core\Persistence\Cache;
 
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\SPI\Persistence\Content\Location;
-use eZ\Publish\SPI\Search\Location\Handler as LocationSearchHandlerInterface;
+use eZ\Publish\SPI\Search\Content\Location\Handler as LocationSearchHandlerInterface;
 
 /**
  * @see eZ\Publish\SPI\Search\Location\Handler

--- a/eZ/Publish/Core/Persistence/Cache/SearchHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/SearchHandler.php
@@ -10,17 +10,17 @@
 namespace eZ\Publish\Core\Persistence\Cache;
 
 use eZ\Publish\SPI\Persistence\Content;
-use eZ\Publish\SPI\Search\Handler as SearchHandlerInterface;
+use eZ\Publish\SPI\Search\Content\Handler as SearchHandlerInterface;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 /**
- * @see eZ\Publish\SPI\Search\Handler
+ * @see eZ\Publish\SPI\Search\Content\Handler
  */
 class SearchHandler extends AbstractHandler implements SearchHandlerInterface
 {
     /**
-     * @see eZ\Publish\SPI\Search\Handler::findContent
+     * @see eZ\Publish\SPI\Search\Content\Handler::findContent
      */
     function findContent( Query $query, array $fieldFilters = array() )
     {
@@ -29,7 +29,7 @@ class SearchHandler extends AbstractHandler implements SearchHandlerInterface
     }
 
     /**
-     * @see eZ\Publish\SPI\Search\Handler::findSingle
+     * @see eZ\Publish\SPI\Search\Content\Handler::findSingle
      */
     public function findSingle( Criterion $filter, array $fieldFilters = array() )
     {
@@ -38,7 +38,7 @@ class SearchHandler extends AbstractHandler implements SearchHandlerInterface
     }
 
     /**
-     * @see eZ\Publish\SPI\Search\Handler::suggest
+     * @see eZ\Publish\SPI\Search\Content\Handler::suggest
      */
     public function suggest( $prefix, $fieldPaths = array(), $limit = 10, Criterion $filter = null )
     {
@@ -56,7 +56,7 @@ class SearchHandler extends AbstractHandler implements SearchHandlerInterface
     }
 
     /**
-     * @see eZ\Publish\SPI\Search\Handler::indexContent
+     * @see eZ\Publish\SPI\Search\Content\Handler::indexContent
      */
     public function indexContent( Content $content )
     {
@@ -65,7 +65,7 @@ class SearchHandler extends AbstractHandler implements SearchHandlerInterface
     }
 
     /**
-     * @see eZ\Publish\SPI\Search\Handler::deleteContent
+     * @see eZ\Publish\SPI\Search\Content\Handler::deleteContent
      */
     public function deleteContent( $contentID, $versionID = null )
     {
@@ -74,7 +74,7 @@ class SearchHandler extends AbstractHandler implements SearchHandlerInterface
     }
 
     /**
-     * @see eZ\Publish\SPI\Search\Handler::deleteLocation
+     * @see eZ\Publish\SPI\Search\Content\Handler::deleteLocation
      */
     public function deleteLocation( $locationId, $contentId )
     {

--- a/eZ/Publish/Core/Persistence/Cache/Tests/PersistenceHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/PersistenceHandlerTest.php
@@ -47,7 +47,7 @@ class PersistenceHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects( $this->never() )->method( $this->anything() );
         $handler = $this->persistenceCacheHandler->searchHandler();
-        $this->assertInstanceOf( 'eZ\\Publish\\SPI\\Search\\Handler', $handler );
+        $this->assertInstanceOf( 'eZ\\Publish\\SPI\\Search\\Content\\Handler', $handler );
         $this->assertInstanceOf( 'eZ\\Publish\\Core\\Persistence\\Cache\\SearchHandler', $handler );
     }
 

--- a/eZ/Publish/Core/Persistence/Cache/Tests/SearchHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/SearchHandlerTest.php
@@ -56,7 +56,7 @@ class SearchHandlerTest extends HandlerTest
             ->expects( $this->never() )
             ->method( $this->anything() );
 
-        $innerHandler = $this->getMock( 'eZ\\Publish\\SPI\\Search\\Handler' );
+        $innerHandler = $this->getMock( 'eZ\\Publish\\SPI\\Search\\Content\\Handler' );
         $this->persistenceHandlerMock
             ->expects( $this->once() )
             ->method( 'searchHandler' )

--- a/eZ/Publish/Core/Persistence/Elasticsearch/Content/Search/Handler.php
+++ b/eZ/Publish/Core/Persistence/Elasticsearch/Content/Search/Handler.php
@@ -13,7 +13,7 @@ use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\Type;
-use eZ\Publish\SPI\Search\Handler as SearchHandlerInterface;
+use eZ\Publish\SPI\Search\Content\Handler as SearchHandlerInterface;
 use eZ\Publish\SPI\Search\FieldType;
 use eZ\Publish\SPI\Persistence\Content\Location;
 use eZ\Publish\SPI\Persistence\Content\Section;

--- a/eZ/Publish/Core/Persistence/Elasticsearch/Content/Search/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Elasticsearch/Content/Search/Location/Handler.php
@@ -11,7 +11,7 @@ namespace eZ\Publish\Core\Persistence\Elasticsearch\Content\Search\Location;
 
 use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\Location;
-use eZ\Publish\SPI\Search\Location\Handler as SearchHandlerInterface;
+use eZ\Publish\SPI\Search\Content\Location\Handler as SearchHandlerInterface;
 use eZ\Publish\SPI\Search\FieldType;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query;

--- a/eZ/Publish/Core/Persistence/Elasticsearch/Handler.php
+++ b/eZ/Publish/Core/Persistence/Elasticsearch/Handler.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\Elasticsearch;
+
+use eZ\Publish\SPI\Search\Handler as HandlerInterface;
+use eZ\Publish\SPI\Search\Content\Handler as ContentSearchHandler;
+use eZ\Publish\SPI\Search\Content\Location\Handler as LocationSearchHandler;
+
+/**
+ * The main handler for the Elasticsearch Search Engine
+ */
+class Handler implements HandlerInterface
+{
+    /**
+     * @var \eZ\Publish\SPI\Search\Content\Handler
+     */
+    protected $contentSearchHandler;
+
+    /**
+     * @var \eZ\Publish\SPI\Search\Content\Location\Handler
+     */
+    protected $locationSearchHandler;
+
+    public function __construct(
+        ContentSearchHandler $contentSearchHandler,
+        LocationSearchHandler $locationSearchHandler
+    )
+    {
+        $this->contentSearchHandler = $contentSearchHandler;
+        $this->locationSearchHandler = $locationSearchHandler;
+    }
+
+    public function contentSearchHandler()
+    {
+        return $this->contentSearchHandler;
+    }
+
+    public function locationSearchHandler()
+    {
+        return $this->locationSearchHandler;
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Search/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Search/Handler.php
@@ -10,7 +10,7 @@
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Search;
 
 use eZ\Publish\SPI\Persistence\Content;
-use eZ\Publish\SPI\Search\Handler as SearchHandlerInterface;
+use eZ\Publish\SPI\Search\Content\Handler as SearchHandlerInterface;
 use eZ\Publish\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldHandler;
 use eZ\Publish\API\Repository\Exceptions\NotImplementedException;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Search/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Search/Location/Handler.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\Core\Persistence\Legacy\Content\Search\Location;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\SPI\Persistence\Content\Location;
-use eZ\Publish\SPI\Search\Location\Handler as LocationSearchHandler;
+use eZ\Publish\SPI\Search\Content\Location\Handler as LocationSearchHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
@@ -51,7 +51,7 @@ class Handler implements LocationSearchHandler
     }
 
     /**
-     * @see \eZ\Publish\SPI\Search\Location\Handler::findLocations
+     * @see \eZ\Publish\SPI\Search\Content\Location\Handler::findLocations
      */
     public function findLocations( LocationQuery $query )
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Search/MainHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Search/MainHandler.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\Legacy\Content\Search;
+
+use eZ\Publish\SPI\Search\Handler as HandlerInterface;
+use eZ\Publish\SPI\Search\Content\Handler as ContentSearchHandler;
+use eZ\Publish\SPI\Search\Content\Location\Handler as LocationSearchHandler;
+
+/**
+ * The main handler for the Legacy Search Engine
+ */
+class MainHandler implements HandlerInterface
+{
+    /**
+     * @var \eZ\Publish\SPI\Search\Content\Handler
+     */
+    protected $contentSearchHandler;
+
+    /**
+     * @var \eZ\Publish\SPI\Search\Content\Location\Handler
+     */
+    protected $locationSearchHandler;
+
+    public function __construct(
+        ContentSearchHandler $contentSearchHandler,
+        LocationSearchHandler $locationSearchHandler
+    )
+    {
+        $this->contentSearchHandler = $contentSearchHandler;
+        $this->locationSearchHandler = $locationSearchHandler;
+    }
+
+    public function contentSearchHandler()
+    {
+        return $this->contentSearchHandler;
+    }
+
+    public function locationSearchHandler()
+    {
+        return $this->locationSearchHandler;
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Type;
 
-use eZ\Publish\SPI\Search\Handler as SearchHandler;
+use eZ\Publish\SPI\Search\Content\Handler as SearchHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry as Registry;
@@ -60,7 +60,7 @@ class ContentUpdater
     /**
      * Creates a new content updater
      *
-     * @param \eZ\Publish\SPI\Search\Handler $searchHandler
+     * @param \eZ\Publish\SPI\Search\Content\Handler $searchHandler
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\Gateway $contentGateway
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry $converterRegistry
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler $storageHandler

--- a/eZ/Publish/Core/Persistence/Legacy/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Handler.php
@@ -13,10 +13,10 @@ use eZ\Publish\SPI\Persistence\Handler as HandlerInterface;
 use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
 use eZ\Publish\SPI\Persistence\Content\Language\Handler as LanguageHandler;
 use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
-use eZ\Publish\SPI\Search\Location\Handler as LocationSearchHandler;
+use eZ\Publish\SPI\Search\Content\Location\Handler as LocationSearchHandler;
 use eZ\Publish\SPI\Persistence\Content\Location\Trash\Handler as TrashHandler;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\Handler as ObjectStateHandler;
-use eZ\Publish\SPI\Search\Handler as ContentSearchHandler;
+use eZ\Publish\SPI\Search\Content\Handler as ContentSearchHandler;
 use eZ\Publish\SPI\Persistence\Content\Section\Handler as SectionHandler;
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
 use eZ\Publish\SPI\Persistence\Content\UrlAlias\Handler as UrlAliasHandler;
@@ -35,7 +35,7 @@ class Handler implements HandlerInterface
     protected $contentHandler;
 
     /**
-     * @var \eZ\Publish\SPI\Search\Handler
+     * @var \eZ\Publish\SPI\Search\Content\Handler
      */
     protected $contentSearchHandler;
 
@@ -55,7 +55,7 @@ class Handler implements HandlerInterface
     protected $locationHandler;
 
     /**
-     * @var \eZ\Publish\SPI\Search\Location\Handler
+     * @var \eZ\Publish\SPI\Search\Content\Location\Handler
      */
     protected $locationSearchHandler;
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/HandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/HandlerTest.php
@@ -64,7 +64,7 @@ class HandlerTest extends TestCase
         $searchHandler = $handler->searchHandler();
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Search\\Handler',
+            'eZ\\Publish\\SPI\\Search\\Content\\Handler',
             $searchHandler
         );
         $this->assertInstanceOf(

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/Handler.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/Handler.php
@@ -16,7 +16,7 @@ use eZ\Publish\SPI\Persistence\Content\Handler as ContentHandler;
 use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\Handler as ObjectStateHandler;
-use eZ\Publish\SPI\Search\Handler as SearchHandlerInterface;
+use eZ\Publish\SPI\Search\Content\Handler as SearchHandlerInterface;
 use eZ\Publish\SPI\Persistence\Content\Section\Handler as SectionHandler;
 use eZ\Publish\SPI\Search\Field;
 use eZ\Publish\SPI\Search\Document;

--- a/eZ/Publish/Core/Persistence/Solr/Content/Search/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Solr/Content/Search/Location/Handler.php
@@ -11,7 +11,7 @@ namespace eZ\Publish\Core\Persistence\Solr\Content\Search\Location;
 
 use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\Location;
-use eZ\Publish\SPI\Search\Location\Handler as SearchHandlerInterface;
+use eZ\Publish\SPI\Search\Content\Location\Handler as SearchHandlerInterface;
 use eZ\Publish\SPI\Search\FieldType;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query;

--- a/eZ/Publish/Core/Persistence/Solr/Handler.php
+++ b/eZ/Publish/Core/Persistence/Solr/Handler.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Persistence\Solr;
+
+use eZ\Publish\SPI\Search\Handler as HandlerInterface;
+use eZ\Publish\SPI\Search\Content\Handler as ContentSearchHandler;
+use eZ\Publish\SPI\Search\Content\Location\Handler as LocationSearchHandler;
+
+/**
+ * The main handler for the Solr Search Engine
+ */
+class Handler implements HandlerInterface
+{
+    /**
+     * @var \eZ\Publish\SPI\Search\Content\Handler
+     */
+    protected $contentSearchHandler;
+
+    /**
+     * @var \eZ\Publish\SPI\Search\Content\Location\Handler
+     */
+    protected $locationSearchHandler;
+
+    public function __construct(
+        ContentSearchHandler $contentSearchHandler,
+        LocationSearchHandler $locationSearchHandler
+    )
+    {
+        $this->contentSearchHandler = $contentSearchHandler;
+        $this->locationSearchHandler = $locationSearchHandler;
+    }
+
+    public function contentSearchHandler()
+    {
+        return $this->contentSearchHandler;
+    }
+
+    public function locationSearchHandler()
+    {
+        return $this->locationSearchHandler;
+    }
+}

--- a/eZ/Publish/Core/Repository/SearchService.php
+++ b/eZ/Publish/Core/Repository/SearchService.php
@@ -21,8 +21,8 @@ use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
-use eZ\Publish\SPI\Search\Handler;
-use eZ\Publish\SPI\Search\Location\Handler as LocationSearchHandler;
+use eZ\Publish\SPI\Search\Content\Handler;
+use eZ\Publish\SPI\Search\Content\Location\Handler as LocationSearchHandler;
 
 /**
  * Search service
@@ -43,12 +43,12 @@ class SearchService implements SearchServiceInterface
     protected $repository;
 
     /**
-     * @var \eZ\Publish\SPI\Search\Handler
+     * @var \eZ\Publish\SPI\Search\Content\Handler
      */
     protected $searchHandler;
 
     /**
-     * @var \eZ\Publish\SPI\Search\Location\Handler
+     * @var \eZ\Publish\SPI\Search\Content\Location\Handler
      */
     protected $locationSearchHandler;
 
@@ -71,8 +71,8 @@ class SearchService implements SearchServiceInterface
      * Setups service with reference to repository object that created it & corresponding handler
      *
      * @param \eZ\Publish\API\Repository\Repository $repository
-     * @param \eZ\Publish\SPI\Search\Handler $searchHandler
-     * @param \eZ\Publish\SPI\Search\Location\Handler $locationSearchHandler
+     * @param \eZ\Publish\SPI\Search\Content\Handler $searchHandler
+     * @param \eZ\Publish\SPI\Search\Content\Location\Handler $locationSearchHandler
      * @param \eZ\Publish\Core\Repository\Helper\DomainMapper $domainMapper
      * @param \eZ\Publish\Core\Repository\PermissionsCriterionHandler $permissionsCriterionHandler
      * @param array $settings

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
@@ -43,10 +43,10 @@ class SearchTest extends BaseServiceMockTest
     public function testConstructor()
     {
         $repositoryMock = $this->getRepositoryMock();
-        /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
-        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Handler' );
-        /** @var \eZ\Publish\SPI\Search\Location\Handler $locationSearchHandlerMock */
-        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Location\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Handler $searchHandlerMock */
+        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Location\Handler $locationSearchHandlerMock */
+        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Location\\Handler' );
         $domainMapperMock = $this->getDomainMapperMock();
         $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
         $settings = array( "teh setting" );
@@ -128,10 +128,10 @@ class SearchTest extends BaseServiceMockTest
     public function testFindContentValidatesLocationCriteriaAndSortClauses( $query, $exceptionMessage )
     {
         $repositoryMock = $this->getRepositoryMock();
-        /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
-        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Handler' );
-        /** @var \eZ\Publish\SPI\Search\Location\Handler $locationSearchHandlerMock */
-        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Location\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Handler $searchHandlerMock */
+        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Location\Handler $locationSearchHandlerMock */
+        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Location\\Handler' );
         $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
 
         $service = new SearchService(
@@ -181,10 +181,10 @@ class SearchTest extends BaseServiceMockTest
     public function testFindSingleValidatesLocationCriteria( $criterion, $exceptionMessage )
     {
         $repositoryMock = $this->getRepositoryMock();
-        /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
-        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Handler' );
-        /** @var \eZ\Publish\SPI\Search\Location\Handler $locationSearchHandlerMock */
-        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Location\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Handler $searchHandlerMock */
+        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Location\Handler $locationSearchHandlerMock */
+        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Location\\Handler' );
         $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
         $service = new SearchService(
             $repositoryMock,
@@ -220,10 +220,10 @@ class SearchTest extends BaseServiceMockTest
     public function testFindContentThrowsHandlerException()
     {
         $repositoryMock = $this->getRepositoryMock();
-        /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
-        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Handler' );
-        /** @var \eZ\Publish\SPI\Search\Location\Handler $locationSearchHandlerMock */
-        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Location\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Handler $searchHandlerMock */
+        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Location\Handler $locationSearchHandlerMock */
+        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Location\\Handler' );
         $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
 
         $service = new SearchService(
@@ -260,10 +260,10 @@ class SearchTest extends BaseServiceMockTest
     public function testFindContentNoPermissionsFilter()
     {
         $repositoryMock = $this->getRepositoryMock();
-        /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
-        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Handler' );
-        /** @var \eZ\Publish\SPI\Search\Location\Handler $locationSearchHandlerMock */
-        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Location\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Handler $searchHandlerMock */
+        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Location\Handler $locationSearchHandlerMock */
+        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Location\\Handler' );
         $domainMapperMock = $this->getDomainMapperMock();
         $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
         $service = new SearchService(
@@ -338,10 +338,10 @@ class SearchTest extends BaseServiceMockTest
     public function testFindContentWithPermission()
     {
         $repositoryMock = $this->getRepositoryMock();
-        /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
-        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Handler' );
-        /** @var \eZ\Publish\SPI\Search\Location\Handler $locationSearchHandlerMock */
-        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Location\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Handler $searchHandlerMock */
+        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Location\Handler $locationSearchHandlerMock */
+        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Location\\Handler' );
         $domainMapperMock = $this->getDomainMapperMock();
         $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
         $service = new SearchService(
@@ -425,10 +425,10 @@ class SearchTest extends BaseServiceMockTest
     public function testFindContentWithNoPermission()
     {
         $repositoryMock = $this->getRepositoryMock();
-        /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
-        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Handler' );
-        /** @var \eZ\Publish\SPI\Search\Location\Handler $locationSearchHandlerMock */
-        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Location\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Handler $searchHandlerMock */
+        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Location\Handler $locationSearchHandlerMock */
+        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Location\\Handler' );
         $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
         $service = new SearchService(
             $repositoryMock,
@@ -514,10 +514,10 @@ class SearchTest extends BaseServiceMockTest
         $contentTypeMock = $this->getMock( "eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType" );
         $fieldDefinitionMock = $this->getMock( "eZ\\Publish\\API\\Repository\\Values\\ContentType\\FieldDefinition" );
         $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
-        /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
-        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Handler' );
-        /** @var \eZ\Publish\SPI\Search\Location\Handler $locationSearchHandlerMock */
-        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Location\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Handler $searchHandlerMock */
+        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Location\Handler $locationSearchHandlerMock */
+        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Location\\Handler' );
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
@@ -581,10 +581,10 @@ class SearchTest extends BaseServiceMockTest
     public function testFindContentWithDefaultQueryValues()
     {
         $repositoryMock = $this->getRepositoryMock();
-        /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
-        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Handler' );
-        /** @var \eZ\Publish\SPI\Search\Location\Handler $locationSearchHandlerMock */
-        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Location\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Handler $searchHandlerMock */
+        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Location\Handler $locationSearchHandlerMock */
+        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Location\\Handler' );
         $domainMapperMock = $this->getDomainMapperMock();
         $service = new SearchService(
             $repositoryMock,
@@ -666,10 +666,10 @@ class SearchTest extends BaseServiceMockTest
     public function testFindSingleThrowsNotFoundException()
     {
         $repositoryMock = $this->getRepositoryMock();
-        /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
-        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Handler' );
-        /** @var \eZ\Publish\SPI\Search\Location\Handler $locationSearchHandlerMock */
-        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Location\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Handler $searchHandlerMock */
+        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Location\Handler $locationSearchHandlerMock */
+        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Location\\Handler' );
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
@@ -700,10 +700,10 @@ class SearchTest extends BaseServiceMockTest
     public function testFindSingleThrowsHandlerException()
     {
         $repositoryMock = $this->getRepositoryMock();
-        /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
-        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Handler' );
-        /** @var \eZ\Publish\SPI\Search\Location\Handler $locationSearchHandlerMock */
-        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Location\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Handler $searchHandlerMock */
+        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Location\Handler $locationSearchHandlerMock */
+        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Location\\Handler' );
         $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
         $service = new SearchService(
             $repositoryMock,
@@ -738,10 +738,10 @@ class SearchTest extends BaseServiceMockTest
     public function testFindSingle()
     {
         $repositoryMock = $this->getRepositoryMock();
-        /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
-        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Handler' );
-        /** @var \eZ\Publish\SPI\Search\Location\Handler $locationSearchHandlerMock */
-        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Location\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Handler $searchHandlerMock */
+        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Location\Handler $locationSearchHandlerMock */
+        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Location\\Handler' );
         $domainMapperMock = $this->getDomainMapperMock();
         $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
         $service = new SearchService(
@@ -805,10 +805,10 @@ class SearchTest extends BaseServiceMockTest
     public function functionFindLocationsWithPermission()
     {
         $repositoryMock = $this->getRepositoryMock();
-        /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
-        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Handler' );
-        /** @var \eZ\Publish\SPI\Search\Location\Handler $locationSearchHandlerMock */
-        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Location\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Handler $searchHandlerMock */
+        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Location\Handler $locationSearchHandlerMock */
+        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Location\\Handler' );
         $domainMapperMock = $this->getDomainMapperMock();
         $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
         $service = new SearchService(
@@ -872,10 +872,10 @@ class SearchTest extends BaseServiceMockTest
     public function testFindLocationsWithNoPermissionsFilter()
     {
         $repositoryMock = $this->getRepositoryMock();
-        /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
-        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Handler' );
-        /** @var \eZ\Publish\SPI\Search\Location\Handler $locationSearchHandlerMock */
-        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Location\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Handler $searchHandlerMock */
+        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Location\Handler $locationSearchHandlerMock */
+        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Location\\Handler' );
         $domainMapperMock = $this->getDomainMapperMock();
         $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
         $service = new SearchService(
@@ -939,10 +939,10 @@ class SearchTest extends BaseServiceMockTest
         $contentTypeMock = $this->getMock( "eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType" );
         $fieldDefinitionMock = $this->getMock( "eZ\\Publish\\API\\Repository\\Values\\ContentType\\FieldDefinition" );
         $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
-        /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
-        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Handler' );
-        /** @var \eZ\Publish\SPI\Search\Location\Handler $locationSearchHandlerMock */
-        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Location\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Handler $searchHandlerMock */
+        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Location\Handler $locationSearchHandlerMock */
+        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Location\\Handler' );
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
@@ -1008,10 +1008,10 @@ class SearchTest extends BaseServiceMockTest
     public function testFindLocationsThrowsHandlerException()
     {
         $repositoryMock = $this->getRepositoryMock();
-        /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
-        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Handler' );
-        /** @var \eZ\Publish\SPI\Search\Location\Handler $locationSearchHandlerMock */
-        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Location\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Handler $searchHandlerMock */
+        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Location\Handler $locationSearchHandlerMock */
+        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Location\\Handler' );
         $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
 
         $service = new SearchService(
@@ -1048,10 +1048,11 @@ class SearchTest extends BaseServiceMockTest
     public function testFindLocationsWithDefaultQueryValues()
     {
         $repositoryMock = $this->getRepositoryMock();
-        /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
-        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Handler' );
-        /** @var \eZ\Publish\SPI\Search\Location\Handler $locationSearchHandlerMock */
-        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Location\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Handler $searchHandlerMock */
+        $searchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Handler' );
+        /** @var \eZ\Publish\SPI\Search\Content\Location\Handler $locationSearchHandlerMock */
+        /** @var \eZ\Publish\SPI\Search\Content\Location\Handler $locationSearchHandlerMock */
+        $locationSearchHandlerMock = $this->getSPIMockHandler( 'Search\\Content\\Location\\Handler' );
         $domainMapperMock = $this->getDomainMapperMock();
         $service = new SearchService(
             $repositoryMock,

--- a/eZ/Publish/SPI/Persistence/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Handler.php
@@ -21,7 +21,7 @@ interface Handler
 
     /**
      * @deprecated In 5.4, moved to own Search SPI
-     * @return \eZ\Publish\SPI\Search\Handler
+     * @return \eZ\Publish\SPI\Search\Content\Handler
      */
     public function searchHandler();
 
@@ -42,7 +42,7 @@ interface Handler
 
     /**
      * @deprecated In 5.4, moved to own Search SPI
-     * @return \eZ\Publish\SPI\Search\Location\Handler
+     * @return \eZ\Publish\SPI\Search\Content\Location\Handler
      */
     public function locationSearchHandler();
 

--- a/eZ/Publish/SPI/Search/Content/Handler.php
+++ b/eZ/Publish/SPI/Search/Content/Handler.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * File containing the Content Search handler interface
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\SPI\Search\Content;
+
+use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query;
+
+/**
+ * The Content Search handler retrieves sets of of Content objects, based on a
+ * set of criteria.
+ */
+interface Handler
+{
+    /**
+     * Finds content objects for the given query.
+     *
+     * @todo define structs for the field filters
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if Query criterion is not applicable to its target
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param array $fieldFilters - a map of filters for the returned fields.
+     *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult With ContentInfo as SearchHit->valueObject
+     */
+    public function findContent( Query $query, array $fieldFilters = array() );
+
+    /**
+     * Performs a query for a single content object
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the object was not found by the query or due to permissions
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if Criterion is not applicable to its target
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if there is more than than one result matching the criterions
+     *
+     * @todo define structs for the field filters
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $filter
+     * @param array $fieldFilters - a map of filters for the returned fields.
+     *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content\ContentInfo
+     */
+    public function findSingle( Criterion $filter, array $fieldFilters = array() );
+
+    /**
+     * Suggests a list of values for the given prefix
+     *
+     * @param string $prefix
+     * @param string[] $fieldpath
+     * @param int $limit
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $filter
+     */
+    public function suggest( $prefix, $fieldPaths = array(), $limit = 10, Criterion $filter = null );
+
+    /**
+     * Indexes a content object
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     *
+     * @return void
+     */
+    public function indexContent( Content $content );
+
+    /**
+     * Deletes a content object from the index
+     *
+     * @param int $contentId
+     * @param int|null $versionId
+     *
+     * @return void
+     */
+    public function deleteContent( $contentId, $versionId = null );
+
+    /**
+     * Deletes a location from the index
+     *
+     * @param mixed $locationId
+     * @param mixed $contentId
+     */
+    public function deleteLocation( $locationId, $contentId );
+}

--- a/eZ/Publish/SPI/Search/Content/Location/Handler.php
+++ b/eZ/Publish/SPI/Search/Content/Location/Handler.php
@@ -7,7 +7,7 @@
  * @version //autogentag//
  */
 
-namespace eZ\Publish\SPI\Search\Location;
+namespace eZ\Publish\SPI\Search\Content\Location;
 
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\SPI\Persistence\Content\Location;

--- a/eZ/Publish/SPI/Search/Handler.php
+++ b/eZ/Publish/SPI/Search/Handler.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the Content Search handler interface
+ * This file is part of the eZ Publish Kernel package
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -9,81 +9,18 @@
 
 namespace eZ\Publish\SPI\Search;
 
-use eZ\Publish\SPI\Persistence\Content;
-use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\API\Repository\Values\Content\Query;
-
 /**
- * The Content Search handler retrieves sets of of Content objects, based on a
- * set of criteria.
+ * The interface for the main Search Engine handlers
  */
 interface Handler
 {
     /**
-     * Finds content objects for the given query.
-     *
-     * @todo define structs for the field filters
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if Query criterion is not applicable to its target
-     *
-     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
-     * @param array $fieldFilters - a map of filters for the returned fields.
-     *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult With ContentInfo as SearchHit->valueObject
+     * @return \eZ\Publish\SPI\Search\Content\Handler
      */
-    public function findContent( Query $query, array $fieldFilters = array() );
+    public function contentSearchHandler();
 
     /**
-     * Performs a query for a single content object
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the object was not found by the query or due to permissions
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if Criterion is not applicable to its target
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if there is more than than one result matching the criterions
-     *
-     * @todo define structs for the field filters
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $filter
-     * @param array $fieldFilters - a map of filters for the returned fields.
-     *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
-     *
-     * @return \eZ\Publish\SPI\Persistence\Content\ContentInfo
+     * @return \eZ\Publish\SPI\Search\Content\Location\Handler
      */
-    public function findSingle( Criterion $filter, array $fieldFilters = array() );
-
-    /**
-     * Suggests a list of values for the given prefix
-     *
-     * @param string $prefix
-     * @param string[] $fieldpath
-     * @param int $limit
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $filter
-     */
-    public function suggest( $prefix, $fieldPaths = array(), $limit = 10, Criterion $filter = null );
-
-    /**
-     * Indexes a content object
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content $content
-     *
-     * @return void
-     */
-    public function indexContent( Content $content );
-
-    /**
-     * Deletes a content object from the index
-     *
-     * @param int $contentId
-     * @param int|null $versionId
-     *
-     * @return void
-     */
-    public function deleteContent( $contentId, $versionId = null );
-
-    /**
-     * Deletes a location from the index
-     *
-     * @param mixed $locationId
-     * @param mixed $contentId
-     */
-    public function deleteLocation( $locationId, $contentId );
+    public function locationSearchHandler();
 }


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-23966, a sub-task for https://jira.ez.no/browse/EZP-23940

Followup: https://jira.ez.no/browse/EZP-23967

This introduces main Search Engine Handler, moving Content and Location search handler namespaces down.
Main Search Engine Handler interface implementations will be put in use in the followup.