### PR TITLE
EZP-24411: Float validators wont work if they were defined as default

### DIFF
--- a/eZ/Publish/Core/FieldType/Float/Type.php
+++ b/eZ/Publish/Core/FieldType/Float/Type.php
@@ -27,11 +27,11 @@ class Type extends FieldType
         'FloatValueValidator' => array(
             'minFloatValue' => array(
                 'type' => 'float',
-                'default' => false
+                'default' => null
             ),
             'maxFloatValue' => array(
                 'type' => 'float',
-                'default' => false
+                'default' => null
             )
         )
     );

--- a/eZ/Publish/Core/FieldType/Tests/FloatTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FloatTest.php
@@ -49,11 +49,11 @@ class FloatTest extends FieldTypeTest
             "FloatValueValidator" => array(
                 "minFloatValue" => array(
                     "type" => "float",
-                    "default" => false
+                    "default" => null
                 ),
                 "maxFloatValue" => array(
                     "type" => "float",
-                    "default" => false
+                    "default" => null
                 )
             )
         );


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24411

The float fieldtypes default value was ending up as from 0 to 0, related with #844