### PR TITLE
EZP-23996: Moved legacy setup event to legacy-bridge

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/RequestEventListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/RequestEventListener.php
@@ -9,19 +9,16 @@
 
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;
 
-use eZ\Bundle\EzPublishCoreBundle\Kernel;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
-use eZ\Publish\SPI\HashGenerator;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Response;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\URILexer;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Routing\RouterInterface;
 
 class RequestEventListener implements EventSubscriberInterface
@@ -58,7 +55,6 @@ class RequestEventListener implements EventSubscriberInterface
     {
         return array(
             KernelEvents::REQUEST => array(
-                array( 'onKernelRequestSetup', 190 ),
                 array( 'onKernelRequestForward', 10 ),
                 array( 'onKernelRequestRedirect', 0 ),
                 // onKernelRequestIndex needs to be before the router (prio 32)
@@ -70,7 +66,7 @@ class RequestEventListener implements EventSubscriberInterface
     /**
      * Checks if the IndexPage is configured and which page must be shown
      *
-     * @param GetResponseEvent $event
+     * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
      */
     public function onKernelRequestIndex( GetResponseEvent $event )
     {
@@ -88,31 +84,6 @@ class RequestEventListener implements EventSubscriberInterface
                 $request->attributes->set( 'semanticPathinfo', $indexPage );
                 $request->attributes->set( 'needsForward', true );
             }
-        }
-    }
-
-    /**
-     * Checks if it's needed to redirect to setup wizard
-     *
-     * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
-     */
-    public function onKernelRequestSetup( GetResponseEvent $event )
-    {
-        if ( $event->getRequestType() == HttpKernelInterface::MASTER_REQUEST )
-        {
-            if ( $this->defaultSiteAccess !== 'setup' )
-                return;
-
-            $request = $event->getRequest();
-            $requestContext = $this->router->getContext();
-            $requestContext->fromRequest( $request );
-            $this->router->setContext( $requestContext );
-            $setupURI = $this->router->generate( 'ezpublishSetup' );
-
-            if ( ( $requestContext->getBaseUrl() . $request->getPathInfo() ) === $setupURI )
-                return;
-
-            $event->setResponse( new RedirectResponse( $setupURI ) );
         }
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RequestEventListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RequestEventListenerTest.php
@@ -14,12 +14,10 @@ use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
-use eZ\Bundle\EzPublishCoreBundle\Kernel;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Routing\RequestContext;
 
 class RequestEventListenerTest extends \PHPUnit_Framework_TestCase
 {
@@ -86,7 +84,6 @@ class RequestEventListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(
             array(
                 KernelEvents::REQUEST => array(
-                    array( 'onKernelRequestSetup', 190 ),
                     array( 'onKernelRequestForward', 10 ),
                     array( 'onKernelRequestRedirect', 0 ),
                     array( 'onKernelRequestIndex', 40 ),
@@ -167,67 +164,6 @@ class RequestEventListenerTest extends \PHPUnit_Framework_TestCase
         $this->requestEventListener->onKernelRequestForward( $event );
         $this->assertSame( $response, $event->getResponse() );
         $this->assertTrue( $event->isPropagationStopped() );
-    }
-
-    public function testOnKernelRequestSetupSubrequest()
-    {
-        $this->router
-            ->expects( $this->never() )
-            ->method( 'getContext' );
-        $this->router
-            ->expects( $this->never() )
-            ->method( 'setContext' );
-
-        $event = new GetResponseEvent( $this->httpKernel, new Request, HttpKernelInterface::SUB_REQUEST );
-        $this->requestEventListener->onKernelRequestSetup( $event );
-        $this->assertFalse( $event->hasResponse() );
-    }
-
-    public function testOnKernelRequestSetupAlreadyHasSiteaccess()
-    {
-        $event = new GetResponseEvent( $this->httpKernel, new Request, HttpKernelInterface::MASTER_REQUEST );
-        $this->requestEventListener->onKernelRequestSetup( $event );
-        $this->assertFalse( $event->hasResponse() );
-    }
-
-    public function testOnKernelRequestSetupAlreadySetupUri()
-    {
-        $this->router
-            ->expects( $this->once() )
-            ->method( 'generate' )
-            ->with( 'ezpublishSetup' )
-            ->will( $this->returnValue( '/setup' ) );
-        $this->router
-            ->expects( $this->once() )
-            ->method( 'getContext' )
-            ->will( $this->returnValue( $this->getMock( 'Symfony\Component\Routing\RequestContext' ) ) );
-
-        $requestEventListener = new RequestEventListener( $this->configResolver, $this->router, 'setup', $this->logger );
-        $event = new GetResponseEvent( $this->httpKernel, Request::create( '/setup' ), HttpKernelInterface::MASTER_REQUEST );
-        $requestEventListener->onKernelRequestSetup( $event );
-        $this->assertFalse( $event->hasResponse() );
-    }
-
-    public function testOnKernelRequestSetup()
-    {
-        $this->router
-            ->expects( $this->once() )
-            ->method( 'generate' )
-            ->with( 'ezpublishSetup' )
-            ->will( $this->returnValue( '/setup' ) );
-        $this->router
-            ->expects( $this->once() )
-            ->method( 'getContext' )
-            ->will( $this->returnValue( $this->getMock( 'Symfony\Component\Routing\RequestContext' ) ) );
-
-        $requestEventListener = new RequestEventListener( $this->configResolver, $this->router, 'setup', $this->logger );
-        $event = new GetResponseEvent( $this->httpKernel, Request::create( '/foo/bar' ), HttpKernelInterface::MASTER_REQUEST );
-        $requestEventListener->onKernelRequestSetup( $event );
-        $this->assertTrue( $event->hasResponse() );
-        /** @var RedirectResponse $response */
-        $response = $event->getResponse();
-        $this->assertInstanceOf( 'Symfony\Component\HttpFoundation\RedirectResponse', $response );
-        $this->assertSame( '/setup', $response->getTargetUrl() );
     }
 
     public function testOnKernelRequestRedirectSubRequest()


### PR DESCRIPTION
> [EZP-23966](https://jira.ez.no/browse/EZP-23996)
> Sub-task of [EZP-23964](https://jira.ez.no/browse/EZP-23994)
> Related to ezsystems/LegacyBridge#7

Removes the Legacy Setup event listener, [moved to legacy-bridge](https://github.com/ezsystems/LegacyBridge/pull/7).