### PR TITLE
Implemented variation purge

### DIFF
--- a/doc/specifications/image/variation_purging.md
+++ b/doc/specifications/image/variation_purging.md
@@ -1,0 +1,43 @@
+# Variation purging
+
+> From eZ Platform 2015.05
+
+## Synopsis and example
+
+Makes it possible to clear all variations generated for an alias. Uses the liip:imagine:cache:remove script.
+Example (the `-v` option will log removals to the console), removing variations for the `large` and `gallery` aliases :
+
+```shell
+php ezpublish/console liip:imagine:cache:remove --filters=large --filters=gallery -v
+```
+
+## Internal changes
+
+Two items have been refactored/introduced:
+- purging of variations from the IORepositoryResolver is done by a `VariationPurger`
+  Aliased service: `ezpublish.image_alias.variation_purger`
+- generation of the alias path from the original path is done by a `VariationPathGenerator`
+  Aliased service: `ezpublish.image_alias.variation_path_generator`
+
+### 2015.05 and above
+
+- Variation Purger: `ezpublish.image_alias.variation_purger.io`
+  Uses the IOService to delete the directory `_aliases/<aliasName>`
+- Path Generator: `ezpublish.image_alias.variation_path_generator.alias_directory`
+  Stores variations in the `_aliases` folder, in a subfolder named after the alias: `_aliases/<aliasName>`
+
+A set of Purger / Path Generator is added for releases from 2015.05. It relies on the new storage method for aliases:
+they're no longer stored in the original's folder, but in a dedicated folder. This makes purging as simple as removing
+the alias folder.
+
+### Earlier versions
+
+- Variation Purger: `ezpublish.image_alias.variation_purger.legacy_storage_image_file`
+  Uses the `LegacyStorageImageFileList` to iterate over originals, and clears the files using the IOService.
+- Path Generator: `ezpublish.image_alias.variation_path_generator.original_directory`
+  Stores variations in the same folder than the original, suffixing the name with `_<aliasName>`.
+
+Uses an ImageFileList service. It comes with a Legacy Storage implementation that lists original images from the
+`ezimagefile` database table. Aliases for each original is tested, and removed if found and applicable using the IOService.
+
+It is much more resource intensive, but it is the best option given the way variations are stored.

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPathGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPathGenerator.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine;
+
+/**
+ * Generates the path to variations of original images.
+ */
+interface VariationPathGenerator
+{
+    /**
+     * Returns the variation for image $originalPath with $filter
+     *
+     * @param string $originalPath
+     * @param string $filter
+     *
+     * @return string
+     */
+    public function getVariationPath( $originalPath, $filter );
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPathGenerator/AliasDirectoryVariationPathGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPathGenerator/AliasDirectoryVariationPathGenerator.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator;
+
+/**
+ * Puts variations in the an _alias/<aliasName> subfolder.
+ *
+ * Example:
+ * my/image/file.jpg -> _aliases/large/my/image/file.jpg
+ */
+class AliasDirectoryVariationPathGenerator implements VariationPathGenerator
+{
+    public function getVariationPath( $originalPath, $filter )
+    {
+        $info = pathinfo( $originalPath );
+        return sprintf(
+            '_aliases/%s/%s/%s%s',
+            $filter,
+            $info['dirname'],
+            $info['filename'],
+            empty( $info['extension'] ) ? '' : '.' . $info['extension']
+        );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPathGenerator/OriginalDirectoryVariationPathGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPathGenerator/OriginalDirectoryVariationPathGenerator.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator;
+
+/**
+ * Puts variations in the same folder than the original, suffixed with the filter name:
+ *
+ * Example:
+ * my/image/file.jpg -> my/image/file_large.jpg
+ */
+class OriginalDirectoryVariationPathGenerator implements VariationPathGenerator
+{
+    public function getVariationPath( $originalPath, $filter )
+    {
+        $info = pathinfo( $originalPath );
+        return sprintf(
+            '%s/%s_%s%s',
+            $info['dirname'],
+            $info['filename'],
+            $filter,
+            empty( $info['extension'] ) ? '' : '.' . $info['extension']
+        );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/IOVariationPurger.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/IOVariationPurger.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger;
+
+use eZ\Publish\Core\IO\IOServiceInterface;
+use eZ\Publish\SPI\Variation\VariationPurger;
+
+/**
+ * Purges image variations using the IOService.
+ *
+ * Depends on aliases being stored in their own folder, with each alias folder mirroring the original files structure.
+ */
+class IOVariationPurger implements VariationPurger
+{
+    /** @var \eZ\Publish\Core\IO\IOServiceInterface */
+    private $io;
+
+    /** @var \Psr\Log\LoggerInterface */
+    private $logger;
+
+    public function __construct( IOServiceInterface $io )
+    {
+        $this->io = $io;
+    }
+
+    /**
+     * @param \Psr\Log\LoggerInterface $logger
+     */
+    public function setLogger( $logger )
+    {
+        $this->logger = $logger;
+    }
+
+    public function purge( array $aliasNames )
+    {
+        foreach ( $aliasNames as $aliasName )
+        {
+            $directory = "_aliases/$aliasName";
+            $this->io->deleteDirectory( $directory );
+
+            if ( isset( $this->logger ) )
+            {
+                $this->logger->info( "Purging alias directory $directory" );
+            }
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileList.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileList.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger;
+
+use Iterator;
+use Countable;
+
+/**
+ * Iterates over BinaryFile id entries for original images.
+ */
+interface ImageFileList extends Countable, Iterator
+{
+
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileRowReader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileRowReader.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger;
+
+/**
+ * Reads original image files from a data source.
+ */
+interface ImageFileRowReader
+{
+    /**
+     * Initializes the reader.
+     *
+     * Can for instance be used to create and execute a database query.
+     */
+    public function init();
+
+    /**
+     * Returns the next row from the data source
+     *
+     * @return mixed|null The row's value, or null if none.
+     */
+    public function getRow();
+
+    /**
+     * Returns the total row count
+     *
+     * @return int
+     */
+    public function getCount();
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileVariationPurger.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileVariationPurger.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator;
+use eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway as ImageStorageGateway;
+use eZ\Publish\Core\IO\Exception\BinaryFileNotFoundException;
+use eZ\Publish\Core\IO\IOServiceInterface;
+use eZ\Publish\SPI\Variation\VariationPurger;
+use Iterator;
+
+/**
+ * Purges image aliases based on image files referenced by the Image FieldType.
+ *
+ * It uses an ImageFileList iterator that lists original images, and the variationPathGenerator + IOService to remove
+ * aliases if they exist.
+ */
+class ImageFileVariationPurger implements VariationPurger
+{
+    /** @var ImageFileList */
+    private $imageFileList;
+
+    /** @var \eZ\Publish\Core\IO\IOServiceInterface */
+    private $ioService;
+
+    /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator */
+    private $variationPathGenerator;
+
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    private $logger;
+
+    public function __construct( Iterator $imageFileList, IOServiceInterface $ioService, VariationPathGenerator $variationPathGenerator )
+    {
+        $this->imageFileList = $imageFileList;
+        $this->ioService = $ioService;
+        $this->variationPathGenerator = $variationPathGenerator;
+    }
+
+    /**
+     * Purge all variations generated for aliases in $aliasName
+     *
+     * @param array $aliasNames
+     */
+    public function purge( array $aliasNames )
+    {
+        foreach ( $this->imageFileList as $originalImageId )
+        {
+            foreach ( $aliasNames as $aliasName )
+            {
+                $variationImageId = $this->variationPathGenerator->getVariationPath( $originalImageId, $aliasName );
+                if ( !$this->ioService->exists( $variationImageId ) )
+                {
+                    continue;
+                }
+
+                $binaryFile = $this->ioService->loadBinaryFile( $variationImageId );
+                $this->ioService->deleteBinaryFile( $binaryFile );
+                if ( isset( $this->logger ) )
+                {
+                    $this->logger->info( "Purging $aliasName variation $variationImageId for original image $originalImageId" );
+                }
+            }
+        }
+    }
+
+    /**
+     * @param \Psr\Log\LoggerInterface $logger
+     */
+    public function setLogger( $logger )
+    {
+        $this->logger = $logger;
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/LegacyStorageImageFileList.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/LegacyStorageImageFileList.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger;
+
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+use eZ\Publish\Core\Persistence\Doctrine\ConnectionHandler;
+
+/**
+ * Iterator for entries in legacy's ezimagefile table.
+ *
+ * The returned items are id of Image BinaryFile (ez-mountains/mount-aconcagua/605-1-eng-GB/Mount-Aconcagua.jpg).
+ */
+class LegacyStorageImageFileList implements ImageFileList
+{
+    /**
+     * Last fetched item
+     * @var mixed
+     */
+    private $item;
+
+    /**
+     * Iteration cursor on $statement
+     * @var int
+     */
+    private $cursor;
+
+    /**
+     * The storage prefix used by legacy, usually the vardir + the 'storage' folder.
+     * Example: var/ezdemo_site/storage
+     * @var string
+     */
+    private $prefix;
+
+    /**
+     * Used to get ezimagefile rows
+     * @var \eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\ImageFileRowReader
+     */
+    private $rowReader;
+
+    /**
+     * @param \eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\ImageFileRowReader $rowReader
+     * @param string $storageDir Folder, relative to the root, where files are stored. Example: var/ezdemo_site/storage
+     * @param string $imagesDir Folder where images are stored, within the storage dir. Example: 'images'
+     */
+    public function __construct( ImageFileRowReader $rowReader, $storageDir, $imagesDir )
+    {
+        $this->prefix = $storageDir . '/' . $imagesDir;
+        $this->rowReader = $rowReader;
+    }
+
+    public function current()
+    {
+        return $this->item;
+    }
+
+    public function next()
+    {
+        $this->fetchRow();
+    }
+
+    public function key()
+    {
+        return $this->cursor;
+    }
+
+    public function valid()
+    {
+        return ( $this->cursor < $this->count() );
+    }
+
+    public function rewind()
+    {
+        $this->cursor = -1;
+        $this->rowReader->init();
+        $this->fetchRow();
+    }
+
+    public function count()
+    {
+        return $this->rowReader->getCount();
+    }
+
+    /**
+     * Fetches the next item from the resultset, moves the cursor forward, and removes the prefix from the image id
+     */
+    private function fetchRow()
+    {
+        $this->cursor++;
+        $imageId = $this->rowReader->getRow();
+
+        if ( substr( $imageId, 0, strlen( $this->prefix ) ) == $this->prefix )
+        {
+            $imageId = ltrim( substr( $imageId, strlen( $this->prefix ) ), '/' );
+        }
+
+        $this->item = $imageId;
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/LegacyStorageImageFileRowReader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/LegacyStorageImageFileRowReader.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger;
+
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+
+class LegacyStorageImageFileRowReader implements ImageFileRowReader
+{
+    /** @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler */
+    private $dbHandler;
+
+    /** @var \PDOStatement */
+    private $statement;
+
+    public function __construct( DatabaseHandler $dbHandler )
+    {
+        $this->dbHandler = $dbHandler;
+    }
+
+    public function init()
+    {
+        $selectQuery = $this->dbHandler->createSelectQuery();
+        $selectQuery->select( 'filepath' )->from( $this->dbHandler->quoteTable( 'ezimagefile' ) );
+        $this->statement = $selectQuery->prepare();
+        $this->statement->execute();
+    }
+
+    public function getRow()
+    {
+        return $this->statement->fetchColumn( 0 );
+    }
+
+    public function getCount()
+    {
+        return $this->statement->rowCount();
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -29,7 +29,9 @@ parameters:
     ezpublish.image_alias.variation_purger.legacy_storage_image_file.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\ImageFileVariationPurger
     ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_list.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\LegacyStorageImageFileList
     ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_row_reader.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\LegacyStorageImageFileRowReader
+    ezpublish.image_alias.variation_purger.io.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\IOVariationPurger
     ezpubish.image_alias.variation_path_generator.original_directory.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator\OriginalDirectoryVariationPathGenerator
+    ezpubish.image_alias.variation_path_generator.alias_directory.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator\AliasDirectoryVariationPathGenerator
 
 services:
     # Filters
@@ -194,7 +196,18 @@ services:
             - { name: liip_imagine.filter.loader, loader: "colorspace/gray" }
 
     ezpublish.image_alias.variation_purger:
+        # < platform 2015.05
         alias: ezpublish.image_alias.variation_purger.legacy_storage_image_file
+        # >= platform 2015.05
+        # alias: ezpublish.image_alias.variation_purger.io
+
+    ezpublish.image_alias.variation_purger.io:
+        class: %ezpublish.image_alias.variation_purger.io.class%
+        arguments:
+            - @ezpublish.fieldType.ezimage.io_service
+            - @ezpublish.image_alias.variation_path_generator.alias_directory
+        calls:
+            - [setLogger, [@?logger]]
 
     ezpublish.image_alias.variation_purger.legacy_storage_image_file:
         class: %ezpublish.image_alias.variation_purger.legacy_storage_image_file.class%
@@ -218,7 +231,14 @@ services:
             - @ezpublish.api.storage_engine.legacy.dbhandler
 
     ezpublish.image_alias.variation_path_generator:
+        # < platform 2015.05
         alias: ezpublish.image_alias.variation_path_generator.original_directory
+        # >= platform 2015.05
+        # alias: ezpublish.image_alias.variation_path_generator.alias_directory
 
     ezpublish.image_alias.variation_path_generator.original_directory:
         class: %ezpubish.image_alias.variation_path_generator.original_directory.class%
+
+    ezpublish.image_alias.variation_path_generator.alias_directory:
+        class: %ezpubish.image_alias.variation_path_generator.alias_directory.class%
+

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -197,9 +197,9 @@ services:
 
     ezpublish.image_alias.variation_purger:
         # < platform 2015.05
-        alias: ezpublish.image_alias.variation_purger.legacy_storage_image_file
+        # alias: ezpublish.image_alias.variation_purger.legacy_storage_image_file
         # >= platform 2015.05
-        # alias: ezpublish.image_alias.variation_purger.io
+        alias: ezpublish.image_alias.variation_purger.io
 
     ezpublish.image_alias.variation_purger.io:
         class: %ezpublish.image_alias.variation_purger.io.class%
@@ -232,13 +232,12 @@ services:
 
     ezpublish.image_alias.variation_path_generator:
         # < platform 2015.05
-        alias: ezpublish.image_alias.variation_path_generator.original_directory
+        # alias: ezpublish.image_alias.variation_path_generator.original_directory
         # >= platform 2015.05
-        # alias: ezpublish.image_alias.variation_path_generator.alias_directory
+        alias: ezpublish.image_alias.variation_path_generator.alias_directory
 
     ezpublish.image_alias.variation_path_generator.original_directory:
         class: %ezpubish.image_alias.variation_path_generator.original_directory.class%
 
     ezpublish.image_alias.variation_path_generator.alias_directory:
         class: %ezpubish.image_alias.variation_path_generator.alias_directory.class%
-

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -26,6 +26,11 @@ parameters:
     ezpublish.image_alias.imagine.filter.swirl.imagick.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Imagick\SwirlFilter
     ezpublish.image_alias.imagine.filter.swirl.gmagick.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Gmagick\SwirlFilter
 
+    ezpublish.image_alias.variation_purger.legacy_storage_image_file.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\ImageFileVariationPurger
+    ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_list.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\LegacyStorageImageFileList
+    ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_row_reader.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\LegacyStorageImageFileRowReader
+    ezpubish.image_alias.variation_path_generator.original_directory.class: eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator\OriginalDirectoryVariationPathGenerator
+
 services:
     # Filters
     ezpublish.image_alias.imagine.filter.unsupported:
@@ -65,7 +70,12 @@ services:
 
     ezpublish.image_alias.imagine.cache_resolver:
         class: %ezpublish.image_alias.imagine.cache_resolver.class%
-        arguments: [@ezpublish.fieldType.ezimage.io_service, @router.request_context, @liip_imagine.filter.configuration]
+        arguments:
+            - @ezpublish.fieldType.ezimage.io_service
+            - @router.request_context
+            - @liip_imagine.filter.configuration
+            - @ezpublish.image_alias.variation_purger
+            - @ezpublish.image_alias.variation_path_generator.alias_directory
         tags:
             - { name: liip_imagine.cache.resolver, resolver: ezpublish }
 
@@ -182,3 +192,33 @@ services:
         public: false
         tags:
             - { name: liip_imagine.filter.loader, loader: "colorspace/gray" }
+
+    ezpublish.image_alias.variation_purger:
+        alias: ezpublish.image_alias.variation_purger.legacy_storage_image_file
+
+    ezpublish.image_alias.variation_purger.legacy_storage_image_file:
+        class: %ezpublish.image_alias.variation_purger.legacy_storage_image_file.class%
+        arguments:
+            - @ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_list
+            - @ezpublish.fieldType.ezimage.io_service
+            - @ezpublish.image_alias.variation_path_generator.original_directory
+        calls:
+            - [setLogger, [@?logger]]
+
+    ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_list:
+        class: %ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_list.class%
+        arguments:
+            - @ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_row_reader
+            - $io.legacy_url_prefix$
+            - $image.published_images_dir$
+
+    ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_row_reader:
+        class: %ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_row_reader.class%
+        arguments:
+            - @ezpublish.api.storage_engine.legacy.dbhandler
+
+    ezpublish.image_alias.variation_path_generator:
+        alias: ezpublish.image_alias.variation_path_generator.original_directory
+
+    ezpublish.image_alias.variation_path_generator.original_directory:
+        class: %ezpubish.image_alias.variation_path_generator.original_directory.class%

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPathGenerator/AliasDirectoryVariationPathGeneratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPathGenerator/AliasDirectoryVariationPathGeneratorTest.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\VariationPathGenerator;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator\AliasDirectoryVariationPathGenerator;
+
+class AliasDirectoryVariationPathGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetVariationPath()
+    {
+        $generator = new AliasDirectoryVariationPathGenerator();
+
+        self::assertEquals(
+            '_aliases/large/path/to/original.png',
+            $generator->getVariationPath( 'path/to/original.png', 'large' )
+        );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPathGenerator/OriginalDirectoryVariationPathGeneratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPathGenerator/OriginalDirectoryVariationPathGeneratorTest.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\VariationPathGenerator;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator\OriginalDirectoryVariationPathGenerator;
+
+class OriginalDirectoryVariationPathGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetVariationPath()
+    {
+        $generator = new OriginalDirectoryVariationPathGenerator();
+        self::assertEquals(
+            'path/to/original_large.png',
+            $generator->getVariationPath( 'path/to/original.png', 'large' )
+        );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/IOVariationPurgerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/IOVariationPurgerTest.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\VariationPurger;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\IOVariationPurger;
+
+class IOVariationPurgerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testPurgesAliasList()
+    {
+        $ioService = $this->getMock( 'eZ\Publish\Core\IO\IOServiceInterface' );
+        $ioService
+            ->expects( $this->exactly( 2 ) )
+            ->method( 'deleteDirectory' )
+            ->withConsecutive(
+                array( '_aliases/medium' ),
+                array( '_aliases/large' )
+            );
+        $purger = new IOVariationPurger( $ioService );
+        $purger->purge( array( 'medium', 'large' ) );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/ImageFileVariationPurgerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/ImageFileVariationPurgerTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\VariationPurger;
+
+use ArrayIterator;
+use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\ImageFileVariationPurger;
+use eZ\Publish\Core\IO\Values\BinaryFile;
+
+class ImageFileVariationPurgerTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \eZ\Publish\Core\IO\IOServiceInterface|\PHPUnit_Framework_MockObject_MockObject */
+    protected $ioServiceMock;
+
+    /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator|\PHPUnit_Framework_MockObject_MockObject */
+    protected $pathGeneratorMock;
+
+    /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\ImageFileVariationPurger */
+    protected $purger;
+
+    public function setUp()
+    {
+        $this->ioServiceMock = $this->getMock( 'eZ\Publish\Core\IO\IOServiceInterface' );
+        $this->pathGeneratorMock = $this->getMock( 'eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator' );
+    }
+
+    public function testIteratesOverItems()
+    {
+        $purger = $this->createPurger(
+            array(
+                'path/to/1st/image.jpg',
+                'path/to/2nd/image.png',
+            )
+        );
+
+        $this->pathGeneratorMock
+            ->expects( $this->exactly( 4 ) )
+            ->method( 'getVariationPath' )
+            ->withConsecutive(
+                array( 'path/to/1st/image.jpg', 'large' ),
+                array( 'path/to/1st/image.jpg', 'gallery' ),
+                array( 'path/to/2nd/image.png', 'large' ),
+                array( 'path/to/2nd/image.png', 'gallery' )
+            );
+
+        $purger->purge( array( 'large', 'gallery' ) );
+    }
+
+    public function testPurgesExistingItem()
+    {
+        $purger = $this->createPurger(
+            array( 'path/to/file.png' )
+        );
+
+        $this->pathGeneratorMock
+            ->expects( $this->once() )
+            ->method( 'getVariationPath' )
+            ->will( $this->returnValue( 'path/to/file_large.png' ) );
+
+        $this->ioServiceMock
+            ->expects( $this->once() )
+            ->method( 'exists' )
+            ->will( $this->returnValue( true ) );
+
+        $this->ioServiceMock
+            ->expects( $this->once() )
+            ->method( 'loadBinaryFile' )
+            ->will( $this->returnValue( new BinaryFile() ) );
+
+        $this->ioServiceMock
+            ->expects( $this->once() )
+            ->method( 'deleteBinaryFile' )
+            ->with( $this->isInstanceOf( 'eZ\Publish\Core\IO\Values\BinaryFile' ) );
+
+        $purger->purge( array( 'large' ) );
+    }
+
+    public function testDoesNotPurgeNotExistingItem()
+    {
+        $purger = $this->createPurger(
+            array( 'path/to/file.png' )
+        );
+
+        $this->pathGeneratorMock
+            ->expects( $this->once() )
+            ->method( 'getVariationPath' )
+            ->will( $this->returnValue( 'path/to/file_large.png' ) );
+
+        $this->ioServiceMock
+            ->expects( $this->once() )
+            ->method( 'exists' )
+            ->will( $this->returnValue( false ) );
+
+        $this->ioServiceMock
+            ->expects( $this->never() )
+            ->method( 'loadBinaryFile' );
+
+        $this->ioServiceMock
+            ->expects( $this->never() )
+            ->method( 'deleteBinaryFile' );
+
+        $purger->purge( array( 'large' ) );
+    }
+
+    private function createPurger( array $fileList )
+    {
+        return new ImageFileVariationPurger( new ArrayIterator( $fileList ), $this->ioServiceMock, $this->pathGeneratorMock );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/LegacyStorageImageFileListTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/LegacyStorageImageFileListTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\VariationPurger;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\LegacyStorageImageFileList;
+
+class LegacyStorageImageFileListTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\ImageFileRowReader|\PHPUnit_Framework_MockObject_MockObject */
+    protected $rowReaderMock;
+
+    /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\LegacyStorageImageFileList */
+    protected $fileList;
+
+    public function setUp()
+    {
+        $this->rowReaderMock = $this->getMock( 'eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\ImageFileRowReader' );
+        $this->fileList = new LegacyStorageImageFileList(
+            $this->rowReaderMock,
+            'var/ezdemo_site/storage',
+            'images'
+        );
+    }
+
+    function testIterator()
+    {
+        $expected = array(
+            'path/to/1st/image.jpg',
+            'path/to/2nd/image.jpg',
+        );
+        $this->configureRowReaderMock( $expected );
+
+        foreach ( $this->fileList as $index => $file )
+        {
+            self::assertEquals( $expected[$index], $file );
+        }
+    }
+
+    /**
+     * Tests that the iterator transforms the ezimagefile value into a binaryfile id
+     */
+    public function testImageIdTransformation()
+    {
+        $this->configureRowReaderMock( array( 'var/ezdemo_site/storage/images/path/to/1st/image.jpg' ) );
+        foreach ( $this->fileList as $file )
+        {
+            self::assertEquals( 'path/to/1st/image.jpg', $file );
+        }
+    }
+
+    private function configureRowReaderMock( array $fileList )
+    {
+        $mockInvocator = $this->rowReaderMock->expects( $this->any() )->method( 'getRow' );
+        call_user_func_array( array( $mockInvocator, 'willReturnOnConsecutiveCalls' ), $fileList );
+
+        $this->rowReaderMock->expects( $this->any() )->method( 'getCount' )->willReturn( count( $fileList ) );
+    }
+}

--- a/eZ/Publish/Core/FieldType/Image/IO/Legacy.php
+++ b/eZ/Publish/Core/FieldType/Image/IO/Legacy.php
@@ -208,6 +208,16 @@ class Legacy implements IOServiceInterface
         $this->publishedIOService->deleteBinaryFile( $binaryFile );
     }
 
+    /**
+     * Deletes a directory.
+     *
+     * @param string $path
+     */
+    public function deleteDirectory( $path )
+    {
+        $this->publishedIOService->deleteDirectory( $path );
+    }
+
     public function newBinaryCreateStructFromUploadedFile( array $uploadedFile )
     {
         return $this->publishedIOService->newBinaryCreateStructFromUploadedFile( $uploadedFile );

--- a/eZ/Publish/Core/IO/IOBinarydataHandler.php
+++ b/eZ/Publish/Core/IO/IOBinarydataHandler.php
@@ -70,4 +70,11 @@ interface IOBinarydataHandler
      * @return string
      */
     public function getIdFromUri( $binaryFileUri );
+
+    /**
+     * Deletes the directory $spiPath and all of its contents
+     *
+     * @param string $spiPath
+     */
+    public function deleteDirectory( $spiPath );
 }

--- a/eZ/Publish/Core/IO/IOBinarydataHandler/Flysystem.php
+++ b/eZ/Publish/Core/IO/IOBinarydataHandler/Flysystem.php
@@ -111,4 +111,9 @@ class Flysystem implements IOBinaryDataHandler
             return ltrim( $binaryFileUri, '/' );
 
     }
+
+    public function deleteDirectory( $spiPath )
+    {
+        $this->filesystem->deleteDir( $spiPath );
+    }
 }

--- a/eZ/Publish/Core/IO/IOMetadataHandler.php
+++ b/eZ/Publish/Core/IO/IOMetadataHandler.php
@@ -62,4 +62,6 @@ interface IOMetadataHandler
      * @return string
      */
     public function getMimeType( $spiBinaryFileId );
+
+    public function deleteDirectory( $spiPath );
 }

--- a/eZ/Publish/Core/IO/IOMetadataHandler/Flysystem.php
+++ b/eZ/Publish/Core/IO/IOMetadataHandler/Flysystem.php
@@ -17,7 +17,7 @@ use League\Flysystem\FilesystemInterface;
 
 class Flysystem implements IOMetadataHandler
 {
-    /** @var  FilesystemInterface */
+    /** @var FilesystemInterface */
     private $filesystem;
 
     public function __construct( FilesystemInterface $filesystem )
@@ -71,5 +71,12 @@ class Flysystem implements IOMetadataHandler
     public function getMimeType( $spiBinaryFileId )
     {
         return $this->filesystem->getMimetype( $spiBinaryFileId );
+    }
+
+    /**
+     * Does nothing, as the binarydata handler takes care of it
+     */
+    public function deleteDirectory( $spiPath )
+    {
     }
 }

--- a/eZ/Publish/Core/IO/IOMetadataHandler/LegacyDFSCluster.php
+++ b/eZ/Publish/Core/IO/IOMetadataHandler/LegacyDFSCluster.php
@@ -245,6 +245,13 @@ SQL
         return $row['datatype'];
     }
 
+    public function deleteDirectory( $spiPath )
+    {
+        $stmt = $this->db->prepare( 'DELETE FROM ezdfsfile WHERE name LIKE ?' );
+        $stmt->bindValue( 1, rtrim( $spiPath, '/' ) . '/%' );
+        $stmt->execute();
+    }
+
     /**
      * Maps an array of data base properties (id, size, mtime, datatype, md5_path, path...) to an SPIBinaryFile object
      *

--- a/eZ/Publish/Core/IO/IOService.php
+++ b/eZ/Publish/Core/IO/IOService.php
@@ -307,4 +307,16 @@ class IOService implements IOServiceInterface
             throw new InvalidBinaryFileIdException( $binaryFileId );
         }
     }
+
+    /**
+     * Deletes a directory.
+     *
+     * @param string $path
+     */
+    public function deleteDirectory( $path )
+    {
+        $prefixedUri = $this->getPrefixedUri( $path );
+        $this->metadataHandler->deleteDirectory( $prefixedUri );
+        $this->binarydataHandler->deleteDirectory( $prefixedUri );
+    }
 }

--- a/eZ/Publish/Core/IO/IOServiceInterface.php
+++ b/eZ/Publish/Core/IO/IOServiceInterface.php
@@ -159,4 +159,11 @@ interface IOServiceInterface
      * @return BinaryFileCreateStruct
      */
     public function newBinaryCreateStructFromUploadedFile( array $uploadedFile );
+
+    /**
+     * Deletes a directory.
+     *
+     * @param string $path
+     */
+    public function deleteDirectory( $path );
 }

--- a/eZ/Publish/Core/IO/Tests/IOBinarydataHandler/FlysystemTest.php
+++ b/eZ/Publish/Core/IO/Tests/IOBinarydataHandler/FlysystemTest.php
@@ -173,4 +173,14 @@ class FlysystemTest extends PHPUnit_Framework_TestCase
             $this->handler->getUri( 'prefix/my/file.png' )
         );
     }
+
+    public function testDeleteDirectory()
+    {
+        $this->filesystem
+            ->expects( $this->once() )
+            ->method( 'deleteDir' )
+            ->with( 'some/path' );
+
+        $this->handler->deleteDirectory( 'some/path' );
+    }
 }

--- a/eZ/Publish/Core/IO/Tests/IOMetadataHandler/FlysystemTest.php
+++ b/eZ/Publish/Core/IO/Tests/IOMetadataHandler/FlysystemTest.php
@@ -62,6 +62,7 @@ class FlysystemTest extends PHPUnit_Framework_TestCase
 
     public function testDelete()
     {
+        $this->filesystem->expects( $this->never() )->method( 'delete' );
         $this->handler->delete( 'prefix/my/file.png' );
     }
 
@@ -136,5 +137,11 @@ class FlysystemTest extends PHPUnit_Framework_TestCase
             ->will( $this->returnValue( 'text/plain' ) );
 
         self::assertEquals( 'text/plain', $this->handler->getMimeType( 'file.txt' ) );
+    }
+
+    public function testDeleteDirectory()
+    {
+        $this->filesystem->expects( $this->never() )->method( 'deleteDir' );
+        $this->handler->deleteDirectory( 'some/path' );
     }
 }

--- a/eZ/Publish/Core/IO/Tests/IOMetadataHandler/LegacyDFSClusterTest.php
+++ b/eZ/Publish/Core/IO/Tests/IOMetadataHandler/LegacyDFSClusterTest.php
@@ -184,6 +184,23 @@ class LegacyDFSClusterTest extends PHPUnit_Framework_TestCase
         self::assertFalse( $this->handler->exists( 'prefix/my/file.png' ) );
     }
 
+    public function testDeletedirectory()
+    {
+        $statement = $this->createDbalStatementMock();
+        $statement
+            ->expects( $this->once() )
+            ->method( 'bindValue' )
+            ->with( 1, 'folder/subfolder/%' );
+
+        $this->dbalMock
+            ->expects( $this->once() )
+            ->method( 'prepare' )
+            ->with( $this->anything() )
+            ->will( $this->returnValue( $statement ) );
+
+        $this->handler->deleteDirectory( 'folder/subfolder/' );
+    }
+
     /**
      * @return \PHPUnit_Framework_MockObject_MockObject
      */

--- a/eZ/Publish/Core/IO/Tests/IOServiceTest.php
+++ b/eZ/Publish/Core/IO/Tests/IOServiceTest.php
@@ -390,6 +390,27 @@ class IOServiceTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers \eZ\Publish\Core\IO\IOService::deleteDirectory()
+     */
+    public function testDeleteDirectory()
+    {
+        $id = "some/directory";
+        $spiId = $this->getPrefixedUri( $id );
+
+        $this->binarydataHandlerMock
+            ->expects( $this->once() )
+            ->method( 'deleteDirectory' )
+            ->with( $spiId );
+
+        $this->metadataHandlerMock
+            ->expects( $this->once() )
+            ->method( 'deleteDirectory' )
+            ->with( $spiId );
+
+        $this->getIOService()->deleteDirectory( 'some/directory' );
+    }
+
+    /**
      * @covers \eZ\Publish\Core\IO\IOService::deleteBinaryFile
      * @expectedException \eZ\Publish\Core\Base\Exceptions\NotFoundException
      * @return mixed Whatever deleteBinaryFile returned

--- a/eZ/Publish/SPI/Variation/VariationPurger.php
+++ b/eZ/Publish/SPI/Variation/VariationPurger.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\SPI\Variation;
+
+/**
+ * Handles physical purging of image variations from storage
+ */
+interface VariationPurger
+{
+    /**
+     * Purge all variations generated for aliases in $aliasNames
+     * @param array $aliasNames
+     */
+    public function purge( array $aliasNames );
+}


### PR DESCRIPTION
> http://jira.ez.no/browse/EZP-23367
> Reboot of #1268
> [specifications](https://github.com/ezsystems/ezpublish-kernel/blob/ezp23367-variation_purge/doc/specifications/image/variation_purging.md)

## Purpose
Allows purging of all variations of one or more aliases using the `liip:imagine:cache:remove` script:

```
php ezpublish/console liip:imagine:cache:purge --filters=medium
```

## Summary
The PR covers both 5.4 and newer versions. It introduces a `VariationPurger` service, used by the `IORepositoryResolver`.

In newer versions, the VariationPurger uses a new storage path for variations, where variations of the same alias are stored in a subfolder mirroring the original images directory (example: `var/ezdemo_site/storage/images/_aliases/medium`). This makes purging of an entire alias as easy as removing this directory.

For older versions, a VariationPurger is introduced that relies on the legacy `ezimagefile` table for listing originals.

## BC handling
Both VariationPurger will be backported to 5.4, but the new one won't be enabled. This makes it possible, by changing the default variation purger, to migrate an existing installation to the new naming scheme, benefit from the performance boost, and be prepared for the Platform 1.0 upgrade.

## TODO
- [x] Describe PR