### PR TITLE
Fix EZP-24268: deleting the last version of the Content should not be allowed

### DIFF
--- a/doc/bc/changes-5.3.md
+++ b/doc/bc/changes-5.3.md
@@ -156,6 +156,10 @@ Changes affecting version compatibility with former or future versions.
   repository configuration for both storage and search engines. Class signature has remained the
   same.
 
+* 5.3.6: `eZ\Publish\Core\Repository\ContentService::deleteVersion()` now throws `BadStateException`
+  when deleting last version of the Content. Since Content without a version does not make sense, in
+  this case `eZ\Publish\Core\Repository\ContentService::deleteContent()` should be used instead.
+
 ## Deprecations
 
 * Method `eZ\Publish\API\Repository\RoleService::removePolicy` is deprecated in

--- a/doc/bc/changes-5.4.md
+++ b/doc/bc/changes-5.4.md
@@ -185,6 +185,10 @@ Changes affecting version compatibility with former or future versions.
   repository configuration for both storage and search engines. Class signature has remained the
   same.
 
+* 5.4.3: `eZ\Publish\Core\Repository\ContentService::deleteVersion()` now throws `BadStateException`
+  when deleting last version of the Content. Since Content without a version does not make sense, in
+  this case `eZ\Publish\Core\Repository\ContentService::deleteContent()` should be used instead.
+
 ## Deprecations
 
 * `imagemagick` siteaccess settings are now deprecated. It is mandatory to remove them.

--- a/doc/bc/changes-6.0.md
+++ b/doc/bc/changes-6.0.md
@@ -113,6 +113,10 @@ Changes affecting version compatibility with former or future versions.
 * `eZ\Publish\API\Repository\ContentTypeService::createContentType` can now accept a `ContentTypeCreateStruct` without
   any `FieldDefinitionCreateStruct`
 
+* `eZ\Publish\Core\Repository\ContentService::deleteVersion()` now throws `BadStateException` when
+  deleting last version of the Content. Since Content without a version does not make sense, in this
+  case `eZ\Publish\Core\Repository\ContentService::deleteContent()` should be used instead.
+
 ## Deprecations
 
 * `eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger::purge()` is deprecated and will be removed in v6.1.

--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -281,9 +281,10 @@ interface ContentService
     public function publishVersion( VersionInfo $versionInfo );
 
     /**
-     * removes the given version
+     * Removes the given version
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is in state published
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is in
+     *         published state or is a last version of the Content
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to remove this version
      *
      * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -2548,9 +2548,10 @@ class ContentServiceTest extends BaseContentServiceTest
      *
      * @return void
      * @see \eZ\Publish\API\Repository\ContentService::deleteVersion()
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testLoadContent
      * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testCreateContent
+     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testPublishVersion
+     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testCreateContentDraft
      */
     public function testDeleteVersion()
     {
@@ -2559,13 +2560,24 @@ class ContentServiceTest extends BaseContentServiceTest
         $contentService = $repository->getContentService();
 
         /* BEGIN: Use Case */
-        $draft = $this->createContentDraftVersion1();
+        $content = $this->createContentVersion1();
+
+        // Create new draft, because published or last version of the Content can't be deleted
+        $draft = $contentService->createContentDraft(
+            $content->getVersionInfo()->getContentInfo()
+        );
 
         // Delete the previously created draft
         $contentService->deleteVersion( $draft->getVersionInfo() );
         /* END: Use Case */
 
-        $contentService->loadContent( $draft->id );
+        $versions = $contentService->loadVersions( $content->getVersionInfo()->getContentInfo() );
+
+        $this->assertCount( 1, $versions );
+        $this->assertEquals(
+            $content->getVersionInfo()->id,
+            $versions[0]->id
+        );
     }
 
     /**
@@ -2574,10 +2586,11 @@ class ContentServiceTest extends BaseContentServiceTest
      * @return void
      * @see \eZ\Publish\API\Repository\ContentService::deleteVersion()
      * @expectedException \eZ\Publish\API\Repository\Exceptions\BadStateException
-     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testDeleteVersion
+     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testLoadContent
+     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testCreateContent
      * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testPublishVersion
      */
-    public function testDeleteVersionThrowsBadStateException()
+    public function testDeleteVersionThrowsBadStateExceptionOnPublishedVersion()
     {
         $repository = $this->getRepository();
 
@@ -2589,6 +2602,30 @@ class ContentServiceTest extends BaseContentServiceTest
         // This call will fail with a "BadStateException", because the content
         // version is currently published.
         $contentService->deleteVersion( $content->getVersionInfo() );
+        /* END: Use Case */
+    }
+
+    /**
+     * Test for the deleteVersion() method.
+     *
+     * @see \eZ\Publish\API\Repository\ContentService::deleteVersion()
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testLoadContent
+     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testCreateContent
+     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testPublishVersion
+     */
+    public function testDeleteVersionThrowsBadStateExceptionOnLastVersion()
+    {
+        $repository = $this->getRepository();
+
+        $contentService = $repository->getContentService();
+
+        /* BEGIN: Use Case */
+        $draft = $this->createContentDraftVersion1();
+
+        // This call will fail with a "BadStateException", because the Content
+        // version is the last version of the Content.
+        $contentService->deleteVersion( $draft->getVersionInfo() );
         /* END: Use Case */
     }
 

--- a/eZ/Publish/Core/REST/Client/ContentService.php
+++ b/eZ/Publish/Core/REST/Client/ContentService.php
@@ -513,9 +513,10 @@ class ContentService implements APIContentService, Sessionable
     }
 
     /**
-     * removes the given version
+     * Removes the given version
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is in state published
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is in
+     *         published state or is a last version of the Content
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to remove this version
      *
      * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1595,9 +1595,10 @@ class ContentService implements ContentServiceInterface
     }
 
     /**
-     * removes the given version
+     * Removes the given version
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is in state published
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is in
+     *         published state or is the last version of the Content
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to remove this version
      *
      * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
@@ -1618,6 +1619,18 @@ class ContentService implements ContentServiceInterface
                 'versionremove',
                 array( 'contentId' => $versionInfo->contentInfo->id, 'versionNo' => $versionInfo->versionNo )
             );
+
+        $versionList = $this->persistenceHandler->contentHandler()->listVersions(
+            $versionInfo->contentInfo->id
+        );
+
+        if ( count( $versionList ) === 1 )
+        {
+            throw new BadStateException(
+                "\$versionInfo",
+                "Version is the last version of the Content and can not be removed"
+            );
+        }
 
         $this->repository->beginTransaction();
         try

--- a/eZ/Publish/Core/SignalSlot/ContentService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentService.php
@@ -430,9 +430,10 @@ class ContentService implements ContentServiceInterface
     }
 
     /**
-     * removes the given version
+     * Removes the given version
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is in state published
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is in
+     *         published state or is the last version of the Content
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to remove this version
      *
      * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24268

This defines and implements throwing `BadStateException` when using `ContentService::deleteVersion()` to delete Content's last version.
In this case `ContentService::deleteContent()` should be used instead.