### PR TITLE
[Travis] execute composer self-update

### DIFF
--- a/bin/.travis/prepare_unittest.sh
+++ b/bin/.travis/prepare_unittest.sh
@@ -12,6 +12,9 @@ if [ "$DB" = "postgresql" ] ; then psql -c "CREATE DATABASE $DB_NAME;" -U postgr
 # Setup github key to avoid api rate limit
 ./bin/.travis/install_composer_github_key.sh
 
+# Update composer to newest version
+composer self-update
+
 # Switch to another Symfony version if asked for
 if [ "$SYMFONY_VERSION" != "" ] ; then composer require --no-update symfony/symfony=$SYMFONY_VERSION ; fi;
 


### PR DESCRIPTION
Failure in https://travis-ci.org/ezsystems/ezpublish-kernel/jobs/59236460#L107 seems to be a temporary problem, as it did not appear on re-running https://github.com/ezsystems/ezpublish-kernel/pull/1235.

This adds `composer self-update` to `bin/.travis/prepare_unittest.sh` script, so that problems caused by outdated composer version are avoided. See https://github.com/ezsystems/ezpublish-kernel-ee/pull/65 for more details (caret operator it this case, as described at https://getcomposer.org/doc/01-basic-usage.md#next-significant-release-tilde-and-caret-operators-).