### PR TITLE
EZP-23788: accept existing file when updating images

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/ImageIntegrationTest.php
@@ -562,4 +562,45 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
             "Asserting image file $originalFileUri has been removed."
         );
     }
+
+    public function testUpdateImageAltTextOnly()
+    {
+        $repository = $this->getRepository();
+
+        $contentService = $repository->getContentService();
+        $contentTypeService = $repository->getContentTypeService();
+        $locationService = $repository->getLocationService();
+
+        $contentType = $contentTypeService->loadContentTypeByIdentifier( 'image' );
+        $createStruct = $contentService->newContentCreateStruct( $contentType, 'eng-GB' );
+
+        $createStruct->setField( 'name', __METHOD__ );
+        $createStruct->setField(
+            'image',
+            new ImageValue(
+                [
+                    'inputUri' => __DIR__ . '/_fixtures/image.jpg',
+                    'fileName' => 'image.jpg',
+                    'fileSize' => filesize( __DIR__ . '/_fixtures/image.jpg' ),
+                    'alternativeText' => 'Initial alternative text'
+                ]
+            )
+        );
+
+        $content = $contentService->createContent(
+            $createStruct,
+            [$locationService->newLocationCreateStruct( 2 )]
+        );
+
+        $imageField = $content->getFieldValue( 'image' );
+        $imageField->alternativeText = 'Updated alternative text';
+
+        $contentService->publishVersion( $content->getVersionInfo() );
+
+        $updateStruct = $contentService->newContentUpdateStruct();
+        $updateStruct->setField( 'image', $imageField );
+
+        $newVersion = $contentService->createContentDraft( $content->contentInfo );
+        $contentService->updateContent( $newVersion->versionInfo, $updateStruct );
+    }
 }

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -78,19 +78,16 @@ class ImageStorage extends GatewayBasedStorage
             {
                 $binaryFile = $this->IOService->loadBinaryFile( $targetPath );
             }
+            else if ( isset( $field->value->externalData['id'] ) )
+            {
+                $binaryFile = $this->IOService->loadBinaryFile( $field->value->externalData['id'] );
+            }
             else
             {
                 if ( isset( $field->value->externalData['inputUri'] ) )
                 {
                     $localFilePath = $field->value->externalData['inputUri'];
                     unset( $field->value->externalData['inputUri'] );
-                }
-                else
-                {
-                    $this->deprecationWarner->log(
-                        "Using the Image\\Value::\$id property to create images is deprecated. Use 'inputUri'"
-                    );
-                    $localFilePath = $field->value->externalData['id'];
                 }
                 $binaryFileCreateStruct = $this->IOService->newBinaryCreateStructFromLocalFile( $localFilePath );
                 $binaryFileCreateStruct->id = $targetPath;

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\FieldType\Image;
 
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Base\Utils\DeprecationWarnerInterface as DeprecationWarner;
 use eZ\Publish\Core\FieldType\GatewayBasedStorage;
 use eZ\Publish\Core\IO\IOServiceInterface;
@@ -82,13 +83,11 @@ class ImageStorage extends GatewayBasedStorage
             {
                 $binaryFile = $this->IOService->loadBinaryFile( $field->value->externalData['id'] );
             }
-            else
+            else if ( isset( $field->value->externalData['inputUri'] ) )
             {
-                if ( isset( $field->value->externalData['inputUri'] ) )
-                {
-                    $localFilePath = $field->value->externalData['inputUri'];
-                    unset( $field->value->externalData['inputUri'] );
-                }
+                $localFilePath = $field->value->externalData['inputUri'];
+                unset( $field->value->externalData['inputUri'] );
+
                 $binaryFileCreateStruct = $this->IOService->newBinaryCreateStructFromLocalFile( $localFilePath );
                 $binaryFileCreateStruct->id = $targetPath;
                 $binaryFile = $this->IOService->createBinaryFile( $binaryFileCreateStruct );
@@ -97,6 +96,14 @@ class ImageStorage extends GatewayBasedStorage
                 $field->value->externalData['width'] = $imageSize[0];
                 $field->value->externalData['height'] = $imageSize[1];
             }
+            else
+            {
+                throw new InvalidArgumentException(
+                    "inputUri",
+                    "No source image could be obtained from the given external data"
+                );
+            }
+
             $field->value->externalData['imageId'] = $versionInfo->contentInfo->id . '-' . $field->id;
             $field->value->externalData['uri'] = $binaryFile->uri;
             $field->value->externalData['id'] = $binaryFile->id;

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -75,13 +75,13 @@ class ImageStorage extends GatewayBasedStorage
                 $field->value->externalData['fileName']
             );
 
