### PR TITLE
Implement EZP-24266: Indexable Relation field type

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/RelationIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/RelationIntegrationTest.php
@@ -21,7 +21,7 @@ use eZ\Publish\API\Repository\Values\Content\Content;
  * @group integration
  * @group field-type
  */
-class RelationFieldTypeIntegrationTest extends RelationBaseIntegrationTest
+class RelationFieldTypeIntegrationTest extends RelationSearchBaseIntegrationTest
 {
     /**
      * Get name of tested field type
@@ -362,5 +362,31 @@ class RelationFieldTypeIntegrationTest extends RelationBaseIntegrationTest
                 $this->getValidCreationFieldData()
             ),
         );
+    }
+
+    protected function getValidSearchValueOne()
+    {
+        // Using different values for Legacy Search Engine, in order to demonstrate that sort will
+        // depend on how search engine stores field type's value. Legacy stores it as integer, while
+        // other engines (Solr and Elasticsearch) store it as string.
+        if ( ltrim( get_class( $this->getSetupFactory() ), '\\' ) === 'eZ\Publish\API\Repository\Tests\SetupFactory\Legacy' )
+        {
+            return 4;
+        }
+
+        return 10;
+    }
+
+    protected function getValidSearchValueTwo()
+    {
+        // Using different values for Legacy Search Engine, in order to demonstrate that sort will
+        // depend on how search engine stores field type's value. Legacy stores it as integer, while
+        // other engines (Solr and Elasticsearch) store it as string.
+        if ( ltrim( get_class( $this->getSetupFactory() ), '\\' ) === 'eZ\Publish\API\Repository\Tests\SetupFactory\Legacy' )
+        {
+            return 49;
+        }
+
+        return 4;
     }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/RelationSearchBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/RelationSearchBaseIntegrationTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\API\Repository\Tests\FieldType;
+
+use eZ\Publish\Core\Repository\Values\Content\Relation;
+use eZ\Publish\API\Repository\Values\Content\Content;
+
+/**
+ * Base integration test for field types handling content relations.
+ *
+ * @group integration
+ * @group field-type
+ * @group relation
+ */
+abstract class RelationSearchBaseIntegrationTest extends SearchBaseIntegrationTest
+{
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Relation[]
+     */
+    abstract public function getCreateExpectedRelations( Content $content );
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Relation[]
+     */
+    abstract public function getUpdateExpectedRelations( Content $content );
+
+    /**
+     * Tests relation processing on field create.
+     */
+    public function testCreateContentRelationsProcessedCorrect()
+    {
+        $content = $this->createContent( $this->getValidCreationFieldData() );
+
+        $this->assertEquals(
+            $this->normalizeRelations(
+                $this->getCreateExpectedRelations( $content )
+            ),
+            $this->normalizeRelations(
+                $this->getRepository()->getContentService()->loadRelations( $content->versionInfo )
+            )
+        );
+    }
+
+    /**
+     * Tests relation processing on field update.
+     */
+    public function testUpdateContentRelationsProcessedCorrect()
+    {
+        $content = $this->updateContent( $this->getValidUpdateFieldData() );
+
+        $this->assertEquals(
+            $this->normalizeRelations(
+                $this->getUpdateExpectedRelations( $content )
+            ),
+            $this->normalizeRelations(
+                $this->getRepository()->getContentService()->loadRelations( $content->versionInfo )
+            )
+        );
+    }
+
+    /**
+     * Normalizes given $relations for easier comparison.
+     *
+     * @param \eZ\Publish\Core\Repository\Values\Content\Relation[] $relations
+     *
+     * @return \eZ\Publish\Core\Repository\Values\Content\Relation[]
+     */
+    protected function normalizeRelations( array $relations )
+    {
+        usort(
+            $relations,
+            function ( Relation $a, Relation $b )
+            {
+                if ( $a->type == $b->type )
+                {
+                    return $a->destinationContentInfo->id < $b->destinationContentInfo->id ? 1 : -1;
+                }
+                return $a->type < $b->type ? 1 : -1;
+            }
+        );
+        $normalized = array_map(
+            function ( Relation $relation )
+            {
+                $newRelation = new Relation(
+                    array(
+                        "id" => null,
+                        "sourceFieldDefinitionIdentifier" => $relation->sourceFieldDefinitionIdentifier,
+                        "type" => $relation->type,
+                        "sourceContentInfo" => $relation->sourceContentInfo,
+                        "destinationContentInfo" => $relation->destinationContentInfo
+                    )
+                );
+                return $newRelation;
+            },
+            $relations
+        );
+
+        return $normalized;
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/ContentId.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/ContentId.php
@@ -10,8 +10,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
+        'id' => 10,
+        'title' => 'Anonymous User',
       ),
        'score' => 1,
        'index' => NULL,
@@ -21,8 +21,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 10,
-        'title' => 'Anonymous User',
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/ContentTypeGroupId.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/ContentTypeGroupId.php
@@ -10,17 +10,6 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
-      ),
-       'score' => 1,
-       'index' => NULL,
-       'highlight' => NULL,
-    )),
-    1 => 
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' => 
-      array (
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -28,7 +17,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    2 => 
+    1 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -39,7 +28,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    3 => 
+    2 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -50,7 +39,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    4 => 
+    3 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -61,12 +50,23 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    5 => 
+    4 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
         'id' => 14,
         'title' => 'Administrator User',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    5 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/DateMetadataLte.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/DateMetadataLte.php
@@ -10,17 +10,6 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
-      ),
-       'score' => 1,
-       'index' => NULL,
-       'highlight' => NULL,
-    )),
-    1 => 
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' => 
-      array (
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -28,7 +17,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    2 => 
+    1 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -39,12 +28,23 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    3 => 
+    2 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
         'id' => 13,
         'title' => 'Editors',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    3 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/DeprecatedContentIdQuery.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/DeprecatedContentIdQuery.php
@@ -10,8 +10,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
+        'id' => 10,
+        'title' => 'Anonymous User',
       ),
        'score' => 1,
        'index' => NULL,
