### PR TITLE
EZP-24253: Implement framework for ContentType creation

### DIFF
--- a/doc/bc/changes-6.0.md
+++ b/doc/bc/changes-6.0.md
@@ -106,6 +106,10 @@ Changes affecting version compatibility with former or future versions.
   repository configuration for both storage and search engines. Class signature has remained the
   same.
   
+* TextLine field type `StringLengthValidator` has changed. `false` isn't considered as valid value any more for
+  `minStringLength` and `maxStringLength`. Use `null` instead of `false` if you want to deactivate these validators.
+  Default validator value has been changed accordingly.
+  
 * `eZ\Publish\API\Repository\ContentTypeService::createContentType` can now accept a `ContentTypeCreateStruct` without
   any `FieldDefinitionCreateStruct`
 

--- a/doc/bc/changes-6.0.md
+++ b/doc/bc/changes-6.0.md
@@ -105,6 +105,9 @@ Changes affecting version compatibility with former or future versions.
   `eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider`, as it now provides
   repository configuration for both storage and search engines. Class signature has remained the
   same.
+  
+* `eZ\Publish\API\Repository\ContentTypeService::createContentType` can now accept a `ContentTypeCreateStruct` without
+  any `FieldDefinitionCreateStruct`
 
 ## Deprecations
 

--- a/eZ/Publish/API/Repository/ContentTypeService.php
+++ b/eZ/Publish/API/Repository/ContentTypeService.php
@@ -103,7 +103,6 @@ interface ContentTypeService
      *         - array of content type groups does not contain at least one content type group
      *         - identifier or remoteId in the content type create struct already exists
      *         - there is a duplicate field identifier in the content type create struct
-     *         - content type create struct does not contain at least one field definition create struct
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
      *         if a field definition in the $contentTypeCreateStruct is not valid
      *

--- a/eZ/Publish/API/Repository/Tests/BaseNonRedundantFieldSetTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseNonRedundantFieldSetTest.php
@@ -40,8 +40,8 @@ abstract class BaseNonRedundantFieldSetTest extends BaseTest
 
         $validatorConfiguration = array(
             'StringLengthValidator' => array(
-                'minStringLength' => false,
-                'maxStringLength' => false,
+                'minStringLength' => null,
+                'maxStringLength' => null,
             ),
         );
 

--- a/eZ/Publish/Core/FieldType/Tests/TextLineTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/TextLineTest.php
@@ -28,7 +28,7 @@ class TextLineTest extends FieldTypeTest
      * NOT take care for test case wide caching of the field type, just return
      * a new instance from this method!
      *
-     * @return FieldType
+     * @return \eZ\Publish\Core\FieldType\FieldType
      */
     protected function createFieldTypeUnderTest()
     {
@@ -53,7 +53,7 @@ class TextLineTest extends FieldTypeTest
                 ),
                 'maxStringLength' => array(
                     'type' => 'int',
-                    'default' => false
+                    'default' => null
                 )
             )
         );
@@ -72,7 +72,7 @@ class TextLineTest extends FieldTypeTest
     /**
      * Returns the empty value expected from the field type.
      *
-     * @return void
+     * @return \eZ\Publish\Core\FieldType\TextLine\Value
      */
     protected function getEmptyValueExpectation()
     {
@@ -331,7 +331,7 @@ class TextLineTest extends FieldTypeTest
             array(
                 array(
                     'StringLengthValidator' => array(
-                        'minStringLength' => false,
+                        'minStringLength' => null,
                     )
                 )
             ),
@@ -345,7 +345,7 @@ class TextLineTest extends FieldTypeTest
             array(
                 array(
                     'StringLengthValidator' => array(
-                        'maxStringLength' => false,
+                        'maxStringLength' => null,
                     )
                 )
             ),

--- a/eZ/Publish/Core/FieldType/TextLine/Type.php
+++ b/eZ/Publish/Core/FieldType/TextLine/Type.php
@@ -31,7 +31,7 @@ class Type extends FieldType
             ),
             'maxStringLength' => array(
                 'type' => 'int',
-                'default' => false
+                'default' => null
             )
         )
     );
