### PR TITLE
Fix EZP-23906: Do not allow creating new content below non-containers

### DIFF
--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -166,6 +166,7 @@ interface ContentService
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if there is a provided remoteId which exists in the system
      *                                                                        or there is no location provided (4.x) or multiple locations
      *                                                                        are under the same parent or if the a field value is not accepted by the field type
+     *                                                                        or if parent location is not a container
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException if a field in the $contentCreateStruct is not valid
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException if a required field is missing or is set to an empty value
      *

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -478,6 +478,7 @@ class ContentService implements ContentServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if there is a provided remoteId which exists in the system
      *                                                                        or there is no location provided (4.x) or multiple locations
      *                                                                        are under the same parent or if the a field value is not accepted by the field type
+     *                                                                        or if parent location is not a container
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException if a field in the $contentCreateStruct is not valid
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException if a required field is missing or is set to an empty value
      *
@@ -563,6 +564,21 @@ class ContentService implements ContentServiceInterface
         else
         {
             $contentCreateStruct->remoteId = $this->domainMapper->getUniqueHash( $contentCreateStruct );
+        }
+
+        // Validate that all locations are containers
+        foreach ( $locationCreateStructs as $locationCreateStruct )
+        {
+            $parentContentInfo = $this->repository->getLocationService()->loadLocation(
+                $locationCreateStruct->parentLocationId
+            )->getContentInfo();
+            $isContainer = $this->repository->getContentTypeService()->loadContentType(
+                $parentContentInfo->contentTypeId
+            )->isContainer;
+            if ( $isContainer === false )
+            {
+                throw new InvalidArgumentException( "\$locationCreateStruct", "'$locationCreateStruct->parentLocationId' is not a container" );
+            }
         }
 
         $spiLocationCreateStructs = $this->buildSPILocationCreateStructs( $locationCreateStructs );


### PR DESCRIPTION
This fixes EZP-23906: The Public API allows to create content under a non container element
https://jira.ez.no/browse/EZP-23906

This patch adds validation of isContainer flag when creating new content.
This validate taking place in the ContentService and when the content is created.. At first glance it might look more appropriate to have that in the LocationService, but the locations are actually not created before the objects are "Published", so that will make it possible to create new objects which you later then then are not able to publish.....