### PR TITLE
Fix EZP-24268: When removing the only content version, also remove content

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -537,6 +537,7 @@ class Handler implements BaseContentHandler
      * Deletes given version, its fields, node assignment, relations and names.
      *
      * Removes the relations, but not the related objects.
+     * If the version is the only version of a content, the content is also deleted.
      *
      * @param int $contentId
      * @param int $versionNo
@@ -554,6 +555,12 @@ class Handler implements BaseContentHandler
         $this->contentGateway->deleteRelations( $contentId, $versionNo );
         $this->contentGateway->deleteVersions( $contentId, $versionNo );
         $this->contentGateway->deleteNames( $contentId, $versionNo );
+
+        $versions = $this->contentGateway->listVersionNumbers( $contentId );
+        if ( empty( $versions ) )
+        {
+            $this->contentGateway->deleteContent( $contentId );
+        }
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
@@ -1105,8 +1105,91 @@ class ContentHandlerTest extends TestCase
                 $this->equalTo( 225 ),
                 $this->equalTo( 2 )
             );
+        $gatewayMock->expects( $this->once() )
+            ->method( 'listVersionNumbers' )
+            ->with(
+                $this->equalTo( 225 )
+            )
+            ->will(
+                $this->returnValue( array( 1 ) )
+            );
+        $gatewayMock->expects( $this->never() )
+            ->method( 'deleteContent' )
+            ->with(
+                $this->equalTo( 225 )
+            );
 
         $handler->deleteVersion( 225, 2 );
+    }
+
+    /**
+     * @covers eZ\Publish\Core\Persistence\Legacy\Content\Handler::deleteVersion
+     *
+     * @return void
+     */
+    public function testDeleteOnlyVersion()
+    {
+        $handler = $this->getContentHandler();
+
+        $gatewayMock = $this->getGatewayMock();
+        $mapperMock = $this->getMapperMock();
+        $locationHandlerMock = $this->getLocationGatewayMock();
+        $fieldHandlerMock = $this->getFieldHandlerMock();
+
+        // Load VersionInfo to delete fields
+        $mapperMock->expects( $this->once() )
+            ->method( 'extractVersionInfoListFromRows' )
+            ->will( $this->returnValue( array( new VersionInfo() ) ) );
+        $gatewayMock->expects( $this->once() )
+            ->method( 'loadVersionInfo' )
+            ->will( $this->returnValue( array( 42 ) ) );
+
+        $locationHandlerMock->expects( $this->once() )
+            ->method( 'deleteNodeAssignment' )
+            ->with(
+                $this->equalTo( 225 ),
+                $this->equalTo( 1 )
+            );
+
+        $fieldHandlerMock->expects( $this->once() )
+            ->method( 'deleteFields' )
+            ->with(
+                $this->equalTo( 225 ),
+                $this->isInstanceOf( 'eZ\\Publish\\SPI\\Persistence\\Content\\VersionInfo' )
+            );
+        $gatewayMock->expects( $this->once() )
+            ->method( 'deleteRelations' )
+            ->with(
+                $this->equalTo( 225 ),
+                $this->equalTo( 1 )
+            );
+        $gatewayMock->expects( $this->once() )
+            ->method( 'deleteVersions' )
+            ->with(
+                $this->equalTo( 225 ),
+                $this->equalTo( 1 )
+            );
+        $gatewayMock->expects( $this->once() )
+            ->method( 'deleteNames' )
+            ->with(
+                $this->equalTo( 225 ),
+                $this->equalTo( 1 )
+            );
+        $gatewayMock->expects( $this->once() )
+            ->method( 'listVersionNumbers' )
+            ->with(
+                $this->equalTo( 225 )
+            )
+            ->will(
+                $this->returnValue( array() )
+            );
+        $gatewayMock->expects( $this->once() )
+            ->method( 'deleteContent' )
+            ->with(
+                $this->equalTo( 225 )
+            );
+
+        $handler->deleteVersion( 225, 1 );
     }
 
     /**

--- a/eZ/Publish/SPI/Persistence/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Handler.php
@@ -158,6 +158,7 @@ interface Handler
      * Deletes given version, its fields, node assignment, relations and names.
      *
      * Removes the relations, but not the related objects.
+     * If the version is the only version of a content, the content is also deleted.
      *
      * @param int $contentId
      * @param int $versionNo


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-24268

##### Problem
If a content version is created and then removed, a row for the content object will still exist, with an incorrect `current_version` field:
```
mysql> select id,current_version from ezcontentobject where remote_id='remoteId';
+-----+-----------------+
| id  | current_version |
+-----+-----------------+
| 219 |               1 |
+-----+-----------------+
1 row in set (0.01 sec)

mysql> select * from ezcontentobject_version where contentobject_id = 219;
Empty set (0.01 sec)
```
The issue also prevents, for example, to reuse the same `remote_id`.

##### Solution
This commit resolves it by also removing the content if it's only version was removed, keeping the DB consistent.