### PR TITLE
EZP-23940: Cleanup (Decouple search handlers from Persistence)

### DIFF
--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/Search/Legacy/CriterionFieldValueHandlerRegistryPassTest.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/Search/Legacy/CriterionFieldValueHandlerRegistryPassTest.php
@@ -7,7 +7,7 @@
  * @version //autogentag//
  */
 
-namespace eZ\Publish\Core\Base\Tests\Container\Compiler\Storage\Legacy;
+namespace eZ\Publish\Core\Base\Tests\Container\Compiler\Search\Legacy;
 
 use eZ\Publish\Core\Base\Container\Compiler\Search\Legacy\CriterionFieldValueHandlerRegistryPass;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/Search/Legacy/SortClauseConverterPassTest.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/Search/Legacy/SortClauseConverterPassTest.php
@@ -7,7 +7,7 @@
  * @version //autogentag//
  */
 
-namespace eZ\Publish\Core\Base\Tests\Container\Compiler\Storage\Legacy;
+namespace eZ\Publish\Core\Base\Tests\Container\Compiler\Search\Legacy;
 
 use eZ\Publish\Core\Base\Container\Compiler\Search\Legacy\SortClauseConverterPass;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/Search/SignalSlotPassTest.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/Search/SignalSlotPassTest.php
@@ -7,7 +7,7 @@
  * @version //autogentag//
  */
 
-namespace eZ\Publish\Core\Base\Tests\Container\Compiler\Storage;
+namespace eZ\Publish\Core\Base\Tests\Container\Compiler\Search;
 
 use eZ\Publish\Core\Base\Container\Compiler\Search\SignalSlotPass;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/Search/Solr/AggregateSortClauseVisitorPassTest.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/Search/Solr/AggregateSortClauseVisitorPassTest.php
@@ -7,7 +7,7 @@
  * @version //autogentag//
  */
 
-namespace eZ\Publish\Core\Base\Tests\Container\Compiler\Storage\Solr;
+namespace eZ\Publish\Core\Base\Tests\Container\Compiler\Search\Solr;
 
 use eZ\Publish\Core\Base\Container\Compiler\Search\Solr\AggregateSortClauseVisitorPass;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;

--- a/eZ/Publish/Core/Search/Common/Slot/CreateLocation.php
+++ b/eZ/Publish/Core/Search/Common/Slot/CreateLocation.php
@@ -30,14 +30,16 @@ class CreateLocation extends Slot
         }
 
         $contentInfo = $this->persistenceHandler->contentHandler()->loadContentInfo( $signal->contentId );
+
         $this->searchHandler->contentSearchHandler()->indexContent(
-            $this->persistenceHandler->contentHandler()->load( $signal->contentId, $contentInfo->currentVersionNo )
+            $this->persistenceHandler->contentHandler()->load(
+                $signal->contentId,
+                $contentInfo->currentVersionNo
+            )
         );
 
-        $locations = $this->persistenceHandler->locationHandler()->loadLocationsByContent( $signal->contentId );
-        foreach ( $locations as $location )
-        {
-            $this->searchHandler->locationSearchHandler()->indexLocation( $location );
-        }
+        $this->searchHandler->locationSearchHandler()->indexLocation(
+            $this->persistenceHandler->locationHandler()->load( $signal->locationId )
+        );
     }
 }

--- a/eZ/Publish/Core/settings/search_engines/elasticsearch/criterion_visitors_content.yml
+++ b/eZ/Publish/Core/settings/search_engines/elasticsearch/criterion_visitors_content.yml
@@ -48,7 +48,7 @@ services:
     ezpublish.search.elasticsearch.content.criterion_visitor.content_type_identifier_in:
         class: %ezpublish.search.elasticsearch.content.criterion_visitor.content_type_identifier_in.class%
         arguments:
-            - @ezpublish.spi.persistence.legacy.content_type.handler
+            - @ezpublish.spi.persistence.content_type_handler
         tags:
             - {name: ezpublish.search.elasticsearch.content.criterion_visitor}
 

--- a/eZ/Publish/Core/settings/search_engines/elasticsearch/criterion_visitors_location.yml
+++ b/eZ/Publish/Core/settings/search_engines/elasticsearch/criterion_visitors_location.yml
@@ -47,7 +47,7 @@ services:
     ezpublish.search.elasticsearch.location.criterion_visitor.content_type_identifier_in:
         class: %ezpublish.search.elasticsearch.location.criterion_visitor.content_type_identifier_in.class%
         arguments:
-            - @ezpublish.spi.persistence.legacy.content_type.handler
+            - @ezpublish.spi.persistence.content_type_handler
         tags:
             - {name: ezpublish.search.elasticsearch.location.criterion_visitor}
 

--- a/eZ/Publish/Core/settings/search_engines/solr/criterion_visitors.yml
+++ b/eZ/Publish/Core/settings/search_engines/solr/criterion_visitors.yml
@@ -110,7 +110,7 @@ services:
     ezpublish.search.solr.content.criterion_visitor.content_type_identifier_in:
         class: %ezpublish.search.solr.content.criterion_visitor.content_type_identifier_in.class%
         arguments:
-            - @ezpublish.spi.persistence.legacy.content_type.handler
+            - @ezpublish.spi.persistence.content_type_handler
         tags:
             - {name: ezpublish.search.solr.content.criterion_visitor}
 
@@ -272,7 +272,7 @@ services:
     ezpublish.search.solr.location.criterion_visitor.content_type_identifier_in:
         class: %ezpublish.search.solr.location.criterion_visitor.content_type_identifier_in.class%
         arguments:
-            - @ezpublish.spi.persistence.legacy.content_type.handler
+            - @ezpublish.spi.persistence.content_type_handler
         tags:
             - {name: ezpublish.search.solr.location.criterion_visitor}
 


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-23940

Just some minor cleanup found after all the PRs.

One fix worth of notice is CreateLocation slot change. This was fixed for Elasticsearch, but when Slots were made common, the Solr implementation was kept by mistake. There is no need to index all Content's Locations when Locations is created. If Locations are sub-documents of Content,  `contentSearchHandler()->indexContent()` with re-index Content with it's sub-documents (both ES and Solr), if Location is also indexed separately then `locationSearchHandler()->indexLocation()` will take care of it (only ES, Solr implementation is empty).

TL; DR: slots should not have to know how data is structured in a particular engine, this is handled by concrete indexing implementation.