### PR TITLE
Implement EZP-24275: Indexable Image field type

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/FileSearchBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/FileSearchBaseIntegrationTest.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\API\Repository\Tests\FieldType;
+
+use RecursiveIteratorIterator;
+use RecursiveDirectoryIterator;
+use FileSystemIterator;
+use UnexpectedValueException;
+
+/**
+ * Integration test for use field type
+ *
+ * @group integration
+ * @group field-type
+ */
+abstract class FileSearchBaseIntegrationTest extends SearchBaseIntegrationTest
+{
+    /**
+     * Base install dir
+     *
+     * @var string
+     */
+    protected static $installDir;
+
+    /**
+     * Root directory for IO files
+     *
+     * @var string
+     */
+    protected static $ioRootDir;
+
+    /**
+     * Storage directory used by the IOHandler
+     * @var string
+     */
+    protected static $storageDir;
+
+    /**
+     * Storage dir settings key
+     */
+    protected static $storageDirConfigKey = 'storage_dir';
+
+    /**
+     * If storage data should not be cleaned up
+     *
+     * @var boolean
+     */
+    protected static $leaveStorageData = false;
+
+    /**
+     * List of path in config:storage_dir that must not be deleted, and must be ignored in these tests
+     * Workaround for FieldType vs. Repository tests. The repository tests require those files since they
+     * match the ones referenced in the database fixtures used by Services tests.
+     * @var array
+     */
+    protected static $ignoredPathList;
+
+    /**
+     * Returns the install dir used by the test
+     *
+     * @return string
+     */
+    protected function getInstallDir()
+    {
+        return self::$installDir;
+    }
+
+    /**
+     * Returns the storage dir used by the test
+     *
+     * @return string
+     */
+    protected function getStorageDir()
+    {
+        return self::$storageDir;
+    }
+
+    /**
+     * Perform storage directory setup on first execution
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        if ( !isset( self::$installDir ) )
+        {
+            self::$installDir = $this->getConfigValue( 'ezpublish.kernel.root_dir' );
+            self::$storageDir = $this->getConfigValue( static::$storageDirConfigKey );
+            self::$ioRootDir = $this->getConfigValue( 'io_root_dir' );
+
+            self::setUpIgnoredPath( $this->getConfigValue( 'ignored_storage_files' ) );
+        }
+    }
+
+    /**
+     * Tears down the test.
+     *
+     * Cleans up the storage directory, if it was used
+     *
+     * @return void
+     */
+    public static function tearDownAfterClass()
+    {
+        parent::tearDownAfterClass();
+        self::cleanupStorageDir();
+    }
+
+    /**
+     * Returns an iterator over the full storage dir.
+     *
+     * @return Iterator
+     */
+    protected static function getStorageDirIterator()
+    {
+        return new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(
+                self::$installDir . '/' . self::$storageDir,
+                FileSystemIterator::KEY_AS_PATHNAME | FileSystemIterator::SKIP_DOTS | FilesystemIterator::CURRENT_AS_FILEINFO
+            ),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+    }
+
+    /**
+     * Removes the given directory path recursively
+     *
+     * @param string $dir
+     *
+     * @return void
+     */
+    protected static function cleanupStorageDir()
+    {
+        if ( self::$installDir == null || self::$storageDir == null || self::$leaveStorageData )
+        {
+            // Nothing to do
+            return;
+        }
+
+        try
+        {
+            $iterator = self::getStorageDirIterator();
+
+            foreach ( $iterator as $path => $fileInfo )
+            {
+                if ( $fileInfo->isDir() )
+                {
+                    if ( !self::isIgnoredPath( dirname( $path ) ) )
+                        rmdir( $path );
+                }
+                else if ( !self::isIgnoredPath( $path ) )
+                {
+                    unlink( $path );
+                }
+            }
+        }
+        catch ( UnexpectedValueException $e )
+        {
+            // The directory to cleanup just doesn't exist
+        }
+    }
+
+    protected static function setUpIgnoredPath( $ignoredFiles )
+    {
+        foreach ( $ignoredFiles as $ignoredFile )
+        {
+            $pathPartsArray = explode( DIRECTORY_SEPARATOR, $ignoredFile );
+            foreach ( $pathPartsArray as $index => $directoryPart )
+            {
+                if ( $directoryPart == '' )
+                    continue;
+                $partPath = implode(
+                    DIRECTORY_SEPARATOR,
+                    array_slice( $pathPartsArray, 0, $index + 1 )
+                );
+                self::$ignoredPathList[realpath( $partPath )] = true;
+            }
+        }
+    }
+
+    /**
+     * Checks if $path must be excluded from filesystem cleanup
+     * @param string $path
+     * @return bool
+     */
+    protected static function isIgnoredPath( $path )
+    {
+        return isset( self::$ignoredPathList[realpath( $path )] );
+    }
+
+    protected function uriExistsOnIO( $uri )
+    {
+        $spiId = str_replace( self::$storageDir, '', ltrim( $uri, '/' ) );
+        $path = self::$ioRootDir . '/' . $spiId;
+        return file_exists( $path );
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/ImageIntegrationTest.php
@@ -11,6 +11,8 @@ namespace eZ\Publish\API\Repository\Tests\FieldType;
 
 use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
 use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 
 /**
  * Integration test for use field type
@@ -18,7 +20,7 @@ use eZ\Publish\API\Repository\Values\Content\Field;
  * @group integration
  * @group field-type
  */
-class ImageIntegrationTest extends FileBaseIntegrationTest
+class ImageIntegrationTest extends FileSearchBaseIntegrationTest
 {
     /**
      * Stores the loaded image path for copy test.
@@ -602,5 +604,226 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
 
         $newVersion = $contentService->createContentDraft( $content->contentInfo );
         $contentService->updateContent( $newVersion->versionInfo, $updateStruct );
+    }
+
+    protected function getValidSearchValueOne()
+    {
+        return new ImageValue(
+            array(
+                'fileName' => 'cafe-terrace-at-night.png',
+                'inputUri' => ( $path = __DIR__ . '/_fixtures/image.png' ),
+                'alternativeText' => 'café terrace at night, also known as the cafe terrace on the place du forum',
+                'fileSize' => filesize( $path ),
+            )
+        );
+    }
+
+    protected function getValidSearchValueTwo()
+    {
+        return new ImageValue(
+            array(
+                'fileName' => 'thatched-cottages-at-cordeville.jpg',
+                'inputUri' => ( $path = __DIR__ . '/_fixtures/image.jpg' ),
+                'alternativeText' => 'chaumes de cordeville à auvers-sur-oise',
+                'fileSize' => filesize( $path ),
+            )
+        );
+    }
+
+    protected function getSearchTargetValueOne()
+    {
+        $value = $this->getValidSearchValueOne();
+        return $value->fileName;
+    }
+
+    protected function getSearchTargetValueTwo()
+    {
+        $value = $this->getValidSearchValueTwo();
+        return $value->fileName;
+    }
+
+    /**
+     * Redefined here in order to execute before tests with modified fields below,
+     * which depend on it for the returned value.
+     */
+    public function testCreateTestContent()
+    {
+        return parent::testCreateTestContent();
+    }
+
+    public function criteriaProviderModifiedFieldAlternativeText()
+    {
+        $valueOne = $this->getValidSearchValueOne();
+        $valueTwo = $this->getValidSearchValueTwo();
+
+        return $this->provideCriteria( $valueOne->alternativeText, $valueTwo->alternativeText );
+    }
+
+    /**
+     * Tests Content Search filtering with Field criterion on the alternative text modified field
+     *
+     * @dataProvider criteriaProviderModifiedFieldAlternativeText
+     * @depends testCreateTestContent
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param boolean $includesOne
+     * @param boolean $includesTwo
+     * @param array $context
+     */
+    public function testFilterContentModifiedFieldAlternativeText(
+        Criterion $criterion,
+        $includesOne,
+        $includesTwo,
+        array $context
+    )
+    {
+        $this->assertFilterContentModifiedField(
+            $criterion,
+            $includesOne,
+            $includesTwo,
+            $context,
+            true,
+            "alternative_text"
+        );
+    }
+
+    /**
+     * Tests Content Search querying with Field criterion on the alternative text modified field
+     *
+     * @dataProvider criteriaProviderModifiedFieldAlternativeText
+     * @depends testCreateTestContent
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param boolean $includesOne
+     * @param boolean $includesTwo
+     * @param array $context
+     */
+    public function testQueryContentModifiedFieldAlternativeText(
+        Criterion $criterion,
+        $includesOne,
+        $includesTwo,
+        array $context
+    )
+    {
+        $this->assertFilterContentModifiedField(
+            $criterion,
+            $includesOne,
+            $includesTwo,
+            $context,
+            false,
+            "alternative_text"
+        );
+    }
+
+    public function criteriaProviderModifiedFieldFileSize()
+    {
+        $valueOne = $this->getValidSearchValueOne();
+        $valueTwo = $this->getValidSearchValueTwo();
+
+        return $this->provideCriteria( $valueOne->fileSize, $valueTwo->fileSize );
+    }
+
+    /**
+     * Tests Content Search filtering with Field criterion on the file size modified field
+     *
+     * @dataProvider criteriaProviderModifiedFieldFileSize
+     * @depends testCreateTestContent
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param boolean $includesOne
+     * @param boolean $includesTwo
+     * @param array $context
+     */
+    public function testFilterContentModifiedFieldFileSize(
+        Criterion $criterion,
+        $includesOne,
+        $includesTwo,
+        array $context
+    )
+    {
+        $this->assertFilterContentModifiedField(
+            $criterion,
+            $includesOne,
+            $includesTwo,
+            $context,
+            true,
+            "file_size"
+        );
+    }
+
+    /**
+     * Tests Content Search querying with Field criterion on the file size modified field
+     *
+     * @dataProvider criteriaProviderModifiedFieldFileSize
+     * @depends testCreateTestContent
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param boolean $includesOne
+     * @param boolean $includesTwo
+     * @param array $context
+     */
+    public function testQueryContentModifiedFieldFileSize(
+        Criterion $criterion,
+        $includesOne,
+        $includesTwo,
+        array $context
+    )
+    {
+        $this->assertFilterContentModifiedField(
+            $criterion,
+            $includesOne,
+            $includesTwo,
+            $context,
+            false,
+            "file_size"
+        );
+    }
+
+    /**
+     * Tests Content Search sort with Field sort clause on the alternative text modified field
+     *
+     * @dataProvider sortClauseProvider
+     * @depends testCreateTestContent
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause
+     * @param boolean $ascending
+     * @param array $context
+     */
+    public function testSortContentModifiedFieldAlternativeText(
+        SortClause $sortClause,
+        $ascending,
+        array $context
+    )
+    {
+        $this->assertSortContentModifiedField(
+            $sortClause,
+            $ascending,
+            $context,
+            "alternative_text"
+        );
+    }
+
+    /**
+     * Tests Content Search sort with Field sort clause on the file size modified field
+     *
+     * @dataProvider sortClauseProvider
+     * @depends testCreateTestContent
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause
+     * @param boolean $ascending
+     * @param array $context
+     */
+    public function testSortContentModifiedFieldFieldSize(
+        SortClause $sortClause,
+        $ascending,
+        array $context
+    )
+    {
+        $this->assertSortContentModifiedField(
+            $sortClause,
+            $ascending,
+            $context,
+            "file_size"
+        );
     }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
@@ -18,6 +18,8 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Field;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalNot;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOperator;
+use eZ\Publish\API\Repository\Values\Content\Query\CustomFieldInterface;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Field as FieldSortClause;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
@@ -154,6 +156,14 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
 
     public function criteriaProvider()
     {
+        return $this->provideCriteria(
+            $this->getSearchTargetValueOne(),
+            $this->getSearchTargetValueTwo()
+        );
+    }
+
+    public function provideCriteria( $valueOne, $valueTwo )
+    {
         return array(
             0 => array(
                 // Tests search with EQ operator.
@@ -163,7 +173,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     value EQ One
                 //
                 // The result should contain Content One.
-                new Field( "data", Operator::EQ, $this->getSearchTargetValueOne() ),
+                new Field( "data", Operator::EQ, $valueOne ),
                 true,
                 false,
             ),
@@ -175,7 +185,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     NOT( value EQ One )
                 //
                 // The result should contain Content Two.
-                new LogicalNot( new Field( "data", Operator::EQ, $this->getSearchTargetValueOne() ) ),
+                new LogicalNot( new Field( "data", Operator::EQ, $valueOne ) ),
                 false,
                 true,
             ),
@@ -187,7 +197,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     value EQ Two
                 //
                 // The result should contain Content Two.
-                new Field( "data", Operator::EQ, $this->getSearchTargetValueTwo() ),
+                new Field( "data", Operator::EQ, $valueTwo ),
                 false,
                 true,
             ),
@@ -199,7 +209,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     NOT( value EQ Two )
                 //
                 // The result should contain Content One.
-                new LogicalNot( new Field( "data", Operator::EQ, $this->getSearchTargetValueTwo() ) ),
+                new LogicalNot( new Field( "data", Operator::EQ, $valueTwo ) ),
                 true,
                 false,
             ),
@@ -211,7 +221,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     value IN [One]
                 //
                 // The result should contain Content One.
-                new Field( "data", Operator::IN, array( $this->getSearchTargetValueOne() ) ),
+                new Field( "data", Operator::IN, array( $valueOne ) ),
                 true,
                 false,
             ),
@@ -224,7 +234,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // The result should contain Content Two.
                 new LogicalNot(
-                    new Field( "data", Operator::IN, array( $this->getSearchTargetValueOne() ) )
+                    new Field( "data", Operator::IN, array( $valueOne ) )
                 ),
                 false,
                 true,
@@ -237,7 +247,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     value IN [Two]
                 //
                 // The result should contain Content Two.
-                new Field( "data", Operator::IN, array( $this->getSearchTargetValueTwo() ) ),
+                new Field( "data", Operator::IN, array( $valueTwo ) ),
                 false,
                 true,
             ),
