### PR TITLE
Fix EZP-24397: Implement FieldDefinition form mapper for ezinteger

### DIFF
--- a/eZ/Publish/Core/FieldType/Integer/Type.php
+++ b/eZ/Publish/Core/FieldType/Integer/Type.php
@@ -27,11 +27,11 @@ class Type extends FieldType
         'IntegerValueValidator' => array(
             'minIntegerValue' => array(
                 'type' => 'int',
-                'default' => null
+                'default' => false
             ),
             'maxIntegerValue' => array(
                 'type' => 'int',
-                'default' => null
+                'default' => false
             )
         )
     );


### PR DESCRIPTION
IntegerValueValidator default should be false, not null, or the form mapper fails. Ref Float type.
https://github.com/ezsystems/repository-forms/pull/10 needs this to work.

https://jira.ez.no/browse/EZP-24397

See https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/FieldType/Float/Type.php#L30
vs https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/FieldType/Integer/Type.php#L30