### PR TITLE
Fix EZP-21721: Displaying an empty XMLText field outputs eZXML

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -445,7 +445,9 @@
 {# You can define a field_value variable before rendering this one if you need special operation for rendering content (i.e. nl2br) #}
 {% block simple_block_field %}
 {% spaceless %}
-    {% set field_value = field_value|default( field.value ) %}
+    {% if field_value is not defined %}
+        {% set field_value = field.value %}
+    {% endif %}
     <div {{ block( 'field_attributes' ) }}>
         {{ field_value|raw }}
     </div>
@@ -454,7 +456,9 @@
 
 {% block simple_inline_field %}
 {% spaceless %}
-    {% set field_value = field_value|default( field.value ) %}
+    {% if field_value is not defined %}
+        {% set field_value = field.value %}
+    {% endif %}
     <span {{ block( 'field_attributes' ) }}>{{ field_value }}</span>
 {% endspaceless %}
 {% endblock %}


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-21721

Originally reported problem was about empty XmlText field being rendered as empty internal XML format, ie:

```xml
<?xml version="1.0" encoding="utf-8"?>
<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"/>
```

The problem was coming from `simple_block_field` and `simple_inline_field` blocks, where Twig's `default` filter was incorrectly used for a case when variable was not defined.
This filter returns passed default value if tested value is [not defined **or empty**](http://twig.sensiolabs.org/doc/filters/default.html). That could not work correctly as what is considered empty by Twig could be a correct result of processing of the field value (in this particular case with `xmltext_to_html5` filter, returning `null` for empty XmlText value).

The problem is fixed by replacing `default` filter with explicit check that a variable is not defined.