### PR TITLE
Fix EZP-24027: Tree selectionRoot string assignment

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Relation.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Relation.php
@@ -86,9 +86,8 @@ class Relation implements Converter
         // Selection root, location ID
 
         $fieldDef->fieldTypeConstraints->fieldSettings['selectionRoot'] =
-            $storageDef->dataInt2 === 0
-            ? ''
-            : $storageDef->dataInt2;
+            $storageDef->dataInt2
+            ?: 0;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Relation.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Relation.php
@@ -86,8 +86,9 @@ class Relation implements Converter
         // Selection root, location ID
 
         $fieldDef->fieldTypeConstraints->fieldSettings['selectionRoot'] =
-            $storageDef->dataInt2
-            ?: 0;
+            $storageDef->dataInt2 === 0
+            ? null
+            : $storageDef->dataInt2;
     }
 
     /**


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24027

In the Relation Converter, method toFieldDefinition(), you use a string assignment in case of "$storageDef->dataInt2" equals 0.
But, it's an integer variable, so it makes an error.
I changed it for a ternary condition without string.
