### PR TITLE
Implemented EZP-24237 Be sure to use dot as decimal separators for latitude and longitude

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -314,8 +314,8 @@
     {% set defaultDraggable = 'true' %}
 
     {% set hasContent = field.value is not null %}
-    {% set latitude = field.value.latitude|default( 0 ) %}
-    {% set longitude = field.value.longitude|default( 0 ) %}
+    {% set latitude = field.value.latitude|default( 0 )|number_format( 6, '.', '' ) %}
+    {% set longitude = field.value.longitude|default( 0 )|number_format( 6, '.', '' ) %}
     {% set address = field.value.address|default( "" ) %}
     {% set mapId = "maplocation-map-" ~ field.id %}
 


### PR DESCRIPTION
WIP
------

Implements https://jira.ez.no/browse/EZP-24237

See http://share.ez.no/forums/ez-publish-5-platform/maplocation-rendering-problem/

For reasons i still don't know, it happens that latitude and longitude are passed with comma as decimal separator to the MapView function 

This patch ensure we pass dot as decimal separator using 6 decimals. 