### PR TITLE
Fix EZP-24423: RichText input validation

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -243,11 +243,11 @@ services:
         class: %ezpublish.fieldType.ezrichtext.validator.xml.class%
         arguments: [%ezpublish.fieldType.ezrichtext.validator.output.ezxhtml5.resources%]
 
-    ezpublish.fieldType.ezrichtext.validator.dispatcher:
+    ezpublish.fieldType.ezrichtext.validator.input.dispatcher:
         class: %ezpublish.fieldType.ezrichtext.validator.dispatcher.class%
         arguments:
             -
-                http://docbook.org/ns/docbook: @ezpublish.fieldType.ezrichtext.validator.docbook
+                http://docbook.org/ns/docbook: null
                 http://ez.no/namespaces/ezpublish5/xhtml5/edit: null
                 http://ez.no/namespaces/ezpublish5/xhtml5: @ezpublish.fieldType.ezrichtext.validator.output.ezxhtml5
 

--- a/eZ/Publish/Core/FieldType/RichText/Type.php
+++ b/eZ/Publish/Core/FieldType/RichText/Type.php
@@ -18,6 +18,7 @@ use eZ\Publish\SPI\FieldType\Value as SPIValue;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\FieldType\Value as BaseValue;
 use eZ\Publish\API\Repository\Values\Content\Relation;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use DOMDocument;
 use RuntimeException;
 
@@ -48,16 +49,26 @@ class Type extends FieldType
     /**
      * @var \eZ\Publish\Core\FieldType\RichText\ValidatorDispatcher
      */
-    protected $validatorDispatcher;
+    protected $inputValidatorDispatcher;
+
+    /**
+     * @var \eZ\Publish\Core\FieldType\RichText\ValidatorDispatcher
+     */
+    protected $internalFormatValidator;
 
     /**
      * @param \eZ\Publish\Core\FieldType\RichText\ConverterDispatcher $inputConverterDispatcher
-     * @param \eZ\Publish\Core\FieldType\RichText\ValidatorDispatcher $validatorDispatcher
+     * @param \eZ\Publish\Core\FieldType\RichText\ValidatorDispatcher $inputValidatorDispatcher
+     * @param \eZ\Publish\Core\FieldType\RichText\Validator $internalFormatValidator
      */
