### PR TITLE
EZP-23941: Move field map to storage 2/2

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
@@ -178,6 +178,7 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
             // Warm cache
             $this->cache->getItem( 'contentType', $type->id )->set( $type );
             $this->cache->getItem( 'contentType', 'identifier', $type->identifier )->set( $type->id );
+            $this->cache->clear( 'searchableFieldMap' );
         }
 
         return $type;
@@ -201,6 +202,7 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
 
         // Clear identifier cache in case it was changed before warming the new one
         $this->cache->clear( 'contentType', 'identifier' );
+        $this->cache->clear( 'searchableFieldMap' );
         $this->cache->getItem( 'contentType', 'identifier', $type->identifier )->set( $typeId );
 
         return $type;
@@ -219,6 +221,7 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
             // Clear type cache and all identifier cache (as we don't know the identifier)
             $this->cache->clear( 'contentType', $typeId );
             $this->cache->clear( 'contentType', 'identifier' );
+            $this->cache->clear( 'searchableFieldMap' );
         }
 
         return $return;
@@ -251,7 +254,9 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
         $return = $this->persistenceHandler->contentTypeHandler()->unlink( $groupId, $typeId, $status );
 
         if ( $status === Type::STATUS_DEFINED )
+        {
             $this->cache->clear( 'contentType', $typeId );
+        }
 
         return $return;
     }
@@ -265,7 +270,9 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
         $return = $this->persistenceHandler->contentTypeHandler()->link( $groupId, $typeId, $status );
 
         if ( $status === Type::STATUS_DEFINED )
+        {
             $this->cache->clear( 'contentType', $typeId );
+        }
 
         return $return;
     }
@@ -301,7 +308,10 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
         );
 
         if ( $status === Type::STATUS_DEFINED )
+        {
             $this->cache->clear( 'contentType', $typeId );
+            $this->cache->clear( 'searchableFieldMap' );
+        }
 
         return $return;
     }
@@ -319,7 +329,10 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
         );
 
         if ( $status === Type::STATUS_DEFINED )
+        {
             $this->cache->clear( 'contentType', $typeId );
+            $this->cache->clear( 'searchableFieldMap' );
+        }
     }
 
     /**
@@ -335,7 +348,10 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
         );
 
         if ( $status === Type::STATUS_DEFINED )
+        {
             $this->cache->clear( 'contentType', $typeId );
+            $this->cache->clear( 'searchableFieldMap' );
+        }
     }
 
     /**
@@ -349,8 +365,28 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
         // Clear type cache and all identifier cache (as we don't know the identifier)
         $this->cache->clear( 'contentType', $typeId );
         $this->cache->clear( 'contentType', 'identifier' );
+        $this->cache->clear( 'searchableFieldMap' );
 
         // clear content cache
         $this->cache->clear( 'content' );//TIMBER! (possible content changes)
+    }
+
+    /**
+     * @see \eZ\Publish\SPI\Persistence\Content\Type\Handler::getSearchableFieldMap
+     */
+    public function getSearchableFieldMap()
+    {
+        $cache = $this->cache->getItem( 'searchableFieldMap' );
+
+        $fieldMap = $cache->get();
+
+        if ( $cache->isMiss() )
+        {
+            $this->logger->logCall( __METHOD__ );
+            $fieldMap = $this->persistenceHandler->contentTypeHandler()->getSearchableFieldMap();
+            $cache->set( $fieldMap );
+        }
+
+        return $fieldMap;
     }
 }

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentTypeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentTypeHandlerTest.php
@@ -674,6 +674,12 @@ class ContentTypeHandlerTest extends HandlerTest
             ->with( 'contentType', 'identifier' )
             ->will( $this->returnValue( true ) );
 
+        $this->cacheMock
+            ->expects( $this->at( 2 ) )
+            ->method( 'clear' )
+            ->with( 'searchableFieldMap' )
+            ->will( $this->returnValue( true ) );
+
         $innerHandler = $this->getMock( 'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler' );
         $this->persistenceHandlerMock
             ->expects( $this->once() )
@@ -707,7 +713,7 @@ class ContentTypeHandlerTest extends HandlerTest
 
         $cacheItemMock2 = $this->getMock( 'Stash\Interfaces\ItemInterface' );
         $this->cacheMock
-            ->expects( $this->at( 2 ) )
+            ->expects( $this->at( 3 ) )
             ->method( 'getItem' )
             ->with( 'contentType', 'identifier', 'forum' )
             ->will( $this->returnValue( $cacheItemMock2 ) );
@@ -884,7 +890,7 @@ class ContentTypeHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects( $this->once() )->method( 'logCall' );
         $this->cacheMock
-            ->expects( $this->once() )
+            ->expects( $this->at( 0 ) )
             ->method( 'clear' )
             ->with( 'contentType', 44 )
             ->will( $this->returnValue( true ) );
@@ -942,7 +948,7 @@ class ContentTypeHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects( $this->once() )->method( 'logCall' );
         $this->cacheMock
-            ->expects( $this->once() )
+            ->expects( $this->at( 0 ) )
             ->method( 'clear' )
             ->with( 'contentType', 44 )
             ->will( $this->returnValue( true ) );
@@ -1026,9 +1032,15 @@ class ContentTypeHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects( $this->once() )->method( 'logCall' );
         $this->cacheMock
-            ->expects( $this->once() )
+            ->expects( $this->at( 0 ) )
             ->method( 'clear' )
             ->with( 'contentType', 44 )
+            ->will( $this->returnValue( true ) );
+
+        $this->cacheMock
+            ->expects( $this->at( 1 ) )
+            ->method( 'clear' )
+            ->with( 'searchableFieldMap' )
             ->will( $this->returnValue( true ) );
 
         $innerHandlerMock = $this->getMock( 'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler' );
