### PR TITLE
EZP-24098: stream binary & media files as well with DFS

### DIFF
--- a/eZ/Bundle/EzPublishIOBundle/EventListener/IoUriMatcher.php
+++ b/eZ/Bundle/EzPublishIOBundle/EventListener/IoUriMatcher.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\EventListener;
+
+interface IoUriMatcher
+{
+    /**
+     * Tests if $uri is a match or not
+     * @param $uri
+     * @return bool
+     */
+    public function matches( $uri );
+}

--- a/eZ/Bundle/EzPublishIOBundle/EventListener/PrefixesIoUriMatcher.php
+++ b/eZ/Bundle/EzPublishIOBundle/EventListener/PrefixesIoUriMatcher.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\EventListener;
+
+/**
+ * Matches an URI against a list of prefixes
+ */
+class PrefixesIoUriMatcher implements IoUriMatcher
+{
+    /** @var string */
+    private $urlPrefix;
+
+    /** @var array */
+    private $binaryPrefixes;
+
+    public function __construct( array $prefixes )
+    {
+        $this->prefixes = array_map(
+            function( $value )
+            {
+                return ltrim( '/', $value );
+            },
+            $prefixes
+        );
+    }
+
+    public function matches( $uri )
+    {
+        foreach ( $this->prefixes as $prefix )
+        {
+            if ( strpos( $uri, $prefix ) === 0 )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/eZ/Bundle/EzPublishIOBundle/EventListener/StreamFileListener.php
+++ b/eZ/Bundle/EzPublishIOBundle/EventListener/StreamFileListener.php
@@ -26,10 +26,13 @@ class StreamFileListener implements EventSubscriberInterface
     /** @var ConfigResolverInterface */
     private $configResolver;
 
-    public function __construct( IOServiceInterface $ioService, ConfigResolverInterface $configResolver )
+    /** @var \eZ\Bundle\EzPublishIOBundle\EventListener\IoUriMatcher */
+    private $uriMatcher;
+
+    public function __construct( IOServiceInterface $ioService, IoUriMatcher $uriMatcher )
     {
         $this->ioService = $ioService;
-        $this->configResolver = $configResolver;
+        $this->uriMatcher = $uriMatcher;
     }
 
     public static function getSubscribedEvents()
@@ -51,7 +54,7 @@ class StreamFileListener implements EventSubscriberInterface
 
         $uri = $event->getRequest()->attributes->get( 'semanticPathinfo' );
 
-        if ( !$this->isIoUri( $uri ) )
+        if ( !$this->uriMatcher->matches( $uri ) )
         {
             return;
         }
@@ -63,15 +66,5 @@ class StreamFileListener implements EventSubscriberInterface
                 $this->ioService
             )
         );
-    }
-
-    /**
-     * Tests if $uri is an IO file uri root
-     * @param string $uri
-     * @return bool
-     */
-    private function isIoUri( $uri )
-    {
-        return ( strpos( ltrim( $uri, '/' ), $this->configResolver->getParameter( 'io.url_prefix' ) ) === 0 );
     }
 }


### PR DESCRIPTION
When using DFS IO handling, images are streamed by a specific event listener. But since each io element type (image, binary, ...) has its own IO Service, the event isn't able to stream binary files (only images).

This WIP change externalizes URI matching to a PrefixIoUriMatcher, that implements an IoUriMatcher interface. The Intention is to add another service that implements the StreamFileListener, but with a different instance (prefix) of the matcher, configured for binary files.

## Open questions
- [ ]  Would it be better to have one event for DFS streaming, and make it implement this logic, instead of having two listeners (perfs) ?