### PR TITLE
EZP-24357: Add a "target" property to ValidationError

### DIFF
--- a/eZ/Publish/Core/FieldType/BinaryBase/Type.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/Type.php
@@ -321,7 +321,8 @@ abstract class Type extends FieldType
                             "The file size cannot exceed %size% bytes.",
                             array(
                                 "size" => $parameters['maxFileSize'],
-                            )
+                            ),
+                            'fileSize'
                         );
                     }
                     break;
@@ -354,7 +355,8 @@ abstract class Type extends FieldType
                             array(
                                 "validator" => $validatorIdentifier,
                                 "parameter" => 'maxFileSize',
-                            )
+                            ),
+                            "[$validatorIdentifier][maxFileSize]"
                         );
                         break;
                     }
@@ -367,6 +369,7 @@ abstract class Type extends FieldType
                                 "validator" => $validatorIdentifier,
                                 "parameter" => 'maxFileSize',
                                 "type" => 'integer',
+                                "[$validatorIdentifier][maxFileSize]"
                             )
                         );
                     }
@@ -377,7 +380,8 @@ abstract class Type extends FieldType
                         null,
                         array(
                             "validator" => $validatorIdentifier
-                        )
+                        ),
+                        "[$validatorIdentifier]"
                     );
             }
         }

--- a/eZ/Publish/Core/FieldType/Country/Type.php
+++ b/eZ/Publish/Core/FieldType/Country/Type.php
@@ -147,7 +147,8 @@ class Type extends FieldType
             $validationErrors[] = new ValidationError(
                 "Field definition does not allow multiple countries to be selected.",
                 null,
-                array()
+                array(),
+                'countries'
             );
         }
 
@@ -160,7 +161,8 @@ class Type extends FieldType
                     null,
                     array(
                         "alpha2" => $alpha2
-                    )
+                    ),
+                    'countries'
                 );
             }
         }
@@ -270,7 +272,8 @@ class Type extends FieldType
                     null,
                     array(
                         "setting" => $name
-                    )
+                    ),
+                    "[$name]"
                 );
                 continue;
             }
@@ -285,7 +288,8 @@ class Type extends FieldType
                             null,
                             array(
                                 "setting" => $name
-                            )
+                            ),
+                            "[$name]"
                         );
                     }
                     break;

--- a/eZ/Publish/Core/FieldType/Date/Type.php
+++ b/eZ/Publish/Core/FieldType/Date/Type.php
@@ -221,7 +221,8 @@ class Type extends FieldType
                     null,
                     array(
                         "setting" => $name
-                    )
+                    ),
+                    "[$name]"
                 );
                 continue;
             }
@@ -240,7 +241,8 @@ class Type extends FieldType
                             null,
                             array(
                                 "setting" => $name
-                            )
+                            ),
+                            "[$name]"
                         );
                     }
                     break;

--- a/eZ/Publish/Core/FieldType/DateAndTime/Type.php
+++ b/eZ/Publish/Core/FieldType/DateAndTime/Type.php
@@ -235,7 +235,8 @@ class Type extends FieldType
                                 null,
                                 array(
                                     "setting" => $name
-                                )
+                                ),
+                                "[$name]"
                             );
                         }
                         break;
@@ -252,7 +253,8 @@ class Type extends FieldType
                                 null,
                                 array(
                                     "setting" => $name
-                                )
+                                ),
+                                "[$name]"
                             );
                         }
                         break;
@@ -269,7 +271,8 @@ class Type extends FieldType
                                         "setting" => $name,
                                         "defaultType" => "defaultType",
                                         "DEFAULT_CURRENT_DATE_ADJUSTED" => "DEFAULT_CURRENT_DATE_ADJUSTED"
-                                    )
+                                    ),
+                                    "[$name]"
                                 );
                             }
                             else if ( !( $value instanceof \DateInterval ) )
@@ -279,7 +282,8 @@ class Type extends FieldType
                                     null,
                                     array(
                                         "setting" => $name
-                                    )
+                                    ),
+                                    "[$name]"
                                 );
                             }
                         }
