### PR TITLE
EZP-24227: Missing Translation Helper in Content Download service definition

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -84,6 +84,7 @@ services:
         arguments:
             - @ezpublish.api.service.content
             - @ezpublish.fieldType.ezbinaryfile.io_service
+            - @ezpublish.translation_helper
         parent: ezpublish.controller.base
 
     ezpublish.controller.page.view:


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-24427

Constructor for the controller needs a third param

ping @bdunogier @andrerom @lolautruche 