### PR TITLE
Fix EZP-24347: Expose FieldType validation from API

### DIFF
--- a/eZ/Publish/API/Repository/FieldType.php
+++ b/eZ/Publish/API/Repository/FieldType.php
@@ -10,6 +10,9 @@
 
 namespace eZ\Publish\API\Repository;
 
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\SPI\FieldType\Value;
+
 /**
  * Interface that FieldTypes expose to the public API
  *
@@ -197,4 +200,38 @@ interface FieldType
      * @return mixed
      */
     public function validatorConfigurationFromHash( $validatorConfigurationHash );
+
+    /**
+     * Validates the validatorConfiguration of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct
+     *
+     * This methods determines if the given $validatorConfiguration is
+     * structurally correct and complies to the validator configuration schema as defined in FieldType.
+     *
+     * @param mixed $validatorConfiguration
+     *
+     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
+     */
+    public function validateValidatorConfiguration( $validatorConfiguration );
+
+    /**
+     * Validates the fieldSettings of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct
+     *
+     * This methods determines if the given $fieldSettings are structurally
+     * correct and comply to the settings schema as defined in FieldType.
+     *
+     * @param mixed $fieldSettings
+     *
+     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
+     */
+    public function validateFieldSettings( $fieldSettings );
+
+    /**
+     * Validates a field value based on the validator configuration in the field definition
+     *
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDef The field definition of the field
+     * @param \eZ\Publish\SPI\FieldType\Value $value The field value for which an action is performed
+     *
+     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
+     */
+    public function validateValue( FieldDefinition $fieldDef, Value $value );
 }

--- a/eZ/Publish/Core/FieldType/Tests/APIFieldTypeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/APIFieldTypeTest.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\FieldType\Tests;
+
+use eZ\Publish\Core\Repository\Values\ContentType\FieldType;
+use PHPUnit_Framework_TestCase;
+
+class APIFieldTypeTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $innerFieldType;
+
+    /**
+     * @var FieldType
+     */
+    private $fieldType;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->innerFieldType = $this->getMock( '\eZ\Publish\SPI\FieldType\FieldType' );
+        $this->fieldType = new FieldType( $this->innerFieldType );
+    }
+
+    public function testValidateValidatorConfigurationNoError()
+    {
+        $validatorConfig = ['foo' => 'bar'];
+        $validationErrors = [];
+        $this->innerFieldType
+            ->expects( $this->once() )
+            ->method( 'validateValidatorConfiguration' )
+            ->with( $validatorConfig )
+            ->willReturn( $validationErrors );
+
+        self::assertSame( $validationErrors, $this->fieldType->validateValidatorConfiguration( $validatorConfig ) );
+    }
+
+    public function testValidateValidatorConfiguration()
+    {
+        $validatorConfig = ['foo' => 'bar'];
+        $validationErrors = [
+            $this->getMock( '\eZ\Publish\SPI\FieldType\ValidationError' ),
+            $this->getMock( '\eZ\Publish\SPI\FieldType\ValidationError' ),
+            $this->getMock( '\eZ\Publish\SPI\FieldType\ValidationError' ),
+        ];
+        $this->innerFieldType
+            ->expects( $this->once() )
+            ->method( 'validateValidatorConfiguration' )
+            ->with( $validatorConfig )
+            ->willReturn( $validationErrors );
+
+        self::assertSame( $validationErrors, $this->fieldType->validateValidatorConfiguration( $validatorConfig ) );
+    }
+
+    public function testValidateFieldSettingsNoError()
+    {
+        $fieldSettings = ['foo' => 'bar'];
+        $validationErrors = [];
+        $this->innerFieldType
+            ->expects( $this->once() )
+            ->method( 'validateFieldSettings' )
+            ->with( $fieldSettings )
+            ->willReturn( $validationErrors );
+
+        self::assertSame( $validationErrors, $this->fieldType->validateFieldSettings( $fieldSettings ) );
+    }
+
+    public function testValidateFieldSettings()
+    {
+        $fieldSettings = ['foo' => 'bar'];
+        $validationErrors = [
+            $this->getMock( '\eZ\Publish\SPI\FieldType\ValidationError' ),
+            $this->getMock( '\eZ\Publish\SPI\FieldType\ValidationError' ),
+            $this->getMock( '\eZ\Publish\SPI\FieldType\ValidationError' ),
+        ];
+        $this->innerFieldType
+            ->expects( $this->once() )
+            ->method( 'validateFieldSettings' )
+            ->with( $fieldSettings )
+            ->willReturn( $validationErrors );
+
+        self::assertSame( $validationErrors, $this->fieldType->validateFieldSettings( $fieldSettings ) );
+    }
+
+    public function testValidateValueNoError()
+    {
+        $fieldDefinition = $this->getMockForAbstractClass( '\eZ\Publish\API\Repository\Values\ContentType\FieldDefinition' );
+        $value = $this->getMockForAbstractClass( '\eZ\Publish\Core\FieldType\Value' );
+        $validationErrors = [];
+        $this->innerFieldType
+            ->expects( $this->once() )
+            ->method( 'validate' )
+            ->with( $fieldDefinition, $value )
+            ->willReturn( $validationErrors );
+
+        self::assertSame( $validationErrors, $this->fieldType->validateValue( $fieldDefinition, $value ) );
+    }
+
+    public function testValidateValue()
+    {
+        $fieldDefinition = $this->getMockForAbstractClass( '\eZ\Publish\API\Repository\Values\ContentType\FieldDefinition' );
+        $value = $this->getMockForAbstractClass( '\eZ\Publish\Core\FieldType\Value' );
+        $validationErrors = [
+            $this->getMock( '\eZ\Publish\SPI\FieldType\ValidationError' ),
+            $this->getMock( '\eZ\Publish\SPI\FieldType\ValidationError' ),
+            $this->getMock( '\eZ\Publish\SPI\FieldType\ValidationError' ),
+        ];
+        $this->innerFieldType
+            ->expects( $this->once() )
+            ->method( 'validate' )
+            ->with( $fieldDefinition, $value )
+            ->willReturn( $validationErrors );
+
+        self::assertSame( $validationErrors, $this->fieldType->validateValue( $fieldDefinition, $value ) );
+    }
+}

