### PR TITLE
Implement EZP-24375: Semantic configuration for multicore Solr search engine

### DIFF
--- a/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
@@ -41,7 +41,6 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root( $this->rootNodeName );
 
         $this->addEndpointsSection( $rootNode );
-        $this->addMappingsSection( $rootNode );
         $this->addConnectionsSection( $rootNode );
 
         return $treeBuilder;
@@ -121,16 +120,70 @@ class Configuration implements ConfigurationInterface
      */
     protected function addConnectionsSection( ArrayNodeDefinition $node )
     {
-        ;
-    }
-
-    /**
-     * Adds mappings definition.
-     *
-     * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node
-     */
-    protected function addMappingsSection( ArrayNodeDefinition $node )
-    {
-        ;
+        $node->children()
+            ->scalarNode( "default_connection" )
+                ->info( "Name of the default connection" )
+            ->end()
+            ->arrayNode( "connections" )
+            ->info( "Solr Search Engine connections configuration" )
+            ->useAttributeAsKey( "connection_name" )
+            ->performNoDeepMerging()
+            ->prototype( "array" )
+                ->children()
+                    ->arrayNode( "entry_points" )
+                        ->info( "An array of endpoint names" )
+                        ->example(
+                            array(
+                                "endpoint1",
+                                "endpoint2",
+                                "endpoint3",
+                            )
+                        )
+                        ->prototype( "scalar" )->end()
+                    ->end()
+                    ->arrayNode( "cluster" )
+                        ->info( "A map of translation language codes and Solr endpoint names, per entity" )
+                        ->example(
+                            array(
+                                "content" => array(
+                                    "cro-HR" => "endpoint1",
+                                    "eng-GB" => "endpoint2",
+                                ),
+                                "location" => array(
+                                    "cro-HR" => "endpoint1",
+                                    "eng-GB" => "endpoint2",
+                                ),
+                            )
+                        )
+                        ->children()
+                            ->arrayNode( "content" )
+                                ->useAttributeAsKey( "language_code" )
+                                ->info( "A map of translation language codes and Solr endpoint names for Content index" )
+                                ->example(
+                                    array(
+                                        "cro-HR" => "endpoint1",
+                                        "eng-GB" => "endpoint2",
+                                    )
+                                )
+                                ->prototype( "scalar" )
+                                ->end()
+                            ->end()
+                            ->arrayNode( "location" )
+                                ->useAttributeAsKey( "language_code" )
+                                ->info( "A map of translation language codes and Solr endpoint names for Location index" )
+                                ->example(
+                                    array(
+                                        "cro-HR" => "endpoint1",
+                                        "eng-GB" => "endpoint2",
+                                    )
+                                )
+                                ->prototype( "scalar" )
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ->end();
     }
 }

--- a/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
@@ -134,7 +134,7 @@ class Configuration implements ConfigurationInterface
                         function( $v )
                         {
                             return (
-                                empty( $v["entry_points"]["content"] ) &&
+                                empty( $v["entry_endpoints"]["content"] ) &&
                                 !empty( $v["cluster"]["content"] )
                             );
                         }
@@ -142,8 +142,8 @@ class Configuration implements ConfigurationInterface
                     ->then(
                         function( $v )
                         {
-                            // If Content search entry points are not provided use cluster endpoints
-                            $v["entry_points"]["content"] = array_values( $v["cluster"]["content"] );
+                            // If Content search entry endpoints are not provided use cluster endpoints
+                            $v["entry_endpoints"]["content"] = array_values( $v["cluster"]["content"] );
                             return $v;
                         }
                     )
@@ -153,7 +153,7 @@ class Configuration implements ConfigurationInterface
                         function( $v )
                         {
                             return (
-                                empty( $v["entry_points"]["location"] ) &&
+                                empty( $v["entry_endpoints"]["location"] ) &&
                                 !empty( $v["cluster"]["location"] )
                             );
                         }
@@ -161,15 +161,15 @@ class Configuration implements ConfigurationInterface
                     ->then(
                         function( $v )
                         {
-                            // If Location search entry points are not provided use cluster endpoints
-                            $v["entry_points"]["location"] = array_values( $v["cluster"]["location"] );
+                            // If Location search entry endpoints are not provided use cluster endpoints
+                            $v["entry_endpoints"]["location"] = array_values( $v["cluster"]["location"] );
                             return $v;
                         }
                     )
                 ->end()
                 ->children()