@@ -250,7 +260,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // The result should contain Content One.
                 new LogicalNot(
-                    new Field( "data", Operator::IN, array( $this->getSearchTargetValueTwo() ) )
+                    new Field( "data", Operator::IN, array( $valueTwo ) )
                 ),
                 true,
                 false,
@@ -267,8 +277,8 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                     "data",
                     Operator::IN,
                     array(
-                        $this->getSearchTargetValueOne(),
-                        $this->getSearchTargetValueTwo(),
+                        $valueOne,
+                        $valueTwo,
                     )
                 ),
                 true,
@@ -287,8 +297,8 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                         "data",
                         Operator::IN,
                         array(
-                            $this->getSearchTargetValueOne(),
-                            $this->getSearchTargetValueTwo(),
+                            $valueOne,
+                            $valueTwo,
                         )
                     )
                 ),
@@ -303,7 +313,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     value GT One
                 //
                 // The result should contain Content Two.
-                new Field( "data", Operator::GT, $this->getSearchTargetValueOne() ),
+                new Field( "data", Operator::GT, $valueOne ),
                 false,
                 true,
             ),
@@ -315,7 +325,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     NOT( value GT One )
                 //
                 // The result should contain Content One.
-                new LogicalNot( new Field( "data", Operator::GT, $this->getSearchTargetValueOne() ) ),
+                new LogicalNot( new Field( "data", Operator::GT, $valueOne ) ),
                 true,
                 false,
             ),