@@ -293,7 +297,8 @@ class Type extends FieldType
                     null,
                     array(
                         "setting" => $name
-                    )
+                    ),
+                    "[$name]"
                 );
             }
         }

--- a/eZ/Publish/Core/FieldType/EmailAddress/Type.php
+++ b/eZ/Publish/Core/FieldType/EmailAddress/Type.php
@@ -49,7 +49,8 @@ class Type extends FieldType
                     null,
                     array(
                         "validator" => $validatorIdentifier
-                    )
+                    ),
+                    "[$validatorIdentifier]"
                 );
                 continue;
             }

--- a/eZ/Publish/Core/FieldType/FieldType.php
+++ b/eZ/Publish/Core/FieldType/FieldType.php
@@ -162,7 +162,8 @@ abstract class FieldType implements FieldTypeInterface
                 null,
                 array(
                     "validator" => $validatorIdentifier
-                )
+                ),
+                "[$validatorIdentifier]"
             );
         }
 
@@ -225,7 +226,8 @@ abstract class FieldType implements FieldTypeInterface
                     null,
                     array(
                         "fieldType" => $this->getFieldTypeIdentifier()
-                    )
+                    ),
+                    'fieldType'
                 )
             );
         }

--- a/eZ/Publish/Core/FieldType/Float/Type.php
+++ b/eZ/Publish/Core/FieldType/Float/Type.php
@@ -56,7 +56,8 @@ class Type extends FieldType
                     null,
                     array(
                         "validator" => $validatorIdentifier
-                    )
+                    ),
+                    "[$validatorIdentifier]"
                 );
 
                 continue;
@@ -75,7 +76,8 @@ class Type extends FieldType
                                 null,
                                 array(
                                     "parameter" => $name
-                                )
+                                ),
+                                "[$validatorIdentifier][$name]"
                             );
                         }
                         break;
@@ -85,7 +87,8 @@ class Type extends FieldType
                             null,
                             array(
                                 "parameter" => $name
-                            )
+                            ),
+                            "[$validatorIdentifier][$name]"
                         );
                 }
             }
@@ -128,7 +131,8 @@ class Type extends FieldType
                 null,
                 array(
                     "size" => $constraints['maxFloatValue']
-                )
+                ),
+                'value'
             );
         }
 
@@ -140,7 +144,8 @@ class Type extends FieldType
                 null,
                 array(
                     "size" => $constraints['minFloatValue']
-                )
+                ),
+                'value'
             );
         }
 

--- a/eZ/Publish/Core/FieldType/ISBN/Type.php
+++ b/eZ/Publish/Core/FieldType/ISBN/Type.php
@@ -152,7 +152,8 @@ class Type extends FieldType
             $validationErrors[] = new ValidationError(
                 "ISBN-10 must be 10 character length",
                 null,
-                array()
+                array(),
+                'isbn'
             );
         }
         // ISBN-10 check
@@ -163,7 +164,8 @@ class Type extends FieldType
                 $validationErrors[] = new ValidationError(
                     "ISBN value must be in a valid ISBN-10 format",
                     null,
-                    array()
+                    array(),
+                    'isbn'
                 );
             }
         }
@@ -175,7 +177,8 @@ class Type extends FieldType
                 $validationErrors[] = new ValidationError(
                     $error,
                     null,
-                    array()
+                    array(),
+                    'isbn'
                 );
             }
         }
@@ -257,7 +260,8 @@ class Type extends FieldType
                     null,
                     array(
                         "setting" => $name
-                    )
+                    ),
+                    "[$name]"
                 );
                 continue;
             }
@@ -272,7 +276,8 @@ class Type extends FieldType
                             null,
                             array(
                                 "setting" => $name
-                            )
+                            ),
+                            "[$name]"
                         );
                     }
                     break;

