### PR TITLE
Update ProxyManager to avoid conflict with Zend Stdlib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "nelmio/cors-bundle": "1.3.*",
         "hautelook/templated-uri-bundle": "~1.0 | ~2.0",
         "pagerfanta/pagerfanta": "~1.0",
-        "ocramius/proxy-manager": "~0.5",
+        "ocramius/proxy-manager": "~1.0",
         "doctrine/doctrine-bundle": "~1.3",
         "liip/imagine-bundle": "~1.0",
         "oneup/flysystem-bundle": "~0.4",
@@ -46,9 +46,6 @@
         "ezsystems/ezpublish": "*",
         "ezsystems/ezpublish-api": "self.version",
         "ezsystems/ezpublish-spi": "self.version"
-    },
-    "conflict": {
-        "zendframework/zend-stdlib": ">=2.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-24484

Proxy manager needs to be updated to 1.0 so we can skip disallowing newer versions of Zend Stdllib that does not have this problem.

Fix for master, 5.3 and 5.4 to avoid the conflict below:
![Conflict with Zend StdLib currently](https://pbs.twimg.com/media/CG9jcFnWcAA9kvl.png:large)