### PR TITLE
Fix: EZP-24093 Fatal Error running ezpublish-kernel tests inside an ezcommunity install

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -23,8 +23,4 @@ if ( !( $settings = include ( __DIR__ . '/config.php' ) ) )
     throw new \RuntimeException( 'Could not read config.php, please copy config.php-DEVELOPMENT to config.php & customize to your needs!' );
 }
 
-// Setup class loader, detect ezpublish-community repo context and use vendor files from there if that is the case
-$rootDir = __DIR__;
-if ( ( $vendorPathPos = strrpos( $rootDir, '/vendor/ezsystems/ezpublish' ) ) !== false )
-    $rootDir = substr( $rootDir, 0, $vendorPathPos );
-require_once $rootDir . "/vendor/autoload.php";
+require_once __DIR__ . "/vendor/autoload.php";


### PR DESCRIPTION
Fixes https://jira.ez.no/browse/EZP-24093

If you do a ezpublish-community install and then you run ezpublish-kernel you'll probably go to your vendor/ezsystems/ezpublish-kernel folder and do what install doc says

* Enter directory cd ezpublish-kernel
* Get Composer using curl curl -s http://getcomposer.org/installer | php
* Install dev dependencies: php composer.phar install --prefer-dist --dev
* Copy config.php-DEVELOPMENT cp config.php-DEVELOPMENT config.php
* Execute phpunit -vc phpunit*.xml with one of:
...

But actually in these case i'm getting an error
```
PHP Fatal error:  Class 'Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase' not found in /home/carlos/ezpublish-community/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Base/Tests/Container/Compiler/FieldTypeCollectionPassTest.php on line 18
```
I think this is caused but what bootstrap.php does in 
https://github.com/ezsystems/ezpublish-kernel/blob/master/bootstrap.php#L28
As it finds ```/home/carlos/ezpublish-community/vendor/ezsystems/ezpublish```, ```rootDir``` is set to ```/home/carlos/ezpublish-community``` and so it loads ```ezpublish-community/vendor/autoload.php``` but in ```ezpublish-community/vendor/composer/autoload_namespaces.php there is no reference to the failing package```.
I suggest not to look for ezpublish-community vendor when running ezpublish-kernel tests