### PR TITLE
Fix EZP-23971: If a user is removed while logged in, session for that user will throw an exception

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Security/User/Provider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/User/Provider.php
@@ -83,8 +83,18 @@ class Provider implements APIUserProviderInterface
             throw new UnsupportedUserException( sprintf( 'Instances of "%s" are not supported.', get_class( $user ) ) );
         }
 
-        $this->repository->setCurrentUser( $user->getAPIUser() );
-        return $user;
+        try
+        {
+            $refreshedAPIUser = $this->repository->getUserService()->loadUser( $user->getAPIUser()->id );
+            $user->setAPIUser( $refreshedAPIUser );
+            $this->repository->setCurrentUser( $refreshedAPIUser );
+
+            return $user;
+        }
+        catch ( NotFoundException $e )
+        {
+            throw new UsernameNotFoundException( $e->getMessage(), 0, $e );
+        }
     }
 
     /**


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-23971

When reloading security token from the session, repository user is not refreshed correctly (i.e. not re-fetched). Consequence is that if the user is modified in the backend (e.g. e-mail changed or user deleted), it's not reflected for the currently logged in user.

This patch fixes it. 
If user isn't found, a `UsernameNotFoundException` will be thrown, allowing [Symfony `ContextListener`](https://github.com/symfony/symfony/blob/2.6/src/Symfony/Component/Security/Http/Firewall/ContextListener.php#L148-L181) (firewall listener loading security info from the session) to reset the security token and kick the user out.