@@ -67,7 +67,7 @@ class Type extends FieldType
                 {
                     case "minStringLength":
                     case "maxStringLength":
-                        if ( $value !== false && !is_integer( $value ) )
+                        if ( $value !== null && !is_integer( $value ) )
                         {
                             $validationErrors[] = new ValidationError(
                                 "Validator parameter '%parameter%' value must be of integer type",

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/TextLine.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/TextLine.php
@@ -99,14 +99,14 @@ class TextLine implements Converter
             $validatorConstraints[self::STRING_LENGTH_VALIDATOR_IDENTIFIER]["maxStringLength"] =
                 $storageDef->dataInt1 != 0 ?
                     (int)$storageDef->dataInt1 :
-                    false;
+                    null;
         }
         if ( isset( $storageDef->dataInt2 ) )
         {
             $validatorConstraints[self::STRING_LENGTH_VALIDATOR_IDENTIFIER]["minStringLength"] =
                 $storageDef->dataInt2 != 0 ?
                     (int)$storageDef->dataInt2 :
-                    false;
+                    null;
         }
 
         $fieldDef->fieldTypeConstraints->validators = $validatorConstraints;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
@@ -115,7 +115,7 @@ class Mapper
             }
 
             $fieldId = (int)$row['ezcontentclass_attribute_id'];
-            if ( !isset( $fields[$fieldId] ) )
+            if ( $fieldId && !isset( $fields[$fieldId] ) )
             {
                 $types[$typeId]->fieldDefinitions[] = $fields[$fieldId] = $this->extractFieldFromRow( $row );
             }

--- a/eZ/Publish/Core/REST/Client/ContentTypeService.php
+++ b/eZ/Publish/Core/REST/Client/ContentTypeService.php
@@ -278,7 +278,6 @@ class ContentTypeService implements APIContentTypeService, Sessionable
      *         - array of content type groups does not contain at least one content type group
      *         - identifier or remoteId in the content type create struct already exists
      *         - there is a duplicate field identifier in the content type create struct
-     *         - content type create struct does not contain at least one field definition create struct
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
      *         if a field definition in the $contentTypeCreateStruct is not valid
      *

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -754,7 +754,6 @@ class ContentTypeService implements ContentTypeServiceInterface
      *         - array of content type groups does not contain at least one content type group
      *         - identifier or remoteId in the content type create struct already exists
      *         - there is a duplicate field identifier in the content type create struct
-     *         - content type create struct does not contain at least one field definition create struct
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
      *         if a field definition in the $contentTypeCreateStruct is not valid
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeValidationException

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -552,14 +552,6 @@ class ContentTypeService implements ContentTypeServiceInterface
             );
         }
 
-        if ( empty( $contentTypeCreateStruct->fieldDefinitions ) )
-        {
-            throw new InvalidArgumentException(
-                "\$contentTypeCreateStruct",
-                "Argument must contain at least one FieldDefinitionCreateStruct"
-            );
-        }
-
         foreach ( $contentTypeCreateStruct->fieldDefinitions as $key => $fieldDefinitionCreateStruct )
         {
             if ( !$fieldDefinitionCreateStruct instanceof FieldDefinitionCreateStruct )

--- a/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentTypeBase.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentTypeBase.php
@@ -1488,13 +1488,10 @@ abstract class ContentTypeBase extends BaseServiceTest
      * Test for the createContentTypeGroup() method.
      *
      * @depends testCreateContentType
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     * @expectedExceptionMessage Argument must contain at least one FieldDefinitionCreateStruct
-     * @covers \eZ\Publish\Core\Repository\ContentTypeService::createContentTypeGroup
      *
      * @return array
      */
-    public function testCreateContentTypeThrowsInvalidArgumentExceptionNoFieldDefinitions()
+    public function testCreateContentTypeWithoutFieldDefinitions()
     {
         /* BEGIN: Use Case */
         $contentTypeService = $this->repository->getContentTypeService();
@@ -1512,11 +1509,14 @@ abstract class ContentTypeBase extends BaseServiceTest
         $typeCreateStruct->descriptions = array( 'eng-US' => 'A description.' );
 
         // Throws an exception because content type create struct does not have any field definition create structs set
-        $type = $contentTypeService->createContentType(
-            $typeCreateStruct,
-            array(
-                // "Content" group
-                $contentTypeService->loadContentTypeGroup( 1 )
+        self::assertInstanceOf(
+            'eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft',
+            $contentTypeService->createContentType(
+                $typeCreateStruct,
+                array(
+                    // "Content" group
+                    $contentTypeService->loadContentTypeGroup( 1 )
+                )
             )
         );
         /* END: Use Case */

--- a/eZ/Publish/Core/SignalSlot/ContentTypeService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentTypeService.php
@@ -187,7 +187,6 @@ class ContentTypeService implements ContentTypeServiceInterface
      *         - array of content type groups does not contain at least one content type group
      *         - identifier or remoteId in the content type create struct already exists
      *         - there is a duplicate field identifier in the content type create struct
-     *         - content type create struct does not contain at least one field definition create struct
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
      *         if a field definition in the $contentTypeCreateStruct is not valid
      *


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24253

Modifications to allow flexible implementation of ContentType forms.

* [x] Allow ContentType creation without FieldDefinition
* [x] Fix TextLine validator default values
* [x] Fix tests
* [x] Add BC note