### PR TITLE
Fix EZP-23405: remove unlimited search hits option

### DIFF
--- a/doc/bc/changes-6.0.md
+++ b/doc/bc/changes-6.0.md
@@ -117,6 +117,27 @@ Changes affecting version compatibility with former or future versions.
   deleting last version of the Content. Since Content without a version does not make sense, in this
   case `eZ\Publish\Core\Repository\ContentService::deleteContent()` should be used instead.
 
+* `eZ\Publish\API\Repository\Values\Content\Query` and `eZ\Publish\API\Repository\Values\Content\LocationQuery`
+  property `$limit` is now defined as `integer` (instead of `integer|null`), which means its value must always be
+  set. By default, it's value will be `10`. No way is provided to return all search hits, pagination should be used
+  if full result set is desired.
+
+* `eZ\Publish\API\Repository\LocationService::loadLocationChildren()` signature has changed, default value of
+  parameter `$limit` is now `10`. No way is provided to return all children, pagination should be used if full
+  result set is desired.
+
+* `eZ\Publish\API\Repository\UserService::loadUsersOfUserGroup()` signature has changed, default value of
+  parameter `$limit` is now `10`. No way is provided to return all users, pagination should be used if full
+  result set is desired.
+
+* `eZ\Publish\API\Repository\UserService::loadSubUserGroups()` signature has changed, parameters `$offset = 0`
+  and `$limit = 10` are added. No way is provided to return all user groups, pagination should be used if full
+  result set is desired.
+
+* `eZ\Publish\API\Repository\UserService::loadUserGroupsOfUser()` signature has changed, parameters `$offset = 0`
+  and `$limit = 10` are added. No way is provided to return all user groups, pagination should be used if full
+  result set is desired.
+
 ## Deprecations
 
 * `eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger::purge()` is deprecated and will be removed in v6.1.

--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -4715,6 +4715,9 @@ Load Subgroups
 :Resource: /user/groups/<ID>/subgroups
 :Method: GET
 :Description: Returns a list of the sub groups
+:Parameters:
+    :offset: the offset of the result set
+    :limit: the number of locations returned
 :Headers:
     :Accept:
          :application/vnd.ez.api.UserGroupList+xml:  if set the user group list returned in xml format (see UserGroup_)
@@ -5061,6 +5064,9 @@ Load Groups Of User
 :Resource: /user/users/<ID>/groups
 :Method: GET
 :Description: Returns a list of user groups the user belongs to. The returned list includes the resources for unassigning a user group if the user is in multiple groups.
+:Parameters:
+    :offset: the offset of the result set
+    :limit: the number of locations returned
 :Headers:
     :Accept:
          :application/vnd.ez.api.UserGroupRefList+xml:  if set the link list of user groups is returned in xml format (see UserGroup_)

--- a/eZ/Publish/API/Repository/LocationService.php
+++ b/eZ/Publish/API/Repository/LocationService.php
@@ -84,11 +84,11 @@ interface LocationService
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location
      * @param int $offset the start offset for paging
-     * @param int $limit the number of locations returned. If $limit = -1 all children starting at $offset are returned
+     * @param int $limit the number of locations returned
      *
      * @return \eZ\Publish\API\Repository\Values\Content\LocationList
      */
