### PR TITLE
EZP-24179: Added [Experimental] Location Search support to REST

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -2120,8 +2120,6 @@ Create View
 :Method:  POST
 :Description: executes a query and returns view including the results
               The View_ input reflects the criteria model of the public API.
-              The "type" attribute of the Query element in the ViewInput can be used to choose between a
-              Location ("location") or a Content ("content", the default) Query.
 :Headers:
     :Accept:
         :application/vnd.ez.api.View+xml: the view in xml format (see View_)
@@ -2129,6 +2127,10 @@ Create View
     :Content-Type:
         :application/vnd.ez.api.ViewInput+xml: the view input in xml format (see View_)
         :application/vnd.ez.api.ViewInput+json: the view input in json format (see View_)
+:Experimental:
+    :Query Type:
+        By default, the Query_ referenced in the ViewInput_ is considered as a Content Query. A Location Query
+        can be used by setting the Query's node "type" attribute to "location".
 :Response: 200 OK
            Note : when persistence will be implemented, it will change to 201 Created
 

--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -2120,6 +2120,8 @@ Create View
 :Method:  POST
 :Description: executes a query and returns view including the results
               The View_ input reflects the criteria model of the public API.
+              The "type" attribute of the Query element in the ViewInput can be used to choose between a
+              Location ("location") or a Content ("content", the default) Query.
 :Headers:
     :Accept:
         :application/vnd.ez.api.View+xml: the view in xml format (see View_)
@@ -2159,7 +2161,7 @@ Perform a query on images withing the media section, sorted by name, limiting re
     <?xml version="1.0" encoding="UTF-8"?>
     <ViewInput>
       <identifier>TitleView</identifier>
-      <Query>
+      <Query type="content">
         <Criteria>
           <ContentTypeIdentifierCriterion>image</ContentTypeIdentifierCriterion>
           <SectionIdentifierCriterion>media</SectionIdentifierCriterion>
@@ -7150,6 +7152,7 @@ View XML Schema
       </xsd:complexType>
 
       <xsd:complexType name="queryType">
+        <xsd:attribute name="type" type="xsd:string" default="content"/>
         <xsd:all>
           <xsd:element name="Criterion" type="criterionType" />
           <xsd:element name="limit" type="xsd:int" />

--- a/eZ/Publish/Core/REST/Server/Controller/Content.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Content.php
@@ -9,11 +9,11 @@
 
 namespace eZ\Publish\Core\REST\Server\Controller;
 
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\Core\REST\Common\Message;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\Core\REST\Server\Values;
 use eZ\Publish\Core\REST\Server\Controller as RestController;
-
 use eZ\Publish\API\Repository\Values\Content\Relation;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
@@ -760,10 +760,20 @@ class Content extends RestController
                 $this->request->getContent()
             )
         );
+
+        if ( $viewInput->query instanceof LocationQuery )
+        {
+            $method = 'findLocations';
+        }
+        else
+        {
+            $method = 'findContent';
+        }
+
         return new Values\RestExecutedView(
             array(
                 'identifier'    => $viewInput->identifier,
-                'searchResults' => $this->repository->getSearchService()->findContent( $viewInput->query ),
+                'searchResults' => $this->repository->getSearchService()->$method( $viewInput->query ),
             )
         );
     }

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ViewInput.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ViewInput.php
@@ -37,28 +37,27 @@ class ViewInput extends CriterionParser
         $restViewInput = new RestViewInput();
 
         // identifier
