### PR TITLE
EZP-23846: Fix XSLTProcessor::transformToXml(): ID eztoc_1_1 already defined

### DIFF
--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/Html5Test.php
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/Html5Test.php
@@ -344,21 +344,21 @@ class Html5Test extends PHPUnit_Framework_TestCase
 
         $convertedDocument = $this->createDocument( $result, false );
 
-        $aux = '<a name="eztoc_1_1" id="eztoc_1_1"></a><h2>Heading 2</h2>
-<a name="eztoc_1_2" id="eztoc_1_2"></a><h2>Heading 2</h2>
-<a name="eztoc_1_3_1" id="eztoc_1_3_1"></a><h3>Heading 3</h3>
+        $aux = '<a id="eztoc_1_1"></a><h2>Heading 2</h2>
+<a id="eztoc_1_2"></a><h2>Heading 2</h2>
+<a id="eztoc_1_3_1"></a><h3>Heading 3</h3>
 <table class="class1" border="1" cellpadding="2" cellspacing="0" width="100%" style="width:100%;" summary="summary1">
 <tr>
 <td valign="top" style="vertical-align: top;">
-<a name="eztoc_1_3_1_1" id="eztoc_1_3_1_1"></a><h2>Heading 2</h2>
-<a name="eztoc_1_3_1_2" id="eztoc_1_3_1_2"></a><h2>Heading 2</h2>
-<a name="eztoc_1_3_1_3_1" id="eztoc_1_3_1_3_1"></a><h3>Heading 3</h3>
-<a name="eztoc_1_3_1_3_2" id="eztoc_1_3_1_3_2"></a><h3>Heading 3</h3>
+<a id="eztoc_1_3_1_1"></a><h2>Heading 2</h2>
+<a id="eztoc_1_3_1_2"></a><h2>Heading 2</h2>
+<a id="eztoc_1_3_1_3_1"></a><h3>Heading 3</h3>
+<a id="eztoc_1_3_1_3_2"></a><h3>Heading 3</h3>
 <table class="class2" border="1" cellpadding="2" cellspacing="0" width="100%" style="width:100%;" summary="summary2">
 <tr>
 <td valign="top" style="vertical-align: top;">
-<a name="eztoc_1_3_1_1" id="eztoc_1_3_1_1"></a><h2>Heading 2</h2>
-<a name="eztoc_1_3_1_2_1" id="eztoc_1_3_1_2_1"></a><h3>Heading 3</h3>
+<a id="eztoc_1_3_1_1"></a><h2>Heading 2</h2>
+<a id="eztoc_1_3_1_2_1"></a><h3>Heading 3</h3>
 </td>
 </tr>
 </table>

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/001-title.xml
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/001-title.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
-  <a id="eztoc_1_1" name="eztoc_1_1"/>
+  <a id="eztoc_1_1"/>
   <h2 class="titleClass">This is a heading.</h2>
-  <a id="eztoc_2_1" name="eztoc_2_1"/>
+  <a id="eztoc_2_1"/>
   <h2 align="left" class="titleClass2">This is a left aligned heading.</h2>
-  <a id="eztoc_3_1_1" name="eztoc_3_1_1"/>
+  <a id="eztoc_3_1_1"/>
   <h3 align="center">This is a centered heading.</h3>
-  <a id="eztoc_4_1_1" name="eztoc_4_1_1"/>
+  <a id="eztoc_4_1_1"/>
   <h3 align="right">This is a right aligned heading.</h3>
-  <a id="eztoc_5_1_1" name="eztoc_5_1_1"/>
+  <a id="eztoc_5_1_1"/>
   <h3 align="justify">This is a justified heading.</h3>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/002-para.xml
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/002-para.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
-  <a id="eztoc_1_1" name="eztoc_1_1"/>
+  <a id="eztoc_1_1"/>
   <h2>This is a heading.</h2>
   <p class="paraClass">This is a paragraph.</p>
   <p class="paraClass2" align="left">This is a left aligned paragraph.</p>

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/003-section.xml
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/003-section.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
-  <a id="eztoc_1_1" name="eztoc_1_1"/>
+  <a id="eztoc_1_1"/>
   <h2>This is a heading.</h2>
   <p>This is a paragraph.</p>
