### PR TITLE
[Quick Test] : make ezselection options a hash

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Selection.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Selection.php
@@ -113,7 +113,7 @@ class Selection implements Converter
         {
             foreach ( $simpleXml->options->option as $option )
             {
-                $options[(int)$option["id"]] = (string)$option["name"];
+                $options[(string)$option["id"]] = (string)$option["name"];
             }
         }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Selection.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Selection.php
@@ -52,10 +52,7 @@ class Selection implements Converter
     {
         if ( $value->dataText !== '' )
         {
-            $fieldValue->data = array_map(
-                'intval',
-                explode( '-', $value->dataText )
-            );
+            $fieldValue->data = explode( '-', $value->dataText );
         }
         else
         {


### PR DESCRIPTION
Options are forced to be numeric indexed which basically prevents reordering.

What about using keys? It technically works in legacy albeit keys are not editable. Is there any problem making this change or should I  make a proper PR?