@@ -21,8 +21,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 10,
-        'title' => 'Anonymous User',
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/DepthIn.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/DepthIn.php
@@ -10,8 +10,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
+        'id' => 10,
+        'title' => 'Anonymous User',
       ),
        'score' => 0.35355337999999997,
        'index' => NULL,
@@ -21,8 +21,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 10,
-        'title' => 'Anonymous User',
+        'id' => 14,
+        'title' => 'Administrator User',
       ),
        'score' => 0.35355337999999997,
        'index' => NULL,
@@ -32,8 +32,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 14,
-        'title' => 'Administrator User',
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 0.35355337999999997,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/DepthLte.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/DepthLte.php
@@ -10,17 +10,6 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
-      ),
-       'score' => 1,
-       'index' => NULL,
-       'highlight' => NULL,
-    )),
-    1 => 
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' => 
-      array (
         'id' => 11,
         'title' => 'Members',
       ),
@@ -28,7 +17,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    2 => 
+    1 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -39,12 +28,23 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    3 => 
+    2 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
         'id' => 13,
         'title' => 'Editors',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    3 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/ContentId.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/ContentId.php
@@ -10,8 +10,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
+        'id' => 10,
+        'title' => 'Anonymous User',
       ),
        'score' => 1,
        'index' => NULL,
@@ -21,8 +21,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 10,
-        'title' => 'Anonymous User',
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/ContentTypeGroupId.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/ContentTypeGroupId.php
@@ -10,17 +10,6 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
-      ),
-       'score' => 1,
-       'index' => NULL,
-       'highlight' => NULL,
-    )),
-    1 => 
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' => 
-      array (
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -28,7 +17,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    2 => 
+    1 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -39,7 +28,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    3 => 
+    2 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -50,7 +39,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    4 => 
+    3 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -61,12 +50,23 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    5 => 
+    4 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
         'id' => 14,
         'title' => 'Administrator User',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    5 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/DateMetadataLte.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/DateMetadataLte.php
@@ -10,17 +10,6 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
-      ),
-       'score' => 1,
-       'index' => NULL,
-       'highlight' => NULL,
-    )),
-    1 => 
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' => 
-      array (
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -28,7 +17,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    2 => 
+    1 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -39,12 +28,23 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    3 => 
+    2 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
         'id' => 13,
         'title' => 'Editors',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    3 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/DepthIn.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/DepthIn.php
@@ -10,8 +10,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
+        'id' => 10,
+        'title' => 'Anonymous User',
       ),
        'score' => 0.35355337999999997,
        'index' => NULL,
