### PR TITLE
Fix EZP-24366: language switcher : UrlAliasGenerator generate wrong u…

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -77,15 +77,8 @@ class UrlAliasGenerator extends Generator
         if ( isset( $parameters['siteaccess'] ) )
         {
             // We generate for a different SiteAccess, so potentially in a different language.
-            // We then loop against configured languages until we find a valid URLAlias.
             $languages = $this->configResolver->getParameter( 'languages', null, $parameters['siteaccess'] );
-            foreach ( $languages as $lang )
-            {
-                if ( $urlAliases = $urlAliasService->listLocationAliases( $location, false, $lang, null, $languages ) )
-                {
-                    break;
-                }
-            }
+            $urlAliases = $urlAliasService->listLocationAliases( $location, false, null, null, $languages );
 
             unset( $parameters['siteaccess'] );
         }

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
@@ -191,13 +191,12 @@ class UrlAliasGeneratorTest extends PHPUnit_Framework_TestCase
 
         $location = new Location( array( 'id' => 123 ) );
         $this->urlAliasService
-            ->expects( $this->exactly( 2 ) )
+            ->expects( $this->exactly( 1 ) )
             ->method( 'listLocationAliases' )
             ->will(
                 $this->returnValueMap(
                     array(
-                        array( $location, false, 'esl-ES', null, $languages, array() ),
-                        array( $location, false, 'fre-FR', null, $languages, array( $urlAlias ) ),
+                        array( $location, false, null, null, $languages, array( $urlAlias ) ),
                     )
                 )
             );


### PR DESCRIPTION
…rl when there is always available

JIRA: https://jira.ez.no/browse/EZP-24366

If the $languageCode parameter of the listLocationAliases function is set, the UrlAliasService doesn't consider the always available flag. Is this behavior correct?

I set this parameter to null. The $prioritizedLanguageList parameter should generates the url correct.