### PR TITLE
[Travis] Run unit tests on PHP 7.0 nightly builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,87 +1,57 @@
 language: php
 
-# run tests on php misc php versions
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - hhvm
-
 # execute unit tests, integration test stubs and integration tests using legacy storage engine
 env:
   global:
     - DB_NAME="testdb"
-  matrix:
-    # If SYMFONY_VERSION is not specified, will take the latest available.
-    - TEST_CONFIG="phpunit.xml"
-    - TEST_CONFIG="phpunit.xml" SYMFONY_VERSION="~2.6@beta"
-    - TEST_CONFIG="phpunit-integration-legacy.xml" SYMFONY_VERSION="~2.6@beta"
-    - TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/$DB_NAME"
-    - TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/$DB_NAME"
-    - SOLR_VERSION="4.10.1" TEST_CONFIG="phpunit-integration-legacy-solr.xml"
-    - ELASTICSEARCH_VERSION="1.4.2" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
-    - BEHAT_PROFILE="demo" TEST="clean"
 
 matrix:
+  # mark as finished before allow_failures are run
+  fast_finish: true
+  # misc nighlty tests we keep an eye on and aim to fix closer to stable versions
   allow_failures:
-    - php: hhvm
-      env: TEST_CONFIG="phpunit.xml" SYMFONY_VERSION="~2.6@beta"
-    - php: hhvm
-      env: TEST_CONFIG="phpunit-integration-legacy.xml" SYMFONY_VERSION="~2.6@beta"
-  exclude:
-# 5.4 run: unit test + postgres integration test
-    - php: 5.4
-      env: TEST_CONFIG="phpunit.xml" SYMFONY_VERSION="~2.6@beta"
-    - php: 5.4
-      env: TEST_CONFIG="phpunit-integration-legacy.xml" SYMFONY_VERSION="~2.6@beta"
-    - php: 5.4
-      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/$DB_NAME"
-    - php: 5.4
-      env: SOLR_VERSION="4.10.1" TEST_CONFIG="phpunit-integration-legacy-solr.xml"
-    - php: 5.4
-      env: ELASTICSEARCH_VERSION="1.4.2" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
-    - php: 5.4
-      env: BEHAT_PROFILE="demo" TEST="clean"
-# 5.5 run: unit test (Symfony 2.3) + mysql integration test + solr 4.x integration test
     - php: 5.5
+      env: TEST_CONFIG="phpunit.xml" SYMFONY_VERSION="~2.7@dev"
+    - php: hhvm-nightly
       env: TEST_CONFIG="phpunit.xml"
-    - php: 5.5
-      env: TEST_CONFIG="phpunit-integration-legacy.xml" SYMFONY_VERSION="~2.6@beta"
-    - php: 5.5
-      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/$DB_NAME"
-    - php: 5.5
-      env: BEHAT_PROFILE="demo" TEST="clean"
-# 5.6 run: unit test + sqlite integration test + behat test
-    - php: 5.6
-      env: TEST_CONFIG="phpunit.xml" SYMFONY_VERSION="~2.6@beta"
-    - php: 5.6
-      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/$DB_NAME"
-    - php: 5.6
-      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/$DB_NAME"
-    - php: 5.6
-      env: SOLR_VERSION="4.10.1" TEST_CONFIG="phpunit-integration-legacy-solr.xml"
-    - php: 5.6
-      env: ELASTICSEARCH_VERSION="1.4.2" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
-# hhvm run: unit test + sqlite integration test
-    - php: hhvm
+    - php: nightly
       env: TEST_CONFIG="phpunit.xml"
-    - php: hhvm
+  include:
+# 5.4
+    - php: 5.4
+      env: TEST_CONFIG="phpunit.xml"
+    - php: 5.4
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/$DB_NAME"
-    - php: hhvm
-      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/$DB_NAME"
-    - php: hhvm
+    - php: 5.4
       env: SOLR_VERSION="4.10.1" TEST_CONFIG="phpunit-integration-legacy-solr.xml"
-    - php: hhvm
+# 5.5
+    - php: 5.5
+      env: TEST_CONFIG="phpunit.xml" SYMFONY_VERSION="~2.7@dev"
+    - php: 5.5
+      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/$DB_NAME"
+    - php: 5.5
       env: ELASTICSEARCH_VERSION="1.4.2" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
-    - php: hhvm
+# 5.6
+    - php: 5.6
+      env: TEST_CONFIG="phpunit.xml"
+    - php: 5.6
+      env: TEST_CONFIG="phpunit-integration-legacy.xml"
+    - php: 5.6
       env: BEHAT_PROFILE="demo" TEST="clean"
+# hhvm-nightly
+    - php: hhvm-nightly
+      env: TEST_CONFIG="phpunit.xml"
+# 7.0 "nightly"
+    - php: nightly
+      env: TEST_CONFIG="phpunit.xml"
+
 
 # test only master (+ Pull requests)
 branches:
   only:
     - master
 
-# setup requirements for running unit tests
+# setup requirements for running unit/integration/behat tests
 before_script:
   # Prepare system
   - if [ "$TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_unittest.sh ; fi
@@ -91,7 +61,7 @@ before_script:
   - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}
   - echo "$TEST_TIMEZONE"
 
-# execute phpunit as the script command
+# execute phpunit or behat as the script command
 script:
   - if [ "$TEST_CONFIG" != "" ] ; then php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1 vendor/bin/phpunit -c $TEST_CONFIG ; fi
   - if [ "$BEHAT_PROFILE" != "" ] ; then cd "$HOME/build/ezpublish-community" && php bin/behat -vv --profile $BEHAT_PROFILE --suite $TEST ; fi


### PR DESCRIPTION
Also:
- change to use include matrix option for easier reading
- change hhvm to use nightly builds as well, and skip integration tests for now as they "pass"*
- change to use symfony  2.7@dev instead of 2.6@beta to make sure we test against 2.7 already 

_* Besides https://github.com/facebook/hhvm/issues/4476<del>, for unit tests we are mainly blocked by https://github.com/facebook/hhvm/issues/5134</del>_