-  <a id="eztoc_2_1_1" name="eztoc_2_1_1"/>
+  <a id="eztoc_2_1_1"/>
   <h3>This is a second heading.</h3>
   <p>This is a second paragraph.</p>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/004-sectionNested.xml
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/004-sectionNested.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
-  <a id="eztoc_1_1" name="eztoc_1_1"/>
+  <a id="eztoc_1_1"/>
   <h2>This is a heading.</h2>
   <p>This is a paragraph.</p>
-  <a id="eztoc_2_1_1" name="eztoc_2_1_1"/>
+  <a id="eztoc_2_1_1"/>
   <h3>This is a second heading.</h3>
   <p>This is a second paragraph.</p>
-  <a id="eztoc_3_1_1_1" name="eztoc_3_1_1_1"/>
+  <a id="eztoc_3_1_1_1"/>
   <h4>This is a third heading.</h4>
   <p>This is a third paragraph.</p>
-  <a id="eztoc_4_1_1_1_1" name="eztoc_4_1_1_1_1"/>
+  <a id="eztoc_4_1_1_1_1"/>
   <h5>This is a fourth heading.</h5>
   <p>This is a fourth paragraph.</p>
-  <a id="eztoc_5_1_1_1_1_1" name="eztoc_5_1_1_1_1_1"/>
+  <a id="eztoc_5_1_1_1_1_1"/>
   <h6>This is a fifth heading.</h6>
   <p>This is a fifth paragraph.</p>
-  <a id="eztoc_6_1_1_1_1_1" name="eztoc_6_1_1_1_1_1"/>
+  <a id="eztoc_6_1_1_1_1_1"/>
   <h6>This is a sixth heading.</h6>
   <p>This is a sixth paragraph.</p>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/005-emphasis.xml
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/005-emphasis.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
-  <a id="eztoc_1_1" name="eztoc_1_1"/>
+  <a id="eztoc_1_1"/>
   <h2>This is a heading.</h2>
   <p>This is a paragraph with <em class="emphasisClass">emphasized</em> text.</p>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/006-emphasisStrong.xml
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/006-emphasisStrong.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
-  <a id="eztoc_1_1" name="eztoc_1_1"/>
+  <a id="eztoc_1_1"/>
   <h2>This is a heading.</h2>
   <p>This is a paragraph with <strong class="emphasisStrongClass">strong</strong> text.</p>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/007-emphasisUnderlined.xml
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/007-emphasisUnderlined.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
-  <a id="eztoc_1_1" name="eztoc_1_1"/>
+  <a id="eztoc_1_1"/>
   <h2>This is a heading.</h2>
   <p>This is a paragraph with <custom name="underline">underlined</custom> text.</p>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/012-literallayout.xml
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/012-literallayout.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
-  <a id="eztoc_1_1" name="eztoc_1_1"/>
+  <a id="eztoc_1_1"/>
   <h2>This is a heading.</h2>
   <p>This is a paragraph<br/>with some<br/>extra <em>CHEESE!</em><br/>and line breaks.</p>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/013-anchor.xml
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/013-anchor.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
-  <a id="eztoc_1_1" name="eztoc_1_1"/>
+  <a id="eztoc_1_1"/>
   <h2>This is a heading.</h2>
   <p>The anchor element<a id="example.anchor.1"/> is empty and contributes nothing to the flow of the content in which it occurs. It is only useful as a target.</p>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/014-link.xml
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/014-link.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
-  <a id="eztoc_1_1" name="eztoc_1_1"/>
+  <a id="eztoc_1_1"/>
   <h2>Assorted array of links</h2>
   <p>
     <a href="" target="_blank" title="Anchor link title" class="linkClass1">Jump to content</a>

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/019-emphasisStrikedthrough.xml
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/019-emphasisStrikedthrough.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
-  <a id="eztoc_1_1" name="eztoc_1_1"/>
+  <a id="eztoc_1_1"/>
   <h2>This is a heading.</h2>
   <p>This is a paragraph with <custom name="strike">strikedthrough</custom> text.</p>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/020-blockquote.xml
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/020-blockquote.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
-  <a id="eztoc_1_1" name="eztoc_1_1"/>
+  <a id="eztoc_1_1"/>
   <h2>Example of blockquote</h2>
   <custom name="quote">
     <p>Don't wake me for the end of the world unless it has very good special effects.</p>

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/021-titleImplicitLevels.xml
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/021-titleImplicitLevels.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
-  <a id="eztoc_1_1" name="eztoc_1_1"/>
+  <a id="eztoc_1_1"/>
   <h2>This is a first level heading.</h2>
