### PR TITLE
EZP-24206: As a Developer I want faster search, using spi cache & indexed columns

### DIFF
--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeIdentifier.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeIdentifier.php
@@ -13,34 +13,12 @@ use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\Core\Persistence\Database\SelectQuery;
-use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
-use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 
 /**
  * Content type criterion handler
  */
-class ContentTypeIdentifier extends CriterionHandler
+class ContentTypeIdentifier extends FieldBase
 {
-    /**
-     * ContentType handler
-     *
-     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
-     */
-    protected $contentTypeHandler;
-
-    /**
-     * Create from content type handler
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
-     */
-    public function __construct( DatabaseHandler $dbHandler, ContentTypeHandler $contentTypeHandler )
-    {
-        parent::__construct( $dbHandler );
-
-        $this->contentTypeHandler = $contentTypeHandler;
-    }
-
     /**
      * Check if this criterion handler accepts to handle the given criterion.
      *

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/Field.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/Field.php
@@ -26,15 +26,8 @@ use RuntimeException;
 /**
  * Field criterion handler
  */
-class Field extends CriterionHandler
+class Field extends FieldBase
 {
-    /**
-     * DB handler to fetch additional field information
-     *
-     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
-     */
-    protected $dbHandler;
-
     /**
      * Field converter registry
      *
@@ -57,34 +50,27 @@ class Field extends CriterionHandler
     protected $transformationProcessor;
 
     /**
-     * Content Type handler
-     *
-     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
-     */
-    protected $contentTypeHandler;
-
-    /**
      * Construct from handler handler
      *
      * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry $fieldConverterRegistry
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Converter $fieldValueConverter
      * @param \eZ\Publish\Core\Persistence\TransformationProcessor $transformationProcessor
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
      */
     public function __construct(
         DatabaseHandler $dbHandler,
+        ContentTypeHandler $contentTypeHandler,
         Registry $fieldConverterRegistry,
         FieldValueConverter $fieldValueConverter,
-        TransformationProcessor $transformationProcessor,
-        ContentTypeHandler $contentTypeHandler
+        TransformationProcessor $transformationProcessor
     )
     {
-        $this->dbHandler = $dbHandler;
+        parent::__construct( $dbHandler, $contentTypeHandler );
+
         $this->fieldConverterRegistry = $fieldConverterRegistry;
         $this->fieldValueConverter = $fieldValueConverter;
         $this->transformationProcessor = $transformationProcessor;
-        $this->contentTypeHandler = $contentTypeHandler;
     }
 
     /**

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldBase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldBase.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
+
+/**
+ * Base criterion handler for field criteria
+ */
+abstract class FieldBase extends CriterionHandler
+{
+    /**
+     * Content Type handler
+     *
+     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
+     */
+    protected $contentTypeHandler;
+
+    /**
+     * Construct from handler handler
+     *
+     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
+     */
+    public function __construct( DatabaseHandler $dbHandler, ContentTypeHandler $contentTypeHandler )
+    {
+        parent::__construct( $dbHandler );
+
+        $this->contentTypeHandler = $contentTypeHandler;
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldRelation.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldRelation.php
@@ -13,6 +13,9 @@ use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\Core\Persistence\Database\SelectQuery;
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use RuntimeException;
 
 /**
@@ -20,6 +23,26 @@ use RuntimeException;
  */
 class FieldRelation extends CriterionHandler
 {
+    /**
+     * ContentType handler
+     *
+     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
+     */
+    protected $contentTypeHandler;
+
+    /**
+     * Construct from handler handler
+     *
+     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
+     */
+    public function __construct( DatabaseHandler $dbHandler, ContentTypeHandler $contentTypeHandler )
+    {
+        parent::__construct( $dbHandler );
+
+        $this->contentTypeHandler = $contentTypeHandler;
+    }
+
     /**
      * Check if this criterion handler accepts to handle the given criterion.
      *
@@ -30,6 +53,42 @@ class FieldRelation extends CriterionHandler
     public function accept( Criterion $criterion )
     {
         return $criterion instanceof Criterion\FieldRelation;
+    }
+
+    /**
+     * Returns a list of IDs of searchable FieldDefinitions for the given criterion target.
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException If no searchable fields are found for the given $fieldIdentifier.
+     *
+     * @param string $fieldDefinitionIdentifier
+     *
+     * @return array
+     */
+    protected function getFieldDefinitionsIds( $fieldDefinitionIdentifier )
+    {
+        $fieldDefinitionIdList = array();
+        $fieldMap = $this->contentTypeHandler->getSearchableFieldMap();
+
+        foreach ( $fieldMap as $contentTypeIdentifier => $fieldIdentifierMap )
+        {
+            // First check if field exists in the current ContentType, there is nothing to do if it doesn't
+            if ( !isset( $fieldIdentifierMap[$fieldDefinitionIdentifier] ) )
+            {
+                continue;
+            }
+
+            $fieldDefinitionIdList[] = $fieldIdentifierMap[$fieldDefinitionIdentifier]["field_definition_id"];
+        }
+
+        if ( empty( $fieldDefinitionIdList ) )
+        {
+            throw new InvalidArgumentException(
+                "\$criterion->target",
+                "No searchable fields found for the given criterion target '{$fieldDefinitionIdentifier}'."
+            );
+        }
+
+        return $fieldDefinitionIdList;
     }
 
     /**
@@ -47,6 +106,7 @@ class FieldRelation extends CriterionHandler
     public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
     {
         $column = $this->dbHandler->quoteColumn( 'to_contentobject_id', 'ezcontentobject_link' );
+        $fieldDefinitionIds = $this->getFieldDefinitionsIds( $criterion->target );
 
         switch ( $criterion->operator )
         {
@@ -65,24 +125,15 @@ class FieldRelation extends CriterionHandler
                             $this->dbHandler->quoteTable( 'ezcontentobject_link' )
                         );
 
-                        $subSelect->innerJoin(
-                            'ezcontentclass_attribute',
-                            $subSelect->expr->eq( 'ezcontentclass_attribute.id', 'ezcontentobject_link.contentclassattribute_id' )
-                        );
-
                         $subSelect->where(
                             $subSelect->expr->lAnd(
                                 $subSelect->expr->eq(
                                     $this->dbHandler->quoteColumn( 'from_contentobject_version', 'ezcontentobject_link' ),
                                     $this->dbHandler->quoteColumn( 'current_version', 'ezcontentobject' )
                                 ),
-                                $subSelect->expr->eq(
-                                    $this->dbHandler->quoteColumn( 'contentclass_id', 'ezcontentclass_attribute' ),
-                                    $this->dbHandler->quoteColumn( 'contentclass_id', 'ezcontentobject' )
-                                ),
-                                $subSelect->expr->eq(
-                                    $this->dbHandler->quoteColumn( 'identifier', 'ezcontentclass_attribute' ),
-                                    $subSelect->bindValue( $criterion->target )
+                                $subSelect->expr->in(
+                                    $this->dbHandler->quoteColumn( 'contentclassattribute_id', 'ezcontentobject_link' ),
+                                    $fieldDefinitionIds
                                 ),
                                 $subSelect->expr->eq(
                                     $column,
@@ -111,11 +162,6 @@ class FieldRelation extends CriterionHandler
                     $this->dbHandler->quoteTable( 'ezcontentobject_link' )
                 );
 
-                $subSelect->innerJoin(
-                    'ezcontentclass_attribute',
-                    $subSelect->expr->eq( 'ezcontentclass_attribute.id', 'ezcontentobject_link.contentclassattribute_id' )
-                );
-
                 return $query->expr->in(
                     $this->dbHandler->quoteColumn( 'id', 'ezcontentobject' ),
                     $subSelect->where(
@@ -124,13 +170,9 @@ class FieldRelation extends CriterionHandler
                                 $this->dbHandler->quoteColumn( 'from_contentobject_version', 'ezcontentobject_link' ),
                                 $this->dbHandler->quoteColumn( 'current_version', 'ezcontentobject' )
                             ),
-                            $subSelect->expr->eq(
-                                $this->dbHandler->quoteColumn( 'contentclass_id', 'ezcontentclass_attribute' ),
-                                $this->dbHandler->quoteColumn( 'contentclass_id', 'ezcontentobject' )
-                            ),
-                            $subSelect->expr->eq(
-                                $this->dbHandler->quoteColumn( 'identifier', 'ezcontentclass_attribute' ),
-                                $subSelect->bindValue( $criterion->target )
+                            $subSelect->expr->in(
+                                $this->dbHandler->quoteColumn( 'contentclassattribute_id', 'ezcontentobject_link' ),
+                                $fieldDefinitionIds
                             ),
                             $subSelect->expr->in(
                                 $column,

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldRelation.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldRelation.php
@@ -13,36 +13,14 @@ use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\Core\Persistence\Database\SelectQuery;
-use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
-use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use RuntimeException;
 
 /**
  * FieldRelation criterion handler
  */
-class FieldRelation extends CriterionHandler
+class FieldRelation extends FieldBase
 {
-    /**
-     * ContentType handler
-     *
-     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
-     */
-    protected $contentTypeHandler;
-
-    /**
-     * Construct from handler handler
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
-     */
-    public function __construct( DatabaseHandler $dbHandler, ContentTypeHandler $contentTypeHandler )
-    {
-        parent::__construct( $dbHandler );
-
-        $this->contentTypeHandler = $contentTypeHandler;
-    }
-
     /**
      * Check if this criterion handler accepts to handle the given criterion.
      *

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MapLocationDistance.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MapLocationDistance.php
@@ -11,18 +11,16 @@ namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
-use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Value\MapLocationValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Persistence\Database\SelectQuery;
-use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
 use RuntimeException;
 
 /**
  * MapLocationDistance criterion handler
  */
-class MapLocationDistance extends CriterionHandler
+class MapLocationDistance extends FieldBase
 {
     /**
      * Distance in kilometers of one degree longitude at the Equator
@@ -33,26 +31,6 @@ class MapLocationDistance extends CriterionHandler
      * Radius of the planet in kilometers
      */
     const EARTH_RADIUS = 6371.01;
-
-    /**
-     * ContentType handler
-     *
-     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
-     */
-    protected $contentTypeHandler;
-
-    /**
-     * Construct from handler handler
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
-     */
-    public function __construct( DatabaseHandler $dbHandler, ContentTypeHandler $contentTypeHandler )
-    {
-        parent::__construct( $dbHandler );
-
-        $this->contentTypeHandler = $contentTypeHandler;
-    }
 
     /**
      * Check if this criterion handler accepts to handle the given criterion.

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerTest.php
@@ -174,6 +174,7 @@ class HandlerTest extends LanguageAwareTestCase
                         ),
                         new Content\Common\Gateway\CriterionHandler\Field(
                             $this->getDatabaseHandler(),
+                            $this->getContentTypeHandler(),
                             $this->getConverterRegistry(),
                             new Content\Common\Gateway\CriterionHandler\FieldValue\Converter(
                                 new Content\Common\Gateway\CriterionHandler\FieldValue\HandlerRegistry(
@@ -192,8 +193,7 @@ class HandlerTest extends LanguageAwareTestCase
                                 ),
                                 $compositeValueHandler
                             ),
-                            $transformationProcessor,
-                            $this->getContentTypeHandler()
+                            $transformationProcessor
                         ),
                         new Content\Common\Gateway\CriterionHandler\ObjectStateId(
                             $this->getDatabaseHandler()

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerTest.php
@@ -212,7 +212,8 @@ class HandlerTest extends LanguageAwareTestCase
                             $this->getDatabaseHandler()
                         ),
                         new Content\Common\Gateway\CriterionHandler\FieldRelation(
-                            $this->getDatabaseHandler()
+                            $this->getDatabaseHandler(),
+                            $this->getContentTypeHandler()
                         ),
                         new Content\Gateway\CriterionHandler\Depth(
                             $this->getDatabaseHandler()

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerTest.php
@@ -12,17 +12,15 @@ namespace eZ\Publish\Core\Search\Legacy\Tests\Content;
 use eZ\Publish\Core\Persistence\Legacy\Tests\Content\LanguageAwareTestCase;
 use eZ\Publish\Core\Persistence;
 use eZ\Publish\Core\Search\Legacy\Content;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler as ContentTypeHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\Mapper as ContentTypeMapper;
 use eZ\Publish\SPI\Persistence\Content as ContentObject;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\DateAndTime;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Integer;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLine;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Url;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase as ContentTypeGateway;
 
 /**
@@ -142,7 +140,8 @@ class HandlerTest extends LanguageAwareTestCase
                             $this->getDatabaseHandler()
                         ),
                         new Content\Common\Gateway\CriterionHandler\ContentTypeIdentifier(
-                            $this->getDatabaseHandler()
+                            $this->getDatabaseHandler(),
+                            $this->getContentTypeHandler()
                         ),
                         new Content\Common\Gateway\CriterionHandler\ContentTypeGroupId(
                             $this->getDatabaseHandler()
@@ -175,15 +174,7 @@ class HandlerTest extends LanguageAwareTestCase
                         ),
                         new Content\Common\Gateway\CriterionHandler\Field(
                             $this->getDatabaseHandler(),
-                            $this->fieldRegistry = new ConverterRegistry(
-                                array(
-                                    'ezdatetime' => new DateAndTime(),
-                                    'ezinteger' => new Integer(),
-                                    'ezstring' => new TextLine(),
-                                    'ezprice' => new Integer(),
-                                    'ezurl' => new Url()
-                                )
-                            ),
+                            $this->getConverterRegistry(),
                             new Content\Common\Gateway\CriterionHandler\FieldValue\Converter(
                                 new Content\Common\Gateway\CriterionHandler\FieldValue\HandlerRegistry(
                                     array(
@@ -201,7 +192,8 @@ class HandlerTest extends LanguageAwareTestCase
                                 ),
                                 $compositeValueHandler
                             ),
-                            $transformationProcessor
+                            $transformationProcessor,
+                            $this->getContentTypeHandler()
                         ),
                         new Content\Common\Gateway\CriterionHandler\ObjectStateId(
                             $this->getDatabaseHandler()
@@ -231,14 +223,50 @@ class HandlerTest extends LanguageAwareTestCase
                     array(
                         new Content\Common\Gateway\SortClauseHandler\ContentId( $this->getDatabaseHandler() ),
                     )
-                ),
-                new ContentTypeGateway(
-                    $this->getDatabaseHandler(),
-                    $this->getLanguageMaskGenerator()
                 )
             ),
             $this->getContentMapperMock()
         );
+    }
+
+    protected $contentTypeHandler;
+
+    protected function getContentTypeHandler()
+    {
+        if ( !isset( $this->contentTypeHandler ) )
+        {
+            $this->contentTypeHandler = new ContentTypeHandler(
+                new ContentTypeGateway(
+                    $this->getDatabaseHandler(),
+                    $this->getLanguageMaskGenerator()
+                ),
+                new ContentTypeMapper( $this->getConverterRegistry() ),
+                $this->getMock( "eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\Update\\Handler" )
+            );
+        }
+
+        return $this->contentTypeHandler;
+    }
+
+    protected function getConverterRegistry()
+    {
+        if ( !isset( $this->fieldRegistry ) )
+        {
+            $this->fieldRegistry = new ConverterRegistry(
+                array(
+                    'ezdatetime' => new Converter\DateAndTime(),
+                    'ezinteger' => new Converter\Integer(),
+                    'ezstring' => new Converter\TextLine(),
+                    'ezprice' => new Converter\Integer(),
+                    'ezurl' => new Converter\Url(),
+                    'ezxmltext' => new Converter\XmlText(),
+                    'ezboolean' => new Converter\Checkbox(),
+                    'ezkeyword' => new Converter\Keyword(),
+                )
+            );
+        }
+
+        return $this->fieldRegistry;
     }
 
     /**

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/Location/HandlerTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/Location/HandlerTest.php
@@ -137,6 +137,7 @@ class HandlerTest extends LanguageAwareTestCase
                         new CommonCriterionHandler\DateMetadata( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\Field(
                             $this->getDatabaseHandler(),
+                            $this->getContentTypeHandler(),
                             $this->getConverterRegistry(),
                             new CommonCriterionHandler\FieldValue\Converter(
                                 new CommonCriterionHandler\FieldValue\HandlerRegistry(
@@ -155,8 +156,7 @@ class HandlerTest extends LanguageAwareTestCase
                                 ),
                                 $compositeValueHandler
                             ),
-                            $transformationProcessor,
-                            $this->getContentTypeHandler()
+                            $transformationProcessor
                         ),
                         new CommonCriterionHandler\FullText(
                             $this->getDatabaseHandler(),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/Location/HandlerTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/Location/HandlerTest.php
@@ -170,10 +170,16 @@ class HandlerTest extends LanguageAwareTestCase
                         new CommonCriterionHandler\LogicalAnd( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\LogicalNot( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\LogicalOr( $this->getDatabaseHandler() ),
-                        new CommonCriterionHandler\MapLocationDistance( $this->getDatabaseHandler() ),
+                        new CommonCriterionHandler\MapLocationDistance(
+                            $this->getDatabaseHandler(),
+                            $this->getContentTypeHandler()
+                        ),
                         new CommonCriterionHandler\MatchAll( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\ObjectStateId( $this->getDatabaseHandler() ),
-                        new CommonCriterionHandler\FieldRelation( $this->getDatabaseHandler() ),
+                        new CommonCriterionHandler\FieldRelation(
+                            $this->getDatabaseHandler(),
+                            $this->getContentTypeHandler()
+                        ),
                         new CommonCriterionHandler\RemoteId( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\SectionId( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\UserMetadata( $this->getDatabaseHandler() ),

--- a/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
@@ -130,8 +130,10 @@ services:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.map_location_distance:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
         class: %ezpublish.search.legacy.gateway.criterion_handler.common.map_location_distance.class%
+        arguments:
+            - @ezpublish.api.storage_engine.legacy.dbhandler
+            - @ezpublish.spi.persistence.content_type_handler
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}

--- a/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
@@ -85,6 +85,7 @@ services:
             - @ezpublish.persistence.legacy.field_value_converter.registry
             - @ezpublish.search.legacy.gateway.criterion_field_value_converter
             - @ezpublish.api.storage_engine.transformation_processor
+            - @ezpublish.spi.persistence.content_type_handler
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}

--- a/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
@@ -160,8 +160,10 @@ services:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.field_relation:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
         class: %ezpublish.search.legacy.gateway.criterion_handler.common.field_relation.class%
+        arguments:
+            - @ezpublish.api.storage_engine.legacy.dbhandler
+            - @ezpublish.spi.persistence.content_type_handler
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}

--- a/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
@@ -63,8 +63,10 @@ services:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.content_type_identifier:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
         class: %ezpublish.search.legacy.gateway.criterion_handler.common.content_type_identifier.class%
+        arguments:
+            - @ezpublish.api.storage_engine.legacy.dbhandler
+            - @ezpublish.spi.persistence.content_type_handler
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}

--- a/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
@@ -33,6 +33,12 @@ services:
         abstract: true
         arguments: [@ezpublish.api.storage_engine.legacy.dbhandler]
 
+    ezpublish.search.legacy.gateway.criterion_handler.field_base:
+        abstract: true
+        arguments:
+            - @ezpublish.api.storage_engine.legacy.dbhandler
+            - @ezpublish.spi.persistence.content_type_handler
+
     ezpublish.search.legacy.gateway.criterion_field_value_handler.base:
         abstract: true
         arguments:
@@ -63,10 +69,8 @@ services:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.content_type_identifier:
+        parent: ezpublish.search.legacy.gateway.criterion_handler.field_base
         class: %ezpublish.search.legacy.gateway.criterion_handler.common.content_type_identifier.class%
-        arguments:
-            - @ezpublish.api.storage_engine.legacy.dbhandler
-            - @ezpublish.spi.persistence.content_type_handler
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
@@ -82,10 +86,10 @@ services:
         class: %ezpublish.search.legacy.gateway.criterion_handler.common.field.class%
         arguments:
             - @ezpublish.api.storage_engine.legacy.dbhandler
+            - @ezpublish.spi.persistence.content_type_handler
             - @ezpublish.persistence.legacy.field_value_converter.registry
             - @ezpublish.search.legacy.gateway.criterion_field_value_converter
             - @ezpublish.api.storage_engine.transformation_processor
-            - @ezpublish.spi.persistence.content_type_handler
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
@@ -130,10 +134,8 @@ services:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.map_location_distance:
+        parent: ezpublish.search.legacy.gateway.criterion_handler.field_base
         class: %ezpublish.search.legacy.gateway.criterion_handler.common.map_location_distance.class%
-        arguments:
-            - @ezpublish.api.storage_engine.legacy.dbhandler
-            - @ezpublish.spi.persistence.content_type_handler
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
@@ -160,10 +162,8 @@ services:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.field_relation:
+        parent: ezpublish.search.legacy.gateway.criterion_handler.field_base
         class: %ezpublish.search.legacy.gateway.criterion_handler.common.field_relation.class%
-        arguments:
-            - @ezpublish.api.storage_engine.legacy.dbhandler
-            - @ezpublish.spi.persistence.content_type_handler
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}


### PR DESCRIPTION
This PR resolves: https://jira.ez.no/browse/EZP-24206

Since decoupling search from persistence, search engine uses cached implementation of storage engine. Initially that was used to implement cached map of searchable fields, which (in Legacy Search Engine) was used to get required field information in Field sort clause handler. This employs the similar approach on two other places:

1. `ContentTypeIdentifier` criterion handler - uses cached storage to find ContentType id from identifier and. Doing that simplifies the generated query, avoiding one sub-query.
2. `Field` criterion handler - uses previously implemented searchable field map to build a map of searchable fields for a given field target. This avoids one separate database query per Field criterion used.

#### Additional fixes

- limited `MapLocationDistance` fields to a given field target
- using `FieldRelation` criterion with no searchable fields will now throw an exception (`InvalidArgumentException`, same as with `Field` and `MapLocationDistance` criteria)

#### TODOs

- [x] apply the same searchable field map fix on `MapLocationDistance` criterion
- [x] apply the same searchable field map fix on `FieldRelation` criterion