### PR TITLE
[Quick Test] : do not store empty URL reference

### DIFF
--- a/eZ/Publish/Core/FieldType/Url/UrlStorage.php
+++ b/eZ/Publish/Core/FieldType/Url/UrlStorage.php
@@ -44,7 +44,12 @@ class UrlStorage extends GatewayBasedStorage
         /** @var \eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway $gateway */
         $gateway = $this->getGateway( $context );
         $url = $field->value->externalData;
-
+        
+        if ( !$url )
+        {
+            return false;
+        }
+        
         $map = $gateway->getUrlIdMap( array( $url ) );
 
         if ( isset( $map[$url] ) )


### PR DESCRIPTION
Quick test to check if Travis CI or anybody else finds it outrageous. 

I currently have a bug when creating contents with empty URL fields : this creates an empty entry in the ezurl table and logs a warning when trying to load it (see L100).
This seems to fix the problem by not storing any URL reference.

If the fix is legit, I'll file a proper issue.
