### PR TITLE
RichText: disable xhtml5edit input validation and fix conversion stylesheet configuration

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -41,6 +41,7 @@ parameters:
 
     ezpublish.fieldType.ezrichtext.converter.input.ezxml.resources: %ezpublish.fieldType.ezrichtext.resources%/stylesheets/ezxml/docbook/core.xsl
     ezpublish.fieldType.ezrichtext.converter.input.xhtml5.resources: %ezpublish.fieldType.ezrichtext.resources%/stylesheets/xhtml5/edit/docbook.xsl
+    ezpublish.fieldType.ezrichtext.converter.edit.xhtml5.resources: %ezpublish.fieldType.ezrichtext.resources%/stylesheets/docbook/xhtml5/edit/xhtml5.xsl
     ezpublish.fieldType.ezrichtext.converter.output.xhtml5.resources: %ezpublish.fieldType.ezrichtext.resources%/stylesheets/docbook/xhtml5/output/xhtml5.xsl
     ezpublish.fieldType.ezrichtext.converter.output.xhtml5.fragment.resources: %ezpublish.fieldType.ezrichtext.resources%/stylesheets/xhtml5/output/fragment.xsl
 
@@ -227,7 +228,7 @@ services:
     ezpublish.fieldType.ezrichtext.converter.edit.xhtml5:
         class: %ezpublish.fieldType.ezrichtext.converter.edit.html5.class%
         arguments:
-            - %ezpublish.fieldType.ezrichtext.converter.output.xhtml5.resources%
+            - %ezpublish.fieldType.ezrichtext.converter.edit.xhtml5.resources%
             - @ezpublish.config.resolver
 
     ezpublish.fieldType.ezrichtext.validator.docbook:

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -248,7 +248,7 @@ services:
         arguments:
             -
                 http://docbook.org/ns/docbook: @ezpublish.fieldType.ezrichtext.validator.docbook
-                http://ez.no/namespaces/ezpublish5/xhtml5/edit: @ezpublish.fieldType.ezrichtext.validator.input.ezxhtml5
+                http://ez.no/namespaces/ezpublish5/xhtml5/edit: null
                 http://ez.no/namespaces/ezpublish5/xhtml5: @ezpublish.fieldType.ezrichtext.validator.output.ezxhtml5
 
     # Image


### PR DESCRIPTION
Two minor changes to RichText field type:

1. fixed incorrect `docbook` to `xhtml5edit` stylesheet configuration, causing incorrect namespace on the conversion result.
2. disabled validation of `xhtml5edit` input

Reported in https://github.com/ezsystems/PlatformUIBundle/pull/235.