-    public function loadLocationChildren( Location $location, $offset = 0, $limit = -1 );
+    public function loadLocationChildren( Location $location, $offset = 0, $limit = 10 );
 
     /**
      * Returns the number of children which are readable by the current user of a location object

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP20018LanguageTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP20018LanguageTest.php
@@ -95,6 +95,7 @@ class EZP20018LanguageTest extends BaseTest
     {
         $query = new Query();
         $query->filter = new LanguageCode( array( "eng-US" ), false );
+        $query->limit = 50;
         $results = $this->getRepository()->getSearchService()->findContent( $query );
 
         $this->assertEquals( 16, $results->totalCount );

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP20018ObjectStateTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP20018ObjectStateTest.php
@@ -56,6 +56,7 @@ class EZP20018ObjectStateTest extends BaseTest
     {
         $query = new Query();
         $query->filter = new ObjectStateId( 1 );
+        $query->limit = 50;
         $results1 = $this->getRepository()->getSearchService()->findContent( $query );
 
         $this->assertEquals( 18, $results1->totalCount );

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP20018VisibilityTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP20018VisibilityTest.php
@@ -51,6 +51,7 @@ class EZP20018VisibilityTest extends BaseTest
     {
         $query = new Query();
         $query->filter = new Visibility( Visibility::VISIBLE );
+        $query->limit = 50;
         $results1 = $this->getRepository()->getSearchService()->findContent( $query );
 
         $this->assertEquals( 18, $results1->totalCount );

--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -330,7 +330,8 @@ class SearchServiceTest extends BaseTest
                     'filter' => new Criterion\Subtree(
                         '/1/'
                     ),
-                    'sortClauses' => array( new SortClause\ContentId() )
+                    'sortClauses' => array( new SortClause\ContentId() ),
+                    'limit' => 50,
                 ),
                 $fixtureDir . 'Status.php',
                 // Result having the same sort level should be sorted between them to be system independent
@@ -367,6 +368,7 @@ class SearchServiceTest extends BaseTest
                     'sortClauses' => array(
                         new SortClause\ContentId(),
                     ),
+                    'limit' => 50,
                 ),
                 $fixtureDir . 'UserMetadata.php',
             ),
@@ -380,6 +382,7 @@ class SearchServiceTest extends BaseTest
                     'sortClauses' => array(
                         new SortClause\ContentId(),
                     ),
+                    'limit' => 50,
                 ),
                 $fixtureDir . 'UserMetadata.php',
             ),
@@ -393,6 +396,7 @@ class SearchServiceTest extends BaseTest
                     'sortClauses' => array(
                         new SortClause\ContentId(),
                     ),
+                    'limit' => 50,
                 ),
                 $fixtureDir . 'UserMetadata.php',
             ),
@@ -406,6 +410,7 @@ class SearchServiceTest extends BaseTest
                     'sortClauses' => array(
                         new SortClause\ContentId(),
                     ),
+                    'limit' => 50,
                 ),
                 $fixtureDir . 'UserMetadata.php',
             ),
@@ -419,6 +424,7 @@ class SearchServiceTest extends BaseTest
                     'sortClauses' => array(
                         new SortClause\ContentId(),
                     ),
+                    'limit' => 50,
                 ),
                 $fixtureDir . 'UserMetadata.php',
             ),
@@ -432,6 +438,7 @@ class SearchServiceTest extends BaseTest
                     'sortClauses' => array(
                         new SortClause\ContentId(),
                     ),
+                    'limit' => 50,
                 ),
                 $fixtureDir . 'UserMetadata.php',
             ),
@@ -445,6 +452,7 @@ class SearchServiceTest extends BaseTest
                     'sortClauses' => array(
                         new SortClause\ContentId(),
                     ),
+                    'limit' => 50,
                 ),
                 $fixtureDir . 'UserMetadata.php',
             ),
@@ -458,6 +466,7 @@ class SearchServiceTest extends BaseTest
                     'sortClauses' => array(
                         new SortClause\ContentId(),
                     ),
+                    'limit' => 50,
                 ),
                 $fixtureDir . 'UserMetadata.php',
             ),
@@ -530,7 +539,8 @@ class SearchServiceTest extends BaseTest
                     'criterion' => new Criterion\Visibility(
                         Criterion\Visibility::VISIBLE
                     ),
-                    'sortClauses' => array( new SortClause\ContentId() )
+                    'sortClauses' => array( new SortClause\ContentId() ),
+                    'limit' => 50,
                 ),
                 $fixtureDir . 'Visibility.php',
             ),
@@ -565,7 +575,8 @@ class SearchServiceTest extends BaseTest
             array(
                 array(
                     'criterion' => new Criterion\Depth( Criterion\Operator::GTE, 2 ),
-                    'sortClauses' => array( new SortClause\ContentId() )
+                    'sortClauses' => array( new SortClause\ContentId() ),
+                    'limit' => 50,
                 ),
                 $fixtureDir . 'DepthGte.php',
             ),
@@ -579,14 +590,16 @@ class SearchServiceTest extends BaseTest
             array(
                 array(
                     'criterion' => new Criterion\Depth( Criterion\Operator::LTE, 2 ),
-                    'sortClauses' => array( new SortClause\ContentId() )
+                    'sortClauses' => array( new SortClause\ContentId() ),
+                    'limit' => 50,
                 ),
                 $fixtureDir . 'DepthLte.php',
             ),
             array(
                 array(
                     'criterion' => new Criterion\Depth( Criterion\Operator::BETWEEN, array( 1, 2 ) ),
-                    'sortClauses' => array( new SortClause\ContentId() )
+                    'sortClauses' => array( new SortClause\ContentId() ),
+                    'limit' => 50,
                 ),
                 $fixtureDir . 'DepthLte.php',
             ),
@@ -621,7 +634,8 @@ class SearchServiceTest extends BaseTest
             array(
                 array(
                     'criterion' => new Criterion\Location\Depth( Criterion\Operator::GTE, 2 ),
-                    'sortClauses' => array( new SortClause\ContentId() )
+                    'sortClauses' => array( new SortClause\ContentId() ),
+                    'limit' => 50,
                 ),
                 $fixtureDir . 'DepthGte.php',
             ),
@@ -635,14 +649,16 @@ class SearchServiceTest extends BaseTest
             array(
                 array(
                     'criterion' => new Criterion\Location\Depth( Criterion\Operator::LTE, 2 ),
-                    'sortClauses' => array( new SortClause\ContentId() )
+                    'sortClauses' => array( new SortClause\ContentId() ),
+                    'limit' => 50,
                 ),
                 $fixtureDir . 'DepthLte.php',
             ),
             array(
                 array(
                     'criterion' => new Criterion\Location\Depth( Criterion\Operator::BETWEEN, array( 1, 2 ) ),
-                    'sortClauses' => array( new SortClause\ContentId() )
+                    'sortClauses' => array( new SortClause\ContentId() ),
+                    'limit' => 50,
                 ),
                 $fixtureDir . 'DepthLte.php',
             ),
@@ -1234,7 +1250,7 @@ class SearchServiceTest extends BaseTest
                 array(
                     'filter' => new Criterion\SectionId( array( 2 ) ),
                     'offset' => 0,
-                    'limit' => 10,
+                    'limit' => 50,
                     'sortClauses' => array(
                         new SortClause\DateModified(),
                         new SortClause\ContentId(),
@@ -1246,7 +1262,7 @@ class SearchServiceTest extends BaseTest
                 array(
                     'filter' => new Criterion\SectionId( array( 4, 2, 6, 3 ) ),
                     'offset' => 0,
-                    'limit' => null,
+                    'limit' => 50,
                     'sortClauses' => array(
                         new SortClause\SectionIdentifier(),
                         new SortClause\ContentId(),
@@ -1258,7 +1274,7 @@ class SearchServiceTest extends BaseTest
                 array(
                     'filter' => new Criterion\SectionId( array( 4, 2, 6, 3 ) ),
                     'offset' => 0,
-                    'limit' => null,
+                    'limit' => 50,
                     'sortClauses' => array(
                         new SortClause\SectionName(),
                         new SortClause\ContentId(),
@@ -1270,7 +1286,7 @@ class SearchServiceTest extends BaseTest
                 array(
                     'filter' => new Criterion\SectionId( array( 2, 3 ) ),
                     'offset' => 0,
-                    'limit' => null,
+                    'limit' => 50,
                     'sortClauses' => array(
                         new SortClause\ContentName(),
                         new SortClause\ContentId(),
@@ -1282,7 +1298,7 @@ class SearchServiceTest extends BaseTest
                 array(
                     'filter' => new Criterion\ContentTypeId( 1 ),
                     'offset' => 0,
-                    'limit' => null,
+                    'limit' => 50,
                     'sortClauses' => array(
                         new SortClause\Field( "folder", "name", Query::SORT_ASC, "eng-US" ),
                         new SortClause\ContentId(),
@@ -1294,7 +1310,7 @@ class SearchServiceTest extends BaseTest
                 array(
                     'filter' => new Criterion\ContentTypeId( array( 1, 3 ) ),
                     'offset' => 0,
-                    'limit' => null,
+                    'limit' => 50,
                     'sortClauses' => array(
                         new SortClause\Field( "folder", "name", Query::SORT_ASC, "eng-US" ),
                         new SortClause\ContentId(),
@@ -1306,7 +1322,7 @@ class SearchServiceTest extends BaseTest
                 array(
                     'filter' => new Criterion\ContentTypeId( array( 1, 3 ) ),
                     'offset' => 0,
-                    'limit' => null,
+                    'limit' => 50,
                     'sortClauses' => array(
                         new SortClause\Field( "folder", "name", Query::SORT_DESC, "eng-US" ),
                         new SortClause\ContentId(),
@@ -2531,7 +2547,7 @@ class SearchServiceTest extends BaseTest
             array(
                 "filter" => new Criterion\ContentTypeId( 1 ),
                 "offset" => 0,
-                "limit" => null,
+                "limit" => 10,
                 "sortClauses" => array(
                     $sortClause,
                     new SortClause\ContentId(),
@@ -3973,6 +3989,7 @@ class SearchServiceTest extends BaseTest
                 'sortClauses' => array(
                     new SortClause\ContentId(),
                 ),
+                'limit' => 50,
             )
         );
 
@@ -4066,6 +4083,7 @@ class SearchServiceTest extends BaseTest
                 'sortClauses' => array(
                     new SortClause\Location\Id(),
                 ),
+                'limit' => 50,
             )
         );
 

--- a/eZ/Publish/API/Repository/UserService.php
+++ b/eZ/Publish/API/Repository/UserService.php
@@ -61,12 +61,14 @@ interface UserService
      * Loads the sub groups of a user group
      *
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
+     * @param int $offset the start offset for paging
+     * @param int $limit the number of user groups returned
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the user group
      */