@@ -1092,9 +1104,15 @@ class ContentTypeHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects( $this->once() )->method( 'logCall' );
         $this->cacheMock
-            ->expects( $this->once() )
+            ->expects( $this->at( 0 ) )
             ->method( 'clear' )
             ->with( 'contentType', 44 )
+            ->will( $this->returnValue( true ) );
+
+        $this->cacheMock
+            ->expects( $this->at( 1 ) )
+            ->method( 'clear' )
+            ->with( 'searchableFieldMap' )
             ->will( $this->returnValue( true ) );
 
         $innerHandlerMock = $this->getMock( 'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler' );
@@ -1158,9 +1176,15 @@ class ContentTypeHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects( $this->once() )->method( 'logCall' );
         $this->cacheMock
-            ->expects( $this->once() )
+            ->expects( $this->at( 0 ) )
             ->method( 'clear' )
             ->with( 'contentType', 44 )
+            ->will( $this->returnValue( true ) );
+
+        $this->cacheMock
+            ->expects( $this->at( 1 ) )
+            ->method( 'clear' )
+            ->with( 'searchableFieldMap' )
             ->will( $this->returnValue( true ) );
 
         $innerHandlerMock = $this->getMock( 'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler' );
@@ -1237,6 +1261,12 @@ class ContentTypeHandlerTest extends HandlerTest
 
         $this->cacheMock
             ->expects( $this->at( 2 ) )
+            ->method( 'clear' )
+            ->with( 'searchableFieldMap' )
+            ->will( $this->returnValue( true ) );
+
+        $this->cacheMock
+            ->expects( $this->at( 3 ) )
             ->method( 'clear' )
             ->with( 'content' )
             ->will( $this->returnValue( true ) );

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
@@ -292,12 +292,9 @@ abstract class Gateway
     abstract public function publishTypeAndFields( $typeId, $sourceStatus, $targetStatus );
 
     /**
-     * Returns field mapping data
-     *
-     * Returns an associative array with ContentType and FieldDefinition identifiers as
-     * first and second level keys respectively, and FieldDefinition ID as value.
+     * Returns searchable fields mapping data
      *
      * @return array
      */
-    abstract public function getFieldMap();
+    abstract public function getSearchableFieldMapData();
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -21,6 +21,7 @@ use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 use eZ\Publish\SPI\Persistence\ValueObject;
 use eZ\Publish\Core\Persistence\Database\Query;
 use eZ\Publish\Core\Persistence\Database\SelectQuery;
+use PDO;
 
 /**
  * Doctrine database based content type gateway.
@@ -1319,29 +1320,30 @@ class DoctrineDatabase extends Gateway
     }
 
     /**
-     * Returns field mapping data
-     *
-     * Returns an associative array with ContentType and FieldDefinition identifiers as
-     * first and second level keys respectively, and FieldDefinition ID as value.
+     * Returns searchable field mapping data
      *
      * @return array
      */
-    public function getFieldMap()
+    public function getSearchableFieldMapData()
     {
         $query = $this->dbHandler->createSelectQuery();
         $query
             ->select(
                 $this->dbHandler->alias(
-                    $this->dbHandler->quoteColumn( "id", "ezcontentclass_attribute" ),
-                    $this->dbHandler->quoteIdentifier( "field_id" )
-                ),
-                $this->dbHandler->alias(
                     $this->dbHandler->quoteColumn( "identifier", "ezcontentclass_attribute" ),
-                    $this->dbHandler->quoteIdentifier( "field_identifier" )
+                    $this->dbHandler->quoteIdentifier( "field_definition_identifier" )
                 ),
                 $this->dbHandler->alias(
                     $this->dbHandler->quoteColumn( "identifier", "ezcontentclass" ),
-                    $this->dbHandler->quoteIdentifier( "type_identifier" )
+                    $this->dbHandler->quoteIdentifier( "content_type_identifier" )
+                ),
+                $this->dbHandler->alias(
+                    $this->dbHandler->quoteColumn( "id", "ezcontentclass_attribute" ),
+                    $this->dbHandler->quoteIdentifier( "field_definition_id" )
+                ),
+                $this->dbHandler->alias(
+                    $this->dbHandler->quoteColumn( "data_type_string", "ezcontentclass_attribute" ),
+                    $this->dbHandler->quoteIdentifier( "field_type_identifier" )
                 )
             )
             ->from(
@@ -1353,19 +1355,16 @@ class DoctrineDatabase extends Gateway
                     $this->dbHandler->quoteColumn( "contentclass_id", "ezcontentclass_attribute" ),
                     $this->dbHandler->quoteColumn( "id", "ezcontentclass" )
                 )
+            )->where(
+                $query->expr->eq(
+                    $this->dbHandler->quoteColumn( "is_searchable", "ezcontentclass_attribute" ),
+                    $query->bindValue( 1, null, PDO::PARAM_INT )
+                )
             );
 
         $statement = $query->prepare( $query );
         $statement->execute();
 
-        $map = array();
-        $rows = $statement->fetchAll( \PDO::FETCH_ASSOC );
-
-        foreach ( $rows as $row )
-        {
-            $map[$row["type_identifier"]][$row["field_identifier"]] = $row["field_id"];
-        }
-
-        return $map;
+        return $statement->fetchAll( \PDO::FETCH_ASSOC );
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
@@ -677,18 +677,15 @@ class ExceptionConversion extends Gateway
     }
 
     /**
-     * Returns field mapping data
-     *
-     * Returns an associative array with ContentType and FieldDefinition identifiers as
-     * first and second level keys respectively, and FieldDefinition ID as value.
+     * Returns searchable field mapping data
      *
      * @return array
      */
