### PR TITLE
Fix EZP-23978: Don't forward on index request when in legacy_mode

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/RequestEventListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/RequestEventListener.php
@@ -76,9 +76,11 @@ class RequestEventListener implements EventSubscriberInterface
     {
         $request = $event->getRequest();
         $semanticPathinfo = $request->attributes->get( 'semanticPathinfo' ) ?: '/';
+        $isLegacyMode = $this->configResolver->getParameter( 'legacy_mode', 'ezsettings' );
         if (
             $event->getRequestType() === HttpKernelInterface::MASTER_REQUEST
             && $semanticPathinfo === '/'
+            && !$isLegacyMode
         )
         {
             $indexPage = $this->configResolver->getParameter( 'index_page' );

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RequestEventListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RequestEventListenerTest.php
@@ -101,11 +101,15 @@ class RequestEventListenerTest extends \PHPUnit_Framework_TestCase
      */
     public function testOnKernelRequestIndexOnIndexPage( $requestPath, $configuredIndexPath, $expectedIndexPath )
     {
+        $configMap = array(
+            array( 'legacy_mode', 'ezsettings', null, false ),
+            array( 'index_page', null, null, $configuredIndexPath ),
+        );
         $this->configResolver
-            ->expects( $this->once() )
+            ->expects( $this->any() )
             ->method( 'getParameter' )
-            ->with( 'index_page' )
-            ->will( $this->returnValue( $configuredIndexPath ) );
+            ->will( $this->returnValueMap( $configMap ) );
+
         $this->request->attributes->set( 'semanticPathinfo', $requestPath );
         $this->requestEventListener->onKernelRequestIndex( $this->event );
         $this->assertEquals( $expectedIndexPath, $this->request->attributes->get( 'semanticPathinfo' ) );


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-23978

When an index (`/`) request exists, don't forward to index_page if siteaccess is using `legacy_mode`

see also: https://github.com/ezsystems/LegacyBridge/pull/5