-            if ( $this->IOService->exists( $targetPath ) )
-            {
-                $binaryFile = $this->IOService->loadBinaryFile( $targetPath );
-            }
-            else if ( isset( $field->value->externalData['id'] ) )
+            if ( isset( $field->value->externalData['id'] ) )
             {
                 $binaryFile = $this->IOService->loadBinaryFile( $field->value->externalData['id'] );
+            }
+            else if ( $this->IOService->exists( $targetPath ) )
+            {
+                $binaryFile = $this->IOService->loadBinaryFile( $targetPath );
             }
             else if ( isset( $field->value->externalData['inputUri'] ) )
             {

--- a/eZ/Publish/Core/IO/TolerantIOService.php
+++ b/eZ/Publish/Core/IO/TolerantIOService.php
@@ -8,6 +8,7 @@
 namespace eZ\Publish\Core\IO;
 
 use eZ\Publish\Core\IO\Exception\BinaryFileNotFoundException;
+use eZ\Publish\Core\IO\Exception\InvalidBinaryFileIdException;
 use eZ\Publish\Core\IO\MetadataHandler;
 use eZ\Publish\Core\IO\Values\BinaryFile;
 use eZ\Publish\Core\IO\Values\MissingBinaryFile;
@@ -79,9 +80,10 @@ class TolerantIOService extends IOService
     {
         $this->checkBinaryFileId( $binaryFileId );
 
-        // @todo An absolute path can in no case be loaded, but throwing an exception is too much (why ?)
         if ( $binaryFileId[0] === '/' )
-            return false;
+        {
+            throw new InvalidBinaryFileIdException( $binaryFileId, "Binary file ids can not begin with a /" );
+        }
 
         try
         {

--- a/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
@@ -280,14 +280,16 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
         }*/
     }
 
-    public function testCreateContentUsingIdPropertyWorksAndThrowsWarning()
+    /**
+     * @expectedException \eZ\Publish\Core\IO\Exception\InvalidBinaryFileIdException
+     */
+    public function testCreateContentUsingIdPropertyThrowsWarning()
     {
         $this->testCreateContentType();
         $contentType = $this->testLoadContentTypeField();
         $this->getDeprecationWarnerMock()
-            ->expects( $this->once() )
-            ->method( 'log' )
-            ->with( $this->stringContains( 'id property' ) );
+            ->expects( $this->never() )
+            ->method( 'log' );
 
         $this->createContent( $contentType, $this->getDeprecatedIdPropertyValue() );
     }


### PR DESCRIPTION
> Implements [EZP-23788](https://jira.ez.no/browse/EZP-23788)

This changes the Image FieldType's external storage handler, to make it accept a reference to an existing image as the `ImageValue::$id` property.

Long story long, this was kind of possible in the initial version, but it depended on `id` (formerly named `path`) referencing both the stored file or the input file, which caused a lot of issues. In 5.2, `path` was reserved for the stored path, and `inputUri` was added for the input file. In 5.4, `path` was renamed to `id`, and became more of an internal field.

## Risks
I believe that allowing to use `id` to reference an existing file makes sense. We might wanna be careful with what happens if an Image's FieldValue is re-used for another field. It was taken into account, but I'm not entirely sure how well. We've had a lot of issues in legacy with this feature of re-using images across attributes...

## TODO
- [x] Check the BC features that were added to the Image FieldType (deprecation warnings and stuff)
- [ ] Test within a REST context