--- a/eZ/Publish/Core/FieldType/Image/Type.php
+++ b/eZ/Publish/Core/FieldType/Image/Type.php
@@ -169,13 +169,13 @@ class Type extends FieldType
 
         if ( isset( $fieldValue->inputUri ) && !getimagesize( $fieldValue->inputUri ) )
         {
-            $errors[] = new ValidationError( "A valid image file is required." );
+            $errors[] = new ValidationError( "A valid image file is required.", null, array(), 'inputUri' );
         }
 
         // BC: Check if file is a valid image if the value of 'id' matches a local file
         if ( isset( $fieldValue->id ) && file_exists( $fieldValue->id ) && !getimagesize( $fieldValue->id ) )
         {
-            $errors[] = new ValidationError( "A valid image file is required." );
+            $errors[] = new ValidationError( "A valid image file is required.", null, array(), 'id' );
         }
 
         foreach ( (array)$fieldDefinition->getValidatorConfiguration() as $validatorIdentifier => $parameters )
@@ -197,7 +197,8 @@ class Type extends FieldType
                             "The file size cannot exceed %size% bytes.",
                             array(
                                 "size" => $parameters['maxFileSize'],
-                            )
+                            ),
+                            'fileSize'
                         );
                     }
                     break;
@@ -230,7 +231,8 @@ class Type extends FieldType
                             array(
                                 "validator" => $validatorIdentifier,
                                 "parameter" => 'maxFileSize',
-                            )
+                            ),
+                            "[$validatorIdentifier]"
                         );
                         break;
                     }
@@ -243,7 +245,8 @@ class Type extends FieldType
                                 "validator" => $validatorIdentifier,
                                 "parameter" => 'maxFileSize',
                                 "type" => 'integer',
-                            )
+                            ),
+                            "[$validatorIdentifier][maxFileSize]"
                         );
                     }
                     break;
@@ -253,7 +256,8 @@ class Type extends FieldType
                         null,
                         array(
                             "validator" => $validatorIdentifier
-                        )
+                        ),
+                        "[$validatorIdentifier]"
                     );
             }
         }

--- a/eZ/Publish/Core/FieldType/Integer/Type.php
+++ b/eZ/Publish/Core/FieldType/Integer/Type.php
@@ -56,7 +56,8 @@ class Type extends FieldType
                     null,
                     array(
                         "validator" => $validatorIdentifier
-                    )
+                    ),
+                    "[$validatorIdentifier]"
                 );
 
                 continue;
@@ -74,7 +75,8 @@ class Type extends FieldType
                                 null,
                                 array(
                                     "parameter" => $name
-                                )
+                                ),
+                                "[$validatorIdentifier][$name]"
                             );
                         }
                         break;
@@ -84,7 +86,8 @@ class Type extends FieldType
                             null,
                             array(
                                 "parameter" => $name
-                            )
+                            ),
+                            "[$validatorIdentifier][$name]"
                         );
                 }
             }
@@ -131,7 +134,8 @@ class Type extends FieldType
                 null,
                 array(
                     "size" => $constraints['maxIntegerValue']
-                )
+                ),
+                'value'
             );
         }
 
@@ -143,7 +147,8 @@ class Type extends FieldType
                 null,
                 array(
                     "size" => $constraints['minIntegerValue']
-                )
+                ),
+                'value'
             );
         }
 

--- a/eZ/Publish/Core/FieldType/Media/Type.php
+++ b/eZ/Publish/Core/FieldType/Media/Type.php
@@ -103,7 +103,8 @@ class Type extends BaseType
                                 null,
                                 array(
                                     "setting" => $name
-                                )
+                                ),
+                                "[$name]"
                             );
                         }
                         break;
@@ -116,7 +117,8 @@ class Type extends BaseType
                     null,
                     array(
                         "setting" => $name
-                    )
+                    ),
+                    "[$name]"
                 );
             }
         }

--- a/eZ/Publish/Core/FieldType/Page/Type.php
+++ b/eZ/Publish/Core/FieldType/Page/Type.php
@@ -84,7 +84,8 @@ class Type extends FieldType
                                 null,
                                 array(
                                     'setting' => $name
-                                )
+                                ),
+                                "[$name]"
                             );
                         }
                         break;
@@ -97,7 +98,8 @@ class Type extends FieldType
                     null,
                     array(
                         'setting' => $name
-                    )
+                    ),
+                    "[$name]"
                 );
             }
         }