@@ -327,7 +337,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     value GT Two
                 //
                 // The result should be empty.
-                new Field( "data", Operator::GT, $this->getSearchTargetValueTwo() ),
+                new Field( "data", Operator::GT, $valueTwo ),
                 false,
                 false,
             ),
@@ -339,7 +349,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     NOT( value GT Two )
                 //
                 // The result should contain both Content One and Content Two.
-                new LogicalNot( new Field( "data", Operator::GT, $this->getSearchTargetValueTwo() ) ),
+                new LogicalNot( new Field( "data", Operator::GT, $valueTwo ) ),
                 true,
                 true,
             ),
@@ -351,7 +361,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     value GTE One
                 //
                 // The result should contain both Content One and Content Two.
-                new Field( "data", Operator::GTE, $this->getSearchTargetValueOne() ),
+                new Field( "data", Operator::GTE, $valueOne ),
                 true,
                 true,
             ),
@@ -363,7 +373,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     NOT( value GTE One )
                 //
                 // The result should be empty.
-                new LogicalNot( new Field( "data", Operator::GTE, $this->getSearchTargetValueOne() ) ),
+                new LogicalNot( new Field( "data", Operator::GTE, $valueOne ) ),
                 false,
                 false,
             ),
@@ -375,7 +385,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     value GTE Two
                 //
                 // The result should contain Content Two.
