### PR TITLE
Implement EZP-24271: Indexable DateAndTime field type

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/DateAndTimeIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/DateAndTimeIntegrationTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\API\Repository\Tests\FieldType;
 
 use eZ\Publish\Core\FieldType\DateAndTime\Value as DateAndTimeValue;
 use eZ\Publish\API\Repository\Values\Content\Field;
+use DateTime;
 
 /**
  * Integration test for use field type
@@ -18,7 +19,7 @@ use eZ\Publish\API\Repository\Values\Content\Field;
  * @group integration
  * @group field-type
  */
-class DateAndTimeIntegrationTest extends BaseIntegrationTest
+class DateAndTimeIntegrationTest extends SearchBaseIntegrationTest
 {
     /**
      * Get name of tested field type
@@ -348,5 +349,39 @@ class DateAndTimeIntegrationTest extends BaseIntegrationTest
                 $this->getValidCreationFieldData()
             ),
         );
+    }
+
+    protected function getValidSearchValueOne()
+    {
+        return "2012-04-15T15:43:56Z";
+    }
+
+    protected function getValidSearchValueTwo()
+    {
+        return "2015-04-15T15:43:56Z";
+    }
+
+    protected function getSearchTargetValueOne()
+    {
+        // Handling Legacy Search Engine, which stores DateAndTime value as integer timestamp
+        if ( ltrim( get_class( $this->getSetupFactory() ), '\\' ) === 'eZ\Publish\API\Repository\Tests\SetupFactory\Legacy' )
+        {
+            $dateTime = new DateTime( $this->getValidSearchValueOne() );
+            return $dateTime->getTimestamp();
+        }
+
+        return parent::getSearchTargetValueOne();
+    }
+
+    protected function getSearchTargetValueTwo()
+    {
+        // Handling Legacy Search Engine, which stores DateAndTime value as integer timestamp
+        if ( ltrim( get_class( $this->getSetupFactory() ), '\\' ) === 'eZ\Publish\API\Repository\Tests\SetupFactory\Legacy' )
+        {
+            $dateTime = new DateTime( $this->getValidSearchValueTwo() );
+            return $dateTime->getTimestamp();
+        }
+
+        return parent::getSearchTargetValueTwo();
     }
 }

--- a/eZ/Publish/Core/FieldType/DateAndTime/SearchField.php
+++ b/eZ/Publish/Core/FieldType/DateAndTime/SearchField.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\FieldType\DateAndTime;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\FieldType\Indexable;
+use eZ\Publish\SPI\Search;
+
+/**
+ * Indexable definition for DateAndTime field type
+ */
+class SearchField implements Indexable
+{
+    /**
+     * Get index data for field for search backend
+     *
+     * @param Field $field
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    public function getIndexData( Field $field )
+    {
+        return array(
+            new Search\Field(
+                'value',
+                $field->value->data['timestamp'],
+                new Search\FieldType\DateField()
+            ),
+        );
+    }
+
+    /**
+     * Get index field types for search backend
+     *
+     * @return \eZ\Publish\SPI\Search\FieldType[]
+     */
+    public function getIndexDefinition()
+    {
+        return array(
+            'value' => new Search\FieldType\DateField(),
+        );
+    }
+
+    /**
+     * Get name of the default field to be used for query and sort.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for query and sort. Default field is typically used by Field
+     * criterion and sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultField()
+    {
+        return "value";
+    }
+}

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Resources/mappings/content.json
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Resources/mappings/content.json
@@ -216,6 +216,16 @@
                         "type": "geo_point"
                     }
                 }
+            },
+            {
+                "field_datetime": {
+                    "path_match": "fields_doc.*_dt",
+                    "match_mapping_type": "date",
+                    "mapping": {
+                        "type": "date",
+                        "index": "not_analyzed"
+                    }
+                }
             }
         ]
     }

--- a/eZ/Publish/Core/settings/indexable_fieldtypes.yml
+++ b/eZ/Publish/Core/settings/indexable_fieldtypes.yml
@@ -2,6 +2,7 @@ parameters:
     ezpublish.fieldType.indexable.ezstring.class: eZ\Publish\Core\FieldType\TextLine\SearchField
     ezpublish.fieldType.indexable.eztext.class: eZ\Publish\Core\FieldType\TextBlock\SearchField
     ezpublish.fieldType.indexable.ezboolean.class: eZ\Publish\Core\FieldType\Checkbox\SearchField
+    ezpublish.fieldType.indexable.ezdatetime.class: eZ\Publish\Core\FieldType\DateAndTime\SearchField
     ezpublish.fieldType.indexable.ezprice.class: eZ\Publish\Core\FieldType\Price\SearchField
     ezpublish.fieldType.indexable.ezgmaplocation.class: eZ\Publish\Core\FieldType\MapLocation\SearchField
     ezpublish.fieldType.indexable.ezcountry.class: eZ\Publish\Core\FieldType\Country\SearchField
@@ -50,6 +51,11 @@ services:
         tags:
             - {name: ezpublish.fieldType.indexable, alias: ezboolean}
 
+    ezpublish.fieldType.indexable.ezdatetime:
+        class: %ezpublish.fieldType.indexable.ezdatetime.class%
+        tags:
+            - {name: ezpublish.fieldType.indexable, alias: ezdatetime}
+
     # TODO: define proper type
     ezpublish.fieldType.indexable.ezxmltext:
         class: %ezpublish.fieldType.indexable.ezstring.class%
@@ -76,7 +82,6 @@ services:
             - {name: ezpublish.fieldType.indexable, alias: ezkeyword}
             - {name: ezpublish.fieldType.indexable, alias: ezdate}
             - {name: ezpublish.fieldType.indexable, alias: eztime}
-            - {name: ezpublish.fieldType.indexable, alias: ezdatetime}
             - {name: ezpublish.fieldType.indexable, alias: ezinisetting}
             - {name: ezpublish.fieldType.indexable, alias: ezpackage}
             - {name: ezpublish.fieldType.indexable, alias: ezurl}


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24271

A subtask of https://jira.ez.no/browse/EZP-24232

This implements `Indexable` definition for `DateAndTime` field type.

Tests account for Legacy Search Engine storing field type's values as integer timestamps.

#### TODOs
- [x] create dynamic mapping for date field in Elasticsearch