### PR TITLE
EZP-24374: Fixed double slashes in REST location path

### DIFF
--- a/eZ/Publish/Core/REST/Server/Controller/Location.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Location.php
@@ -238,7 +238,7 @@ class Location extends RestController
                 $this->router->generate(
                     'ezpublish_rest_loadLocation',
                     array(
-                        'locationPath' => rtrim( $locationToMove->pathString, '/' ),
+                        'locationPath' => trim( $locationToMove->pathString, '/' ),
                     )
                 )
             );

--- a/eZ/Publish/Core/REST/Server/Controller/Trash.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Trash.php
@@ -190,7 +190,7 @@ class Trash extends RestController
             $this->router->generate(
                 'ezpublish_rest_loadLocation',
                 array(
-                    'locationPath' => rtrim( $location->pathString, '/' ),
+                    'locationPath' => trim( $location->pathString, '/' ),
                 )
             )
         );

--- a/eZ/Publish/Core/REST/Server/Controller/User.php
+++ b/eZ/Publish/Core/REST/Server/Controller/User.php
@@ -686,7 +686,7 @@ class User extends RestController
             $this->router->generate(
                 'ezpublish_rest_loadUserGroup',
                 array(
-                    'groupPath' => $destinationGroupLocation->pathString . $userGroupLocation->id
+                    'groupPath' => trim( $destinationGroupLocation->pathString, '/' ) . '/' . $userGroupLocation->id
                 )
             )
         );


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24374

Some location hrefs have a double `/`. This should ensure that they're gone.

## Testing done
none