### PR TITLE
EZP-23967: fix container: configure search handler in EzPublishCoreBundle

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
@@ -53,6 +53,13 @@ services:
         factory_method: buildStorageEngine
         public: false
 
+    ezpublish.spi.search_handler:
+        alias: ezpublish.spi.search_engine
+
+    ezpublish.spi.search_engine:
+        alias: ezpublish.spi.search.legacy
+        public: false
+
     # Signal Slot API wrapper
     ezpublish.signalslot.event_converter_slot:
         class: %ezpublish.signalslot.event_converter_slot.class%


### PR DESCRIPTION
A small fix missing in merged https://github.com/ezsystems/ezpublish-kernel/pull/1170

This adds `ezpublish.spi.search_handler` to container configuration in EzPublishCoreBundle.