-    public function loadSubUserGroups( UserGroup $userGroup );
+    public function loadSubUserGroups( UserGroup $userGroup, $offset = 0, $limit = 10 );
 
     /**
      * Removes a user group
@@ -245,10 +247,12 @@ interface UserService
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed read the user or user group
      *
      * @param \eZ\Publish\API\Repository\Values\User\User $user
+     * @param int $offset the start offset for paging
+     * @param int $limit the number of user groups returned
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
      */
-    public function loadUserGroupsOfUser( User $user );
+    public function loadUserGroupsOfUser( User $user, $offset = 0, $limit = 10 );
 
     /**
      * Loads the users of a user group
@@ -256,12 +260,12 @@ interface UserService
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the users or user group
      *
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
-     * @param int $offset
-     * @param int $limit
+     * @param int $offset the start offset for paging
+     * @param int $limit the number of users returned
      *
      * @return \eZ\Publish\API\Repository\Values\User\User[]
      */
-    public function loadUsersOfUserGroup( UserGroup $userGroup, $offset = 0, $limit = -1 );
+    public function loadUsersOfUserGroup( UserGroup $userGroup, $offset = 0, $limit = 10 );
 
     /**
      * Instantiate a user create class

--- a/eZ/Publish/API/Repository/Values/Content/Query.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query.php
@@ -79,12 +79,12 @@ class Query extends ValueObject
     /**
      * Query limit
      *
-     * Limit for number of search hits to return, no limit if not set (null).
+     * Limit for number of search hits to return.
      * If value is `0`, search query will not return any search hits, useful for doing a count.
      *
-     * @var int|null
+     * @var int
      */