-  <a id="eztoc_2_1" name="eztoc_2_1"/>
+  <a id="eztoc_2_1"/>
   <h2>This is a second level heading.</h2>
-  <a id="eztoc_3_1_1" name="eztoc_3_1_1"/>
+  <a id="eztoc_3_1_1"/>
   <h3>This is a third level heading.</h3>
-  <a id="eztoc_4_1_1_1" name="eztoc_4_1_1_1"/>
+  <a id="eztoc_4_1_1_1"/>
   <h4>This is a fourth level heading.</h4>
-  <a id="eztoc_5_1_1_1_1" name="eztoc_5_1_1_1_1"/>
+  <a id="eztoc_5_1_1_1_1"/>
   <h5>This is a fifth level heading.</h5>
-  <a id="eztoc_6_1_1_1_1_1" name="eztoc_6_1_1_1_1_1"/>
+  <a id="eztoc_6_1_1_1_1_1"/>
   <h6>This is a sixth level heading.</h6>
-  <a id="eztoc_7_1_1_1_1_1" name="eztoc_7_1_1_1_1_1"/>
+  <a id="eztoc_7_1_1_1_1_1"/>
   <h6>This is a seventh level heading.</h6>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/026-tableTitles.xml
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/026-tableTitles.xml
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
-  <a id="eztoc_1_1" name="eztoc_1_1"/>
+  <a id="eztoc_1_1"/>
   <h2>Heading 2</h2>
-  <a id="eztoc_2_1" name="eztoc_2_1"/>
+  <a id="eztoc_2_1"/>
   <h2>Heading 2</h2>
-  <a id="eztoc_3_1_1" name="eztoc_3_1_1"/>
+  <a id="eztoc_3_1_1"/>
   <h3>Heading 3</h3>
   <table border="1" cellpadding="2" cellspacing="0" class="class1" style="width:100%;" summary="summary1" width="100%">
     <tr>
       <td style="vertical-align: top;" valign="top">
-        <a id="eztoc_1_1" name="eztoc_1_1"/>
+        <a id="eztoc_1_1"/>
         <h2>Heading 2</h2>
-        <a id="eztoc_2_1" name="eztoc_2_1"/>
+        <a id="eztoc_2_1"/>
         <h2>Heading 2</h2>
-        <a id="eztoc_3_1_1" name="eztoc_3_1_1"/>
+        <a id="eztoc_3_1_1"/>
         <h3>Heading 3</h3>
-        <a id="eztoc_4_1_1" name="eztoc_4_1_1"/>
+        <a id="eztoc_4_1_1"/>
         <h3>Heading 3</h3>
         <table border="1" cellpadding="2" cellspacing="0" class="class2" style="width:100%;" summary="summary2" width="100%">
           <tr>
             <td style="vertical-align: top;" valign="top">
-              <a id="eztoc_1_1" name="eztoc_1_1"/>
+              <a id="eztoc_1_1"/>
               <h2>Heading 2</h2>
