### PR TITLE
EZP-23941: Move field map to storage 1/2

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
@@ -1967,6 +1967,15 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
             isset( $contentVersion2Draft->fields["byline"] ),
             "New field was not added to draft version."
         );
+
+        $this->assertEquals(
+            $contentVersion1Archived->getField( "byline" )->id,
+            $contentVersion1Published->getField( "byline" )->id
+        );
+        $this->assertEquals(
+            $contentVersion1Published->getField( "byline" )->id,
+            $contentVersion2Draft->getField( "byline" )->id
+        );
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
@@ -388,4 +388,13 @@ abstract class Gateway
      * @return int ID the inserted ID
      */
     abstract public function insertRelation( RelationCreateStruct $createStruct );
+
+    /**
+     * Returns all Content IDs for a given $contentTypeId.
+     *
+     * @param int $contentTypeId
+     *
+     * @return int[]
+     */
+    abstract public function getContentIdsByContentTypeId( $contentTypeId );
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -1820,4 +1820,30 @@ class DoctrineDatabase extends Gateway
             // No match, do nothing
         }
     }
+
+    /**
+     * Returns all Content IDs for a given $contentTypeId.
+     *
+     * @param int $contentTypeId
+     *
+     * @return int[]
+     */
+    public function getContentIdsByContentTypeId( $contentTypeId )
+    {
+        $query = $this->dbHandler->createSelectQuery();
+        $query
+            ->select( $this->dbHandler->quoteColumn( "id" ) )
+            ->from( $this->dbHandler->quoteTable( "ezcontentobject" ) )
+            ->where(
+                $query->expr->eq(
+                    $this->dbHandler->quoteColumn( "contentclass_id" ),
+                    $query->bindValue( $contentTypeId, null, PDO::PARAM_INT )
+                )
+            );
+
+        $statement = $query->prepare();
+        $statement->execute();
+
+        return $statement->fetchAll( PDO::FETCH_COLUMN );
+    }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
@@ -886,4 +886,27 @@ class ExceptionConversion extends Gateway
             throw new RuntimeException( 'Database error', 0, $e );
         }
     }
