### PR TITLE
EZP-23524: Implement field filters for Legacy Search Engine

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchServiceFieldFiltersTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceFieldFiltersTest.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Publish\API\Repository\Tests;
 
-use eZ\Publish\API\Repository\Tests\SetupFactory\LegacyElasticsearch;
+use eZ\Publish\API\Repository\Tests\SetupFactory\LegacySolr;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
@@ -29,12 +29,32 @@ class SearchServiceFieldFiltersTest extends BaseTest
     {
         $setupFactory = $this->getSetupFactory();
 
-        if ( !$setupFactory instanceof LegacyElasticsearch )
+        if ( $setupFactory instanceof LegacySolr )
         {
-            $this->markTestIncomplete( "ATM implemented only for Elasticsearch storage" );
+            $this->markTestIncomplete( "Not implemented for Solr Search Engine" );
         }
 
         parent::setUp();
+    }
+
+    protected function checkFullTextFilteringSupport()
+    {
+        if ( ltrim( get_class( $this->getSetupFactory() ), '\\' ) === 'eZ\\Publish\\API\\Repository\\Tests\\SetupFactory\\Legacy' )
+        {
+            $this->markTestSkipped(
+                "Legacy Search Engine does not support field filters with Fulltext criterion"
+            );
+        }
+    }
+
+    protected function checkCustomFieldsSupport()
+    {
+        if ( ltrim( get_class( $this->getSetupFactory() ), '\\' ) === 'eZ\\Publish\\API\\Repository\\Tests\\SetupFactory\\Legacy' )
+        {
+            $this->markTestSkipped(
+                "Legacy Search Engine does not support custom fields"
+            );
+        }
     }
 
     protected function addMapLocationToFolderType()
