### PR TITLE
Fix EZP-23971: if a user is removed while logged in, the session for tha...

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Security/EventListener/SecurityListener.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/EventListener/SecurityListener.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Security\EventListener;
 
 use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute;
@@ -211,6 +212,15 @@ class SecurityListener implements EventSubscriberInterface
         if ( $token === null )
         {
             return;
+        }
+
+        try
+        {
+            $this->repository->getUserService()->loadUser( $this->repository->getCurrentUser()->contentInfo->id );
+        }
+        catch ( NotFoundException $e )
+        {
+            $this->repository->setCurrentUser( $this->repository->getUserService()->loadUser( 10 ) );
         }
 
         if (


### PR DESCRIPTION
...t user will cause a fatal error

Test if the user exists by reloading it. If it doesn't, login anonymous user.

This is certainly NOT the way to fix this issue (though it does fix the reported bug), but I could use some feedback on a better way to fix it.