### PR TITLE
Implement EZP-24266: Indexable Float field type

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
@@ -1069,13 +1069,13 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
         $typeCreate->names = array( "eng-GB" => "Blog post" );
 
         $fieldCreate = $contentTypeService->newFieldDefinitionCreateStruct(
-            'temperature', 'ezfloat'
+            'temperature', 'ezinteger'
         );
         $fieldCreate->isSearchable = true;
         $fieldCreate->validatorConfiguration = array(
-            'FloatValueValidator' => array(
-                'minFloatValue' => "forty two point one",
-                'maxFloatValue' => "75.3",
+            'IntegerValueValidator' => array(
+                'minIntegerValue' => "forty two point one",
+                'maxIntegerValue' => 75,
             )
         );
         $typeCreate->addFieldDefinition( $fieldCreate );
@@ -1087,7 +1087,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
 
         try
         {
-            // Throws validation exception, because field can't be created as searchable and it's validator configuration is invalid
+            // Throws validation exception, because field's validator configuration is invalid
             $contentType = $contentTypeService->createContentType( $typeCreate, $groups );
         }
         catch ( ContentTypeFieldDefinitionValidationException $e )
@@ -1102,20 +1102,15 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
         $this->assertCount( 1, $validationErrors );
         $this->assertArrayHasKey( "temperature", $validationErrors );
         $this->assertInternalType( "array", $validationErrors["temperature"] );
-        $this->assertCount( 2, $validationErrors["temperature"] );
+        $this->assertCount( 1, $validationErrors["temperature"] );
         $this->assertInstanceOf( "eZ\\Publish\\Core\\FieldType\\ValidationError", $validationErrors["temperature"][0] );
-        $this->assertInstanceOf( "eZ\\Publish\\Core\\FieldType\\ValidationError", $validationErrors["temperature"][1] );
 
         $this->assertEquals(
-            new Message( "FieldType 'ezfloat' is not searchable" ),
-            $validationErrors["temperature"][0]->getTranslatableMessage()
-        );
-        $this->assertEquals(
             new Message(
-                "Validator parameter '%parameter%' value must be of numeric type",
-                array( "parameter" => "minFloatValue" )
+                "Validator parameter '%parameter%' value must be of integer type",
+                array( "parameter" => "minIntegerValue" )
             ),
-            $validationErrors["temperature"][1]->getTranslatableMessage()
+            $validationErrors["temperature"][0]->getTranslatableMessage()
         );
     }
 
@@ -1475,13 +1470,13 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
         $userContentTypeDraft = $contentTypeService->createContentTypeDraft( $userContentType );
 
         $fieldDefCreate = $contentTypeService->newFieldDefinitionCreateStruct(
-            'temperature', 'ezfloat'
+            'temperature', 'ezinteger'
         );
         $fieldDefCreate->isSearchable = true;
         $fieldDefCreate->validatorConfiguration = array(
-            'FloatValueValidator' => array(
-                'minFloatValue' => "42.1",
-                'maxFloatValue' => "seventy five point three",
+            'IntegerValueValidator' => array(
+                'minIntegerValue' => 42,
+                'maxIntegerValue' => 75.3,
             )
         );
         $fieldDefCreate->fieldGroup = 'blog-meta';
@@ -1493,7 +1488,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
 
         try
         {
-            // Throws an exception because 'ezfloat' field type can't be created as searchable
+            // Throws an exception because field's validator configuration is invalid
             $contentTypeService->addFieldDefinition( $userContentTypeDraft, $fieldDefCreate );
         }
         catch ( ContentTypeFieldDefinitionValidationException $e )
@@ -1508,20 +1503,15 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
         $this->assertCount( 1, $validationErrors );
         $this->assertArrayHasKey( "temperature", $validationErrors );
         $this->assertInternalType( "array", $validationErrors["temperature"] );
-        $this->assertCount( 2, $validationErrors["temperature"] );
+        $this->assertCount( 1, $validationErrors["temperature"] );
         $this->assertInstanceOf( "eZ\\Publish\\Core\\FieldType\\ValidationError", $validationErrors["temperature"][0] );
-        $this->assertInstanceOf( "eZ\\Publish\\Core\\FieldType\\ValidationError", $validationErrors["temperature"][1] );
 
         $this->assertEquals(
-            new Message( "FieldType 'ezfloat' is not searchable" ),
-            $validationErrors["temperature"][0]->getTranslatableMessage()
-        );
-        $this->assertEquals(
             new Message(
-                "Validator parameter '%parameter%' value must be of numeric type",
-                array( "parameter" => "maxFloatValue" )
+                "Validator parameter '%parameter%' value must be of integer type",
+                array( "parameter" => "maxIntegerValue" )
             ),
-            $validationErrors["temperature"][1]->getTranslatableMessage()
+            $validationErrors["temperature"][0]->getTranslatableMessage()
         );
     }
 

