### PR TITLE
EZP-23078: As a UI developer, I want to have access to an HTML5 version of the RichText fields

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
@@ -289,6 +289,8 @@ services:
 
     ezpublish_rest.field_type_processor.ezrichtext:
         class: %ezpublish_rest.field_type_processor.ezrichtext.class%
+        arguments:
+            - @ezpublish.fieldType.ezrichtext.converter.edit.xhtml5
         tags:
             - { name: ezpublish_rest.field_type_processor, alias: ezrichtext }
 

--- a/eZ/Publish/Core/REST/Common/FieldTypeProcessor/RichTextProcessor.php
+++ b/eZ/Publish/Core/REST/Common/FieldTypeProcessor/RichTextProcessor.php
@@ -11,9 +11,36 @@ namespace eZ\Publish\Core\REST\Common\FieldTypeProcessor;
 
 use eZ\Publish\Core\REST\Common\FieldTypeProcessor;
 use eZ\Publish\Core\FieldType\RichText\Type;
+use eZ\Publish\Core\FieldType\RichText\Converter;
+use DOMDocument;
 
 class RichTextProcessor extends FieldTypeProcessor
 {
+    /**
+     * @var \eZ\Publish\Core\FieldType\RichText\Converter
+     */
+    protected $docbookToXhtml5EditConverter;
+
+    public function __construct( Converter $docbookToXhtml5EditConverter )
+    {
+        $this->docbookToXhtml5EditConverter = $docbookToXhtml5EditConverter;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function postProcessValueHash( $outgoingValueHash )
+    {
+        $document = new DOMDocument();
+        $document->loadXML( $outgoingValueHash["xml"] );
+
+        $outgoingValueHash["xhtml5edit"] = $this->docbookToXhtml5EditConverter
+            ->convert( $document )
+            ->saveXML();
+
+        return $outgoingValueHash;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/RichTextProcessorTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/RichTextProcessorTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\REST\Common\Tests\FieldTypeProcessor;
 
 use eZ\Publish\Core\REST\Common\FieldTypeProcessor\RichTextProcessor;
 use PHPUnit_Framework_TestCase;
+use DOMDocument;
 
 class RichTextProcessorTest extends PHPUnit_Framework_TestCase
 {
@@ -61,11 +62,56 @@ class RichTextProcessorTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testPostProcessValueHash()
+    {
+        $processor = $this->getProcessor();
+
+        $outputValue = array(
+            "xml" => <<<EOT
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <title>Some text</title>
+    <para>Foobar</para>
+</section>
+EOT
+        );
+        $processedOutputValue = $outputValue;
+        $processedOutputValue["xhtml5edit"] = <<<EOT
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
+    <h1>Some text</h1>
+    <p>Foobar</p>
+</section>
+
+EOT;
+
+        $convertedDocument = new DOMDocument();
+        $convertedDocument->loadXML( $processedOutputValue["xhtml5edit"] );
+
+        $this->converter
+            ->expects( $this->once() )
+            ->method( "convert" )
+            ->with( $this->isInstanceOf( "DOMDocument" ) )
+            ->will( $this->returnValue( $convertedDocument ) );
+
+        $this->assertEquals(
+            $processedOutputValue,
+            $processor->postProcessValueHash( $outputValue )
+        );
+    }
+
+    /**
+     * @var \eZ\Publish\Core\FieldType\RichText\Converter|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $converter;
+
     /**
      * @return \eZ\Publish\Core\REST\Common\FieldTypeProcessor\RichTextProcessor
      */
     protected function getProcessor()
     {
-        return new RichTextProcessor;
+        $this->converter = $this->getMock( "eZ\\Publish\\Core\\FieldType\\RichText\\Converter" );
+
+        return new RichTextProcessor( $this->converter );
     }
 }


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24078

For REST access this adds the value in XHTML5 editing format alongside the value in internal format.
This is acheved thorugh standard REST extension point -- FieldTypeProcessor, by overriding default implementation of `postProcessValueHash` method, so that injected converter is used to convert internal format to the desired format, which is then added to the output hash.

The value will then be avialable over REST under `xhtml5edit` key, like:

```xml
  <fieldValue>
      <value key="xml">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
&lt;section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0"&gt;
&lt;title ezxhtml:level="2"&gt;This is a heading.&lt;/title&gt;
&lt;/section&gt;
</value>
      <value key="xhtml5edit">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
&lt;section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit"&gt;
&lt;h2&gt;This is a heading.&lt;/h2&gt;
&lt;/section&gt;
</value>
  </fieldValue>
```

The field type's value in internal format could not be replaced with the value in XHTML5 edit format as this would effectively mean changing our internal format.

Testing: unit test + manual integration tests.