-    public function __construct(ConverterDispatcher $inputConverterDispatcher, ValidatorDispatcher $validatorDispatcher)
-    {
+    public function __construct(
+        ConverterDispatcher $inputConverterDispatcher,
+        ValidatorDispatcher $inputValidatorDispatcher,
+        Validator $internalFormatValidator
+    ) {
         $this->inputConverterDispatcher = $inputConverterDispatcher;
-        $this->validatorDispatcher = $validatorDispatcher;
+        $this->inputValidatorDispatcher = $inputValidatorDispatcher;
+        $this->internalFormatValidator = $internalFormatValidator;
     }
 
     /**
@@ -145,7 +156,7 @@ class Type extends FieldType
         }
 
         if ($inputValue instanceof DOMDocument) {
-            $errors = $this->validatorDispatcher->dispatch($inputValue);
+            $errors = $this->inputValidatorDispatcher->dispatch($inputValue);
             if (!empty($errors)) {
                 throw new InvalidArgumentException(
                     '$inputValue',
@@ -153,17 +164,9 @@ class Type extends FieldType
                 );
             }
 
-            $inputValue = $this->inputConverterDispatcher->dispatch($inputValue);
-
-            $errors = $this->validatorDispatcher->dispatch($inputValue);
-            if (!empty($errors)) {
-                throw new InvalidArgumentException(
-                    '$inputValue',
-                    'Validation of XML content failed: ' . implode("\n", $errors)
-                );
-            }
-
-            $inputValue = new Value($inputValue);
+            $inputValue = new Value(
+                $this->inputConverterDispatcher->dispatch($inputValue)
+            );
         }
 
         return $inputValue;
@@ -222,7 +225,36 @@ class Type extends FieldType
     }
 
     /**
-     * Returns sortKey information.
+     * Validates a field based on the validators in the field definition
+     *
+     * This is a base implementation, returning an empty array() that indicates
+     * that no validation errors occurred. Overwrite in derived types, if
+     * validation is supported.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     *
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition The field definition of the field
+     * @param \eZ\Publish\Core\FieldType\RichText\Value $value The field value for which an action is performed
+     *
+     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
+     */
+    public function validate(FieldDefinition $fieldDefinition, SPIValue $value)
+    {
+        $validationErrors = array();
+
+        $errors = $this->internalFormatValidator->validate($value->xml);
+
+        if (!empty($errors)) {
+            $validationErrors[] = new ValidationError(
+                "Validation of XML content failed:\n" . join("\n", $errors)
+            );
+        }
+
+        return $validationErrors;
+    }
+
+    /**
+     * Returns sortKey information
      *
      * @see \eZ\Publish\Core\FieldType
      *

--- a/eZ/Publish/Core/FieldType/RichText/Type.php
+++ b/eZ/Publish/Core/FieldType/RichText/Type.php
@@ -160,8 +160,8 @@ class Type extends FieldType
                 $errors = $this->inputValidatorDispatcher->dispatch($inputValue);
                 if (!empty($errors)) {
                     throw new InvalidArgumentException(
-                        "\$inputValue",
-                        "Validation of XML content failed: " . join("\n", $errors)
+                        '$inputValue',
+                        'Validation of XML content failed: ' . implode("\n", $errors)
                     );
                 }
             }
@@ -227,7 +227,7 @@ class Type extends FieldType
     }
 
     /**
-     * Validates a field based on the validators in the field definition
+     * Validates a field based on the validators in the field definition.
      *
      * This is a base implementation, returning an empty array() that indicates
      * that no validation errors occurred. Overwrite in derived types, if
@@ -248,7 +248,7 @@ class Type extends FieldType
 
         if (!empty($errors)) {
             $validationErrors[] = new ValidationError(
-                "Validation of XML content failed:\n" . join("\n", $errors)
+                "Validation of XML content failed:\n" . implode("\n", $errors)
             );
         }
 
@@ -256,7 +256,7 @@ class Type extends FieldType
     }
 
     /**
-     * Returns sortKey information
+     * Returns sortKey information.
      *
      * @see \eZ\Publish\Core\FieldType
      *

--- a/eZ/Publish/Core/FieldType/RichText/Type.php
+++ b/eZ/Publish/Core/FieldType/RichText/Type.php
@@ -42,33 +42,33 @@ class Type extends FieldType
     );
 
     /**
-     * @var \eZ\Publish\Core\FieldType\RichText\ConverterDispatcher
-     */
-    protected $inputConverterDispatcher;
-
-    /**
-     * @var \eZ\Publish\Core\FieldType\RichText\ValidatorDispatcher
-     */
-    protected $inputValidatorDispatcher;
-
-    /**
      * @var \eZ\Publish\Core\FieldType\RichText\ValidatorDispatcher
      */
     protected $internalFormatValidator;
 
     /**
-     * @param \eZ\Publish\Core\FieldType\RichText\ConverterDispatcher $inputConverterDispatcher
-     * @param \eZ\Publish\Core\FieldType\RichText\ValidatorDispatcher $inputValidatorDispatcher
+     * @var \eZ\Publish\Core\FieldType\RichText\ConverterDispatcher
+     */
+    protected $inputConverterDispatcher;
+
+    /**
+     * @var null|\eZ\Publish\Core\FieldType\RichText\ValidatorDispatcher
+     */
+    protected $inputValidatorDispatcher;
+
+    /**
      * @param \eZ\Publish\Core\FieldType\RichText\Validator $internalFormatValidator
+     * @param \eZ\Publish\Core\FieldType\RichText\ConverterDispatcher $inputConverterDispatcher
+     * @param null|\eZ\Publish\Core\FieldType\RichText\ValidatorDispatcher $inputValidatorDispatcher
      */
     public function __construct(
+        Validator $internalFormatValidator,
         ConverterDispatcher $inputConverterDispatcher,
-        ValidatorDispatcher $inputValidatorDispatcher,
-        Validator $internalFormatValidator
+        ValidatorDispatcher $inputValidatorDispatcher = null
     ) {
+        $this->internalFormatValidator = $internalFormatValidator;
         $this->inputConverterDispatcher = $inputConverterDispatcher;
         $this->inputValidatorDispatcher = $inputValidatorDispatcher;
-        $this->internalFormatValidator = $internalFormatValidator;
     }
 
     /**
@@ -156,12 +156,14 @@ class Type extends FieldType
         }
 
         if ($inputValue instanceof DOMDocument) {
-            $errors = $this->inputValidatorDispatcher->dispatch($inputValue);
-            if (!empty($errors)) {
-                throw new InvalidArgumentException(
-                    '$inputValue',
-                    'Validation of XML content failed: ' . implode("\n", $errors)
-                );
+            if ($this->inputValidatorDispatcher !== null) {
+                $errors = $this->inputValidatorDispatcher->dispatch($inputValue);
+                if (!empty($errors)) {
+                    throw new InvalidArgumentException(
+                        "\$inputValue",
+                        "Validation of XML content failed: " . join("\n", $errors)
+                    );
+                }
             }
 
             $inputValue = new Value(

--- a/eZ/Publish/Core/FieldType/Tests/RichTextTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichTextTest.php
@@ -36,12 +36,12 @@ class RichTextTest extends PHPUnit_Framework_TestCase
         $fieldType = new RichTextType(
             new Validator(
                 array(
-                    $this->getAbsolutePath("eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng"),
-                    $this->getAbsolutePath("eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/docbook.iso.sch.xsl"),
+                    $this->getAbsolutePath('eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng'),
+                    $this->getAbsolutePath('eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/docbook.iso.sch.xsl'),
                 )
             ),
-            new ConverterDispatcher(array("http://docbook.org/ns/docbook" => null)),
-            new ValidatorDispatcher(array("http://docbook.org/ns/docbook" => null))
+            new ConverterDispatcher(array('http://docbook.org/ns/docbook' => null)),
+            new ValidatorDispatcher(array('http://docbook.org/ns/docbook' => null))
         );
         $fieldType->setTransformationProcessor($this->getTransformationProcessorMock());
 
@@ -117,7 +117,7 @@ class RichTextTest extends PHPUnit_Framework_TestCase
                 '<?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0-variant ezpublish-1.0">
   <h1>This is not valid, but acceptValue() will not validate it.</h1>
-</section>'
+</section>',
             ),
         );
     }
@@ -184,8 +184,8 @@ class RichTextTest extends PHPUnit_Framework_TestCase
                 array(
                     new ValidationError(
                         "Validation of XML content failed:\n" .
-                        "Error in 3:0: Element section has extra content: h1"
-                    )
+                        'Error in 3:0: Element section has extra content: h1'
+                    ),
                 ),
             ),
             array(
@@ -197,7 +197,7 @@ class RichTextTest extends PHPUnit_Framework_TestCase
                     new ValidationError(
                         "Validation of XML content failed:\n" .
                         "/*[local-name()='section' and namespace-uri()='http://docbook.org/ns/docbook']: The root element must have a version attribute."
-                    )
+                    ),
                 ),
             ),
         );
@@ -216,7 +216,7 @@ class RichTextTest extends PHPUnit_Framework_TestCase
 
         /** @var \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition|\PHPUnit_Framework_MockObject_MockObject $fieldDefinitionMock */
         $fieldDefinitionMock = $this->getMock(
-            "eZ\\Publish\\API\\Repository\\Values\\ContentType\\FieldDefinition"
+            'eZ\\Publish\\API\\Repository\\Values\\ContentType\\FieldDefinition'
         );
 
         $validationErrors = $fieldType->validate($fieldDefinitionMock, $value);

--- a/eZ/Publish/Core/FieldType/Tests/RichTextTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichTextTest.php
@@ -34,14 +34,14 @@ class RichTextTest extends PHPUnit_Framework_TestCase
     protected function getFieldType()
     {
         $fieldType = new RichTextType(
-            new ConverterDispatcher(array("http://docbook.org/ns/docbook" => null)),
-            new ValidatorDispatcher(array("http://docbook.org/ns/docbook" => null)),
             new Validator(
                 array(
                     $this->getAbsolutePath("eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng"),
                     $this->getAbsolutePath("eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/docbook.iso.sch.xsl"),
                 )
-            )
+            ),
+            new ConverterDispatcher(array("http://docbook.org/ns/docbook" => null)),
+            new ValidatorDispatcher(array("http://docbook.org/ns/docbook" => null))
         );
         $fieldType->setTransformationProcessor($this->getTransformationProcessorMock());
 

--- a/eZ/Publish/Core/settings/fieldtype_services.yml
+++ b/eZ/Publish/Core/settings/fieldtype_services.yml
@@ -67,11 +67,11 @@ services:
         class: %ezpublish.fieldType.ezrichtext.validator.xml.class%
         arguments: [%ezpublish.fieldType.ezrichtext.validator.docbook.resources%]
 
-    ezpublish.fieldType.ezrichtext.validator.dispatcher:
+    ezpublish.fieldType.ezrichtext.validator.input.dispatcher:
         class: %ezpublish.fieldType.ezrichtext.validator.dispatcher.class%
         arguments:
             -
-                http://docbook.org/ns/docbook: @ezpublish.fieldType.ezrichtext.validator.docbook
+                http://docbook.org/ns/docbook: null
 
     # Page
     ezpublish.fieldType.ezpage.pageService:

--- a/eZ/Publish/Core/settings/fieldtypes.yml
+++ b/eZ/Publish/Core/settings/fieldtypes.yml
@@ -396,7 +396,8 @@ services:
         parent: ezpublish.fieldType
         arguments:
             - @ezpublish.fieldType.ezrichtext.converter.input.dispatcher
-            - @ezpublish.fieldType.ezrichtext.validator.dispatcher
+            - @ezpublish.fieldType.ezrichtext.validator.input.dispatcher
+            - @ezpublish.fieldType.ezrichtext.validator.docbook
         tags:
             - {name: ezpublish.fieldType, alias: ezrichtext}
 

--- a/eZ/Publish/Core/settings/fieldtypes.yml
+++ b/eZ/Publish/Core/settings/fieldtypes.yml
@@ -395,9 +395,9 @@ services:
         class: %ezpublish.fieldType.ezrichtext.class%
         parent: ezpublish.fieldType
         arguments:
+            - @ezpublish.fieldType.ezrichtext.validator.docbook
             - @ezpublish.fieldType.ezrichtext.converter.input.dispatcher
             - @ezpublish.fieldType.ezrichtext.validator.input.dispatcher
-            - @ezpublish.fieldType.ezrichtext.validator.docbook
         tags:
             - {name: ezpublish.fieldType, alias: ezrichtext}
 

--- a/eZ/Publish/SPI/Tests/FieldType/RichTextIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/RichTextIntegrationTest.php
@@ -60,12 +60,12 @@ class RichTextIntegrationTest extends BaseIntegrationTest
         $fieldType = new FieldType\RichText\Type(
             new FieldType\RichText\Validator(
                 array(
-                    $this->getAbsolutePath("eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng"),
-                    $this->getAbsolutePath("eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/docbook.iso.sch.xsl"),
+                    $this->getAbsolutePath('eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng'),
+                    $this->getAbsolutePath('eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/docbook.iso.sch.xsl'),
                 )
             ),
             new FieldType\RichText\ConverterDispatcher(array()),
-            new FieldType\RichText\ValidatorDispatcher(array("http://docbook.org/ns/docbook" => null,))
+            new FieldType\RichText\ValidatorDispatcher(array('http://docbook.org/ns/docbook' => null))
         );
         $fieldType->setTransformationProcessor($this->getTransformationProcessor());
 

--- a/eZ/Publish/SPI/Tests/FieldType/RichTextIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/RichTextIntegrationTest.php
@@ -59,14 +59,11 @@ class RichTextIntegrationTest extends BaseIntegrationTest
     {
         $fieldType = new FieldType\RichText\Type(
             new FieldType\RichText\ConverterDispatcher(array()),
-            new FieldType\RichText\ValidatorDispatcher(
+            new FieldType\RichText\ValidatorDispatcher(array("http://docbook.org/ns/docbook" => null,)),
+            new FieldType\RichText\Validator(
                 array(
-                    'http://docbook.org/ns/docbook' => new FieldType\RichText\Validator(
-                        array(
-                            $this->getAbsolutePath('eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng'),
-                            $this->getAbsolutePath('eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/docbook.iso.sch.xsl'),
-                        )
-                    ),
+                    $this->getAbsolutePath("eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng"),
+                    $this->getAbsolutePath("eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/docbook.iso.sch.xsl"),
                 )
             )
         );

--- a/eZ/Publish/SPI/Tests/FieldType/RichTextIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/RichTextIntegrationTest.php
@@ -58,14 +58,14 @@ class RichTextIntegrationTest extends BaseIntegrationTest
     public function getCustomHandler()
     {
         $fieldType = new FieldType\RichText\Type(
-            new FieldType\RichText\ConverterDispatcher(array()),
-            new FieldType\RichText\ValidatorDispatcher(array("http://docbook.org/ns/docbook" => null,)),
             new FieldType\RichText\Validator(
                 array(
                     $this->getAbsolutePath("eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng"),
                     $this->getAbsolutePath("eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/docbook.iso.sch.xsl"),
                 )
-            )
+            ),
+            new FieldType\RichText\ConverterDispatcher(array()),
+            new FieldType\RichText\ValidatorDispatcher(array("http://docbook.org/ns/docbook" => null,))
         );
         $fieldType->setTransformationProcessor($this->getTransformationProcessor());
 


### PR DESCRIPTION
This resolves https://jira.ez.no/browse/EZP-24423

RichText was using the same validator dispatcher to validate both the input value and the result of conversion to the internal format.

This makes internal format validator a separate dependency. Method `validate()` is now implemented, using internal format validator to validate the value in the internal format, either provided as such or converted from one of the input formats.

Also, input validator dispatcher is made optional.