### PR TITLE
EZP-24213: FullText stopWordThreshold should be percentage of content count

### DIFF
--- a/doc/bc/changes-5.3.md
+++ b/doc/bc/changes-5.3.md
@@ -102,6 +102,17 @@ Changes affecting version compatibility with former or future versions.
 
     Legacy Search Engine is at the moment of writing the only officially supported Search Engine.
 
+* 5.3.5: Legacy Search Engine FullText searchThresholdValue -> stopWordThresholdFactor
+
+    EZP-24213: the "Stop Word Threshold" configuration, `searchThresholdValue`, was hardcoded
+    to 20 items. It is now changed to `stopWordThresholdFactor`, a factor (between 0 and 1)
+    for the percentage of content objects to set the Stop Word Threshold to. Default value
+    is set to 0.66, meaning if you search for a common word like "the", it will be ignored
+    from the search expression if more then 66% of your content contains the word.
+
+    Note: Does not affect future Solr/ElasticSearch search engines which has far more
+          advanced search options built in.
+
 ## Deprecations
 
 * Method `eZ\Publish\API\Repository\RoleService::removePolicy` is deprecated in

--- a/doc/bc/changes-5.4.md
+++ b/doc/bc/changes-5.4.md
@@ -131,6 +131,17 @@ Changes affecting version compatibility with former or future versions.
     * `ezpublish.search.legacy.gateway.sort_clause_handler.content`
     * `ezpublish.search.legacy.gateway.sort_clause_handler.location`
 
+* 5.4.2: Legacy Search Engine FullText searchThresholdValue -> stopWordThresholdFactor
+
+    EZP-24213: the "Stop Word Threshold" configuration, `searchThresholdValue`, was hardcoded
+    to 20 items. It is now changed to `stopWordThresholdFactor`, a factor (between 0 and 1)
+    for the percentage of content objects to set the Stop Word Threshold to. Default value
+    is set to 0.66, meaning if you search for a common word like "the", it will be ignored
+    from the search expression if more then 66% of your content contains the word.
+
+    Note: Does not affect future Solr/ElasticSearch search engines which has far more
+          advanced search options built in.
+
 ## Deprecations
 
 * `imagemagick` siteaccess settings are now deprecated. It is mandatory to remove them.

--- a/doc/bc/changes-6.0.md
+++ b/doc/bc/changes-6.0.md
@@ -54,6 +54,17 @@ Changes affecting version compatibility with former or future versions.
     * `ezpublish.search.legacy.gateway.sort_clause_handler.content`
     * `ezpublish.search.legacy.gateway.sort_clause_handler.location`
 
+* Legacy Search Engine FullText searchThresholdValue -> stopWordThresholdFactor
+
+    EZP-24213: the "Stop Word Threshold" configuration, `searchThresholdValue`, was hardcoded
+    to 20 items. It is now changed to `stopWordThresholdFactor`, a factor (between 0 and 1)
+    for the percentage of content objects to set the Stop Word Threshold to. Default value
+    is set to 0.66, meaning if you search for a common word like "the", it will be ignored
+    from the search expression if more then 66% of your content contains the word.
+
+    Note: Does not affect future Solr/ElasticSearch search engines which has far more
+          advanced search options built in.
+
 ## Deprecations
 
 * `eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger::purge()` is deprecated and will be removed in v6.1.

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerTest.php
@@ -1215,9 +1215,15 @@ class HandlerTest extends LanguageAwareTestCase
 
     public function testFullTextFilterStopwordRemoval()
     {
+        $handler = $this->getContentSearchHandler(
+            array(
+                'stopWordThresholdFactor' => 0.1
+            )
+        );
+
         $this->assertSearchResults(
             array(),
-            $this->getContentSearchHandler()->findContent(
+            $handler->findContent(
                 new Query(
                     array(
                         'filter' => new Criterion\FullText( 'the' ),
@@ -1230,13 +1236,13 @@ class HandlerTest extends LanguageAwareTestCase
 
     public function testFullTextFilterNoStopwordRemoval()
     {
-        $locator = $this->getContentSearchHandler(
+        $handler = $this->getContentSearchHandler(
             array(
-                'searchThresholdValue' => PHP_INT_MAX
+                'stopWordThresholdFactor' => 1
             )
         );
 
-        $result = $locator->findContent(
+        $result = $handler->findContent(
             new Query(
                 array(
                     'filter' => new Criterion\FullText(
@@ -1257,6 +1263,18 @@ class HandlerTest extends LanguageAwareTestCase
                     },
                     $result->searchHits
                 )
+            )
+        );
+    }
+
+    /**
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testFullTextFilterInvalidStopwordThreshold()
+    {
+        $this->getContentSearchHandler(
+            array(
+                'stopWordThresholdFactor' => 2
             )
         );
     }

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/Location/HandlerTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/Location/HandlerTest.php
@@ -1142,9 +1142,14 @@ class HandlerTest extends LanguageAwareTestCase
 
     public function testFullTextFilterStopwordRemoval()
     {
+        $handler = $this->getLocationSearchHandler(
+            array(
+                'stopWordThresholdFactor' => 0.1
+            )
+        );
         $this->assertSearchResults(
             array(),
-            $this->getLocationSearchHandler()->findLocations(
+            $handler->findLocations(
                 new LocationQuery(
                     array(
                         'filter' => new Criterion\FullText( 'the' ),
@@ -1159,7 +1164,7 @@ class HandlerTest extends LanguageAwareTestCase
     {
         $handler = $this->getLocationSearchHandler(
             array(
-                'searchThresholdValue' => PHP_INT_MAX
+                'stopWordThresholdFactor' => 1
             )
         );
 
@@ -1186,6 +1191,18 @@ class HandlerTest extends LanguageAwareTestCase
                     },
                     $result->searchHits
                 )
+            )
+        );
+    }
+
+    /**
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testFullTextFilterInvalidStopwordThreshold()
+    {
+        $this->getLocationSearchHandler(
+            array(
+                'stopWordThresholdFactor' => 2
             )
         );
     }


### PR DESCRIPTION
TL;DR; FullText was hardcoded to disable search on phrases that exists in more then 20 content objects..
See issue for details: https://jira.ez.no/browse/EZP-24213

*Approach: In original discussion with @pspanja I suggested exposing a spiContentHandler->getTotalCount() method to provide total count and cache it in SPI cache. I have initial work on that, however ended up just caching it locally on FullTextHandler as that turned out to much simpler and a count query is compared to everything else we do here very fast. If someone see some immediate value also other places in having spiContentHandler->getTotalCount() I can re add it, or do it as followup.*