### PR TITLE
Fix EZP-24241: Aliases/Variations clearing and purging is impossible

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/IORepositoryResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/IORepositoryResolver.php
@@ -119,12 +119,7 @@ class IORepositoryResolver implements ResolverInterface
             foreach ( $filters as $filter )
             {
                 $filteredImagePath = $this->getFilePath( $path, $filter );
-                if ( !$this->ioService->exists( $filteredImagePath ) )
-                {
-                    continue;
-                }
-
-                $binaryFile = $this->ioService->loadBinaryFile( $filteredImagePath );
+                $binaryFile = $this->ioService->loadBinaryFileByUri( $filteredImagePath );
                 $this->ioService->deleteBinaryFile( $binaryFile );
             }
         }


### PR DESCRIPTION
Hi,

It's not possible to clear (or purge) the variation/alias of images. ( probably since LiipImagine Bundle )
There was this Issue: https://jira.ez.no/browse/EZP-23518 and this PR: https://github.com/ezsystems/ezpublish-kernel/pull/1141

Then, after the fix the warnings are gone but the Aliases/Variations are not deleted, the feature itself was not tested.

Then :
1/ the clearing doesn't work because it was based on the legacy expiry
2/ the purge doesn't work because of a bug in the source code.

I've already talked about this issue with Bertrand D. he confirmed there is work to do on this topic 
Then I know my solution is a workaround... but it opens the discussion and gives a solution for those who wants to clear the aliases ;-)

And last subject, the liip:imagine:cache:remove command doesn't seem to work either with eZ, probably because image paths are different for each contents ( I didn't dig this last behavior)

Issue: https://jira.ez.no/browse/EZP-24241

- [x] Find a workaround
- [ ] Fix the variation purge
- [ ] Give a way to expire/clear the variations
- [ ] Find a way to be able to use the LiipImagine command

Thanks!

ping @bdunogier @lolautruche 