### PR TITLE
Fix EZP-24046: Username/login is case sensitive

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RepositoryAuthenticationProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RepositoryAuthenticationProvider.php
@@ -52,7 +52,7 @@ class RepositoryAuthenticationProvider extends DaoAuthenticationProvider
         {
             try
             {
-                $apiUser = $this->repository->getUserService()->loadUserByCredentials( $token->getUsername(), $token->getCredentials() );
+                $apiUser = $this->repository->getUserService()->loadUserByCredentials( $user->getAPIUser()->login, $token->getCredentials() );
             }
             catch ( NotFoundException $e )
             {


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-24046

`loadUserByCredentials()` is the method that will compute the password hash, however, by using what has been introduced in the form `$token->getUsername()` it might not match the case that has been used while registering.
Since the `$user` object has already been fetched (based on the input) and contains the login with the same case as at the time of registration/password hash creation, it can be used to generate the password hash correctly.