-                new Field( "data", Operator::GTE, $this->getSearchTargetValueTwo() ),
+                new Field( "data", Operator::GTE, $valueTwo ),
                 false,
                 true,
             ),
@@ -387,7 +397,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     NOT( value GTE Two )
                 //
                 // The result should contain Content One.
-                new LogicalNot( new Field( "data", Operator::GTE, $this->getSearchTargetValueTwo() ) ),
+                new LogicalNot( new Field( "data", Operator::GTE, $valueTwo ) ),
                 true,
                 false,
             ),
@@ -399,7 +409,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     value LT One
                 //
                 // The result should be empty.
-                new Field( "data", Operator::LT, $this->getSearchTargetValueOne() ),
+                new Field( "data", Operator::LT, $valueOne ),
                 false,
                 false,
             ),
@@ -411,7 +421,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     NOT( value LT One )
                 //
                 // The result should contain both Content One and Content Two.
-                new LogicalNot( new Field( "data", Operator::LT, $this->getSearchTargetValueOne() ) ),
+                new LogicalNot( new Field( "data", Operator::LT, $valueOne ) ),
                 true,
                 true,
             ),
@@ -423,7 +433,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     value LT Two
                 //
                 // The result should contain Content One.
-                new Field( "data", Operator::LT, $this->getSearchTargetValueTwo() ),
+                new Field( "data", Operator::LT, $valueTwo ),
                 true,
                 false,
             ),