-        if (!array_key_exists( 'identifier', $data )) {
+        if ( !array_key_exists( 'identifier', $data ) )
+        {
             throw new Exceptions\Parser( "Missing <identifier> attribute for <ViewInput>." );
         }
         $restViewInput->identifier = $data['identifier'];
 
         // query
-        if (!array_key_exists( 'Query', $data ) || !is_array( $data['Query'] )) {
+        if ( !array_key_exists( 'Query', $data ) || !is_array( $data['Query'] ) )
+        {
             throw new Exceptions\Parser( "Missing <Query> attribute for <ViewInput>." );
         }
 
-        if ( !isset( $data['Query']['_type'] ) || $data['Query']['_type'] == 'content' )
-        {
-            $query = new Query();
-        }
-        else if ( isset( $data['Query']['_type'] ) || $data['Query']['_type'] == 'location' )
+        if ( isset( $data['Query']['_type'] ) && $data['Query']['_type'] == 'location' )
         {
             $query = new LocationQuery();
         }
         else
         {
-            throw new Exceptions\Parser( "Unknown query type '{$data['Query']['_type']}'" );
+            $query = new Query();
         }
+
         $queryData = $data['Query'];
 
         // Criteria

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ViewInput.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ViewInput.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\Core\REST\Server\Input\Parser\Criterion as CriterionParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
@@ -36,19 +37,28 @@ class ViewInput extends CriterionParser
         $restViewInput = new RestViewInput();
 
         // identifier
-        if ( !array_key_exists( 'identifier', $data ) )
-        {
+        if (!array_key_exists( 'identifier', $data )) {
             throw new Exceptions\Parser( "Missing <identifier> attribute for <ViewInput>." );
         }
-        $restViewInput->identifier  = $data['identifier'];
+        $restViewInput->identifier = $data['identifier'];
 
         // query
-        if ( !array_key_exists( 'Query', $data ) || !is_array( $data['Query'] ) )
-        {
+        if (!array_key_exists( 'Query', $data ) || !is_array( $data['Query'] )) {
             throw new Exceptions\Parser( "Missing <Query> attribute for <ViewInput>." );
         }
 
-        $query = new Query();
+        if ( !isset( $data['Query']['_type'] ) || $data['Query']['_type'] == 'content' )
+        {
+            $query = new Query();
+        }
+        else if ( isset( $data['Query']['_type'] ) || $data['Query']['_type'] == 'location' )
+        {
+            $query = new LocationQuery();
+        }
+        else
+        {
+            throw new Exceptions\Parser( "Unknown query type '{$data['Query']['_type']}'" );
+        }
         $queryData = $data['Query'];
 
         // Criteria

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestExecutedView.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestExecutedView.php
@@ -135,7 +135,8 @@ class RestExecutedView extends ValueObjectVisitor
         {
             return $this->mapContentSearchHit( $searchHit->valueObject );
         }
-        else if ( $searchHit->valueObject instanceof Location )
+
+        if ( $searchHit->valueObject instanceof Location )
         {
             return $this->mapLocationSearchHit( $searchHit->valueObject );
         }

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestExecutedView.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestExecutedView.php
@@ -9,6 +9,9 @@
 
 namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
@@ -16,6 +19,7 @@ use eZ\Publish\Core\REST\Server\Values\RestContent as RestContentValue;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\Core\REST\Server\Values\RestLocation;
 
 /**
  * Section value object visitor
@@ -109,16 +113,7 @@ class RestExecutedView extends ValueObjectVisitor
 
             $generator->startObjectElement( 'value' );
 
-            /** @var \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo */
-            $contentInfo = $searchHit->valueObject->contentInfo;
-            $restContent = new RestContentValue(
-                $contentInfo,
-                $this->locationService->loadLocation( $contentInfo->mainLocationId ),
-                $searchHit->valueObject,
-                $this->contentTypeService->loadContentType( $contentInfo->contentTypeId ),
-                $this->contentService->loadRelations( $searchHit->valueObject->getVersionInfo() )
-            );
-            $visitor->visitValueObject( $restContent );
+            $visitor->visitValueObject( $this->mapSearchHit( $searchHit ) );
             $generator->endObjectElement( 'value' );
             $generator->endObjectElement( 'searchHit' );
         }
@@ -133,5 +128,38 @@ class RestExecutedView extends ValueObjectVisitor
 
         $generator->endObjectElement( 'View' );
     }
-}
 
+    private function mapSearchHit( SearchHit $searchHit )
+    {
+        if ( $searchHit->valueObject instanceof Content )
+        {
+            return $this->mapContentSearchHit( $searchHit->valueObject );
+        }
+        else if ( $searchHit->valueObject instanceof Location )
+        {
+            return $this->mapLocationSearchHit( $searchHit->valueObject );
+        }
+    }
+
+    /**
+     * @return RestContent
+     */
+    private function mapContentSearchHit( Content $content )
+    {
+        return new RestContentValue(
+            $content->contentInfo,
+            $this->locationService->loadLocation( $content->contentInfo->mainLocationId ),
+            $content,
+            $this->contentTypeService->loadContentType( $content->contentInfo->contentTypeId ),
+            $this->contentService->loadRelations( $content->getVersionInfo() )
+        );
+    }
+
+    /**
+     * @return RestLocation
+     */
+    private function mapLocationSearchHit( Location $location )
+    {
+        return new RestLocation( $location, 0, true );
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Values/RestLocation.php
+++ b/eZ/Publish/Core/REST/Server/Values/RestLocation.php
@@ -32,12 +32,19 @@ class RestLocation extends RestValue
     public $childCount;
 
     /**
+     * @var bool
+     */
+    private $includeContentInfo;
+
+    /**
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location
      * @param int $childCount
+     * @param bool $includeContentInfo
      */
-    public function __construct( Location $location, $childCount )
+    public function __construct( Location $location, $childCount, $includeContentInfo )
     {
         $this->location = $location;
         $this->childCount = $childCount;
+        $this->includeContentInfo = $includeContentInfo;
     }
 }

--- a/eZ/Publish/Core/REST/Server/Values/RestLocation.php
+++ b/eZ/Publish/Core/REST/Server/Values/RestLocation.php
@@ -32,19 +32,12 @@ class RestLocation extends RestValue
     public $childCount;
 
     /**
-     * @var bool
-     */
-    private $includeContentInfo;
-
-    /**
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location
      * @param int $childCount
-     * @param bool $includeContentInfo
      */
-    public function __construct( Location $location, $childCount, $includeContentInfo )
+    public function __construct( Location $location, $childCount )
     {
         $this->location = $location;
         $this->childCount = $childCount;
-        $this->includeContentInfo = $includeContentInfo;
     }
 }


### PR DESCRIPTION
> Status: work in progress
> http://jira.ez.no/browse/EZP-24179

The ViewInput payload supports an extra "type" attribute on the Query node.
It can be set to either 'content' (the default), to run a Content Search, or 'location' to run a Location Search.

The result with contain either Content or Location objects, instead of only Content before.

Example:

```sh
echo '<?xml version="1.0" encoding="UTF-8"?>
<ViewInput>
  <identifier>subitems</identifier>
  <Query type="location">
    <Criteria>
      <ParentLocationIdCriterion>2</ParentLocationIdCriterion>
    </Criteria>
    <limit>10</limit>
    <offset>0</offset>
    <SortClauses>
      <SortClause>
        <LocationPriority direction="desc" />
      </SortClause>
    </SortClauses>
  </Query>
</ViewInput>' | http POST http://ezplatform/api/ezp/v2/content/views Content-Type:application/vnd.ez.api.ViewInput+xml
```

Output: https://gist.github.com/bdunogier/b025e54f8164328c14fb.