### PR TITLE
Implement EZP-24272: Indexable Time field type

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/TimeIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/TimeIntegrationTest.php
@@ -19,7 +19,7 @@ use DateTime;
  * @group integration
  * @group field-type
  */
-class TimeIntegrationTest extends BaseIntegrationTest
+class TimeIntegrationTest extends SearchBaseIntegrationTest
 {
     /**
      * Get name of tested field type
@@ -340,5 +340,25 @@ class TimeIntegrationTest extends BaseIntegrationTest
                 $this->getValidCreationFieldData()
             ),
         );
+    }
+
+    protected function getValidSearchValueOne()
+    {
+        return new TimeValue( $this->getSearchTargetValueOne() );
+    }
+
+    protected function getValidSearchValueTwo()
+    {
+        return new TimeValue( $this->getSearchTargetValueTwo() );
+    }
+
+    protected function getSearchTargetValueOne()
+    {
+        return 9600;
+    }
+
+    protected function getSearchTargetValueTwo()
+    {
+        return 14400;
     }
 }

--- a/eZ/Publish/Core/FieldType/Time/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Time/SearchField.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\FieldType\Time;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\FieldType\Indexable;
+use eZ\Publish\SPI\Search;
+
+/**
+ * Indexable definition for Time field type
+ */
+class SearchField implements Indexable
+{
+    /**
+     * Get index data for field for search backend
+     *
+     * @param Field $field
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    public function getIndexData( Field $field )
+    {
+        return array(
+            new Search\Field(
+                'value',
+                $field->value->data,
+                new Search\FieldType\IntegerField()
+            ),
+        );
+    }
+
+    /**
+     * Get index field types for search backend
+     *
+     * @return \eZ\Publish\SPI\Search\FieldType[]
+     */
+    public function getIndexDefinition()
+    {
+        return array(
+            'value' => new Search\FieldType\IntegerField(),
+        );
+    }
+
+    /**
+     * Get name of the default field to be used for query and sort.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for query and sort. Default field is typically used by Field
+     * criterion and sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultField()
+    {
+        return "value";
+    }
+}

--- a/eZ/Publish/Core/settings/indexable_fieldtypes.yml
+++ b/eZ/Publish/Core/settings/indexable_fieldtypes.yml
@@ -14,6 +14,7 @@ parameters:
     ezpublish.fieldType.indexable.ezcountry.class: eZ\Publish\Core\FieldType\Country\SearchField
     ezpublish.fieldType.indexable.ezinteger.class: eZ\Publish\Core\FieldType\Integer\SearchField
     ezpublish.fieldType.indexable.ezfloat.class: eZ\Publish\Core\FieldType\Float\SearchField
+    ezpublish.fieldType.indexable.eztime.class: eZ\Publish\Core\FieldType\Time\SearchField
     ezpublish.fieldType.indexable.unindexed.class: eZ\Publish\Core\FieldType\Unindexed
 
 services:
@@ -67,6 +68,11 @@ services:
         tags:
             - {name: ezpublish.fieldType.indexable, alias: ezbinaryfile}
 
+    ezpublish.fieldType.indexable.eztime:
+        class: %ezpublish.fieldType.indexable.eztime.class%
+        tags:
+            - {name: ezpublish.fieldType.indexable, alias: eztime}
+
     ezpublish.fieldType.indexable.eztext:
         class: %ezpublish.fieldType.indexable.eztext.class%
         tags:
@@ -110,7 +116,6 @@ services:
             - {name: ezpublish.fieldType.indexable, alias: ezuser}
             - {name: ezpublish.fieldType.indexable, alias: ezkeyword}
             - {name: ezpublish.fieldType.indexable, alias: ezdate}
-            - {name: ezpublish.fieldType.indexable, alias: eztime}
             - {name: ezpublish.fieldType.indexable, alias: ezinisetting}
             - {name: ezpublish.fieldType.indexable, alias: ezpackage}
             - {name: ezpublish.fieldType.indexable, alias: ezurl}


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24272

A subtask of https://jira.ez.no/browse/EZP-24232

This implements `Indexable` definition for `Time` field type. Time value is indexed as integer (time of day as number of seconds).

Note that providing integer field value is interpreted a giving a timestamp, so field type's value object is constructed directly. This required dedicated methods to provide Field search target value in the field type integration tests (implemented in previous sub-tasks).