-              <a id="eztoc_2_1_1" name="eztoc_2_1_1"/>
+              <a id="eztoc_2_1_1"/>
               <h3>Heading 3</h3>
             </td>
           </tr>

--- a/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/108-expandTable.xml
+++ b/eZ/Publish/Core/FieldType/Tests/XmlText/Converter/_fixtures/html5/output/108-expandTable.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
-  <a name="eztoc_1_1" id="eztoc_1_1"></a><h2>Heading 2</h2>
-  <a name="eztoc_1_2" id="eztoc_1_2"></a><h2>Heading 2</h2>
-  <a name="eztoc_1_3_1" id="eztoc_1_3_1"></a><h3>Heading 3</h3>
+  <a id="eztoc_1_1"></a><h2>Heading 2</h2>
+  <a id="eztoc_1_2"></a><h2>Heading 2</h2>
+  <a id="eztoc_1_3_1"></a><h3>Heading 3</h3>
   <table class="class1" border="1" cellpadding="2" cellspacing="0" width="100%" style="width:100%;" summary="summary1">
     <tr>
       <td valign="top" style="vertical-align: top;">
-        <a name="eztoc_1_3_1_1" id="eztoc_1_3_1_1"></a><h2>Heading 2</h2>
-        <a name="eztoc_1_3_1_2" id="eztoc_1_3_1_2"></a><h2>Heading 2</h2>
-        <a name="eztoc_1_3_1_3_1" id="eztoc_1_3_1_3_1"></a><h3>Heading 3</h3>
-        <a name="eztoc_1_3_1_3_2" id="eztoc_1_3_1_3_2"></a><h3>Heading 3</h3>
+        <a id="eztoc_1_3_1_1"></a><h2>Heading 2</h2>
+        <a id="eztoc_1_3_1_2"></a><h2>Heading 2</h2>
+        <a id="eztoc_1_3_1_3_1"></a><h3>Heading 3</h3>
+        <a id="eztoc_1_3_1_3_2"></a><h3>Heading 3</h3>
         <table class="class2" border="1" cellpadding="2" cellspacing="0" width="100%" style="width:100%;" summary="summary2">
           <tr>
             <td valign="top" style="vertical-align: top;">
-              <a name="eztoc_1_3_1_1" id="eztoc_1_3_1_1"></a><h2>Heading 2</h2>
-              <a name="eztoc_1_3_1_2_1" id="eztoc_1_3_1_2_1"></a><h3>Heading 3</h3>
+              <a id="eztoc_1_3_1_1"></a><h2>Heading 2</h2>
+              <a id="eztoc_1_3_1_2_1"></a><h3>Heading 3</h3>
             </td>
           </tr>
         </table>

--- a/eZ/Publish/Core/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl
+++ b/eZ/Publish/Core/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl
@@ -27,7 +27,7 @@
             <xsl:number count="section[ancestor::section] | header" level="multiple"/>
         </xsl:variable>
 
-        <a name="eztoc_{translate($name, '.', '_')}" id="eztoc_{translate($name, '.', '_')}"/>
+        <a id="eztoc_{translate($name, '.', '_')}"/>
         <xsl:element name="h{$level}">
             <xsl:copy-of select="@class"/>
             <xsl:copy-of select="@align"/>


### PR DESCRIPTION
[WIP] 
----
Fixes: https://jira.ez.no/browse/EZP-23846

Found this issue in the tracker. I'm experiencing it too. As said there, seems to be caused by the anchors added when trasforming ```header```

I did some manually tests and found that deleting name attribute makes the warning dissapear. 

I deleted name because [is not supported by html5](http://www.w3schools.com/tags/att_a_name.asp). My worry is if this name could be needed for anything else. (old browsers or whatever).   

Let me know if you find this workaround as a good solution and if so, i could add some test.

ping @pspanja @lolautruche @andrerom 

Edit: Tests will need to be updated as they expect name attribute in the anchors. 