### PR TITLE
EZP-23367: Implement variations purging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
         "ezsystems/ezpublish-spi": "self.version"
     },
     "conflict": {
-        "zendframework/zend-stdlib": ">=2.3"
+        "zendframework/zend-stdlib": ">=2.3",
+        "symfony/symfony": ">=2.7"
     },
     "autoload": {
         "psr-4": {

--- a/doc/specifications/image/variation_purging.md
+++ b/doc/specifications/image/variation_purging.md
@@ -1,0 +1,43 @@
+# Variation purging
+
+> From eZ Platform 2015.05
+
+## Synopsis and example
+
+Makes it possible to clear all variations generated for an alias. Uses the liip:imagine:cache:remove script.
+Example (the `-v` option will log removals to the console), removing variations for the `large` and `gallery` aliases :
+
+```shell
+php ezpublish/console liip:imagine:cache:remove --filters=large --filters=gallery -v
+```
+
+## Internal changes
+
+Two items have been refactored/introduced:
+- purging of variations from the IORepositoryResolver is done by a `VariationPurger`
+  Aliased service: `ezpublish.image_alias.variation_purger`
+- generation of the alias path from the original path is done by a `VariationPathGenerator`
+  Aliased service: `ezpublish.image_alias.variation_path_generator`
+
+### 2015.05 and above
+
+- Variation Purger: `ezpublish.image_alias.variation_purger.io`
+  Uses the IOService to delete the directory `_aliases/<aliasName>`
+- Path Generator: `ezpublish.image_alias.variation_path_generator.alias_directory`
+  Stores variations in the `_aliases` folder, in a subfolder named after the alias: `_aliases/<aliasName>`
+
+A set of Purger / Path Generator is added for releases from 2015.05. It relies on the new storage method for aliases:
+they're no longer stored in the original's folder, but in a dedicated folder. This makes purging as simple as removing
+the alias folder.
+
+### Earlier versions
+
+- Variation Purger: `ezpublish.image_alias.variation_purger.legacy_storage_image_file`
+  Uses the `LegacyStorageImageFileList` to iterate over originals, and clears the files using the IOService.
+- Path Generator: `ezpublish.image_alias.variation_path_generator.original_directory`
+  Stores variations in the same folder than the original, suffixing the name with `_<aliasName>`.
+
+Uses an ImageFileList service. It comes with a Legacy Storage implementation that lists original images from the
+`ezimagefile` database table. Aliases for each original is tested, and removed if found and applicable using the IOService.
+
+It is much more resource intensive, but it is the best option given the way variations are stored.

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/IORepositoryResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/IORepositoryResolver.php
@@ -114,10 +114,17 @@ class IORepositoryResolver implements ResolverInterface
      */
     public function remove( array $paths, array $filters )
     {
-        // TODO: $paths may be empty, meaning that all generated images corresponding to $filters need to be removed.
         if ( empty( $filters ) )
         {
             $filters = array_keys( $this->filterConfiguration->all() );
+        }
+
+        if ( empty( $paths ) )
+        {
+            foreach ( $filters as $filter )
+            {
+                $this->ioService->deleteDirectory( $filter );
+            }
         }
 
         foreach ( $paths as $path )

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPathGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPathGenerator.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine;
+
+interface VariationPathGenerator
+{
+    public function getVariationPath( $originalPath, $filter );
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPathGenerator/AliasDirectoryVariationPathGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPathGenerator/AliasDirectoryVariationPathGenerator.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator;
+
+/**
+ * Puts variations in the an _alias/<aliasName> subfolder.²
+ *
+ * Example:
+ * my/image/file.jpg -> _aliases/large/my/image/file.jpg
+ */
+class AliasDirectoryVariationPathGenerator implements VariationPathGenerator
+{
+    public function getVariationPath( $originalPath, $filter )
+    {
+        $info = pathinfo( $originalPath );
+        return sprintf(
+            '_aliases/%s/%s/%s%s',
+            $filter,
+            $info['dirname'],
+            $info['filename'],
+            empty( $info['extension'] ) ? '' : '.' . $info['extension']
+        );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPathGenerator/OriginalDirectoryVariationPathGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPathGenerator/OriginalDirectoryVariationPathGenerator.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator;
+
+/**
+ * Puts variations in the same folder than the original, suffixed with the filter name:
+ *
+ * Example:
+ * my/image/file.jpg -> my/image/file_large.jpg
+ */
+class OriginalDirectoryVariationPathGenerator implements VariationPathGenerator
+{
+    public function getVariationPath( $originalPath, $filter )
+    {
+        $info = pathinfo( $originalPath );
+        return sprintf(
+            '%s/%s_%s%s',
+            $info['dirname'],
+            $info['filename'],
+            $filter,
+            empty( $info['extension'] ) ? '' : '.' . $info['extension']
+        );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/IOVariationPurger.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/IOVariationPurger.php
@@ -2,7 +2,7 @@
 /**
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Bundle\EzPublishCoreBundle\Imagine;
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger;
 
 use eZ\Publish\Core\IO\IOServiceInterface;
 use eZ\Publish\SPI\Variation\VariationPurger;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/IOVariationPurger.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/IOVariationPurger.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine;
+
+use eZ\Publish\Core\IO\IOServiceInterface;
+use eZ\Publish\SPI\Variation\VariationPurger;
+
+/**
+ * Purges image variations using the IOService.
+ *
+ * Depends on aliases being stored in their own folder, with each alias folder mirroring the original files structure.
+ */
+class IOVariationPurger implements VariationPurger
+{
+    /** @var \eZ\Publish\Core\IO\IOServiceInterface */
+    private $io;
+
+    public function __construct( IOServiceInterface $io )
+    {
+        $this->io = $io;
+    }
+
+    public function purge( array $aliasNames )
+    {
+        foreach ( $aliasNames as $aliasName )
+        {
+            $this->io->deleteDirectory( $aliasName );
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileList.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileList.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger;
+
+use Iterator;
+use Countable;
+
+interface ImageFileList extends Countable, Iterator
+{
+
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileRowReader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileRowReader.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger;
+
+interface ImageFileRowReader
+{
+    public function init();
+
+    public function getRow();
+
+    public function getCount();
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileVariationPurger.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileVariationPurger.php
@@ -45,23 +45,21 @@ class ImageFileVariationPurger implements VariationPurger
      */
     public function purge( array $aliasNames )
     {
-        foreach ( $this->imageFileList as $imageFile )
+        foreach ( $this->imageFileList as $originalImageId )
         {
             foreach ( $aliasNames as $aliasName )
             {
-                $variationPath = $this->variationPathGenerator->getVariationPath( $imageFile, $aliasName );
-                try
-                {
-                    $binaryFile = $this->ioService->loadBinaryFileByUri( $variationPath );
-                }
-                catch ( BinaryFileNotFoundException $e )
+                $variationImageId = $this->variationPathGenerator->getVariationPath( $originalImageId, $aliasName );
+                if ( !$this->ioService->exists( $variationImageId ) )
                 {
                     continue;
                 }
-                // $this->ioService->deleteBinaryFile( $binaryFile );
+
+                $binaryFile = $this->ioService->loadBinaryFile( $variationImageId );
+                $this->ioService->deleteBinaryFile( $binaryFile );
                 if ( isset( $this->logger ) )
                 {
-                    $this->logger->info( "Purging $aliasName variation $variationPath for original image $imageFile" );
+                    $this->logger->info( "Purging $aliasName variation $variationImageId for original image $originalImageId" );
                 }
             }
         }

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileVariationPurger.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileVariationPurger.php
@@ -9,6 +9,7 @@ use eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway as ImageStorageGateway;
 use eZ\Publish\Core\IO\Exception\BinaryFileNotFoundException;
 use eZ\Publish\Core\IO\IOServiceInterface;
 use eZ\Publish\SPI\Variation\VariationPurger;
+use Iterator;
 
 /**
  * Purges image aliases based on image files referenced by the Image FieldType.
@@ -31,7 +32,7 @@ class ImageFileVariationPurger implements VariationPurger
      */
     private $logger;
 
-    public function __construct( ImageFileList $imageFileList, IOServiceInterface $ioService, VariationPathGenerator $variationPathGenerator )
+    public function __construct( Iterator $imageFileList, IOServiceInterface $ioService, VariationPathGenerator $variationPathGenerator )
     {
         $this->imageFileList = $imageFileList;
         $this->ioService = $ioService;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileVariationPurger.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileVariationPurger.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator;
+use eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway as ImageStorageGateway;
+use eZ\Publish\Core\IO\Exception\BinaryFileNotFoundException;
+use eZ\Publish\Core\IO\IOServiceInterface;
+use eZ\Publish\SPI\Variation\VariationPurger;
+
+/**
+ * Purges image aliases based on image files referenced by the Image FieldType.
+ *
+ * It uses the FieldType's Storage Gateway.
+ */
+class ImageFileVariationPurger implements VariationPurger
+{
+    /** @var ImageFileList */
+    private $imageFileList;
+
+    /** @var \eZ\Publish\Core\IO\IOServiceInterface */
+    private $ioService;
+
+    /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator */
+    private $variationPathGenerator;
+
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    private $logger;
+
+    public function __construct( ImageFileList $imageFileList, IOServiceInterface $ioService, VariationPathGenerator $variationPathGenerator )
+    {
+        $this->imageFileList = $imageFileList;
+        $this->ioService = $ioService;
+        $this->variationPathGenerator = $variationPathGenerator;
+    }
+
+    /**
+     * Purge all variations generated for aliases in $aliasName
+     *
+     * @param array $aliasNames
+     */
+    public function purge( array $aliasNames )
+    {
+        foreach ( $this->imageFileList as $imageFile )
+        {
+            foreach ( $aliasNames as $aliasName )
+            {
+                $variationPath = $this->variationPathGenerator->getVariationPath( $imageFile, $aliasName );
+                try
+                {
+                    $binaryFile = $this->ioService->loadBinaryFileByUri( $variationPath );
+                }
+                catch ( BinaryFileNotFoundException $e )
+                {
+                    continue;
+                }
+                // $this->ioService->deleteBinaryFile( $binaryFile );
+                if ( isset( $this->logger ) )
+                {
+                    $this->logger->info( "Purging $aliasName variation $variationPath for original image $imageFile" );
+                }
+            }
+        }
+    }
+
+    /**
+     * @param \Psr\Log\LoggerInterface $logger
+     */
+    public function setLogger( $logger )
+    {
+        $this->logger = $logger;
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/LegacyStorageImageFileList.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/LegacyStorageImageFileList.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger;
+
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+use eZ\Publish\Core\Persistence\Doctrine\ConnectionHandler;
+
+/**
+ * Iterator for entries in legacy's ezimagefile table.
+ *
+ * The returned items are uris to files, e.g. var/ezdemo_site/storage/images/...
+ */
+class LegacyStorageImageFileList implements ImageFileList
+{
+    /**
+     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
+     */
+    private $dbHandler;
+
+    /**
+     * Database statement
+     * @var \PDOStatement
+     */
+    private $statement;
+
+    /**
+     * Last fetched item
+     * @var mixed
+     */
+    private $item;
+
+    /**
+     * Iteration cursor on $statement
+     * @var int
+     */
+    private $cursor;
+
+    public function __construct( DatabaseHandler $dbHandler )
+    {
+        $this->dbHandler = $dbHandler;
+    }
+
+    /**
+     * (PHP 5 &gt;= 5.0.0)<br/>
+     * Return the current element
+     * @link http://php.net/manual/en/iterator.current.php
+     * @return mixed Can return any type.
+     */
+    public function current()
+    {
+        return '/' . $this->item;
+    }
+
+    public function next()
+    {
+        $this->cursor++;
+        $this->item = $this->statement->fetchColumn( 0 );
+    }
+
+    public function key()
+    {
+        return $this->cursor;
+    }
+
+    public function valid()
+    {
+        return ( $this->cursor < $this->count() );
+    }
+
+    public function rewind()
+    {
+        $this->cursor = 0;
+
+        $selectQuery = $this->dbHandler->createSelectQuery();
+        $selectQuery->select( 'filepath' )->from( $this->dbHandler->quoteTable( 'ezimagefile' ) );
+        $this->statement = $selectQuery->prepare();
+        $this->statement->execute();
+        $this->item = $this->statement->fetchColumn( 0 );
+    }
+
+    public function count()
+    {
+        return $this->statement->rowCount();
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/LegacyStorageImageFileRowReader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/LegacyStorageImageFileRowReader.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger;
+
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+
+class LegacyStorageImageFileRowReader implements ImageFileRowReader
+{
+    /** @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler */
+    private $dbHandler;
+
+    /** @var \PDOStatement */
+    private $statement;
+
+
+    public function __construct( DatabaseHandler $dbHandler )
+    {
+        $this->dbHandler = $dbHandler;
+    }
+
+    public function init()
+    {
+        $selectQuery = $this->dbHandler->createSelectQuery();
+        $selectQuery->select( 'filepath' )->from( $this->dbHandler->quoteTable( 'ezimagefile' ) );
+        $this->statement = $selectQuery->prepare();
+        $this->statement->execute();
+    }
+
+    public function getRow()
+    {
+        return $this->statement->fetchColumn( 0 );
+    }
+
+    public function getCount()
+    {
+        return $this->statement->rowCount();
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -26,6 +26,10 @@ parameters:
     ezpublish.image_alias.imagine.filter.swirl.imagick.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Imagick\SwirlFilter
     ezpublish.image_alias.imagine.filter.swirl.gmagick.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Gmagick\SwirlFilter
 
+    ezpublish.image_alias.variation_purger.legacy_storage_image_file.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\ImageFileVariationPurger
+    ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_list.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\LegacyStorageImageFileList
+    ezpubish.image_alias.variation_path_generator.original_directory.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator\OriginalDirectoryVariationPathGenerator
+
 services:
     # Filters
     ezpublish.image_alias.imagine.filter.unsupported:
@@ -182,3 +186,19 @@ services:
         public: false
         tags:
             - { name: liip_imagine.filter.loader, loader: "colorspace/gray" }
+
+    ezpublish.image_alias.variation_purger.legacy_storage_image_file:
+        class: %ezpublish.image_alias.variation_purger.legacy_storage_image_file.class%
+        arguments:
+            - @ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_list
+            - @ezpublish.fieldType.ezimage.io_service
+            - @ezpublish.image_alias.variation_path_generator.original_directory
+        calls:
+            - [setLogger, [@?logger]]
+
+    ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_list:
+        class: %ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_list.class%
+        arguments: [@ezpublish.api.storage_engine.legacy.dbhandler]
+
+    ezpublish.image_alias.variation_path_generator.original_directory:
+        class: %ezpubish.image_alias.variation_path_generator.original_directory.class%

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -194,13 +194,11 @@ services:
         tags:
             - { name: liip_imagine.filter.loader, loader: "colorspace/gray" }
 
-    # < platform 2015.05
     ezpublish.image_alias.variation_purger:
+        # < platform 2015.05
         alias: ezpublish.image_alias.variation_purger.legacy_storage_image_file
-
-    # >= platform 2015.05
-    #ezpublish.image_alias.variation_purger:
-    #    alias: ezpublish.image_alias.variation_purger.io
+        # >= platform 2015.05
+        # alias: ezpublish.image_alias.variation_purger.io
 
     ezpublish.image_alias.variation_purger.io:
         class: %ezpublish.image_alias.variation_purger.io.class%
@@ -222,13 +220,11 @@ services:
             - $io.legacy_url_prefix$
             - $image.published_images_dir$
 
-    # < platform 2015.05
     ezpublish.image_alias.variation_path_generator:
+        # < platform 2015.05
         alias: ezpublish.image_alias.variation_path_generator.original_directory
-
-    # >= platform 2015.05
-    #ezpublish.image_alias.variation_path_generator:
-    #    alias: ezpublish.image_alias.variation_path_generator.original_directory
+        # >= platform 2015.05
+        alias: ezpublish.image_alias.variation_path_generator.alias_directory
 
     ezpublish.image_alias.variation_path_generator.original_directory:
         class: %ezpubish.image_alias.variation_path_generator.original_directory.class%

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -28,6 +28,7 @@ parameters:
 
     ezpublish.image_alias.variation_purger.legacy_storage_image_file.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\ImageFileVariationPurger
     ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_list.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\LegacyStorageImageFileList
+    ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_row_reader.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\LegacyStorageImageFileRowReader
     ezpublish.image_alias.variation_purger.io.class: eZ\Bundle\EzPublishCoreBundle\Imagine\IOVariationPurger
     ezpubish.image_alias.variation_path_generator.original_directory.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator\OriginalDirectoryVariationPathGenerator
     ezpubish.image_alias.variation_path_generator.alias_directory.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator\AliasDirectoryVariationPathGenerator
@@ -216,9 +217,14 @@ services:
     ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_list:
         class: %ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_list.class%
         arguments:
-            - @ezpublish.api.storage_engine.legacy.dbhandler
+            - @ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_row_reader
             - $io.legacy_url_prefix$
             - $image.published_images_dir$
+
+    ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_row_reader:
+        class: %ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_row_reader.class%
+        arguments:
+            - @ezpublish.api.storage_engine.legacy.dbhandler
 
     ezpublish.image_alias.variation_path_generator:
         # < platform 2015.05

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -29,6 +29,7 @@ parameters:
     ezpublish.image_alias.variation_purger.legacy_storage_image_file.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\ImageFileVariationPurger
     ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_list.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\LegacyStorageImageFileList
     ezpubish.image_alias.variation_path_generator.original_directory.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator\OriginalDirectoryVariationPathGenerator
+    ezpubish.image_alias.variation_path_generator.alias_directory.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator\AliasDirectoryVariationPathGenerator
 
 services:
     # Filters
@@ -187,6 +188,10 @@ services:
         tags:
             - { name: liip_imagine.filter.loader, loader: "colorspace/gray" }
 
+    ezpublish.image_alias.variation_purger.io:
+        class: %ezpublish.image_alias.variation_purger.io.class%
+        arguments: [@ezpublish.fieldType.ezimage.io_service]
+
     ezpublish.image_alias.variation_purger.legacy_storage_image_file:
         class: %ezpublish.image_alias.variation_purger.legacy_storage_image_file.class%
         arguments:
@@ -202,3 +207,7 @@ services:
 
     ezpublish.image_alias.variation_path_generator.original_directory:
         class: %ezpubish.image_alias.variation_path_generator.original_directory.class%
+
+    ezpublish.image_alias.variation_path_generator.alias_directory:
+        class: %ezpubish.image_alias.variation_path_generator.alias_directory.class%
+

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -71,7 +71,12 @@ services:
 
     ezpublish.image_alias.imagine.cache_resolver:
         class: %ezpublish.image_alias.imagine.cache_resolver.class%
-        arguments: [@ezpublish.fieldType.ezimage.io_service, @router.request_context, @liip_imagine.filter.configuration]
+        arguments:
+            - @ezpublish.fieldType.ezimage.io_service
+            - @router.request_context
+            - @liip_imagine.filter.configuration
+            - @ezpublish.image_alias.variation_purger
+            - @ezpublish.image_alias.variation_path_generator.alias_directory
         tags:
             - { name: liip_imagine.cache.resolver, resolver: ezpublish }
 
@@ -189,6 +194,14 @@ services:
         tags:
             - { name: liip_imagine.filter.loader, loader: "colorspace/gray" }
 
+    # < platform 2015.05
+    ezpublish.image_alias.variation_purger:
+        alias: ezpublish.image_alias.variation_purger.legacy_storage_image_file
+
+    # >= platform 2015.05
+    #ezpublish.image_alias.variation_purger:
+    #    alias: ezpublish.image_alias.variation_purger.io
+
     ezpublish.image_alias.variation_purger.io:
         class: %ezpublish.image_alias.variation_purger.io.class%
         arguments: [@ezpublish.fieldType.ezimage.io_service]
@@ -208,6 +221,14 @@ services:
             - @ezpublish.api.storage_engine.legacy.dbhandler
             - $io.legacy_url_prefix$
             - $image.published_images_dir$
+
+    # < platform 2015.05
+    ezpublish.image_alias.variation_path_generator:
+        alias: ezpublish.image_alias.variation_path_generator.original_directory
+
+    # >= platform 2015.05
+    #ezpublish.image_alias.variation_path_generator:
+    #    alias: ezpublish.image_alias.variation_path_generator.original_directory
 
     ezpublish.image_alias.variation_path_generator.original_directory:
         class: %ezpubish.image_alias.variation_path_generator.original_directory.class%

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -28,6 +28,7 @@ parameters:
 
     ezpublish.image_alias.variation_purger.legacy_storage_image_file.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\ImageFileVariationPurger
     ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_list.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\LegacyStorageImageFileList
+    ezpublish.image_alias.variation_purger.io.class: eZ\Bundle\EzPublishCoreBundle\Imagine\IOVariationPurger
     ezpubish.image_alias.variation_path_generator.original_directory.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator\OriginalDirectoryVariationPathGenerator
     ezpubish.image_alias.variation_path_generator.alias_directory.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator\AliasDirectoryVariationPathGenerator
 
@@ -203,7 +204,10 @@ services:
 
     ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_list:
         class: %ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_list.class%
-        arguments: [@ezpublish.api.storage_engine.legacy.dbhandler]
+        arguments:
+            - @ezpublish.api.storage_engine.legacy.dbhandler
+            - $io.legacy_url_prefix$
+            - $image.published_images_dir$
 
     ezpublish.image_alias.variation_path_generator.original_directory:
         class: %ezpubish.image_alias.variation_path_generator.original_directory.class%

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/IORepositoryResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/IORepositoryResolverTest.php
@@ -11,10 +11,12 @@ namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine;
 
 use eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\FilterConfiguration;
 use eZ\Bundle\EzPublishCoreBundle\Imagine\IORepositoryResolver;
+use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\IO\Values\BinaryFile;
 use eZ\Publish\Core\IO\Values\BinaryFileCreateStruct;
 use eZ\Publish\Core\IO\Values\MissingBinaryFile;
+use eZ\Publish\SPI\Variation\VariationPurger;
 use Liip\ImagineBundle\Model\Binary;
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\Request;
@@ -47,6 +49,12 @@ class IORepositoryResolverTest extends PHPUnit_Framework_TestCase
      */
     private $filterConfiguration;
 
+    /** @var \eZ\Publish\SPI\Variation\VariationPurger|\PHPUnit_Framework_MockObject_MockObject */
+    protected $variationPurger;
+
+    /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator|\PHPUnit_Framework_MockObject_MockObject */
+    protected $variationPathGenerator;
+
     protected function setUp()
     {
         parent::setUp();
@@ -55,7 +63,15 @@ class IORepositoryResolverTest extends PHPUnit_Framework_TestCase
         $this->configResolver = $this->getMock( 'eZ\Publish\Core\MVC\ConfigResolverInterface' );
         $this->filterConfiguration = new FilterConfiguration();
         $this->filterConfiguration->setConfigResolver( $this->configResolver );
-        $this->imageResolver = new IORepositoryResolver( $this->ioService, $this->requestContext, $this->filterConfiguration );
+        $this->variationPurger = $this->getMock( 'eZ\Publish\SPI\Variation\VariationPurger' );
+        $this->variationPathGenerator = $this->getMock( 'eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator' );
+        $this->imageResolver = new IORepositoryResolver(
+            $this->ioService,
+            $this->requestContext,
+            $this->filterConfiguration,
+            $this->variationPurger,
+            $this->variationPathGenerator
+        );
     }
 
     /**
@@ -63,6 +79,11 @@ class IORepositoryResolverTest extends PHPUnit_Framework_TestCase
      */
     public function testGetFilePath( $path, $filter, $expected )
     {
+        $this->variationPathGenerator
+            ->expects( $this->once() )
+            ->method( 'getVariationPath' )
+            ->with( $path, $filter )
+            ->willReturn( $expected );
         $this->assertSame( $expected, $this->imageResolver->getFilePath( $path, $filter ) );
     }
 
@@ -82,6 +103,12 @@ class IORepositoryResolverTest extends PHPUnit_Framework_TestCase
         $path = 'Tardis/bigger/in-the-inside/RiverSong.jpg';
         $aliasPath = 'Tardis/bigger/in-the-inside/RiverSong_thumbnail.jpg';
 
+        $this->variationPathGenerator
+            ->expects( $this->once() )
+            ->method( 'getVariationPath' )
+            ->with( $path, $filter )
+            ->willReturn( $aliasPath );
+
         $this->ioService
             ->expects( $this->once() )
             ->method( 'exists' )
@@ -97,6 +124,12 @@ class IORepositoryResolverTest extends PHPUnit_Framework_TestCase
         $path = 'Tardis/bigger/in-the-inside/RiverSong.jpg';
         $aliasPath = 'Tardis/bigger/in-the-inside/RiverSong_thumbnail.jpg';
 
+        $this->variationPathGenerator
+            ->expects( $this->once() )
+            ->method( 'getVariationPath' )
+            ->with( $path, $filter )
+            ->willReturn( $aliasPath );
+
         $this->ioService
             ->expects( $this->once() )
             ->method( 'exists' )
@@ -109,19 +142,22 @@ class IORepositoryResolverTest extends PHPUnit_Framework_TestCase
     /**
      * @dataProvider resolveProvider
      */
-    public function testResolve( $path, $filter, $requestUrl, $expected )
+    public function testResolve( $path, $filter, $variationPath, $requestUrl, $expected )
     {
         if ( $requestUrl )
         {
             $this->requestContext->fromRequest( Request::create( $requestUrl ) );
         }
 
-        $storageDir = '/var/doctorwho/storage/images';
         $this->ioService
-            ->expects( $this->once() )
+            ->expects( $this->any() )
             ->method( 'loadBinaryFile' )
-            ->with( $path )
-            ->will( $this->returnValue( new BinaryFile( array( 'uri' => "$storageDir/$path" ) ) ) );
+            ->will( $this->returnValue( new BinaryFile( array( 'uri' => $variationPath ) ) ) );
+
+        $this->variationPathGenerator
+            ->expects( $this->any() )
+            ->method( 'getVariationPath' )
+            ->willReturn( $variationPath );
 
         $result = $this->imageResolver->resolve( $path, $filter );
         $this->assertSame( $expected, $result );
@@ -162,37 +198,51 @@ class IORepositoryResolverTest extends PHPUnit_Framework_TestCase
         return array(
             array(
                 'Tardis/bigger/in-the-inside/RiverSong.jpg',
-                IORepositoryResolver::VARIATION_ORIGINAL, null,
+                IORepositoryResolver::VARIATION_ORIGINAL,
+                '/var/doctorwho/storage/images/Tardis/bigger/in-the-inside/RiverSong.jpg',
+                null,
                 'http://localhost/var/doctorwho/storage/images/Tardis/bigger/in-the-inside/RiverSong.jpg'
             ),
             array(
                 'Tardis/bigger/in-the-inside/RiverSong.jpg',
-                'thumbnail', null,
+                'thumbnail',
+                '/var/doctorwho/storage/images/Tardis/bigger/in-the-inside/RiverSong_thumbnail.jpg',
+                null,
                 'http://localhost/var/doctorwho/storage/images/Tardis/bigger/in-the-inside/RiverSong_thumbnail.jpg'
             ),
             array(
                 'Tardis/bigger/in-the-inside/RiverSong.jpg',
-                'thumbnail', 'http://localhost',
+                'thumbnail',
+                '/var/doctorwho/storage/images/Tardis/bigger/in-the-inside/RiverSong_thumbnail.jpg',
+                'http://localhost',
                 'http://localhost/var/doctorwho/storage/images/Tardis/bigger/in-the-inside/RiverSong_thumbnail.jpg'
             ),
             array(
                 'CultOfScaro/Dalek-fisherman.png',
-                'so_ridiculous', 'http://doctor.who:7890',
+                'so_ridiculous',
+                '/var/doctorwho/storage/images/CultOfScaro/Dalek-fisherman_so_ridiculous.png',
+                'http://doctor.who:7890',
                 'http://doctor.who:7890/var/doctorwho/storage/images/CultOfScaro/Dalek-fisherman_so_ridiculous.png'
             ),
             array(
                 'CultOfScaro/Dalek-fisherman.png',
-                'so_ridiculous', 'https://doctor.who',
+                'so_ridiculous',
+                '/var/doctorwho/storage/images/CultOfScaro/Dalek-fisherman_so_ridiculous.png',
+                'https://doctor.who',
                 'https://doctor.who/var/doctorwho/storage/images/CultOfScaro/Dalek-fisherman_so_ridiculous.png'
             ),
             array(
                 'CultOfScaro/Dalek-fisherman.png',
-                'so_ridiculous', 'https://doctor.who:1234',
+                'so_ridiculous',
+                '/var/doctorwho/storage/images/CultOfScaro/Dalek-fisherman_so_ridiculous.png',
+                'https://doctor.who:1234',
                 'https://doctor.who:1234/var/doctorwho/storage/images/CultOfScaro/Dalek-fisherman_so_ridiculous.png'
             ),
             array(
                 'CultOfScaro/Dalek-fisherman.png',
-                IORepositoryResolver::VARIATION_ORIGINAL, 'https://doctor.who:1234',
+                IORepositoryResolver::VARIATION_ORIGINAL,
+                '/var/doctorwho/storage/images/CultOfScaro/Dalek-fisherman.png',
+                'https://doctor.who:1234',
                 'https://doctor.who:1234/var/doctorwho/storage/images/CultOfScaro/Dalek-fisherman.png'
             ),
         );
@@ -211,12 +261,9 @@ class IORepositoryResolverTest extends PHPUnit_Framework_TestCase
             ->method( 'newBinaryCreateStructFromLocalFile' )
             ->will( $this->returnValue( $createStruct ) );
 
-        $expectedStruct = clone $createStruct;
-        $expectedStruct->id = $aliasPath;
         $this->ioService
             ->expects( $this->once() )
-            ->method( 'createBinaryFile' )
-            ->with( $this->equalTo( $expectedStruct ) );
+            ->method( 'createBinaryFile' );
 
         $this->imageResolver->store( $binary, $path, $filter );
     }
@@ -231,6 +278,19 @@ class IORepositoryResolverTest extends PHPUnit_Framework_TestCase
             ->method( 'getParameter' )
             ->with( 'image_variations' )
             ->will( $this->returnValue( $filters ) );
+
+        $this->variationPathGenerator
+            ->expects( $this->exactly( count( $filters ) ) )
+            ->method( 'getVariationPath' )
+            ->will(
+                $this->returnValueMap(
+                    array(
+                        array( 'foo/bar/test.jpg', 'filter1', 'foo/bar/test_filter1.jpg '),
+                        array( 'foo/bar/test.jpg', 'filter2', 'foo/bar/test_filter2.jpg '),
+                        array( 'foo/bar/test.jpg', 'chaud_cacao', 'foo/bar/test_chaud_cacao.jpg' ),
+                    )
+                )
+            );
 
         $fileToDelete = 'foo/bar/test_chaud_cacao.jpg';
         $this->ioService
@@ -252,6 +312,7 @@ class IORepositoryResolverTest extends PHPUnit_Framework_TestCase
             ->method( 'loadBinaryFile' )
             ->with( $fileToDelete )
             ->will( $this->returnValue( $binaryFile ) );
+
         $this->ioService
             ->expects( $this->once() )
             ->method( 'deleteBinaryFile' )
@@ -271,6 +332,19 @@ class IORepositoryResolverTest extends PHPUnit_Framework_TestCase
             ->with( 'image_variations' )
             ->will( $this->returnValue( array() ) );
 
+        $this->variationPathGenerator
+            ->expects( $this->exactly( count( $filters ) ) )
+            ->method( 'getVariationPath' )
+            ->will(
+                $this->returnValueMap(
+                    array(
+                        array( 'foo/bar/test.jpg', 'filter1', 'foo/bar/test_filter1.jpg '),
+                        array( 'foo/bar/test.jpg', 'filter2', 'foo/bar/test_filter2.jpg '),
+                        array( 'foo/bar/test.jpg', 'chaud_cacao', 'foo/bar/test_chaud_cacao.jpg' ),
+                    )
+                )
+            );
+
         $fileToDelete = 'foo/bar/test_chaud_cacao.jpg';
         $this->ioService
             ->expects( $this->exactly( count( $filters ) ) )
@@ -291,6 +365,7 @@ class IORepositoryResolverTest extends PHPUnit_Framework_TestCase
             ->method( 'loadBinaryFile' )
             ->with( $fileToDelete )
             ->will( $this->returnValue( $binaryFile ) );
+
         $this->ioService
             ->expects( $this->once() )
             ->method( 'deleteBinaryFile' )

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/IORepositoryResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/IORepositoryResolverTest.php
@@ -285,8 +285,8 @@ class IORepositoryResolverTest extends PHPUnit_Framework_TestCase
             ->will(
                 $this->returnValueMap(
                     array(
-                        array( 'foo/bar/test.jpg', 'filter1', 'foo/bar/test_filter1.jpg '),
-                        array( 'foo/bar/test.jpg', 'filter2', 'foo/bar/test_filter2.jpg '),
+                        array( 'foo/bar/test.jpg', 'filter1', 'foo/bar/test_filter1.jpg ' ),
+                        array( 'foo/bar/test.jpg', 'filter2', 'foo/bar/test_filter2.jpg ' ),
                         array( 'foo/bar/test.jpg', 'chaud_cacao', 'foo/bar/test_chaud_cacao.jpg' ),
                     )
                 )
@@ -338,8 +338,8 @@ class IORepositoryResolverTest extends PHPUnit_Framework_TestCase
             ->will(
                 $this->returnValueMap(
                     array(
-                        array( 'foo/bar/test.jpg', 'filter1', 'foo/bar/test_filter1.jpg '),
-                        array( 'foo/bar/test.jpg', 'filter2', 'foo/bar/test_filter2.jpg '),
+                        array( 'foo/bar/test.jpg', 'filter1', 'foo/bar/test_filter1.jpg ' ),
+                        array( 'foo/bar/test.jpg', 'filter2', 'foo/bar/test_filter2.jpg ' ),
                         array( 'foo/bar/test.jpg', 'chaud_cacao', 'foo/bar/test_chaud_cacao.jpg' ),
                     )
                 )

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/IOVariationPurgerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/IOVariationPurgerTest.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\VariationPurger;
+
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\IOVariationPurger;
+
+class IOVariationPurgerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testPurgesAliasList()
+    {
+        $ioService = $this->getMock( 'eZ\Publish\Core\IO\IOServiceInterface' );
+        $ioService
+            ->expects( $this->exactly( 2 ) )
+            ->method( 'deleteDirectory' )
+            ->withConsecutive(
+                array( 'medium' ),
+                array( 'large' )
+            );
+        $purger = new IOVariationPurger( $ioService );
+        $purger->purge( array( 'medium', 'large' ) );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/ImageFileVariationPurgerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/ImageFileVariationPurgerTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\VariationPurger;
+
+
+use ArrayIterator;
+use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\ImageFileVariationPurger;
+use eZ\Publish\Core\IO\Values\BinaryFile;
+
+class ImageFileVariationPurgerTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \eZ\Publish\Core\IO\IOServiceInterface|\PHPUnit_Framework_MockObject_MockObject */
+    protected $ioServiceMock;
+
+    /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator|\PHPUnit_Framework_MockObject_MockObject */
+    protected $pathGeneratorMock;
+
+    /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\ImageFileVariationPurger */
+    protected $purger;
+
+    public function setUp()
+    {
+        $this->ioServiceMock = $this->getMock( 'eZ\Publish\Core\IO\IOServiceInterface' );
+        $this->pathGeneratorMock = $this->getMock( 'eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator' );
+    }
+
+    public function testIteratesOverItems()
+    {
+        $purger = $this->createPurger(
+            array(
+                'path/to/1st/image.jpg',
+                'path/to/2nd/image.png',
+            )
+        );
+
+        $this->pathGeneratorMock
+            ->expects( $this->exactly( 4 ) )
+            ->method( 'getVariationPath' )
+            ->withConsecutive(
+                array( 'path/to/1st/image.jpg', 'large' ),
+                array( 'path/to/1st/image.jpg', 'gallery' ),
+                array( 'path/to/2nd/image.png', 'large' ),
+                array( 'path/to/2nd/image.png', 'gallery' )
+            );
+
+        $purger->purge( array( 'large', 'gallery' ) );
+    }
+
+    public function testPurgesExistingItem()
+    {
+        $purger = $this->createPurger(
+            array( 'path/to/file.png' )
+        );
+
+        $this->pathGeneratorMock
+            ->expects( $this->once() )
+            ->method( 'getVariationPath' )
+            ->will( $this->returnValue( 'path/to/file_large.png' ) );
+
+        $this->ioServiceMock
+            ->expects( $this->once() )
+            ->method( 'exists' )
+            ->will( $this->returnValue( true ) );
+
+        $this->ioServiceMock
+            ->expects( $this->once() )
+            ->method( 'loadBinaryFile' )
+            ->will( $this->returnValue( new BinaryFile() ) );
+
+        $this->ioServiceMock
+            ->expects( $this->once() )
+            ->method( 'deleteBinaryFile' )
+            ->with( $this->isInstanceOf( 'eZ\Publish\Core\IO\Values\BinaryFile' ) );
+
+        $purger->purge( array( 'large' ) );
+    }
+
+    public function testDoesNotPurgeNotExistingItem()
+    {
+        $purger = $this->createPurger(
+            array( 'path/to/file.png' )
+        );
+
+        $this->pathGeneratorMock
+            ->expects( $this->once() )
+            ->method( 'getVariationPath' )
+            ->will( $this->returnValue( 'path/to/file_large.png' ) );
+
+        $this->ioServiceMock
+            ->expects( $this->once() )
+            ->method( 'exists' )
+            ->will( $this->returnValue( false ) );
+
+        $this->ioServiceMock
+            ->expects( $this->never() )
+            ->method( 'loadBinaryFile' );
+
+        $this->ioServiceMock
+            ->expects( $this->never() )
+            ->method( 'deleteBinaryFile' );
+
+        $purger->purge( array( 'large' ) );
+    }
+
+    private function createPurger( array $fileList )
+    {
+        return new ImageFileVariationPurger( new ArrayIterator( $fileList ), $this->ioServiceMock, $this->pathGeneratorMock );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/LegacyStorageImageFileListTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/LegacyStorageImageFileListTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\VariationPurger;
+
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\LegacyStorageImageFileList;
+
+class LegacyStorageImageFileListTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\ImageFileRowReader|\PHPUnit_Framework_MockObject_MockObject */
+    protected $rowReaderMock;
+
+    /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\LegacyStorageImageFileList */
+    protected $fileList;
+
+    public function setUp()
+    {
+        $this->rowReaderMock = $this->getMock( 'eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\ImageFileRowReader' );
+        $this->fileList = new LegacyStorageImageFileList(
+            $this->rowReaderMock,
+            'var/ezdemo_site/storage',
+            'images'
+        );
+    }
+
+    function testIterator()
+    {
+        $expected = array(
+            'path/to/1st/image.jpg',
+            'path/to/2nd/image.jpg',
+        );
+        $this->configureRowReaderMock( $expected );
+
+        foreach ( $this->fileList as $index => $file )
+        {
+            self::assertEquals( $expected[$index], $file );
+        }
+    }
+
+    /**
+     * Tests that the iterator transforms the ezimagefile value into a binaryfile id
+     */
+    public function testImageIdTransformation()
+    {
+        $this->configureRowReaderMock( array( 'var/ezdemo_site/storage/images/path/to/1st/image.jpg' ) );
+        foreach ( $this->fileList as $file )
+        {
+            self::assertEquals( 'path/to/1st/image.jpg', $file );
+        }
+    }
+
+    private function configureRowReaderMock( array $fileList )
+    {
+        $mockInvocator = $this->rowReaderMock->expects( $this->any() )->method( 'getRow' );
+        call_user_func_array( array( $mockInvocator, 'willReturnOnConsecutiveCalls' ), $fileList );
+
+        $this->rowReaderMock->expects( $this->any() )->method( 'getCount' )->willReturn( count( $fileList ) );
+    }
+}

--- a/eZ/Publish/Core/FieldType/Image/IO/Legacy.php
+++ b/eZ/Publish/Core/FieldType/Image/IO/Legacy.php
@@ -208,6 +208,16 @@ class Legacy implements IOServiceInterface
         $this->publishedIOService->deleteBinaryFile( $binaryFile );
     }
 
+    /**
+     * Deletes a directory.
+     *
+     * @param string $path
+     */
+    public function deleteDirectory( $path )
+    {
+        $this->publishedIOService->deleteDirectory( $path );
+    }
+
     public function newBinaryCreateStructFromUploadedFile( array $uploadedFile )
     {
         return $this->publishedIOService->newBinaryCreateStructFromUploadedFile( $uploadedFile );

--- a/eZ/Publish/Core/IO/IOBinarydataHandler.php
+++ b/eZ/Publish/Core/IO/IOBinarydataHandler.php
@@ -70,4 +70,6 @@ interface IOBinarydataHandler
      * @return string
      */
     public function getIdFromUri( $binaryFileUri );
+
+    public function deleteDirectory( $spiPath );
 }

--- a/eZ/Publish/Core/IO/IOBinarydataHandler/Flysystem.php
+++ b/eZ/Publish/Core/IO/IOBinarydataHandler/Flysystem.php
@@ -111,4 +111,9 @@ class Flysystem implements IOBinaryDataHandler
             return ltrim( $binaryFileUri, '/' );
 
     }
+
+    public function deleteDirectory( $spiPath )
+    {
+        $this->filesystem->deleteDir( $spiPath );
+    }
 }

--- a/eZ/Publish/Core/IO/IOMetadataHandler.php
+++ b/eZ/Publish/Core/IO/IOMetadataHandler.php
@@ -62,4 +62,6 @@ interface IOMetadataHandler
      * @return string
      */
     public function getMimeType( $spiBinaryFileId );
+
+    public function deleteDirectory( $spiPath );
 }

--- a/eZ/Publish/Core/IO/IOMetadataHandler/Flysystem.php
+++ b/eZ/Publish/Core/IO/IOMetadataHandler/Flysystem.php
@@ -17,7 +17,7 @@ use League\Flysystem\FilesystemInterface;
 
 class Flysystem implements IOMetadataHandler
 {
-    /** @var  FilesystemInterface */
+    /** @var FilesystemInterface */
     private $filesystem;
 
     public function __construct( FilesystemInterface $filesystem )
@@ -71,5 +71,10 @@ class Flysystem implements IOMetadataHandler
     public function getMimeType( $spiBinaryFileId )
     {
         return $this->filesystem->getMimetype( $spiBinaryFileId );
+    }
+
+    public function deleteDirectory( $spiPath )
+    {
+        $this->filesystem->deleteDir( $spiPath );
     }
 }

--- a/eZ/Publish/Core/IO/IOMetadataHandler/LegacyDFSCluster.php
+++ b/eZ/Publish/Core/IO/IOMetadataHandler/LegacyDFSCluster.php
@@ -245,6 +245,13 @@ SQL
         return $row['datatype'];
     }
 
+    public function deleteDirectory( $spiPath )
+    {
+        $stmt = $this->db->prepare( 'DELETE FROM ezdfsfile WHERE name LIKE ?' );
+        $stmt->bindValue( 1, rtrim( $spiPath, '/' ) . '/%' );
+        $stmt->execute();
+    }
+
     /**
      * Maps an array of data base properties (id, size, mtime, datatype, md5_path, path...) to an SPIBinaryFile object
      *

--- a/eZ/Publish/Core/IO/IOService.php
+++ b/eZ/Publish/Core/IO/IOService.php
@@ -307,4 +307,16 @@ class IOService implements IOServiceInterface
             throw new InvalidBinaryFileIdException( $binaryFileId );
         }
     }
+
+    /**
+     * Deletes a directory.
+     *
+     * @param string $path
+     */
+    public function deleteDirectory( $path )
+    {
+        $prefixedUri = $this->getPrefixedUri( $path );
+        $this->metadataHandler->deleteDirectory( $prefixedUri );
+        $this->binarydataHandler->deleteDirectory( $prefixedUri );
+    }
 }

--- a/eZ/Publish/Core/IO/IOServiceInterface.php
+++ b/eZ/Publish/Core/IO/IOServiceInterface.php
@@ -159,4 +159,11 @@ interface IOServiceInterface
      * @return BinaryFileCreateStruct
      */
     public function newBinaryCreateStructFromUploadedFile( array $uploadedFile );
+
+    /**
+     * Deletes a directory.
+     *
+     * @param string $path
+     */
+    public function deleteDirectory( $path );
 }

--- a/eZ/Publish/SPI/Variation/VariationPurger.php
+++ b/eZ/Publish/SPI/Variation/VariationPurger.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\SPI\Variation;
+
+/**
+ * Handles physical purging of image variations from storage
+ */
+interface VariationPurger
+{
+    /**
+     * Purge all variations generated for aliases in $aliasName
+     * @param array $aliasNames
+     */
+    public function purge( array $aliasNames );
+}

--- a/eZ/Publish/SPI/Variation/VariationPurger.php
+++ b/eZ/Publish/SPI/Variation/VariationPurger.php
@@ -10,7 +10,7 @@ namespace eZ\Publish\SPI\Variation;
 interface VariationPurger
 {
     /**
-     * Purge all variations generated for aliases in $aliasName
+     * Purge all variations generated for aliases in $aliasNames
      * @param array $aliasNames
      */
     public function purge( array $aliasNames );


### PR DESCRIPTION
> http://jira.ez.no/browse/EZP-23367
> Also fixes https://jira.ez.no/browse/EZP-23369

This makes it possible to remove all instances of an image alias.
## Changes
- aliases are now stored in `vardir/storage/images/_aliases/aliasName`

## Use-cases

### Removing all variations of an alias
Can be executed after an alias has been removed from the configuration.

```
php ezpublish/console liip:imagine:cache:remove --filters=large
```

### Removing all variations
For maintenance
```
php ezpublish/console liip:imagine:cache:remove
```