### PR TITLE
Implement EZP-24269: Indexable TextBlock field type

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseContentTypeServiceTest.php
@@ -98,7 +98,7 @@ abstract class BaseContentTypeServiceTest extends BaseTest
         $bodyFieldCreate->fieldSettings = array(
             'textRows' => 80
         );
-        $bodyFieldCreate->isSearchable = true;
+        $bodyFieldCreate->isSearchable = false;
 
         $typeCreate->addFieldDefinition( $bodyFieldCreate );
 

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchableTextBlock.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchableTextBlock.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\API\Repository\Tests\FieldType;
+
+use eZ\Publish\Core\FieldType\TextBlock\Type;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+
+/**
+ * TextBlock field type is not searchable in Legacy search engine, but will
+ * be searchable with Solr and Elasticsearch search engines.
+ *
+ * This is implementation simply extends the original implementation in order to
+ * define the field type as searchable, so that it can be tested.
+ */
+class SearchableTextBlock extends Type
+{
+    public function isSearchable()
+    {
+        return true;
+    }
+
+    static protected function checkValueType( $value )
+    {
+        $fieldTypeFQN = "eZ\\Publish\\Core\\FieldType\\TextBlock\\Value";
+        $valueFQN = substr_replace( $fieldTypeFQN, "Value", strrpos( $fieldTypeFQN, "\\" ) + 1 );
+
+        if ( !$value instanceof $valueFQN )
+        {
+            throw new InvalidArgumentType( "\$value", $valueFQN, $value );
+        }
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/FieldType/TextBlockIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/TextBlockIntegrationTest.php
@@ -18,7 +18,7 @@ use eZ\Publish\API\Repository\Values\Content\Field;
  * @group integration
  * @group field-type
  */
-class TextBlockIntegrationTest extends BaseIntegrationTest
+class TextBlockIntegrationTest extends SearchBaseIntegrationTest
 {
     /**
      * Get name of tested field type
@@ -319,5 +319,15 @@ class TextBlockIntegrationTest extends BaseIntegrationTest
             array( new TextBlockValue( 0 ) ),
             array( new TextBlockValue( "0" ) ),
         );
+    }
+
+    protected function getValidSearchValueOne()
+    {
+        return 'caution is the " path to \\mediocrity';
+    }
+
+    protected function getValidSearchValueTwo()
+    {
+        return "truth suffers from ' \\too much analysis";
     }
 }

--- a/eZ/Publish/Core/FieldType/Integer/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Integer/SearchField.php
@@ -14,7 +14,7 @@ use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
 /**
- * Indexable definition for TextLine field type
+ * Indexable definition for Integer field type
  */
 class SearchField implements Indexable
 {

--- a/eZ/Publish/Core/FieldType/TextBlock/SearchField.php
+++ b/eZ/Publish/Core/FieldType/TextBlock/SearchField.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\FieldType\TextBlock;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\FieldType\Indexable;
+use eZ\Publish\SPI\Search;
+
+/**
+ * Indexable definition for TextBlock field type
+ */
+class SearchField implements Indexable
+{
+    /**
+     * Get index data for field for search backend
+     *
+     * @param Field $field
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    public function getIndexData( Field $field )
+    {
+        return array(
+            new Search\Field(
+                'value',
+                $field->value->data,
+                new Search\FieldType\MultipleStringField()
+            ),
+        );
+    }
+
+    /**
+     * Get index field types for search backend
+     *
+     * @return \eZ\Publish\SPI\Search\FieldType[]
+     */
+    public function getIndexDefinition()
+    {
+        return array(
+            'value' => new Search\FieldType\MultipleStringField(),
+        );
+    }
+
+    /**
+     * Get name of the default field to be used for query and sort.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for query and sort. Default field is typically used by Field
+     * criterion and sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultField()
+    {
+        return "value";
+    }
+}

--- a/eZ/Publish/Core/FieldType/TextBlock/Type.php
+++ b/eZ/Publish/Core/FieldType/TextBlock/Type.php
@@ -168,7 +168,7 @@ class Type extends FieldType
      */
     public function isSearchable()
     {
-        return true;
+        return false;
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentTypeBase.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentTypeBase.php
@@ -1050,7 +1050,7 @@ abstract class ContentTypeBase extends BaseServiceTest
         $bodyFieldCreate->isTranslatable = true;
         $bodyFieldCreate->isRequired = false;
         $bodyFieldCreate->isInfoCollector = false;
-        $bodyFieldCreate->isSearchable = true;
+        $bodyFieldCreate->isSearchable = false;
         $bodyFieldCreate->defaultValue = "";
         //$bodyFieldCreate->validatorConfiguration
         $bodyFieldCreate->fieldSettings = array(
@@ -1168,7 +1168,7 @@ abstract class ContentTypeBase extends BaseServiceTest
         $bodyFieldCreate->isTranslatable = true;
         $bodyFieldCreate->isRequired = false;
         $bodyFieldCreate->isInfoCollector = false;
-        $bodyFieldCreate->isSearchable = true;
+        $bodyFieldCreate->isSearchable = false;
         $bodyFieldCreate->defaultValue = "";
         //$bodyFieldCreate->validatorConfiguration
         $bodyFieldCreate->fieldSettings = array(
@@ -3356,7 +3356,7 @@ abstract class ContentTypeBase extends BaseServiceTest
         $fieldDefinitionUpdateStruct->fieldSettings = array(
             "textRows" => $fieldDefinition->fieldSettings["textRows"] + 1
         );
-        $fieldDefinitionUpdateStruct->isSearchable = !$fieldDefinition->isSearchable;
+        $fieldDefinitionUpdateStruct->isSearchable = $fieldDefinition->isSearchable;
 
         $contentTypeService->updateFieldDefinition(
             $contentTypeDraft,

--- a/eZ/Publish/Core/Search/Solr/Content/CriterionVisitor.php
+++ b/eZ/Publish/Core/Search/Solr/Content/CriterionVisitor.php
@@ -61,6 +61,9 @@ abstract class CriterionVisitor
         $endValue   = '*';
         $endBrace   = ']';
 
+        $start = $this->prepareValue( $start );
+        $end = $this->prepareValue( $end );
+
         switch ( $operator )
         {
             case Operator::GT:
@@ -91,6 +94,30 @@ abstract class CriterionVisitor
         }
 
         return "$startBrace$startValue TO $endValue$endBrace";
+    }
+
+    /**
+     * Converts given $value to the appropriate Solr representation.
+     *
+     * The value will be converted to string representation and escaped if needed.
+     *
+     * @param mixed $value
+     *
+     * @return string
+     */
+    protected function prepareValue( $value )
+    {
+        switch ( gettype( $value ) )
+        {
+            case "boolean":
+                return ( $value ? "true" : "false" );
+
+            case "string":
+                return '"' . preg_replace( '/("|\\\)/', '\\\$1', $value ) . '"';
+
+            default:
+                return (string)$value;
+        }
     }
 }
 

--- a/eZ/Publish/Core/Search/Solr/Content/CriterionVisitor/Field/FieldIn.php
+++ b/eZ/Publish/Core/Search/Solr/Content/CriterionVisitor/Field/FieldIn.php
@@ -63,9 +63,11 @@ class FieldIn extends Field
         $queries = array();
         foreach ( $criterion->value as $value )
         {
+            $preparedValue = $this->prepareValue( $value );
+
             foreach ( $fieldNames as $name )
             {
-                $queries[] = $name . ':"' . $value . '"';
+                $queries[] = $name . ':' . $preparedValue;
             }
         }
 

--- a/eZ/Publish/Core/settings/indexable_fieldtypes.yml
+++ b/eZ/Publish/Core/settings/indexable_fieldtypes.yml
@@ -1,5 +1,6 @@
 parameters:
     ezpublish.fieldType.indexable.ezstring.class: eZ\Publish\Core\FieldType\TextLine\SearchField
+    ezpublish.fieldType.indexable.eztext.class: eZ\Publish\Core\FieldType\TextBlock\SearchField
     ezpublish.fieldType.indexable.ezprice.class: eZ\Publish\Core\FieldType\Price\SearchField
     ezpublish.fieldType.indexable.ezgmaplocation.class: eZ\Publish\Core\FieldType\MapLocation\SearchField
     ezpublish.fieldType.indexable.ezcountry.class: eZ\Publish\Core\FieldType\Country\SearchField
@@ -38,9 +39,8 @@ services:
         tags:
             - {name: ezpublish.fieldType.indexable, alias: ezfloat}
 
-    # TODO: define proper type
     ezpublish.fieldType.indexable.eztext:
-        class: %ezpublish.fieldType.indexable.ezstring.class%
+        class: %ezpublish.fieldType.indexable.eztext.class%
         tags:
             - {name: ezpublish.fieldType.indexable, alias: eztext}
 


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24269

A subtask of https://jira.ez.no/browse/EZP-24232

This implements `Indexable` definition for `TextBlock` field type.

The field type was incorrectly defined as searchable, while it is not searchable in Legacy Search Engine.
That is here fixed, and for the purpose of testing test field type that defines the original field type as searchable is implemented. Also, ContentType service tests needed to be adapted.

Solr's base `CriterionVisitor` now implements `prepareValue()` method, which is used to convert and escape the search target value to the proper Solr representation. This will be further employed in next sub-tasks.