### PR TITLE
Fix EZP-24053: Preview locks content object, and cause version edit conflict

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
@@ -14,6 +14,7 @@ parameters:
 
     ezpublish.api.content.class: eZ\Publish\Core\Repository\Values\Content\Content
     ezpublish.api.location.class: eZ\Publish\Core\Repository\Values\Content\Location
+    ezpublish.api.version.class: eZ\Publish\Core\Repository\Values\Content\VersionInfo
 
 services:
     # API

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
@@ -9,10 +9,12 @@ _ezpublishLocation:
 _ezpublishPreviewContent:
     path: /content/versionview/{contentId}/{versionNo}/{language}/site_access/{siteAccessName}
     defaults: { _controller: ezpublish.controller.content.preview:previewContentAction }
+    methods:  [GET]
 
 _ezpublishPreviewContentDefaultSa:
     path: /content/versionview/{contentId}/{versionNo}/{language}
     defaults: { _controller: ezpublish.controller.content.preview:previewContentAction }
+    methods:  [GET]
 
 _ez_user_hash:
     path: /_fos_user_context_hash

--- a/eZ/Publish/Core/Helper/ContentPreviewHelper.php
+++ b/eZ/Publish/Core/Helper/ContentPreviewHelper.php
@@ -9,6 +9,8 @@
 
 namespace eZ\Publish\Core\Helper;
 
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
@@ -26,6 +28,21 @@ class ContentPreviewHelper implements SiteAccessAware
      * @var \eZ\Publish\Core\MVC\Symfony\SiteAccess
      */
     protected $originalSiteAccess;
