### PR TITLE
Implement EZP-21794: integration test framework for Search with Field criterion and sort clause

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/IntegerIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/IntegerIntegrationTest.php
@@ -335,12 +335,12 @@ class IntegerIntegrationTest extends SearchBaseIntegrationTest
         );
     }
 
-    protected function getSearchValueA()
+    protected function getValidSearchValueOne()
     {
         return 25;
     }
 
-    protected function getSearchValueB()
+    protected function getValidSearchValueTwo()
     {
         return 26;
     }

--- a/eZ/Publish/API/Repository/Tests/FieldType/IntegerIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/IntegerIntegrationTest.php
@@ -18,7 +18,7 @@ use eZ\Publish\API\Repository\Values\Content\Field;
  * @group integration
  * @group field-type
  */
-class IntegerIntegrationTest extends BaseIntegrationTest
+class IntegerIntegrationTest extends SearchBaseIntegrationTest
 {
     /**
      * Get name of tested field type
@@ -333,6 +333,16 @@ class IntegerIntegrationTest extends BaseIntegrationTest
             array( new IntegerValue( 0 ) ),
             array( new IntegerValue( 0.0 ) ),
         );
+    }
+
+    protected function getSearchValueA()
+    {
+        return 25;
+    }
+
+    protected function getSearchValueB()
+    {
+        return 26;
     }
 }
 

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
@@ -124,85 +124,73 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
     {
         return array(
             0 => array(
-                /**
-                 * Tests search with EQ operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     value EQ A
-                 *
-                 * The result should contain Content A.
-                 */
+                // Tests search with EQ operator.
+                //
+                // Simplified representation:
+                //
+                //     value EQ A
+                //
+                // The result should contain Content A.
                 new Field( "data", Operator::EQ, $this->getSearchValueA() ),
                 true,
                 false,
             ),
             1 => array(
-                /**
-                 * Tests search with EQ operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     NOT( value EQ A )
-                 *
-                 * The result should contain Content B.
-                 */
+                // Tests search with EQ operator.
+                //
+                // Simplified representation:
+                //
+                //     NOT( value EQ A )
+                //
+                // The result should contain Content B.
                 new LogicalNot( new Field( "data", Operator::EQ, $this->getSearchValueA() ) ),
                 false,
                 true,
             ),
             2 => array(
-                /**
-                 * Tests search with EQ operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     value EQ B
-                 *
-                 * The result should contain Content B.
-                 */
+                // Tests search with EQ operator.
+                //
+                // Simplified representation:
+                //
+                //     value EQ B
+                //
+                // The result should contain Content B.
                 new Field( "data", Operator::EQ, $this->getSearchValueB() ),
                 false,
                 true,
             ),
             3 => array(
-                /**
-                 * Tests search with EQ operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     NOT( value EQ B )
-                 *
-                 * The result should contain Content A.
-                 */
+                // Tests search with EQ operator.
+                //
+                // Simplified representation:
+                //
+                //     NOT( value EQ B )
+                //
+                // The result should contain Content A.
                 new LogicalNot( new Field( "data", Operator::EQ, $this->getSearchValueB() ) ),
                 true,
                 false,
             ),
             4 => array(
-                /**
-                 * Tests search with IN operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     value IN [A]
-                 *
-                 * The result should contain Content A.
-                 */
+                // Tests search with IN operator.
+                //
+                // Simplified representation:
+                //
+                //     value IN [A]
+                //
+                // The result should contain Content A.
                 new Field( "data", Operator::IN, array( $this->getSearchValueA() ) ),
                 true,
                 false,
             ),
             5 => array(
-                /**
-                 * Tests search with IN operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     NOT( value IN [A] )
-                 *
-                 * The result should contain Content B.
-                 */
+                // Tests search with IN operator.
+                //
+                // Simplified representation:
+                //
+                //     NOT( value IN [A] )
+                //
+                // The result should contain Content B.
                 new LogicalNot(
                     new Field( "data", Operator::IN, array( $this->getSearchValueA() ) )
                 ),
@@ -210,29 +198,25 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 true,
             ),
             6 => array(
-                /**
-                 * Tests search with IN operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     value IN [B]
-                 *
-                 * The result should contain Content B.
-                 */
+                // Tests search with IN operator.
+                //
+                // Simplified representation:
+                //
+                //     value IN [B]
+                //
+                // The result should contain Content B.
                 new Field( "data", Operator::IN, array( $this->getSearchValueB() ) ),
                 false,
                 true,
             ),
             7 => array(
-                /**
-                 * Tests search with IN operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     NOT( value IN [B] )
-                 *
-                 * The result should contain Content A.
-                 */
+                // Tests search with IN operator.
+                //
+                // Simplified representation:
+                //
+                //     NOT( value IN [B] )
+                //
+                // The result should contain Content A.
                 new LogicalNot(
                     new Field( "data", Operator::IN, array( $this->getSearchValueB() ) )
                 ),
@@ -240,15 +224,13 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 false,
             ),
             8 => array(
-                /**
-                 * Tests search with IN operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     value IN [A,B]
-                 *
-                 * The result should contain both Content A and Content B.
-                 */
+                // Tests search with IN operator.
+                //
+                // Simplified representation:
+                //
+                //     value IN [A,B]
+                //
+                // The result should contain both Content A and Content B.
                 new Field(
                     "data",
                     Operator::IN,
@@ -261,15 +243,13 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 true,
             ),
             9 => array(
-                /**
-                 * Tests search with IN operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     NOT( value IN [A,B] )
-                 *
-                 * The result should be empty.
-                 */
+                // Tests search with IN operator.
+                //
+                // Simplified representation:
+                //
+                //     NOT( value IN [A,B] )
+                //
+                // The result should be empty.
                 new LogicalNot(
                     new Field(
                         "data",
@@ -284,239 +264,205 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 false,
             ),
             10 => array(
-                /**
-                 * Tests search with GT operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     value GT A
-                 *
-                 * The result should contain Content B.
-                 */
+                // Tests search with GT operator.
+                //
+                // Simplified representation:
+                //
+                //     value GT A
+                //
+                // The result should contain Content B.
                 new Field( "data", Operator::GT, $this->getSearchValueA() ),
                 false,
                 true,
             ),
             11 => array(
-                /**
-                 * Tests search with GT operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     NOT( value GT A )
-                 *
-                 * The result should contain Content A.
-                 */
+                // Tests search with GT operator.
+                //
+                // Simplified representation:
+                //
+                //     NOT( value GT A )
+                //
+                // The result should contain Content A.
                 new LogicalNot( new Field( "data", Operator::GT, $this->getSearchValueA() ) ),
                 true,
                 false,
             ),
             12 => array(
-                /**
-                 * Tests search with GT operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     value GT B
-                 *
-                 * The result should be empty.
-                 */
+                // Tests search with GT operator.
+                //
+                // Simplified representation:
+                //
+                //     value GT B
+                //
+                // The result should be empty.
                 new Field( "data", Operator::GT, $this->getSearchValueB() ),
                 false,
                 false,
             ),
             13 => array(
-                /**
-                 * Tests search with GT operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     NOT( value GT B )
-                 *
-                 * The result should contain both Content A and Content B.
-                 */
+                // Tests search with GT operator.
+                //
+                // Simplified representation:
+                //
+                //     NOT( value GT B )
+                //
+                // The result should contain both Content A and Content B.
                 new LogicalNot( new Field( "data", Operator::GT, $this->getSearchValueB() ) ),
                 true,
                 true,
             ),
             14 => array(
-                /**
-                 * Tests search with GTE operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     value GTE A
-                 *
-                 * The result should contain both Content A and Content B.
-                 */
+                // Tests search with GTE operator.
+                //
+                // Simplified representation:
+                //
+                //     value GTE A
+                //
+                // The result should contain both Content A and Content B.
                 new Field( "data", Operator::GTE, $this->getSearchValueA() ),
                 true,
                 true,
             ),
             15 => array(
-                /**
-                 * Tests search with GTE operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     NOT( value GTE A )
-                 *
-                 * The result should be empty.
-                 */
+                // Tests search with GTE operator.
+                //
+                // Simplified representation:
+                //
+                //     NOT( value GTE A )
+                //
+                // The result should be empty.
                 new LogicalNot( new Field( "data", Operator::GTE, $this->getSearchValueA() ) ),
                 false,
                 false,
             ),
             16 => array(
-                /**
-                 * Tests search with GTE operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     value GTE B
-                 *
-                 * The result should contain Content B.
-                 */
+                // Tests search with GTE operator.
+                //
+                // Simplified representation:
+                //
+                //     value GTE B
+                //
+                // The result should contain Content B.
                 new Field( "data", Operator::GTE, $this->getSearchValueB() ),
                 false,
                 true,
             ),
             17 => array(
-                /**
-                 * Tests search with GTE operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     NOT( value GTE B )
-                 *
-                 * The result should contain Content A.
-                 */
+                // Tests search with GTE operator.
+                //
+                // Simplified representation:
+                //
+                //     NOT( value GTE B )
+                //
+                // The result should contain Content A.
                 new LogicalNot( new Field( "data", Operator::GTE, $this->getSearchValueB() ) ),
                 true,
                 false,
             ),
             18 => array(
-                /**
-                 * Tests search with LT operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     value LT A
-                 *
-                 * The result should be empty.
-                 */
+                // Tests search with LT operator.
+                //
+                // Simplified representation:
+                //
+                //     value LT A
+                //
+                // The result should be empty.
                 new Field( "data", Operator::LT, $this->getSearchValueA() ),
                 false,
                 false,
             ),
             19 => array(
-                /**
-                 * Tests search with LT operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     NOT( value LT A )
-                 *
-                 * The result should contain both Content A and Content B.
-                 */
+                // Tests search with LT operator.
+                //
+                // Simplified representation:
+                //
+                //     NOT( value LT A )
+                //
+                // The result should contain both Content A and Content B.
                 new LogicalNot( new Field( "data", Operator::LT, $this->getSearchValueA() ) ),
                 true,
                 true,
             ),
             20 => array(
-                /**
-                 * Tests search with LT operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     value LT B
-                 *
-                 * The result should contain Content A.
-                 */
+                // Tests search with LT operator.
+                //
+                // Simplified representation:
+                //
+                //     value LT B
+                //
+                // The result should contain Content A.
                 new Field( "data", Operator::LT, $this->getSearchValueB() ),
                 true,
                 false,
             ),
             21 => array(
-                /**
-                 * Tests search with LT operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     NOT( value LT B )
-                 *
-                 * The result should contain Content B.
-                 */
+                // Tests search with LT operator.
+                //
+                // Simplified representation:
+                //
+                //     NOT( value LT B )
+                //
+                // The result should contain Content B.
                 new LogicalNot( new Field( "data", Operator::LT, $this->getSearchValueB() ) ),
                 false,
                 true,
             ),
             22 => array(
-                /**
-                 * Tests search with LTE operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     value LTE A
-                 *
-                 * The result should contain Content A.
-                 */
+                // Tests search with LTE operator.
+                //
+                // Simplified representation:
+                //
+                //     value LTE A
+                //
+                // The result should contain Content A.
                 new Field( "data", Operator::LTE, $this->getSearchValueA() ),
                 true,
                 false,
             ),
             23 => array(
-                /**
-                 * Tests search with LTE operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     NOT( value LTE A )
-                 *
-                 * The result should contain Content B.
-                 */
+                // Tests search with LTE operator.
+                //
+                // Simplified representation:
+                //
+                //     NOT( value LTE A )
+                //
+                // The result should contain Content B.
                 new LogicalNot( new Field( "data", Operator::LTE, $this->getSearchValueA() ) ),
                 false,
                 true,
             ),
             24 => array(
-                /**
-                 * Tests search with LTE operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     value LTE B
-                 *
-                 * The result should contain both Content A and Content B.
-                 */
+                // Tests search with LTE operator.
+                //
+                // Simplified representation:
+                //
+                //     value LTE B
+                //
+                // The result should contain both Content A and Content B.
                 new Field( "data", Operator::LTE, $this->getSearchValueB() ),
                 true,
                 true,
             ),
             25 => array(
-                /**
-                 * Tests search with LTE operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     NOT( value LTE B )
-                 *
-                 * The result should be empty.
-                 */
+                // Tests search with LTE operator.
+                //
+                // Simplified representation:
+                //
+                //     NOT( value LTE B )
+                //
+                // The result should be empty.
                 new LogicalNot( new Field( "data", Operator::LTE, $this->getSearchValueB() ) ),
                 false,
                 false,
             ),
             26 => array(
-                /**
-                 * Tests search with BETWEEN operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     value BETWEEN [A,B]
-                 *
-                 * The result should contain both Content A and Content B.
-                 */
+                // Tests search with BETWEEN operator.
+                //
+                // Simplified representation:
+                //
+                //     value BETWEEN [A,B]
+                //
+                // The result should contain both Content A and Content B.
                 new Field(
                     "data",
                     Operator::BETWEEN,
@@ -529,15 +475,13 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 true,
             ),
             27 => array(
-                /**
-                 * Tests search with BETWEEN operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     NOT( value BETWEEN [A,B] )
-                 *
-                 * The result should contain both Content A and Content B.
-                 */
+                // Tests search with BETWEEN operator.
+                //
+                // Simplified representation:
+                //
+                //     NOT( value BETWEEN [A,B] )
+                //
+                // The result should contain both Content A and Content B.
                 new LogicalNot(
                     new Field(
                         "data",
@@ -552,15 +496,13 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 false,
             ),
             28 => array(
-                /**
-                 * Tests search with BETWEEN operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     value BETWEEN [B,A]
-                 *
-                 * The result should be empty.
-                 */
+                // Tests search with BETWEEN operator.
+                //
+                // Simplified representation:
+                //
+                //     value BETWEEN [B,A]
+                //
+                // The result should be empty.
                 new Field(
                     "data",
                     Operator::BETWEEN,
@@ -573,15 +515,13 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 false,
             ),
             29 => array(
-                /**
-                 * Tests search with BETWEEN operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     NOT( value BETWEEN [B,A] )
-                 *
-                 * The result should contain both Content A and Content B.
-                 */
+                // Tests search with BETWEEN operator.
+                //
+                // Simplified representation:
+                //
+                //     NOT( value BETWEEN [B,A] )
+                //
+                // The result should contain both Content A and Content B.
                 new LogicalNot(
                     new Field(
                         "data",
@@ -596,57 +536,49 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 true,
             ),
             30 => array(
-                /**
-                 * Tests search with CONTAINS operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     value CONTAINS A
-                 *
-                 * The result should contain Content A.
-                 */
+                // Tests search with CONTAINS operator.
+                //
+                // Simplified representation:
+                //
+                //     value CONTAINS A
+                //
+                // The result should contain Content A.
                 new Field( "data", Operator::CONTAINS, $this->getSearchValueA() ),
                 true,
                 false,
             ),
             31 => array(
-                /**
-                 * Tests search with CONTAINS operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     NOT( value CONTAINS A )
-                 *
-                 * The result should contain Content B.
-                 */
+                // Tests search with CONTAINS operator.
+                //
+                // Simplified representation:
+                //
+                //     NOT( value CONTAINS A )
+                //
+                // The result should contain Content B.
                 new LogicalNot( new Field( "data", Operator::CONTAINS, $this->getSearchValueA() ) ),
                 false,
                 true,
             ),
             32 => array(
-                /**
-                 * Tests search with CONTAINS operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     value CONTAINS B
-                 *
-                 * The result should contain Content B.
-                 */
+                // Tests search with CONTAINS operator.
+                //
+                // Simplified representation:
+                //
+                //     value CONTAINS B
+                //
+                // The result should contain Content B.
                 new Field( "data", Operator::CONTAINS, $this->getSearchValueB() ),
                 false,
                 true,
             ),
             33 => array(
-                /**
-                 * Tests search with CONTAINS operator.
-                 *
-                 * Simplified representation:
-                 *
-                 *     NOT( value CONTAINS B )
-                 *
-                 * The result should contain Content A.
-                 */
+                // Tests search with CONTAINS operator.
+                //
+                // Simplified representation:
+                //
+                //     NOT( value CONTAINS B )
+                //
+                // The result should contain Content A.
                 new LogicalNot(
                     new Field( "data", Operator::CONTAINS, $this->getSearchValueB() )
                 ),

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
@@ -43,12 +43,12 @@ use eZ\Publish\API\Repository\Tests\SetupFactory\LegacyElasticsearch;
  * To get the test working extend it in a concrete field type test and implement
  * methods:
  *
- * - getSearchValueA()
- * - getSearchValueB()
+ * - getValidSearchValueOne()
+ * - getValidSearchValueTwo()
  *
- * In the test descriptions Content object created with values A and B are referred to as
- * Content A, and Content B. See the descriptions of the abstract declarations of these
- * methods for more details on how to choose proper values.
+ * In the test descriptions Content object created with values One and Two are referred to
+ * as Content One, and Content Two. See the descriptions of the abstract declarations of
+ * these methods for more details on how to choose proper values.
  *
  * Note: this test case does not concern itself with testing field filters, behaviour
  * of multiple sort clauses or combination with other criteria. These are tested
@@ -58,34 +58,34 @@ use eZ\Publish\API\Repository\Tests\SetupFactory\LegacyElasticsearch;
 abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
 {
     /**
-     * Get field value A.
+     * Get search field value One.
      *
      * The value must be valid for Content creation.
      *
      * When Field sort clause with ascending order is used on the tested field,
      * Content containing the field with this value must come before the Content
-     * with value B.
+     * with value One.
      *
      * Opposite should be the case when using descending order.
      *
      * @return mixed
      */
-    abstract protected function getSearchValueA();
+    abstract protected function getValidSearchValueOne();
 
     /**
-     * Get field value B.
+     * Get search field value Two.
      *
      * The value must be valid for Content creation.
      *
      * When Field sort clause with ascending order is used on the tested field,
      * Content containing the field with this value must come after the Content
-     * with value A.
+     * with value One.
      *
      * Opposite should be the case when using descending order.
      *
      * @return mixed
      */
-    abstract protected function getSearchValueB();
+    abstract protected function getValidSearchValueTwo();
 
     /**
      * Creates and returns content with given $fieldData
@@ -128,10 +128,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     value EQ A
+                //     value EQ One
                 //
-                // The result should contain Content A.
-                new Field( "data", Operator::EQ, $this->getSearchValueA() ),
+                // The result should contain Content One.
+                new Field( "data", Operator::EQ, $this->getValidSearchValueOne() ),
                 true,
                 false,
             ),
@@ -140,10 +140,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     NOT( value EQ A )
+                //     NOT( value EQ One )
                 //
-                // The result should contain Content B.
-                new LogicalNot( new Field( "data", Operator::EQ, $this->getSearchValueA() ) ),
+                // The result should contain Content Two.
+                new LogicalNot( new Field( "data", Operator::EQ, $this->getValidSearchValueOne() ) ),
                 false,
                 true,
             ),
@@ -152,10 +152,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     value EQ B
+                //     value EQ Two
                 //
-                // The result should contain Content B.
-                new Field( "data", Operator::EQ, $this->getSearchValueB() ),
+                // The result should contain Content Two.
+                new Field( "data", Operator::EQ, $this->getValidSearchValueTwo() ),
                 false,
                 true,
             ),
@@ -164,10 +164,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     NOT( value EQ B )
+                //     NOT( value EQ Two )
                 //
-                // The result should contain Content A.
-                new LogicalNot( new Field( "data", Operator::EQ, $this->getSearchValueB() ) ),
+                // The result should contain Content One.
+                new LogicalNot( new Field( "data", Operator::EQ, $this->getValidSearchValueTwo() ) ),
                 true,
                 false,
             ),
@@ -176,10 +176,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     value IN [A]
+                //     value IN [One]
                 //
-                // The result should contain Content A.
-                new Field( "data", Operator::IN, array( $this->getSearchValueA() ) ),
+                // The result should contain Content One.
+                new Field( "data", Operator::IN, array( $this->getValidSearchValueOne() ) ),
                 true,
                 false,
             ),
@@ -188,11 +188,11 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     NOT( value IN [A] )
+                //     NOT( value IN [One] )
                 //
-                // The result should contain Content B.
+                // The result should contain Content Two.
                 new LogicalNot(
-                    new Field( "data", Operator::IN, array( $this->getSearchValueA() ) )
+                    new Field( "data", Operator::IN, array( $this->getValidSearchValueOne() ) )
                 ),
                 false,
                 true,
@@ -202,10 +202,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     value IN [B]
+                //     value IN [Two]
                 //
-                // The result should contain Content B.
-                new Field( "data", Operator::IN, array( $this->getSearchValueB() ) ),
+                // The result should contain Content Two.
+                new Field( "data", Operator::IN, array( $this->getValidSearchValueTwo() ) ),
                 false,
                 true,
             ),
@@ -214,11 +214,11 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     NOT( value IN [B] )
+                //     NOT( value IN [Two] )
                 //
-                // The result should contain Content A.
+                // The result should contain Content One.
                 new LogicalNot(
-                    new Field( "data", Operator::IN, array( $this->getSearchValueB() ) )
+                    new Field( "data", Operator::IN, array( $this->getValidSearchValueTwo() ) )
                 ),
                 true,
                 false,
@@ -228,15 +228,15 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     value IN [A,B]
+                //     value IN [One,Two]
                 //
-                // The result should contain both Content A and Content B.
+                // The result should contain both Content One and Content Two.
                 new Field(
                     "data",
                     Operator::IN,
                     array(
-                        $this->getSearchValueA(),
-                        $this->getSearchValueB(),
+                        $this->getValidSearchValueOne(),
+                        $this->getValidSearchValueTwo(),
                     )
                 ),
                 true,
@@ -247,7 +247,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     NOT( value IN [A,B] )
+                //     NOT( value IN [One,Two] )
                 //
                 // The result should be empty.
                 new LogicalNot(
@@ -255,8 +255,8 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                         "data",
                         Operator::IN,
                         array(
-                            $this->getSearchValueA(),
-                            $this->getSearchValueB(),
+                            $this->getValidSearchValueOne(),
+                            $this->getValidSearchValueTwo(),
                         )
                     )
                 ),
@@ -268,10 +268,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     value GT A
+                //     value GT One
                 //
-                // The result should contain Content B.
-                new Field( "data", Operator::GT, $this->getSearchValueA() ),
+                // The result should contain Content Two.
+                new Field( "data", Operator::GT, $this->getValidSearchValueOne() ),
                 false,
                 true,
             ),
@@ -280,10 +280,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     NOT( value GT A )
+                //     NOT( value GT One )
                 //
-                // The result should contain Content A.
-                new LogicalNot( new Field( "data", Operator::GT, $this->getSearchValueA() ) ),
+                // The result should contain Content One.
+                new LogicalNot( new Field( "data", Operator::GT, $this->getValidSearchValueOne() ) ),
                 true,
                 false,
             ),
@@ -292,10 +292,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     value GT B
+                //     value GT Two
                 //
                 // The result should be empty.
-                new Field( "data", Operator::GT, $this->getSearchValueB() ),
+                new Field( "data", Operator::GT, $this->getValidSearchValueTwo() ),
                 false,
                 false,
             ),
@@ -304,10 +304,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     NOT( value GT B )
+                //     NOT( value GT Two )
                 //
-                // The result should contain both Content A and Content B.
-                new LogicalNot( new Field( "data", Operator::GT, $this->getSearchValueB() ) ),
+                // The result should contain both Content One and Content Two.
+                new LogicalNot( new Field( "data", Operator::GT, $this->getValidSearchValueTwo() ) ),
                 true,
                 true,
             ),
@@ -316,10 +316,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     value GTE A
+                //     value GTE One
                 //
-                // The result should contain both Content A and Content B.
-                new Field( "data", Operator::GTE, $this->getSearchValueA() ),
+                // The result should contain both Content One and Content Two.
+                new Field( "data", Operator::GTE, $this->getValidSearchValueOne() ),
                 true,
                 true,
             ),
@@ -328,10 +328,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     NOT( value GTE A )
+                //     NOT( value GTE One )
                 //
                 // The result should be empty.
-                new LogicalNot( new Field( "data", Operator::GTE, $this->getSearchValueA() ) ),
+                new LogicalNot( new Field( "data", Operator::GTE, $this->getValidSearchValueOne() ) ),
                 false,
                 false,
             ),
@@ -340,10 +340,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     value GTE B
+                //     value GTE Two
                 //
-                // The result should contain Content B.
-                new Field( "data", Operator::GTE, $this->getSearchValueB() ),
+                // The result should contain Content Two.
+                new Field( "data", Operator::GTE, $this->getValidSearchValueTwo() ),
                 false,
                 true,
             ),
@@ -352,10 +352,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     NOT( value GTE B )
+                //     NOT( value GTE Two )
                 //
-                // The result should contain Content A.
-                new LogicalNot( new Field( "data", Operator::GTE, $this->getSearchValueB() ) ),
+                // The result should contain Content One.
+                new LogicalNot( new Field( "data", Operator::GTE, $this->getValidSearchValueTwo() ) ),
                 true,
                 false,
             ),
@@ -364,10 +364,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     value LT A
+                //     value LT One
                 //
                 // The result should be empty.
-                new Field( "data", Operator::LT, $this->getSearchValueA() ),
+                new Field( "data", Operator::LT, $this->getValidSearchValueOne() ),
                 false,
                 false,
             ),
@@ -376,10 +376,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     NOT( value LT A )
+                //     NOT( value LT One )
                 //
-                // The result should contain both Content A and Content B.
-                new LogicalNot( new Field( "data", Operator::LT, $this->getSearchValueA() ) ),
+                // The result should contain both Content One and Content Two.
+                new LogicalNot( new Field( "data", Operator::LT, $this->getValidSearchValueOne() ) ),
                 true,
                 true,
             ),
@@ -388,10 +388,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     value LT B
+                //     value LT Two
                 //
-                // The result should contain Content A.
-                new Field( "data", Operator::LT, $this->getSearchValueB() ),
+                // The result should contain Content One.
+                new Field( "data", Operator::LT, $this->getValidSearchValueTwo() ),
                 true,
                 false,
             ),
@@ -400,10 +400,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     NOT( value LT B )
+                //     NOT( value LT Two )
                 //
-                // The result should contain Content B.
-                new LogicalNot( new Field( "data", Operator::LT, $this->getSearchValueB() ) ),
+                // The result should contain Content Two.
+                new LogicalNot( new Field( "data", Operator::LT, $this->getValidSearchValueTwo() ) ),
                 false,
                 true,
             ),
@@ -412,10 +412,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     value LTE A
+                //     value LTE One
                 //
-                // The result should contain Content A.
-                new Field( "data", Operator::LTE, $this->getSearchValueA() ),
+                // The result should contain Content One.
+                new Field( "data", Operator::LTE, $this->getValidSearchValueOne() ),
                 true,
                 false,
             ),
@@ -424,10 +424,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     NOT( value LTE A )
+                //     NOT( value LTE One )
                 //
-                // The result should contain Content B.
-                new LogicalNot( new Field( "data", Operator::LTE, $this->getSearchValueA() ) ),
+                // The result should contain Content Two.
+                new LogicalNot( new Field( "data", Operator::LTE, $this->getValidSearchValueOne() ) ),
                 false,
                 true,
             ),
@@ -436,10 +436,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     value LTE B
+                //     value LTE Two
                 //
-                // The result should contain both Content A and Content B.
-                new Field( "data", Operator::LTE, $this->getSearchValueB() ),
+                // The result should contain both Content One and Content Two.
+                new Field( "data", Operator::LTE, $this->getValidSearchValueTwo() ),
                 true,
                 true,
             ),
@@ -448,10 +448,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     NOT( value LTE B )
+                //     NOT( value LTE Two )
                 //
                 // The result should be empty.
-                new LogicalNot( new Field( "data", Operator::LTE, $this->getSearchValueB() ) ),
+                new LogicalNot( new Field( "data", Operator::LTE, $this->getValidSearchValueTwo() ) ),
                 false,
                 false,
             ),
@@ -460,15 +460,15 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     value BETWEEN [A,B]
+                //     value BETWEEN [One,Two]
                 //
-                // The result should contain both Content A and Content B.
+                // The result should contain both Content One and Content Two.
                 new Field(
                     "data",
                     Operator::BETWEEN,
                     array(
-                        $this->getSearchValueA(),
-                        $this->getSearchValueB(),
+                        $this->getValidSearchValueOne(),
+                        $this->getValidSearchValueTwo(),
                     )
                 ),
                 true,
@@ -479,16 +479,16 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     NOT( value BETWEEN [A,B] )
+                //     NOT( value BETWEEN [One,Two] )
                 //
-                // The result should contain both Content A and Content B.
+                // The result should contain both Content One and Content Two.
                 new LogicalNot(
                     new Field(
                         "data",
                         Operator::BETWEEN,
                         array(
-                            $this->getSearchValueA(),
-                            $this->getSearchValueB(),
+                            $this->getValidSearchValueOne(),
+                            $this->getValidSearchValueTwo(),
                         )
                     )
                 ),
@@ -500,15 +500,15 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     value BETWEEN [B,A]
+                //     value BETWEEN [Two,One]
                 //
                 // The result should be empty.
                 new Field(
                     "data",
                     Operator::BETWEEN,
                     array(
-                        $this->getSearchValueB(),
-                        $this->getSearchValueA(),
+                        $this->getValidSearchValueTwo(),
+                        $this->getValidSearchValueOne(),
                     )
                 ),
                 false,
@@ -519,16 +519,16 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     NOT( value BETWEEN [B,A] )
+                //     NOT( value BETWEEN [Two,One] )
                 //
-                // The result should contain both Content A and Content B.
+                // The result should contain both Content One and Content Two.
                 new LogicalNot(
                     new Field(
                         "data",
                         Operator::BETWEEN,
                         array(
-                            $this->getSearchValueB(),
-                            $this->getSearchValueA(),
+                            $this->getValidSearchValueTwo(),
+                            $this->getValidSearchValueOne(),
                         )
                     )
                 ),
@@ -540,10 +540,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     value CONTAINS A
+                //     value CONTAINS One
                 //
-                // The result should contain Content A.
-                new Field( "data", Operator::CONTAINS, $this->getSearchValueA() ),
+                // The result should contain Content One.
+                new Field( "data", Operator::CONTAINS, $this->getValidSearchValueOne() ),
                 true,
                 false,
             ),
@@ -552,10 +552,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     NOT( value CONTAINS A )
+                //     NOT( value CONTAINS One )
                 //
-                // The result should contain Content B.
-                new LogicalNot( new Field( "data", Operator::CONTAINS, $this->getSearchValueA() ) ),
+                // The result should contain Content Two.
+                new LogicalNot( new Field( "data", Operator::CONTAINS, $this->getValidSearchValueOne() ) ),
                 false,
                 true,
             ),
@@ -564,10 +564,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     value CONTAINS B
+                //     value CONTAINS Two
                 //
-                // The result should contain Content B.
-                new Field( "data", Operator::CONTAINS, $this->getSearchValueB() ),
+                // The result should contain Content Two.
+                new Field( "data", Operator::CONTAINS, $this->getValidSearchValueTwo() ),
                 false,
                 true,
             ),
@@ -576,11 +576,11 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // Simplified representation:
                 //
-                //     NOT( value CONTAINS B )
+                //     NOT( value CONTAINS Two )
                 //
-                // The result should contain Content A.
+                // The result should contain Content One.
                 new LogicalNot(
-                    new Field( "data", Operator::CONTAINS, $this->getSearchValueB() )
+                    new Field( "data", Operator::CONTAINS, $this->getValidSearchValueTwo() )
                 ),
                 true,
                 false,
@@ -633,12 +633,12 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
         return array(
             $repository,
             $this->createTestSearchContent(
-                $this->getSearchValueA(),
+                $this->getValidSearchValueOne(),
                 $repository,
                 $contentType
             )->id,
             $this->createTestSearchContent(
-                $this->getSearchValueB(),
+                $this->getValidSearchValueTwo(),
                 $repository,
                 $contentType
             )->id,
@@ -652,21 +652,21 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
      * @depends testCreateTestContent
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param boolean $includesA
-     * @param boolean $includesB
+     * @param boolean $includesOne
+     * @param boolean $includesTwo
      * @param array $context
      */
     public function testFilterContent(
         Criterion $criterion,
-        $includesA,
-        $includesB,
+        $includesOne,
+        $includesTwo,
         array $context
     )
     {
-        list( $repository, $contentAId, $contentBId ) = $context;
+        list( $repository, $contentOneId, $contentTwoId ) = $context;
         $searchResult = $this->findContent( $repository, $criterion, true );
 
-        $this->assertFindResult( $searchResult, $includesA, $includesB, $contentAId, $contentBId );
+        $this->assertFindResult( $searchResult, $includesOne, $includesTwo, $contentOneId, $contentTwoId );
     }
 
     /**
@@ -676,21 +676,21 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
      * @depends testCreateTestContent
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param boolean $includesA
-     * @param boolean $includesB
+     * @param boolean $includesOne
+     * @param boolean $includesTwo
      * @param array $context
      */
     public function testQueryContent(
         Criterion $criterion,
-        $includesA,
-        $includesB,
+        $includesOne,
+        $includesTwo,
         array $context
     )
     {
-        list( $repository, $contentAId, $contentBId ) = $context;
+        list( $repository, $contentOneId, $contentTwoId ) = $context;
         $searchResult = $this->findContent( $repository, $criterion, false );
 
-        $this->assertFindResult( $searchResult, $includesA, $includesB, $contentAId, $contentBId );
+        $this->assertFindResult( $searchResult, $includesOne, $includesTwo, $contentOneId, $contentTwoId );
     }
 
     /**
@@ -714,10 +714,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
             );
         }
 
-        list( $repository, $contentAId, $contentBId ) = $context;
+        list( $repository, $contentOneId, $contentTwoId ) = $context;
         $searchResult = $this->sortContent( $repository, $sortClause );
 
-        $this->assertSortResult( $searchResult, $ascending, $contentAId, $contentBId );
+        $this->assertSortResult( $searchResult, $ascending, $contentOneId, $contentTwoId );
     }
 
     /**
@@ -727,14 +727,14 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
      * @depends testCreateTestContent
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param boolean $includesA
-     * @param boolean $includesB
+     * @param boolean $includesOne
+     * @param boolean $includesTwo
      * @param array $context
      */
     public function testFilterLocations(
         Criterion $criterion,
-        $includesA,
-        $includesB,
+        $includesOne,
+        $includesTwo,
         array $context
     )
     {
@@ -754,10 +754,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
             );
         }
 
-        list( $repository, $contentAId, $contentBId ) = $context;
+        list( $repository, $contentOneId, $contentTwoId ) = $context;
         $searchResult = $this->findLocations( $repository, $criterion, true );
 
-        $this->assertFindResult( $searchResult, $includesA, $includesB, $contentAId, $contentBId );
+        $this->assertFindResult( $searchResult, $includesOne, $includesTwo, $contentOneId, $contentTwoId );
     }
 
     /**
@@ -767,14 +767,14 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
      * @depends testCreateTestContent
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param boolean $includesA
-     * @param boolean $includesB
+     * @param boolean $includesOne
+     * @param boolean $includesTwo
      * @param array $context
      */
     public function testQueryLocations(
         Criterion $criterion,
-        $includesA,
-        $includesB,
+        $includesOne,
+        $includesTwo,
         array $context
     )
     {
@@ -794,10 +794,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
             );
         }
 
-        list( $repository, $contentAId, $contentBId ) = $context;
+        list( $repository, $contentOneId, $contentTwoId ) = $context;
         $searchResult = $this->findLocations( $repository, $criterion, false );
 
-        $this->assertFindResult( $searchResult, $includesA, $includesB, $contentAId, $contentBId );
+        $this->assertFindResult( $searchResult, $includesOne, $includesTwo, $contentOneId, $contentTwoId );
     }
 
     /**
@@ -828,10 +828,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
             );
         }
 
-        list( $repository, $contentAId, $contentBId ) = $context;
+        list( $repository, $contentOneId, $contentTwoId ) = $context;
         $searchResult = $this->sortLocations( $repository, $sortClause );
 
-        $this->assertSortResult( $searchResult, $ascending, $contentAId, $contentBId );
+        $this->assertSortResult( $searchResult, $ascending, $contentOneId, $contentTwoId );
     }
 
     /**
@@ -992,40 +992,40 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
     /**
      * Asserts expected result, deliberately ignoring order.
      *
-     * Search result can be empty, contain both Content A and Content B or only one of them.
+     * Search result can be empty, contain both Content One and Content Two or only one of them.
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Search\SearchResult $searchResult
-     * @param boolean $includesA
-     * @param boolean $includesB
-     * @param string|int $contentAId
-     * @param string|int $contentBId
+     * @param boolean $includesOne
+     * @param boolean $includesTwo
+     * @param string|int $contentOneId
+     * @param string|int $contentTwoId
      */
     protected function assertFindResult(
         SearchResult $searchResult,
-        $includesA,
-        $includesB,
-        $contentAId,
-        $contentBId
+        $includesOne,
+        $includesTwo,
+        $contentOneId,
+        $contentTwoId
     )
     {
         $contentIdList = $this->getResultContentIdList( $searchResult );
 
-        if ( $includesA && $includesB )
+        if ( $includesOne && $includesTwo )
         {
             $this->assertEquals( 2, $searchResult->totalCount );
             $this->assertNotEquals( $contentIdList[0], $contentIdList[1] );
 
             $this->assertThat(
                 $contentIdList[0],
-                $this->logicalOr( $this->equalTo( $contentAId ), $this->equalTo( $contentBId ) )
+                $this->logicalOr( $this->equalTo( $contentOneId ), $this->equalTo( $contentTwoId ) )
             );
 
             $this->assertThat(
                 $contentIdList[1],
-                $this->logicalOr( $this->equalTo( $contentAId ), $this->equalTo( $contentBId ) )
+                $this->logicalOr( $this->equalTo( $contentOneId ), $this->equalTo( $contentTwoId ) )
             );
         }
-        else if ( !$includesA && !$includesB )
+        else if ( !$includesOne && !$includesTwo )
         {
             $this->assertEquals( 0, $searchResult->totalCount );
         }
@@ -1033,45 +1033,45 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
         {
             $this->assertEquals( 1, $searchResult->totalCount );
 
-            if ( $includesA )
+            if ( $includesOne )
             {
-                $this->assertEquals( $contentAId, $contentIdList[0] );
+                $this->assertEquals( $contentOneId, $contentIdList[0] );
             }
 
-            if ( $includesB )
+            if ( $includesTwo )
             {
-                $this->assertEquals( $contentBId, $contentIdList[0] );
+                $this->assertEquals( $contentTwoId, $contentIdList[0] );
             }
         }
     }
 
     /**
-     * Asserts order of the given $searchResult, both Content A and B are always expected.
+     * Asserts order of the given $searchResult, both Content One and Two are always expected.
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Search\SearchResult $searchResult
      * @param boolean $ascending Denotes ascending order if true, descending order if false
-     * @param string|int $contentAId
-     * @param string|int $contentBId
+     * @param string|int $contentOneId
+     * @param string|int $contentTwoId
      */
     protected function assertSortResult(
         SearchResult $searchResult,
         $ascending,
-        $contentAId,
-        $contentBId
+        $contentOneId,
+        $contentTwoId
     )
     {
         $contentIdList = $this->getResultContentIdList( $searchResult );
 
-        $indexA = 0;
-        $indexB = 1;
+        $indexOne = 0;
+        $indexTwo = 1;
 
         if ( !$ascending )
         {
-            $indexA = 1;
-            $indexB = 0;
+            $indexOne = 1;
+            $indexTwo = 0;
         }
 
-        $this->assertEquals( $contentAId, $contentIdList[$indexA] );
-        $this->assertEquals( $contentBId, $contentIdList[$indexB] );
+        $this->assertEquals( $contentOneId, $contentIdList[$indexOne] );
+        $this->assertEquals( $contentTwoId, $contentIdList[$indexTwo] );
     }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
@@ -956,7 +956,6 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 "sortClauses" => array(
                     $sortClause,
                 ),
-
             )
         );
 

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
@@ -1,0 +1,1146 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\API\Repository\Tests\FieldType;
+
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Field;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalNot;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Field as FieldSortClause;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use eZ\Publish\API\Repository\Tests\SetupFactory\LegacySolr;
+use eZ\Publish\API\Repository\Tests\SetupFactory\LegacyElasticsearch;
+
+/**
+ * Integration test for searching and sorting with Field criterion and Field sort clause.
+ *
+ * This abstract test case should be used as a base for a specific field type search
+ * integration tests. It will first create two Content objects with two distinct field
+ * values, then execute a series of tests for Field criterion and Field sort clause,
+ * explicitly limited on these two values.
+ *
+ * Field criterion will be tested for each supported operator in all possible ways,
+ * combined with LogicalNot criterion, while Field sort clause will be tested in
+ * ascending and descending order.
+ *
+ * Same set of tests will be executed for each type of search (Content search, Location
+ * search), and in case of a criterion separately for a filtering and querying type of
+ * Query.
+ *
+ * To get the test working extend it in a concrete field type test and implement
+ * methods:
+ *
+ * - getSearchValueA()
+ * - getSearchValueB()
+ *
+ * In the test descriptions Content object created with values A and B are referred to as
+ * Content A, and Content B. See the descriptions of the abstract declarations of these
+ * methods for more details on how to choose proper values.
+ *
+ * Note: this test case does not concern itself with testing field filters, behaviour
+ * of multiple sort clauses or combination with other criteria. These are tested
+ * elsewhere as a general field search cases, which enables keeping this test case
+ * simple.
+ */
+abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
+{
+    /**
+     * Get field value A.
+     *
+     * The value must be valid for Content creation.
+     *
+     * When Field sort clause with ascending order is used on the tested field,
+     * Content containing the field with this value must come before the Content
+     * with value B.
+     *
+     * Opposite should be the case when using descending order.
+     *
+     * @return mixed
+     */
+    abstract protected function getSearchValueA();
+
+    /**
+     * Get field value B.
+     *
+     * The value must be valid for Content creation.
+     *
+     * When Field sort clause with ascending order is used on the tested field,
+     * Content containing the field with this value must come after the Content
+     * with value A.
+     *
+     * Opposite should be the case when using descending order.
+     *
+     * @return mixed
+     */
+    abstract protected function getSearchValueB();
+
+    /**
+     * Creates and returns content with given $fieldData
+     *
+     * @param mixed $fieldData
+     * @param \eZ\Publish\API\Repository\Repository $repository
+     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content
+     */
+    protected function createTestSearchContent( $fieldData, Repository $repository, $contentType )
+    {
+        $contentService = $repository->getContentService();
+        $locationService = $repository->getLocationService();
+
+        $createStruct = $contentService->newContentCreateStruct( $contentType, "eng-US" );
+        $createStruct->setField( "name", "Test object" );
+        $createStruct->setField(
+            "data",
+            $fieldData
+        );
+
+        $locationCreateStruct = $locationService->newLocationCreateStruct( 2 );
+
+        return $contentService->publishVersion(
+            $contentService->createContent(
+                $createStruct,
+                array(
+                    $locationCreateStruct,
+                )
+            )->versionInfo
+        );
+    }
+
+    public function criteriaProvider()
+    {
+        return array(
+            0 => array(
+                /**
+                 * Tests search with EQ operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     value EQ A
+                 *
+                 * The result should contain Content A.
+                 */
+                new Field( "data", Operator::EQ, $this->getSearchValueA() ),
+                true,
+                false,
+            ),
+            1 => array(
+                /**
+                 * Tests search with EQ operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     NOT( value EQ A )
+                 *
+                 * The result should contain Content B.
+                 */
+                new LogicalNot( new Field( "data", Operator::EQ, $this->getSearchValueA() ) ),
+                false,
+                true,
+            ),
+            2 => array(
+                /**
+                 * Tests search with EQ operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     value EQ B
+                 *
+                 * The result should contain Content B.
+                 */
+                new Field( "data", Operator::EQ, $this->getSearchValueB() ),
+                false,
+                true,
+            ),
+            3 => array(
+                /**
+                 * Tests search with EQ operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     NOT( value EQ B )
+                 *
+                 * The result should contain Content A.
+                 */
+                new LogicalNot( new Field( "data", Operator::EQ, $this->getSearchValueB() ) ),
+                true,
+                false,
+            ),
+            4 => array(
+                /**
+                 * Tests search with IN operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     value IN [A]
+                 *
+                 * The result should contain Content A.
+                 */
+                new Field( "data", Operator::IN, array( $this->getSearchValueA() ) ),
+                true,
+                false,
+            ),
+            5 => array(
+                /**
+                 * Tests search with IN operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     NOT( value IN [A] )
+                 *
+                 * The result should contain Content B.
+                 */
+                new LogicalNot(
+                    new Field( "data", Operator::IN, array( $this->getSearchValueA() ) )
+                ),
+                false,
+                true,
+            ),
+            6 => array(
+                /**
+                 * Tests search with IN operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     value IN [B]
+                 *
+                 * The result should contain Content B.
+                 */
+                new Field( "data", Operator::IN, array( $this->getSearchValueB() ) ),
+                false,
+                true,
+            ),
+            7 => array(
+                /**
+                 * Tests search with IN operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     NOT( value IN [B] )
+                 *
+                 * The result should contain Content A.
+                 */
+                new LogicalNot(
+                    new Field( "data", Operator::IN, array( $this->getSearchValueB() ) )
+                ),
+                true,
+                false,
+            ),
+            8 => array(
+                /**
+                 * Tests search with IN operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     value IN [A,B]
+                 *
+                 * The result should contain both Content A and Content B.
+                 */
+                new Field(
+                    "data",
+                    Operator::IN,
+                    array(
+                        $this->getSearchValueA(),
+                        $this->getSearchValueB(),
+                    )
+                ),
+                true,
+                true,
+            ),
+            9 => array(
+                /**
+                 * Tests search with IN operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     NOT( value IN [A,B] )
+                 *
+                 * The result should be empty.
+                 */
+                new LogicalNot(
+                    new Field(
+                        "data",
+                        Operator::IN,
+                        array(
+                            $this->getSearchValueA(),
+                            $this->getSearchValueB(),
+                        )
+                    )
+                ),
+                false,
+                false,
+            ),
+            10 => array(
+                /**
+                 * Tests search with GT operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     value GT A
+                 *
+                 * The result should contain Content B.
+                 */
+                new Field( "data", Operator::GT, $this->getSearchValueA() ),
+                false,
+                true,
+            ),
+            11 => array(
+                /**
+                 * Tests search with GT operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     NOT( value GT A )
+                 *
+                 * The result should contain Content A.
+                 */
+                new LogicalNot( new Field( "data", Operator::GT, $this->getSearchValueA() ) ),
+                true,
+                false,
+            ),
+            12 => array(
+                /**
+                 * Tests search with GT operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     value GT B
+                 *
+                 * The result should be empty.
+                 */
+                new Field( "data", Operator::GT, $this->getSearchValueB() ),
+                false,
+                false,
+            ),
+            13 => array(
+                /**
+                 * Tests search with GT operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     NOT( value GT B )
+                 *
+                 * The result should contain both Content A and Content B.
+                 */
+                new LogicalNot( new Field( "data", Operator::GT, $this->getSearchValueB() ) ),
+                true,
+                true,
+            ),
+            14 => array(
+                /**
+                 * Tests search with GTE operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     value GTE A
+                 *
+                 * The result should contain both Content A and Content B.
+                 */
+                new Field( "data", Operator::GTE, $this->getSearchValueA() ),
+                true,
+                true,
+            ),
+            15 => array(
+                /**
+                 * Tests search with GTE operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     NOT( value GTE A )
+                 *
+                 * The result should be empty.
+                 */
+                new LogicalNot( new Field( "data", Operator::GTE, $this->getSearchValueA() ) ),
+                false,
+                false,
+            ),
+            16 => array(
+                /**
+                 * Tests search with GTE operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     value GTE B
+                 *
+                 * The result should contain Content B.
+                 */
+                new Field( "data", Operator::GTE, $this->getSearchValueB() ),
+                false,
+                true,
+            ),
+            17 => array(
+                /**
+                 * Tests search with GTE operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     NOT( value GTE B )
+                 *
+                 * The result should contain Content A.
+                 */
+                new LogicalNot( new Field( "data", Operator::GTE, $this->getSearchValueB() ) ),
+                true,
+                false,
+            ),
+            18 => array(
+                /**
+                 * Tests search with LT operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     value LT A
+                 *
+                 * The result should be empty.
+                 */
+                new Field( "data", Operator::LT, $this->getSearchValueA() ),
+                false,
+                false,
+            ),
+            19 => array(
+                /**
+                 * Tests search with LT operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     NOT( value LT A )
+                 *
+                 * The result should contain both Content A and Content B.
+                 */
+                new LogicalNot( new Field( "data", Operator::LT, $this->getSearchValueA() ) ),
+                true,
+                true,
+            ),
+            20 => array(
+                /**
+                 * Tests search with LT operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     value LT B
+                 *
+                 * The result should contain Content A.
+                 */
+                new Field( "data", Operator::LT, $this->getSearchValueB() ),
+                true,
+                false,
+            ),
+            21 => array(
+                /**
+                 * Tests search with LT operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     NOT( value LT B )
+                 *
+                 * The result should contain Content B.
+                 */
+                new LogicalNot( new Field( "data", Operator::LT, $this->getSearchValueB() ) ),
+                false,
+                true,
+            ),
+            22 => array(
+                /**
+                 * Tests search with LTE operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     value LTE A
+                 *
+                 * The result should contain Content A.
+                 */
+                new Field( "data", Operator::LTE, $this->getSearchValueA() ),
+                true,
+                false,
+            ),
+            23 => array(
+                /**
+                 * Tests search with LTE operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     NOT( value LTE A )
+                 *
+                 * The result should contain Content B.
+                 */
+                new LogicalNot( new Field( "data", Operator::LTE, $this->getSearchValueA() ) ),
+                false,
+                true,
+            ),
+            24 => array(
+                /**
+                 * Tests search with LTE operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     value LTE B
+                 *
+                 * The result should contain both Content A and Content B.
+                 */
+                new Field( "data", Operator::LTE, $this->getSearchValueB() ),
+                true,
+                true,
+            ),
+            25 => array(
+                /**
+                 * Tests search with LTE operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     NOT( value LTE B )
+                 *
+                 * The result should be empty.
+                 */
+                new LogicalNot( new Field( "data", Operator::LTE, $this->getSearchValueB() ) ),
+                false,
+                false,
+            ),
+            26 => array(
+                /**
+                 * Tests search with BETWEEN operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     value BETWEEN [A,B]
+                 *
+                 * The result should contain both Content A and Content B.
+                 */
+                new Field(
+                    "data",
+                    Operator::BETWEEN,
+                    array(
+                        $this->getSearchValueA(),
+                        $this->getSearchValueB(),
+                    )
+                ),
+                true,
+                true,
+            ),
+            27 => array(
+                /**
+                 * Tests search with BETWEEN operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     NOT( value BETWEEN [A,B] )
+                 *
+                 * The result should contain both Content A and Content B.
+                 */
+                new LogicalNot(
+                    new Field(
+                        "data",
+                        Operator::BETWEEN,
+                        array(
+                            $this->getSearchValueA(),
+                            $this->getSearchValueB(),
+                        )
+                    )
+                ),
+                false,
+                false,
+            ),
+            28 => array(
+                /**
+                 * Tests search with BETWEEN operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     value BETWEEN [B,A]
+                 *
+                 * The result should be empty.
+                 */
+                new Field(
+                    "data",
+                    Operator::BETWEEN,
+                    array(
+                        $this->getSearchValueB(),
+                        $this->getSearchValueA(),
+                    )
+                ),
+                false,
+                false,
+            ),
+            29 => array(
+                /**
+                 * Tests search with BETWEEN operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     NOT( value BETWEEN [B,A] )
+                 *
+                 * The result should contain both Content A and Content B.
+                 */
+                new LogicalNot(
+                    new Field(
+                        "data",
+                        Operator::BETWEEN,
+                        array(
+                            $this->getSearchValueB(),
+                            $this->getSearchValueA(),
+                        )
+                    )
+                ),
+                true,
+                true,
+            ),
+            30 => array(
+                /**
+                 * Tests search with CONTAINS operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     value CONTAINS A
+                 *
+                 * The result should contain Content A.
+                 */
+                new Field( "data", Operator::CONTAINS, $this->getSearchValueA() ),
+                true,
+                false,
+            ),
+            31 => array(
+                /**
+                 * Tests search with CONTAINS operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     NOT( value CONTAINS A )
+                 *
+                 * The result should contain Content B.
+                 */
+                new LogicalNot( new Field( "data", Operator::CONTAINS, $this->getSearchValueA() ) ),
+                false,
+                true,
+            ),
+            32 => array(
+                /**
+                 * Tests search with CONTAINS operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     value CONTAINS B
+                 *
+                 * The result should contain Content B.
+                 */
+                new Field( "data", Operator::CONTAINS, $this->getSearchValueB() ),
+                false,
+                true,
+            ),
+            33 => array(
+                /**
+                 * Tests search with CONTAINS operator.
+                 *
+                 * Simplified representation:
+                 *
+                 *     NOT( value CONTAINS B )
+                 *
+                 * The result should contain Content A.
+                 */
+                new LogicalNot(
+                    new Field( "data", Operator::CONTAINS, $this->getSearchValueB() )
+                ),
+                true,
+                false,
+            ),
+        );
+    }
+
+    public function sortClauseProvider()
+    {
+        return array(
+            0 => array(
+                new FieldSortClause(
+                    "test-" . $this->getTypeName(),
+                    "data",
+                    Query::SORT_ASC
+                ),
+                true
+            ),
+            1 => array(
+                new FieldSortClause(
+                    "test-" . $this->getTypeName(),
+                    "data",
+                    Query::SORT_DESC
+                ),
+                false
+            ),
+        );
+    }
+
+    /**
+     * Creates test Content and Locations and returns the context for subsequent testing
+     *
+     * Context consists of repository instance and created Content IDs.
+     *
+     * @return \eZ\Publish\API\Repository\Repository
+     */
+    public function testCreateTestContent()
+    {
+        $repository = $this->getRepository();
+        $fieldTypeService = $repository->getFieldTypeService();
+        $fieldType = $fieldTypeService->getFieldType( $this->getTypeName() );
+
+        if ( !$fieldType->isSearchable() )
+        {
+            $this->markTestSkipped( "Field type '{$this->getTypeName()}' is not searchable." );
+        }
+
+        $contentType = $this->testCreateContentType();
+
+        return array(
+            $repository,
+            $this->createTestSearchContent(
+                $this->getSearchValueA(),
+                $repository,
+                $contentType
+            )->id,
+            $this->createTestSearchContent(
+                $this->getSearchValueB(),
+                $repository,
+                $contentType
+            )->id,
+        );
+    }
+
+    /**
+     * Tests Content Search querying with Field criterion on a field of specific field type
+     *
+     * @dataProvider criteriaProvider
+     * @depends testCreateTestContent
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param boolean $includesA
+     * @param boolean $includesB
+     * @param array $context
+     */
+    public function testFilterContent(
+        Criterion $criterion,
+        $includesA,
+        $includesB,
+        array $context
+    )
+    {
+        list( $repository, $contentAId, $contentBId ) = $context;
+        $searchResult = $this->findContent( $repository, $criterion, true );
+
+        $this->assertFindResult( $searchResult, $includesA, $includesB, $contentAId, $contentBId );
+    }
+
+    /**
+     * Tests Content Search querying with Field criterion on a field of specific field type
+     *
+     * @dataProvider criteriaProvider
+     * @depends testCreateTestContent
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param boolean $includesA
+     * @param boolean $includesB
+     * @param array $context
+     */
+    public function testQueryContent(
+        Criterion $criterion,
+        $includesA,
+        $includesB,
+        array $context
+    )
+    {
+        list( $repository, $contentAId, $contentBId ) = $context;
+        $searchResult = $this->findContent( $repository, $criterion, false );
+
+        $this->assertFindResult( $searchResult, $includesA, $includesB, $contentAId, $contentBId );
+    }
+
+    /**
+     * Tests Content Search sort with Field sort clause on a field of specific field type
+     *
+     * @dataProvider sortClauseProvider
+     * @depends testCreateTestContent
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause
+     * @param boolean $ascending
+     * @param array $context
+     */
+    public function testSortContent( SortClause $sortClause, $ascending, array $context )
+    {
+        $setupFactory = $this->getSetupFactory();
+
+        if ( $setupFactory instanceof LegacySolr )
+        {
+            $this->markTestSkipped(
+                "For Solr engine fields are not searchable with Location Search"
+            );
+        }
+
+        list( $repository, $contentAId, $contentBId ) = $context;
+        $searchResult = $this->sortContent( $repository, $sortClause );
+
+        $this->assertSortResult( $searchResult, $ascending, $contentAId, $contentBId );
+    }
+
+    /**
+     * Tests Location Search filtering with Field criterion on a field of specific field type
+     *
+     * @dataProvider criteriaProvider
+     * @depends testCreateTestContent
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param boolean $includesA
+     * @param boolean $includesB
+     * @param array $context
+     */
+    public function testFilterLocations(
+        Criterion $criterion,
+        $includesA,
+        $includesB,
+        array $context
+    )
+    {
+        $setupFactory = $this->getSetupFactory();
+
+        if ( $setupFactory instanceof LegacySolr )
+        {
+            $this->markTestSkipped(
+                "For Solr engine fields are not searchable with Location Search"
+            );
+        }
+
+        if ( $setupFactory instanceof LegacyElasticsearch )
+        {
+            $this->markTestSkipped(
+                "For Elasticsearch engine fields are not searchable with Location Search"
+            );
+        }
+
+        list( $repository, $contentAId, $contentBId ) = $context;
+        $searchResult = $this->findLocations( $repository, $criterion, true );
+
+        $this->assertFindResult( $searchResult, $includesA, $includesB, $contentAId, $contentBId );
+    }
+
+    /**
+     * Tests Location Search querying with Field criterion on a field of specific field type
+     *
+     * @dataProvider criteriaProvider
+     * @depends testCreateTestContent
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param boolean $includesA
+     * @param boolean $includesB
+     * @param array $context
+     */
+    public function testQueryLocations(
+        Criterion $criterion,
+        $includesA,
+        $includesB,
+        array $context
+    )
+    {
+        $setupFactory = $this->getSetupFactory();
+
+        if ( $setupFactory instanceof LegacySolr )
+        {
+            $this->markTestSkipped(
+                "For Solr engine fields are not searchable with Location Search"
+            );
+        }
+
+        if ( $setupFactory instanceof LegacyElasticsearch )
+        {
+            $this->markTestSkipped(
+                "For Elasticsearch engine fields are not searchable with Location Search"
+            );
+        }
+
+        list( $repository, $contentAId, $contentBId ) = $context;
+        $searchResult = $this->findLocations( $repository, $criterion, false );
+
+        $this->assertFindResult( $searchResult, $includesA, $includesB, $contentAId, $contentBId );
+    }
+
+    /**
+     * Tests Location Search sort with Field sort clause on a field of specific field type
+     *
+     * @dataProvider sortClauseProvider
+     * @depends testCreateTestContent
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause
+     * @param boolean $ascending
+     * @param array $context
+     */
+    public function testSortLocations( SortClause $sortClause, $ascending, array $context )
+    {
+        $setupFactory = $this->getSetupFactory();
+
+        if ( $setupFactory instanceof LegacySolr )
+        {
+            $this->markTestSkipped(
+                "For Solr engine fields are not searchable with Location Search"
+            );
+        }
+
+        if ( $setupFactory instanceof LegacyElasticsearch )
+        {
+            $this->markTestSkipped(
+                "For Elasticsearch engine fields are not searchable with Location Search"
+            );
+        }
+
+        list( $repository, $contentAId, $contentBId ) = $context;
+        $searchResult = $this->sortLocations( $repository, $sortClause );
+
+        $this->assertSortResult( $searchResult, $ascending, $contentAId, $contentBId );
+    }
+
+    /**
+     * Returns SearchResult of the tested Content for the given $criterion
+     *
+     * @param \eZ\Publish\API\Repository\Repository $repository
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param boolean $filter Denotes search by filtering if true, search by querying if false
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
+     */
+    protected function findContent( Repository $repository, Criterion $criterion, $filter )
+    {
+        $searchService = $repository->getSearchService();
+
+        if ( $filter )
+        {
+            $criteriaProperty = "filter";
+        }
+        else
+        {
+            $criteriaProperty = "query";
+        }
+
+        $query = new Query(
+            array(
+                $criteriaProperty => new Criterion\LogicalAnd(
+                    array(
+                        new Criterion\ContentTypeIdentifier( "test-" . $this->getTypeName() ),
+                        $criterion,
+                    )
+                ),
+            )
+        );
+
+        return $searchService->findContent( $query );
+    }
+
+    /**
+     * Returns SearchResult of the tested Content for the given $sortClause
+     *
+     * @param \eZ\Publish\API\Repository\Repository $repository
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
+     */
+    protected function sortContent( Repository $repository, SortClause $sortClause )
+    {
+        $searchService = $repository->getSearchService();
+
+        $query = new Query(
+            array(
+                "filter" => new Criterion\ContentTypeIdentifier( "test-" . $this->getTypeName() ),
+                "sortClauses" => array(
+                    $sortClause,
+                ),
+
+            )
+        );
+
+        return $searchService->findContent( $query );
+    }
+
+    /**
+     * Returns SearchResult of the tested Locations for the given $criterion
+     *
+     * @param \eZ\Publish\API\Repository\Repository $repository
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param boolean $filter Denotes search by filtering if true, search by querying if false
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
+     */
+    protected function findLocations( Repository $repository, Criterion $criterion, $filter )
+    {
+        $searchService = $repository->getSearchService();
+
+        if ( $filter )
+        {
+            $criteriaProperty = "filter";
+        }
+        else
+        {
+            $criteriaProperty = "query";
+        }
+
+        $query = new LocationQuery(
+            array(
+                $criteriaProperty => new Criterion\LogicalAnd(
+                    array(
+                        new Criterion\ContentTypeIdentifier( "test-" . $this->getTypeName() ),
+                        $criterion,
+                    )
+                ),
+            )
+        );
+
+        return $searchService->findContent( $query );
+    }
+
+    /**
+     * Returns SearchResult of the tested Locations for the given $sortClause
+     *
+     * @param \eZ\Publish\API\Repository\Repository $repository
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
+     */
+    protected function sortLocations( Repository $repository, SortClause $sortClause )
+    {
+        $searchService = $repository->getSearchService();
+
+        $query = new LocationQuery(
+            array(
+                "filter" => new Criterion\ContentTypeIdentifier( "test-" . $this->getTypeName() ),
+                "sortClauses" => array(
+                    $sortClause,
+                ),
+            )
+        );
+
+        return $searchService->findLocations( $query );
+    }
+
+    /**
+     * Returns a list of Content IDs from given $searchResult, with order preserved
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Search\SearchResult $searchResult
+     *
+     * @return array
+     */
+    protected function getResultContentIdList( SearchResult $searchResult )
+    {
+        $contentIdList = array();
+
+        foreach ( $searchResult->searchHits as $searchHit )
+        {
+            $valueObject = $searchHit->valueObject;
+
+            switch ( true )
+            {
+                case $valueObject instanceof Content:
+                    $contentIdList[] = $valueObject->id;
+                    break;
+
+                case $valueObject instanceof Location:
+                    $contentIdList[] = $valueObject->contentId;
+                    break;
+
+                default:
+                    throw new \RuntimeException(
+                        "Unknown search result hit type: " . get_class( $searchHit->valueObject )
+                    );
+            }
+        }
+
+        return $contentIdList;
+    }
+
+    /**
+     * Asserts expected result, deliberately ignoring order.
+     *
+     * Search result can be empty, contain both Content A and Content B or only one of them.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Search\SearchResult $searchResult
+     * @param boolean $includesA
+     * @param boolean $includesB
+     * @param string|int $contentAId
+     * @param string|int $contentBId
+     */
+    protected function assertFindResult(
+        SearchResult $searchResult,
+        $includesA,
+        $includesB,
+        $contentAId,
+        $contentBId
+    )
+    {
+        $contentIdList = $this->getResultContentIdList( $searchResult );
+
+        if ( $includesA && $includesB )
+        {
+            $this->assertEquals( 2, $searchResult->totalCount );
+            $this->assertNotEquals( $contentIdList[0], $contentIdList[1] );
+
+            $this->assertThat(
+                $contentIdList[0],
+                $this->logicalOr( $this->equalTo( $contentAId ), $this->equalTo( $contentBId ) )
+            );
+
+            $this->assertThat(
+                $contentIdList[1],
+                $this->logicalOr( $this->equalTo( $contentAId ), $this->equalTo( $contentBId ) )
+            );
+        }
+        else if ( !$includesA && !$includesB )
+        {
+            $this->assertEquals( 0, $searchResult->totalCount );
+        }
+        else
+        {
+            $this->assertEquals( 1, $searchResult->totalCount );
+
+            if ( $includesA )
+            {
+                $this->assertEquals( $contentAId, $contentIdList[0] );
+            }
+
+            if ( $includesB )
+            {
+                $this->assertEquals( $contentBId, $contentIdList[0] );
+            }
+        }
+    }
+
+    /**
+     * Asserts order of the given $searchResult, both Content A and B are always expected.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Search\SearchResult $searchResult
+     * @param boolean $ascending Denotes ascending order if true, descending order if false
+     * @param string|int $contentAId
+     * @param string|int $contentBId
+     */
+    protected function assertSortResult(
+        SearchResult $searchResult,
+        $ascending,
+        $contentAId,
+        $contentBId
+    )
+    {
+        $contentIdList = $this->getResultContentIdList( $searchResult );
+
+        $indexA = 0;
+        $indexB = 1;
+
+        if ( !$ascending )
+        {
+            $indexA = 1;
+            $indexB = 0;
+        }
+
+        $this->assertEquals( $contentAId, $contentIdList[$indexA] );
+        $this->assertEquals( $contentBId, $contentIdList[$indexB] );
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/FieldType/TextLineIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/TextLineIntegrationTest.php
@@ -337,12 +337,12 @@ class TextLineIntegrationTest extends SearchBaseIntegrationTest
         );
     }
 
-    protected function getSearchValueA()
+    protected function getValidSearchValueOne()
     {
         return "a";
     }
 
-    protected function getSearchValueB()
+    protected function getValidSearchValueTwo()
     {
         return "b";
     }

--- a/eZ/Publish/API/Repository/Tests/FieldType/TextLineIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/TextLineIntegrationTest.php
@@ -18,7 +18,7 @@ use eZ\Publish\API\Repository\Values\Content\Field;
  * @group integration
  * @group field-type
  */
-class TextLineIntegrationTest extends BaseIntegrationTest
+class TextLineIntegrationTest extends SearchBaseIntegrationTest
 {
     /**
      * Get name of tested field type
@@ -335,5 +335,15 @@ class TextLineIntegrationTest extends BaseIntegrationTest
             array( new TextLineValue( 0 ) ),
             array( new TextLineValue( "0" ) ),
         );
+    }
+
+    protected function getSearchValueA()
+    {
+        return "a";
+    }
+
+    protected function getSearchValueB()
+    {
+        return "b";
     }
 }

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/Field/FieldRange.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/Field/FieldRange.php
@@ -54,7 +54,7 @@ class FieldRange extends Field
     protected function getCondition( Criterion $criterion )
     {
         $fieldNames = $this->getFieldNames( $criterion, $criterion->target );
-        $criterion->value = (array)$criterion->value;
+        $value = (array)$criterion->value;
 
         if ( empty( $fieldNames ) )
         {
@@ -64,8 +64,8 @@ class FieldRange extends Field
             );
         }
 
-        $start = $criterion->value[0];
-        $end = isset( $criterion->value[1] ) ? $criterion->value[1] : null;
+        $start = $value[0];
+        $end = isset( $value[1] ) ? $value[1] : null;
         $range = $this->getRange( $criterion->operator, $start, $end );
 
         $ranges = array();

--- a/eZ/Publish/Core/Search/Solr/Content/CriterionVisitor/Field/FieldRange.php
+++ b/eZ/Publish/Core/Search/Solr/Content/CriterionVisitor/Field/FieldRange.php
@@ -50,8 +50,9 @@ class FieldRange extends Field
      */
     public function visit( Criterion $criterion, CriterionVisitor $subVisitor = null )
     {
-        $start = $criterion->value[0];
-        $end   = isset( $criterion->value[1] ) ? $criterion->value[1] : null;
+        $value = (array)$criterion->value;
+        $start = $value[0];
+        $end = isset( $value[1] ) ? $value[1] : null;
 
         if ( ( $criterion->operator === Operator::LT ) ||
              ( $criterion->operator === Operator::LTE ) )
@@ -61,7 +62,6 @@ class FieldRange extends Field
         }
 
         $fieldNames = $this->getFieldNames( $criterion, $criterion->target );
-        $criterion->value = (array)$criterion->value;
 
         if ( empty( $fieldNames ) )
         {


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-21794

This implements field type integration test framework for search with Field criterion and Field sort clause.
In order to get it working for a specific field type, concrete test needs to extend the base one, implementing two abstract methods:

* `getSearchValueA()`
* `getSearchValueB()`

These provide distinct valid field type input values, which will be used to create two test Content objects.

Field criterion will be tested on these Content objects, for each supported operator, combined with `LogicalNot` criterion.
Field sort clause will be tested in ascending and descending sorting order.

Same set of tests will be executed for each type of search (Content search, Location search), and in case of a criterion separately for a filtering and querying type of Query.

ATM the tests are implemented for `Integer` and `TextLine` field types.
`LIKE` operator is not yet covered as it is not implemented by either Solr or Elasticsearch, and actual behaviour might be different from what is implemented for Legacy search engine.

Note that this test case does not concern itself with testing field filters, behaviour of multiple sort clauses or combination with other criteria. These are tested elsewhere as a general field search cases, which enables keeping this test case simple.

#### Aditional fixes

* faulty generation of range expression in Solr search engine
* argument mutation when visiting range operators in Solr and Elasticsearch engines

#### Followups

1. https://jira.ez.no/browse/EZP-24173: Indexable field type implementation needs dedicated sort field
2. https://jira.ez.no/browse/EZP-24174: Solr and Elasticsearch: Implement visiting LIKE operator for Field criterion