+
+    /**
+     * Returns all Content IDs for a given $contentTypeId.
+     *
+     * @param int $contentTypeId
+     *
+     * @return int[]
+     */
+    public function getContentIdsByContentTypeId( $contentTypeId )
+    {
+        try
+        {
+            return $this->innerGateway->getContentIdsByContentTypeId( $contentTypeId );
+        }
+        catch ( DBALException $e )
+        {
+            throw new RuntimeException( 'Database error', 0, $e );
+        }
+        catch ( PDOException $e )
+        {
+            throw new RuntimeException( 'Database error', 0, $e );
+        }
+    }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater.php
@@ -39,13 +39,6 @@ class ContentUpdater
     protected $converterRegistry;
 
     /**
-     * Search handler
-     *
-     * @var \eZ\Publish\Core\Search\Legacy\Content\Handler
-     */
-    protected $searchHandler;
-
-    /**
      * Storage handler
      *
      * @var \eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler
@@ -60,20 +53,17 @@ class ContentUpdater
     /**
      * Creates a new content updater
      *
-     * @param \eZ\Publish\SPI\Search\Content\Handler $searchHandler
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\Gateway $contentGateway
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry $converterRegistry
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler $storageHandler
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\Mapper $contentMapper
      */
     public function __construct(
-        SearchHandler $searchHandler,
         ContentGateway $contentGateway,
         Registry $converterRegistry,
         StorageHandler $storageHandler,
         ContentMapper $contentMapper )
     {
-        $this->searchHandler = $searchHandler;
         $this->contentGateway = $contentGateway;
         $this->converterRegistry = $converterRegistry;
         $this->storageHandler = $storageHandler;
@@ -152,11 +142,16 @@ class ContentUpdater
      */
     public function applyUpdates( $contentTypeId, array $actions )
     {
-        foreach ( $this->loadContentObjects( $contentTypeId ) as $contentInfo )
+        if ( empty( $actions ) )
+        {
+            return;
+        }
+
+        foreach ( $this->getContentIdsByContentTypeId( $contentTypeId ) as $contentId )
         {
             foreach ( $actions as $action )
             {
-                $action->apply( $contentInfo );
+                $action->apply( $contentId );
             }
         }
     }
@@ -166,24 +161,10 @@ class ContentUpdater
      *
      * @param mixed $contentTypeId
      *
-     * @return \eZ\Publish\SPI\Persistence\Content\ContentInfo[]
+     * @return int[]
      */
-    protected function loadContentObjects( $contentTypeId )
+    protected function getContentIdsByContentTypeId( $contentTypeId )
     {
-        $result = $this->searchHandler->findContent(
-            new Query(
-                array(
-                    'filter' => new Criterion\ContentTypeId( $contentTypeId )
-                )
-            )
-        );
-
-        $contentInfo = array();
-        foreach ( $result->searchHits as $hit )
-        {
-            $contentInfo[] = $hit->valueObject;
-        }
-
-        return $contentInfo;
+        return $this->contentGateway->getContentIdsByContentTypeId( $contentTypeId );
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action.php
@@ -9,7 +9,6 @@
 
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Type\ContentUpdater;
 
-use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use eZ\Publish\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
 
 /**
@@ -37,9 +36,7 @@ abstract class Action
     /**
      * Applies the action to the given $content
      *
-     * @param \eZ\Publish\SPI\Persistence\Content\ContentInfo $contentInfo
-     *
-     * @return void
+     * @param int $contentId
      */
-    abstract public function apply( ContentInfo $contentInfo );
+    abstract public function apply( $contentId );
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action/AddField.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action/AddField.php
@@ -11,7 +11,6 @@ namespace eZ\Publish\Core\Persistence\Legacy\Content\Type\ContentUpdater\Action;
 
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\ContentUpdater\Action;
 use eZ\Publish\SPI\Persistence\Content;
-use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
@@ -65,7 +64,8 @@ class AddField extends Action
         FieldDefinition $fieldDef,
         Converter $converter,
         StorageHandler $storageHandler,
-        ContentMapper $contentMapper)
+        ContentMapper $contentMapper
+    )
     {
         $this->contentGateway = $contentGateway;
         $this->fieldDefinition = $fieldDef;
@@ -77,43 +77,66 @@ class AddField extends Action
     /**
      * Applies the action to the given $content
      *
-     * @param \eZ\Publish\SPI\Persistence\Content\ContentInfo $contentInfo
+     * @param int $contentId
      */
-    public function apply( ContentInfo $contentInfo )
+    public function apply( $contentId )
     {
-        $languageCodeSet = array();
-        $versionNumbers = $this->contentGateway->listVersionNumbers( $contentInfo->id );
+        $versionNumbers = $this->contentGateway->listVersionNumbers( $contentId );
+        $languageCodeToFieldId = array();
 
-        $contentRows = $this->contentGateway->load( $contentInfo->id, $contentInfo->currentVersionNo );
-        $contentList = $this->contentMapper->extractContentFromRows( $contentRows );
-        $content = $contentList[0];
-
-        foreach ( $content->fields as $field )
+        foreach ( $versionNumbers as $versionNo )
         {
-            if ( isset( $languageCodeSet[$field->languageCode] ) )
-            {
-                continue;
-            }
+            $contentRows = $this->contentGateway->load( $contentId, $versionNo );
+            $contentList = $this->contentMapper->extractContentFromRows( $contentRows );
+            $content = $contentList[0];
+            $languageCodeSet = array();
 
-            $languageCodeSet[$field->languageCode] = true;
-
-            foreach ( $versionNumbers as $versionNo )
+            // Each subsequent Content version can have additional language(s)
+            foreach ( $content->fields as $field )
             {
-                $this->insertField(
+                $languageCode = $field->languageCode;
+
+                // Add once for each language per version
+                if ( isset( $languageCodeSet[$languageCode] ) )
+                {
+                    continue;
+                }
+
+                $languageCodeSet[$languageCode] = true;
+
+                // Check if field was already inserted for current language code,
+                // in that case we need to preserve its ID across versions
+                if ( isset( $languageCodeToFieldId[$languageCode] ) )
+                {
+                    $fieldId = $languageCodeToFieldId[$languageCode];
+                }
+                else
+                {
+                    $fieldId = null;
+                }
+
+                $languageCodeToFieldId[$languageCode] = $this->insertField(
                     $content,
-                    $this->createField( $versionNo, $field->languageCode )
+                    $this->createField(
+                        $fieldId,
+                        $versionNo,
+                        $languageCode
+                    )
                 );
             }
         }
     }
 
     /**
-     * Inserts given $field and appends it to the given $content field collection.
+     * Inserts given $field to the internal and external storage.
+     *
+     * If $field->id is null, creating new field id will be created.
+     * Otherwise it will be inserted for the given $content version, reusing existing Field id.
      *
      * @param \eZ\Publish\SPI\Persistence\Content $content
      * @param \eZ\Publish\SPI\Persistence\Content\Field $field
      *
-     * @return void
+     * @return int The ID of the field that was inserted
      */
     protected function insertField( Content $content, Field $field )
     {
@@ -123,11 +146,24 @@ class AddField extends Action
             $storageValue
         );
 
-        $field->id = $this->contentGateway->insertNewField(
-            $content,
-            $field,
-            $storageValue
-        );
+        if ( isset( $field->id ) )
+        {
+            // Insert with existing Field id and given Content version number
+            $this->contentGateway->insertExistingField(
+                $content,
+                $field,
+                $storageValue
+            );
+        }
+        else
+        {
+            // Insert with creating new Field id and given Content version number
+            $field->id = $this->contentGateway->insertNewField(
+                $content,
+                $field,
+                $storageValue
+            );
+        }
 
         // If the storage handler returns true, it means that $field value has been modified
         // So we need to update it in order to store those modifications
@@ -140,38 +176,30 @@ class AddField extends Action
                 $storageValue
             );
 
-            if ( $this->fieldDefinition->isTranslatable )
-            {
-                $this->contentGateway->updateField(
-                    $field,
-                    $storageValue
-                );
-            }
-            else
-            {
-                $this->contentGateway->updateNonTranslatableField(
-                    $field,
-                    $storageValue,
-                    $content->versionInfo->contentInfo->id
-                );
-            }
+            $this->contentGateway->updateField(
+                $field,
+                $storageValue
+            );
         }
 