--- a/eZ/Publish/Core/FieldType/Relation/Type.php
+++ b/eZ/Publish/Core/FieldType/Relation/Type.php
@@ -61,7 +61,8 @@ class Type extends FieldType
                     null,
                     array(
                         "setting" => $name
-                    )
+                    ),
+                    "[$name]"
                 );
                 continue;
             }
@@ -78,7 +79,8 @@ class Type extends FieldType
                                 "setting" => $name,
                                 "selection_browse" => self::SELECTION_BROWSE,
                                 "selection_dropdown" => self::SELECTION_DROPDOWN
-                            )
+                            ),
+                            "[$name]"
                         );
                     }
                     break;
@@ -90,7 +92,8 @@ class Type extends FieldType
                             null,
                             array(
                                 "setting" => $name
-                            )
+                            ),
+                            "[$name]"
                         );
                     }
                     break;

--- a/eZ/Publish/Core/FieldType/RelationList/Type.php
+++ b/eZ/Publish/Core/FieldType/RelationList/Type.php
@@ -69,7 +69,8 @@ class Type extends FieldType
                     null,
                     array(
                         "setting" => $name
-                    )
+                    ),
+                    "[$name]"
                 );
                 continue;
             }
@@ -86,7 +87,8 @@ class Type extends FieldType
                                 "setting" => $name,
                                 "selection_browse" => self::SELECTION_BROWSE,
                                 "selection_dropdown" => self::SELECTION_DROPDOWN
-                            )
+                            ),
+                            "[$name]"
                         );
                     }
                     break;
@@ -98,7 +100,8 @@ class Type extends FieldType
                             null,
                             array(
                                 "setting" => $name
-                            )
+                            ),
+                            "[$name]"
                         );
                     }
                     break;
@@ -110,7 +113,8 @@ class Type extends FieldType
                             null,
                             array(
                                 "setting" => $name
-                            )
+                            ),
+                            "[$name]"
                         );
                     }
                     break;

--- a/eZ/Publish/Core/FieldType/RichText/Type.php
+++ b/eZ/Publish/Core/FieldType/RichText/Type.php
@@ -357,7 +357,8 @@ class Type extends FieldType
                                 null,
                                 array(
                                     "setting" => $name
-                                )
+                                ),
+                                "[$name]"
                             );
                         }
                         break;
@@ -373,7 +374,8 @@ class Type extends FieldType
                                 null,
                                 array(
                                     "setting" => $name
-                                )
+                                ),
+                                "[$name]"
                             );
                         }
                         break;
@@ -386,7 +388,8 @@ class Type extends FieldType
                     null,
                     array(
                         "setting" => $name
-                    )
+                    ),
+                    "[$name]"
                 );
             }
         }

--- a/eZ/Publish/Core/FieldType/Selection/Type.php
+++ b/eZ/Publish/Core/FieldType/Selection/Type.php
@@ -67,7 +67,8 @@ class Type extends FieldType
                                 "fieldType" => $this->getFieldTypeIdentifier(),
                                 "setting"   => $settingKey,
                                 "type"      => "bool",
-                            )
+                            ),
+                            "[$settingKey]"
                         );
                     }
                     break;
@@ -81,7 +82,8 @@ class Type extends FieldType
                                 "fieldType" => $this->getFieldTypeIdentifier(),
                                 "setting"   => $settingKey,
                                 "type"      => "hash",
-                            )
+                            ),
+                            "[$settingKey]"
                         );
                     }
                     break;
@@ -91,7 +93,8 @@ class Type extends FieldType
                         null,
                         array(
                             "setting" => $settingKey
-                        )
+                        ),
+                        "[$settingKey]"
                     );
             }
         }
@@ -202,7 +205,8 @@ class Type extends FieldType
             $validationErrors[] = new ValidationError(
                 "Field definition does not allow multiple options to be selected.",
                 null,
-                array()
+                array(),
+                'selection'
             );
         }
 
@@ -215,7 +219,8 @@ class Type extends FieldType
                     null,
                     array(
                         "index" => $optionIndex
-                    )
+                    ),
+                    'selection'
                 );
             }
         }