@@ -21,8 +21,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 10,
-        'title' => 'Anonymous User',
+        'id' => 14,
+        'title' => 'Administrator User',
       ),
        'score' => 0.35355337999999997,
        'index' => NULL,
@@ -32,8 +32,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 14,
-        'title' => 'Administrator User',
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 0.35355337999999997,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/DepthLte.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/DepthLte.php
@@ -10,17 +10,6 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
-      ),
-       'score' => 1,
-       'index' => NULL,
-       'highlight' => NULL,
-    )),
-    1 => 
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' => 
-      array (
         'id' => 11,
         'title' => 'Members',
       ),
@@ -28,7 +17,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    2 => 
+    1 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -39,12 +28,23 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    3 => 
+    2 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
         'id' => 13,
         'title' => 'Editors',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    3 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/LogicalOr.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/LogicalOr.php
@@ -10,8 +10,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
+        'id' => 10,
+        'title' => 'Anonymous User',
       ),
        'score' => 1,
        'index' => NULL,
@@ -21,8 +21,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 10,
-        'title' => 'Anonymous User',
+        'id' => 12,
+        'title' => 'Administrator users',
       ),
        'score' => 1,
        'index' => NULL,
@@ -32,8 +32,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 12,
-        'title' => 'Administrator users',
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/RemoteId.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/RemoteId.php
@@ -10,8 +10,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
+        'id' => 10,
+        'title' => 'Anonymous User',
       ),
        'score' => 1,
        'index' => NULL,
@@ -21,8 +21,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 10,
-        'title' => 'Anonymous User',
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/SectionId.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/SectionId.php
@@ -10,17 +10,6 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
-      ),
-       'score' => 1,
-       'index' => NULL,
-       'highlight' => NULL,
-    )),
-    1 => 
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' => 
-      array (
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -28,7 +17,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    2 => 
+    1 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -39,7 +28,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    3 => 
+    2 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -50,7 +39,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    4 => 
+    3 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -61,12 +50,23 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    5 => 
+    4 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
         'id' => 14,
         'title' => 'Administrator User',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    5 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/SortSectionIdentifier.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/SortSectionIdentifier.php
@@ -76,17 +76,6 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
-      ),
-       'score' => 1,
-       'index' => NULL,
-       'highlight' => NULL,
-    )),
-    7 => 
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' => 
-      array (
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -94,7 +83,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    8 => 
+    7 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -105,7 +94,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    9 => 
+    8 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -116,7 +105,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    10 => 
+    9 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -127,12 +116,23 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    11 => 
+    10 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
         'id' => 14,
         'title' => 'Administrator User',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    11 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/SortSectionName.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/SortSectionName.php
@@ -76,17 +76,6 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
-      ),
-       'score' => 1,
-       'index' => NULL,
-       'highlight' => NULL,
-    )),
-    7 => 
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' => 
-      array (
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -94,7 +83,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    8 => 
+    7 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -105,7 +94,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    9 => 
+    8 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -116,7 +105,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    10 => 
+    9 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -127,12 +116,23 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    11 => 
+    10 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
         'id' => 14,
         'title' => 'Administrator User',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    11 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/Subtree.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/Subtree.php
@@ -10,17 +10,6 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
-      ),
-       'score' => 1,
-       'index' => NULL,
-       'highlight' => NULL,
-    )),
-    1 => 
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' => 
-      array (
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -28,7 +17,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    2 => 
+    1 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -39,7 +28,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    3 => 
+    2 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -50,7 +39,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    4 => 
+    3 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -61,12 +50,23 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    5 => 
+    4 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
         'id' => 14,
         'title' => 'Administrator User',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    5 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/UserMetadata.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/UserMetadata.php
@@ -10,17 +10,6 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
-      ),
-       'score' => 1,
-       'index' => NULL,
-       'highlight' => NULL,
-    )),
-    1 => 
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' => 
-      array (
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -28,7 +17,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    2 => 
+    1 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -39,7 +28,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    3 => 
+    2 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -50,7 +39,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    4 => 
+    3 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -61,12 +50,23 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    5 => 
+    4 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
         'id' => 14,
         'title' => 'Administrator User',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    5 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/Visibility.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Location/Visibility.php
@@ -10,17 +10,6 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
-      ),
-       'score' => 1.6931472000000001,
-       'index' => NULL,
-       'highlight' => NULL,
-    )),
-    1 => 
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' => 
-      array (
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -28,7 +17,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    2 => 
+    1 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -39,7 +28,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    3 => 
+    2 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -50,7 +39,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    4 => 
+    3 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -61,7 +50,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    5 => 
+    4 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -69,6 +58,17 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
         'title' => 'Administrator User',
       ),
        'score' => 1.9555115000000001,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    5 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
