### PR TITLE
Tweak install text to reflect demo-clean install

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
@@ -92,13 +92,13 @@ ________________/\\\\\\\\\\\\\\\____________/\\\\\\\\\\\\\____/\\\\\\___________
 
 <fg=cyan>Welcome to eZ Platform!</fg=cyan>
 
-<options=underscore>You may now complete eZ Platform installation with the following command:</options=underscore>
-<comment>    $ php ezpublish/console ezplatform:install clean</comment>
+<options=underscore>You may now complete the eZ Platform installation with ezplatform:install command, example of use:</options=underscore>
+<comment>    $ php ezpublish/console ezplatform:install --env prod demo-clean</comment>
 
 <options=underscore>After executing this, you can launch your browser* and get started.</options=underscore>
 
 
-* Assuming you have configured your web server (Apache/Nginx) correctly (see doc/ folder in eZ Platform <root-directory>)
+* Assuming you have setup directory permissions and configured your web server (Apache/Nginx) correctly (see Readme.md and doc/ folder in eZ Platform <root-directory>).
 EOT
         );
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
@@ -98,7 +98,7 @@ ________________/\\\\\\\\\\\\\\\____________/\\\\\\\\\\\\\____/\\\\\\___________
 <options=underscore>After executing this, you can launch your browser* and get started.</options=underscore>
 
 
-* Assuming you have setup directory permissions and configured your web server (Apache/Nginx) correctly (see Readme.md and doc/ folder in eZ Platform <root-directory>).
+* Assuming you have setup directory permissions and configured your web server (Apache/Nginx) correctly (see Install.md and doc/ folder in eZ Platform <root-directory>).
 EOT
         );
     }


### PR DESCRIPTION
Change welcome text to make sure directory permissions are mentioned, default example of install is using demo-clean and that it more clearly states it is and example.