-                    ->arrayNode( "entry_points" )
-                        ->info( "A set of endpoint names, per search type" )
+                    ->arrayNode( "entry_endpoints" )
+                        ->info( "A set of entry endpoint names, per search type" )
                         ->addDefaultsIfNotSet()
                         ->example(
                             array(

--- a/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
@@ -16,6 +16,20 @@ class Configuration implements ConfigurationInterface
 {
     protected $rootNodeName;
 
+    /**
+     * Holds default endpoint values
+     *
+     * @var array
+     */
+    protected $defaultEndpointValues = array(
+        "scheme" => "http",
+        "host" => "127.0.0.1",
+        "port" => 8983,
+        "user" => null,
+        "pass" => null,
+        "path" => "/solr",
+    );
+
     public function __construct( $rootNodeName )
     {
         $this->rootNodeName = $rootNodeName;
@@ -26,36 +40,97 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root( $this->rootNodeName );
 
+        $this->addEndpointsSection( $rootNode );
+        $this->addMappingsSection( $rootNode );
         $this->addConnectionsSection( $rootNode );
 
         return $treeBuilder;
     }
 
     /**
-     * Adds semantic configuration definition.
+     * Adds endpoints definition.
      *
      * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node
      */
-    protected function addConnectionsSection( ArrayNodeDefinition $node )
+    protected function addEndpointsSection( ArrayNodeDefinition $node )
     {
         $node->children()
-            ->scalarNode( "default_connection" )
-                ->info( "Name of the default connection" )
-            ->end()
-            ->arrayNode( "connections" )
-                ->info( "Solr Search Engine connections configuration" )
-                ->useAttributeAsKey( "connection_name" )
+            ->arrayNode( "endpoints" )
+                ->info( "Solr Search Engine endpoints configuration" )
+                ->useAttributeAsKey( "endpoint_name" )
                 ->performNoDeepMerging()
                 ->prototype( "array" )
+                    ->beforeNormalization()
+                        ->ifTrue(
+                            function( $v )
+                            {
+                                return isset( $v["dsn"] );
+                            }
+                        )
+                        ->then(
+                            function( $v )
+                            {
+                                // Provided DSN will override overlapping standalone values
+                                $parts = parse_url( $v["dsn"] );
+                                unset( $v["dsn"] );
+
+                                if ( isset( $parts["scheme"] ) ) $v["scheme"] = $parts["scheme"];
+                                if ( isset( $parts["host"] ) ) $v["host"] = $parts["host"];
+                                if ( isset( $parts["port"] ) ) $v["port"] = $parts["port"];
+                                if ( isset( $parts["user"] ) ) $v["user"] = $parts["user"];
+                                if ( isset( $parts["pass"] ) ) $v["pass"] = $parts["pass"];
+                                if ( isset( $parts["path"] ) ) $v["path"] = $parts["path"];
+
+                                return $v;
+                            }
+                        )
+                    ->end()
+                    ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode( "server" )
+                        ->scalarNode( "scheme" )
+                            ->defaultValue( $this->defaultEndpointValues["scheme"] )
+                        ->end()
+                        ->scalarNode( "host" )
+                            ->defaultValue( $this->defaultEndpointValues["host"] )
+                        ->end()
+                        ->scalarNode( "port" )
+                            ->defaultValue( $this->defaultEndpointValues["port"] )
+                        ->end()
+                        ->scalarNode( "user" )
+                            ->defaultValue( $this->defaultEndpointValues["user"] )
+                        ->end()
+                        ->scalarNode( "pass" )
+                            ->defaultValue( $this->defaultEndpointValues["pass"] )
+                        ->end()
+                        ->scalarNode( "path" )
+                            ->defaultValue( $this->defaultEndpointValues["path"] )
+                        ->end()
+                        ->scalarNode( "core" )
                             ->isRequired()
-                            ->info( "Address of the Solr server" )
-                            ->example( "https://username:password@hostname.com/path:1234" )
                         ->end()
                     ->end()
                 ->end()
             ->end()
         ->end();
+    }
+
+    /**
+     * Adds connections definition.
+     *
+     * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node
+     */
+    protected function addConnectionsSection( ArrayNodeDefinition $node )
+    {
+        ;
+    }
+
+    /**
+     * Adds mappings definition.
+     *
+     * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $node
+     */
+    protected function addMappingsSection( ArrayNodeDefinition $node )
+    {
+        ;
     }
 }

--- a/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
@@ -131,18 +131,48 @@ class Configuration implements ConfigurationInterface
             ->prototype( "array" )
                 ->children()
                     ->arrayNode( "entry_points" )
-                        ->info( "An array of endpoint names" )
+                        ->info( "A set of endpoint names, per search type" )
+                        ->addDefaultsIfNotSet()
                         ->example(
                             array(
-                                "endpoint1",
-                                "endpoint2",
-                                "endpoint3",
+                                "content" => array(
+                                    "endpoint1",
+                                    "endpoint2",
+                                ),
+                                "location" => array(
+                                    "endpoint1",
+                                    "endpoint2",
+                                ),
                             )
                         )
-                        ->prototype( "scalar" )->end()
+                        ->children()
+                            ->arrayNode( "content" )
+                                ->info( "A set of endpoint names for Content index" )
+                                ->example(
+                                    array(
+                                        "endpoint1",
+                                        "endpoint2",
+                                    )
+                                )
+                                ->prototype( "scalar" )
+                                ->end()
+                            ->end()
+                            ->arrayNode( "location" )
+                                ->info( "A set of endpoint names for Location index" )
+                                ->example(
+                                    array(
+                                        "endpoint1",
+                                        "endpoint2",
+                                    )
+                                )
+                                ->prototype( "scalar" )
+                                ->end()
+                            ->end()
+                        ->end()
                     ->end()
                     ->arrayNode( "cluster" )
-                        ->info( "A map of translation language codes and Solr endpoint names, per entity" )
+                        ->info( "A map of translation language codes and Solr endpoint names, per search type" )
+                        ->addDefaultsIfNotSet()
                         ->example(
                             array(
                                 "content" => array(

--- a/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
@@ -187,6 +187,7 @@ class Configuration implements ConfigurationInterface
                         )
                         ->children()
                             ->arrayNode( "content" )
+                                ->normalizeKeys( false )
                                 ->useAttributeAsKey( "language_code" )
                                 ->info( "A map of translation language codes and Solr endpoint names for Content index" )
                                 ->example(
@@ -199,6 +200,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                             ->arrayNode( "location" )
+                                ->normalizeKeys( false )
                                 ->useAttributeAsKey( "language_code" )
                                 ->info( "A map of translation language codes and Solr endpoint names for Location index" )
                                 ->example(

--- a/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
@@ -171,7 +171,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
                     ->end()
                     ->arrayNode( "cluster" )
-                        ->info( "A map of translation language codes and Solr endpoint names, per search type" )
+                        ->info( "Cluster map, consisting of a mapping of translation language codes and Solr endpoint names, per search type" )
                         ->addDefaultsIfNotSet()
                         ->example(
                             array(

--- a/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
@@ -161,7 +161,7 @@ class Configuration implements ConfigurationInterface
                     ->then(
                         function( $v )
                         {
-                            // If Location searcg entry points are not provided use cluster endpoints
+                            // If Location search entry points are not provided use cluster endpoints
                             $v["entry_points"]["location"] = array_values( $v["cluster"]["location"] );
                             return $v;
                         }

--- a/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
@@ -55,7 +55,7 @@ class Configuration implements ConfigurationInterface
     {
         $node->children()
             ->arrayNode( "endpoints" )
-                ->info( "Solr Search Engine endpoints configuration" )
+                ->info( "Solr Search Engine endpoint configuration" )
                 ->useAttributeAsKey( "endpoint_name" )
                 ->performNoDeepMerging()
                 ->prototype( "array" )
@@ -125,7 +125,7 @@ class Configuration implements ConfigurationInterface
                 ->info( "Name of the default connection" )
             ->end()
             ->arrayNode( "connections" )
-            ->info( "Solr Search Engine connections configuration" )
+            ->info( "Solr Search Engine connection configuration" )
             ->useAttributeAsKey( "connection_name" )
             ->performNoDeepMerging()
             ->prototype( "array" )

--- a/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/Configuration.php
@@ -129,6 +129,44 @@ class Configuration implements ConfigurationInterface
             ->useAttributeAsKey( "connection_name" )
             ->performNoDeepMerging()
             ->prototype( "array" )
+                ->beforeNormalization()
+                    ->ifTrue(
+                        function( $v )
+                        {
+                            return (
+                                empty( $v["entry_points"]["content"] ) &&
+                                !empty( $v["cluster"]["content"] )
+                            );
+                        }
+                    )
+                    ->then(
+                        function( $v )
+                        {
+                            // If Content search entry points are not provided use cluster endpoints
+                            $v["entry_points"]["content"] = array_values( $v["cluster"]["content"] );
+                            return $v;
+                        }
+                    )
+                ->end()
+                ->beforeNormalization()
+                    ->ifTrue(
+                        function( $v )
+                        {
+                            return (
+                                empty( $v["entry_points"]["location"] ) &&
+                                !empty( $v["cluster"]["location"] )
+                            );
+                        }
+                    )
+                    ->then(
+                        function( $v )
+                        {
+                            // If Location searcg entry points are not provided use cluster endpoints
+                            $v["entry_points"]["location"] = array_values( $v["cluster"]["location"] );
+                            return $v;
+                        }
+                    )
+                ->end()
                 ->children()
                     ->arrayNode( "entry_points" )
                         ->info( "A set of endpoint names, per search type" )
@@ -147,7 +185,7 @@ class Configuration implements ConfigurationInterface
                         )
                         ->children()
                             ->arrayNode( "content" )
-                                ->info( "A set of endpoint names for Content index" )
+                                ->info( "A set of endpoint names for Content index. If not set cluster endpoints will be used." )
                                 ->example(
                                     array(
                                         "endpoint1",
@@ -158,7 +196,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                             ->arrayNode( "location" )
-                                ->info( "A set of endpoint names for Location index" )
+                                ->info( "A set of endpoint names for Location index. If not set cluster endpoints will be used." )
                                 ->example(
                                     array(
                                         "endpoint1",

--- a/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/EzPublishSolrSearchEngineExtension.php
+++ b/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/EzPublishSolrSearchEngineExtension.php
@@ -22,9 +22,9 @@ class EzPublishSolrSearchEngineExtension extends Extension
     const MAIN_SEARCH_ENGINE_ID = "ezpublish.spi.search.solr";
     const CONTENT_SEARCH_HANDLER_ID = "ezpublish.spi.search.solr.content_handler";
     const CONTENT_SEARCH_GATEWAY_ID = "ezpublish.search.solr.content.gateway.native";
+    const CONTENT_ENDPOINT_RESOLVER_ID = "ezpublish.search.solr.content.gateway.endpoint_resolver.native.content";
     const LOCATION_SEARCH_HANDLER_ID = "ezpublish.spi.search.solr.location_handler";
     const LOCATION_SEARCH_GATEWAY_ID = "ezpublish.search.solr.location.gateway.native";
-    const CONTENT_ENDPOINT_RESOLVER_ID = "ezpublish.search.solr.content.gateway.endpoint_resolver.native.content";
     const LOCATION_ENDPOINT_RESOLVER_ID = "ezpublish.search.solr.content.gateway.endpoint_resolver.native.location";
 
     /**
@@ -111,6 +111,10 @@ class EzPublishSolrSearchEngineExtension extends Extension
         {
             $this->defineEndpoint( $container, $name, $params );
         }
+
+        // Search engine itself, for given connection name
+        $searchEngineDef = $container->findDefinition( self::MAIN_SEARCH_ENGINE_ID );
+        $searchEngineDef->setFactory( [new Reference( 'ezpublish.solr.engine_factory' ), 'buildEngine'] );
     }
 
     /**
@@ -163,10 +167,6 @@ class EzPublishSolrSearchEngineExtension extends Extension
         $locationSearchHandlerId = self::LOCATION_SEARCH_HANDLER_ID . ".$connectionName";
         $container->setDefinition( $locationSearchHandlerId, $locationSearchHandlerDefinition );
         $container->setParameter( "$alias.connection.$connectionName.location_handler_id", $locationSearchHandlerId );
-
-        // Search engine itself, for given connection name
-        $searchEngineDef = $container->findDefinition( self::MAIN_SEARCH_ENGINE_ID );
-        $searchEngineDef->setFactory( [new Reference( 'ezpublish.solr.engine_factory' ), 'buildEngine'] );
     }
 
     /**

--- a/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/EzPublishSolrSearchEngineExtension.php
+++ b/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/EzPublishSolrSearchEngineExtension.php
@@ -24,7 +24,8 @@ class EzPublishSolrSearchEngineExtension extends Extension
     const CONTENT_SEARCH_GATEWAY_ID = "ezpublish.search.solr.content.gateway.native";
     const LOCATION_SEARCH_HANDLER_ID = "ezpublish.spi.search.solr.location_handler";
     const LOCATION_SEARCH_GATEWAY_ID = "ezpublish.search.solr.location.gateway.native";
-    const ENDPOINT_RESOLVER_ID = "ezpublish.search.solr.content.gateway.endpoint_resolver.native";
+    const CONTENT_ENDPOINT_RESOLVER_ID = "ezpublish.search.solr.content.gateway.endpoint_resolver.native.content";
+    const LOCATION_ENDPOINT_RESOLVER_ID = "ezpublish.search.solr.content.gateway.endpoint_resolver.native.location";
 
     /**
      * Endpoint class
@@ -123,16 +124,16 @@ class EzPublishSolrSearchEngineExtension extends Extension
     {
         $alias = $this->getAlias();
 
-        // Endpoint resolver
-        $endpointResolverId = static::ENDPOINT_RESOLVER_ID . ".$connectionName";
-        $endpointResolverDef = new DefinitionDecorator( self::ENDPOINT_RESOLVER_ID );
-        $endpointResolverDef->replaceArgument( 0, $connectionParams['entry_points'] );
-        $endpointResolverDef->replaceArgument( 1, $connectionParams['cluster'] );
-        $container->setDefinition( $endpointResolverId, $endpointResolverDef );
+        // Content endpoint resolver
+        $contentEndpointResolverId = static::CONTENT_ENDPOINT_RESOLVER_ID . ".$connectionName";
+        $contentEndpointResolverDef = new DefinitionDecorator( self::CONTENT_ENDPOINT_RESOLVER_ID );
+        $contentEndpointResolverDef->replaceArgument( 0, $connectionParams['entry_points']['content'] );
+        $contentEndpointResolverDef->replaceArgument( 1, $connectionParams['cluster']['content'] );
+        $container->setDefinition( $contentEndpointResolverId, $contentEndpointResolverDef );
 
         // Content search gateway
         $contentSearchGatewayDef = new DefinitionDecorator( self::CONTENT_SEARCH_GATEWAY_ID );
-        $contentSearchGatewayDef->replaceArgument( 1, new Reference( $endpointResolverId ) );
+        $contentSearchGatewayDef->replaceArgument( 1, new Reference( $contentEndpointResolverId ) );
         $contentSearchGatewayId = self::CONTENT_SEARCH_GATEWAY_ID . ".$connectionName";
         $container->setDefinition( $contentSearchGatewayId, $contentSearchGatewayDef );
 
@@ -143,9 +144,16 @@ class EzPublishSolrSearchEngineExtension extends Extension
         $container->setDefinition( $contentSearchHandlerId, $contentSearchHandlerDefinition );
         $container->setParameter( "$alias.connection.$connectionName.content_handler_id", $contentSearchHandlerId );
 
+        // Location endpoint resolver
+        $locationEndpointResolverId = static::CONTENT_ENDPOINT_RESOLVER_ID . ".$connectionName";
+        $locationEndpointResolverDef = new DefinitionDecorator( self::CONTENT_ENDPOINT_RESOLVER_ID );
+        $locationEndpointResolverDef->replaceArgument( 0, $connectionParams['entry_points']['location'] );
+        $locationEndpointResolverDef->replaceArgument( 1, $connectionParams['cluster']['location'] );
+        $container->setDefinition( $locationEndpointResolverId, $locationEndpointResolverDef );
+
         // Location search gateway
         $locationSearchGatewayDef = new DefinitionDecorator( self::LOCATION_SEARCH_GATEWAY_ID );
-        $locationSearchGatewayDef->replaceArgument( 1, new Reference( $endpointResolverId ) );
+        $locationSearchGatewayDef->replaceArgument( 1, new Reference( $locationEndpointResolverId ) );
         $locationSearchGatewayId = self::LOCATION_SEARCH_GATEWAY_ID . ".$connectionName";
         $container->setDefinition( $locationSearchGatewayId, $locationSearchGatewayDef );
 

--- a/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/EzPublishSolrSearchEngineExtension.php
+++ b/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/EzPublishSolrSearchEngineExtension.php
@@ -131,7 +131,7 @@ class EzPublishSolrSearchEngineExtension extends Extension
         // Content endpoint resolver
         $contentEndpointResolverId = static::CONTENT_ENDPOINT_RESOLVER_ID . ".$connectionName";
         $contentEndpointResolverDef = new DefinitionDecorator( self::CONTENT_ENDPOINT_RESOLVER_ID );
-        $contentEndpointResolverDef->replaceArgument( 0, $connectionParams['entry_points']['content'] );
+        $contentEndpointResolverDef->replaceArgument( 0, $connectionParams['entry_endpoints']['content'] );
         $contentEndpointResolverDef->replaceArgument( 1, $connectionParams['cluster']['content'] );
         $container->setDefinition( $contentEndpointResolverId, $contentEndpointResolverDef );
 
@@ -151,7 +151,7 @@ class EzPublishSolrSearchEngineExtension extends Extension
         // Location endpoint resolver
         $locationEndpointResolverId = static::LOCATION_ENDPOINT_RESOLVER_ID . ".$connectionName";
         $locationEndpointResolverDef = new DefinitionDecorator( self::CONTENT_ENDPOINT_RESOLVER_ID );
-        $locationEndpointResolverDef->replaceArgument( 0, $connectionParams['entry_points']['location'] );
+        $locationEndpointResolverDef->replaceArgument( 0, $connectionParams['entry_endpoints']['location'] );
         $locationEndpointResolverDef->replaceArgument( 1, $connectionParams['cluster']['location'] );
         $container->setDefinition( $locationEndpointResolverId, $locationEndpointResolverDef );
 

--- a/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/EzPublishSolrSearchEngineExtension.php
+++ b/eZ/Bundle/EzPublishSolrSearchEngineBundle/DependencyInjection/EzPublishSolrSearchEngineExtension.php
@@ -145,7 +145,7 @@ class EzPublishSolrSearchEngineExtension extends Extension
         $container->setParameter( "$alias.connection.$connectionName.content_handler_id", $contentSearchHandlerId );
 
         // Location endpoint resolver
-        $locationEndpointResolverId = static::CONTENT_ENDPOINT_RESOLVER_ID . ".$connectionName";
+        $locationEndpointResolverId = static::LOCATION_ENDPOINT_RESOLVER_ID . ".$connectionName";
         $locationEndpointResolverDef = new DefinitionDecorator( self::CONTENT_ENDPOINT_RESOLVER_ID );
         $locationEndpointResolverDef->replaceArgument( 0, $connectionParams['entry_points']['location'] );
         $locationEndpointResolverDef->replaceArgument( 1, $connectionParams['cluster']['location'] );

--- a/eZ/Bundle/EzPublishSolrSearchEngineBundle/EzPublishSolrSearchEngineBundle.php
+++ b/eZ/Bundle/EzPublishSolrSearchEngineBundle/EzPublishSolrSearchEngineBundle.php
@@ -15,6 +15,7 @@ use eZ\Publish\Core\Base\Container\Compiler\Search\Solr\AggregateCriterionVisito
 use eZ\Publish\Core\Base\Container\Compiler\Search\Solr\AggregateFacetBuilderVisitorPass;
 use eZ\Publish\Core\Base\Container\Compiler\Search\Solr\AggregateFieldValueMapperPass;
 use eZ\Publish\Core\Base\Container\Compiler\Search\Solr\AggregateSortClauseVisitorPass;
+use eZ\Publish\Core\Base\Container\Compiler\Search\Solr\EndpointRegistryPass;
 use eZ\Publish\Core\Base\Container\Compiler\Search\FieldRegistryPass;
 use eZ\Publish\Core\Base\Container\Compiler\Search\SignalSlotPass;
 
@@ -23,10 +24,13 @@ class EzPublishSolrSearchEngineBundle extends Bundle
     public function build( ContainerBuilder $container )
     {
         parent::build( $container );
+
         $container->addCompilerPass( new AggregateCriterionVisitorPass );
         $container->addCompilerPass( new AggregateFacetBuilderVisitorPass );
         $container->addCompilerPass( new AggregateFieldValueMapperPass );
         $container->addCompilerPass( new AggregateSortClauseVisitorPass );
+        $container->addCompilerPass( new EndpointRegistryPass );
+
         $container->addCompilerPass( new FieldRegistryPass );
         $container->addCompilerPass( new SignalSlotPass );
     }

--- a/eZ/Bundle/EzPublishSolrSearchEngineBundle/Tests/DependencyInjection/EzPublishSolrSearchEngineExtensionTest.php
+++ b/eZ/Bundle/EzPublishSolrSearchEngineBundle/Tests/DependencyInjection/EzPublishSolrSearchEngineExtensionTest.php
@@ -41,7 +41,7 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
 
     public function testEmpty()
     {
-        $this->load( array() );
+        $this->load();
     }
 
     public function dataProviderForTestEndpoint()
@@ -156,10 +156,86 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
             array(
                 "endpoints" => array(
                     "endpoint0" => array(
-                        "dsn" => "https://12.13.14.15:4444/solr"
+                        "dsn" => "https://12.13.14.15:4444/solr",
                     ),
                 ),
             )
         );
+    }
+
+    public function dataProviderForTestConnection()
+    {
+        return array(
+            array(
+                array(
+                    "connections" => array(),
+                ),
+            ),
+            array(
+                array(
+                    "connections" => array(
+                        "connection1" => array(),
+                    ),
+                ),
+            ),
+            array(
+                array(
+                    "connections" => array(
+                        "connection1" => array(
+                            "entry_points" => array(),
+                            "cluster" => array(),
+                        ),
+                    ),
+                ),
+            ),
+            array(
+                array(
+                    "connections" => array(
+                        "connection1" => array(
+                            "entry_points" => array(
+                                "endpoint1",
+                                "endpoint2",
+                            ),
+                            "cluster" => array(
+                                "content" => array(),
+                                "location" => array(),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+            array(
+                array(
+                    "connections" => array(
+                        "connection1" => array(
+                            "entry_points" => array(
+                                "endpoint1",
+                                "endpoint2",
+                            ),
+                            "cluster" => array(
+                                "content" => array(
+                                    "cro-HR" => "endpoint1",
+                                    "eng-GB" => "endpoint2",
+                                    "gal-MW" => "endpoint3",
+                                ),
+                                "location" => array(
+                                    "cro-HR" => "endpoint2",
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * @param array $configurationValues
+     *
+     * @dataProvider dataProviderForTestConnection
+     */
+    public function testConnection( $configurationValues )
+    {
+        $this->load( $configurationValues );
     }
 }

--- a/eZ/Bundle/EzPublishSolrSearchEngineBundle/Tests/DependencyInjection/EzPublishSolrSearchEngineExtensionTest.php
+++ b/eZ/Bundle/EzPublishSolrSearchEngineBundle/Tests/DependencyInjection/EzPublishSolrSearchEngineExtensionTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Bundle\EzPublishSolrSearchEngineBundle\Tests\DependencyInjection;
+
+use eZ\Bundle\EzPublishSolrSearchEngineBundle\DependencyInjection\EzPublishSolrSearchEngineExtension;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Symfony\Component\Yaml\Yaml;
+
+class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
+{
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension
+     */
+    private $extension;
+
+    protected function setUp()
+    {
+        $this->extension = new EzPublishSolrSearchEngineExtension();
+
+        parent::setUp();
+    }
+
+    protected function getContainerExtensions()
+    {
+        return array( $this->extension );
+    }
+
+    protected function getMinimalConfiguration()
+    {
+        return Yaml::parse(
+            file_get_contents( __DIR__ . "/Fixtures/minimal.yml" )
+        );
+    }
+
+    public function testEmpty()
+    {
+        $this->load( array() );
+    }
+
+    public function dataProviderForTestEndpoint()
+    {
+        return array(
+            array(
+                "endpoint_dsn",
+                array(
+                    "dsn" => "https://jura:pura@10.10.10.10:5434/jolr",
+                    "core" => "core0",
+                ),
+                array(
+                    "scheme" => "https",
+                    "host" => "10.10.10.10",
+                    "port" => 5434,
+                    "user" => "jura",
+                    "pass" => "pura",
+                    "path" => "/jolr",
+                    "core" => "core0",
+                ),
+            ),
+            array(
+                "endpoint_standalone",
+                array(
+                    "scheme" => "https",
+                    "host" => "22.22.22.22",
+                    "port" => 1232,
+                    "user" => "jura",
+                    "pass" => "pura",
+                    "path" => "/holr",
+                    "core" => "core1",
+                ),
+                array(
+                    "scheme" => "https",
+                    "host" => "22.22.22.22",
+                    "port" => 1232,
+                    "user" => "jura",
+                    "pass" => "pura",
+                    "path" => "/holr",
+                    "core" => "core1",
+                ),
+            ),
+            array(
+                "endpoint_override",
+                array(
+                    "dsn" => "https://miles:teg@257.258.259.400:5555/noship",
+                    "scheme" => "http",
+                    "host" => "farm.com",
+                    "port" => 1234,
+                    "core" => "core2",
+                    "user" => "darwi",
+                    "pass" => "odrade",
+                    "path" => "/dunr",
+                ),
+                array(
+                    "scheme" => "https",
+                    "host" => "257.258.259.400",
+                    "port" => 5555,
+                    "user" => "miles",
+                    "pass" => "teg",
+                    "path" => "/noship",
+                    "core" => "core2",
+                ),
+            ),
+            array(
+                "endpoint_defaults",
+                array(
+                    "core" => "core3"
+                ),
+                array(
+                    "scheme" => "http",
+                    "host" => "127.0.0.1",
+                    "port" => 8983,
+                    "user" => null,
+                    "pass" => null,
+                    "path" => "/solr",
+                    "core" => "core3",
+                ),
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider dataProviderForTestEndpoint
+     *
+     * @param string $endpointName
+     * @param array $endpointValues
+     * @param array $expectedArgument
+     */
+    public function testEndpoint( $endpointName, $endpointValues, $expectedArgument )
+    {
+        $this->load( array( "endpoints" => array( $endpointName => $endpointValues ) ) );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithTag(
+            "ez_search_engine_solr.endpoints.{$endpointName}",
+            "ezpublish.search.solr.endpoint",
+            array( "alias" => $endpointName )
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            "ez_search_engine_solr.endpoints.{$endpointName}",
+            0,
+            $expectedArgument
+        );
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     */
+    public function testEndpointCoreRequired()
+    {
+        $this->load(
+            array(
+                "endpoints" => array(
+                    "endpoint0" => array(
+                        "dsn" => "https://12.13.14.15:4444/solr"
+                    ),
+                ),
+            )
+        );
+    }
+}

--- a/eZ/Bundle/EzPublishSolrSearchEngineBundle/Tests/DependencyInjection/EzPublishSolrSearchEngineExtensionTest.php
+++ b/eZ/Bundle/EzPublishSolrSearchEngineBundle/Tests/DependencyInjection/EzPublishSolrSearchEngineExtensionTest.php
@@ -193,8 +193,8 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
                     "connections" => array(
                         "connection1" => array(
                             "entry_points" => array(
-                                "endpoint1",
-                                "endpoint2",
+                                "content" => array(),
+                                "location" => array(),
                             ),
                             "cluster" => array(
                                 "content" => array(),
@@ -209,8 +209,13 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
                     "connections" => array(
                         "connection1" => array(
                             "entry_points" => array(
-                                "endpoint1",
-                                "endpoint2",
+                                "content" => array(
+                                    "endpoint1",
+                                    "endpoint2",
+                                ),
+                                "location" => array(
+                                    "endpoint2",
+                                ),
                             ),
                             "cluster" => array(
                                 "content" => array(

--- a/eZ/Bundle/EzPublishSolrSearchEngineBundle/Tests/DependencyInjection/EzPublishSolrSearchEngineExtensionTest.php
+++ b/eZ/Bundle/EzPublishSolrSearchEngineBundle/Tests/DependencyInjection/EzPublishSolrSearchEngineExtensionTest.php
@@ -182,7 +182,7 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
                 array(
                     "connections" => array(
                         "connection1" => array(
-                            "entry_points" => array(),
+                            "entry_endpoints" => array(),
                             "cluster" => array(),
                         ),
                     ),
@@ -192,7 +192,7 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
                 array(
                     "connections" => array(
                         "connection1" => array(
-                            "entry_points" => array(
+                            "entry_endpoints" => array(
                                 "content" => array(),
                                 "location" => array(),
                             ),
@@ -222,7 +222,7 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
         $configurationValues = array(
             "connections" => array(
                 "connection1" => array(
-                    "entry_points" => array(
+                    "entry_endpoints" => array(
                         "content" => array(
                             "endpoint1",
                             "endpoint2",

--- a/eZ/Bundle/EzPublishSolrSearchEngineBundle/Tests/DependencyInjection/EzPublishSolrSearchEngineExtensionTest.php
+++ b/eZ/Bundle/EzPublishSolrSearchEngineBundle/Tests/DependencyInjection/EzPublishSolrSearchEngineExtensionTest.php
@@ -204,33 +204,6 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
                     ),
                 ),
             ),
-            array(
-                array(
-                    "connections" => array(
-                        "connection1" => array(
-                            "entry_points" => array(
-                                "content" => array(
-                                    "endpoint1",
-                                    "endpoint2",
-                                ),
-                                "location" => array(
-                                    "endpoint2",
-                                ),
-                            ),
-                            "cluster" => array(
-                                "content" => array(
-                                    "cro-HR" => "endpoint1",
-                                    "eng-GB" => "endpoint2",
-                                    "gal-MW" => "endpoint3",
-                                ),
-                                "location" => array(
-                                    "cro-HR" => "endpoint2",
-                                ),
-                            ),
-                        ),
-                    ),
-                ),
-            ),
         );
     }
 
@@ -239,8 +212,89 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
      *
      * @dataProvider dataProviderForTestConnection
      */
-    public function testConnection( $configurationValues )
+    public function testConnectionLoad( $configurationValues )
     {
         $this->load( $configurationValues );
+    }
+
+    public function testConnection()
+    {
+        $configurationValues = array(
+            "connections" => array(
+                "connection1" => array(
+                    "entry_points" => array(
+                        "content" => array(
+                            "endpoint1",
+                            "endpoint2",
+                        ),
+                        "location" => array(
+                            "endpoint2",
+                        ),
+                    ),
+                    "cluster" => array(
+                        "content" => array(
+                            "cro-HR" => "endpoint1",
+                            "eng-GB" => "endpoint2",
+                            "gal-MW" => "endpoint3",
+                        ),
+                        "location" => array(
+                            "cro-HR" => "endpoint2",
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->load( $configurationValues );
+
+        $this->assertContainerBuilderHasParameter(
+            "ez_search_engine_solr.default_connection",
+            "connection1"
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            "ezpublish.search.solr.content.gateway.endpoint_resolver.native.content.connection1",
+            0,
+            array(
+                "endpoint1",
+                "endpoint2",
+            )
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            "ezpublish.search.solr.content.gateway.endpoint_resolver.native.content.connection1",
+            1,
+            array(
+                "cro-HR" => "endpoint1",
+                "eng-GB" => "endpoint2",
+                "gal-MW" => "endpoint3",
+            )
+        );
+        $this->assertContainerBuilderHasService(
+            "ezpublish.search.solr.content.gateway.native.connection1"
+        );
+        $this->assertContainerBuilderHasService(
+            "ezpublish.spi.search.solr.content_handler.connection1"
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            "ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1",
+            0,
+            array(
+                "endpoint2",
+            )
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            "ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1",
+            1,
+            array(
+                "cro-HR" => "endpoint2",
+            )
+        );
+        $this->assertContainerBuilderHasService(
+            "ezpublish.search.solr.location.gateway.native.connection1"
+        );
+        $this->assertContainerBuilderHasService(
+            "ezpublish.spi.search.solr.location_handler.connection1"
+        );
     }
 }

--- a/eZ/Bundle/EzPublishSolrSearchEngineBundle/Tests/DependencyInjection/EzPublishSolrSearchEngineExtensionTest.php
+++ b/eZ/Bundle/EzPublishSolrSearchEngineBundle/Tests/DependencyInjection/EzPublishSolrSearchEngineExtensionTest.php
@@ -297,4 +297,77 @@ class EzPublishSolrSearchEngineExtensionTest extends AbstractExtensionTestCase
             "ezpublish.spi.search.solr.location_handler.connection1"
         );
     }
+
+    public function testConnectionDefaults()
+    {
+        $configurationValues = array(
+            "connections" => array(
+                "connection1" => array(
+                    "cluster" => array(
+                        "content" => array(
+                            "cro-HR" => "endpoint1",
+                            "eng-GB" => "endpoint2",
+                            "gal-MW" => "endpoint3",
+                        ),
+                        "location" => array(
+                            "cro-HR" => "endpoint2",
+                        ),
+                    ),
+                ),
+            ),
+        );
+
+        $this->load( $configurationValues );
+
+        $this->assertContainerBuilderHasParameter(
+            "ez_search_engine_solr.default_connection",
+            "connection1"
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            "ezpublish.search.solr.content.gateway.endpoint_resolver.native.content.connection1",
+            0,
+            array(
+                "endpoint1",
+                "endpoint2",
+                "endpoint3",
+            )
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            "ezpublish.search.solr.content.gateway.endpoint_resolver.native.content.connection1",
+            1,
+            array(
+                "cro-HR" => "endpoint1",
+                "eng-GB" => "endpoint2",
+                "gal-MW" => "endpoint3",
+            )
+        );
+        $this->assertContainerBuilderHasService(
+            "ezpublish.search.solr.content.gateway.native.connection1"
+        );
+        $this->assertContainerBuilderHasService(
+            "ezpublish.spi.search.solr.content_handler.connection1"
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            "ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1",
+            0,
+            array(
+                "endpoint2",
+            )
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            "ezpublish.search.solr.content.gateway.endpoint_resolver.native.location.connection1",
+            1,
+            array(
+                "cro-HR" => "endpoint2",
+            )
+        );
+        $this->assertContainerBuilderHasService(
+            "ezpublish.search.solr.location.gateway.native.connection1"
+        );
+        $this->assertContainerBuilderHasService(
+            "ezpublish.spi.search.solr.location_handler.connection1"
+        );
+    }
 }

--- a/eZ/Publish/API/Repository/Tests/SetupFactory/LegacySolr.php
+++ b/eZ/Publish/API/Repository/Tests/SetupFactory/LegacySolr.php
@@ -56,6 +56,7 @@ class LegacySolr extends Legacy
             $containerBuilder->addCompilerPass( new Compiler\Search\Solr\AggregateFacetBuilderVisitorPass() );
             $containerBuilder->addCompilerPass( new Compiler\Search\Solr\AggregateFieldValueMapperPass() );
             $containerBuilder->addCompilerPass( new Compiler\Search\Solr\AggregateSortClauseVisitorPass() );
+            $containerBuilder->addCompilerPass( new Compiler\Search\Solr\EndpointRegistryPass() );
             $containerBuilder->addCompilerPass( new Compiler\Search\FieldRegistryPass() );
             $containerBuilder->addCompilerPass( new Compiler\Search\SignalSlotPass() );
 

--- a/eZ/Publish/Core/Base/Container/Compiler/Search/Solr/EndpointRegistryPass.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/Search/Solr/EndpointRegistryPass.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Base\Container\Compiler\Search\Solr;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use LogicException;
+
+/**
+ * This compiler pass will register Solr Endpoints.
+ */
+class EndpointRegistryPass implements CompilerPassInterface
+{
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     *
+     * @throws \LogicException
+     */
+    public function process( ContainerBuilder $container )
+    {
+        if (
+            !$container->hasDefinition(
+                "ezpublish.search.solr.content.gateway.endpoint_registry"
+            )
+        )
+        {
+            return;
+        }
+
+        $fieldRegistryDefinition = $container->getDefinition(
+            "ezpublish.search.solr.content.gateway.endpoint_registry"
+        );
+
+        $endpoints = $container->findTaggedServiceIds( "ezpublish.search.solr.endpoint" );
+
+        foreach ( $endpoints as $id => $attributes )
+        {
+            foreach ( $attributes as $attribute )
+            {
+                if ( !isset( $attribute["alias"] ) )
+                {
+                    throw new LogicException(
+                        "'ezpublish.search.solr.endpoint' service tag needs an 'alias' attribute " .
+                        "to identify the Endpoint. None given."
+                    );
+                }
+
+                $fieldRegistryDefinition->addMethodCall(
+                    "registerEndpoint",
+                    array(
+                        $attribute["alias"],
+                        new Reference( $id ),
+                    )
+                );
+            }
+        }
+    }
+}

--- a/eZ/Publish/Core/Search/Solr/Content/DocumentMapper/NativeDocumentMapper.php
+++ b/eZ/Publish/Core/Search/Solr/Content/DocumentMapper/NativeDocumentMapper.php
@@ -28,7 +28,7 @@ use eZ\Publish\Core\Search\Common\FieldNameGenerator;
 /**
  *
  */
-class TranslationDocumentMapper implements DocumentMapper
+class NativeDocumentMapper implements DocumentMapper
 {
     /**
      * Field registry

--- a/eZ/Publish/Core/Search/Solr/Content/DocumentMapper/NativeDocumentMapper.php
+++ b/eZ/Publish/Core/Search/Solr/Content/DocumentMapper/NativeDocumentMapper.php
@@ -26,7 +26,7 @@ use eZ\Publish\Core\Search\Common\FieldRegistry;
 use eZ\Publish\Core\Search\Common\FieldNameGenerator;
 
 /**
- *
+ * NativeDocumentMapper maps Solr backend documents per Content translation
  */
 class NativeDocumentMapper implements DocumentMapper
 {

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway.php
@@ -31,10 +31,12 @@ abstract class Gateway
     abstract public function find( Query $query, array $fieldFilters = array() );
 
     /**
-     * Indexes a block of documents, which in our case is a Content preceded by its Locations.
-     * In Solr block is identifiable by '_root_' field which holds a parent document (Content) id.
+     * Indexes an array of documents.
      *
-     * @param \eZ\Publish\SPI\Search\Document[] $documents
+     * Documents are given as an array of the array of documents. The array of documents
+     * holds documents for all translations of the particular entity.
+     *
+     * @param \eZ\Publish\SPI\Search\Document[][] $documents
      */
     abstract public function bulkIndexDocuments( array $documents );
 

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway.php
@@ -41,6 +41,7 @@ abstract class Gateway
     abstract public function bulkIndexDocuments( array $documents );
 
     /**
+     * Deletes documents by the given $query.
      *
      * @param string $query
      */

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/Endpoint.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/Endpoint.php
@@ -24,56 +24,56 @@ use eZ\Publish\SPI\Search\FieldType;
 class Endpoint extends ValueObject
 {
     /**
-     *
+     * Holds scheme, 'http' or 'https'
      *
      * @var string
      */
     protected $scheme;
 
     /**
-     *
+     * Holds basic HTTP authentication username
      *
      * @var string
      */
     protected $user;
 
     /**
-     *
+     * Holds basic HTTP authentication password
      *
      * @var string
      */
     protected $pass;
 
     /**
-     *
+     * Holds hostname
      *
      * @var string
      */
     protected $host;
 
     /**
-     *
+     * Holds port number
      *
      * @var int
      */
     protected $port;
 
     /**
-     *
+     * Holds path
      *
      * @var string
      */
     protected $path;
 
     /**
-     *
+     * Holds core name
      *
      * @var string
      */
     protected $core;
 
     /**
-     *
+     * Returns Endpoint's identifier, to be used for targeting specific logical indexes
      *
      * @return string
      */
@@ -83,7 +83,7 @@ class Endpoint extends ValueObject
     }
 
     /**
-     *
+     * Returns full HTTP URL of the Endpoint
      *
      * @return string
      */

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/Endpoint.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/Endpoint.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Search\Solr\Content\Gateway;
+
+use eZ\Publish\SPI\Persistence\ValueObject;
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * @property-read string $scheme
+ * @property-read string $user
+ * @property-read string $pass
+ * @property-read string $host
+ * @property-read int $port
+ * @property-read string $path
+ * @property-read string $core
+ */
+class Endpoint extends ValueObject
+{
+    /**
+     *
+     *
+     * @var string
+     */
+    protected $scheme;
+
+    /**
+     *
+     *
+     * @var string
+     */
+    protected $user;
+
+    /**
+     *
+     *
+     * @var string
+     */
+    protected $pass;
+
+    /**
+     *
+     *
+     * @var string
+     */
+    protected $host;
+
+    /**
+     *
+     *
+     * @var int
+     */
+    protected $port;
+
+    /**
+     *
+     *
+     * @var string
+     */
+    protected $path;
+
+    /**
+     *
+     *
+     * @var string
+     */
+    protected $core;
+
+    /**
+     *
+     *
+     * @return string
+     */
+    public function getIdentifier()
+    {
+        return "{$this->host}:{$this->port}/{$this->path}/{$this->core}";
+    }
+
+    /**
+     *
+     *
+     * @return string
+     */
+    public function getURL()
+    {
+        $authorization = ( !empty( $this->username ) ? "{$this->user}:{$this->pass}" : "" );
+
+        return "{$this->scheme}://{$authorization}" . $this->getIdentifier();
+    }
+}

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/Endpoint.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/Endpoint.php
@@ -79,7 +79,7 @@ class Endpoint extends ValueObject
      */
     public function getIdentifier()
     {
-        return "{$this->host}:{$this->port}/{$this->path}/{$this->core}";
+        return "{$this->host}:{$this->port}{$this->path}/{$this->core}";
     }
 
     /**

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointProvider.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointProvider.php
@@ -31,7 +31,7 @@ interface EndpointProvider
      *
      * @param mixed $documentType
      *
-     * @return string
+     * @return \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint
      */
     public function getEntryPoint( $documentType );
 
@@ -41,7 +41,7 @@ interface EndpointProvider
      * @param mixed $documentType
      * @param string $languageCode
      *
-     * @return string
+     * @return \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint
      */
     public function getIndexingTarget( $documentType, $languageCode );
 
@@ -51,7 +51,7 @@ interface EndpointProvider
      * @param mixed $documentType
      * @param array $languageSettings
      *
-     * @return string[]
+     * @return \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint[]
      */
     public function getSearchTargets( $documentType, array $languageSettings );
 
@@ -60,7 +60,7 @@ interface EndpointProvider
      *
      * @param mixed $documentType
      *
-     * @return string[]
+     * @return \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint[]
      */
     public function getAllEndpoints( $documentType );
 }

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointProvider/TranslationEndpointProvider.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointProvider/TranslationEndpointProvider.php
@@ -19,13 +19,6 @@ use RuntimeException;
 class TranslationEndpointProvider implements EndpointProvider
 {
     /**
-     * Endpoint registry service
-     *
-     * @var \eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointRegistry
-     */
-    protected $endpointRegistry;
-
-    /**
      * Holds a map of Solr entry points
      *
      * @var array
@@ -42,17 +35,14 @@ class TranslationEndpointProvider implements EndpointProvider
     /**
      * Create from registry and mapping configuration
      *
-     * @param \eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointRegistry
      * @param array $entryPointMap
      * @param array $endpointMap
      */
     public function __construct(
-        EndpointRegistry $endpointRegistry,
         array $entryPointMap = array(),
         array $endpointMap = array()
     )
     {
-        $this->endpointRegistry = $endpointRegistry;
         $this->entryPointMap = $entryPointMap;
         $this->endpointMap = $endpointMap;
     }
@@ -61,14 +51,12 @@ class TranslationEndpointProvider implements EndpointProvider
     {
         if ( !is_array( $this->entryPointMap ) )
         {
-            return $this->endpointRegistry->getEndpoint( $this->entryPointMap );
+            return $this->entryPointMap;
         }
 
         if ( isset( $this->entryPointMap[$documentType] ) )
         {
-            return $this->endpointRegistry->getEndpoint(
-                $this->entryPointMap[$documentType]
-            );
+            return $this->entryPointMap[$documentType];
         }
 
         throw new RuntimeException(
@@ -87,14 +75,10 @@ class TranslationEndpointProvider implements EndpointProvider
                 );
             }
 
-            return $this->endpointRegistry->getEndpoint(
-                $this->endpointMap[$documentType][$languageCode]
-            );
+            return $this->endpointMap[$documentType][$languageCode];
         }
 
-        return $this->endpointRegistry->getEndpoint(
-            $this->endpointMap[$documentType]
-        );
+        return $this->endpointMap[$documentType];
     }
 
     public function getSearchTargets( $documentType, array $languageSettings )
@@ -131,14 +115,10 @@ class TranslationEndpointProvider implements EndpointProvider
                 $targets[] = $this->endpointMap[$documentType][$languageCode];
             }
 
-            return $this->getEndpoints( $targets );
+            return $targets;
         }
 
-        return array(
-            $this->endpointRegistry->getEndpoint(
-                $this->endpointMap[$documentType]
-            )
-        );
+        return array( $this->endpointMap[$documentType] );
     }
 
     public function getAllEndpoints( $documentType )
@@ -152,34 +132,9 @@ class TranslationEndpointProvider implements EndpointProvider
 
         if ( is_array( $this->endpointMap[$documentType] ) )
         {
-            return $this->getEndpoints(
-                array_values( $this->endpointMap[$documentType] )
-            );
+            return array_values( $this->endpointMap[$documentType] );
         }
 
-        return array(
-            $this->endpointRegistry->getEndpoint(
-                $this->endpointMap[$documentType]
-            )
-        );
-    }
-
-    /**
-     * Returns an array of Endpoints for the given array of Endpoint identifiers
-     *
-     * @param array $identifiers
-     *
-     * @return \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint[]
-     */
-    protected function getEndpoints( array $identifiers )
-    {
-        $endpoints = array();
-
-        foreach ( $identifiers as $identifier )
-        {
-            $endpoints[] = $this->endpointRegistry->getEndpoint( $identifier );
-        }
-
-        return $endpoints;
+        return array( $this->endpointMap[$documentType] );
     }
 }

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointProvider/TranslationEndpointProvider.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointProvider/TranslationEndpointProvider.php
@@ -14,11 +14,16 @@ use RuntimeException;
 
 /**
  * TranslationEndpointProvider provides Solr endpoints for a Content translations
- *
- * @todo create Endpoint class
  */
 class TranslationEndpointProvider implements EndpointProvider
 {
+    /**
+     * Holds a map of Solr entry points
+     *
+     * @var array
+     */
+    protected $entryPointMap;
+
     /**
      * Holds a map of Solr endpoints
      *
@@ -28,41 +33,31 @@ class TranslationEndpointProvider implements EndpointProvider
 
     /**
      * Create from configuration
+     *
+     * @param array $entryPointMap
+     * @param array $endpointMap
      */
-    public function __construct()
+    public function __construct( array $entryPointMap = array(), array $endpointMap = array() )
     {
-        $this->endpointMap = array(
-            self::DOCUMENT_TYPE_CONTENT => array(
-                "eng-GB" => "http://localhost:8983/solr/core0",
-                "eng-US" => "http://localhost:8983/solr/core1",
-                "por-PT" => "http://localhost:8983/solr/core2",
-                "ger-DE" => "http://localhost:8983/solr/core3",
-            ),
-            self::DOCUMENT_TYPE_LOCATION => array(
-                "eng-GB" => "http://localhost:8983/solr/core4",
-                "eng-US" => "http://localhost:8983/solr/core5",
-                "por-PT" => "http://localhost:8983/solr/core6",
-                "ger-DE" => "http://localhost:8983/solr/core7",
-            ),
-        );
+        $this->entryPointMap = $entryPointMap;
+        $this->endpointMap = $endpointMap;
     }
 
-    /**
-     *
-     *
-     * @param mixed $documentType
-     *
-     * @return string
-     */
     public function getEntryPoint( $documentType )
     {
-        // @todo implement real entry point selection
-        if ( is_array( $this->endpointMap[$documentType] ) )
+        if ( !is_array( $this->entryPointMap ) )
         {
-            return $this->endpointMap[$documentType]["eng-GB"];
+            return $this->entryPointMap;
         }
 
-        return $this->endpointMap[$documentType];
+        if ( isset( $this->entryPointMap[$documentType] ) )
+        {
+            return $this->entryPointMap[$documentType];
+        }
+
+        throw new RuntimeException(
+            "Document type '{$documentType}' is not mapped to Solr core entry point"
+        );
     }
 
     public function getIndexingTarget( $documentType, $languageCode )

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointProvider/TranslationEndpointProvider.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointProvider/TranslationEndpointProvider.php
@@ -164,6 +164,13 @@ class TranslationEndpointProvider implements EndpointProvider
         );
     }
 
+    /**
+     * Returns an array of Endpoints for the given array of Endpoint identifiers
+     *
+     * @param array $identifiers
+     *
+     * @return \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint[]
+     */
     protected function getEndpoints( array $identifiers )
     {
         $endpoints = array();

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointRegistry.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointRegistry.php
@@ -37,18 +37,18 @@ class EndpointRegistry
     }
 
     /**
-     * Register Endpoint
+     * Registers $endpoint with $name
      *
      * @param string $name
-     * @param \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint $endpoints
+     * @param \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint $endpoint
      */
-    public function registerEndpoint( $name, Endpoint $endpoints )
+    public function registerEndpoint( $name, Endpoint $endpoint )
     {
-        $this->endpoint[$name] = $endpoints;
+        $this->endpoint[$name] = $endpoint;
     }
 
     /**
-     * Get Endpoint
+     * Get Endpoint with $name
      *
      * @param string $name
      *

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointRegistry.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointRegistry.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Search\Solr\Content\Gateway;
+
+use OutOfBoundsException;
+
+/**
+ * Registry for Solr search engine Endpoints
+ */
+class EndpointRegistry
+{
+    /**
+     * Registered endpoints
+     *
+     * @var array(string => Endpoint)
+     */
+    protected $endpoint = array();
+
+    /**
+     * Construct from optional array of Endpoints
+     *
+     * @param \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint[] $endpoints
+     */
+    public function __construct( array $endpoints = array() )
+    {
+        foreach ( $endpoints as $name => $endpoint )
+        {
+            $this->registerEndpoint( $name, $endpoint );
+        }
+    }
+
+    /**
+     * Register Endpoint
+     *
+     * @param string $name
+     * @param \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint $endpoints
+     */
+    public function registerEndpoint( $name, Endpoint $endpoints )
+    {
+        $this->endpoint[$name] = $endpoints;
+    }
+
+    /**
+     * Get Endpoint
+     *
+     * @param string $name
+     *
+     * @return \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint
+     */
+    public function getEndpoint( $name )
+    {
+        if ( !isset( $this->endpoint[$name] ) )
+        {
+            throw new OutOfBoundsException( "No Endpoint registered for '{$name}'." );
+        }
+
+        return $this->endpoint[$name];
+    }
+}
+

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver.php
@@ -17,14 +17,14 @@ use eZ\Publish\SPI\Search\FieldType;
 interface EndpointResolver
 {
     /**
-     * Returns the endpoint used for distributed search
+     * Returns the Endpoint used as entry point for distributed search
      *
      * @return \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint
      */
     public function getEntryPoint();
 
     /**
-     * Returns endpoint that indexes Content translations in the given $languageCode
+     * Returns Endpoint that indexes Content translations in the given $languageCode
      *
      * @param string $languageCode
      *
@@ -33,7 +33,7 @@ interface EndpointResolver
     public function getIndexingTarget( $languageCode );
 
     /**
-     * Returns an array of endpoints for the given $languageSettings
+     * Returns an array of Endpoints for the given $languageSettings
      *
      * @param array $languageSettings
      *
@@ -42,7 +42,7 @@ interface EndpointResolver
     public function getSearchTargets( array $languageSettings );
 
     /**
-     * Returns all endpoints
+     * Returns all Endpoints
      *
      * @return \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint[]
      */

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver.php
@@ -21,7 +21,7 @@ interface EndpointResolver
      *
      * @return \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint
      */
-    public function getEntryPoint();
+    public function getEntryEndpoint();
 
     /**
      * Returns Endpoint that indexes Content translations in the given $languageCode

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver.php
@@ -17,50 +17,34 @@ use eZ\Publish\SPI\Search\FieldType;
 interface EndpointResolver
 {
     /**
-     * @todo consider moving
-     */
-    const DOCUMENT_TYPE_CONTENT = "content";
-
-    /**
-     * @todo consider moving
-     */
-    const DOCUMENT_TYPE_LOCATION = "location";
-
-    /**
-     * Returns the endpoint used for distributed search, for the given $documentType
-     *
-     * @param mixed $documentType
+     * Returns the endpoint used for distributed search
      *
      * @return \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint
      */
-    public function getEntryPoint( $documentType );
+    public function getEntryPoint();
 
     /**
-     * Returns endpoint that indexes Content translations in the given $documentType and $languageCode
+     * Returns endpoint that indexes Content translations in the given $languageCode
      *
-     * @param mixed $documentType
      * @param string $languageCode
      *
      * @return \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint
      */
-    public function getIndexingTarget( $documentType, $languageCode );
+    public function getIndexingTarget( $languageCode );
 
     /**
-     * Returns an array of endpoints for the given $documentType and $languageSettings
+     * Returns an array of endpoints for the given $languageSettings
      *
-     * @param mixed $documentType
      * @param array $languageSettings
      *
      * @return \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint[]
      */
-    public function getSearchTargets( $documentType, array $languageSettings );
+    public function getSearchTargets( array $languageSettings );
 
     /**
-     * Returns all endpoints for the given $documentType
-     *
-     * @param mixed $documentType
+     * Returns all endpoints
      *
      * @return \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint[]
      */
-    public function getAllEndpoints( $documentType );
+    public function getEndpoints();
 }

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver.php
@@ -12,9 +12,9 @@ namespace eZ\Publish\Core\Search\Solr\Content\Gateway;
 use eZ\Publish\SPI\Search\FieldType;
 
 /**
- * Endpoint provider provides Solr backend endpoints
+ * Endpoint resolver resolves Solr backend endpoints
  */
-interface EndpointProvider
+interface EndpointResolver
 {
     /**
      * @todo consider moving

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver/NativeEndpointResolver.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver/NativeEndpointResolver.php
@@ -18,24 +18,31 @@ use RuntimeException;
 class NativeEndpointResolver implements EndpointResolver
 {
     /**
-     * Holds an array of Solr entry points
+     * Holds an array of Solr entry point names
      *
      * @var string[]
      */
     protected $entryPoints;
 
     /**
-     * Holds a map of Endpoints, with language codes as keys
+     * Holds a map of Endpoint names, with language codes as keys
+     *
+     * <code>
+     *  array(
+     *      "cro-HR" => "endpoint1",
+     *      "eng-GB" => "endpoint2",
+     *  );
+     * </code>
      *
      * @var string[]
      */
     protected $endpointMap;
 
     /**
-     * Create from Endpoints
+     * Create from Endpoint names
      *
-     * @param \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint[] $entryPoints
-     * @param \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint[] $endpointMap
+     * @param string[] $entryPoints
+     * @param string[] $endpointMap
      */
     public function __construct( array $entryPoints = array(), array $endpointMap = array() )
     {

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver/NativeEndpointResolver.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver/NativeEndpointResolver.php
@@ -22,7 +22,7 @@ class NativeEndpointResolver implements EndpointResolver
      *
      * @var string[]
      */
-    protected $entryEndpoints;
+    private $entryEndpoints;
 
     /**
      * Holds a map of Endpoint names, with language codes as keys
@@ -36,7 +36,7 @@ class NativeEndpointResolver implements EndpointResolver
      *
      * @var string[]
      */
-    protected $endpointMap;
+    private $endpointMap;
 
     /**
      * Create from Endpoint names

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver/NativeEndpointResolver.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver/NativeEndpointResolver.php
@@ -18,11 +18,11 @@ use RuntimeException;
 class NativeEndpointResolver implements EndpointResolver
 {
     /**
-     * Holds an array of Solr entry point names
+     * Holds an array of Solr entry endpoint names
      *
      * @var string[]
      */
-    protected $entryPoints;
+    protected $entryEndpoints;
 
     /**
      * Holds a map of Endpoint names, with language codes as keys
@@ -41,23 +41,23 @@ class NativeEndpointResolver implements EndpointResolver
     /**
      * Create from Endpoint names
      *
-     * @param string[] $entryPoints
+     * @param string[] $entryEndpoints
      * @param string[] $endpointMap
      */
-    public function __construct( array $entryPoints = array(), array $endpointMap = array() )
+    public function __construct( array $entryEndpoints = array(), array $endpointMap = array() )
     {
-        $this->entryPoints = $entryPoints;
+        $this->entryEndpoints = $entryEndpoints;
         $this->endpointMap = $endpointMap;
     }
 
-    public function getEntryPoint()
+    public function getEntryEndpoint()
     {
-        if ( empty( $this->entryPoints ) )
+        if ( empty( $this->entryEndpoints ) )
         {
-            throw new RuntimeException( "Not entry points defined" );
+            throw new RuntimeException( "Not entry endpoints defined" );
         }
 
-        return reset( $this->entryPoints );
+        return reset( $this->entryEndpoints );
     }
 
     public function getIndexingTarget( $languageCode )

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver/NativeEndpointResolver.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver/NativeEndpointResolver.php
@@ -13,9 +13,9 @@ use eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointResolver;
 use RuntimeException;
 
 /**
- * TranslationEndpointResolver provides Solr endpoints for a Content translations
+ * NativeEndpointResolver provides Solr endpoints for a Content translations
  */
-class TranslationEndpointResolver implements EndpointResolver
+class NativeEndpointResolver implements EndpointResolver
 {
     /**
      * Holds a map of Solr entry points

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver/NativeEndpointResolver.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver/NativeEndpointResolver.php
@@ -94,7 +94,7 @@ class NativeEndpointResolver implements EndpointResolver
 
         if ( empty( $targets ) )
         {
-            throw new RuntimeException( "No endpoints defined" );
+            throw new RuntimeException( "No endpoints defined for given language settings" );
         }
 
         return $targets;

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver/NativeEndpointResolver.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver/NativeEndpointResolver.php
@@ -25,14 +25,14 @@ class NativeEndpointResolver implements EndpointResolver
     protected $entryPoints;
 
     /**
-     * Holds a map of Solr endpoints, with language codes as keys
+     * Holds a map of Endpoints, with language codes as keys
      *
      * @var string[]
      */
     protected $endpointMap;
 
     /**
-     * Create from endpoints
+     * Create from Endpoints
      *
      * @param \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint[] $entryPoints
      * @param \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint[] $endpointMap

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver/TranslationEndpointResolver.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/EndpointResolver/TranslationEndpointResolver.php
@@ -7,16 +7,15 @@
  * @version //autogentag//
  */
 
-namespace eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointProvider;
+namespace eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointResolver;
 
-use eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointProvider;
-use eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointRegistry;
+use eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointResolver;
 use RuntimeException;
 
 /**
- * TranslationEndpointProvider provides Solr endpoints for a Content translations
+ * TranslationEndpointResolver provides Solr endpoints for a Content translations
  */
-class TranslationEndpointProvider implements EndpointProvider
+class TranslationEndpointResolver implements EndpointResolver
 {
     /**
      * Holds a map of Solr entry points

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/HttpClient.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/HttpClient.php
@@ -20,11 +20,11 @@ interface HttpClient
      * Returns the result from the remote server.
      *
      * @param string $method
-     * @param string $server
+     * @param \eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint $endpoint
      * @param string $path
      * @param \eZ\Publish\Core\Search\Solr\Content\Gateway\Message $message
      *
      * @return \eZ\Publish\Core\Search\Solr\Content\Gateway\Message
      */
-    public function request( $method, $server, $path, Message $message = null );
+    public function request( $method, Endpoint $endpoint, $path, Message $message = null );
 }

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/Message.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/Message.php
@@ -33,8 +33,6 @@ class Message
      *
      * @param array $headers
      * @param string $body
-     *
-     * @return void
      */
     public function __construct( array $headers = array(), $body = '' )
     {
@@ -42,4 +40,3 @@ class Message
         $this->body    = $body;
     }
 }
-

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
@@ -251,7 +251,10 @@ class Native extends Gateway
     }
 
     /**
+     * Returns a filtering condition for the given language settings.
      *
+     * The condition ensures the same Content will be matched only once across all
+     * targeted translation endpoints.
      *
      * @param array $languageSettings
      *
@@ -281,7 +284,11 @@ class Native extends Gateway
     }
 
     /**
+     * Returns a filtering condition for the given list of language codes and
+     * a selected language code among them.
      *
+     * Note that the list of language codes is assumed to be prioritized, that is sorted by
+     * priority, descending.
      *
      * @param array $languageCodes
      * @param string $selectedLanguageCode
@@ -361,6 +368,7 @@ class Native extends Gateway
     }
 
     /**
+     * Deletes documents by the given $query.
      *
      * @param string $query
      */

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
@@ -150,25 +150,12 @@ class Native extends Gateway
                     $query->sortClauses
                 )
             ),
+            "shards" => $this->getShards( $fieldFilters ),
             "start" => $query->offset,
             "rows" => $query->limit,
             "fl" => "*,score",
             "wt" => "json",
         );
-
-        $endpoints = $this->endpointResolver->getSearchTargets(
-            $this->documentType,
-            $fieldFilters
-        );
-        if ( !empty( $endpoints ) )
-        {
-            foreach ( $endpoints as $endpoint )
-            {
-                $parameters["shards"][] = $this->endpointRegistry->getEndpoint( $endpoint )->getIdentifier();
-            }
-
-            $parameters["shards"] = implode( ",", $parameters["shards"] );
-        }
 
         // @todo: Extract method
         $response = $this->client->request(
@@ -199,6 +186,32 @@ class Native extends Gateway
         }
 
         return $result;
+    }
+
+    /**
+     * Returns search targets for given language settings
+     *
+     * @param array $languageSettings
+     *
+     * @return string
+     */
+    protected function getShards( $languageSettings )
+    {
+        $shards = array();
+        $endpoints = $this->endpointResolver->getSearchTargets(
+            $this->documentType,
+            $languageSettings
+        );
+
+        if ( !empty( $endpoints ) )
+        {
+            foreach ( $endpoints as $endpoint )
+            {
+                $shards[] = $this->endpointRegistry->getEndpoint( $endpoint )->getIdentifier();
+            }
+        }
+
+        return implode( ",", $shards );
     }
 
     /**

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
@@ -141,13 +141,7 @@ class Native extends Gateway
         $parameters = array(
             "q" => $this->criterionVisitor->visit( $query->query ),
             "fq" => $this->criterionVisitor->visit( $query->filter ),
-            "sort" => implode(
-                ", ",
-                array_map(
-                    array( $this->sortClauseVisitor, "visit" ),
-                    $query->sortClauses
-                )
-            ),
+            "sort" => $this->getSortClauses( $query->sortClauses ),
             "start" => $query->offset,
             "rows" => $query->limit,
             "fl" => "*,score",
@@ -195,6 +189,24 @@ class Native extends Gateway
         }
 
         return $result;
+    }
+
+    /**
+     * Converts an array of sort clause object to a Solr representation
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sortClauses
+     *
+     * @return string
+     */
+    protected function getSortClauses( array $sortClauses )
+    {
+        return implode(
+            ", ",
+            array_map(
+                array( $this->sortClauseVisitor, "visit" ),
+                $sortClauses
+            )
+        );
     }
 
     /**

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
@@ -35,9 +35,9 @@ class Native extends Gateway
     protected $client;
 
     /**
-     * @var \eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointProvider
+     * @var \eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointResolver
      */
-    protected $endpointProvider;
+    protected $endpointResolver;
 
     /**
      * Endpoint registry service
@@ -93,7 +93,7 @@ class Native extends Gateway
      * Construct from HTTP client
      *
      * @param HttpClient $client
-     * @param \eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointProvider $endpointProvider
+     * @param \eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointResolver $endpointResolver
      * @param \eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointRegistry $endpointRegistry
      * @param CriterionVisitor $criterionVisitor
      * @param SortClauseVisitor $sortClauseVisitor
@@ -104,7 +104,7 @@ class Native extends Gateway
      */
     public function __construct(
         HttpClient $client,
-        EndpointProvider $endpointProvider,
+        EndpointResolver $endpointResolver,
         EndpointRegistry $endpointRegistry,
         CriterionVisitor $criterionVisitor,
         SortClauseVisitor $sortClauseVisitor,
@@ -115,7 +115,7 @@ class Native extends Gateway
     )
     {
         $this->client              = $client;
-        $this->endpointProvider = $endpointProvider;
+        $this->endpointResolver = $endpointResolver;
         $this->endpointRegistry = $endpointRegistry;
         $this->criterionVisitor    = $criterionVisitor;
         $this->sortClauseVisitor   = $sortClauseVisitor;
@@ -156,7 +156,7 @@ class Native extends Gateway
             "wt" => "json",
         );
 
-        $endpoints = $this->endpointProvider->getSearchTargets(
+        $endpoints = $this->endpointResolver->getSearchTargets(
             $this->documentType,
             $fieldFilters
         );
@@ -174,7 +174,7 @@ class Native extends Gateway
         $response = $this->client->request(
             'GET',
             $this->endpointRegistry->getEndpoint(
-                $this->endpointProvider->getEntryPoint( $this->documentType )
+                $this->endpointResolver->getEntryPoint( $this->documentType )
             ),
             '/select?' .
             http_build_query( $parameters ) .
@@ -289,7 +289,7 @@ class Native extends Gateway
         $result = $this->client->request(
             'POST',
             $this->endpointRegistry->getEndpoint(
-                $this->endpointProvider->getIndexingTarget( $this->documentType, $languageCode )
+                $this->endpointResolver->getIndexingTarget( $this->documentType, $languageCode )
             ),
             '/update?' .
             ( $this->commit ? "softCommit=true&" : "" ) . 'wt=json',
@@ -315,7 +315,7 @@ class Native extends Gateway
      */
     public function deleteByQuery( $query )
     {
-        $endpoints = $this->endpointProvider->getAllEndpoints( $this->documentType );
+        $endpoints = $this->endpointResolver->getAllEndpoints( $this->documentType );
 
         foreach ( $endpoints as $endpointName )
         {
@@ -341,7 +341,7 @@ class Native extends Gateway
      */
     public function purgeIndex()
     {
-        $endpoints = $this->endpointProvider->getAllEndpoints( $this->documentType );
+        $endpoints = $this->endpointResolver->getAllEndpoints( $this->documentType );
 
         foreach ( $endpoints as $endpointName )
         {

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
@@ -165,7 +165,7 @@ class Native extends Gateway
         $response = $this->client->request(
             'GET',
             $this->endpointRegistry->getEndpoint(
-                $this->endpointResolver->getEntryPoint()
+                $this->endpointResolver->getEntryEndpoint()
             ),
             "/select?{$queryString}"
         );

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
@@ -86,8 +86,6 @@ class Native extends Gateway
      */
     protected $commit = true;
 
-    protected $documentType;
-
     /**
      * Construct from HTTP client
      *
@@ -99,7 +97,6 @@ class Native extends Gateway
      * @param FacetBuilderVisitor $facetBuilderVisitor
      * @param FieldValueMapper $fieldValueMapper
      * @param FieldNameGenerator $nameGenerator
-     * @param string $documentType
      */
     public function __construct(
         HttpClient $client,
@@ -109,8 +106,7 @@ class Native extends Gateway
         SortClauseVisitor $sortClauseVisitor,
         FacetBuilderVisitor $facetBuilderVisitor,
         FieldValueMapper $fieldValueMapper,
-        FieldNameGenerator $nameGenerator,
-        $documentType
+        FieldNameGenerator $nameGenerator
     )
     {
         $this->client              = $client;
@@ -121,7 +117,6 @@ class Native extends Gateway
         $this->facetBuilderVisitor = $facetBuilderVisitor;
         $this->fieldValueMapper    = $fieldValueMapper;
         $this->nameGenerator       = $nameGenerator;
-        $this->documentType = $documentType;
     }
 
     /**
@@ -170,7 +165,7 @@ class Native extends Gateway
         $response = $this->client->request(
             'GET',
             $this->endpointRegistry->getEndpoint(
-                $this->endpointResolver->getEntryPoint( $this->documentType )
+                $this->endpointResolver->getEntryPoint()
             ),
             "/select?{$queryString}"
         );
@@ -234,10 +229,7 @@ class Native extends Gateway
     protected function getSearchTargets( $languageSettings )
     {
         $shards = array();
-        $endpoints = $this->endpointResolver->getSearchTargets(
-            $this->documentType,
-            $languageSettings
-        );
+        $endpoints = $this->endpointResolver->getSearchTargets( $languageSettings );
 
         if ( !empty( $endpoints ) )
         {
@@ -347,7 +339,7 @@ class Native extends Gateway
         $result = $this->client->request(
             'POST',
             $this->endpointRegistry->getEndpoint(
-                $this->endpointResolver->getIndexingTarget( $this->documentType, $languageCode )
+                $this->endpointResolver->getIndexingTarget( $languageCode )
             ),
             '/update?' .
             ( $this->commit ? "softCommit=true&" : "" ) . 'wt=json',
@@ -374,7 +366,7 @@ class Native extends Gateway
      */
     public function deleteByQuery( $query )
     {
-        $endpoints = $this->endpointResolver->getAllEndpoints( $this->documentType );
+        $endpoints = $this->endpointResolver->getEndpoints();
 
         foreach ( $endpoints as $endpointName )
         {
@@ -400,7 +392,7 @@ class Native extends Gateway
      */
     public function purgeIndex()
     {
-        $endpoints = $this->endpointResolver->getAllEndpoints( $this->documentType );
+        $endpoints = $this->endpointResolver->getEndpoints();
 
         foreach ( $endpoints as $endpointName )
         {

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
@@ -152,7 +152,12 @@ class Native extends Gateway
         );
         if ( !empty( $endpoints ) )
         {
-            $parameters["shards"] = implode( ",", $endpoints );
+            foreach ( $endpoints as $endpoint )
+            {
+                $parameters["shards"][] = $endpoint->getIdentifier();
+            }
+
+            $parameters["shards"] = implode( ",", $parameters["shards"] );
         }
 
         // @todo: Extract method
@@ -268,15 +273,10 @@ class Native extends Gateway
 
     protected function bulkIndexTranslationDocuments( array $documents, $languageCode )
     {
-        $server = $this->endpointProvider->getIndexingTarget(
-            $this->documentType,
-            $languageCode
-        );
-
         $updates = $this->createUpdates( $documents );
         $result = $this->client->request(
             'POST',
-            $server,
+            $this->endpointProvider->getIndexingTarget( $this->documentType, $languageCode ),
             '/update?' .
             ( $this->commit ? "softCommit=true&" : "" ) . 'wt=json',
             new Message(

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/Native.php
@@ -307,8 +307,10 @@ class Native extends Gateway
     }
 
     /**
-     * Indexes a block of documents, which in our case is a Content preceded by its Locations.
-     * In Solr block is identifiable by '_root_' field which holds a parent document (Content) id.
+     * Indexes an array of documents.
+     *
+     * Documents are given as an array of the array of documents. The array of documents
+     * holds documents for all translations of the particular entity.
      *
      * @param \eZ\Publish\SPI\Search\Document[][] $documents
      *
@@ -318,9 +320,9 @@ class Native extends Gateway
     {
         $map = array();
 
-        foreach ( $documents as $documents2 )
+        foreach ( $documents as $translationDocuments )
         {
-            foreach ( $documents2 as $document )
+            foreach ( $translationDocuments as $document )
             {
                 $map[$document->languageCode][] = $document;
             }

--- a/eZ/Publish/Core/settings/search_engines/solr.yml
+++ b/eZ/Publish/Core/settings/search_engines/solr.yml
@@ -11,7 +11,7 @@ parameters:
     ezpublish.search.solr.content.gateway.native.class: eZ\Publish\Core\Search\Solr\Content\Gateway\Native
     ezpublish.search.solr.content.gateway.endpoint_resolver.native.class: eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointResolver\NativeEndpointResolver
     ezpublish.spi.search.solr.content_handler.class: eZ\Publish\Core\Search\Solr\Content\Handler
-    ezpublish.search.solr.content.document_mapper.translation_document_mapper.class: eZ\Publish\Core\Search\Solr\Content\DocumentMapper\TranslationDocumentMapper
+    ezpublish.search.solr.content.document_mapper.native.class: eZ\Publish\Core\Search\Solr\Content\DocumentMapper\NativeDocumentMapper
     ezpublish.search.solr.result_extractor.loading.class: eZ\Publish\Core\Search\Solr\Content\ResultExtractor\LoadingResultExtractor
     ezpublish.spi.search.solr.location_handler.class: eZ\Publish\Core\Search\Solr\Content\Location\Handler
 
@@ -22,8 +22,8 @@ services:
     ezpublish.search.solr.content.gateway.endpoint_resolver:
         alias: ezpublish.search.solr.content.gateway.endpoint_resolver.native
 
-    ezpublish.search.solr.content.document_mapper.translation_document_mapper:
-        class: %ezpublish.search.solr.content.document_mapper.translation_document_mapper.class%
+    ezpublish.search.solr.content.document_mapper.native:
+        class: %ezpublish.search.solr.content.document_mapper.native.class%
         arguments:
             - @ezpublish.search.common.field_registry
             - @ezpublish.spi.persistence.content_handler
@@ -34,7 +34,7 @@ services:
             - @ezpublish.search.common.field_name_generator
 
     ezpublish.search.solr.content.document_mapper:
-        alias: ezpublish.search.solr.content.document_mapper.translation_document_mapper
+        alias: ezpublish.search.solr.content.document_mapper.native
 
     ezpublish.search.solr.result_extractor.loading:
         class: %ezpublish.search.solr.result_extractor.loading.class%

--- a/eZ/Publish/Core/settings/search_engines/solr.yml
+++ b/eZ/Publish/Core/settings/search_engines/solr.yml
@@ -15,21 +15,32 @@ parameters:
     ezpublish.search.solr.content.document_mapper.native.class: eZ\Publish\Core\Search\Solr\Content\DocumentMapper\NativeDocumentMapper
     ezpublish.search.solr.result_extractor.loading.class: eZ\Publish\Core\Search\Solr\Content\ResultExtractor\LoadingResultExtractor
     ezpublish.spi.search.solr.location_handler.class: eZ\Publish\Core\Search\Solr\Content\Location\Handler
-    ezpublish.search.solr.content.gateway.endpoint_resolver.entry_points: []
-    ezpublish.search.solr.content.gateway.endpoint_resolver.cluster: []
+    ezpublish.search.solr.content.gateway.endpoint_resolver.entry_points.content: []
+    ezpublish.search.solr.content.gateway.endpoint_resolver.entry_points.location: []
+    ezpublish.search.solr.content.gateway.endpoint_resolver.cluster.content: []
+    ezpublish.search.solr.content.gateway.endpoint_resolver.cluster.location: []
 
 services:
     ezpublish.search.solr.content.gateway.endpoint_registry:
         class: %ezpublish.search.solr.content.gateway.endpoint_registry.class%
 
-    ezpublish.search.solr.content.gateway.endpoint_resolver.native:
+    ezpublish.search.solr.content.gateway.endpoint_resolver.native.content:
         class: %ezpublish.search.solr.content.gateway.endpoint_resolver.native.class%
         arguments:
-            - %ezpublish.search.solr.content.gateway.endpoint_resolver.entry_points%
-            - %ezpublish.search.solr.content.gateway.endpoint_resolver.cluster%
+            - %ezpublish.search.solr.content.gateway.endpoint_resolver.entry_points.content%
+            - %ezpublish.search.solr.content.gateway.endpoint_resolver.cluster.content%
 
-    ezpublish.search.solr.content.gateway.endpoint_resolver:
-        alias: ezpublish.search.solr.content.gateway.endpoint_resolver.native
+    ezpublish.search.solr.content.gateway.endpoint_resolver.native.location:
+        class: %ezpublish.search.solr.content.gateway.endpoint_resolver.native.class%
+        arguments:
+            - %ezpublish.search.solr.content.gateway.endpoint_resolver.entry_points.location%
+            - %ezpublish.search.solr.content.gateway.endpoint_resolver.cluster.location%
+
+    ezpublish.search.solr.content.gateway.endpoint_resolver.content:
+        alias: ezpublish.search.solr.content.gateway.endpoint_resolver.native.content
+
+    ezpublish.search.solr.content.gateway.endpoint_resolver.location:
+        alias: ezpublish.search.solr.content.gateway.endpoint_resolver.native.location
 
     ezpublish.search.solr.content.document_mapper.native:
         class: %ezpublish.search.solr.content.document_mapper.native.class%
@@ -59,14 +70,13 @@ services:
         class: %ezpublish.search.solr.content.gateway.native.class%
         arguments:
             - @ezpublish.search.solr.content.gateway.client.http.stream
-            - @ezpublish.search.solr.content.gateway.endpoint_resolver
+            - @ezpublish.search.solr.content.gateway.endpoint_resolver.content
             - @ezpublish.search.solr.content.gateway.endpoint_registry
             - @ezpublish.search.solr.content.criterion_visitor.aggregate
             - @ezpublish.search.solr.content.sort_clause_visitor.aggregate
             - @ezpublish.search.solr.content.facet_builder_visitor.aggregate
             - @ezpublish.search.solr.content.field_value_mapper.aggregate
             - @ezpublish.search.common.field_name_generator
-            - 'content'
 
     ezpublish.search.solr.content.gateway:
         alias: ezpublish.search.solr.content.gateway.native
@@ -84,14 +94,13 @@ services:
         class: %ezpublish.search.solr.content.gateway.native.class%
         arguments:
             - @ezpublish.search.solr.content.gateway.client.http.stream
-            - @ezpublish.search.solr.content.gateway.endpoint_resolver
+            - @ezpublish.search.solr.content.gateway.endpoint_resolver.location
             - @ezpublish.search.solr.content.gateway.endpoint_registry
             - @ezpublish.search.solr.location.criterion_visitor.aggregate
             - @ezpublish.search.solr.location.sort_clause_visitor.aggregate
             - @ezpublish.search.solr.location.facet_builder_visitor.aggregate
             - @ezpublish.search.solr.content.field_value_mapper.aggregate
             - @ezpublish.search.common.field_name_generator
-            - 'location'
 
     ezpublish.search.solr.location.gateway:
         alias: ezpublish.search.solr.location.gateway.native

--- a/eZ/Publish/Core/settings/search_engines/solr.yml
+++ b/eZ/Publish/Core/settings/search_engines/solr.yml
@@ -15,6 +15,7 @@ parameters:
     ezpublish.search.solr.content.document_mapper.native.class: eZ\Publish\Core\Search\Solr\Content\DocumentMapper\NativeDocumentMapper
     ezpublish.search.solr.result_extractor.loading.class: eZ\Publish\Core\Search\Solr\Content\ResultExtractor\LoadingResultExtractor
     ezpublish.spi.search.solr.location_handler.class: eZ\Publish\Core\Search\Solr\Content\Location\Handler
+    # Endpoint resolver arguments must be set in order to be overrideable
     ezpublish.search.solr.content.gateway.endpoint_resolver.entry_points.content: []
     ezpublish.search.solr.content.gateway.endpoint_resolver.entry_points.location: []
     ezpublish.search.solr.content.gateway.endpoint_resolver.cluster.content: []

--- a/eZ/Publish/Core/settings/search_engines/solr.yml
+++ b/eZ/Publish/Core/settings/search_engines/solr.yml
@@ -9,18 +9,18 @@ parameters:
     ezpublish.search.solr.connection.server: http://localhost:8983/solr/core0
     ezpublish.spi.search.solr.class: eZ\Publish\Core\Search\Solr\Handler
     ezpublish.search.solr.content.gateway.native.class: eZ\Publish\Core\Search\Solr\Content\Gateway\Native
-    ezpublish.search.solr.content.gateway.endpoint_provider.translation_endpoint_provider.class: eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointProvider\TranslationEndpointProvider
+    ezpublish.search.solr.content.gateway.endpoint_resolver.translation_endpoint_resolver.class: eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointResolver\TranslationEndpointResolver
     ezpublish.spi.search.solr.content_handler.class: eZ\Publish\Core\Search\Solr\Content\Handler
     ezpublish.search.solr.content.document_mapper.translation_document_mapper.class: eZ\Publish\Core\Search\Solr\Content\DocumentMapper\TranslationDocumentMapper
     ezpublish.search.solr.result_extractor.loading.class: eZ\Publish\Core\Search\Solr\Content\ResultExtractor\LoadingResultExtractor
     ezpublish.spi.search.solr.location_handler.class: eZ\Publish\Core\Search\Solr\Content\Location\Handler
 
 services:
-    ezpublish.search.solr.content.gateway.endpoint_provider.translation_endpoint_provider:
-        class: %ezpublish.search.solr.content.gateway.endpoint_provider.translation_endpoint_provider.class%
+    ezpublish.search.solr.content.gateway.endpoint_resolver.translation_endpoint_resolver:
+        class: %ezpublish.search.solr.content.gateway.endpoint_resolver.translation_endpoint_resolver.class%
 
-    ezpublish.search.solr.content.gateway.endpoint_provider:
-        alias: ezpublish.search.solr.content.gateway.endpoint_provider.translation_endpoint_provider
+    ezpublish.search.solr.content.gateway.endpoint_resolver:
+        alias: ezpublish.search.solr.content.gateway.endpoint_resolver.translation_endpoint_resolver
 
     ezpublish.search.solr.content.document_mapper.translation_document_mapper:
         class: %ezpublish.search.solr.content.document_mapper.translation_document_mapper.class%
@@ -50,7 +50,7 @@ services:
         class: %ezpublish.search.solr.content.gateway.native.class%
         arguments:
             - @ezpublish.search.solr.content.gateway.client.http.stream
-            - @ezpublish.search.solr.content.gateway.endpoint_provider
+            - @ezpublish.search.solr.content.gateway.endpoint_resolver
             - @ezpublish.search.solr.content.gateway.endpoint_registry
             - @ezpublish.search.solr.content.criterion_visitor.aggregate
             - @ezpublish.search.solr.content.sort_clause_visitor.aggregate
@@ -75,7 +75,7 @@ services:
         class: %ezpublish.search.solr.content.gateway.native.class%
         arguments:
             - @ezpublish.search.solr.content.gateway.client.http.stream
-            - @ezpublish.search.solr.content.gateway.endpoint_provider
+            - @ezpublish.search.solr.content.gateway.endpoint_resolver
             - @ezpublish.search.solr.content.gateway.endpoint_registry
             - @ezpublish.search.solr.location.criterion_visitor.aggregate
             - @ezpublish.search.solr.location.sort_clause_visitor.aggregate

--- a/eZ/Publish/Core/settings/search_engines/solr.yml
+++ b/eZ/Publish/Core/settings/search_engines/solr.yml
@@ -9,18 +9,18 @@ parameters:
     ezpublish.search.solr.connection.server: http://localhost:8983/solr/core0
     ezpublish.spi.search.solr.class: eZ\Publish\Core\Search\Solr\Handler
     ezpublish.search.solr.content.gateway.native.class: eZ\Publish\Core\Search\Solr\Content\Gateway\Native
-    ezpublish.search.solr.content.gateway.endpoint_resolver.translation_endpoint_resolver.class: eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointResolver\TranslationEndpointResolver
+    ezpublish.search.solr.content.gateway.endpoint_resolver.native.class: eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointResolver\NativeEndpointResolver
     ezpublish.spi.search.solr.content_handler.class: eZ\Publish\Core\Search\Solr\Content\Handler
     ezpublish.search.solr.content.document_mapper.translation_document_mapper.class: eZ\Publish\Core\Search\Solr\Content\DocumentMapper\TranslationDocumentMapper
     ezpublish.search.solr.result_extractor.loading.class: eZ\Publish\Core\Search\Solr\Content\ResultExtractor\LoadingResultExtractor
     ezpublish.spi.search.solr.location_handler.class: eZ\Publish\Core\Search\Solr\Content\Location\Handler
 
 services:
-    ezpublish.search.solr.content.gateway.endpoint_resolver.translation_endpoint_resolver:
-        class: %ezpublish.search.solr.content.gateway.endpoint_resolver.translation_endpoint_resolver.class%
+    ezpublish.search.solr.content.gateway.endpoint_resolver.native:
+        class: %ezpublish.search.solr.content.gateway.endpoint_resolver.native.class%
 
     ezpublish.search.solr.content.gateway.endpoint_resolver:
-        alias: ezpublish.search.solr.content.gateway.endpoint_resolver.translation_endpoint_resolver
+        alias: ezpublish.search.solr.content.gateway.endpoint_resolver.native
 
     ezpublish.search.solr.content.document_mapper.translation_document_mapper:
         class: %ezpublish.search.solr.content.document_mapper.translation_document_mapper.class%

--- a/eZ/Publish/Core/settings/search_engines/solr.yml
+++ b/eZ/Publish/Core/settings/search_engines/solr.yml
@@ -51,6 +51,7 @@ services:
         arguments:
             - @ezpublish.search.solr.content.gateway.client.http.stream
             - @ezpublish.search.solr.content.gateway.endpoint_provider
+            - @ezpublish.search.solr.content.gateway.endpoint_registry
             - @ezpublish.search.solr.content.criterion_visitor.aggregate
             - @ezpublish.search.solr.content.sort_clause_visitor.aggregate
             - @ezpublish.search.solr.content.facet_builder_visitor.aggregate
@@ -75,6 +76,7 @@ services:
         arguments:
             - @ezpublish.search.solr.content.gateway.client.http.stream
             - @ezpublish.search.solr.content.gateway.endpoint_provider
+            - @ezpublish.search.solr.content.gateway.endpoint_registry
             - @ezpublish.search.solr.location.criterion_visitor.aggregate
             - @ezpublish.search.solr.location.sort_clause_visitor.aggregate
             - @ezpublish.search.solr.location.facet_builder_visitor.aggregate

--- a/eZ/Publish/Core/settings/search_engines/solr.yml
+++ b/eZ/Publish/Core/settings/search_engines/solr.yml
@@ -9,15 +9,24 @@ parameters:
     ezpublish.search.solr.connection.server: http://localhost:8983/solr/core0
     ezpublish.spi.search.solr.class: eZ\Publish\Core\Search\Solr\Handler
     ezpublish.search.solr.content.gateway.native.class: eZ\Publish\Core\Search\Solr\Content\Gateway\Native
+    ezpublish.search.solr.content.gateway.endpoint_registry.class: eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointRegistry
     ezpublish.search.solr.content.gateway.endpoint_resolver.native.class: eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointResolver\NativeEndpointResolver
     ezpublish.spi.search.solr.content_handler.class: eZ\Publish\Core\Search\Solr\Content\Handler
     ezpublish.search.solr.content.document_mapper.native.class: eZ\Publish\Core\Search\Solr\Content\DocumentMapper\NativeDocumentMapper
     ezpublish.search.solr.result_extractor.loading.class: eZ\Publish\Core\Search\Solr\Content\ResultExtractor\LoadingResultExtractor
     ezpublish.spi.search.solr.location_handler.class: eZ\Publish\Core\Search\Solr\Content\Location\Handler
+    ezpublish.search.solr.content.gateway.endpoint_resolver.entry_points: []
+    ezpublish.search.solr.content.gateway.endpoint_resolver.cluster: []
 
 services:
+    ezpublish.search.solr.content.gateway.endpoint_registry:
+        class: %ezpublish.search.solr.content.gateway.endpoint_registry.class%
+
     ezpublish.search.solr.content.gateway.endpoint_resolver.native:
         class: %ezpublish.search.solr.content.gateway.endpoint_resolver.native.class%
+        arguments:
+            - %ezpublish.search.solr.content.gateway.endpoint_resolver.entry_points%
+            - %ezpublish.search.solr.content.gateway.endpoint_resolver.cluster%
 
     ezpublish.search.solr.content.gateway.endpoint_resolver:
         alias: ezpublish.search.solr.content.gateway.endpoint_resolver.native

--- a/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
@@ -19,6 +19,7 @@ parameters:
         -
             var/ezdemo_site/storage/images/design/plain-site/172-2-eng-US/eZ-Publish-Demo-Design-without-demo-content1.png
     ezpublish.solr.endpoint.class: eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint
+    ezpublish.search.solr.content.gateway.endpoint_registry.class: eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointRegistry
 
 services:
     ezpublish.cache_pool.spi.cache.decorator:
@@ -107,20 +108,34 @@ services:
                 path: solr
                 core: core7
 
+    ezpublish.search.solr.content.gateway.endpoint_registry:
+        class: %ezpublish.search.solr.content.gateway.endpoint_registry.class%
+        arguments:
+            -
+                endpoint0: @ezpublish.solr.endpoint0
+                endpoint1: @ezpublish.solr.endpoint1
+                endpoint2: @ezpublish.solr.endpoint2
+                endpoint3: @ezpublish.solr.endpoint3
+                endpoint4: @ezpublish.solr.endpoint4
+                endpoint5: @ezpublish.solr.endpoint5
+                endpoint6: @ezpublish.solr.endpoint6
+                endpoint7: @ezpublish.solr.endpoint7
+
     ezpublish.search.solr.content.gateway.endpoint_provider.translation_endpoint_provider:
         class: %ezpublish.search.solr.content.gateway.endpoint_provider.translation_endpoint_provider.class%
         arguments:
+            - @ezpublish.search.solr.content.gateway.endpoint_registry
             -
-                content: @ezpublish.solr.endpoint0
-                location: @ezpublish.solr.endpoint0
+                content: endpoint0
+                location: endpoint0
             -
                 content:
-                    eng-GB: @ezpublish.solr.endpoint0
-                    eng-US: @ezpublish.solr.endpoint1
-                    por-PT: @ezpublish.solr.endpoint2
-                    ger-DE: @ezpublish.solr.endpoint3
+                    eng-GB: endpoint0
+                    eng-US: endpoint1
+                    por-PT: endpoint2
+                    ger-DE: endpoint3
                 location:
-                    eng-GB: @ezpublish.solr.endpoint4
-                    eng-US: @ezpublish.solr.endpoint5
-                    por-PT: @ezpublish.solr.endpoint6
-                    ger-DE: @ezpublish.solr.endpoint7
+                    eng-GB: endpoint4
+                    eng-US: endpoint5
+                    por-PT: endpoint6
+                    ger-DE: endpoint7

--- a/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
@@ -37,6 +37,8 @@ services:
                 port: 8983
                 path: solr
                 core: core0
+        tags:
+            - {name: ezpublish.search.solr.endpoint, alias: endpoint0}
 
     ezpublish.solr.endpoint1:
         class: %ezpublish.solr.endpoint.class%
@@ -47,6 +49,8 @@ services:
                 port: 8983
                 path: solr
                 core: core1
+        tags:
+            - {name: ezpublish.search.solr.endpoint, alias: endpoint1}
 
     ezpublish.solr.endpoint2:
         class: %ezpublish.solr.endpoint.class%
@@ -57,6 +61,8 @@ services:
                 port: 8983
                 path: solr
                 core: core2
+        tags:
+            - {name: ezpublish.search.solr.endpoint, alias: endpoint2}
 
     ezpublish.solr.endpoint3:
         class: %ezpublish.solr.endpoint.class%
@@ -67,6 +73,8 @@ services:
                 port: 8983
                 path: solr
                 core: core3
+        tags:
+            - {name: ezpublish.search.solr.endpoint, alias: endpoint3}
 
     ezpublish.solr.endpoint4:
         class: %ezpublish.solr.endpoint.class%
@@ -77,6 +85,8 @@ services:
                 port: 8983
                 path: solr
                 core: core4
+        tags:
+            - {name: ezpublish.search.solr.endpoint, alias: endpoint4}
 
     ezpublish.solr.endpoint5:
         class: %ezpublish.solr.endpoint.class%
@@ -87,6 +97,8 @@ services:
                 port: 8983
                 path: solr
                 core: core5
+        tags:
+            - {name: ezpublish.search.solr.endpoint, alias: endpoint5}
 
     ezpublish.solr.endpoint6:
         class: %ezpublish.solr.endpoint.class%
@@ -97,6 +109,8 @@ services:
                 port: 8983
                 path: solr
                 core: core6
+        tags:
+            - {name: ezpublish.search.solr.endpoint, alias: endpoint6}
 
     ezpublish.solr.endpoint7:
         class: %ezpublish.solr.endpoint.class%
@@ -107,19 +121,11 @@ services:
                 port: 8983
                 path: solr
                 core: core7
+        tags:
+            - {name: ezpublish.search.solr.endpoint, alias: endpoint7}
 
     ezpublish.search.solr.content.gateway.endpoint_registry:
         class: %ezpublish.search.solr.content.gateway.endpoint_registry.class%
-        arguments:
-            -
-                endpoint0: @ezpublish.solr.endpoint0
-                endpoint1: @ezpublish.solr.endpoint1
-                endpoint2: @ezpublish.solr.endpoint2
-                endpoint3: @ezpublish.solr.endpoint3
-                endpoint4: @ezpublish.solr.endpoint4
-                endpoint5: @ezpublish.solr.endpoint5
-                endpoint6: @ezpublish.solr.endpoint6
-                endpoint7: @ezpublish.solr.endpoint7
 
     ezpublish.search.solr.content.gateway.endpoint_provider.translation_endpoint_provider:
         class: %ezpublish.search.solr.content.gateway.endpoint_provider.translation_endpoint_provider.class%

--- a/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
@@ -28,7 +28,7 @@ services:
     ezpublish.spi.search_engine:
         alias: ezpublish.spi.search.solr
 
-    ezpublish.solr.endpoint0:
+    ezpublish.search.solr.endpoint.endpoint0:
         class: %ezpublish.solr.endpoint.class%
         arguments:
             -
@@ -40,7 +40,7 @@ services:
         tags:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint0}
 
-    ezpublish.solr.endpoint1:
+    ezpublish.search.solr.endpoint.endpoint1:
         class: %ezpublish.solr.endpoint.class%
         arguments:
             -
@@ -52,7 +52,7 @@ services:
         tags:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint1}
 
-    ezpublish.solr.endpoint2:
+    ezpublish.search.solr.endpoint.endpoint2:
         class: %ezpublish.solr.endpoint.class%
         arguments:
             -
@@ -64,7 +64,7 @@ services:
         tags:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint2}
 
-    ezpublish.solr.endpoint3:
+    ezpublish.search.solr.endpoint.endpoint3:
         class: %ezpublish.solr.endpoint.class%
         arguments:
             -
@@ -76,7 +76,7 @@ services:
         tags:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint3}
 
-    ezpublish.solr.endpoint4:
+    ezpublish.search.solr.endpoint.endpoint4:
         class: %ezpublish.solr.endpoint.class%
         arguments:
             -
@@ -88,7 +88,7 @@ services:
         tags:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint4}
 
-    ezpublish.solr.endpoint5:
+    ezpublish.search.solr.endpoint.endpoint5:
         class: %ezpublish.solr.endpoint.class%
         arguments:
             -
@@ -100,7 +100,7 @@ services:
         tags:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint5}
 
-    ezpublish.solr.endpoint6:
+    ezpublish.search.solr.endpoint.endpoint6:
         class: %ezpublish.solr.endpoint.class%
         arguments:
             -
@@ -112,7 +112,7 @@ services:
         tags:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint6}
 
-    ezpublish.solr.endpoint7:
+    ezpublish.search.solr.endpoint.endpoint7:
         class: %ezpublish.solr.endpoint.class%
         arguments:
             -

--- a/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
@@ -19,7 +19,23 @@ parameters:
         -
             var/ezdemo_site/storage/images/design/plain-site/172-2-eng-US/eZ-Publish-Demo-Design-without-demo-content1.png
     ezpublish.solr.endpoint.class: eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint
-    ezpublish.search.solr.content.gateway.endpoint_registry.class: eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointRegistry
+
+    ezpublish.search.solr.content.gateway.endpoint_resolver.entry_points:
+        -
+            content: endpoint0
+            location: endpoint0
+    ezpublish.search.solr.content.gateway.endpoint_resolver.cluster:
+        -
+            content:
+                eng-GB: endpoint0
+                eng-US: endpoint1
+                por-PT: endpoint2
+                ger-DE: endpoint3
+            location:
+                eng-GB: endpoint4
+                eng-US: endpoint5
+                por-PT: endpoint6
+                ger-DE: endpoint7
 
 services:
     ezpublish.cache_pool.spi.cache.decorator:
@@ -123,24 +139,3 @@ services:
                 core: core7
         tags:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint7}
-
-    ezpublish.search.solr.content.gateway.endpoint_registry:
-        class: %ezpublish.search.solr.content.gateway.endpoint_registry.class%
-
-    ezpublish.search.solr.content.gateway.endpoint_resolver.native:
-        class: %ezpublish.search.solr.content.gateway.endpoint_resolver.native.class%
-        arguments:
-            -
-                content: endpoint0
-                location: endpoint0
-            -
-                content:
-                    eng-GB: endpoint0
-                    eng-US: endpoint1
-                    por-PT: endpoint2
-                    ger-DE: endpoint3
-                location:
-                    eng-GB: endpoint4
-                    eng-US: endpoint5
-                    por-PT: endpoint6
-                    ger-DE: endpoint7

--- a/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
@@ -127,8 +127,8 @@ services:
     ezpublish.search.solr.content.gateway.endpoint_registry:
         class: %ezpublish.search.solr.content.gateway.endpoint_registry.class%
 
-    ezpublish.search.solr.content.gateway.endpoint_provider.translation_endpoint_provider:
-        class: %ezpublish.search.solr.content.gateway.endpoint_provider.translation_endpoint_provider.class%
+    ezpublish.search.solr.content.gateway.endpoint_resolver.translation_endpoint_resolver:
+        class: %ezpublish.search.solr.content.gateway.endpoint_resolver.translation_endpoint_resolver.class%
         arguments:
             -
                 content: endpoint0

--- a/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
@@ -20,22 +20,20 @@ parameters:
             var/ezdemo_site/storage/images/design/plain-site/172-2-eng-US/eZ-Publish-Demo-Design-without-demo-content1.png
     ezpublish.solr.endpoint.class: eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint
 
-    ezpublish.search.solr.content.gateway.endpoint_resolver.entry_points:
-        -
-            content: endpoint0
-            location: endpoint0
-    ezpublish.search.solr.content.gateway.endpoint_resolver.cluster:
-        -
-            content:
-                eng-GB: endpoint0
-                eng-US: endpoint1
-                por-PT: endpoint2
-                ger-DE: endpoint3
-            location:
-                eng-GB: endpoint4
-                eng-US: endpoint5
-                por-PT: endpoint6
-                ger-DE: endpoint7
+    ezpublish.search.solr.content.gateway.endpoint_resolver.entry_points.content:
+          - endpoint0
+    ezpublish.search.solr.content.gateway.endpoint_resolver.entry_points.location:
+          - endpoint0
+    ezpublish.search.solr.content.gateway.endpoint_resolver.cluster.content:
+          eng-GB: endpoint0
+          eng-US: endpoint1
+          por-PT: endpoint2
+          ger-DE: endpoint3
+    ezpublish.search.solr.content.gateway.endpoint_resolver.cluster.location:
+          eng-GB: endpoint4
+          eng-US: endpoint5
+          por-PT: endpoint6
+          ger-DE: endpoint7
 
 services:
     ezpublish.cache_pool.spi.cache.decorator:

--- a/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
@@ -130,7 +130,6 @@ services:
     ezpublish.search.solr.content.gateway.endpoint_provider.translation_endpoint_provider:
         class: %ezpublish.search.solr.content.gateway.endpoint_provider.translation_endpoint_provider.class%
         arguments:
-            - @ezpublish.search.solr.content.gateway.endpoint_registry
             -
                 content: endpoint0
                 location: endpoint0

--- a/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
@@ -49,7 +49,7 @@ services:
                 scheme: http
                 host: localhost
                 port: 8983
-                path: solr
+                path: /solr
                 core: core0
         tags:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint0}
@@ -61,7 +61,7 @@ services:
                 scheme: http
                 host: localhost
                 port: 8983
-                path: solr
+                path: /solr
                 core: core1
         tags:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint1}
@@ -73,7 +73,7 @@ services:
                 scheme: http
                 host: localhost
                 port: 8983
-                path: solr
+                path: /solr
                 core: core2
         tags:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint2}
@@ -85,7 +85,7 @@ services:
                 scheme: http
                 host: localhost
                 port: 8983
-                path: solr
+                path: /solr
                 core: core3
         tags:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint3}
@@ -97,7 +97,7 @@ services:
                 scheme: http
                 host: localhost
                 port: 8983
-                path: solr
+                path: /solr
                 core: core4
         tags:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint4}
@@ -109,7 +109,7 @@ services:
                 scheme: http
                 host: localhost
                 port: 8983
-                path: solr
+                path: /solr
                 core: core5
         tags:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint5}
@@ -121,7 +121,7 @@ services:
                 scheme: http
                 host: localhost
                 port: 8983
-                path: solr
+                path: /solr
                 core: core6
         tags:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint6}
@@ -133,7 +133,7 @@ services:
                 scheme: http
                 host: localhost
                 port: 8983
-                path: solr
+                path: /solr
                 core: core7
         tags:
             - {name: ezpublish.search.solr.endpoint, alias: endpoint7}

--- a/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
@@ -18,6 +18,7 @@ parameters:
     ignored_storage_files:
         -
             var/ezdemo_site/storage/images/design/plain-site/172-2-eng-US/eZ-Publish-Demo-Design-without-demo-content1.png
+    ezpublish.solr.endpoint.class: eZ\Publish\Core\Search\Solr\Content\Gateway\Endpoint
 
 services:
     ezpublish.cache_pool.spi.cache.decorator:
@@ -25,3 +26,101 @@ services:
 
     ezpublish.spi.search_engine:
         alias: ezpublish.spi.search.solr
+
+    ezpublish.solr.endpoint0:
+        class: %ezpublish.solr.endpoint.class%
+        arguments:
+            -
+                scheme: http
+                host: localhost
+                port: 8983
+                path: solr
+                core: core0
+
+    ezpublish.solr.endpoint1:
+        class: %ezpublish.solr.endpoint.class%
+        arguments:
+            -
+                scheme: http
+                host: localhost
+                port: 8983
+                path: solr
+                core: core1
+
+    ezpublish.solr.endpoint2:
+        class: %ezpublish.solr.endpoint.class%
+        arguments:
+            -
+                scheme: http
+                host: localhost
+                port: 8983
+                path: solr
+                core: core2
+
+    ezpublish.solr.endpoint3:
+        class: %ezpublish.solr.endpoint.class%
+        arguments:
+            -
+                scheme: http
+                host: localhost
+                port: 8983
+                path: solr
+                core: core3
+
+    ezpublish.solr.endpoint4:
+        class: %ezpublish.solr.endpoint.class%
+        arguments:
+            -
+                scheme: http
+                host: localhost
+                port: 8983
+                path: solr
+                core: core4
+
+    ezpublish.solr.endpoint5:
+        class: %ezpublish.solr.endpoint.class%
+        arguments:
+            -
+                scheme: http
+                host: localhost
+                port: 8983
+                path: solr
+                core: core5
+
+    ezpublish.solr.endpoint6:
+        class: %ezpublish.solr.endpoint.class%
+        arguments:
+            -
+                scheme: http
+                host: localhost
+                port: 8983
+                path: solr
+                core: core6
+
+    ezpublish.solr.endpoint7:
+        class: %ezpublish.solr.endpoint.class%
+        arguments:
+            -
+                scheme: http
+                host: localhost
+                port: 8983
+                path: solr
+                core: core7
+
+    ezpublish.search.solr.content.gateway.endpoint_provider.translation_endpoint_provider:
+        class: %ezpublish.search.solr.content.gateway.endpoint_provider.translation_endpoint_provider.class%
+        arguments:
+            -
+                content: @ezpublish.solr.endpoint0
+                location: @ezpublish.solr.endpoint0
+            -
+                content:
+                    eng-GB: @ezpublish.solr.endpoint0
+                    eng-US: @ezpublish.solr.endpoint1
+                    por-PT: @ezpublish.solr.endpoint2
+                    ger-DE: @ezpublish.solr.endpoint3
+                location:
+                    eng-GB: @ezpublish.solr.endpoint4
+                    eng-US: @ezpublish.solr.endpoint5
+                    por-PT: @ezpublish.solr.endpoint6
+                    ger-DE: @ezpublish.solr.endpoint7

--- a/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy_solr.yml
@@ -127,8 +127,8 @@ services:
     ezpublish.search.solr.content.gateway.endpoint_registry:
         class: %ezpublish.search.solr.content.gateway.endpoint_registry.class%
 
-    ezpublish.search.solr.content.gateway.endpoint_resolver.translation_endpoint_resolver:
-        class: %ezpublish.search.solr.content.gateway.endpoint_resolver.translation_endpoint_resolver.class%
+    ezpublish.search.solr.content.gateway.endpoint_resolver.native:
+        class: %ezpublish.search.solr.content.gateway.endpoint_resolver.native.class%
         arguments:
             -
                 content: endpoint0


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24375

Previously configuration was hardcoded in the engine, this implements semantic configuration for multicore Solr search engine implementation.

New configuration example:

```yml
ez_search_engine_solr:
    endpoints:
        endpoint1:
            dsn: http://localhost:8983/solr
            core: core1
        endpoint2:
            dsn: http://localhost:8983/solr
            core: core2
    connections:
        connection1:
            entry_endpoints:
                content:
                    - endpoint1
                location:
                    - endpoint2
            cluster:
                content:
                    cro-HR: endpoint1
                    eng-GB: endpoint2
                location:
                    cro-HR: endpoint1
                    eng-GB: endpoint2
```

Repository configuration remains the same:

```yml
ezpublish:
    repositories:
        main:
            storage:
                engine: legacy
                connection: database_connection
            search:
                engine: solr
                connection: connection1
```
Endpoints represent Solr cores (separate logical indexes) and are configured separately from connections.
Connections consist of `entry_endpoints` and `cluster` keys, which configure previously defined endpoints for each search handler (or type of search), content and location.
`entry_endpoints` defines a set of entry endpoints for distributed search, while `cluster` defines mapping of endpoints to language codes, meaning it defines which core indexes which Content translations.

Bundle will process endpoint configuration and define `Endpoint` services for each configured endpoint, tagged with `ezpublish.search.solr.endpoint`. These will be registered with `EndpointRegistry` service in a compiler pass.

`EndpointProvider` is here renamed to `EndpointResolver`. Connection parameters will be passed to that service, using the definition decoration system to decorate search engine dependency graph per connection, as was the case before.

`EndpointProvider` is simplified, so it doesn't contain mapping for both search handlers (Content and Location). Each handler is now configured with endpoint provider containing it's own endpoint mapping. Note that it is possible to define multiple endpoints as entry points, while only first one will be used. In future entry point selection strategies will be implemented on top of that.