@@ -203,6 +223,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testFullTextQueryLanguageAll( $type = null )
     {
+        $this->checkFullTextFilteringSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -246,6 +268,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testFullTextQueryLanguage( $type = null )
     {
+        $this->checkFullTextFilteringSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -284,6 +308,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testFullTextQueryLanguageComplement( $type = null )
     {
+        $this->checkFullTextFilteringSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -322,6 +348,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testFullTextQueryLanguageEmpty( $type = null )
     {
+        $this->checkFullTextFilteringSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -359,6 +387,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testFullTextQueryLanguageAlwaysAvailable( $type = null )
     {
+        $this->checkFullTextFilteringSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -402,6 +432,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testFullTextQueryLanguageAlwaysAvailableComplement( $type = null )
     {
+        $this->checkFullTextFilteringSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -445,6 +477,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testFullTextQueryAlwaysAvailable( $type = null )
     {
+        $this->checkFullTextFilteringSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -488,6 +522,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testFullTextQueryAlwaysAvailableComplement( $type = null )
     {
+        $this->checkFullTextFilteringSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -527,6 +563,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testFullTextQueryAlwaysAvailableEmpty( $type = null )
     {
+        $this->checkFullTextFilteringSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -1559,6 +1597,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testModifiedFieldQueryAll( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -1608,6 +1648,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testModifiedFieldQuery( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -1652,6 +1694,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testModifiedFieldQueryComplement( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -1696,6 +1740,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testModifiedFieldQueryEmpty( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -1739,6 +1785,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testModifiedFieldQueryLanguageAlwaysAvailable( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -1784,6 +1832,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testModifiedFieldQueryLanguageAlwaysAvailableComplement( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -1829,6 +1879,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testModifiedFieldQueryAlwaysAvailable( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -1873,6 +1925,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testModifiedFieldQueryAlwaysAvailableComplement( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -1914,6 +1968,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testModifiedFieldQueryAlwaysAvailableEmpty( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -1954,6 +2010,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testModifiedFieldRangeQueryAll( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -1999,6 +2057,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testModifiedFieldRangeQuery( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -2039,6 +2099,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testModifiedFieldRangeQueryComplement( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -2079,6 +2141,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testModifiedFieldRangeQueryEmpty( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -2118,6 +2182,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testModifiedFieldRangeQueryLanguageAlwaysAvailable( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -2163,6 +2229,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testModifiedFieldRangeQueryLanguageAlwaysAvailableComplement( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -2208,6 +2276,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testModifiedFieldRangeQueryAlwaysAvailable( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -2253,6 +2323,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testModifiedFieldRangeQueryAlwaysAvailableComplement( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -2294,6 +2366,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testModifiedFieldRangeQueryAlwaysAvailableEmpty( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -3184,6 +3258,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testCustomFieldQueryAll( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -3231,6 +3307,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testCustomFieldQuery( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -3273,6 +3351,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testCustomFieldQueryComplement( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -3315,6 +3395,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testCustomFieldQueryEmpty( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -3356,6 +3438,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testCustomFieldQueryLanguageAlwaysAvailable( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -3403,6 +3487,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testCustomFieldQueryLanguageAlwaysAvailableComplement( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -3450,6 +3536,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testCustomFieldQueryAlwaysAvailable( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -3497,6 +3585,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testCustomFieldQueryAlwaysAvailableComplement( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -3540,6 +3630,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testCustomFieldQueryAlwaysAvailableEmpty( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -3582,6 +3674,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testCustomFieldRangeQueryAll( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -3625,6 +3719,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testCustomFieldRangeQuery( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -3663,6 +3759,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testCustomFieldRangeQueryComplement( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -3701,6 +3799,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testCustomFieldRangeQueryEmpty( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -3738,6 +3838,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testCustomFieldRangeQueryLanguageAlwaysAvailable( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -3781,6 +3883,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testCustomFieldRangeQueryLanguageAlwaysAvailableComplement( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -3824,6 +3928,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testCustomFieldRangeQueryAlwaysAvailable( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -3867,6 +3973,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testCustomFieldRangeQueryAlwaysAvailableComplement( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";
@@ -3906,6 +4014,8 @@ class SearchServiceFieldFiltersTest extends BaseTest
      */
     public function testCustomFieldRangeQueryAlwaysAvailableEmpty( $type = null )
     {
+        $this->checkCustomFieldsSupport();
+
         if ( $type === null )
         {
             $type = "query";

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriteriaConverter.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriteriaConverter.php
@@ -53,16 +53,21 @@ class CriteriaConverter
      *
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function convertCriteria( SelectQuery $query, Criterion $criterion )
+    public function convertCriteria(
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters = array()
+    )
     {
         foreach ( $this->handlers as $handler )
         {
             if ( $handler->accept( $criterion ) )
             {
-                return $handler->handle( $this, $query, $criterion );
+                return $handler->handle( $this, $query, $criterion, $fieldFilters );
             }
         }
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler.php
@@ -65,8 +65,14 @@ abstract class CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      */
-    abstract public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion );
+    abstract public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    );
 
     /**
      * Returns a unique table name

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentId.php
@@ -39,10 +39,16 @@ class ContentId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         return $query->expr->in(
             $this->dbHandler->quoteColumn( "id", "ezcontentobject" ),

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeGroupId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeGroupId.php
@@ -39,10 +39,16 @@ class ContentTypeGroupId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $subSelect = $query->subSelect();
         $subSelect

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeId.php
@@ -39,10 +39,16 @@ class ContentTypeId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         return $query->expr->in(
             $this->dbHandler->quoteColumn( 'contentclass_id', 'ezcontentobject' ),

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeIdentifier.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeIdentifier.php
@@ -39,10 +39,16 @@ class ContentTypeIdentifier extends FieldBase
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $idList = array();
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeIdentifier.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeIdentifier.php
@@ -13,12 +13,37 @@ use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\Core\Persistence\Database\SelectQuery;
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
 
 /**
  * Content type criterion handler
  */
-class ContentTypeIdentifier extends FieldBase
+class ContentTypeIdentifier extends CriterionHandler
 {
+    /**
+     * Content Type handler
+     *
+     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
+     */
+    protected $contentTypeHandler;
+
+    /**
+     * Construct from handler handler
+     *
+     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
+     */
+    public function __construct(
+        DatabaseHandler $dbHandler,
+        ContentTypeHandler $contentTypeHandler
+    )
+    {
+        parent::__construct( $dbHandler );
+
+        $this->contentTypeHandler = $contentTypeHandler;
+    }
+
     /**
      * Check if this criterion handler accepts to handle the given criterion.
      *

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/DateMetadata.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/DateMetadata.php
@@ -40,10 +40,16 @@ class DateMetadata extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $column = $this->dbHandler->quoteColumn(
             $criterion->target === Criterion\DateMetadata::MODIFIED ?

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/Field.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/Field.php
@@ -9,7 +9,6 @@
 
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
-use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Converter as FieldValueConverter;
@@ -21,6 +20,7 @@ use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Persistence\TransformationProcessor;
 use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
+use eZ\Publish\SPI\Persistence\Content\Language\Handler as LanguageHandler;
 use RuntimeException;
 
 /**
@@ -54,6 +54,7 @@ class Field extends FieldBase
      *
      * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
      * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\Language\Handler $languageHandler
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry $fieldConverterRegistry
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Converter $fieldValueConverter
      * @param \eZ\Publish\Core\Persistence\TransformationProcessor $transformationProcessor
@@ -61,12 +62,13 @@ class Field extends FieldBase
     public function __construct(
         DatabaseHandler $dbHandler,
         ContentTypeHandler $contentTypeHandler,
+        LanguageHandler $languageHandler,
         Registry $fieldConverterRegistry,
         FieldValueConverter $fieldValueConverter,
         TransformationProcessor $transformationProcessor
     )
     {
-        parent::__construct( $dbHandler, $contentTypeHandler );
+        parent::__construct( $dbHandler, $contentTypeHandler, $languageHandler );
 
         $this->fieldConverterRegistry = $fieldConverterRegistry;
         $this->fieldValueConverter = $fieldValueConverter;
@@ -197,6 +199,8 @@ class Field extends FieldBase
                 count( $whereExpressions ) > 1 ? $subSelect->expr->lOr( $whereExpressions ) : $whereExpressions[0]
             )
         );
+
+        $this->addFieldFiltersConditions( $subSelect, $fieldFilters );
 
         return $query->expr->in(
             $this->dbHandler->quoteColumn( 'id', 'ezcontentobject' ),

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/Field.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/Field.php
@@ -141,10 +141,16 @@ class Field extends FieldBase
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $fieldsInformation = $this->getFieldsInformation( $criterion->target );
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldBase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldBase.php
@@ -12,6 +12,8 @@ namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
+use eZ\Publish\SPI\Persistence\Content\Language\Handler as LanguageHandler;
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Base criterion handler for field criteria
@@ -30,11 +32,124 @@ abstract class FieldBase extends CriterionHandler
      *
      * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
      * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\Language\Handler $languageHandler
      */
-    public function __construct( DatabaseHandler $dbHandler, ContentTypeHandler $contentTypeHandler )
+    public function __construct(
+        DatabaseHandler $dbHandler,
+        ContentTypeHandler $contentTypeHandler,
+        LanguageHandler $languageHandler
+    )
     {
         parent::__construct( $dbHandler );
 
         $this->contentTypeHandler = $contentTypeHandler;
+        $this->languageHandler = $languageHandler;
+    }
+
+    /**
+     * Returns the bitmask for the list languages in given $fieldFilters
+     *
+     * The method will return null if no languages are contained in $fieldFilters.
+     * Note: 'useAlwaysAvailable' filter is ignored here.
+     *
+     * @param array $fieldFilters
+     *
+     * @return null|int
+     */
+    protected function getFieldFiltersLanguageMask( array $fieldFilters )
+    {
+        if ( empty( $fieldFilters["languages"] ) )
+        {
+            return null;
+        }
+
+        $mask = 0;
+
+        foreach ( $fieldFilters["languages"] as $languageCode )
+        {
+            $mask |= $this->languageHandler->loadByLanguageCode( $languageCode )->id;
+        }
+
+        return $mask;
+    }
+
+    /**
+     * Adds field filters condition to the WHERE clause of the given $query.
+     *
+     * Conditions are combined with existing ones using logical AND operator.
+     *
+     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
+     * @param array $fieldFilters
+     */
+    protected function addFieldFiltersConditions( SelectQuery $query, array $fieldFilters )
+    {
+        $languageMask = $this->getFieldFiltersLanguageMask( $fieldFilters );
+
+        // Only apply if languages are defined in $fieldFilters;
+        // 'useAlwaysAvailable' does not make sense on its own
+        if ( $languageMask === null )
+        {
+            return;
+        }
+
+        // Condition for the language part of $fieldFilters
+        $languageMaskExpression = $query->expr->gt(
+            $query->expr->bitAnd(
+                $this->dbHandler->quoteColumn( "language_id", "ezcontentobject_attribute" ),
+                $query->bindValue( $languageMask, null, \PDO::PARAM_INT )
+            ),
+            $query->bindValue( 0, null, \PDO::PARAM_INT )
+        );
+
+        // If 'useAlwaysAvailable' is set to true, additionally factor in condition for the
+        // Content's main language that is marked as always available
+        if (
+            isset( $fieldFilters["useAlwaysAvailable"] )
+            && $fieldFilters["useAlwaysAvailable"] === true
+        )
+        {
+            $query->where(
+                $query->expr->lOr(
+                    // Matching on a given list of languages
+                    $languageMaskExpression,
+                    // Matching always available in main language
+                    $query->expr->lAnd(
+                        // 1. match main language - since ezcontentobject.initial_language_id column
+                        // does not use first bit (always available bit), we can ignore the fact
+                        // that ezcontentobject_attribute.language_id does
+                        $query->expr->gt(
+                            $query->expr->bitAnd(
+                                $this->dbHandler->quoteColumn(
+                                    "language_id",
+                                    "ezcontentobject_attribute"
+                                ),
+                                $this->dbHandler->quoteColumn(
+                                    "initial_language_id",
+                                    "ezcontentobject"
+                                )
+                            ),
+                            $query->bindValue( 0, null, \PDO::PARAM_INT )
+                        ),
+                        // 2. ensure it is always available - ezcontentobject_attribute.language_id
+                        // uses first bit (always available bit)
+                        $query->expr->gt(
+                            $query->expr->bitAnd(
+                                $this->dbHandler->quoteColumn(
+                                    "language_id",
+                                    "ezcontentobject_attribute"
+                                ),
+                                $query->bindValue( 1, null, \PDO::PARAM_INT )
+                            ),
+                            $query->bindValue( 0, null, \PDO::PARAM_INT )
+                        )
+                    )
+                )
+            );
+        }
+        else
+        {
+            // Matching on a given list of languages
+            $query->where( $languageMaskExpression );
+        }
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldRelation.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldRelation.php
@@ -77,11 +77,17 @@ class FieldRelation extends FieldBase
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      * @throws RuntimeException
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $column = $this->dbHandler->quoteColumn( 'to_contentobject_id', 'ezcontentobject_link' );
         $fieldDefinitionIds = $this->getFieldDefinitionsIds( $criterion->target );

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldRelation.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldRelation.php
@@ -172,4 +172,3 @@ class FieldRelation extends FieldBase
         }
     }
 }
-

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldRelation.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldRelation.php
@@ -136,6 +136,7 @@ class FieldRelation extends FieldBase
                         $subRequest
                     );
                 }
+                // Intentionally omitting break
 
             case Criterion\Operator::IN:
                 $subSelect = $query->subSelect();

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FullText.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FullText.php
@@ -230,10 +230,16 @@ class FullText extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $subSelect = $query->subSelect();
         $subSelect

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LanguageCode.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LanguageCode.php
@@ -58,10 +58,16 @@ class LanguageCode extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $languages = array_flip( $criterion->value );
         /** @var $criterion \eZ\Publish\API\Repository\Values\Content\Query\Criterion\LanguageCode */

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalAnd.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalAnd.php
@@ -39,15 +39,21 @@ class LogicalAnd extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $subexpressions = array();
         foreach ( $criterion->criteria as $subCriterion )
         {
-            $subexpressions[] = $converter->convertCriteria( $query, $subCriterion );
+            $subexpressions[] = $converter->convertCriteria( $query, $subCriterion, $fieldFilters );
         }
         return $query->expr->lAnd( $subexpressions );
     }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalNot.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalNot.php
@@ -39,13 +39,19 @@ class LogicalNot extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         return $query->expr->not(
-            $converter->convertCriteria( $query, $criterion->criteria[0] )
+            $converter->convertCriteria( $query, $criterion->criteria[0], $fieldFilters )
         );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalOr.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalOr.php
@@ -39,15 +39,21 @@ class LogicalOr extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $subexpressions = array();
         foreach ( $criterion->criteria as $subCriterion )
         {
-            $subexpressions[] = $converter->convertCriteria( $query, $subCriterion );
+            $subexpressions[] = $converter->convertCriteria( $query, $subCriterion, $fieldFilters );
         }
         return $query->expr->lOr( $subexpressions );
     }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MapLocationDistance.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MapLocationDistance.php
@@ -102,10 +102,16 @@ class MapLocationDistance extends FieldBase
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $fieldDefinitionIds = $this->getFieldDefinitionIds( $criterion->target );
         $subSelect = $query->subSelect();

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MapLocationDistance.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MapLocationDistance.php
@@ -241,6 +241,8 @@ class MapLocationDistance extends FieldBase
                 )
             );
 
+        $this->addFieldFiltersConditions( $subSelect, $fieldFilters );
+
         return $query->expr->in(
             $this->dbHandler->quoteColumn( 'id', 'ezcontentobject' ),
             $subSelect
@@ -328,5 +330,4 @@ class MapLocationDistance extends FieldBase
 
         return $boundingCoordinates;
     }
-
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MatchAll.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MatchAll.php
@@ -39,10 +39,16 @@ class MatchAll extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         return $query->bindValue( '1' );
     }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MatchNone.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MatchNone.php
@@ -38,10 +38,16 @@ class MatchNone extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         return $query->expr->not( $query->bindValue( '1' ) );
     }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ObjectStateId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ObjectStateId.php
@@ -44,10 +44,16 @@ class ObjectStateId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $subSelect = $query->subSelect();
         $subSelect

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/RemoteId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/RemoteId.php
@@ -39,10 +39,16 @@ class RemoteId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         return $query->expr->in(
             $this->dbHandler->quoteColumn( 'remote_id', 'ezcontentobject' ),

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/SectionId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/SectionId.php
@@ -39,10 +39,16 @@ class SectionId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         return $query->expr->in(
             $this->dbHandler->quoteColumn( 'section_id', 'ezcontentobject' ),

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/UserMetadata.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/UserMetadata.php
@@ -40,10 +40,16 @@ class UserMetadata extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         switch ( $criterion->target )
         {

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway.php
@@ -26,11 +26,18 @@ abstract class Gateway
      * @param int $offset
      * @param int|null $limit
      * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sort
-     * @param string[] $translations
+     * @param array $fieldFilters
      * @param bool $doCount
      *
      * @return mixed[][]
      */
-    abstract public function find( Criterion $criterion, $offset = 0, $limit = null, array $sort = null, array $translations = null, $doCount = true );
+    abstract public function find(
+        Criterion $criterion,
+        $offset = 0,
+        $limit = null,
+        array $sort = null,
+        array $fieldFilters = array(),
+        $doCount = true
+    );
 }
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Depth.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Depth.php
@@ -40,10 +40,16 @@ class Depth extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $table = $this->getUniqueTableName();
         $column = $this->dbHandler->quoteColumn( 'depth', $table );

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/LocationId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/LocationId.php
@@ -39,10 +39,16 @@ class LocationId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $subSelect = $query->subSelect();
         $subSelect

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/LocationPriority.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/LocationPriority.php
@@ -39,10 +39,16 @@ class LocationPriority extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $subSelect = $query->subSelect();
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/LocationRemoteId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/LocationRemoteId.php
@@ -39,10 +39,16 @@ class LocationRemoteId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $subSelect = $query->subSelect();
         $subSelect

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/ParentLocationId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/ParentLocationId.php
@@ -39,10 +39,16 @@ class ParentLocationId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $subSelect = $query->subSelect();
         $subSelect

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/PermissionSubtree.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/PermissionSubtree.php
@@ -40,10 +40,16 @@ class PermissionSubtree extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $table = "permission_subtree";
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Subtree.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Subtree.php
@@ -39,10 +39,16 @@ class Subtree extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $table = $this->getUniqueTableName();
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Visibility.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Visibility.php
@@ -44,10 +44,16 @@ class Visibility extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $subSelect = $query->subSelect();
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -129,30 +129,7 @@ class DoctrineDatabase extends Gateway
             )
         );
 
-        if ( $translations === null )
-        {
-            return $condition;
-        }
-
-        $translationQuery = $query->subSelect();
-        $translationQuery->select(
-            $this->handler->quoteColumn( 'contentobject_id' )
-        )->from(
-            $this->handler->quoteTable( 'ezcontentobject_attribute' )
-        )->where(
-            $translationQuery->expr->in(
-                $this->handler->quoteColumn( 'language_code' ),
-                $translations
-            )
-        );
-
-        return $query->expr->lAnd(
-            $condition,
-            $query->expr->in(
-                $this->handler->quoteColumn( 'id', 'ezcontentobject' ),
-                $translationQuery
-            )
-        );
+        return $condition;
     }
 
     /**

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -77,16 +77,23 @@ class DoctrineDatabase extends Gateway
      * @param int $offset
      * @param int|null $limit
      * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sort
-     * @param string[] $translations
+     * @param array $fieldFilters
      * @param bool $doCount
      *
      * @return mixed[][]
      */
-    public function find( Criterion $criterion, $offset = 0, $limit = null, array $sort = null, array $translations = null, $doCount = true )
+    public function find(
+        Criterion $criterion,
+        $offset = 0,
+        $limit = null,
+        array $sort = null,
+        array $fieldFilters = array(),
+        $doCount = true
+    )
     {
         $limit = $limit !== null ? $limit : self::MAX_LIMIT;
 
-        $count = $doCount ? $this->getResultCount( $criterion, $sort, $translations ) : null;
+        $count = $doCount ? $this->getResultCount( $criterion, $sort, $fieldFilters ) : null;
 
         if ( !$doCount && $limit === 0 )
         {
@@ -98,7 +105,7 @@ class DoctrineDatabase extends Gateway
             return array( 'count' => $count, 'rows' => array() );
         }
 
-        $contentInfoList = $this->getContentInfoList( $criterion, $sort, $offset, $limit, $translations );
+        $contentInfoList = $this->getContentInfoList( $criterion, $sort, $offset, $limit, $fieldFilters );
 
         return array(
             'count' => $count,
@@ -111,14 +118,14 @@ class DoctrineDatabase extends Gateway
      *
      * @param Criterion $filter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param mixed $translations
+     * @param array $fieldFilters
      *
      * @return string
      */
-    protected function getQueryCondition( Criterion $filter, SelectQuery $query, $translations )
+    protected function getQueryCondition( Criterion $filter, SelectQuery $query, $fieldFilters )
     {
         $condition = $query->expr->lAnd(
-            $this->criteriaConverter->convertCriteria( $query, $filter ),
+            $this->criteriaConverter->convertCriteria( $query, $filter, $fieldFilters ),
             $query->expr->eq(
                 'ezcontentobject.status',
                 ContentInfo::STATUS_PUBLISHED
@@ -137,10 +144,10 @@ class DoctrineDatabase extends Gateway
      *
      * @param Criterion $filter
      * @param array $sort
-     * @param mixed $translations
+     * @param array $fieldFilters
      * @return int
      */
-    protected function getResultCount( Criterion $filter, $sort, $translations )
+    protected function getResultCount( Criterion $filter, $sort, $fieldFilters )
     {
         $query = $this->handler->createSelectQuery();
 
@@ -161,7 +168,7 @@ class DoctrineDatabase extends Gateway
         }
 
         $query->where(
-            $this->getQueryCondition( $filter, $query, $translations )
+            $this->getQueryCondition( $filter, $query, $fieldFilters )
         );
 
         $statement = $query->prepare();
@@ -177,11 +184,11 @@ class DoctrineDatabase extends Gateway
      * @param array $sort
      * @param mixed $offset
      * @param mixed $limit
-     * @param mixed $translations
+     * @param array $fieldFilters
      *
      * @return int[]
      */
-    protected function getContentInfoList( Criterion $filter, $sort, $offset, $limit, $translations )
+    protected function getContentInfoList( Criterion $filter, $sort, $offset, $limit, $fieldFilters )
     {
         $query = $this->handler->createSelectQuery();
         $query->selectDistinct(
@@ -223,7 +230,7 @@ class DoctrineDatabase extends Gateway
         }
 
         $query->where(
-            $this->getQueryCondition( $filter, $query, $translations )
+            $this->getQueryCondition( $filter, $query, $fieldFilters )
         );
 
         if ( $sort !== null )

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/ExceptionConversion.php
@@ -45,18 +45,25 @@ class ExceptionConversion extends Gateway
      * @param int $offset
      * @param int|null $limit
      * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sort
-     * @param string[] $translations
+     * @param array $fieldFilters
      * @param bool $doCount
      *
      * @throws \RuntimeException
      *
      * @return mixed[][]
      */
-    public function find( Criterion $criterion, $offset = 0, $limit = null, array $sort = null, array $translations = null, $doCount = true )
+    public function find(
+        Criterion $criterion,
+        $offset = 0,
+        $limit = null,
+        array $sort = null,
+        array $fieldFilters = array(),
+        $doCount = true
+    )
     {
         try
         {
-            return $this->innerGateway->find( $criterion, $offset, $limit, $sort, $translations, $doCount );
+            return $this->innerGateway->find( $criterion, $offset, $limit, $sort, $fieldFilters, $doCount );
         }
         catch ( DBALException $e )
         {

--- a/eZ/Publish/Core/Search/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Handler.php
@@ -98,7 +98,14 @@ class Handler implements SearchHandlerInterface
         // combine the query with the filter
         $filter = new Criterion\LogicalAnd( array( $query->query, $query->filter ) );
 
-        $data = $this->gateway->find( $filter, $query->offset, $query->limit, $query->sortClauses, null, $query->performCount );
+        $data = $this->gateway->find(
+            $filter,
+            $query->offset,
+            $query->limit,
+            $query->sortClauses,
+            $fieldFilters,
+            $query->performCount
+        );
 
         $result = new SearchResult();
         $result->time = microtime( true ) - $start;

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/Depth.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/Depth.php
@@ -40,10 +40,16 @@ class Depth extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $column = $this->dbHandler->quoteColumn( 'depth', 'ezcontentobject_tree' );
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/IsMainLocation.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/IsMainLocation.php
@@ -40,10 +40,16 @@ class IsMainLocation extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $idColumn = $this->dbHandler->quoteColumn( 'node_id', 'ezcontentobject_tree' );
         $mainIdColumn = $this->dbHandler->quoteColumn( 'main_node_id', 'ezcontentobject_tree' );

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/Priority.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/Priority.php
@@ -40,10 +40,16 @@ class Priority extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $column = $this->dbHandler->quoteColumn( 'priority' );
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/LocationId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/LocationId.php
@@ -39,10 +39,16 @@ class LocationId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         return $query->expr->in(
             $this->dbHandler->quoteColumn( 'node_id', 'ezcontentobject_tree' ),

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/LocationRemoteId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/LocationRemoteId.php
@@ -39,10 +39,16 @@ class LocationRemoteId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         return $query->expr->in(
             $this->dbHandler->quoteColumn( 'remote_id', 'ezcontentobject_tree' ),

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/ParentLocationId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/ParentLocationId.php
@@ -39,10 +39,16 @@ class ParentLocationId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         return $query->expr->in(
             $this->dbHandler->quoteColumn( 'parent_node_id', 'ezcontentobject_tree' ),

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Subtree.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Subtree.php
@@ -40,10 +40,16 @@ class Subtree extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $statements = array();
         foreach ( $criterion->value as $pattern )

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Visibility.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Visibility.php
@@ -41,10 +41,16 @@ class Visibility extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
+     * @param array $fieldFilters
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
-    public function handle( CriteriaConverter $converter, SelectQuery $query, Criterion $criterion )
+    public function handle(
+        CriteriaConverter $converter,
+        SelectQuery $query,
+        Criterion $criterion,
+        array $fieldFilters
+    )
     {
         $column = $this->dbHandler->quoteColumn( 'is_invisible', 'ezcontentobject_tree' );
 

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerSortTest.php
@@ -83,7 +83,8 @@ class HandlerSortTest extends LanguageAwareTestCase
                         new Content\Common\Gateway\CriterionHandler\SectionId( $db ),
                         new Content\Common\Gateway\CriterionHandler\ContentTypeIdentifier(
                             $db,
-                            $this->getContentTypeHandler()
+                            $this->getContentTypeHandler(),
+                            $this->getLanguageHandler()
                         ),
                     )
                 ),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerSortTest.php
@@ -83,8 +83,7 @@ class HandlerSortTest extends LanguageAwareTestCase
                         new Content\Common\Gateway\CriterionHandler\SectionId( $db ),
                         new Content\Common\Gateway\CriterionHandler\ContentTypeIdentifier(
                             $db,
-                            $this->getContentTypeHandler(),
-                            $this->getLanguageHandler()
+                            $this->getContentTypeHandler()
                         ),
                     )
                 ),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerTest.php
@@ -141,7 +141,8 @@ class HandlerTest extends LanguageAwareTestCase
                         ),
                         new Content\Common\Gateway\CriterionHandler\ContentTypeIdentifier(
                             $this->getDatabaseHandler(),
-                            $this->getContentTypeHandler()
+                            $this->getContentTypeHandler(),
+                            $this->getLanguageHandler()
                         ),
                         new Content\Common\Gateway\CriterionHandler\ContentTypeGroupId(
                             $this->getDatabaseHandler()
@@ -175,6 +176,7 @@ class HandlerTest extends LanguageAwareTestCase
                         new Content\Common\Gateway\CriterionHandler\Field(
                             $this->getDatabaseHandler(),
                             $this->getContentTypeHandler(),
+                            $this->getLanguageHandler(),
                             $this->getConverterRegistry(),
                             new Content\Common\Gateway\CriterionHandler\FieldValue\Converter(
                                 new Content\Common\Gateway\CriterionHandler\FieldValue\HandlerRegistry(
@@ -213,7 +215,8 @@ class HandlerTest extends LanguageAwareTestCase
                         ),
                         new Content\Common\Gateway\CriterionHandler\FieldRelation(
                             $this->getDatabaseHandler(),
-                            $this->getContentTypeHandler()
+                            $this->getContentTypeHandler(),
+                            $this->getLanguageHandler()
                         ),
                         new Content\Gateway\CriterionHandler\Depth(
                             $this->getDatabaseHandler()

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerTest.php
@@ -141,8 +141,7 @@ class HandlerTest extends LanguageAwareTestCase
                         ),
                         new Content\Common\Gateway\CriterionHandler\ContentTypeIdentifier(
                             $this->getDatabaseHandler(),
-                            $this->getContentTypeHandler(),
-                            $this->getLanguageHandler()
+                            $this->getContentTypeHandler()
                         ),
                         new Content\Common\Gateway\CriterionHandler\ContentTypeGroupId(
                             $this->getDatabaseHandler()

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/Location/HandlerSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/Location/HandlerSortTest.php
@@ -101,8 +101,7 @@ class HandlerSortTest extends LanguageAwareTestCase
                         new CommonCriterionHandler\SectionId( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\ContentTypeIdentifier(
                             $this->getDatabaseHandler(),
-                            $this->getContentTypeHandler(),
-                            $this->getLanguageHandler()
+                            $this->getContentTypeHandler()
                         ),
                     )
                 ),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/Location/HandlerSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/Location/HandlerSortTest.php
@@ -101,7 +101,8 @@ class HandlerSortTest extends LanguageAwareTestCase
                         new CommonCriterionHandler\SectionId( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\ContentTypeIdentifier(
                             $this->getDatabaseHandler(),
-                            $this->getContentTypeHandler()
+                            $this->getContentTypeHandler(),
+                            $this->getLanguageHandler()
                         ),
                     )
                 ),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/Location/HandlerTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/Location/HandlerTest.php
@@ -132,8 +132,7 @@ class HandlerTest extends LanguageAwareTestCase
                         new CommonCriterionHandler\ContentTypeId( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\ContentTypeIdentifier(
                             $this->getDatabaseHandler(),
-                            $this->getContentTypeHandler(),
-                            $this->getLanguageHandler()
+                            $this->getContentTypeHandler()
                         ),
                         new CommonCriterionHandler\DateMetadata( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\Field(

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/Location/HandlerTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/Location/HandlerTest.php
@@ -132,12 +132,14 @@ class HandlerTest extends LanguageAwareTestCase
                         new CommonCriterionHandler\ContentTypeId( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\ContentTypeIdentifier(
                             $this->getDatabaseHandler(),
-                            $this->getContentTypeHandler()
+                            $this->getContentTypeHandler(),
+                            $this->getLanguageHandler()
                         ),
                         new CommonCriterionHandler\DateMetadata( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\Field(
                             $this->getDatabaseHandler(),
                             $this->getContentTypeHandler(),
+                            $this->getLanguageHandler(),
                             $this->getConverterRegistry(),
                             new CommonCriterionHandler\FieldValue\Converter(
                                 new CommonCriterionHandler\FieldValue\HandlerRegistry(
@@ -172,13 +174,15 @@ class HandlerTest extends LanguageAwareTestCase
                         new CommonCriterionHandler\LogicalOr( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\MapLocationDistance(
                             $this->getDatabaseHandler(),
-                            $this->getContentTypeHandler()
+                            $this->getContentTypeHandler(),
+                            $this->getLanguageHandler()
                         ),
                         new CommonCriterionHandler\MatchAll( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\ObjectStateId( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\FieldRelation(
                             $this->getDatabaseHandler(),
-                            $this->getContentTypeHandler()
+                            $this->getContentTypeHandler(),
+                            $this->getLanguageHandler()
                         ),
                         new CommonCriterionHandler\RemoteId( $this->getDatabaseHandler() ),
                         new CommonCriterionHandler\SectionId( $this->getDatabaseHandler() ),

--- a/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
@@ -70,8 +70,10 @@ services:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.content_type_identifier:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.field_base
         class: %ezpublish.search.legacy.gateway.criterion_handler.common.content_type_identifier.class%
+        arguments:
+            - @ezpublish.api.storage_engine.legacy.dbhandler
+            - @ezpublish.spi.persistence.content_type_handler
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}

--- a/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
@@ -38,6 +38,7 @@ services:
         arguments:
             - @ezpublish.api.storage_engine.legacy.dbhandler
             - @ezpublish.spi.persistence.content_type_handler
+            - @ezpublish.spi.persistence.language_handler
 
     ezpublish.search.legacy.gateway.criterion_field_value_handler.base:
         abstract: true
@@ -87,6 +88,7 @@ services:
         arguments:
             - @ezpublish.api.storage_engine.legacy.dbhandler
             - @ezpublish.spi.persistence.content_type_handler
+            - @ezpublish.spi.persistence.language_handler
             - @ezpublish.persistence.legacy.field_value_converter.registry
             - @ezpublish.search.legacy.gateway.criterion_field_value_converter
             - @ezpublish.api.storage_engine.transformation_processor

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -40,6 +40,7 @@
             <file>eZ/Publish/API/Repository/Tests/URLWildcardServiceAuthorizationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/ObjectStateServiceAuthorizationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SearchServiceTest.php</file>
+            <file>eZ/Publish/API/Repository/Tests/SearchServiceFieldFiltersTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SearchServiceAuthorizationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LimitationTest.php</file>


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-23524

#### What are field filters?

Basically, a second parameter of the [`SearchService::find()`](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/API/Repository/SearchService.php#L50) method. That is similar to what is available on some of the `ContentService:loadContent*` methods, which optionally accept a list of languages and always available indicator.

Contrary to the requirements for loading Content, in search implementation field filters conditions need to be added to the search backend query. That is needed in order to limit matching to specific languages and avoid `NotFound` exceptions when loading matched Content in `SearchService`.

#### Implementation

Ideally implementation would cover following criteria:

1. Field
2. MapLocationDistance
3. FieldRelation
4. FullText

However field filters support is here implemented only for `Field` and `MapLocationDistance` criteria.

`FieldRelation` can't support it as the required data does not exist in `ezcontentobject_link` table. In addition to `contentclassattribute_id` column that would require `contentobjectattribute_id`, so that `ezcontentobject_attribute` can be joined and field filter conditions applied.

`FullText` criterion can't support it as it relies on Legacy Stack's `eZSearchEngine` implementation, which does not support language filtering with fulltext search.