### PR TITLE
Fix EZP-24397: Implement FieldDefinition form mapper for ezinteger

### DIFF
--- a/eZ/Publish/Core/FieldType/Integer/Type.php
+++ b/eZ/Publish/Core/FieldType/Integer/Type.php
@@ -68,7 +68,7 @@ class Type extends FieldType
                 {
                     case "minIntegerValue":
                     case "maxIntegerValue":
-                        if ( $value !== false && !is_integer( $value ) )
+                        if ( $value !== null && !is_integer( $value ) )
                         {
                             $validationErrors[] = new ValidationError(
                                 "Validator parameter '%parameter%' value must be of integer type",

--- a/eZ/Publish/Core/FieldType/Tests/IntegerTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/IntegerTest.php
@@ -306,7 +306,7 @@ class IntegerTest extends FieldTypeTest
             array(
                 array(
                     'IntegerValueValidator' => array(
-                        'minIntegerValue' => false,
+                        'minIntegerValue' => null,
                     )
                 )
             ),
@@ -320,7 +320,7 @@ class IntegerTest extends FieldTypeTest
             array(
                 array(
                     'IntegerValueValidator' => array(
-                        'maxIntegerValue' => false,
+                        'maxIntegerValue' => null,
                     )
                 )
             ),

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Integer.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Integer.php
@@ -89,7 +89,7 @@ class Integer implements Converter
      */
     public function toFieldDefinition( StorageFieldDefinition $storageDef, FieldDefinition $fieldDef )
     {
-        $validatorParameters = array( 'minIntegerValue' => false, 'maxIntegerValue' => false );
+        $validatorParameters = array( 'minIntegerValue' => null, 'maxIntegerValue' => null );
         if ( $storageDef->dataInt4 & self::HAS_MIN_VALUE )
         {
             $validatorParameters['minIntegerValue'] = $storageDef->dataInt1;


### PR DESCRIPTION
Default values must be null, not false. Required for https://github.com/ezsystems/repository-forms/pull/10
Thanks @lolautruche

https://jira.ez.no/browse/EZP-24397