--- a/eZ/Publish/Core/FieldType/Tests/CountryTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/CountryTest.php
@@ -610,7 +610,8 @@ class CountryTest extends FieldTypeTest
                 ),
                 array(
                     new ValidationError(
-                        "Field definition does not allow multiple countries to be selected."
+                        "Field definition does not allow multiple countries to be selected.",
+                        null, array(), 'countries'
                     ),
                 ),
             ),
@@ -636,7 +637,8 @@ class CountryTest extends FieldTypeTest
                         null,
                         array(
                             "alpha2" => "LE"
-                        )
+                        ),
+                        'countries'
                     ),
                 ),
             ),

--- a/eZ/Publish/Core/FieldType/Tests/EmailAddressTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/EmailAddressTest.php
@@ -543,7 +543,8 @@ class EmailAddressTest extends FieldTypeTest
                 new EmailAddressValue( "jane.doe.example.com" ),
                 array(
                     new ValidationError(
-                        "The value must be a valid email address."
+                        "The value must be a valid email address.",
+                        null, array(), 'email'
                     ),
                 ),
             ),

--- a/eZ/Publish/Core/FieldType/Tests/FloatTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FloatTest.php
@@ -574,7 +574,8 @@ class FloatTest extends FieldTypeTest
                         null,
                         array(
                             "size" => 5.1
-                        )
+                        ),
+                        'value'
                     ),
                 ),
             ),
@@ -594,7 +595,8 @@ class FloatTest extends FieldTypeTest
                         null,
                         array(
                             "size" => 10.5
-                        )
+                        ),
+                        'value'
                     ),
                 ),
             ),
@@ -614,14 +616,16 @@ class FloatTest extends FieldTypeTest
                         null,
                         array(
                             "size" => 5.1
-                        )
+                        ),
+                        'value'
                     ),
                     new ValidationError(
                         "The value can not be lower than %size%.",
                         null,
                         array(
                             "size" => 10.5
-                        )
+                        ),
+                        'value'
                     ),
                 ),
             ),

--- a/eZ/Publish/Core/FieldType/Tests/ISBNTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ISBNTest.php
@@ -331,8 +331,9 @@ class ISBNTest extends FieldTypeTest
                 new ISBNValue( "9789722514095" ),
                 array(
                     new ValidationError(
-                        "ISBN-10 must be 10 character length"
-                    ),
+                        "ISBN-10 must be 10 character length",
+                        null, array(), 'isbn'
+                    )
                 ),
             ),
         );

--- a/eZ/Publish/Core/FieldType/Tests/ImageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageTest.php
@@ -633,7 +633,8 @@ class ImageTest extends FieldTypeTest
                         "The file size cannot exceed %size% bytes.",
                         array(
                             "size" => 0.01,
-                        )
+                        ),
+                        'fileSize'
                     ),
                 )
             ),
@@ -658,7 +659,8 @@ class ImageTest extends FieldTypeTest
                 ),
                 array(
                     new ValidationError(
-                        "A valid image file is required."
+                        "A valid image file is required.",
+                        null, array(), 'id'
                     ),
                 ),
             ),
@@ -683,14 +685,16 @@ class ImageTest extends FieldTypeTest
                 ),
                 array(
                     new ValidationError(
-                        "A valid image file is required."
+                        "A valid image file is required.",
+                        null, array(), 'id'
                     ),
                     new ValidationError(
                         "The file size cannot exceed %size% byte.",
                         "The file size cannot exceed %size% bytes.",
                         array(
                             "size" => 0.01,
-                        )
+                        ),
+                        'fileSize'
                     ),
                 ),
             ),

--- a/eZ/Publish/Core/FieldType/Tests/IntegerTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/IntegerTest.php
@@ -574,7 +574,8 @@ class IntegerTest extends FieldTypeTest
                         null,
                         array(
                             "size" => 5
-                        )
+                        ),
+                        'value'
                     ),
                 )
             ),
@@ -594,7 +595,8 @@ class IntegerTest extends FieldTypeTest
                         null,
                         array(
                             "size" => 10
-                        )
+                        ),
+                        'value'
                     ),
                 ),
             ),