+      ),
+       'score' => 1.6931472000000001,
        'index' => NULL,
        'highlight' => NULL,
     )),

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/LogicalOr.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/LogicalOr.php
@@ -10,8 +10,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
+        'id' => 10,
+        'title' => 'Anonymous User',
       ),
        'score' => 1,
        'index' => NULL,
@@ -21,8 +21,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 10,
-        'title' => 'Anonymous User',
+        'id' => 12,
+        'title' => 'Administrator users',
       ),
        'score' => 1,
        'index' => NULL,
@@ -32,8 +32,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 12,
-        'title' => 'Administrator users',
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/RemoteId.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/RemoteId.php
@@ -10,8 +10,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
+        'id' => 10,
+        'title' => 'Anonymous User',
       ),
        'score' => 1,
        'index' => NULL,
@@ -21,8 +21,8 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 10,
-        'title' => 'Anonymous User',
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/SectionId.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/SectionId.php
@@ -10,17 +10,6 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
-      ),
-       'score' => 1,
-       'index' => NULL,
-       'highlight' => NULL,
-    )),
-    1 => 
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' => 
-      array (
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -28,7 +17,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    2 => 
+    1 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -39,7 +28,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    3 => 
+    2 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -50,7 +39,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    4 => 
+    3 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -61,12 +50,23 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    5 => 
+    4 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
         'id' => 14,
         'title' => 'Administrator User',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    5 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/SortFieldMultipleTypes.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/SortFieldMultipleTypes.php
@@ -1,148 +1,148 @@
 <?php
 
 return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(array(
-    'facets' =>
-        array (
-        ),
-    'searchHits' =>
-        array (
-            0 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 56,
-                            'title' => 'Design',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            1 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 50,
-                            'title' => 'Files',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            2 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 49,
-                            'title' => 'Images',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            3 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 41,
-                            'title' => 'Media',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            4 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 51,
-                            'title' => 'Multimedia',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            5 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 45,
-                            'title' => 'Setup',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            6 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 4,
-                            'title' => 'Users',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            7 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 11,
-                            'title' => 'Members',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            8 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 12,
-                            'title' => 'Administrator users',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            9 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 13,
-                            'title' => 'Editors',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            10 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 42,
-                            'title' => 'Anonymous Users',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            11 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 59,
-                            'title' => 'Partners',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-
-        ),
-    'spellSuggestion' => NULL,
-    'time' => 1,
-    'timedOut' => NULL,
-    'maxScore' => 1.0,
-    'totalCount' => 12,
+   'facets' => 
+  array (
+  ),
+   'searchHits' => 
+  array (
+    0 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 56,
+        'title' => 'Design',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    1 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 50,
+        'title' => 'Files',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    2 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 49,
+        'title' => 'Images',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    3 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 41,
+        'title' => 'Media',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    4 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 51,
+        'title' => 'Multimedia',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    5 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 45,
+        'title' => 'Setup',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    6 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 11,
+        'title' => 'Members',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    7 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 12,
+        'title' => 'Administrator users',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    8 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 13,
+        'title' => 'Editors',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    9 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    10 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 42,
+        'title' => 'Anonymous Users',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    11 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 59,
+        'title' => 'Partners',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+  ),
+   'spellSuggestion' => NULL,
+   'time' => 1,
+   'timedOut' => NULL,
+   'maxScore' => 1,
+   'totalCount' => 12,
 ));
+

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/SortFieldMultipleTypesReverse.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/SortFieldMultipleTypesReverse.php
@@ -1,148 +1,148 @@
 <?php
 
 return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(array(
-    'facets' =>
-        array (
-        ),
-    'searchHits' =>
-        array (
-            0 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 45,
-                            'title' => 'Setup',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            1 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 51,
-                            'title' => 'Multimedia',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            2 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 41,
-                            'title' => 'Media',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            3 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 49,
-                            'title' => 'Images',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            4 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 50,
-                            'title' => 'Files',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            5 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 56,
-                            'title' => 'Design',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            6 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 4,
-                            'title' => 'Users',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            7 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 11,
-                            'title' => 'Members',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            8 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 12,
-                            'title' => 'Administrator users',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            9 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 13,
-                            'title' => 'Editors',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            10 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 42,
-                            'title' => 'Anonymous Users',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            11 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 59,
-                            'title' => 'Partners',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-
-        ),
-    'spellSuggestion' => NULL,
-    'time' => 1,
-    'timedOut' => NULL,
-    'maxScore' => 1.0,
-    'totalCount' => 12,
+   'facets' => 
+  array (
+  ),
+   'searchHits' => 
+  array (
+    0 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 45,
+        'title' => 'Setup',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    1 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 51,
+        'title' => 'Multimedia',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    2 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 41,
+        'title' => 'Media',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    3 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 49,
+        'title' => 'Images',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    4 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 50,
+        'title' => 'Files',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    5 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 56,
+        'title' => 'Design',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    6 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 11,
+        'title' => 'Members',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    7 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 12,
+        'title' => 'Administrator users',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    8 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 13,
+        'title' => 'Editors',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    9 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    10 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 42,
+        'title' => 'Anonymous Users',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    11 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 59,
+        'title' => 'Partners',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+  ),
+   'spellSuggestion' => NULL,
+   'time' => 1,
+   'timedOut' => NULL,
+   'maxScore' => 1,
+   'totalCount' => 12,
 ));
+

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/SortFieldMultipleTypesSlice.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/SortFieldMultipleTypesSlice.php
@@ -1,70 +1,71 @@
 <?php
 
 return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(array(
-    'facets' =>
-        array (
-        ),
-    'searchHits' =>
-        array (
-            0 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 41,
-                            'title' => 'Media',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            1 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 51,
-                            'title' => 'Multimedia',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            2 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 45,
-                            'title' => 'Setup',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            3 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 4,
-                            'title' => 'Users',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            4 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 11,
-                            'title' => 'Members',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-        ),
-    'spellSuggestion' => NULL,
-    'time' => 1,
-    'timedOut' => NULL,
-    'maxScore' => 1.0,
-    'totalCount' => 12,
+   'facets' => 
+  array (
+  ),
+   'searchHits' => 
+  array (
+    0 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 41,
+        'title' => 'Media',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    1 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 51,
+        'title' => 'Multimedia',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    2 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 45,
+        'title' => 'Setup',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    3 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 11,
+        'title' => 'Members',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    4 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 12,
+        'title' => 'Administrator users',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+  ),
+   'spellSuggestion' => NULL,
+   'time' => 1,
+   'timedOut' => NULL,
+   'maxScore' => 1,
+   'totalCount' => 12,
 ));
+

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/SortFieldMultipleTypesSliceReverse.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/SortFieldMultipleTypesSliceReverse.php
@@ -1,71 +1,71 @@
 <?php
 
 return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(array(
-    'facets' =>
-        array (
-        ),
-    'searchHits' =>
-        array (
-            0 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 49,
-                            'title' => 'Images',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            1 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 50,
-                            'title' => 'Files',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            2 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 56,
-                            'title' => 'Design',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            3 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 4,
-                            'title' => 'Users',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-            4 =>
-                eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-                    'valueObject' =>
-                        array (
-                            'id' => 11,
-                            'title' => 'Members',
-                        ),
-                    'score' => 1.0,
-                    'index' => NULL,
-                    'highlight' => NULL,
-                )),
-
-        ),
-    'spellSuggestion' => NULL,
-    'time' => 1,
-    'timedOut' => NULL,
-    'maxScore' => 1.0,
-    'totalCount' => 12,
+   'facets' => 
+  array (
+  ),
+   'searchHits' => 
+  array (
+    0 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 49,
+        'title' => 'Images',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    1 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 50,
+        'title' => 'Files',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    2 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 56,
+        'title' => 'Design',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    3 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 11,
+        'title' => 'Members',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    4 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 12,
+        'title' => 'Administrator users',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+  ),
+   'spellSuggestion' => NULL,
+   'time' => 1,
+   'timedOut' => NULL,
+   'maxScore' => 1,
+   'totalCount' => 12,
 ));