-    public $limit;
+    public $limit = 10;
 
     /**
      * If true spellcheck suggestions are returned

--- a/eZ/Publish/Core/REST/Client/LocationService.php
+++ b/eZ/Publish/Core/REST/Client/LocationService.php
@@ -236,13 +236,12 @@ class LocationService implements APILocationService, Sessionable
      * Loads children which are readable by the current user of a location object sorted by sortField and sortOrder
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location
-     *
      * @param int $offset the start offset for paging
-     * @param int $limit the number of locations returned. If $limit = -1 all children starting at $offset are returned
+     * @param int $limit the number of locations returned
      *
      * @return \eZ\Publish\API\Repository\Values\Content\LocationList
      */
-    public function loadLocationChildren( Location $location, $offset = 0, $limit = -1 )
+    public function loadLocationChildren( Location $location, $offset = 0, $limit = 10 )
     {
         $values = $this->requestParser->parse( 'location', $location->id );
         $response = $this->client->request(

--- a/eZ/Publish/Core/REST/Client/UserService.php
+++ b/eZ/Publish/Core/REST/Client/UserService.php
@@ -123,12 +123,14 @@ class UserService implements APIUserService, Sessionable
      * Loads the sub groups of a user group
      *
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
+     * @param int $offset the start offset for paging
+     * @param int $limit the number of user groups returned
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the user group
      */
-    public function loadSubUserGroups( UserGroup $userGroup )
+    public function loadSubUserGroups( UserGroup $userGroup, $offset = 0, $limit = 10 )
     {
         throw new \Exception( "@todo: Implement." );
     }
@@ -338,10 +340,12 @@ class UserService implements APIUserService, Sessionable
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed read the user or user group
      *
      * @param \eZ\Publish\API\Repository\Values\User\User $user
+     * @param int $offset the start offset for paging
+     * @param int $limit the number of user groups returned
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
      */
-    public function loadUserGroupsOfUser( User $user)
+    public function loadUserGroupsOfUser( User $user, $offset = 0, $limit = 10 )
     {
         throw new \Exception( "@todo: Implement." );
     }
@@ -352,12 +356,12 @@ class UserService implements APIUserService, Sessionable
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the users or user group
      *
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
-     * @param int $offset
-     * @param int $limit
+     * @param int $offset the start offset for paging
+     * @param int $limit the number of users returned
      *
      * @return \eZ\Publish\API\Repository\Values\User\User[]
      */
-    public function loadUsersOfUserGroup( UserGroup $userGroup, $offset = 0, $limit = -1)
+    public function loadUsersOfUserGroup( UserGroup $userGroup, $offset = 0, $limit = 10 )
     {
         throw new \Exception( "@todo: Implement." );
     }

--- a/eZ/Publish/Core/REST/Server/Controller/Location.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Location.php
@@ -354,7 +354,7 @@ class Location extends RestController
     public function loadLocationChildren( $locationPath )
     {
         $offset = $this->request->query->has( 'offset' ) ? (int)$this->request->query->get( 'offset' ) : 0;
-        $limit = $this->request->query->has( 'limit' ) ? (int)$this->request->query->get( 'limit' ) : -1;
+        $limit = $this->request->query->has( 'limit' ) ? (int)$this->request->query->get( 'limit' ) : 10;
 
         $restLocations = array();
         $locationId = $this->extractLocationIdFromPath( $locationPath );
@@ -364,7 +364,7 @@ class Location extends RestController
                     $locationId
                 ),
                 $offset >= 0 ? $offset : 0,
-                $limit >= 0 ? $limit : -1
+                $limit >= 0 ? $limit : 10
             )->locations as $location
         )
         {

--- a/eZ/Publish/Core/REST/Server/Controller/User.php
+++ b/eZ/Publish/Core/REST/Server/Controller/User.php
@@ -701,6 +701,9 @@ class User extends RestController
      */
     public function loadSubUserGroups( $groupPath )
     {
+        $offset = $this->request->query->has( 'offset' ) ? (int)$this->request->query->get( 'offset' ) : 0;
+        $limit = $this->request->query->has( 'limit' ) ? (int)$this->request->query->get( 'limit' ) : 10;
+
         $userGroupLocation = $this->locationService->loadLocation(
             $this->extractLocationIdFromPath( $groupPath )
         );
@@ -709,7 +712,11 @@ class User extends RestController
             $userGroupLocation->contentId
         );
 
-        $subGroups = $this->userService->loadSubUserGroups( $userGroup );
+        $subGroups = $this->userService->loadSubUserGroups(
+            $userGroup,
+            $offset >= 0 ? $offset : 0,
+            $limit >= 0 ? $limit : 10
+        );
 
         $restUserGroups = array();
         foreach ( $subGroups as $subGroup )
@@ -752,8 +759,15 @@ class User extends RestController
      */
     public function loadUserGroupsOfUser( $userId )
     {
+        $offset = $this->request->query->has( 'offset' ) ? (int)$this->request->query->get( 'offset' ) : 0;
+        $limit = $this->request->query->has( 'limit' ) ? (int)$this->request->query->get( 'limit' ) : 10;
+
         $user = $this->userService->loadUser( $userId );
-        $userGroups = $this->userService->loadUserGroupsOfUser( $user );
+        $userGroups = $this->userService->loadUserGroupsOfUser(
+            $user,
+            $offset >= 0 ? $offset : 0,
+            $limit >= 0 ? $limit : 10
+        );
 
         $restUserGroups = array();
         foreach ( $userGroups as $userGroup )
@@ -796,12 +810,12 @@ class User extends RestController
         );
 
         $offset = $this->request->query->has( 'offset' ) ? (int)$this->request->query->get( 'offset' ) : 0;
-        $limit = $this->request->query->has( 'limit' ) ? (int)$this->request->query->get( 'limit' ) : -1;
+        $limit = $this->request->query->has( 'limit' ) ? (int)$this->request->query->get( 'limit' ) : 10;
 
         $users = $this->userService->loadUsersOfUserGroup(
             $userGroup,
             $offset >= 0 ? $offset : 0,
-            $limit >= 0 ? $limit : -1
+            $limit >= 0 ? $limit : 10
         );
 
         $restUsers = array();

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -280,13 +280,12 @@ class LocationService implements LocationServiceInterface
      * Loads children which are readable by the current user of a location object sorted by sortField and sortOrder
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location
-     *
      * @param int $offset the start offset for paging
-     * @param int $limit the number of locations returned. If $limit = -1 all children starting at $offset are returned
+     * @param int $limit the number of locations returned
      *
      * @return \eZ\Publish\API\Repository\Values\Content\LocationList
      */
-    public function loadLocationChildren( APILocation $location, $offset = 0, $limit = -1 )
+    public function loadLocationChildren( APILocation $location, $offset = 0, $limit = 10 )
     {
         if ( !$this->domainMapper->isValidLocationSortField( $location->sortField ) )
             throw new InvalidArgumentValue( "sortField", $location->sortField, "Location" );

--- a/eZ/Publish/Core/Repository/SearchService.php
+++ b/eZ/Publish/Core/Repository/SearchService.php
@@ -21,6 +21,7 @@ use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\SPI\Search\Content\Handler;
 use eZ\Publish\SPI\Search\Content\Location\Handler as LocationSearchHandler;
 
@@ -31,12 +32,6 @@ use eZ\Publish\SPI\Search\Content\Location\Handler as LocationSearchHandler;
  */
 class SearchService implements SearchServiceInterface
 {
-    /**
-     * 2^30, since PHP_INT_MAX can cause overflows in DB systems, if PHP is run
-     * on 64 bit systems
-     */
-    const MAX_LIMIT = 1073741824;
-
     /**
      * @var \eZ\Publish\Core\Repository\Repository
      */
@@ -114,6 +109,24 @@ class SearchService implements SearchServiceInterface
      */
     public function findContent( Query $query, array $fieldFilters = array(), $filterOnUserPermissions = true )
     {
+        if ( !is_int( $query->offset ) )
+        {
+            throw new InvalidArgumentType(
+                "\$query->offset",
+                "integer",
+                $query->offset
+            );
+        }
+
+        if ( !is_int( $query->limit ) )
+        {
+            throw new InvalidArgumentType(
+                "\$query->limit",
+                "integer",
+                $query->limit
+            );
+        }
+
         $query = clone $query;
         $query->filter = $query->filter ?: new Criterion\MatchAll();
 
@@ -125,11 +138,6 @@ class SearchService implements SearchServiceInterface
         if ( $filterOnUserPermissions && !$this->permissionsCriterionHandler->addPermissionsCriterion( $query->filter ) )
         {
             return new SearchResult( array( 'time' => 0, 'totalCount' => 0 ) );
-        }
-
-        if ( $query->limit === null )
-        {
-            $query->limit = self::MAX_LIMIT;
         }
 
         $result = $this->searchHandler->findContent( $query, $fieldFilters );
@@ -300,6 +308,24 @@ class SearchService implements SearchServiceInterface
      */
     public function findLocations( LocationQuery $query, $filterOnUserPermissions = true )
     {
+        if ( !is_int( $query->offset ) )
+        {
+            throw new InvalidArgumentType(
+                "\$query->offset",
+                "integer",
+                $query->offset
+            );
+        }
+
+        if ( !is_int( $query->limit ) )
+        {
+            throw new InvalidArgumentType(
+                "\$query->limit",
+                "integer",
+                $query->limit
+            );
+        }
+
         $query = clone $query;
         $query->filter = $query->filter ?: new Criterion\MatchAll();
 
@@ -308,11 +334,6 @@ class SearchService implements SearchServiceInterface
         if ( $filterOnUserPermissions && !$this->permissionsCriterionHandler->addPermissionsCriterion( $query->filter ) )
         {
             return new SearchResult( array( 'time' => 0, 'totalCount' => 0 ) );
-        }
-
-        if ( $query->limit === null )
-        {
-            $query->limit = self::MAX_LIMIT;
         }
 
         $result = $this->locationSearchHandler->findLocations( $query );

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
@@ -290,7 +290,7 @@ class SearchTest extends BaseServiceMockTest
             );
 
         $serviceQuery = new Query;
-        $handlerQuery = new Query( array( "filter" => new Criterion\MatchAll(), "limit" => SearchService::MAX_LIMIT ) );
+        $handlerQuery = new Query( array( "filter" => new Criterion\MatchAll(), "limit" => 10 ) );
         $fieldFilters = array();
         $spiContentInfo = new SPIContentInfo;
         $contentMock = $this->getMockForAbstractClass( "eZ\\Publish\\API\\Repository\\Values\\Content\\Content" );
@@ -626,7 +626,7 @@ class SearchTest extends BaseServiceMockTest
                 new Query(
                     array(
                         "filter" => new Criterion\MatchAll(),
-                        "limit" => 1073741824
+                        "limit" => 10
                     )
                 ),
                 array()
@@ -890,7 +890,7 @@ class SearchTest extends BaseServiceMockTest
         $repositoryMock->expects( $this->never() )->method( "hasAccess" );
 
         $serviceQuery = new LocationQuery;
-        $handlerQuery = new LocationQuery( array( "filter" => new Criterion\MatchAll(), "limit" => SearchService::MAX_LIMIT ) );
+        $handlerQuery = new LocationQuery( array( "filter" => new Criterion\MatchAll(), "limit" => 10 ) );
         $spiLocation = new SPILocation;
         $locationMock = $this->getMockForAbstractClass( "eZ\\Publish\\API\\Repository\\Values\\Content\\Location" );
 
@@ -1078,7 +1078,7 @@ class SearchTest extends BaseServiceMockTest
                 new LocationQuery(
                     array(
                         "filter" => new Criterion\MatchAll(),
-                        "limit" => 1073741824
+                        "limit" => 10
                     )
                 )
             )

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -162,12 +162,14 @@ class UserService implements UserServiceInterface
      * Loads the sub groups of a user group
      *
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
+     * @param int $offset the start offset for paging
+     * @param int $limit the number of user groups returned
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the user group
      */
-    public function loadSubUserGroups( APIUserGroup $userGroup )
+    public function loadSubUserGroups( APIUserGroup $userGroup, $offset = 0, $limit = 10 )
     {
         $locationService = $this->repository->getLocationService();
 
@@ -185,7 +187,9 @@ class UserService implements UserServiceInterface
         $searchResult = $this->searchSubGroups(
             $mainGroupLocation->id,
             $mainGroupLocation->sortField,
-            $mainGroupLocation->sortOrder
+            $mainGroupLocation->sortOrder,
+            $offset,
+            $limit
         );
         if ( $searchResult->totalCount == 0 )
             return array();
@@ -210,12 +214,12 @@ class UserService implements UserServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
      */
-    protected function searchSubGroups( $locationId, $sortField = null, $sortOrder = Location::SORT_ORDER_ASC, $offset = 0, $limit = -1 )
+    protected function searchSubGroups( $locationId, $sortField = null, $sortOrder = Location::SORT_ORDER_ASC, $offset = 0, $limit = 10 )
     {
         $searchQuery = new Query();
 
-        $searchQuery->offset = $offset >= 0 ? (int)$offset : 0;
-        $searchQuery->limit = $limit >= 0 ? (int)$limit  : null;
+        $searchQuery->offset = $offset;
+        $searchQuery->limit = $limit;
 
         $searchQuery->filter = new CriterionLogicalAnd(
             array(
@@ -894,10 +898,12 @@ class UserService implements UserServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed read the user or user group
      *
      * @param \eZ\Publish\API\Repository\Values\User\User $user
+     * @param int $offset the start offset for paging
+     * @param int $limit the number of user groups returned
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
      */
-    public function loadUserGroupsOfUser( APIUser $user )
+    public function loadUserGroupsOfUser( APIUser $user, $offset = 0, $limit = 10 )
     {
         $locationService = $this->repository->getLocationService();
 
@@ -917,8 +923,8 @@ class UserService implements UserServiceInterface
 
         $searchQuery = new Query();
 
-        $searchQuery->offset = 0;
-        $searchQuery->limit = null;
+        $searchQuery->offset = $offset;
+        $searchQuery->limit = $limit;
         $searchQuery->performCount = false;
 
         $searchQuery->filter = new CriterionLogicalAnd(
@@ -945,12 +951,12 @@ class UserService implements UserServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the users or user group
      *
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
-     * @param int $offset
-     * @param int $limit
+     * @param int $offset the start offset for paging
+     * @param int $limit the number of users returned
      *
      * @return \eZ\Publish\API\Repository\Values\User\User[]
      */
-    public function loadUsersOfUserGroup( APIUserGroup $userGroup, $offset = 0, $limit = -1 )
+    public function loadUsersOfUserGroup( APIUserGroup $userGroup, $offset = 0, $limit = 10 )
     {
         $loadedUserGroup = $this->loadUserGroup( $userGroup->id );
 
@@ -970,8 +976,8 @@ class UserService implements UserServiceInterface
             )
         );
 
-        $searchQuery->offset = $offset > 0 ? (int)$offset : 0;
-        $searchQuery->limit = $limit >= 1 ? (int)$limit : null;
+        $searchQuery->offset = $offset;
+        $searchQuery->limit = $limit;
         $searchQuery->performCount = false;
 
         $searchQuery->sortClauses = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Gateway/Native.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Gateway/Native.php
@@ -208,22 +208,9 @@ class Native extends Gateway
                 $query->sortClauses
             ),
             "track_scores" => true,
+            "from" => $query->offset,
+            "size" => $query->limit,
         );
-
-        if ( $query->offset !== null )
-        {
-            $ast["from"] = $query->offset;
-        }
-
-        // TODO: for some reason 1073741824 causes out of memory...
-        if ( $query->limit !== null && $query->limit !== 1073741824 )
-        {
-            $ast["size"] = $query->limit;
-        }
-        if ( $query->limit == 1073741824 )
-        {
-            $ast["size"] = 1000;
-        }
 
         $response = $this->findRaw( json_encode( $ast ), $type );
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway.php
@@ -24,7 +24,7 @@ abstract class Gateway
      *
      * @param Criterion $criterion
      * @param int $offset
-     * @param int|null $limit
+     * @param int $limit
      * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sort
      * @param array $fieldFilters
      * @param bool $doCount
@@ -33,8 +33,8 @@ abstract class Gateway
      */
     abstract public function find(
         Criterion $criterion,
-        $offset = 0,
-        $limit = null,
+        $offset,
+        $limit,
         array $sort = null,
         array $fieldFilters = array(),
         $doCount = true

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -24,12 +24,6 @@ use eZ\Publish\Core\Persistence\Database\SelectQuery;
 class DoctrineDatabase extends Gateway
 {
     /**
-     * 2^30, since PHP_INT_MAX can cause overflows in DB systems, if PHP is run
-     * on 64 bit systems
-     */
-    const MAX_LIMIT = 1073741824;
-
-    /**
      * Database handler
      *
      * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
@@ -75,7 +69,7 @@ class DoctrineDatabase extends Gateway
      *
      * @param Criterion $criterion
      * @param int $offset
-     * @param int|null $limit
+     * @param int $limit
      * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sort
      * @param array $fieldFilters
      * @param bool $doCount
@@ -84,15 +78,13 @@ class DoctrineDatabase extends Gateway
      */
     public function find(
         Criterion $criterion,
-        $offset = 0,
-        $limit = null,
+        $offset,
+        $limit,
         array $sort = null,
         array $fieldFilters = array(),
         $doCount = true
     )
     {
-        $limit = $limit !== null ? $limit : self::MAX_LIMIT;
-
         $count = $doCount ? $this->getResultCount( $criterion, $sort, $fieldFilters ) : null;
 
         if ( !$doCount && $limit === 0 )

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway.php
@@ -22,11 +22,11 @@ abstract class Gateway
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param int $offset
-     * @param int|null $limit
+     * @param int $limit
      * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sortClauses
      * @param bool $doCount
      *
      * @return mixed[][]
      */
-    abstract public function find( Criterion $criterion, $offset = 0, $limit = null, array $sortClauses = null, $doCount = true );
+    abstract public function find( Criterion $criterion, $offset, $limit, array $sortClauses = null, $doCount = true );
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -68,13 +68,13 @@ class DoctrineDatabase extends Gateway
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param int $offset
-     * @param int|null $limit
+     * @param int $limit
      * @param null|\eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sortClauses
      * @param bool $doCount
      *
      * @return mixed[][]
      */
-    public function find( Criterion $criterion, $offset = 0, $limit = null, array $sortClauses = null, $doCount = true )
+    public function find( Criterion $criterion, $offset, $limit, array $sortClauses = null, $doCount = true )
     {
         $count = $doCount ? $this->getTotalCount( $criterion, $sortClauses ) : null;
 
@@ -137,10 +137,7 @@ class DoctrineDatabase extends Gateway
             $this->sortClauseConverter->applyOrderBy( $selectQuery );
         }
 
-        $selectQuery->limit(
-            $limit > 0 ? $limit : self::MAX_LIMIT,
-            $offset
-        );
+        $selectQuery->limit( $limit, $offset );
 
         $statement = $selectQuery->prepare();
         $statement->execute();

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerTest.php
@@ -714,6 +714,7 @@ class HandlerTest extends LanguageAwareTestCase
                 new Query(
                     array(
                         'criterion' => new Criterion\Depth( Criterion\Operator::IN, array( 1, 2 ) ),
+                        'limit' => 50,
                     )
                 )
             )
@@ -742,6 +743,7 @@ class HandlerTest extends LanguageAwareTestCase
                 new Query(
                     array(
                         'criterion' => new Criterion\Depth( Criterion\Operator::GT, 4 ),
+                        'limit' => 50,
                     )
                 )
             )
@@ -756,6 +758,7 @@ class HandlerTest extends LanguageAwareTestCase
                 new Query(
                     array(
                         'criterion' => new Criterion\Depth( Criterion\Operator::GTE, 5 ),
+                        'limit' => 50,
                     )
                 )
             )
@@ -785,6 +788,7 @@ class HandlerTest extends LanguageAwareTestCase
                 new Query(
                     array(
                         'criterion' => new Criterion\Depth( Criterion\Operator::LTE, 2 ),
+                        'limit' => 50,
                     )
                 )
             )

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/Location/HandlerTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/Location/HandlerTest.php
@@ -456,6 +456,7 @@ class HandlerTest extends LanguageAwareTestCase
                 new LocationQuery(
                     array(
                         'filter' => new Criterion\Location\Depth( Criterion\Operator::IN, array( 1, 2 ) ),
+                        'limit' => 50,
                     )
                 )
             )
@@ -484,6 +485,7 @@ class HandlerTest extends LanguageAwareTestCase
                 new LocationQuery(
                     array(
                         'filter' => new Criterion\Location\Depth( Criterion\Operator::GT, 4 ),
+                        'limit' => 50,
                     )
                 )
             )
@@ -498,6 +500,7 @@ class HandlerTest extends LanguageAwareTestCase
                 new LocationQuery(
                     array(
                         'filter' => new Criterion\Location\Depth( Criterion\Operator::GTE, 5 ),
+                        'limit' => 50,
                     )
                 )
             )
@@ -527,6 +530,7 @@ class HandlerTest extends LanguageAwareTestCase
                 new LocationQuery(
                     array(
                         'filter' => new Criterion\Location\Depth( Criterion\Operator::LTE, 2 ),
+                        'limit' => 50,
                     )
                 )
             )

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
@@ -120,19 +120,11 @@ class Native extends Gateway
                     $query->sortClauses
                 )
             ),