@@ -614,14 +616,16 @@ class IntegerTest extends FieldTypeTest
                         null,
                         array(
                             "size" => 5
-                        )
+                        ),
+                        'value'
                     ),
                     new ValidationError(
                         "The value can not be lower than %size%.",
                         null,
                         array(
                             "size" => 10
-                        )
+                        ),
+                        'value'
                     ),
                 ),
             ),

--- a/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
@@ -524,7 +524,8 @@ class SelectionTest extends FieldTypeTest
                 new SelectionValue( array( 0, 1 ) ),
                 array(
                     new ValidationError(
-                        "Field definition does not allow multiple options to be selected."
+                        "Field definition does not allow multiple options to be selected.",
+                        null, array(), 'selection'
                     ),
                 ),
             ),
@@ -542,7 +543,8 @@ class SelectionTest extends FieldTypeTest
                         null,
                         array(
                             "index" => 3
-                        )
+                        ),
+                        'selection'
                     ),
                 ),
             ),

--- a/eZ/Publish/Core/FieldType/Tests/TextLineTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/TextLineTest.php
@@ -609,7 +609,8 @@ class TextLineTest extends FieldTypeTest
                         "The string can not be shorter than %size% characters.",
                         array(
                             "size" => 5
-                        )
+                        ),
+                        'text'
                     ),
                 ),
             ),
@@ -629,7 +630,8 @@ class TextLineTest extends FieldTypeTest
                         "The string can not exceed %size% characters.",
                         array(
                             "size" => 10
-                        )
+                        ),
+                        'text'
                     ),
                 ),
             ),
@@ -649,14 +651,16 @@ class TextLineTest extends FieldTypeTest
                         "The string can not exceed %size% characters.",
                         array(
                             "size" => 5
-                        )
+                        ),
+                        'text'
                     ),
                     new ValidationError(
                         "The string can not be shorter than %size% character.",
                         "The string can not be shorter than %size% characters.",
                         array(
                             "size" => 10
-                        )
+                        ),
+                        'text'
                     ),
                 ),
             ),

--- a/eZ/Publish/Core/FieldType/TextBlock/Type.php
+++ b/eZ/Publish/Core/FieldType/TextBlock/Type.php
@@ -196,7 +196,8 @@ class Type extends FieldType
                                 null,
                                 array(
                                     "setting" => $name
-                                )
+                                ),
+                                "[$name]"
                             );
                         }
                         break;
@@ -209,7 +210,8 @@ class Type extends FieldType
                     null,
                     array(
                         "setting" => $name
-                    )
+                    ),
+                    "[$name]"
                 );
             }
         }

--- a/eZ/Publish/Core/FieldType/TextLine/Type.php
+++ b/eZ/Publish/Core/FieldType/TextLine/Type.php
@@ -74,7 +74,8 @@ class Type extends FieldType
                                 null,
                                 array(
                                     "parameter" => $name
-                                )
+                                ),
+                                "[$validatorIdentifier][$name]"
                             );
                         }
                         break;
@@ -127,7 +128,8 @@ class Type extends FieldType
                 "The string can not exceed %size% characters.",
                 array(
                     "size" => $constraints['maxStringLength']
-                )
+                ),
+                'text'
             );
         }
 
@@ -141,7 +143,8 @@ class Type extends FieldType
                 "The string can not be shorter than %size% characters.",
                 array(
                     "size" => $constraints['minStringLength']
-                )
+                ),
+                'text'
             );
         }
 

--- a/eZ/Publish/Core/FieldType/Time/Type.php
+++ b/eZ/Publish/Core/FieldType/Time/Type.php
@@ -206,7 +206,8 @@ class Type extends FieldType
                     null,
                     array(
                         "setting" => $name
-                    )
+                    ),
+                    "[$name]"
                 );
                 continue;
             }
@@ -221,7 +222,8 @@ class Type extends FieldType
                             null,
                             array(
                                 "setting" => $name
-                            )
+                            ),
+                            "[$name]"
                         );
                     }
                     break;
@@ -237,7 +239,8 @@ class Type extends FieldType
                             null,
                             array(
                                 "setting" => $name
-                            )
+                            ),
+                            "[$name]"
                         );
                     }
                     break;