+

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/SortSectionIdentifier.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/SortSectionIdentifier.php
@@ -76,17 +76,6 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
-      ),
-       'score' => 1,
-       'index' => NULL,
-       'highlight' => NULL,
-    )),
-    7 => 
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' => 
-      array (
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -94,7 +83,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    8 => 
+    7 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -105,7 +94,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    9 => 
+    8 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -116,7 +105,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    10 => 
+    9 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -127,12 +116,23 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    11 => 
+    10 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
         'id' => 14,
         'title' => 'Administrator User',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    11 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/SortSectionName.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/SortSectionName.php
@@ -76,17 +76,6 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
-      ),
-       'score' => 1,
-       'index' => NULL,
-       'highlight' => NULL,
-    )),
-    7 => 
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' => 
-      array (
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -94,7 +83,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    8 => 
+    7 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -105,7 +94,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    9 => 
+    8 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -116,7 +105,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    10 => 
+    9 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -127,12 +116,23 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    11 => 
+    10 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
         'id' => 14,
         'title' => 'Administrator User',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    11 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Subtree.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Subtree.php
@@ -10,17 +10,6 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
-      ),
-       'score' => 1,
-       'index' => NULL,
-       'highlight' => NULL,
-    )),
-    1 => 
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' => 
-      array (
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -28,7 +17,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    2 => 
+    1 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -39,7 +28,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    3 => 
+    2 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -50,7 +39,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    4 => 
+    3 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -61,12 +50,23 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    5 => 
+    4 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
         'id' => 14,
         'title' => 'Administrator User',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    5 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/UserMetadata.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/UserMetadata.php
@@ -10,17 +10,6 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
-      ),
-       'score' => 1,
-       'index' => NULL,
-       'highlight' => NULL,
-    )),
-    1 => 
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' => 
-      array (
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -28,7 +17,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    2 => 
+    1 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -39,7 +28,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    3 => 
+    2 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -50,7 +39,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    4 => 
+    3 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -61,12 +50,23 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    5 => 
+    4 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
         'id' => 14,
         'title' => 'Administrator User',
+      ),
+       'score' => 1,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    5 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
       ),
        'score' => 1,
        'index' => NULL,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Visibility.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/Visibility.php