-        $content->fields[] = $field;
+        return $field->id;
     }
 
     /**
+     * Creates new Field value object, setting given parameters and default value
+     * for a field definition the action is constructed for.
      *
-     *
+     * @param null|int $id
      * @param int $versionNo
      * @param string $languageCode
      *
      * @return \eZ\Publish\SPI\Persistence\Content\Field
      */
-    protected function createField( $versionNo, $languageCode )
+    protected function createField( $id, $versionNo, $languageCode )
     {
         $field = new Field();
 
+        $field->id = $id;
         $field->fieldDefinitionId = $this->fieldDefinition->id;
         $field->type = $this->fieldDefinition->fieldType;
         $field->value = clone $this->fieldDefinition->defaultValue;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdaterTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdaterTest.php
@@ -142,54 +142,33 @@ class ContentUpdaterTest extends PHPUnit_Framework_TestCase
             '',
             false
         );
-        $actionA->expects( $this->exactly( 2 ) )
+        $actionA->expects( $this->at( 0 ) )
             ->method( 'apply' )
-            ->with(
-                $this->isInstanceOf(
-                    '\\eZ\\Publish\\SPI\\Persistence\\Content\\ContentInfo'
-                )
-            );
+            ->with( 11 );
+        $actionA->expects( $this->at( 1 ) )
+            ->method( 'apply' )
+            ->with( 22 );
         $actionB = $this->getMockForAbstractClass(
             '\\eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\ContentUpdater\\Action',
             array(),
             '',
             false
         );
-        $actionB->expects( $this->exactly( 2 ) )
+        $actionB->expects( $this->at( 0 ) )
             ->method( 'apply' )
-            ->with(
-                $this->isInstanceOf(
-                    '\\eZ\\Publish\\SPI\\Persistence\\Content\\ContentInfo'
-                )
-            );
+            ->with( 11 );
+        $actionB->expects( $this->at( 1 ) )
+            ->method( 'apply' )
+            ->with( 22 );
 
         $actions = array( $actionA, $actionB );
 
-        $contentInfo = new ContentInfo();
-
-        $result = new SearchResult();
-
-        $hit    = new SearchHit();
-        $hit->valueObject = $contentInfo;
-        $result->searchHits[] = $hit;
-
-        $hit    = new SearchHit();
-        $hit->valueObject = clone $contentInfo;
-        $result->searchHits[] = $hit;
-
-        $this->getSearchHandlerMock()
+        $this->getContentGatewayMock()
             ->expects( $this->once() )