@@ -435,7 +445,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     NOT( value LT Two )
                 //
                 // The result should contain Content Two.
-                new LogicalNot( new Field( "data", Operator::LT, $this->getSearchTargetValueTwo() ) ),
+                new LogicalNot( new Field( "data", Operator::LT, $valueTwo ) ),
                 false,
                 true,
             ),
@@ -447,7 +457,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     value LTE One
                 //
                 // The result should contain Content One.
-                new Field( "data", Operator::LTE, $this->getSearchTargetValueOne() ),
+                new Field( "data", Operator::LTE, $valueOne ),
                 true,
                 false,
             ),
@@ -459,7 +469,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     NOT( value LTE One )
                 //
                 // The result should contain Content Two.
-                new LogicalNot( new Field( "data", Operator::LTE, $this->getSearchTargetValueOne() ) ),
+                new LogicalNot( new Field( "data", Operator::LTE, $valueOne ) ),
                 false,
                 true,
             ),
@@ -471,7 +481,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     value LTE Two
                 //
                 // The result should contain both Content One and Content Two.
-                new Field( "data", Operator::LTE, $this->getSearchTargetValueTwo() ),
+                new Field( "data", Operator::LTE, $valueTwo ),
                 true,
                 true,
             ),
@@ -483,7 +493,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     NOT( value LTE Two )
                 //
                 // The result should be empty.
-                new LogicalNot( new Field( "data", Operator::LTE, $this->getSearchTargetValueTwo() ) ),
+                new LogicalNot( new Field( "data", Operator::LTE, $valueTwo ) ),
                 false,
                 false,
             ),
@@ -499,8 +509,8 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                     "data",
                     Operator::BETWEEN,
                     array(
-                        $this->getSearchTargetValueOne(),
-                        $this->getSearchTargetValueTwo(),
+                        $valueOne,
+                        $valueTwo,
                     )
                 ),
                 true,
@@ -519,8 +529,8 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                         "data",
                         Operator::BETWEEN,
                         array(
-                            $this->getSearchTargetValueOne(),
-                            $this->getSearchTargetValueTwo(),
+                            $valueOne,
+                            $valueTwo,
                         )
                     )
                 ),
@@ -539,8 +549,8 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                     "data",
                     Operator::BETWEEN,
                     array(
-                        $this->getSearchTargetValueTwo(),
-                        $this->getSearchTargetValueOne(),
+                        $valueTwo,
+                        $valueOne,
                     )
                 ),
                 false,
@@ -559,8 +569,8 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                         "data",
                         Operator::BETWEEN,
                         array(
-                            $this->getSearchTargetValueTwo(),
-                            $this->getSearchTargetValueOne(),
+                            $valueTwo,
+                            $valueOne,
                         )
                     )
                 ),
@@ -575,7 +585,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     value CONTAINS One
                 //
                 // The result should contain Content One.
-                new Field( "data", Operator::CONTAINS, $this->getSearchTargetValueOne() ),
+                new Field( "data", Operator::CONTAINS, $valueOne ),
                 true,
                 false,
             ),
@@ -587,7 +597,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     NOT( value CONTAINS One )
                 //
                 // The result should contain Content Two.
-                new LogicalNot( new Field( "data", Operator::CONTAINS, $this->getSearchTargetValueOne() ) ),
+                new LogicalNot( new Field( "data", Operator::CONTAINS, $valueOne ) ),
                 false,
                 true,
             ),
@@ -599,7 +609,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //     value CONTAINS Two
                 //
                 // The result should contain Content Two.
-                new Field( "data", Operator::CONTAINS, $this->getSearchTargetValueTwo() ),
+                new Field( "data", Operator::CONTAINS, $valueTwo ),
                 false,
                 true,
             ),
@@ -612,7 +622,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 //
                 // The result should contain Content One.
                 new LogicalNot(
-                    new Field( "data", Operator::CONTAINS, $this->getSearchTargetValueTwo() )
+                    new Field( "data", Operator::CONTAINS, $valueTwo )
                 ),
                 true,
                 false,