+            "start" => $query->offset,
+            "rows" => $query->limit,
             "fl" => "*,score",
             "wt" => "json",
         );
-
-        if ( $query->offset !== null )
-        {
-            $parameters["start"] = $query->offset;
-        }
-
-        if ( $query->limit !== null )
-        {
-            $parameters["rows"] = $query->limit;
-        }
 
         // @todo: Extract method
         $response = $this->client->request(

--- a/eZ/Publish/Core/Search/Solr/Content/Location/Gateway/Native.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Location/Gateway/Native.php
@@ -107,19 +107,11 @@ class Native extends Gateway
                     $query->sortClauses
                 )
             ),
+            "start" => $query->offset,
+            "rows" => $query->limit,
             "fl" => "*,score",
             "wt" => "json",
         );
-
-        if ( $query->offset !== null )
-        {
-            $parameters["start"] = $query->offset;
-        }
-
-        if ( $query->limit !== null )
-        {
-            $parameters["rows"] = $query->limit;
-        }
 
         // @todo: Extract method
         $response = $this->client->request(

--- a/eZ/Publish/Core/SignalSlot/LocationService.php
+++ b/eZ/Publish/Core/SignalSlot/LocationService.php
@@ -140,11 +140,11 @@ class LocationService implements LocationServiceInterface
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location
      * @param int $offset the start offset for paging
-     * @param int $limit the number of locations returned. If $limit = -1 all children starting at $offset are returned
+     * @param int $limit the number of locations returned
      *
      * @return \eZ\Publish\API\Repository\Values\Content\LocationList
      */
-    public function loadLocationChildren( Location $location, $offset = 0, $limit = -1 )
+    public function loadLocationChildren( Location $location, $offset = 0, $limit = 10 )
     {
         return $this->service->loadLocationChildren( $location, $offset, $limit );
     }

--- a/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
@@ -98,7 +98,7 @@ class UserServiceTest extends ServiceTest
             ),
             array(
                 'loadSubUserGroups',
-                array( $parentGroup ),
+                array( $parentGroup, 1, 1 ),
                 array( $userGroup ),
                 0
             ),
