### PR TITLE
Fix EZP-24106: ez_is_field_empty does not work for a Page field

### DIFF
--- a/eZ/Publish/Core/FieldType/Page/Type.php
+++ b/eZ/Publish/Core/FieldType/Page/Type.php
@@ -119,6 +119,31 @@ class Type extends FieldType
     }
 
     /**
+     * Returns if the given $value is considered empty by the field type
+     *
+     * @param \eZ\Publish\Core\FieldType\Page\Value $value
+     *
+     * @return boolean
+     */
+    public function isEmptyValue( SPIValue $value )
+    {
+        if ( $value === null || $value == $this->getEmptyValue() )
+        {
+            return true;
+        }
+
+        foreach ( $value->page->zones as $zone )
+        {
+            if ( !empty( $zone->blocks ) )
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Converts an $hash to the Value defined by the field type
      *
      * @param mixed $hash

--- a/eZ/Publish/Core/FieldType/Tests/PageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/PageTest.php
@@ -466,4 +466,52 @@ class PageTest extends FieldTypeTest
             array( new PageValue( $this->getPageReference() ), "" )
         );
     }
+
+    /**
+     * Data provider for valid input to isEmptyValue().
+     *
+     * Returns an array of data provider sets with 2 arguments:
+     *
+     * 1. The valid input to isEmptyValue()
+     * 2. The expected return value from isEmptyValue()
+     *
+     * For example:
+     *
+     * <code>
+     *  return array(
+     *      array(
+     *          new PageValue(),
+     *          true
+     *      ),
+     *      array(
+     *          new PageValue( $this->getPageReference() ),
+     *          false
+     *      ),
+     *      // ...
+     *  );
+     * </code>
+     *
+     * @return array
+     */
+    public function providerForTestIsEmptyValue()
+    {
+        return array(
+            array( new PageValue(), true ),
+            array( new PageValue( $this->getPageReference() ), false ),
+        );
+    }
+
+    /**
+     * @dataProvider providerForTestIsEmptyValue
+     */
+    public function testIsEmptyValue( $value, $state )
+    {
+        $fieldType = $this->getFieldTypeUnderTest();
+
+        $this->assertEquals(
+            $state,
+            $fieldType->isEmptyValue( $value ),
+            "Value did not evaluate as " . ( $state ? "" : "non-" ) . "empty"
+        );
+    }
 }

--- a/eZ/Publish/Core/FieldType/Tests/PageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/PageTest.php
@@ -274,7 +274,7 @@ class PageTest extends FieldTypeTest
             ),
             array(
                 new PageValue( new Page() ),
-                new PageValue( new Page() )
+                new PageValue()
             )
         );
     }


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24106

This overrides default `FieldType::isEmptyValue()` implementation for `Page` field type.
The check is now similar to what is done in Legacy Stack datatype, see https://github.com/ezsystems/ezflow-ls-extension/blob/master/datatypes/ezpage/ezpagetype.php#L184.

Note that this ignores `Page::$layout` property when checking if the value is empty. This means `Page` field type value can be non-empty, but have no content to display in the templates. Handling this properly would require introducing something like `hasContent()`. Suggestions on how to handle this are wellcome.

#### Followup

1. https://jira.ez.no/browse/EZP-24183: FieldType::isEmptyValue( $value ) should check $value type