### PR TITLE
Fix EZP-24399: Cross-siteaccess links do not take tree_root into account

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -79,11 +79,13 @@ class UrlAliasGenerator extends Generator
             // We generate for a different SiteAccess, so potentially in a different language.
             $languages = $this->configResolver->getParameter( 'languages', null, $parameters['siteaccess'] );
             $urlAliases = $urlAliasService->listLocationAliases( $location, false, null, null, $languages );
-
+            // Use the target SiteAccess root location
+            $rootLocationId = $this->configResolver->getParameter( 'content.tree_root.location_id', null, $parameters['siteaccess'] );
             unset( $parameters['siteaccess'] );
         }
         else
         {
+            $rootLocationId = $this->rootLocationId;
             $urlAliases = $urlAliasService->listLocationAliases( $location, false );
         }
 
@@ -97,9 +99,9 @@ class UrlAliasGenerator extends Generator
         {
             $path = $urlAliases[0]->path;
             // Remove rootLocation's prefix if needed.
-            if ( $this->rootLocationId !== null )
+            if ( $rootLocationId !== null )
             {
-                $pathPrefix = $this->getPathPrefixByRootLocationId( $this->rootLocationId );
+                $pathPrefix = $this->getPathPrefixByRootLocationId( $rootLocationId );
                 // "/" cannot be considered as a path prefix since it's root, so we ignore it.
                 if ( $pathPrefix !== '/' && mb_stripos( $path, $pathPrefix ) === 0 )
                 {
@@ -109,7 +111,7 @@ class UrlAliasGenerator extends Generator
                 // This is most likely an error (from content edition or link generation logic).
                 else if ( $pathPrefix !== '/' && !$this->isUriPrefixExcluded( $path ) && $this->logger !== null )
                 {
-                    $this->logger->warning( "Generating a link to a location outside root content tree: '$path' is outside tree starting to location #$this->rootLocationId" );
+                    $this->logger->warning( "Generating a link to a location outside root content tree: '$path' is outside tree starting to location #$rootLocationId" );
                 }
             }
         }

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -74,11 +74,10 @@ class UrlAliasGenerator extends Generator
     public function doGenerate( $location, array $parameters )
     {
         $urlAliasService = $this->repository->getURLAliasService();
-        $siteaccess = isset( $parameters['siteaccess'] ) ? $parameters['siteaccess'] : null;
-        if ( $siteaccess )
+        if ( isset( $parameters['siteaccess'] ) )
         {
             // We generate for a different SiteAccess, so potentially in a different language.
-            $languages = $this->configResolver->getParameter( 'languages', null, $siteaccess );
+            $languages = $this->configResolver->getParameter( 'languages', null, $parameters['siteaccess'] );
             $urlAliases = $urlAliasService->listLocationAliases( $location, false, null, null, $languages );
 
             unset( $parameters['siteaccess'] );
@@ -113,13 +112,6 @@ class UrlAliasGenerator extends Generator
                     $this->logger->warning( "Generating a link to a location outside root content tree: '$path' is outside tree starting to location #$this->rootLocationId" );
                 }
             }
-        }
-        // Fallback to root location in language switcher
-        else if ( $siteaccess !== null && $this->rootLocationId !== null && $this->rootLocationId !== $location->id )
-        {
-            $locationService = $this->repository->getLocationService();
-            $location = $locationService->loadLocation( $this->rootLocationId );
-            return $this->doGenerate( $location, array( 'siteaccess' => $siteaccess ) );
         }
         else
         {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24399

When generating cross-siteaccess links, the destination root location should be taken into account (so the path prefix is removed from the url).

Note: 
This does NOT (yet) modify the variables on the "fallback" section as it may be reverted, see https://github.com/ezsystems/ezpublish-kernel/pull/1259

TODO: 
- [x] Add/update tests