@@ -207,7 +207,7 @@ class UserServiceTest extends ServiceTest
             ),
             array(
                 'loadUserGroupsOfUser',
-                array( $user ),
+                array( $user, 1, 1 ),
                 array( $userGroup ),
                 0
             ),

--- a/eZ/Publish/Core/SignalSlot/UserService.php
+++ b/eZ/Publish/Core/SignalSlot/UserService.php
@@ -110,14 +110,16 @@ class UserService implements UserServiceInterface
      * Loads the sub groups of a user group
      *
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
+     * @param int $offset the start offset for paging
+     * @param int $limit the number of user groups returned
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the user group
      */
-    public function loadSubUserGroups( UserGroup $userGroup )
+    public function loadSubUserGroups( UserGroup $userGroup, $offset = 0, $limit = 10 )
     {
-        return $this->service->loadSubUserGroups( $userGroup );
+        return $this->service->loadSubUserGroups( $userGroup, $offset, $limit );
     }
 
     /**
@@ -394,12 +396,14 @@ class UserService implements UserServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed read the user or user group
      *
      * @param \eZ\Publish\API\Repository\Values\User\User $user
+     * @param int $offset the start offset for paging
+     * @param int $limit the number of user groups returned
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
      */
-    public function loadUserGroupsOfUser( User $user )
+    public function loadUserGroupsOfUser( User $user, $offset = 0, $limit = 10 )
     {
-        return $this->service->loadUserGroupsOfUser( $user );
+        return $this->service->loadUserGroupsOfUser( $user, $offset, $limit );
     }
 
     /**
@@ -408,12 +412,12 @@ class UserService implements UserServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the users or user group
      *
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
-     * @param int $offset
-     * @param int $limit
+     * @param int $offset the start offset for paging
+     * @param int $limit the number of users returned
      *
      * @return \eZ\Publish\API\Repository\Values\User\User[]
      */