--- a/eZ/Publish/API/Repository/Tests/FieldType/FloatIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/FloatIntegrationTest.php
@@ -9,8 +9,10 @@
 
 namespace eZ\Publish\API\Repository\Tests\FieldType;
 
+use eZ\Publish\Core\FieldType\Float\Type;
 use eZ\Publish\Core\FieldType\Float\Value as FloatValue;
 use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 
 /**
  * Integration test for use field type
@@ -18,7 +20,7 @@ use eZ\Publish\API\Repository\Values\Content\Field;
  * @group integration
  * @group field-type
  */
-class FloatIntegrationTest extends BaseIntegrationTest
+class FloatIntegrationTest extends SearchBaseIntegrationTest
 {
     /**
      * Get name of tested field type
@@ -333,5 +335,15 @@ class FloatIntegrationTest extends BaseIntegrationTest
             array( new FloatValue( 0 ) ),
             array( new FloatValue( 0.0 ) ),
         );
+    }
+
+    protected function getValidSearchValueOne()
+    {
+        return 25.519;
+    }
+
+    protected function getValidSearchValueTwo()
+    {
+        return 25.59;
     }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchableFloat.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchableFloat.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\API\Repository\Tests\FieldType;
+
+use eZ\Publish\Core\FieldType\Float\Type;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+
+/**
+ * Float field type is not searchable in Legacy search engine, but will
+ * be searchable with Solr and Elasticsearch search engines.
+ *
+ * This is implementation simply extends the original implementation in order to
+ * define the field type as searchable, so that it can be tested.
+ */
+class SearchableFloat extends Type
+{
+    public function isSearchable()
+    {
+        return true;
+    }
+
+    static protected function checkValueType( $value )
+    {
+        $fieldTypeFQN = "eZ\\Publish\\Core\\FieldType\\Float\\Value";
+        $valueFQN = substr_replace( $fieldTypeFQN, "Value", strrpos( $fieldTypeFQN, "\\" ) + 1 );
+
+        if ( !$value instanceof $valueFQN )
+        {
+            throw new InvalidArgumentType( "\$value", $valueFQN, $value );
+        }
+    }
+}

--- a/eZ/Publish/Core/FieldType/Float/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Float/SearchField.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\FieldType\Float;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\FieldType\Indexable;
+use eZ\Publish\SPI\Search;
+
+/**
+ * Indexable definition for Float field type
+ */
+class SearchField implements Indexable
+{
+    /**
+     * Get index data for field for search backend
+     *
+     * @param Field $field
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    public function getIndexData( Field $field )
+    {
+        return array(
+            new Search\Field(
+                'value',
+                $field->value->data,
+                new Search\FieldType\FloatField()
+            ),
+        );
+    }
+
+    /**
+     * Get index field types for search backend
+     *
+     * @return \eZ\Publish\SPI\Search\FieldType[]
+     */
+    public function getIndexDefinition()
+    {
+        return array(
+            'value' => new Search\FieldType\FloatField(),
+        );
+    }
+
+    /**
+     * Get name of the default field to be used for query and sort.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for query and sort. Default field is typically used by Field
+     * criterion and sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultField()
+    {
+        return "value";
+    }
+}

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/FieldValueMapper/FloatMapper.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/FieldValueMapper/FloatMapper.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper;
+
+use eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper;
+use eZ\Publish\SPI\Search\FieldType\FloatField;
+use eZ\Publish\SPI\Search\Field;
+
+/**
+ * Maps FloatField document field values to something Elasticsearch can index.
+ */
+class FloatMapper extends FieldValueMapper
+{
+    /**
+     * Check if field can be mapped
+     *
+     * @param \eZ\Publish\SPI\Search\Field $field
+     *
+     * @return boolean
+     */
+    public function canMap( Field $field )
+    {
+        return $field->type instanceof FloatField;
+    }
+
+    /**
+     * Map field value to a proper Elasticsearch representation
+     *
+     * @param \eZ\Publish\SPI\Search\Field $field
+     *
+     * @return mixed
+     */
+    public function map( Field $field )
+    {
+        return (float)$field->value;
+    }
+}

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Resources/mappings/content.json
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Resources/mappings/content.json
@@ -170,7 +170,7 @@
                 }
             },
             {
-                "field_integer": {
+                "field_float": {
                     "path_match": "fields_doc.*_f",
                     "match_mapping_type": "float",
                     "mapping": {
@@ -180,7 +180,7 @@
                 }
             },
             {
-                "field_integer": {
+                "field_long": {
                     "path_match": "fields_doc.*_l",
                     "match_mapping_type": "long",
                     "mapping": {
@@ -190,7 +190,7 @@
                 }
             },
             {
-                "field_integer": {
+                "field_double": {
                     "path_match": "fields_doc.*_d",
                     "match_mapping_type": "double",
                     "mapping": {
@@ -200,7 +200,7 @@
                 }
             },
             {
-                "field_integer": {
+                "field_boolean": {
                     "path_match": "fields_doc.*_b",
                     "match_mapping_type": "boolean",
                     "mapping": {

--- a/eZ/Publish/Core/Search/Solr/Content/FieldValueMapper/FloatMapper.php
+++ b/eZ/Publish/Core/Search/Solr/Content/FieldValueMapper/FloatMapper.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Search\Solr\Content\FieldValueMapper;
+
+use eZ\Publish\Core\Search\Solr\Content\FieldValueMapper;
+use eZ\Publish\SPI\Search\FieldType\FloatField;
+use eZ\Publish\SPI\Search\Field;
+
+/**
+ * Maps raw document field values to something Solr can index.
+ */
+class FloatMapper extends FieldValueMapper
+{
+    /**
+     * Check if field can be mapped
+     *
+     * @param Field $field
+     *
+     * @return boolean
+     */
+    public function canMap( Field $field )
+    {
+        return $field->type instanceof FloatField;
+    }
+
+    /**
+     * Map field value to a proper Solr representation
+     *
+     * @param Field $field
+     *
+     * @return mixed
+     */
+    public function map( Field $field )
+    {
+        return (float)$field->value;
+    }
+}

--- a/eZ/Publish/Core/settings/indexable_fieldtypes.yml
+++ b/eZ/Publish/Core/settings/indexable_fieldtypes.yml
@@ -4,6 +4,7 @@ parameters:
     ezpublish.fieldType.indexable.ezgmaplocation.class: eZ\Publish\Core\FieldType\MapLocation\SearchField
     ezpublish.fieldType.indexable.ezcountry.class: eZ\Publish\Core\FieldType\Country\SearchField
     ezpublish.fieldType.indexable.ezinteger.class: eZ\Publish\Core\FieldType\Integer\SearchField
+    ezpublish.fieldType.indexable.ezfloat.class: eZ\Publish\Core\FieldType\Float\SearchField
     ezpublish.fieldType.indexable.unindexed.class: eZ\Publish\Core\FieldType\Unindexed
 
 services:
@@ -32,6 +33,11 @@ services:
         tags:
             - {name: ezpublish.fieldType.indexable, alias: ezinteger}
 
+    ezpublish.fieldType.indexable.ezfloat:
+        class: %ezpublish.fieldType.indexable.ezfloat.class%
+        tags:
+            - {name: ezpublish.fieldType.indexable, alias: ezfloat}
+
     # TODO: define proper type
     ezpublish.fieldType.indexable.eztext:
         class: %ezpublish.fieldType.indexable.ezstring.class%
@@ -59,7 +65,6 @@ services:
     ezpublish.fieldType.indexable.unindexed:
         class: %ezpublish.fieldType.indexable.unindexed.class%
         tags:
-            - {name: ezpublish.fieldType.indexable, alias: ezfloat}
             - {name: ezpublish.fieldType.indexable, alias: ezuser}
             - {name: ezpublish.fieldType.indexable, alias: ezimage}
             - {name: ezpublish.fieldType.indexable, alias: ezboolean}

--- a/eZ/Publish/Core/settings/search_engines/elasticsearch/field_value_mappers.yml
+++ b/eZ/Publish/Core/settings/search_engines/elasticsearch/field_value_mappers.yml
@@ -3,6 +3,7 @@ parameters:
     ezpublish.search.elasticsearch.content.field_value_mapper.date.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\DateMapper
     ezpublish.search.elasticsearch.content.field_value_mapper.document.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\DocumentMapper
     ezpublish.search.elasticsearch.content.field_value_mapper.geo_location.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\GeoLocationMapper
+    ezpublish.search.elasticsearch.content.field_value_mapper.float.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\FloatMapper
     ezpublish.search.elasticsearch.content.field_value_mapper.identifier.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\IdentifierMapper
     ezpublish.search.elasticsearch.content.field_value_mapper.integer.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\IntegerMapper
     ezpublish.search.elasticsearch.content.field_value_mapper.multiple_boolean.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\MultipleBooleanMapper
@@ -29,6 +30,11 @@ services:
 
     ezpublish.search.elasticsearch.content.field_value_mapper.geo_location:
         class: %ezpublish.search.elasticsearch.content.field_value_mapper.geo_location.class%
+        tags:
+            - {name: ezpublish.search.elasticsearch.content.field_value_mapper}
+
+    ezpublish.search.elasticsearch.content.field_value_mapper.float:
+        class: %ezpublish.search.elasticsearch.content.field_value_mapper.float.class%
         tags:
             - {name: ezpublish.search.elasticsearch.content.field_value_mapper}
 

--- a/eZ/Publish/Core/settings/search_engines/solr/field_value_mappers.yml
+++ b/eZ/Publish/Core/settings/search_engines/solr/field_value_mappers.yml
@@ -4,6 +4,7 @@ parameters:
     ezpublish.search.solr.content.field_value_mapper.string.class: eZ\Publish\Core\Search\Solr\Content\FieldValueMapper\StringMapper
     ezpublish.search.solr.content.field_value_mapper.multiple_string.class: eZ\Publish\Core\Search\Solr\Content\FieldValueMapper\MultipleStringMapper
     ezpublish.search.solr.content.field_value_mapper.integer.class: eZ\Publish\Core\Search\Solr\Content\FieldValueMapper\IntegerMapper
+    ezpublish.search.solr.content.field_value_mapper.float.class: eZ\Publish\Core\Search\Solr\Content\FieldValueMapper\FloatMapper
     ezpublish.search.solr.content.field_value_mapper.date.class: eZ\Publish\Core\Search\Solr\Content\FieldValueMapper\DateMapper
     ezpublish.search.solr.content.field_value_mapper.price.class: eZ\Publish\Core\Search\Solr\Content\FieldValueMapper\PriceMapper
     ezpublish.search.solr.content.field_value_mapper.boolean.class: eZ\Publish\Core\Search\Solr\Content\FieldValueMapper\BooleanMapper
@@ -33,6 +34,11 @@ services:
 
     ezpublish.search.solr.content.field_value_mapper.integer:
         class: %ezpublish.search.solr.content.field_value_mapper.integer.class%
+        tags:
+            - {name: ezpublish.search.solr.content.field_value_mapper}
+
+    ezpublish.search.solr.content.field_value_mapper.float:
+        class: %ezpublish.search.solr.content.field_value_mapper.float.class%
         tags:
             - {name: ezpublish.search.solr.content.field_value_mapper}
 

--- a/eZ/Publish/Core/settings/tests/integration_legacy_elasticsearch.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy_elasticsearch.yml
@@ -1,4 +1,7 @@
 parameters:
+    # Redefining default ezfloat field type class with the implementation that defines the type
+    # as searchable. Needed in order to test searching wiht Elasticsearch engine.
+    ezpublish.fieldType.ezfloat.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableFloat
     languages:
         - eng-US
         - eng-GB

--- a/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
@@ -1,4 +1,7 @@
 parameters:
+    # Redefining default ezfloat field type class with the implementation that defines the type
+    # as searchable. Needed in order to test searching wiht Solr engine.
+    ezpublish.fieldType.ezfloat.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableFloat
     languages:
         - eng-US
         - eng-GB


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24266

A subtask of https://jira.ez.no/browse/EZP-24232

This implements `Indexable` definition for `Float` field type.

The field type is not searchable in Legacy engine, because the implementation uses sort keys (int and string), but will be searchable with Solr and Elasticsearch engines. For the purpose of testing test field type that defines the original field type as searchable is implemented, also ContentType service tests needed to be adapted.