### PR TITLE
REST: Implement ViewInput SortClauses parsing

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -2169,6 +2169,7 @@ Perform a query on images withing the media section, sorted by name, limiting re
         <SortClauses>
           <SortClause>
             <SortField>NAME</SortField>
+            <SortOrder>DESC</SortOrder>
           </SortClause>
         </SortClauses>
         <FacetBuilders>

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
@@ -343,6 +343,9 @@ services:
     ezpublish_rest.input.parser.ViewInput:
         parent: ezpublish_rest.input.parser
         class: %ezpublish_rest.input.parser.ViewInput.class%
+        arguments:
+            - @ezpublish.api.service.location
+            - @ezpublish_rest.parser_tools
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.ViewInput }
 

--- a/eZ/Publish/API/Repository/LocationService.php
+++ b/eZ/Publish/API/Repository/LocationService.php
@@ -202,5 +202,15 @@ interface LocationService
      * @return \eZ\Publish\API\Repository\Values\Content\LocationUpdateStruct
      */
     public function newLocationUpdateStruct();
+
+    /**
+     * Instantiates a correct sort clause object based on provided location sort field and sort order
+     *
+     * @param int $sortField
+     * @param int $sortOrder
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\SortClause
+     */
+    public function getSortClauseBySortField( $sortField, $sortOrder = Location::SORT_ORDER_ASC );
 }
 

--- a/eZ/Publish/Core/REST/Client/LocationService.php
+++ b/eZ/Publish/Core/REST/Client/LocationService.php
@@ -359,4 +359,17 @@ class LocationService implements APILocationService, Sessionable
     {
         throw new \Exception( "@todo: Implement." );
     }
+
+    /**
+     * Instantiates a correct sort clause object based on provided location sort field and sort order
+     *
+     * @param int $sortField
+     * @param int $sortOrder
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\SortClause
+     */
+    public function getSortClauseBySortField( $sortField, $sortOrder = Location::SORT_ORDER_ASC )
+    {
+        throw new \Exception( "@todo: Implement." );
+    }
 }

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -803,7 +803,7 @@ class LocationService implements LocationServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\SortClause
      */
-    protected function getSortClauseBySortField( $sortField, $sortOrder = APILocation::SORT_ORDER_ASC )
+    public function getSortClauseBySortField( $sortField, $sortOrder = APILocation::SORT_ORDER_ASC )
     {
         $sortOrder = $sortOrder == APILocation::SORT_ORDER_DESC ? Query::SORT_DESC : Query::SORT_ASC;
         switch ( $sortField )

--- a/eZ/Publish/Core/SignalSlot/LocationService.php
+++ b/eZ/Publish/Core/SignalSlot/LocationService.php
@@ -355,4 +355,17 @@ class LocationService implements LocationServiceInterface
     {
         return $this->service->newLocationUpdateStruct();
     }
+
+    /**
+     * Instantiates a correct sort clause object based on provided location sort field and sort order
+     *
+     * @param int $sortField
+     * @param int $sortOrder
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\SortClause
+     */
+    public function getSortClauseBySortField( $sortField, $sortOrder = Location::SORT_ORDER_ASC )
+    {
+        return $this->service->getSortClauseBySortField( $sortField, $sortOrder );
+    }
 }


### PR DESCRIPTION
I chose to make `eZ\Publish\Core\Repository\LocationService::getSortClauseBySortField` public, because I didn't want to re-implement it, as it is already duplicated in `eZ\Publish\Core\Repository\UserService`.