### PR TITLE
Silence deprecation notices with Symfony 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   # misc nighlty tests we keep an eye on and aim to fix closer to stable versions
   allow_failures:
     - php: 5.5
-      env: TEST_CONFIG="phpunit.xml" SYMFONY_VERSION="~2.7@dev"
+      env: TEST_CONFIG="phpunit.xml" SYMFONY_VERSION="~2.8@dev"
     - php: hhvm-nightly
       env: TEST_CONFIG="phpunit.xml"
     - php: nightly

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -9,6 +9,9 @@
  * @version //autogentag//
  */
 
+// Silencing deprecation errors from Symfony 2.7
+error_reporting( error_reporting() & ~E_USER_DEPRECATED );
+
 // Get global config.php settings
 if ( !file_exists( __DIR__ . '/config.php' ) )
 {

--- a/config.php-DEVELOPMENT
+++ b/config.php-DEVELOPMENT
@@ -12,9 +12,6 @@
  * @doc Copy this file to config.php to get started!
  */
 
-// Optional: only for development, comment in production
-error_reporting( E_ALL | E_STRICT );
-
 // Required: Settings bellow are runtime settings that needs to be set here, you can
 // optionally also override any other setting here.
 return array(


### PR DESCRIPTION
This is based by what's done in SensioDistributionBundle:
https://github.com/sensiolabs/SensioDistributionBundle/commit/0db645c7e01286d7ca8fa79b61539f6aa644b25c

Deprecation errors should not block tests.