### PR TITLE
Fix EZP-24459: SiteAccess should not be a synchronized service any more

### DIFF
--- a/doc/bc/changes-6.0.md
+++ b/doc/bc/changes-6.0.md
@@ -138,6 +138,9 @@ Changes affecting version compatibility with former or future versions.
   and `$limit = 10` are added. No way is provided to return all user groups, pagination should be used if full
   result set is desired.
 
+* SiteAccess service (`ezpublish.siteaccess`) is not synchronized any more.
+  Synchronized services are deprecated as of Symfony 2.7.
+
 ## Deprecations
 
 * `eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger::purge()` is deprecated and will be removed in v6.1.

--- a/eZ/Bundle/EzPublishCoreBundle/Console/Application.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Console/Application.php
@@ -46,9 +46,9 @@ class Application extends BaseApplication
         parent::registerCommands();
 
         $container = $this->getKernel()->getContainer();
-        $this->siteAccessName = $this->siteAccessName ?: $container->getParameter( 'ezpublish.siteaccess.default' );
-        $siteAccess = new SiteAccess( $this->siteAccessName, 'cli' );
-        $container->set( 'ezpublish.siteaccess', $siteAccess );
+        $siteAccess = $container->get( 'ezpublish.siteaccess' );
+        $siteAccess->name = $this->siteAccessName ?: $container->getParameter( 'ezpublish.siteaccess.default' );
+        $siteAccess->matchingType = 'cli';
     }
 
 }

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -171,10 +171,6 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
         }
         $container->setParameter( 'ezpublish.siteaccess.groups_by_siteaccess', $groupsBySiteaccess );
         ConfigurationProcessor::setGroupsBySiteAccess( $groupsBySiteaccess );
-
-        // Manually setting ezpublish.siteaccess synchronized
-        // as it's not possible to silent the deprecation warning in YAML.
-        $container->findDefinition( 'ezpublish.siteaccess' )->setSynchronized( true, false );
     }
 
     private function registerImageMagickConfiguration( array $config, ContainerBuilder $container )

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/SiteAccessListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/SiteAccessListener.php
@@ -55,10 +55,12 @@ class SiteAccessListener extends ContainerAware implements EventSubscriberInterf
     public function onSiteAccessMatch( PostSiteAccessMatchEvent $event )
     {
         $request = $event->getRequest();
-        $siteAccess = $event->getSiteAccess();
-        // Injecting matched SiteAccess in the ServiceContainer.
-        // All services depending on it will be "synchronized" with it.
-        $this->container->set( 'ezpublish.siteaccess', $siteAccess );
+        $matchedSiteAccess = $event->getSiteAccess();
+
+        $siteAccess = $this->container->get( 'ezpublish.siteaccess' );
+        $siteAccess->name = $matchedSiteAccess->name;
+        $siteAccess->matchingType = $matchedSiteAccess->matchingType;
+        $siteAccess->matcher = $matchedSiteAccess->matcher;
 
         // We already have semanticPathinfo (sub-request)
         if ( $request->attributes->has( 'semanticPathinfo' ) )

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -30,7 +30,7 @@ services:
     # Siteaccess is injected in the container at runtime
     ezpublish.siteaccess:
         class: %ezpublish.siteaccess.class%
-        arguments: [%ezpublish.siteaccess.default.name%]
+        arguments: [%ezpublish.siteaccess.default.name%, 'uninitialized']
 
     ezpublish.config.resolver.core:
         class: %ezpublish.config.resolver.dynamic.class%

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SiteAccessListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SiteAccessListenerTest.php
@@ -108,19 +108,24 @@ class SiteAccessListenerTest extends PHPUnit_Framework_TestCase
             $matcher = $this->getMock( 'eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher' );
         }
 
+        $defaultSiteAccess = new SiteAccess( 'default' );
         $siteAccess = new SiteAccess( 'test', 'test', $matcher );
         $request = Request::create( $uri );
         $event = new PostSiteAccessMatchEvent( $siteAccess, $request, HttpKernelInterface::MASTER_REQUEST );
 
         $this->container
             ->expects( $this->once() )
-            ->method( 'set' )
-            ->with( 'ezpublish.siteaccess', $siteAccess );
+            ->method( 'get' )
+            ->with( 'ezpublish.siteaccess' )
+            ->willReturn( $defaultSiteAccess );
 
         $this->listener->onSiteAccessMatch( $event );
         $this->assertSame( $expectedSemanticPathinfo, $request->attributes->get( 'semanticPathinfo' ) );
         $this->assertSame( $expectedVPArray, $request->attributes->get( 'viewParameters' ) );
         $this->assertSame( $expectedVPString, $request->attributes->get( 'viewParametersString' ) );
+        $this->assertSame( $defaultSiteAccess->name, $siteAccess->name );
+        $this->assertSame( $defaultSiteAccess->matchingType, $siteAccess->matchingType );
+        $this->assertSame( $defaultSiteAccess->matcher, $siteAccess->matcher );
     }
 
     /**
@@ -128,6 +133,7 @@ class SiteAccessListenerTest extends PHPUnit_Framework_TestCase
      */
     public function testOnSiteAccessMatchSubRequest( $uri, $semanticPathinfo, $vpString, $expectedViewParameters )
     {
+        $defaultSiteAccess = new SiteAccess( 'default' );
         $siteAccess = new SiteAccess( 'test', 'test', $this->getMock( 'eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher' ) );
         $request = Request::create( $uri );
         $request->attributes->set( 'semanticPathinfo', $semanticPathinfo );
@@ -139,12 +145,16 @@ class SiteAccessListenerTest extends PHPUnit_Framework_TestCase
 
         $this->container
             ->expects( $this->once() )
-            ->method( 'set' )
-            ->with( 'ezpublish.siteaccess', $siteAccess );
+            ->method( 'get' )
+            ->with( 'ezpublish.siteaccess' )
+            ->willReturn( $defaultSiteAccess );
 
         $this->listener->onSiteAccessMatch( $event );
         $this->assertSame( $semanticPathinfo, $request->attributes->get( 'semanticPathinfo' ) );
         $this->assertSame( $expectedViewParameters, $request->attributes->get( 'viewParameters' ) );
         $this->assertSame( $vpString, $request->attributes->get( 'viewParametersString' ) );
+        $this->assertSame( $defaultSiteAccess->name, $siteAccess->name );
+        $this->assertSame( $defaultSiteAccess->matchingType, $siteAccess->matchingType );
+        $this->assertSame( $defaultSiteAccess->matcher, $siteAccess->matcher );
     }
 }


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24459

Follow-up of #1221.
After investigation, it is actually not necessary to *fix* ContentPreview since the previewed SiteAccess is already correctly handled, as the content preview is rendered through a sub-request. In this regard, SiteAccess match done normally (not limited to master request).