### PR TITLE
Fix EZP-24158: Need to clear cache manually after platform install

### DIFF
--- a/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
@@ -21,6 +21,7 @@ services:
             - @database_connection
             - []
             - @cache_clearer
+            - @filesystem
             - %kernel.cache_dir%
         tags:
             - { name: console.command }


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-24158

Reproduced with ezpublish-docker VM.

*Context: This was the parts I skipped when I first added cache clearing by copying what CacheClearing command is doing, part still skipped is cache warmup. Maybe we could rather just reuse the cache clearing command here, afaik there is a way to do that but I don't remember how and I think I remember it being rather hackish looking but might be wrong.*