-    public function loadUsersOfUserGroup( UserGroup $userGroup, $offset = 0, $limit = -1 )
+    public function loadUsersOfUserGroup( UserGroup $userGroup, $offset = 0, $limit = 10 )
     {
         return $this->service->loadUsersOfUserGroup( $userGroup, $offset, $limit );
     }


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-23405

This removes the option for returning unlimited number of search hits.

While this worked with relational database (Legacy Search Engine), Solr and Elasticsearch were never made to provide for this. Using big number to fake unlimited (`1073741824` for Legacy Search Engine) routinely causes OOM exceptions with Solr and Elasticsearch.

Solr and Elasticsearch were made to work with returning relatively small number of hits, providing paging/scrolling for the case when full set is required.

This removes `null` as an alias for unlimited in `Query` objects, and also in methods that rely on search:

* LocationService::loadLocationChildren()
* UserService:: loadSubUserGroups()
* UserService:: loadUserGroupsOfUser()
* UserService:: loadUsersOfUserGroup()

Default limit value is now set to 10.

Note that this does not change methods that provide pagination with unlimited option, but do not use Search, like:

* ObjectStateService::loadObjectStateGroups()
* UrlAliasService::listGlobalAliases()

### TODOs

- [x] update REST server implementation and spec.
- [x] complete BC notes