-    public function getFieldMap()
+    public function getSearchableFieldMapData()
     {
         try
         {
-            return $this->innerGateway->getFieldMap();
+            return $this->innerGateway->getSearchableFieldMapData();
         }
         catch ( DBALException $e )
         {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
@@ -619,4 +619,23 @@ class Handler implements BaseContentTypeHandler
 
         $this->updateHandler->publishNewType( $toType, Type::STATUS_DEFINED );
     }
+
+    /**
+     * @see \eZ\Publish\SPI\Persistence\Content\Type\Handler::getSearchableFieldMap
+     */
+    public function getSearchableFieldMap()
+    {
+        $fieldMap = [];
+        $rows = $this->contentTypeGateway->getSearchableFieldMapData();
+
+        foreach ( $rows as $row )
+        {
+            $fieldMap[$row["content_type_identifier"]][$row["field_definition_identifier"]] = [
+                "field_type_identifier" => $row["field_type_identifier"],
+                "field_definition_id" => $row["field_definition_id"],
+            ];
+        }
+
+        return $fieldMap;
+    }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/MemoryCachingHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/MemoryCachingHandler.php
@@ -51,6 +51,13 @@ class MemoryCachingHandler implements BaseContentTypeHandler
     protected $fieldDefinitions;
 
     /**
+     * Local in-memory cache for searchable field map in one single request
+     *
+     * @var array
+     */
+    protected $searchableFieldMap = null;
+
+    /**
      * Creates a new content type handler.
      *
      * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $handler
@@ -416,6 +423,19 @@ class MemoryCachingHandler implements BaseContentTypeHandler
     }
 
     /**
+     * @see \eZ\Publish\SPI\Persistence\Content\Type\Handler::getSearchableFieldMap
+     */
+    public function getSearchableFieldMap()
+    {
+        if ( $this->searchableFieldMap !== null )
+        {
+            return $this->searchableFieldMap;
+        }
+
+        return $this->searchableFieldMap = $this->innerHandler->getSearchableFieldMap();
+    }
+
+    /**
      * Clear internal caches
      *
      * @return void
@@ -423,5 +443,6 @@ class MemoryCachingHandler implements BaseContentTypeHandler
     public function clearCache()
     {
         $this->groups = $this->contentTypes = $this->fieldDefinitions = array();
+        $this->searchableFieldMap = null;
     }
 }

--- a/eZ/Publish/Core/Search/Common/FieldNameResolver.php
+++ b/eZ/Publish/Core/Search/Common/FieldNameResolver.php
@@ -61,44 +61,28 @@ class FieldNameResolver
     }
 
     /**
-     * Get field type information
+     * Get content type, field definition and field type mapping information
      *
      * Returns an array in the form:
      *
      * <code>
      *  array(
-     *      "content-type-identifier" => array(
-     *          "field-definition-identifier" => "field-type-identifier",
-     *          …
+     *      "<ContentType identifier>" => array(
+     *          "<FieldDefinition identifier>" => array(
+     *              "field_definition_id" => "<FieldDefinition id>",
+     *              "field_type_identifier" => "<FieldType identifier>",
+     *          ),
+     *          ...
      *      ),
-     *      …
+     *      ...
      *  )
      * </code>
      *
      * @return array
      */
-    protected function getFieldMap()
+    protected function getSearchableFieldMap()
     {
-        $fieldTypes = [];
-
-        foreach ( $this->contentTypeHandler->loadAllGroups() as $group )
-        {
-            foreach ( $this->contentTypeHandler->loadContentTypes( $group->id ) as $contentType )
-            {
-                foreach ( $contentType->fieldDefinitions as $fieldDefinition )
-                {
-                    if ( !$fieldDefinition->isSearchable )
-                    {
-                        continue;
-                    }
-
-                    $fieldTypes[$contentType->identifier][$fieldDefinition->identifier] =
-                        $fieldDefinition->fieldType;
-                }
-            }
-        }
-
-        return $fieldTypes;
+        return $this->contentTypeHandler->getSearchableFieldMap();
     }
 
     /**
@@ -126,7 +110,7 @@ class FieldNameResolver
         $name = null
     )
     {
-        $fieldMap = $this->getFieldMap();
+        $fieldMap = $this->getSearchableFieldMap();
         $fieldNames = [];
 
         foreach ( $fieldMap as $contentTypeIdentifier => $fieldIdentifierMap )
@@ -140,7 +124,7 @@ class FieldNameResolver
             // If $fieldTypeIdentifier is given it must match current field definition
             if (
                 $fieldTypeIdentifier !== null &&
-                $fieldTypeIdentifier !== $fieldIdentifierMap[$fieldDefinitionIdentifier]
+                $fieldTypeIdentifier !== $fieldIdentifierMap[$fieldDefinitionIdentifier]["field_type_identifier"]
             )
             {
                 continue;
@@ -150,7 +134,7 @@ class FieldNameResolver
                 $criterion,
                 $contentTypeIdentifier,
                 $fieldDefinitionIdentifier,
-                $fieldIdentifierMap[$fieldDefinitionIdentifier],
+                $fieldIdentifierMap[$fieldDefinitionIdentifier]["field_type_identifier"],
                 $name
             );
         }
@@ -185,7 +169,7 @@ class FieldNameResolver
         $name = null
     )
     {
-        $fieldMap = $this->getFieldMap();
+        $fieldMap = $this->getSearchableFieldMap();
 
         // First check if field exists in type, there is nothing to do if it doesn't
         if ( !isset( $fieldMap[$contentTypeIdentifier][$fieldDefinitionIdentifier] ) )
@@ -197,7 +181,7 @@ class FieldNameResolver
             $sortClause,
             $contentTypeIdentifier,
             $fieldDefinitionIdentifier,
-            $fieldMap[$contentTypeIdentifier][$fieldDefinitionIdentifier],
+            $fieldMap[$contentTypeIdentifier][$fieldDefinitionIdentifier]["field_type_identifier"],
             $name
         );
     }

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/SortClauseVisitor/Field/Field.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/SortClauseVisitor/Field/Field.php
@@ -52,7 +52,7 @@ class Field extends FieldBase
         if ( $fieldName === null )
         {
             throw new InvalidArgumentException(
-                "\$sortClause->target",
+                "\$sortClause->targetData",
                 "No searchable fields found for the given sort clause target ".
                 "'{$target->fieldIdentifier}' on '{$target->typeIdentifier}'."
             );

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/SortClauseVisitor/Field/MapLocationDistance.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/SortClauseVisitor/Field/MapLocationDistance.php
@@ -73,7 +73,7 @@ class MapLocationDistance extends FieldBase
         if ( $fieldName === null )
         {
             throw new InvalidArgumentException(
-                "\$sortClause->target",
+                "\$sortClause->targetData",
                 "No searchable fields found for the given sort clause target ".
                 "'{$target->fieldIdentifier}' on '{$target->typeIdentifier}'."
             );

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseConverter.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseConverter.php
@@ -98,9 +98,8 @@ class SortClauseConverter
      *
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sortClauses
-     * @param array $fieldMap
      */
-    public function applyJoin( SelectQuery $query, array $sortClauses, array $fieldMap )
+    public function applyJoin( SelectQuery $query, array $sortClauses )
     {
         foreach ( $sortClauses as $nr => $sortClause )
         {
@@ -108,7 +107,7 @@ class SortClauseConverter
             {
                 if ( $handler->accept( $sortClause ) )
                 {
-                    $handler->applyJoin( $query, $sortClause, $nr, $fieldMap );
+                    $handler->applyJoin( $query, $sortClause, $nr );
                     continue 2;
                 }
             }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler.php
@@ -64,9 +64,8 @@ abstract class SortClauseHandler
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
      * @param int $number
-     * @param array $fieldMap
      */
-    public function applyJoin( SelectQuery $query, SortClause $sortClause, $number, array $fieldMap )
+    public function applyJoin( SelectQuery $query, SortClause $sortClause, $number )
     {
     }
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/Field.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/Field.php
@@ -11,10 +11,12 @@ namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
 
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\SPI\Persistence\Content\Language\Handler as LanguageHandler;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use eZ\Publish\SPI\Persistence\Content\Type;
 use eZ\Publish\Core\Persistence\Database\SelectQuery;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use PDO;
 
 /**
@@ -30,14 +32,28 @@ class Field extends SortClauseHandler
     protected $languageHandler;
 
     /**
+     * Content Type handler
+     *
+     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
+     */
+    protected $contentTypeHandler;
+
+    /**
      * Creates a new Field sort clause handler
      *
      * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
      * @param \eZ\Publish\SPI\Persistence\Content\Language\Handler $languageHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
      */
-    public function __construct( DatabaseHandler $dbHandler, LanguageHandler $languageHandler )
+    public function __construct(
+        DatabaseHandler $dbHandler,
+        LanguageHandler $languageHandler,
+        ContentTypeHandler $contentTypeHandler
+    )
     {
         $this->languageHandler = $languageHandler;
+        $this->contentTypeHandler = $contentTypeHandler;
+
         parent::__construct( $dbHandler );
     }
 
@@ -116,15 +132,25 @@ class Field extends SortClauseHandler
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
      * @param int $number
-     * @param array $fieldMap
      *
      * @return void
      */
-    public function applyJoin( SelectQuery $query, SortClause $sortClause, $number, array $fieldMap )
+    public function applyJoin( SelectQuery $query, SortClause $sortClause, $number )
     {
         /** @var \eZ\Publish\API\Repository\Values\Content\Query\SortClause\Target\FieldTarget $fieldTarget */
         $fieldTarget = $sortClause->targetData;
-        $fieldDefinitionId = $fieldMap[$fieldTarget->typeIdentifier][$fieldTarget->fieldIdentifier];
+        $fieldMap = $this->contentTypeHandler->getSearchableFieldMap();
+
+        if ( !isset( $fieldMap[$fieldTarget->typeIdentifier][$fieldTarget->fieldIdentifier]["field_definition_id"] ) )
+        {
+            throw new InvalidArgumentException(
+                "\$sortClause->targetData",
+                "No searchable fields found for the given sort clause target ".
+                "'{$fieldTarget->fieldIdentifier}' on '{$fieldTarget->typeIdentifier}'."
+            );
+        }
+
+        $fieldDefinitionId = $fieldMap[$fieldTarget->typeIdentifier][$fieldTarget->fieldIdentifier]["field_definition_id"];
         $table = $this->getSortTableName( $number );
 
         if ( $fieldTarget->languageCode === null )

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/SectionName.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/SectionName.php
@@ -64,11 +64,10 @@ class SectionName extends SortClauseHandler
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
      * @param int $number
-     * @param array $fieldMap
      *
      * @return void
      */
-    public function applyJoin( SelectQuery $query, SortClause $sortClause, $number, array $fieldMap )
+    public function applyJoin( SelectQuery $query, SortClause $sortClause, $number )
     {
         $table = $this->getSortTableName( $number );
         $query

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -9,15 +9,12 @@
 
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway;
 
-use eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway as ContentTypeGateway;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseConverter;
 use eZ\Publish\Core\Search\Legacy\Content\Location\Gateway;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Field;
-use eZ\Publish\API\Repository\Values\Content\Query\SortClause\MapLocationDistance;
 use PDO;
 
 /**
@@ -49,29 +46,21 @@ class DoctrineDatabase extends Gateway
     private $sortClauseConverter;
 
     /**
-     * @var \eZ\Publish\Core\Search\Legacy\Content\Type\Gateway
-     */
-    protected $contentTypeGateway;
-
-    /**
      * Construct from database handler
      *
      * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $handler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $criteriaConverter
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseConverter $sortClauseConverter
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway $contentTypeGateway
      */
     public function __construct(
         DatabaseHandler $handler,
         CriteriaConverter $criteriaConverter,
-        SortClauseConverter $sortClauseConverter,
-        ContentTypeGateway $contentTypeGateway
+        SortClauseConverter $sortClauseConverter
     )
     {
         $this->handler = $handler;
         $this->criteriaConverter = $criteriaConverter;
         $this->sortClauseConverter = $sortClauseConverter;
-        $this->contentTypeGateway = $contentTypeGateway;
     }
 
     /**
@@ -87,8 +76,7 @@ class DoctrineDatabase extends Gateway
      */
     public function find( Criterion $criterion, $offset = 0, $limit = null, array $sortClauses = null, $doCount = true )
     {
-        $fieldMap = $this->getFieldMap( $sortClauses );
-        $count = $doCount ? $this->getTotalCount( $criterion, $sortClauses, $fieldMap ) : null;
+        $count = $doCount ? $this->getTotalCount( $criterion, $sortClauses ) : null;
 
         if ( !$doCount && $limit === 0 )
         {
@@ -123,7 +111,7 @@ class DoctrineDatabase extends Gateway
 
         if ( $sortClauses !== null )
         {
-            $this->sortClauseConverter->applyJoin( $selectQuery, $sortClauses, $fieldMap );
+            $this->sortClauseConverter->applyJoin( $selectQuery, $sortClauses );
         }
 
         $selectQuery->where(
@@ -168,11 +156,10 @@ class DoctrineDatabase extends Gateway
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param null|\eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sortClauses
-     * @param array $fieldMap
      *
      * @return array
      */
-    protected function getTotalCount( Criterion $criterion, $sortClauses, array $fieldMap )
+    protected function getTotalCount( Criterion $criterion, $sortClauses )
     {
         $query = $this->handler->createSelectQuery();
         $query
@@ -191,7 +178,7 @@ class DoctrineDatabase extends Gateway
 
         if ( $sortClauses !== null )
         {
-            $this->sortClauseConverter->applyJoin( $query, $sortClauses, $fieldMap );
+            $this->sortClauseConverter->applyJoin( $query, $sortClauses );
         }
 
         $query->where(
@@ -217,27 +204,5 @@ class DoctrineDatabase extends Gateway
 
         $res = $statement->fetchAll( PDO::FETCH_ASSOC );
         return (int)$res[0]['count'];
-    }
-
-    /**
-     * Returns the field map if given $sortClauses contain a Field sort clause.
-     *
-     * Otherwise an empty array is returned.
-     *
-     * @param null|\eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sortClauses
-     *
-     * @return array
-     */
-    protected function getFieldMap( $sortClauses )
-    {
-        foreach ( (array)$sortClauses as $sortClause )
-        {
-            if ( $sortClause instanceof Field || $sortClause instanceof MapLocationDistance )
-            {
-                return $this->contentTypeGateway->getFieldMap();
-            }
-        }
-
-        return array();
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerSortTest.php
@@ -18,6 +18,7 @@ use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase as ContentTypeGateway;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler as ContentTypeHandler;
 
 /**
  * Test case for ContentSearchHandler
@@ -90,7 +91,11 @@ class HandlerSortTest extends LanguageAwareTestCase
                         new Content\Common\Gateway\SortClauseHandler\SectionIdentifier( $db ),
                         new Content\Common\Gateway\SortClauseHandler\SectionName( $db ),
                         new Content\Common\Gateway\SortClauseHandler\ContentName( $db ),
-                        new Content\Common\Gateway\SortClauseHandler\Field( $db, $this->getLanguageHandler() ),
+                        new Content\Common\Gateway\SortClauseHandler\Field(
+                            $db,
+                            $this->getLanguageHandler(),
+                            $this->getContentTypeHandler()
+                        ),
                     )
                 ),
                 new ContentTypeGateway(
@@ -99,6 +104,34 @@ class HandlerSortTest extends LanguageAwareTestCase
                 )
             ),
             $this->getContentMapperMock()
+        );
+    }
+
+    protected $contentTypeGateway;
+
+    protected function getContentTypeGateway()
+    {
+        if ( !isset( $this->contentTypeGateway ) )
+        {
+            $this->contentTypeGateway = new ContentTypeGateway(
+                $this->getDatabaseHandler(),
+                $this->getLanguageMaskGenerator()
+            );
+        }
+
+        return $this->contentTypeGateway;
+    }
+
+    protected function getContentTypeHandler()
+    {
+        return new ContentTypeHandler(
+            $this->getContentTypeGateway(),
+            $this->getMockBuilder( "eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\Mapper" )
+                ->disableOriginalConstructor()
+                ->getMock(),
+            $this->getMockBuilder( "eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\Update\\Handler" )
+                ->disableOriginalConstructor()
+                ->getMock()
         );
     }
 

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/Location/HandlerSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/Location/HandlerSortTest.php
@@ -23,6 +23,7 @@ use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseConverter;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler as CommonSortClauseHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler as LocationSortClauseHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase as ContentTypeGateway;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler as ContentTypeHandler;
 
 /**
  * Test case for LocationSearchHandler
@@ -112,7 +113,11 @@ class HandlerSortTest extends LanguageAwareTestCase
                         new CommonSortClauseHandler\DatePublished( $this->getDatabaseHandler() ),
                         new CommonSortClauseHandler\SectionIdentifier( $this->getDatabaseHandler() ),
                         new CommonSortClauseHandler\SectionName( $this->getDatabaseHandler() ),
-                        new CommonSortClauseHandler\Field( $this->getDatabaseHandler(), $this->getLanguageHandler() ),
+                        new CommonSortClauseHandler\Field(
+                            $this->getDatabaseHandler(),
+                            $this->getLanguageHandler(),
+                            $this->getContentTypeHandler()
+                        ),
                     )
                 ),
                 new ContentTypeGateway(
@@ -121,6 +126,34 @@ class HandlerSortTest extends LanguageAwareTestCase
                 )
             ),
             $this->getLocationMapperMock()
+        );
+    }
+
+    protected $contentTypeGateway;
+
+    protected function getContentTypeGateway()
+    {
+        if ( !isset( $this->contentTypeGateway ) )
+        {
+            $this->contentTypeGateway = new ContentTypeGateway(
+                $this->getDatabaseHandler(),
+                $this->getLanguageMaskGenerator()
+            );
+        }
+
+        return $this->contentTypeGateway;
+    }
+
+    protected function getContentTypeHandler()
+    {
+        return new ContentTypeHandler(
+            $this->getContentTypeGateway(),
+            $this->getMockBuilder( "eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\Mapper" )
+                ->disableOriginalConstructor()
+                ->getMock(),
+            $this->getMockBuilder( "eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\Update\\Handler" )
+                ->disableOriginalConstructor()
+                ->getMock()
         );
     }
 

--- a/eZ/Publish/Core/Search/Solr/Content/SortClauseVisitor/MapLocationDistance.php
+++ b/eZ/Publish/Core/Search/Solr/Content/SortClauseVisitor/MapLocationDistance.php
@@ -106,7 +106,7 @@ class MapLocationDistance extends SortClauseVisitor
         if ( $fieldName === null )
         {
             throw new InvalidArgumentException(
-                "\$sortClause->target",
+                "\$sortClause->targetData",
                 "No searchable fields found for the given sort clause target ".
                 "'{$target->fieldIdentifier}' on '{$target->typeIdentifier}'."
             );

--- a/eZ/Publish/Core/Search/Tests/FieldNameResolverTest.php
+++ b/eZ/Publish/Core/Search/Tests/FieldNameResolverTest.php
@@ -21,20 +21,26 @@ class FieldNameResolverTest extends TestCase
 {
     public function testGetFieldNamesReturnsEmptyArray()
     {
-        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getFieldMap", "getIndexFieldName" ) );
+        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getSearchableFieldMap", "getIndexFieldName" ) );
         $criterionMock = $this->getCriterionMock();
 
         $mockedFieldNameResolver
             ->expects( $this->once() )
-            ->method( "getFieldMap" )
+            ->method( "getSearchableFieldMap" )
             ->will(
                 $this->returnValue(
                     array(
                         "content_type_identifier_1" => array(
-                            "field_definition_identifier_1" => "field_type_identifier_1",
+                            "field_definition_identifier_1" => array(
+                                "field_definition_id" => "field_definition_id_1",
+                                "field_type_identifier" => "field_type_identifier_1",
+                            ),
                         ),
                         "content_type_identifier_2" => array(
-                            "field_definition_identifier_2" => "field_type_identifier_2",
+                            "field_definition_identifier_2" => array(
+                                "field_definition_id" => "field_definition_id_2",
+                                "field_type_identifier" => "field_type_identifier_2",
+                            ),
                         ),
                     )
                 )
@@ -53,21 +59,30 @@ class FieldNameResolverTest extends TestCase
 
     public function testGetFieldNames()
     {
-        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getFieldMap", "getIndexFieldName" ) );
+        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getSearchableFieldMap", "getIndexFieldName" ) );
         $criterionMock = $this->getCriterionMock();
 
         $mockedFieldNameResolver
             ->expects( $this->once() )
-            ->method( "getFieldMap" )
+            ->method( "getSearchableFieldMap" )
             ->will(
                 $this->returnValue(
                     array(
                         "content_type_identifier_1" => array(
-                            "field_definition_identifier_1" => "field_type_identifier_1",
+                            "field_definition_identifier_1" => array(
+                                "field_definition_id" => "field_definition_id_1",
+                                "field_type_identifier" => "field_type_identifier_1",
+                            ),
                         ),
                         "content_type_identifier_2" => array(
-                            "field_definition_identifier_1" => "field_type_identifier_2",
-                            "field_definition_identifier_2" => "field_type_identifier_3",
+                            "field_definition_identifier_1" => array(
+                                "field_definition_id" => "field_definition_id_2",
+                                "field_type_identifier" => "field_type_identifier_2",
+                            ),
+                            "field_definition_identifier_2" => array(
+                                "field_definition_id" => "field_definition_id_3",
+                                "field_type_identifier" => "field_type_identifier_3",
+                            ),
                         ),
                     )
                 )
@@ -118,21 +133,30 @@ class FieldNameResolverTest extends TestCase
 
     public function testGetFieldNamesWithNamedField()
     {
-        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getFieldMap", "getIndexFieldName" ) );
+        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getSearchableFieldMap", "getIndexFieldName" ) );
         $criterionMock = $this->getCriterionMock();
 
         $mockedFieldNameResolver
             ->expects( $this->once() )
-            ->method( "getFieldMap" )
+            ->method( "getSearchableFieldMap" )
             ->will(
                 $this->returnValue(
                     array(
                         "content_type_identifier_1" => array(
-                            "field_definition_identifier_1" => "field_type_identifier_1",
+                            "field_definition_identifier_1" => array(
+                                "field_definition_id" => "field_definition_id_1",
+                                "field_type_identifier" => "field_type_identifier_1",
+                            ),
                         ),
                         "content_type_identifier_2" => array(
-                            "field_definition_identifier_1" => "field_type_identifier_2",
-                            "field_definition_identifier_2" => "field_type_identifier_3",
+                            "field_definition_identifier_1" => array(
+                                "field_definition_id" => "field_definition_id_2",
+                                "field_type_identifier" => "field_type_identifier_2",
+                            ),
+                            "field_definition_identifier_2" => array(
+                                "field_definition_id" => "field_definition_id_3",
+                                "field_type_identifier" => "field_type_identifier_3",
+                            ),
                         ),
                     )
                 )
@@ -185,21 +209,30 @@ class FieldNameResolverTest extends TestCase
 
     public function testGetFieldNamesWithTypedField()
     {
-        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getFieldMap", "getIndexFieldName" ) );
+        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getSearchableFieldMap", "getIndexFieldName" ) );
         $criterionMock = $this->getCriterionMock();
 
         $mockedFieldNameResolver
             ->expects( $this->once() )
-            ->method( "getFieldMap" )
+            ->method( "getSearchableFieldMap" )
             ->will(
                 $this->returnValue(
                     array(
                         "content_type_identifier_1" => array(
-                            "field_definition_identifier_1" => "field_type_identifier_1",
+                            "field_definition_identifier_1" => array(
+                                "field_definition_id" => "field_definition_id_1",
+                                "field_type_identifier" => "field_type_identifier_1",
+                            ),
                         ),
                         "content_type_identifier_2" => array(
-                            "field_definition_identifier_1" => "field_type_identifier_2",
-                            "field_definition_identifier_2" => "field_type_identifier_3",
+                            "field_definition_identifier_1" => array(
+                                "field_definition_id" => "field_definition_id_2",
+                                "field_type_identifier" => "field_type_identifier_2",
+                            ),
+                            "field_definition_identifier_2" => array(
+                                "field_definition_id" => "field_definition_id_3",
+                                "field_type_identifier" => "field_type_identifier_3",
+                            ),
                         ),
                     )
                 )
@@ -237,21 +270,30 @@ class FieldNameResolverTest extends TestCase
 
     public function testGetFieldNamesWithTypedAndNamedField()
     {
-        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getFieldMap", "getIndexFieldName" ) );
+        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getSearchableFieldMap", "getIndexFieldName" ) );
         $criterionMock = $this->getCriterionMock();
 
         $mockedFieldNameResolver
             ->expects( $this->once() )
-            ->method( "getFieldMap" )
+            ->method( "getSearchableFieldMap" )
             ->will(
                 $this->returnValue(
                     array(
                         "content_type_identifier_1" => array(
-                            "field_definition_identifier_1" => "field_type_identifier_1",
+                            "field_definition_identifier_1" => array(
+                                "field_definition_id" => "field_definition_id_1",
+                                "field_type_identifier" => "field_type_identifier_1",
+                            ),
                         ),
                         "content_type_identifier_2" => array(
-                            "field_definition_identifier_1" => "field_type_identifier_2",
-                            "field_definition_identifier_2" => "field_type_identifier_3",
+                            "field_definition_identifier_1" => array(
+                                "field_definition_id" => "field_definition_id_2",
+                                "field_type_identifier" => "field_type_identifier_2",
+                            ),
+                            "field_definition_identifier_2" => array(
+                                "field_definition_id" => "field_definition_id_3",
+                                "field_type_identifier" => "field_type_identifier_3",
+                            ),
                         ),
                     )
                 )
@@ -289,17 +331,20 @@ class FieldNameResolverTest extends TestCase
 
     public function testGetSortFieldName()
     {
-        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getFieldMap", "getIndexFieldName" ) );
+        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getSearchableFieldMap", "getIndexFieldName" ) );
         $sortClauseMock = $this->getSortClauseMock();
 
         $mockedFieldNameResolver
             ->expects( $this->once() )
-            ->method( "getFieldMap" )
+            ->method( "getSearchableFieldMap" )
             ->will(
                 $this->returnValue(
                     array(
                         "content_type_identifier" => array(
-                            "field_definition_identifier" => "field_type_identifier",
+                            "field_definition_identifier" => array(
+                                "field_definition_id" => "field_definition_id",
+                                "field_type_identifier" => "field_type_identifier",
+                            ),
                         ),
                     )
                 )
@@ -331,17 +376,20 @@ class FieldNameResolverTest extends TestCase
 
     public function testGetSortFieldNameReturnsNull()
     {
-        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getFieldMap", "getIndexFieldName" ) );
+        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getSearchableFieldMap", "getIndexFieldName" ) );
         $sortClauseMock = $this->getSortClauseMock();
 
         $mockedFieldNameResolver
             ->expects( $this->once() )
-            ->method( "getFieldMap" )
+            ->method( "getSearchableFieldMap" )
             ->will(
                 $this->returnValue(
                     array(
                         "content_type_identifier" => array(
-                            "field_definition_identifier" => "field_type_identifier",
+                            "field_definition_identifier" => array(
+                                "field_definition_id" => "field_definition_id",
+                                "field_type_identifier" => "field_type_identifier",
+                            ),
                         ),
                     )
                 )
@@ -359,7 +407,7 @@ class FieldNameResolverTest extends TestCase
 
     public function testGetIndexFieldNameCustomField()
     {
-        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getFieldMap" ) );
+        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getSearchableFieldMap" ) );
 
         $customFieldMock = $this->getMock(
             "eZ\\Publish\\API\\Repository\\Values\\Content\\Query\\CustomFieldInterface"
@@ -388,7 +436,7 @@ class FieldNameResolverTest extends TestCase
 
     public function testGetIndexFieldNameNamedField()
     {
-        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getFieldMap" ) );
+        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getSearchableFieldMap" ) );
         $indexFieldType = $this->getIndexFieldTypeMock();
         $searchFieldTypeMock = $this->getSearchFieldTypeMock();
 
@@ -449,7 +497,7 @@ class FieldNameResolverTest extends TestCase
 
     public function testGetIndexFieldNameDefaultField()
     {
-        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getFieldMap" ) );
+        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getSearchableFieldMap" ) );
         $indexFieldType = $this->getIndexFieldTypeMock();
         $searchFieldTypeMock = $this->getSearchFieldTypeMock();
 
@@ -518,7 +566,7 @@ class FieldNameResolverTest extends TestCase
      */
     public function testGetIndexFieldNameDefaultFieldThrowsRuntimeException()
     {
-        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getFieldMap" ) );
+        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getSearchableFieldMap" ) );
         $indexFieldType = $this->getIndexFieldTypeMock();
         $searchFieldTypeMock = $this->getSearchFieldTypeMock();
 
@@ -562,7 +610,7 @@ class FieldNameResolverTest extends TestCase
      */
     public function testGetIndexFieldNameNamedFieldThrowsRuntimeException()
     {
-        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getFieldMap" ) );
+        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getSearchableFieldMap" ) );
         $indexFieldType = $this->getIndexFieldTypeMock();
         $searchFieldTypeMock = $this->getSearchFieldTypeMock();
 

--- a/eZ/Publish/Core/settings/search_engines/legacy.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy.yml
@@ -23,7 +23,6 @@ services:
             - @ezpublish.api.storage_engine.legacy.dbhandler
             - @ezpublish.search.legacy.gateway.criteria_converter.content
             - @ezpublish.search.legacy.gateway.sort_clause_converter.content
-            - @ezpublish.persistence.legacy.content_type.gateway
 
     ezpublish.search.legacy.gateway.content.exception_conversion:
         class: %ezpublish.search.legacy.gateway.content.exception_conversion.class%
@@ -40,7 +39,6 @@ services:
             - @ezpublish.api.storage_engine.legacy.dbhandler
             - @ezpublish.search.legacy.gateway.criteria_converter.location
             - @ezpublish.search.legacy.gateway.sort_clause_converter.location
-            - @ezpublish.persistence.legacy.content_type.gateway
 
     ezpublish.search.legacy.gateway.location.exception_conversion:
         class: %ezpublish.search.legacy.gateway.location.exception_conversion.class%

--- a/eZ/Publish/Core/settings/search_engines/legacy/sort_clause_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/sort_clause_handlers_common.yml
@@ -47,6 +47,7 @@ services:
         arguments:
             - @ezpublish.api.storage_engine.legacy.dbhandler
             - @ezpublish.spi.persistence.language_handler
+            - @ezpublish.spi.persistence.content_type_handler
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
@@ -56,6 +57,7 @@ services:
         arguments:
             - @ezpublish.api.storage_engine.legacy.dbhandler
             - @ezpublish.spi.persistence.language_handler
+            - @ezpublish.spi.persistence.content_type_handler
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}

--- a/eZ/Publish/SPI/Persistence/Content/Type/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/Handler.php
@@ -280,4 +280,28 @@ interface Handler
      * @return void
      */
     public function publish( $contentTypeId );
+
+    /**
+     * Returns content type, field definition and field type mapping information
+     * for search engine usage. Only searchable field definitions will be included
+     * in the returned data.
+     *
+     * Returns an array in the form:
+     *
+     * <code>
+     *  array(
+     *      "<ContentType identifier>" => array(
+     *          "<FieldDefinition identifier>" => array(
+     *              "field_definition_id" => "<FieldDefinition id>",
+     *              "field_type_identifier" => "<FieldType identifier>",
+     *          ),
+     *          ...
+     *      ),
+     *      ...
+     *  )
+     * </code>
+     *
+     * @return array
+     */
+    public function getSearchableFieldMap();
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -35,6 +35,9 @@
     <testsuite name="eZ\Publish\Core\Persistence\Doctrine">
       <directory>eZ/Publish/Core/Persistence/Doctrine/Tests</directory>
     </testsuite>
+    <testsuite name="eZ\Publish\Core\Search">
+      <directory>eZ/Publish/Core/Search/Tests</directory>
+    </testsuite>
     <testsuite name="eZ\Publish\Core\Search\Solr">
       <directory>eZ/Publish/Core/Search/Solr/Tests</directory>
     </testsuite>


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-23941

This adds `getFieldMap()` method to the ContentType handler.
The method is added to the interface and implemented in all handler implementations: Cache storage, Legacy storage, memory caching implementation in Legacy storage. 
It returns field map data in the form:

```php
array(
    "<ContentType identifier>" => array(
        "<FieldDefinition identifier>" => array(
            "field_definition_id" => "<FieldDefinition id>",
            "field_type_identifier" => "<FieldType identifier>",
        ),
        ...
    ),
    ...
)
```

This data is used by search implementations to map Field criteria and sort clauses to the field in the index backend or storage.

#### Fixed bugs

Legacy Search Engine allowed sorting on the data of the fields that are not searchable, for example template_look/title (`ezsetting` FieldType, was present in integration tests). The field map implementation considers only searchable fields, which means trying to sort on non-searchable fields will now result in `InvalidArgumentException`.

#### TODOs
- [x] Close as obsolete https://jira.ez.no/browse/EZP-22834
- [ ] Squash