@@ -10,17 +10,6 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
-        'id' => 4,
-        'title' => 'Users',
-      ),
-       'score' => 2.0414538000000002,
-       'index' => NULL,
-       'highlight' => NULL,
-    )),
-    1 => 
-    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
-       'valueObject' => 
-      array (
         'id' => 10,
         'title' => 'Anonymous User',
       ),
@@ -28,7 +17,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    2 => 
+    1 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -39,7 +28,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    3 => 
+    2 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -50,7 +39,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    4 => 
+    3 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -61,7 +50,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
        'index' => NULL,
        'highlight' => NULL,
     )),
-    5 => 
+    4 => 
     eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
        'valueObject' => 
       array (
@@ -69,6 +58,17 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
         'title' => 'Administrator User',
       ),
        'score' => 2.1631507999999999,
+       'index' => NULL,
+       'highlight' => NULL,
+    )),
+    5 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
+      ),
+       'score' => 2.0414538000000002,
        'index' => NULL,
        'highlight' => NULL,
     )),

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/ContentId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/ContentId.php
@@ -16,6 +16,13 @@ use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
  * Sets sort direction on Content ID for a content query
  *
  * Especially useful to get reproducible search results in tests.
+ *
+ * Note: order will vary per search engine, depending on how Content ID is stored in the search
+ * backend. For Legacy search engine IDs are stored as integers, while with Solr and Elasticsearch
+ * engines they are stored as strings. Hence the difference will be basically the one between
+ * numerical and alphabetical order of sorting.
+ *
+ * This reflects API definition of IDs as mixed type (integer or string).
  */
 class ContentId extends SortClause
 {

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Field.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Field.php
@@ -17,6 +17,14 @@ use eZ\Publish\API\Repository\Values\Content\Query\CustomFieldInterface;
 
 /**
  * Sets sort direction on a field value for a content query
+ *
+ * Note: for fields of some field types order will vary per search engine. This comes from the
+ * different way of storing IDs in the search backend, and therefore relates to the field types
+ * that store ID value for sorting (Relation field type). For Legacy search engine IDs are stored as
+ * integers, while with Solr and Elasticsearch engines they are stored as strings. In that case the
+ * difference will be basically the one between numerical and alphabetical order of sorting.
+ *
+ * This reflects API definition of IDs as mixed type (integer or string).
  */
 class Field extends SortClause implements CustomFieldInterface
 {

--- a/eZ/Publish/Core/FieldType/Relation/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Relation/SearchField.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\FieldType\Relation;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\FieldType\Indexable;
+use eZ\Publish\SPI\Search;
+
+/**
+ * Indexable definition for Relation field type
+ */
+class SearchField implements Indexable
+{
+    /**
+     * Get index data for field for search backend
+     *
+     * @param Field $field
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    public function getIndexData( Field $field )
+    {
+        return array(
+            new Search\Field(
+                'value',
+                $field->value->data,
+                new Search\FieldType\StringField()
+            ),
+        );
+    }
+
+    /**
+     * Get index field types for search backend
+     *
+     * @return \eZ\Publish\SPI\Search\FieldType[]
+     */
+    public function getIndexDefinition()
+    {
+        return array(
+            'value' => new Search\FieldType\StringField(),
+        );
+    }
+
+    /**
+     * Get name of the default field to be used for query and sort.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for query and sort. Default field is typically used by Field
+     * criterion and sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultField()
+    {
+        return "value";
+    }
+}

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Resources/mappings/content.json
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Resources/mappings/content.json
@@ -3,7 +3,7 @@
         "dynamic": false,
         "_all" : { "enabled": false },
         "properties": {
-            "id": { "type": "integer", "index": "not_analyzed" },
+            "id": { "type": "string", "index": "not_analyzed" },
             "type_id": { "type": "string", "index": "not_analyzed" },
             "group_mid": { "type": "string", "index": "not_analyzed" },
             "version_id": { "type": "integer", "index": "not_analyzed" },
@@ -25,7 +25,7 @@
                 "type": "nested",
                 "dynamic": false,
                 "properties": {
-                    "id": { "type": "integer", "index": "not_analyzed" },
+                    "id": { "type": "string", "index": "not_analyzed" },
                     "priority_i": { "type": "integer", "index": "not_analyzed" },
                     "hidden_b": { "type": "boolean", "index": "not_analyzed" },
                     "invisible_b": { "type": "boolean", "index": "not_analyzed" },

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Resources/mappings/location.json
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Resources/mappings/location.json
@@ -2,12 +2,12 @@
     "location": {
         "dynamic": false,
         "properties": {
-            "id": { "type": "integer", "index": "not_analyzed" },
+            "id": { "type": "string", "index": "not_analyzed" },
             "priority_i": { "type": "integer", "index": "not_analyzed" },
             "hidden_b": { "type": "boolean", "index": "not_analyzed" },
             "invisible_b": { "type": "boolean", "index": "not_analyzed" },
             "remote_id_id": { "type": "string", "index": "not_analyzed" },
-            "content_id_id": { "type": "integer", "index": "not_analyzed" },
+            "content_id_id": { "type": "string", "index": "not_analyzed" },
             "parent_id_id": { "type": "string", "index": "not_analyzed" },
             "path_string_id": { "type": "string", "index": "not_analyzed" },
             "depth_i": { "type": "integer", "index": "not_analyzed" },
@@ -16,7 +16,7 @@
             "is_main_location_b": { "type": "boolean", "index": "not_analyzed" },
             "content_type_id": { "type": "string", "index": "not_analyzed" },
             "content_group_mid": { "type": "string", "index": "not_analyzed" },
-            "content_version_id": { "type": "integer", "index": "not_analyzed" },
+            "content_version_id": { "type": "string", "index": "not_analyzed" },
             "content_status_id": { "type": "string", "index": "not_analyzed" },
             "content_name_s": { "type": "string", "index": "not_analyzed" },
             "content_creator_id": { "type": "string", "index": "not_analyzed" },

--- a/eZ/Publish/Core/settings/indexable_fieldtypes.yml
+++ b/eZ/Publish/Core/settings/indexable_fieldtypes.yml
@@ -6,6 +6,7 @@ parameters:
     ezpublish.fieldType.indexable.ezemail.class: eZ\Publish\Core\FieldType\EmailAddress\SearchField
     ezpublish.fieldType.indexable.ezimage.class: eZ\Publish\Core\FieldType\Image\SearchField
     ezpublish.fieldType.indexable.ezmedia.class: eZ\Publish\Core\FieldType\Media\SearchField
+    ezpublish.fieldType.indexable.ezobjectrelation.class: eZ\Publish\Core\FieldType\Relation\SearchField
     ezpublish.fieldType.indexable.ezprice.class: eZ\Publish\Core\FieldType\Price\SearchField
     ezpublish.fieldType.indexable.ezgmaplocation.class: eZ\Publish\Core\FieldType\MapLocation\SearchField
     ezpublish.fieldType.indexable.ezcountry.class: eZ\Publish\Core\FieldType\Country\SearchField
@@ -92,6 +93,11 @@ services:
         tags:
             - {name: ezpublish.fieldType.indexable, alias: ezisbn}
 
+    ezpublish.fieldType.indexable.ezobjectrelation:
+        class: %ezpublish.fieldType.indexable.ezobjectrelation.class%
+        tags:
+            - {name: ezpublish.fieldType.indexable, alias: ezobjectrelation}
+
     ezpublish.fieldType.indexable.unindexed:
         class: %ezpublish.fieldType.indexable.unindexed.class%
         tags:
@@ -102,7 +108,6 @@ services:
             - {name: ezpublish.fieldType.indexable, alias: ezinisetting}
             - {name: ezpublish.fieldType.indexable, alias: ezpackage}
             - {name: ezpublish.fieldType.indexable, alias: ezurl}
-            - {name: ezpublish.fieldType.indexable, alias: ezobjectrelation}
             - {name: ezpublish.fieldType.indexable, alias: ezmultioption}
             - {name: ezpublish.fieldType.indexable, alias: ezauthor}
             - {name: ezpublish.fieldType.indexable, alias: ezsrrating}


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24266

A subtask of https://jira.ez.no/browse/EZP-24232

This implements `Indexable` definition for `Relation` field type.

Since not all searchable field types have `Indexable` definition implemented, this required `RelationSearchBaseIntegrationTest`. This is temporary and will be removed when all searchable field types are covered.