@@ -702,6 +712,152 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
     }
 
     /**
+     * Asserts search result for modified field
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param boolean $includesOne
+     * @param boolean $includesTwo
+     * @param array $context
+     * @param boolean $filter
+     * @param string $fieldName
+     */
+    public function assertFilterContentModifiedField(
+        Criterion $criterion,
+        $includesOne,
+        $includesTwo,
+        array $context,
+        $filter,
+        $fieldName
+    )
+    {
+        $this->modifyFieldCriterion( $criterion, $fieldName );
+
+        list( $repository, $contentOneId, $contentTwoId ) = $context;
+        $searchResult = $this->findContent( $repository, $criterion, $filter );
+
+        $this->assertFindResult( $searchResult, $includesOne, $includesTwo, $contentOneId, $contentTwoId );
+    }
+
+    /**
+     * Tests Content Search sort with Field sort clause on a field of specific field type
+     *
+     * @dataProvider sortClauseProvider
+     * @depends testCreateTestContent
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause
+     * @param boolean $ascending
+     * @param array $context
+     * @param string $fieldName
+     */
+    public function assertSortContentModifiedField(
+        SortClause $sortClause,
+        $ascending,
+        array $context,
+        $fieldName
+    )
+    {
+        $setupFactory = $this->getSetupFactory();
+
+        if ( $setupFactory instanceof LegacySolr )
+        {
+            $this->markTestSkipped(
+                "For Solr engine Field sort clause is not yet implemented"
+            );
+        }
+
+        $this->modifyFieldSortClause( $sortClause, $fieldName );
+
+        list( $repository, $contentOneId, $contentTwoId ) = $context;
+        $searchResult = $this->sortContent( $repository, $sortClause );
+
+        $this->assertSortResult( $searchResult, $ascending, $contentOneId, $contentTwoId );
+    }
+
+    /**
+     * Sets given custom field $fieldName on a Field criteria.
+     *
+     * $fieldName refers to additional field (to the default field) defined in Indexable definition,
+     * and is resolved using FieldNameResolver.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param string $fieldName
+     */
+    protected function modifyFieldCriterion( Criterion $criterion, $fieldName )
+    {
+        $setupFactory = $this->getSetupFactory();
+        /** @var \Symfony\Component\DependencyInjection\ContainerBuilder $container */
+        $container = $setupFactory->getServiceContainer()->getInnerContainer();
+
+        /** @var \eZ\Publish\Core\Search\Common\FieldNameResolver $fieldNameResolver */
+        $fieldNameResolver = $container->get( "ezpublish.search.common.field_name_resolver" );
+        $resolvedFieldNames = $fieldNameResolver->getFieldNames(
+            $criterion,
+            "data",
+            $this->getTypeName(),
+            $fieldName
+        );
+        $resolvedFieldName = reset( $resolvedFieldNames );
+        $criterion = array( $criterion );
+
+        $this->doModifyField( $criterion, $resolvedFieldName );
+    }
+
+    /**
+     * Sets given custom field $fieldName on a Field sort clause.
+     *
+     * $fieldName refers to additional field (to the default field) defined in Indexable definition,
+     * and is resolved using FieldNameResolver.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
+     * @param string $fieldName
+     */
+    protected function modifyFieldSortClause( SortClause $sortClause, $fieldName )
+    {
+        $setupFactory = $this->getSetupFactory();
+        /** @var \Symfony\Component\DependencyInjection\ContainerBuilder $container */
+        $container = $setupFactory->getServiceContainer()->getInnerContainer();
+
+        /** @var \eZ\Publish\Core\Search\Common\FieldNameResolver $fieldNameResolver */
+        $fieldNameResolver = $container->get( "ezpublish.search.common.field_name_resolver" );
+        $resolvedFieldName = $fieldNameResolver->getSortFieldName(
+            $sortClause,
+            "test-" . $this->getTypeName(),
+            "data",
+            $fieldName
+        );
+        $sortClause = array( $sortClause );
+
+        $this->doModifyField( $sortClause, $resolvedFieldName );
+    }
+
+    /**
+     * Sets given custom field $fieldName on a Field criteria or sort clauses.
+     *
+     * Implemented separately to utilize recursion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion[]|\eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $criteriaOrSortClauses
+     * @param string $fieldName
+     */
+    protected function doModifyField( array $criteriaOrSortClauses, $fieldName )
+    {
+        foreach ( $criteriaOrSortClauses as $criterionOrSortClause )
+        {
+            if ( $criterionOrSortClause instanceof LogicalOperator )
+            {
+                $this->doModifyField( $criterionOrSortClause->criteria, $fieldName );
+            }
+            else if ( $criterionOrSortClause instanceof CustomFieldInterface )
+            {
+                $criterionOrSortClause->setCustomField(
+                    "test-" . $this->getTypeName(),
+                    "data",
+                    $fieldName
+                );
+            }
+        }
+    }
+
+    /**
      * Tests Content Search querying with Field criterion on a field of specific field type
      *
      * @dataProvider criteriaProvider
@@ -742,7 +898,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
         if ( $setupFactory instanceof LegacySolr )
         {
             $this->markTestSkipped(
-                "For Solr engine fields are not searchable with Location Search"
+                "For Solr engine Field sort clause is not yet implemented"
             );
         }
 

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchableImage.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchableImage.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\API\Repository\Tests\FieldType;
+
+use eZ\Publish\Core\FieldType\Image\Type;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+
+/**
+ * Image field type is not searchable in Legacy search engine, but will
+ * be searchable with Solr and Elasticsearch search engines.
+ *
+ * This is implementation simply extends the original implementation in order to
+ * define the field type as searchable, so that it can be tested.
+ */
+class SearchableImage extends Type
+{
+    public function isSearchable()
+    {
+        return true;
+    }
+
+    static protected function checkValueType( $value )
+    {
+        $fieldTypeFQN = "eZ\\Publish\\Core\\FieldType\\Image\\Value";
+        $valueFQN = substr_replace( $fieldTypeFQN, "Value", strrpos( $fieldTypeFQN, "\\" ) + 1 );
+
+        if ( !$value instanceof $valueFQN )
+        {
+            throw new InvalidArgumentType( "\$value", $valueFQN, $value );
+        }
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/SetupFactory/LegacyElasticsearch.php
+++ b/eZ/Publish/API/Repository/Tests/SetupFactory/LegacyElasticsearch.php
@@ -39,7 +39,7 @@ class LegacyElasticsearch extends Legacy
         return $repository;
     }
 
-    protected function getServiceContainer()
+    public function getServiceContainer()
     {
         if ( !isset( self::$serviceContainer ) )
         {

--- a/eZ/Publish/API/Repository/Tests/SetupFactory/LegacySolr.php
+++ b/eZ/Publish/API/Repository/Tests/SetupFactory/LegacySolr.php
@@ -39,7 +39,7 @@ class LegacySolr extends Legacy
         return $repository;
     }
 
-    protected function getServiceContainer()
+    public function getServiceContainer()
     {
         if ( !isset( self::$serviceContainer ) )
         {

--- a/eZ/Publish/Core/FieldType/Image/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Image/SearchField.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\FieldType\Image;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\FieldType\Indexable;
+use eZ\Publish\SPI\Search;
+
+/**
+ * Indexable definition for TextLine field type
+ */
+class SearchField implements Indexable
+{
+    /**
+     * Get index data for field for search backend
+     *
+     * @param Field $field
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    public function getIndexData( Field $field )
+    {
+        return array(
+            new Search\Field(
+                "filename",
+                $field->value->data["fileName"],
+                new Search\FieldType\StringField()
+            ),
+            new Search\Field(
+                "alternative_text",
+                $field->value->data["alternativeText"],
+                new Search\FieldType\StringField()
+            ),
+            new Search\Field(
+                "file_size",
+                $field->value->data["fileSize"],
+                new Search\FieldType\IntegerField()
+            ),
+        );
+    }
+
+    /**
+     * Get index field types for search backend
+     *
+     * @return \eZ\Publish\SPI\Search\FieldType[]
+     */
+    public function getIndexDefinition()
+    {
+        return array(
+            "filename" => new Search\FieldType\StringField(),
+            "alternative_text" => new Search\FieldType\StringField(),
+            "file_size" => new Search\FieldType\IntegerField(),
+        );
+    }
+
+    /**
+     * Get name of the default field to be used for query and sort.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for query and sort. Default field is typically used by Field
+     * criterion and sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultField()
+    {
+        return "filename";
+    }
+}

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/Field/FieldRange.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/Field/FieldRange.php
@@ -105,7 +105,7 @@ class FieldRange extends Field
 
         $fieldFilter = $this->getFieldFilter( $fieldFilters );
 
-        if ( $fieldFilters !== null )
+        if ( $fieldFilter !== null )
         {
             $filter["nested"]["filter"] = array(
                 "and" => array(

--- a/eZ/Publish/Core/settings/indexable_fieldtypes.yml
+++ b/eZ/Publish/Core/settings/indexable_fieldtypes.yml
@@ -4,6 +4,7 @@ parameters:
     ezpublish.fieldType.indexable.ezboolean.class: eZ\Publish\Core\FieldType\Checkbox\SearchField
     ezpublish.fieldType.indexable.ezdatetime.class: eZ\Publish\Core\FieldType\DateAndTime\SearchField
     ezpublish.fieldType.indexable.ezemail.class: eZ\Publish\Core\FieldType\EmailAddress\SearchField
+    ezpublish.fieldType.indexable.ezimage.class: eZ\Publish\Core\FieldType\Image\SearchField
     ezpublish.fieldType.indexable.ezprice.class: eZ\Publish\Core\FieldType\Price\SearchField
     ezpublish.fieldType.indexable.ezgmaplocation.class: eZ\Publish\Core\FieldType\MapLocation\SearchField
     ezpublish.fieldType.indexable.ezcountry.class: eZ\Publish\Core\FieldType\Country\SearchField
@@ -47,6 +48,11 @@ services:
         tags:
             - {name: ezpublish.fieldType.indexable, alias: ezemail}
 
+    ezpublish.fieldType.indexable.ezimage:
+        class: %ezpublish.fieldType.indexable.ezimage.class%
+        tags:
+            - {name: ezpublish.fieldType.indexable, alias: ezimage}
+
     ezpublish.fieldType.indexable.eztext:
         class: %ezpublish.fieldType.indexable.eztext.class%
         tags:
@@ -84,7 +90,6 @@ services:
         class: %ezpublish.fieldType.indexable.unindexed.class%
         tags:
             - {name: ezpublish.fieldType.indexable, alias: ezuser}
-            - {name: ezpublish.fieldType.indexable, alias: ezimage}
             - {name: ezpublish.fieldType.indexable, alias: ezkeyword}
             - {name: ezpublish.fieldType.indexable, alias: ezdate}
             - {name: ezpublish.fieldType.indexable, alias: eztime}

--- a/eZ/Publish/Core/settings/tests/integration_legacy_elasticsearch.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy_elasticsearch.yml
@@ -2,6 +2,9 @@ parameters:
     # Redefining default ezfloat field type class with the implementation that defines the type
     # as searchable. Needed in order to test searching wiht Elasticsearch engine.
     ezpublish.fieldType.ezfloat.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableFloat
+    # Redefining default ezimage field type class with the implementation that defines the type
+    # as searchable. Needed in order to test searching wiht Elasticsearch engine.
+    ezpublish.fieldType.ezimage.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableImage
     languages:
         - eng-US
         - eng-GB

--- a/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
@@ -2,6 +2,9 @@ parameters:
     # Redefining default ezfloat field type class with the implementation that defines the type
     # as searchable. Needed in order to test searching wiht Solr engine.
     ezpublish.fieldType.ezfloat.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableFloat
+    # Redefining default ezimage field type class with the implementation that defines the type
+    # as searchable. Needed in order to test searching wiht Solr engine.
+    ezpublish.fieldType.ezimage.class: eZ\Publish\API\Repository\Tests\FieldType\SearchableImage
     languages:
         - eng-US
         - eng-GB


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24275

A subtask of https://jira.ez.no/browse/EZP-24232

Additionally to the file name, which is the default value used by Field criterion and sort clause, Image field type also indexes alternative text and file size. These can be targeted by using `CustomFieldInterface:: setCustomField()` method. Test framework is here refactored to allow testing of these custom fields. However this is a bit awkward, and calls for a refactoring to make testing simpler for the new implementations.

Since not all searchable field types have Indexable definition implemented, this required `FileSearchBaseIntegrationTest`. This is temporary and will be removed when all searchable field types are covered.

Dedicated methods to provide Field search target value was needed, this was taken from https://github.com/ezsystems/ezpublish-kernel/pull/1230.

Solr's base `CriterionVisitor` now implements `prepareValue()` method, which is used to convert and escape the search target value to the proper Solr representation. This is taken from https://github.com/ezsystems/ezpublish-kernel/pull/1229.

#### Additional fixes

Small bug in Elasticsearch's `FieldRange` criterion visitor, where wrong variable was checked, causing `null` to be used as a filter in case when there are no field filters defined. This did not affect the behavior as Elasticsearch seems to be tolerant to it.

#### Followups

1. https://jira.ez.no/browse/EZP-24310: Refactor field type search integration tests to better support custom fields