-            ->method( 'findContent' )
-            ->with(
-                $this->equalTo(
-                    new Query(
-                        array(
-                            'filter' => new CriterionContentTypeId( 23 )
-                        )
-                    )
-                )
-            )->will(
-                $this->returnValue( $result )
+            ->method( 'getContentIdsByContentTypeId' )
+            ->with( 23 )
+            ->will(
+                $this->returnValue( array( 11, 22 ) )
             );
 
         $updater->applyUpdates( 23, $actions );
@@ -274,26 +253,6 @@ class ContentUpdaterTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Returns a Search Handler mock
-     *
-     * @return \eZ\Publish\Core\Search\Legacy\Content\Handler
-     */
-    protected function getSearchHandlerMock()
-    {
-        if ( !isset( $this->searchHandlerMock ) )
-        {
-            $this->searchHandlerMock = $this->getMock(
-                'eZ\\Publish\\Core\\Search\\Legacy\\Content\\Handler',
-                array(),
-                array(),
-                '',
-                false
-            );
-        }
-        return $this->searchHandlerMock;
-    }
-
-    /**
      * Returns a Content StorageHandler mock
      *
      * @return \eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler
@@ -343,7 +302,6 @@ class ContentUpdaterTest extends PHPUnit_Framework_TestCase
         if ( !isset( $this->contentUpdater ) )
         {
             $this->contentUpdater = new ContentUpdater(
-                $this->getSearchHandlerMock(),
                 $this->getContentGatewayMock(),
                 $this->getConverterRegistryMock(),
                 $this->getContentStorageHandlerMock(),

--- a/eZ/Publish/Core/settings/search_engines/legacy/sort_clause_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/sort_clause_handlers_common.yml
@@ -46,7 +46,7 @@ services:
         class: %ezpublish.search.legacy.gateway.sort_clause_handler.common.field.class%
         arguments:
             - @ezpublish.api.storage_engine.legacy.dbhandler
-            - @ezpublish.spi.persistence.legacy.language.handler
+            - @ezpublish.spi.persistence.language_handler
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
@@ -55,7 +55,7 @@ services:
         class: %ezpublish.search.legacy.gateway.sort_clause_handler.common.map_location_distance.class%
         arguments:
             - @ezpublish.api.storage_engine.legacy.dbhandler
-            - @ezpublish.spi.persistence.legacy.language.handler
+            - @ezpublish.spi.persistence.language_handler
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}

--- a/eZ/Publish/Core/settings/search_engines/solr/criterion_visitors.yml
+++ b/eZ/Publish/Core/settings/search_engines/solr/criterion_visitors.yml
@@ -104,9 +104,6 @@ services:
         tags:
             - {name: ezpublish.search.solr.content.criterion_visitor}
 
-    # TODO: when Solr storage is enabled and multiple Solr storage engines are used simultaneously
-    # 'ezpublish.spi.persistence.legacy.content_type.handler' dependency will need to be set through
-    # alias or factory
     ezpublish.search.solr.content.criterion_visitor.content_type_identifier_in:
         class: %ezpublish.search.solr.content.criterion_visitor.content_type_identifier_in.class%
         arguments:
@@ -266,9 +263,6 @@ services:
         tags:
             - {name: ezpublish.search.solr.location.criterion_visitor}
 
-    # TODO: when Solr storage is enabled and multiple Solr storage engines are used simultaneously
-    # 'ezpublish.spi.persistence.legacy.content_type.handler' dependency will need to be set through
-    # alias or factory
     ezpublish.search.solr.location.criterion_visitor.content_type_identifier_in:
         class: %ezpublish.search.solr.location.criterion_visitor.content_type_identifier_in.class%
         arguments:

--- a/eZ/Publish/Core/settings/storage_engines/legacy/content_type.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/content_type.yml
@@ -35,7 +35,6 @@ services:
     ezpublish.persistence.legacy.content_type.content_updater:
         class: %ezpublish.persistence.legacy.content_type.content_updater.class%
         arguments:
-            - @ezpublish.spi.search.legacy.handler.content
             - @ezpublish.persistence.legacy.content.gateway
             - @ezpublish.persistence.legacy.field_value_converter.registry
             - @ezpublish.persistence.legacy.external_storage_handler

--- a/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
@@ -587,6 +587,7 @@ abstract class BaseIntegrationTest extends TestCase
         $loader->load( 'repository.yml' );
         $loader->load( 'fieldtype_external_storages.yml' );
         $loader->load( 'storage_engines/common.yml' );
+        $loader->load( 'storage_engines/shortcuts.yml' );
         $loader->load( 'storage_engines/legacy.yml' );
         $loader->load( 'search_engines/legacy.yml' );
         $loader->load( 'storage_engines/cache.yml' );

--- a/eZ/Publish/SPI/Tests/FieldType/FileBaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/FileBaseIntegrationTest.php
@@ -150,6 +150,7 @@ abstract class FileBaseIntegrationTest extends BaseIntegrationTest
         $loader->load( 'repository.yml' );
         $loader->load( 'fieldtype_external_storages.yml' );
         $loader->load( 'storage_engines/common.yml' );
+        $loader->load( 'storage_engines/shortcuts.yml' );
         $loader->load( 'storage_engines/legacy.yml' );
         $loader->load( 'search_engines/legacy.yml' );
         $loader->load( 'storage_engines/cache.yml' );


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-23941

First part of the issue, required to implement the field map on the ContentType handler.

`ContentUpdater` service, used by ContentType handler to update Content instances when FieldDefinition is added or removed was using search handler to find Content instances of a specific ContentType.
This would create a circular dependency and therefore needed to be removed. Search handler is here replaced by new method in Content gateway `getContentIdsByType()`.

Additionally a bug in `ContentUpdater` is fixed, where added Field ids were not retained across versions and external storages were not notified for store/delete for all necessary versions.