--- a/eZ/Publish/Core/FieldType/ValidationError.php
+++ b/eZ/Publish/Core/FieldType/ValidationError.php
@@ -29,20 +29,31 @@ class ValidationError implements ValidationErrorInterface
     protected $plural;
 
     /**
-     * @var string
+     * @var array
      */
     protected $values;
+
+    /**
+     * Element on which the error occurred
+     * e.g. property name or property path compatible with Symfony PropertyAccess component.
+     *
+     * Example: StringLengthValidator[minStringLength]
+     *
+     * @var string
+     */
+    protected $target;
 
     /**
      * @param string $singular
      * @param string $plural
      * @param array $values
      */
-    public function __construct( $singular, $plural = null, array $values = array() )
+    public function __construct( $singular, $plural = null, array $values = array(), $target = null )
     {
         $this->singular = $singular;
         $this->plural = $plural;
         $this->values = $values;
+        $this->target = $target;
     }
 
     /**
@@ -67,5 +78,15 @@ class ValidationError implements ValidationErrorInterface
                 $this->values
             );
         }
+    }
+
+    public function setTarget( $target )
+    {
+        $this->target = $target;
+    }
+
+    public function getTarget()
+    {
+        return $this->target;
     }
 }

--- a/eZ/Publish/Core/FieldType/Validator/EmailAddressValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/EmailAddressValidator.php
@@ -55,7 +55,8 @@ class EmailAddressValidator extends Validator
                             null,
                             array(
                                 "parameter" => $name
-                            )
+                            ),
+                            "[EmailAddressValidator][$name]"
                         );
                     }
                     break;
@@ -65,7 +66,8 @@ class EmailAddressValidator extends Validator
                         null,
                         array(
                             "parameter" => $name
-                        )
+                        ),
+                        "[EmailAddressValidator][$name]"
                     );
             }
         }
@@ -100,7 +102,8 @@ class EmailAddressValidator extends Validator
         $this->errors[] = new ValidationError(
             "The value must be a valid email address.",
             null,
-            array()
+            array(),
+            'email'
         );
         return false;
     }

--- a/eZ/Publish/Core/FieldType/XmlText/Type.php
+++ b/eZ/Publish/Core/FieldType/XmlText/Type.php
@@ -283,7 +283,8 @@ class Type extends FieldType
                                 null,
                                 array(
                                     "setting" => $name
-                                )
+                                ),
+                                "[$name]"
                             );
                         }
                         break;
@@ -299,7 +300,8 @@ class Type extends FieldType
                                 null,
                                 array(
                                     "setting" => $name
-                                )
+                                ),
+                                "[$name]"
                             );
                         }
                         break;
@@ -312,7 +314,8 @@ class Type extends FieldType
                     null,
                     array(
                         "setting" => $name
-                    )
+                    ),
+                    "[$name]"
                 );
             }
         }

--- a/eZ/Publish/SPI/FieldType/ValidationError.php
+++ b/eZ/Publish/SPI/FieldType/ValidationError.php
@@ -22,5 +22,25 @@ use eZ\Publish\API\Repository\Translatable;
  */
 interface ValidationError extends Translatable
 {
+    /**
+     * Sets the target element on which the error occurred.
+     *
+     * E.g. Property of a Field value which didn't validate against validation.
+     * Can be a property path compatible with Symfony PropertyAccess component.
+     *
+     * Examples:
+     * - "[StringLengthValidator][minStringLength]" => Target is "minStringLength" key under "StringLengthValidator" key (fieldtype validator configuration)
+     * - "my_field_definition_identifier"
+     *
+     * @param string $target
+     */
+    public function setTarget( $target );
+
+    /**
+     * Returns the target element on which the error occurred.
+     *
+     * @return string
+     */
+    public function getTarget();
 }
 


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24357

Added a target property/getter to `\eZ\Publish\SPI\FieldType\ValidationError`
so that we can easily identify on which field validation errors occur (at field type level).

This is helpful for RepositoryForms, in order to display the error message in the appropriate context.