+
+    /**
+     * @var bool
+     */
+    private $previewActive = false;
+
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\Content
+     */
+    private $previewedContent;
+
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\Location
+     */
+    private $previewedLocation;
 
     public function __construct( EventDispatcherInterface $eventDispatcher )
     {
@@ -73,5 +90,53 @@ class ContentPreviewHelper implements SiteAccessAware
         $this->eventDispatcher->dispatch( MVCEvents::CONFIG_SCOPE_RESTORE, $event );
 
         return $event->getSiteAccess();
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isPreviewActive()
+    {
+        return $this->previewActive;
+    }
+
+    /**
+     * @param boolean $previewActive
+     */
+    public function setPreviewActive( $previewActive )
+    {
+        $this->previewActive = (bool)$previewActive;
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Content
+     */
+    public function getPreviewedContent()
+    {
+        return $this->previewedContent;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $previewedContent
+     */
+    public function setPreviewedContent( Content $previewedContent)
+    {
+        $this->previewedContent = $previewedContent;
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Location
+     */
+    public function getPreviewedLocation()
+    {
+        return $this->previewedLocation;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $previewedLocation
+     */
+    public function setPreviewedLocation( Location $previewedLocation )
+    {
+        $this->previewedLocation = $previewedLocation;
     }
 }

--- a/eZ/Publish/Core/Helper/Tests/ContentPreviewHelperTest.php
+++ b/eZ/Publish/Core/Helper/Tests/ContentPreviewHelperTest.php
@@ -23,15 +23,15 @@ class ContentPreviewHelperTest extends PHPUnit_Framework_TestCase
     private $eventDispatcher;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \eZ\Publish\Core\Helper\ContentPreviewHelper
      */
-    private $configResolver;
+    private $previewHelper;
 
     protected function setUp()
     {
         parent::setUp();
         $this->eventDispatcher = $this->getMock( 'Symfony\Component\EventDispatcher\EventDispatcherInterface' );
-        $this->configResolver = $this->getMock( 'eZ\Publish\Core\MVC\ConfigResolverInterface' );
+        $this->previewHelper = new ContentPreviewHelper( $this->eventDispatcher );
     }
 
     public function testChangeConfigScope()
@@ -45,14 +45,10 @@ class ContentPreviewHelperTest extends PHPUnit_Framework_TestCase
             ->with( MVCEvents::CONFIG_SCOPE_CHANGE, $this->equalTo( $event ) );
 
         $originalSiteAccess = new SiteAccess( 'foo', 'bar' );
-        $helper = new ContentPreviewHelper(
-            $this->eventDispatcher,
-            $this->configResolver
-        );
-        $helper->setSiteAccess( $originalSiteAccess );
+        $this->previewHelper->setSiteAccess( $originalSiteAccess );
         $this->assertEquals(
             $newSiteAccess,
-            $helper->changeConfigScope( $newSiteAccessName )
+            $this->previewHelper->changeConfigScope( $newSiteAccessName )
         );
     }
 
@@ -65,14 +61,35 @@ class ContentPreviewHelperTest extends PHPUnit_Framework_TestCase
             ->method( 'dispatch' )
             ->with( MVCEvents::CONFIG_SCOPE_RESTORE, $this->equalTo( $event ) );
 
-        $helper = new ContentPreviewHelper(
-            $this->eventDispatcher,
-            $this->configResolver
-        );
-        $helper->setSiteAccess( $originalSiteAccess );
+        $this->previewHelper->setSiteAccess( $originalSiteAccess );
         $this->assertEquals(
             $originalSiteAccess,
-            $helper->restoreConfigScope()
+            $this->previewHelper->restoreConfigScope()
         );
+    }
+
+    public function testPreviewActive()
+    {
+        $this->assertFalse( $this->previewHelper->isPreviewActive() );
+        $this->previewHelper->setPreviewActive( true );
+        $this->assertTrue( $this->previewHelper->isPreviewActive() );
+        $this->previewHelper->setPreviewActive( false );
+        $this->assertFalse( $this->previewHelper->isPreviewActive() );
+    }
+
+    public function testPreviewedContent()
+    {
+        $this->assertNull( $this->previewHelper->getPreviewedContent() );
+        $content = $this->getMock( '\eZ\Publish\API\Repository\Values\Content\Content' );
+        $this->previewHelper->setPreviewedContent( $content );
+        $this->assertSame( $content, $this->previewHelper->getPreviewedContent() );
+    }
+
+    public function testPreviewedLocation()
+    {
+        $this->assertNull( $this->previewHelper->getPreviewedLocation() );
+        $location = $this->getMock( '\eZ\Publish\API\Repository\Values\Content\Location' );
+        $this->previewHelper->setPreviewedLocation( $location );
+        $this->assertSame( $location, $this->previewHelper->getPreviewedLocation() );
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
@@ -78,10 +78,14 @@ class PreviewController
 
     public function previewContentAction( $contentId, $versionNo, $language, $siteAccessName = null )
     {
+        $this->previewHelper->setPreviewActive( true );
+
         try
         {
             $content = $this->contentService->loadContent( $contentId, array( $language ), $versionNo );
             $location = $this->locationProvider->loadMainLocation( $contentId );
+            $this->previewHelper->setPreviewedContent( $content );
+            $this->previewHelper->setPreviewedLocation( $location );
         }
         catch ( UnauthorizedException $e )
         {
@@ -108,6 +112,7 @@ class PreviewController
         $response->headers->remove( 'expires' );
 
         $this->previewHelper->restoreConfigScope();
+        $this->previewHelper->setPreviewActive( false );
 
         return $response;
     }

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Tests/Controller/Content/PreviewControllerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Tests/Controller/Content/PreviewControllerTest.php
@@ -166,6 +166,25 @@ class PreviewControllerTest extends PHPUnit_Framework_TestCase
 
         // PreviewHelper expectations
         $this->previewHelper
+            ->expects( $this->exactly( 2 ) )
+            ->method( 'setPreviewActive' )
+            ->will(
+                $this->returnValueMap(
+                    array(
+                        array( true, null ),
+                        array( false, null ),
+                    )
+                )
+            );
+        $this->previewHelper
+            ->expects( $this->once() )
+            ->method( 'setPreviewedContent' )
+            ->with( $content );
+        $this->previewHelper
+            ->expects( $this->once() )
+            ->method( 'setPreviewedLocation' )
+            ->with( $location );
+        $this->previewHelper
             ->expects( $this->once() )
             ->method( 'getOriginalSiteAccess' )
             ->will( $this->returnValue( $previousSiteAccess ) );


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24053
> https://jira.ez.no/browse/EZP-24052

This issue was due to an incomplete implementation of legacy website toolbar (handling preview was missing).
This PR ensures that:

* Content preview route is only used with Http GET (POST will be used by legacy to publish or go back to editing).
* One can easily check if preview is active and retrieve previewed content/location.

ContentPreviewHelper is now used to check if preview is active and to get previewed content/location since as of Symfony 2.4, request attributes from the master request are not passed to sub-requests any more. Furthermore, it's cleaner to be able to get this information through a dedicated service instead of request attributes.

LegacyBridge related PR: https://github.com/ezsystems/LegacyBridge/pull/22