--- a/eZ/Publish/Core/REST/Client/FieldType.php
+++ b/eZ/Publish/Core/REST/Client/FieldType.php
@@ -10,7 +10,9 @@
 namespace eZ\Publish\Core\REST\Client;
 
 use eZ\Publish\API\Repository\FieldType as APIFieldType;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\SPI;
+use eZ\Publish\SPI\FieldType\Value;
 
 class FieldType implements APIFieldType
 {
@@ -244,5 +246,48 @@ class FieldType implements APIFieldType
     public function validatorConfigurationFromHash( $validatorConfigurationHash )
     {
         return $this->innerFieldType->validatorConfigurationFromHash( $validatorConfigurationHash );
+    }
+
+    /**
+     * Validates the validatorConfiguration of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct
+     *
+     * This methods determines if the given $validatorConfiguration is
+     * structurally correct and complies to the validator configuration schema as defined in FieldType.
+     *
+     * @param mixed $validatorConfiguration
+     *
+     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
+     */
+    public function validateValidatorConfiguration( $validatorConfiguration )
+    {
+        return $this->innerFieldType->validateValidatorConfiguration( $validatorConfiguration );
+    }
+
+    /**
+     * Validates the fieldSettings of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct
+     *
+     * This methods determines if the given $fieldSettings are structurally
+     * correct and comply to the settings schema as defined in FieldType.
+     *
+     * @param mixed $fieldSettings
+     *
+     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
+     */
+    public function validateFieldSettings( $fieldSettings )
+    {
+        return $this->innerFieldType->validateFieldSettings( $fieldSettings );
+    }
+
+    /**
+     * Validates a field value based on the validator configuration in the field definition
+     *
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDef The field definition of the field
+     * @param \eZ\Publish\SPI\FieldType\Value $value The field value for which an action is performed
+     *
+     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
+     */
+    public function validateValue( FieldDefinition $fieldDef, Value $value )
+    {
+        return $this->innerFieldType->validate( $fieldDef, $value );
     }
 }

--- a/eZ/Publish/Core/Repository/Values/ContentType/FieldType.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/FieldType.php
@@ -10,7 +10,9 @@
 namespace eZ\Publish\Core\Repository\Values\ContentType;
 
 use eZ\Publish\API\Repository\FieldType as FieldTypeInterface;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition as APIFieldDefinition;
 use eZ\Publish\SPI\FieldType\FieldType as SPIFieldTypeInterface;
+use eZ\Publish\SPI\FieldType\Value;
 
 /**
  * This class represents a FieldType available to Public API users
@@ -250,5 +252,48 @@ class FieldType implements FieldTypeInterface
     public function validatorConfigurationFromHash( $validatorConfigurationHash )
     {
         return $this->internalFieldType->validatorConfigurationFromHash( $validatorConfigurationHash );
+    }
+
+    /**
+     * Validates the validatorConfiguration of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct
+     *
+     * This methods determines if the given $validatorConfiguration is
+     * structurally correct and complies to the validator configuration schema as defined in FieldType.
+     *
+     * @param mixed $validatorConfiguration
+     *
+     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
+     */
+    public function validateValidatorConfiguration( $validatorConfiguration )
+    {
+        return $this->internalFieldType->validateValidatorConfiguration( $validatorConfiguration );
+    }
+
+    /**
+     * Validates the fieldSettings of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct
+     *
+     * This methods determines if the given $fieldSettings are structurally
+     * correct and comply to the settings schema as defined in FieldType.
+     *
+     * @param mixed $fieldSettings
+     *
+     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
+     */
+    public function validateFieldSettings( $fieldSettings )
+    {
+        return $this->internalFieldType->validateFieldSettings( $fieldSettings );
+    }
+
+    /**
+     * Validates a field value based on the validator configuration in the field definition
+     *
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDef The field definition of the field
+     * @param \eZ\Publish\SPI\FieldType\Value $value The field value for which an action is performed
+     *
+     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
+     */
+    public function validateValue( APIFieldDefinition $fieldDef, Value $value )
+    {
+        return $this->internalFieldType->validate( $fieldDef, $value );
     }
 }


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24347

Added following public method to `eZ\Publish\API\Repository\FieldType`:

* `validateValue()`
* `validateValidatorConfiguration()`
* `validateFieldSettings()`

They're just proxies to internal SPI FieldType (the real one).
This makes it possible to do validation from outside the repository (e.g. using Symfony Validation component)