### PR TITLE
Fix EZP-24025: Make sure to clear cache on install

### DIFF
--- a/bin/.travis/prepare_behat.sh
+++ b/bin/.travis/prepare_behat.sh
@@ -2,25 +2,14 @@
 
 # File for setting up system for behat testing, just like done in DemoBundle's .travis.yml
 
+git fetch --unshallow && git checkout -b tmp_travis_branch
 export BRANCH_BUILD_DIR=$TRAVIS_BUILD_DIR
 export TRAVIS_BUILD_DIR="$HOME/build/ezpublish-community"
 cd "$HOME/build"
 
 # Change the branch and/or remote to use a different ezpublish branch/distro
-git clone --depth 1 --single-branch --branch master https://github.com/ezsystems/ezpublish-community.git
+git clone --depth 1 --single-branch --branch travis_improvements https://github.com/ezsystems/ezpublish-community.git
 cd ezpublish-community
 
-# Use this if you depend on another branch for a dependency (only works for the ezsystems remote)
-# (note that packagist may take time to update the references, leading to errors. Just retrigger the build)
-#
-# Example:
-# composer require --no-update ezsystems/DemoBundle:dev-MyCustomBranch
 
-# Prepare system (Apache, Mysql, Sahi/Selenium, eZ Publish)
-./bin/.travis/prepare_system.sh
-./bin/.travis/prepare_testsystem.sh
-./bin/.travis/prepare_ezpublish.sh
-
-# Replace kernel with the one from pull-request/current checkout
-rm -rf vendor/ezsystems/ezpublish-kernel
-mv "$BRANCH_BUILD_DIR" vendor/ezsystems/ezpublish-kernel
+./bin/.travis/setup_from_external_repo.sh $BRANCH_BUILD_DIR "ezsystems/ezpublish-kernel:dev-tmp_travis_branch"

--- a/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
@@ -13,6 +13,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 
 class InstallPlatformCommand extends Command
 {
@@ -21,6 +22,12 @@ class InstallPlatformCommand extends Command
 
     /** @var \Symfony\Component\Console\Output\OutputInterface */
     private $output;
+
+    /** @var \Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface */
+    private $cacheClearer;
+
+    /** @var string */
+    private $cacheDir;
 
     /** @var \EzSystems\PlatformInstallerBundle\Installer\Installer[] */
     private $installers = array();
@@ -31,10 +38,12 @@ class InstallPlatformCommand extends Command
     const EXIT_UNKNOWN_INSTALL_TYPE = 6;
     const EXIT_MISSING_PERMISSIONS = 7;
 
-    public function __construct( Connection $db, array $installers )
+    public function __construct( Connection $db, array $installers, CacheClearerInterface $cacheClearer, $cacheDir )
     {
         $this->db = $db;
         $this->installers = $installers;
+        $this->cacheClearer = $cacheClearer;
+        $this->cacheDir = $cacheDir;
         parent::__construct();
     }
 
@@ -69,6 +78,7 @@ class InstallPlatformCommand extends Command
         $installer->importSchema();
         $installer->importData();
         $installer->importBinaries();
+        $this->cacheClear( $output );
     }
 
     private function checkPermissions()
@@ -133,6 +143,17 @@ class InstallPlatformCommand extends Command
             $this->output->writeln( "Please check the database configuration in parameters.yml" );
             exit( self::EXIT_GENERAL_DATABASE_ERROR );
         }
+    }
+
+    private function cacheClear( OutputInterface $output )
+    {
+        if ( !is_writable( $this->cacheDir ) )
+        {
+            throw new \RuntimeException( sprintf( 'Unable to write in the "%s" directory', $this->cacheDir ) );
+        }
+
+        $output->writeln( sprintf( 'Clearing cache for directory <info>%s</info>', $this->cacheDir ) );
+        $this->cacheClearer->clear( $this->cacheDir );
     }
 
     /**

--- a/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
@@ -21,6 +21,6 @@ services:
             - @database_connection
             - []
             - @cache_clearer
-            - $kernel.cache_dir
+            - %kernel.cache_dir%
         tags:
             - { name: console.command }

--- a/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
@@ -17,6 +17,10 @@ services:
 
     ezplatform.installer.install_command:
         class: %ezplatform.installer.install_command.class%
-        arguments: [ @database_connection, [] ]
+        arguments:
+            - @database_connection
+            - []
+            - @cache_clearer
+            - $kernel.cache_dir
         tags:
             - { name: console.command }


### PR DESCRIPTION
Behat setup wasn't running with the code of the orignal PR, so issues with it was not detected.
Issue was use of $ as opposed to %%, but until this is fixed and merged setup for behat must run correctly first.

(cherry picked from commit cc65c191068301ec19d5aa8faee2966c1ba4618c from #1197)