### PR TITLE
EZP-23550: Implement content/download

### DIFF
--- a/doc/specifications/proposed/content_download/content_download.md
+++ b/doc/specifications/proposed/content_download/content_download.md
@@ -1,0 +1,97 @@
+# Content download
+
+> Author: bd@ez.no
+
+## Summary
+This feature covers downloading of Content binary files over HTTP.
+
+It includes:
+- generation of a download link from a BinaryFile / Media Field,
+- permissions checking (the user must be allowed to read the Content)
+- streaming of the file over HTTP
+
+## Components
+
+### Route
+
+Path: `/content/download/{contentId}/{fieldIdentifier}/{filename}`
+
+Example: `/content/download/68/file/My-file.pdf`
+
+#### Arguments
+
+- contentId
+
+  ID of the Content the field is part of
+
+- fieldIdentifier
+
+  Field Definition identifier of the Binary / Media Field.
+
+- filename
+
+  Name of the file to send for download. Can be any valid file name.
+
+#### Query parameters
+
+- version (optional)
+
+  The version number the file must be downloaded for. Requires the versionview permission.
+  If not specified, the published version is used.
+
+- language (optional)
+
+  The language the file must be downloaded for.
+  If not specified, the prioritized languages list of the matched siteaccess is used.
+
+The controller action will load the content based on the content id, and identify the field using the identifier. The
+binary file referenced by the Field Value will then be streamed, using the active IO Service.
+
+It *should* also support HTTP caching, by making sure the proper headers are sent.
+
+It *could* support resuming (a *must* for media files).
+
+### Download link generation
+
+#### PHP/Twig
+The [Route Reference](https://doc.ez.no/display/EZP/RouteReference) mechanism will be used for this:
+
+```twig
+  {% set routeReference = ez_route( 'ez_content_download', {'content': content, 'fieldIdentifier': 'file' } ) %}
+  <a href="{{ path( routeReference ) }}">{{ binary_file_field.fileName }}</a>
+```
+
+##### Arguments
+
+The arguments are the same than the `ez_content_download` route.
+
+The only difference is that instead of providing the `contentId`, the route reference expects a `content`, as an API
+Content Value Object.
+
+#### REST
+An extra attribute will be added to Fields of BinaryFile/Media type: `downloadUri`. It will contain the download uri for
+the Field's contents.
+
+## Backward compatibility
+Since it is common practice to copy/save file download links, it is possible that a legacy link will be used on occasions.
+This can be covered by adding a route that matches the legacy route, and redirects to the new route:
+
+```
+/content/download/123/45678/version/6/file/bc.pdf
+```
+
+would be redirected to
+
+```
+/content/download/123/file_field/bc.pdf?version=6
+```
+
+
+## Options
+
+### IgorwFileServeBundle
+
+> https://github.com/igorw/IgorwFileServeBundle
+
+A package meant to replace the BinaryResponse we currently use. Supports server-side mechanism such as X-SendFile, but
+seems to be stalled a bit.

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ContentDownloadRouteReferenceListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ContentDownloadRouteReferenceListener.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\EventListener;
+
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\Helper\TranslationHelper;
+use eZ\Publish\Core\MVC\Symfony\Event\RouteReferenceGenerationEvent;
+use eZ\Publish\Core\MVC\Symfony\MVCEvents;
+use InvalidArgumentException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ContentDownloadRouteReferenceListener implements EventSubscriberInterface
+{
+    const ROUTE_NAME = 'ez_content_download';
+    const OPT_FIELD_IDENTIFIER = 'fieldIdentifier';
+    const OPT_CONTENT = 'content';
+    const OPT_CONTENT_ID = 'contentId';
+    const OPT_DOWNLOAD_NAME = 'filename';
+    const OPT_LANGUAGE = 'language';
+    const OPT_VERSION = 'version';
+
+    /** @var \eZ\Publish\Core\Helper\TranslationHelper */
+    private $translationHelper;
+
+    public function __construct( TranslationHelper $translationHelper )
+    {
+        $this->translationHelper = $translationHelper;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            MVCEvents::ROUTE_REFERENCE_GENERATION => 'onRouteReferenceGeneration'
+        );
+    }
+
+    /**
+     * @throws \InvalidArgumentException If the required arguments are not correct
+     */
+    public function onRouteReferenceGeneration( RouteReferenceGenerationEvent $event )
+    {
+        $routeReference = $event->getRouteReference();
+
+        if ( $routeReference->getRoute() != self::ROUTE_NAME )
+        {
+            return;
+        }
+
+        $options = $routeReference->getParams();
+
+        $resolver = new OptionsResolver();
+        $this->configureOptions( $resolver );
+        $options = $resolver->resolve( $options );
+
+        if ( isset( $options[self::OPT_LANGUAGE]) )
+        {
+            $routeReference->set( self::OPT_LANGUAGE, $options[self::OPT_LANGUAGE] );
+        }
+
+        if ( isset( $options[self::OPT_VERSION] ) )
+        {
+            $routeReference->set( self::OPT_VERSION, $options[self::OPT_VERSION] );
+        }
+
+        $routeReference->set( self::OPT_CONTENT_ID, $options[self::OPT_CONTENT_ID] );
+        $routeReference->set( self::OPT_DOWNLOAD_NAME, $options[self::OPT_DOWNLOAD_NAME] );
+    }
+
+    /**
+     * @param $resolver
+     */
+    protected function configureOptions( OptionsResolver $resolver )
+    {
+        $resolver->setRequired( [ self::OPT_CONTENT, self::OPT_FIELD_IDENTIFIER ] );
+        $resolver->setDefaults( [ self::OPT_VERSION => null, self::OPT_LANGUAGE => null ] );
+        $resolver->setAllowedTypes( self::OPT_CONTENT, 'eZ\Publish\API\Repository\Values\Content\Content' );
+        $resolver->setAllowedTypes( self::OPT_FIELD_IDENTIFIER, 'string' );
+        $resolver->setDefault(
+            self::OPT_CONTENT_ID,
+            function ( Options $options )
+            {
+                return $options[self::OPT_CONTENT]->id;
+            }
+        );
+
+        $resolver->setDefault(
+            self::OPT_DOWNLOAD_NAME,
+            function( Options $options )
+            {
+                $field = $this->translationHelper->getTranslatedField(
+                    $options[self::OPT_CONTENT],
+                    $options[self::OPT_FIELD_IDENTIFIER],
+                    $options[self::OPT_LANGUAGE]
+                );
+                if ( !$field instanceof Field )
+                {
+                    throw new InvalidArgumentException(
+                        sprintf(
+                            "The '%s' parameter did not match a known Field",
+                            self::OPT_FIELD_IDENTIFIER
+                        )
+                    );
+                }
+                return $field->value->fileName;
+            }
+        );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
@@ -17,6 +17,7 @@ parameters:
     ezpublish.route_reference.generator.class: eZ\Publish\Core\MVC\Symfony\Routing\Generator\RouteReferenceGenerator
     ezpublish.route_reference.listener.language_switch.class: eZ\Publish\Core\MVC\Symfony\EventListener\LanguageSwitchListener
     ezpublish.original_request_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\OriginalRequestListener
+    ezpublish.route_reference.listener.content_download.class: eZ\Bundle\EzPublishCoreBundle\EventListener\ContentDownloadRouteReferenceListener
 
 services:
     ezpublish.chain_router:
@@ -120,3 +121,9 @@ services:
         class: %ezpublish.original_request_listener.class%
         tags:
             - { name: kernel.event_subscriber }
+
+    ezpublish.route_reference.listener.content_download:
+        class: eZ\Bundle\EzPublishCoreBundle\EventListener\ContentDownloadRouteReferenceListener
+        tags:
+            - { name: kernel.event_subscriber }
+        arguments: [@ezpublish.translation_helper]

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
@@ -18,3 +18,7 @@ _ezpublishPreviewContentDefaultSa:
 
 _ez_user_hash:
     path: /_fos_user_context_hash
+
+ez_content_download:
+    path: /content/download/{contentId}/{fieldIdentifier}/{filename}
+    defaults: { _controller: ezpublish.controller.content.download:downloadBinaryFileAction }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -8,6 +8,7 @@ parameters:
     ezpublish.controller.base.class: eZ\Publish\Core\MVC\Symfony\Controller\Controller
     ezpublish.controller.content.view.class: eZ\Publish\Core\MVC\Symfony\Controller\Content\ViewController
     ezpublish.controller.content.preview.class: eZ\Publish\Core\MVC\Symfony\Controller\Content\PreviewController
+    ezpublish.controller.content.download.class: eZ\Publish\Core\MVC\Symfony\Controller\Content\DownloadController
     ezpublish.controller.page.view.class: eZ\Bundle\EzPublishCoreBundle\Controller\PageController
 
     # Param converters
@@ -77,6 +78,13 @@ services:
 
     ezpublish.controller.content.preview:
         alias: ezpublish.controller.content.preview.core
+
+    ezpublish.controller.content.download:
+        class: %ezpublish.controller.content.download.class%
+        arguments:
+            - @ezpublish.api.service.content
+            - @ezpublish.fieldType.ezbinaryfile.io_service
+        parent: ezpublish.controller.base
 
     ezpublish.controller.page.view:
         class: %ezpublish.controller.page.view.class%

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -201,14 +201,11 @@
 {% endspaceless %}
 {% endblock %}
 
-{# @todo: handle the unit of the fileSize (si operator in legacy template engine) #}
 {% block ezbinaryfile_field %}
 {% spaceless %}
     {% if not ez_is_field_empty( content, field ) %}
-        {% set uri = 'content/download/' ~ contentInfo.id ~ '/' ~ field.id
-                        ~ '/version/' ~ contentInfo.currentVersionNo ~  "/file/"
-                        ~ field.value.fileName|escape( 'url' ) %}
-        <a href="{{ path( 'ez_legacy', {'module_uri': uri} ) }}"
+        {% set route_reference = ez_route( 'ez_content_download', { 'content': content, 'fieldIdentifier': field.fieldDefIdentifier } ) %}
+        <a href="{{ path( route_reference ) }}"
             {{ block( 'field_attributes' ) }}>{{ field.value.fileName }}</a>&nbsp;({{ field.value.fileSize|ez_file_size( 1 ) }})
     {% endif %}
 {% endspaceless %}
@@ -219,9 +216,8 @@
 {% spaceless %}
     {% set type = fieldSettings.mediaType %}
     {% set value = field.value %}
-    {% set uri = 'content/download/' ~ contentInfo.id ~ '/' ~ field.id
-                    ~ '/' ~ value.fileName|escape( 'url' ) %}
-    {% set download = path( 'ez_legacy', {'module_uri': uri } ) %}
+    {% set route_reference = ez_route( 'ez_content_download', {'content': content, 'fieldIdentifier': field.fieldDefIdentifier} ) %}
+    {% set download = path( route_reference ) %}
     {% set width = value.width > 0 ? 'width="' ~ value.width ~ '"' : "" %}
     {% set height = value.height > 0 ? 'height="' ~ value.height ~ '"' : "" %}
     <div {{ block( 'field_attributes' ) }}>

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ContentDownloadRouteReferenceListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ContentDownloadRouteReferenceListenerTest.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;
+
+use eZ\Bundle\EzPublishCoreBundle\EventListener\ContentDownloadRouteReferenceListener;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\FieldType\BinaryFile\Value as BinaryFileValue;
+use eZ\Publish\Core\MVC\Symfony\Event\RouteReferenceGenerationEvent;
+use eZ\Publish\Core\MVC\Symfony\Routing\RouteReference;
+use eZ\Publish\Core\Repository\Values\Content\Content;
+use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use PHPUnit_Framework_TestCase;
+use stdClass;
+use Symfony\Component\HttpFoundation\Request;
+
+class ContentDownloadRouteReferenceListenerTest extends PHPUnit_Framework_TestCase
+{
+    /** @var \eZ\Publish\Core\Helper\TranslationHelper|\PHPUnit_Framework_MockObject_MockObject */
+    protected $translationHelperMock;
+
+    public function setUp()
+    {
+        $this->translationHelperMock = $this
+            ->getMockBuilder( 'eZ\Publish\Core\Helper\TranslationHelper' )
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function testIgnoresOtherRoutes()
+    {
+        $routeReference = new RouteReference( 'some_route' );
+        $event = new RouteReferenceGenerationEvent( $routeReference, new Request() );
+        $eventListener = $this->getListener();
+
+        $eventListener->onRouteReferenceGeneration( $event );
+
+        self::assertEquals( 'some_route', $routeReference->getRoute() );
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testThrowsExceptionOnBadContentParameter()
+    {
+        $routeReference = new RouteReference(
+            ContentDownloadRouteReferenceListener::ROUTE_NAME,
+            [
+                ContentDownloadRouteReferenceListener::OPT_CONTENT => new stdClass(),
+                ContentDownloadRouteReferenceListener::OPT_FIELD_IDENTIFIER => null
+            ]
+        );
+        $event = new RouteReferenceGenerationEvent( $routeReference, new Request() );
+        $eventListener = $this->getListener();
+
+        $eventListener->onRouteReferenceGeneration( $event );
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testThrowsExceptionOnBadFieldIdentifier()
+    {
+        $content = new Content(
+            [
+                'internalFields' => [],
+                'versionInfo' => new VersionInfo(
+                    [
+                        'contentInfo' => new ContentInfo( ['mainLanguageCode' => 'eng-GB'] )
+                    ]
+                )
+            ]
+        );
+
+        $routeReference = new RouteReference(
+            ContentDownloadRouteReferenceListener::ROUTE_NAME,
+            [
+                ContentDownloadRouteReferenceListener::OPT_CONTENT => $content,
+                ContentDownloadRouteReferenceListener::OPT_FIELD_IDENTIFIER => 'field'
+            ]
+        );
+        $event = new RouteReferenceGenerationEvent( $routeReference, new Request() );
+        $eventListener = $this->getListener();
+
+        $eventListener->onRouteReferenceGeneration( $event );
+    }
+
+    public function testGeneratesCorrectRouteReference()
+    {
+        $content = $this->getCompleteContent();
+
+        $routeReference = new RouteReference(
+            ContentDownloadRouteReferenceListener::ROUTE_NAME,
+            [
+                ContentDownloadRouteReferenceListener::OPT_CONTENT => $content,
+                ContentDownloadRouteReferenceListener::OPT_FIELD_IDENTIFIER => 'file'
+            ]
+        );
+        $event = new RouteReferenceGenerationEvent( $routeReference, new Request() );
+        $eventListener = $this->getListener();
+
+        $this
+            ->translationHelperMock
+            ->expects( $this->once() )
+            ->method( 'getTranslatedField' )
+            ->will( $this->returnValue( $content->getField( 'file', 'eng-GB' ) ) );
+        $eventListener->onRouteReferenceGeneration( $event );
+
+        self::assertEquals( '42', $routeReference->get( ContentDownloadRouteReferenceListener::OPT_CONTENT_ID ) );
+        self::assertEquals( 'file', $routeReference->get( ContentDownloadRouteReferenceListener::OPT_FIELD_IDENTIFIER ) );
+        self::assertEquals( 'Test-file.pdf', $routeReference->get( ContentDownloadRouteReferenceListener::OPT_DOWNLOAD_NAME ) );
+    }
+
+    public function testDownloadNameOverrideWorks()
+    {
+        $content = $this->getCompleteContent();
+
+        $routeReference = new RouteReference(
+            ContentDownloadRouteReferenceListener::ROUTE_NAME,
+            [
+                ContentDownloadRouteReferenceListener::OPT_CONTENT => $content,
+                ContentDownloadRouteReferenceListener::OPT_FIELD_IDENTIFIER => 'file',
+                ContentDownloadRouteReferenceListener::OPT_DOWNLOAD_NAME => 'My-custom-filename.pdf'
+            ]
+        );
+        $event = new RouteReferenceGenerationEvent( $routeReference, new Request() );
+        $eventListener = $this->getListener();
+
+        $eventListener->onRouteReferenceGeneration( $event );
+
+        self::assertEquals( 'My-custom-filename.pdf', $routeReference->get( ContentDownloadRouteReferenceListener::OPT_DOWNLOAD_NAME ) );
+    }
+
+    /**
+     * @return \eZ\Publish\Core\Repository\Values\Content\Content
+     */
+    protected function getCompleteContent()
+    {
+        return new Content(
+            [
+                'internalFields' =>
+                    [
+                        new Field(
+                            [
+                                'fieldDefIdentifier' => 'file',
+                                'languageCode' => 'eng-GB',
+                                'value' => new BinaryFileValue( [ 'fileName' => 'Test-file.pdf' ] )
+                            ]
+                        )
+                    ],
+                'versionInfo' => new VersionInfo(
+                    [
+                        'contentInfo' => new ContentInfo( [ 'id' => 42, 'mainLanguageCode' => 'eng-GB' ] )
+                    ]
+                )
+            ]
+        );
+    }
+
+    protected function getListener()
+    {
+        return new ContentDownloadRouteReferenceListener( $this->translationHelperMock );
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Controller\Content;
+
+use eZ\Bundle\EzPublishIOBundle\BinaryStreamResponse;
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\Helper\TranslationHelper;
+use eZ\Publish\Core\IO\IOService;
+use eZ\Publish\Core\MVC\Symfony\Controller\Controller;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+
+class DownloadController extends Controller
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /** @var \eZ\Publish\Core\IO\IOService */
+    private $ioService;
+
+    /** @var \eZ\Publish\Core\Helper\TranslationHelper */
+    private $translationHelper;
+
+    public function __construct( ContentService $contentService, IOService $ioService, TranslationHelper $translationHelper )
+    {
+        $this->contentService = $contentService;
+        $this->ioService = $ioService;
+        $this->translationHelper = $translationHelper;
+    }
+
+    /**
+     * @param mixed $contentId ID of a valid Content
+     * @param string $fieldIdentifier Field Definition identifier of the Field the file must be downloaded from
+     * @param string $filename
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *
+     * @return \eZ\Bundle\EzPublishIOBundle\BinaryStreamResponse
+     */
+    public function downloadBinaryFileAction( $contentId, $fieldIdentifier, $filename, Request $request )
+    {
+        if ( $request->query->has( 'version' ) )
+        {
+            $content = $this->contentService->loadContent( $contentId, null, $request->query->get( 'version' ) );
+        }
+        else
+        {
+            $content = $this->contentService->loadContent( $contentId );
+        }
+
+        $field = $this->translationHelper->getTranslatedField(
+            $content, $fieldIdentifier,
+            $request->query->has( 'language' ) ? $request->query->get( 'language' ) : null
+        );
+        if ( !$field instanceof Field )
+        {
+            throw new InvalidArgumentException(
+                "'{$fieldIdentifier}' field not present on content #{$content->contentInfo->id} '{$content->contentInfo->name}'"
+            );
+        }
+
+        $response = new BinaryStreamResponse( $this->ioService->loadBinaryFile( $field->value->id ), $this->ioService );
+        $response->setContentDisposition( ResponseHeaderBag::DISPOSITION_ATTACHMENT, $filename );
+        return $response;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Routing/RouteReference.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/RouteReference.php
@@ -46,7 +46,7 @@ class RouteReference
     }
 
     /**
-     * @return \Symfony\Component\HttpFoundation\ParameterBag
+     * @return array
      */
     public function getParams()
     {


### PR DESCRIPTION
> http://jira.ez.no/browse/EZP-23550
> [specifications](https://github.com/ezsystems/ezpublish-kernel/blob/ezp23550-content_download/doc/specifications/proposed/content_download/content_download.md)

## TODO
- [x] Implement link generation
- [x] Update binaryfile in `content_fields.html.twig`
- [x] Update media in `content_fields.html.twig`
- [x] Handle `versionNumber` argument
- [x] Handle `downloadName` argument
- [ ] ~~Add a REST `downloadUri` property to BinaryFile and MediaFile responses~~
- [ ] ~~HTTP caching~~
- [x] Resume support (should be supported out of the box by `BinaryStreamResponse`)