### PR TITLE
Fix EZP-24279: use defined liip_imagine variation settings

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/FilterConfiguration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/FilterConfiguration.php
@@ -36,15 +36,14 @@ class FilterConfiguration extends BaseFilterConfiguration
             return parent::get( $filter );
         }
 
-        $filterConfig = array(
+        $filterConfig = isset( $this->filters[$filter] ) ? parent::get( $filter ) : array();
+        return array(
             'cache' => 'ezpublish',
             'data_loader' => 'ezpublish',
             'reference' => isset( $configuredVariations[$filter]['reference'] ) ? $configuredVariations[$filter]['reference'] : null,
             'filters' => $this->getVariationFilters( $filter, $configuredVariations ),
             'post_processors' => $this->getVariationPostProcessors( $filter, $configuredVariations )
-        );
-
-        return $filterConfig;
+        ) + $filterConfig;
     }
 
     public function all()

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/FilterConfigurationTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/FilterConfigurationTest.php
@@ -177,6 +177,39 @@ class FilterConfigurationTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testGetEzVariationImagineOptions()
+    {
+        $imagineConfig = array(
+            'foo_option' => 'foo',
+            'bar_option' => 'bar'
+        );
+        $this->filterConfiguration->set( 'some_variation', $imagineConfig );
+
+        $filters = array( 'some_filter' => array() );
+        $reference = 'another_variation';
+        $variations = array(
+            'some_variation' => array( 'reference' => $reference, 'filters' => $filters )
+        );
+        $this->configResolver
+            ->expects( $this->once() )
+            ->method( 'getParameter' )
+            ->with( 'image_variations' )
+            ->will( $this->returnValue( $variations ) );
+
+        $this->assertSame(
+            array(
+                'cache' => 'ezpublish',
+                'data_loader' => 'ezpublish',
+                'reference' => $reference,
+                'filters' => $filters,
+                'post_processors' => array(),
+                'foo_option' => 'foo',
+                'bar_option' => 'bar'
+            ),
+            $this->filterConfiguration->get( 'some_variation' )
+        );
+    }
+
     public function testAll()
     {
         $fooConfig = array( 'fooconfig' );


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24279

Problem: for existing image variations, it is not possible to define liip_imagine settings.
While it may be possible to introduce new semantic config options, the settings under `liip_imagine` configuration block should also apply.

This does that, making possible to define settings such as `jpeg_quality` (or future settings) for existing variations.
(see also https://jira.ez.no/browse/EZP-24167 - Image variations JPEG quality)