### PR TITLE
Fix EZP-24457: Change Request injection to RequestStack

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/FragmentListenerFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/FragmentListenerFactory.php
@@ -9,7 +9,7 @@
 
 namespace eZ\Bundle\EzPublishCoreBundle\Fragment;
 
-use Symfony\Component\HttpFoundation\Request;
+use eZ\Publish\Core\MVC\Symfony\RequestStackAware;
 use Symfony\Component\HttpKernel\UriSigner;
 
 /**
@@ -18,22 +18,14 @@ use Symfony\Component\HttpKernel\UriSigner;
  */
 class FragmentListenerFactory
 {
-    /**
-     * @var \Symfony\Component\HttpFoundation\Request
-     */
-    private $request;
-
-    public function setRequest( Request $request = null )
-    {
-        $this->request = $request;
-    }
+    use RequestStackAware;
 
     public function buildFragmentListener( UriSigner $uriSigner, $fragmentPath, $fragmentListenerClass )
     {
         // Ensure that current pathinfo ends with configured fragment path.
         // If so, consider it as the fragment path.
         // This ensures to have URI siteaccess compatible fragment paths.
-        $pathInfo = $this->request->getPathInfo();
+        $pathInfo = $this->getCurrentRequest()->getPathInfo();
         if ( substr( $pathInfo, -strlen( $fragmentPath ) ) === $fragmentPath )
         {
             $fragmentPath = $pathInfo;

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -69,7 +69,7 @@ services:
         class: %ezpublish.fieldType.locale.parameterProvider.class%
         arguments: [@ezpublish.locale.converter]
         calls:
-            - [setRequest, [@?request=]]
+            - [setRequestStack, [@request_stack]]
         tags:
             - {name: ezpublish.fieldType.parameterProvider, alias: ezdatetime}
             - {name: ezpublish.fieldType.parameterProvider, alias: ezdate}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
@@ -109,7 +109,7 @@ services:
       class: %ezpublish.route_reference.generator.class%
       arguments: [@event_dispatcher]
       calls:
-        - [setRequest, [@?request=]]
+        - [setRequestStack, [@request_stack]]
 
     ezpublish.route_reference.listener.language_switch:
         class: %ezpublish.route_reference.listener.language_switch.class%

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/security.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/security.yml
@@ -34,8 +34,6 @@ services:
     ezpublish.security.controller:
         class: %ezpublish.security.controller.class%
         arguments: [@templating, @ezpublish.config.resolver, @?form.csrf_provider]
-        calls:
-            - [setRequest, [@?request=]]
 
     ezpublish.security.login_listener:
         class: %ezpublish.security.login_listener.class%

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -72,8 +72,6 @@ services:
             - @ezpublish.content_preview_helper
             - @security.context
             - @ezpublish.content_preview.location_provider
-        calls:
-            - [setRequest, [@?request=]]
 
     ezpublish.controller.content.preview:
         alias: ezpublish.controller.content.preview.core
@@ -122,7 +120,7 @@ services:
         class: %ezpublish.fragment_listener.factory.class%
         arguments: [%fragment.path%]
         calls:
-            - [setRequest, [@?request=]]
+            - [setRequestStack, [@request_stack]]
 
     ezpublish.decorated_fragment_renderer:
         class: %ezpublish.decorated_fragment_renderer.class%

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -98,7 +98,7 @@ services:
         class: %ezpublish.templating.global_helper.core.class%
         arguments: [@ezpublish.config.resolver, @ezpublish.api.service.location, @router, @ezpublish.translation_helper]
         calls:
-            - [setRequest, [@?request=]]
+            - [setRequestStack, [@request_stack]]
 
     ezpublish.templating.global_helper:
         alias: ezpublish.templating.global_helper.core

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/FragmentListenerFactoryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/FragmentListenerFactoryTest.php
@@ -12,6 +12,7 @@ namespace eZ\Bundle\EzPublishCoreBundle\Tests\Fragment;
 use eZ\Bundle\EzPublishCoreBundle\Fragment\FragmentListenerFactory;
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\UriSigner;
 use ReflectionObject;
 
@@ -26,9 +27,11 @@ class FragmentListenerFactoryTest extends PHPUnit_Framework_TestCase
         $uriSigner = new UriSigner( 'my_precious_secret' );
         $baseFragmentPath = '/_fragment';
         $request = Request::create( $requestUri );
+        $requestStack = new RequestStack();
+        $requestStack->push( $request );
 
         $factory = new FragmentListenerFactory();
-        $factory->setRequest( $request );
+        $factory->setRequestStack( $requestStack );
         $listener = $factory->buildFragmentListener( $uriSigner, $baseFragmentPath, $listenerClass );
         $this->assertInstanceOf( $listenerClass, $listener );
 

--- a/eZ/Bundle/EzPublishRestBundle/ApiLoader/Factory.php
+++ b/eZ/Bundle/EzPublishRestBundle/ApiLoader/Factory.php
@@ -2,6 +2,7 @@
 namespace eZ\Bundle\EzPublishRestBundle\ApiLoader;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\RequestStackAware;
 use eZ\Publish\Core\REST\Common\FieldTypeProcessor;
 use eZ\Publish\Core\REST\Common;
 use eZ\Publish\API\Repository\Repository;
@@ -10,6 +11,8 @@ use Symfony\Component\Routing\RouterInterface;
 
 class Factory
 {
+    use RequestStackAware;
+
     /**
      * @var \eZ\Publish\Core\MVC\ConfigResolverInterface
      */
@@ -21,11 +24,6 @@ class Factory
     protected $repository;
 
     /**
-     * @var \Symfony\Component\HttpFoundation\Request
-     */
-    protected $request;
-
-    /**
      * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
      * @param \eZ\Publish\API\Repository\Repository $repository
      */
@@ -35,17 +33,10 @@ class Factory
         $this->repository = $repository;
     }
 
-    /**
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     */
-    public function setRequest( Request $request = null )
-    {
-        $this->request = $request;
-    }
-
     public function getBinaryFileFieldTypeProcessor()
     {
-        $hostPrefix = isset( $this->request ) ? rtrim( $this->request->getUriForPath( '/' ), '/' ) : '';
+        $request = $this->getCurrentRequest();
+        $hostPrefix = isset( $request ) ? rtrim( $request->getUriForPath( '/' ), '/' ) : '';
 
         return new FieldTypeProcessor\BinaryProcessor( sys_get_temp_dir(), $hostPrefix );
     }

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
@@ -118,7 +118,7 @@ services:
         class: %ezpublish_rest.factory.class%
         arguments: [@ezpublish.config.resolver, @ezpublish.api.repository]
         calls:
-            - [setRequest, [@?request=]]
+            - [setRequestStack, [@request_stack]]
 
     ezpublish_rest.controller.base:
         class: %ezpublish_rest.controller.base.class%
@@ -127,7 +127,6 @@ services:
             - [ setInputDispatcher, [@ezpublish_rest.input.dispatcher] ]
             - [ setRouter, [@router] ]
             - [ setRequestParser, [@ezpublish_rest.request_parser] ]
-            - [ setRequest, [@?request=] ]
             - [ setRepository, [@ezpublish.api.repository] ]
 
     ezpublish_rest.controller.root:

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -797,6 +797,6 @@ services:
         arguments:
             - @ezpublish.config.resolver
         calls:
-            - [setRequest, [@?request=]]
+            - [setRequestStack, [@request_stack]]
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Values\CachedValue }

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
@@ -47,11 +47,6 @@ class PreviewController
     private $authorizationChecker;
 
     /**
-     * @var \Symfony\Component\HttpFoundation\Request
-     */
-    private $request;
-
-    /**
      * @var \eZ\Publish\Core\Helper\PreviewLocationProvider
      */
     private $locationProvider;
@@ -71,12 +66,7 @@ class PreviewController
         $this->locationProvider = $locationProvider;
     }
 
-    public function setRequest( Request $request = null )
-    {
-        $this->request = $request;
-    }
-
-    public function previewContentAction( $contentId, $versionNo, $language, $siteAccessName = null )
+    public function previewContentAction( Request $request, $contentId, $versionNo, $language, $siteAccessName = null )
     {
         $this->previewHelper->setPreviewActive( true );
 
@@ -105,7 +95,7 @@ class PreviewController
         }
 
         $response = $this->kernel->handle(
-            $this->getForwardRequest( $location, $content, $siteAccess ),
+            $this->getForwardRequest( $location, $content, $siteAccess, $request ),
             HttpKernelInterface::SUB_REQUEST
         );
         $response->headers->remove( 'cache-control' );
@@ -123,12 +113,13 @@ class PreviewController
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location
      * @param \eZ\Publish\API\Repository\Values\Content\Content $content
      * @param \eZ\Publish\Core\MVC\Symfony\SiteAccess $previewSiteAccess
+     * @param Request $request
      *
      * @return \Symfony\Component\HttpFoundation\Request
      */
-    protected function getForwardRequest( Location $location, Content $content, SiteAccess $previewSiteAccess )
+    protected function getForwardRequest( Location $location, Content $content, SiteAccess $previewSiteAccess, Request $request )
     {
-        return $this->request->duplicate(
+        return $request->duplicate(
             null, null,
             array(
                 '_controller' => 'ez_content:viewLocation',
@@ -146,7 +137,7 @@ class PreviewController
                     'isPreview' => true
                 ),
                 'siteaccess' => $previewSiteAccess,
-                'semanticPathinfo' => $this->request->attributes->get( 'semanticPathinfo' ),
+                'semanticPathinfo' => $request->attributes->get( 'semanticPathinfo' ),
             )
         );
     }

--- a/eZ/Publish/Core/MVC/Symfony/Controller/SecurityController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/SecurityController.php
@@ -33,11 +33,6 @@ class SecurityController
      */
     protected $csrfProvider;
 
-    /**
-     * @var \Symfony\Component\HttpFoundation\Request
-     */
-    protected $request;
-
     public function __construct( EngineInterface $templateEngine, ConfigResolverInterface $configResolver, CsrfProviderInterface $csrfProvider = null )
     {
         $this->templateEngine = $templateEngine;
@@ -45,21 +40,13 @@ class SecurityController
         $this->csrfProvider = $csrfProvider;
     }
 
-    /**
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     */
-    public function setRequest( Request $request = null )
+    public function loginAction( Request $request )
     {
-        $this->request = $request;
-    }
+        $session = $request->getSession();
 
-    public function loginAction()
-    {
-        $session = $this->request->getSession();
-
-        if ( $this->request->attributes->has( Security::AUTHENTICATION_ERROR ) )
+        if ( $request->attributes->has( Security::AUTHENTICATION_ERROR ) )
         {
-            $error = $this->request->attributes->get( Security::AUTHENTICATION_ERROR );
+            $error = $request->attributes->get( Security::AUTHENTICATION_ERROR );
         }
         else
         {

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Tests/Controller/Content/PreviewControllerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Tests/Controller/Content/PreviewControllerTest.php
@@ -94,7 +94,7 @@ class PreviewControllerTest extends PHPUnit_Framework_TestCase
             ->method( 'loadContent' )
             ->with( $contentId, array( $lang ), $versionNo )
             ->will( $this->throwException( new UnauthorizedException( 'foo', 'bar' ) ) );
-        $controller->previewContentAction( $contentId, $versionNo, $lang, 'test' );
+        $controller->previewContentAction( new Request(), $contentId, $versionNo, $lang, 'test' );
     }
 
     /**
@@ -127,7 +127,7 @@ class PreviewControllerTest extends PHPUnit_Framework_TestCase
             ->with( $this->equalTo( new AuthorizationAttribute( 'content', 'versionread', array( 'valueObject' => $content ) ) ) )
             ->will( $this->returnValue( false ) );
 
-        $controller->previewContentAction( $contentId, $versionNo, $lang, 'test' );
+        $controller->previewContentAction( new Request(), $contentId, $versionNo, $lang, 'test' );
     }
 
     public function testPreview()
@@ -213,10 +213,9 @@ class PreviewControllerTest extends PHPUnit_Framework_TestCase
             ->will( $this->returnValue( $expectedResponse ) );
 
         $controller = $this->getPreviewController();
-        $controller->setRequest( $request );
         $this->assertSame(
             $expectedResponse,
-            $controller->previewContentAction( $contentId, $versionNo, $lang, $previewSiteAccessName )
+            $controller->previewContentAction( $request, $contentId, $versionNo, $lang, $previewSiteAccessName )
         );
     }
 
@@ -276,10 +275,9 @@ class PreviewControllerTest extends PHPUnit_Framework_TestCase
             ->will( $this->returnValue( $expectedResponse ) );
 
         $controller = $this->getPreviewController();
-        $controller->setRequest( $request );
         $this->assertSame(
             $expectedResponse,
-            $controller->previewContentAction( $contentId, $versionNo, $lang )
+            $controller->previewContentAction( $request, $contentId, $versionNo, $lang )
         );
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/View/ParameterProvider/LocaleParameterProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/View/ParameterProvider/LocaleParameterProvider.php
@@ -12,6 +12,7 @@ namespace eZ\Publish\Core\MVC\Symfony\FieldType\View\ParameterProvider;
 use eZ\Publish\Core\MVC\Symfony\FieldType\View\ParameterProviderInterface;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\Core\MVC\Symfony\Locale\LocaleConverterInterface;
+use eZ\Publish\Core\MVC\Symfony\RequestStackAware;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -19,10 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class LocaleParameterProvider implements ParameterProviderInterface
 {
-    /**
-     * @var \Symfony\Component\HttpFoundation\Request
-     */
-    protected $request;
+    use RequestStackAware;
 
     /**
      * @var \eZ\Publish\Core\MVC\Symfony\Locale\LocaleConverterInterface
@@ -32,14 +30,6 @@ class LocaleParameterProvider implements ParameterProviderInterface
     public function __construct( LocaleConverterInterface $localeConverter )
     {
         $this->localeConverter = $localeConverter;
-    }
-
-    /**
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     */
-    public function setRequest( Request $request = null )
-    {
-        $this->request = $request;
     }
 
     /**
@@ -56,9 +46,10 @@ class LocaleParameterProvider implements ParameterProviderInterface
     {
         $parameters = array();
 
-        if ( $this->request && $this->request->attributes->has( '_locale' ) )
+        $request = $this->getCurrentRequest();
+        if ( $request && $request->attributes->has( '_locale' ) )
         {
-            $parameters['locale'] = $this->request->attributes->get( '_locale' );
+            $parameters['locale'] = $request->attributes->get( '_locale' );
         }
         else
         {

--- a/eZ/Publish/Core/MVC/Symfony/RequestStackAware.php
+++ b/eZ/Publish/Core/MVC/Symfony/RequestStackAware.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\MVC\Symfony;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Facilitates injection/access to request stack, and thus access to ongoing request
+ * for services that need it.
+ */
+trait RequestStackAware
+{
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @return RequestStack
+     */
+    public function getRequestStack()
+    {
+        return $this->requestStack;
+    }
+
+    /**
+     * @param RequestStack $requestStack
+     */
+    public function setRequestStack( RequestStack $requestStack )
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * @return null|\Symfony\Component\HttpFoundation\Request
+     */
+    protected function getCurrentRequest()
+    {
+        return $this->requestStack->getCurrentRequest();
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/RouteReferenceGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/RouteReferenceGenerator.php
@@ -11,30 +11,23 @@ namespace eZ\Publish\Core\MVC\Symfony\Routing\Generator;
 
 use eZ\Publish\Core\MVC\Symfony\Event\RouteReferenceGenerationEvent;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
+use eZ\Publish\Core\MVC\Symfony\RequestStackAware;
 use eZ\Publish\Core\MVC\Symfony\Routing\RouteReference;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 class RouteReferenceGenerator implements RouteReferenceGeneratorInterface
 {
+    use RequestStackAware;
+
     /**
      * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
      */
     private $dispatcher;
 
-    /**
-     * @var \Symfony\Component\HttpFoundation\Request
-     */
-    private $request;
-
     public function __construct( EventDispatcherInterface $dispatcher )
     {
         $this->dispatcher = $dispatcher;
-    }
-
-    public function setRequest( Request $request = null )
-    {
-        $this->request = $request;
     }
 
     /**
@@ -48,13 +41,14 @@ class RouteReferenceGenerator implements RouteReferenceGeneratorInterface
      */
     public function generate( $resource = null, array $params = array() )
     {
+        $request = $this->getCurrentRequest();
         if ( $resource === null )
         {
-            $resource = $this->request->attributes->get( '_route' );
-            $params += $this->request->attributes->get( '_route_params', array() );
+            $resource = $request->attributes->get( '_route' );
+            $params += $request->attributes->get( '_route_params', array() );
         }
 
-        $event = new RouteReferenceGenerationEvent( new RouteReference( $resource, $params ), $this->request );
+        $event = new RouteReferenceGenerationEvent( new RouteReference( $resource, $params ), $request );
         $this->dispatcher->dispatch( MVCEvents::ROUTE_REFERENCE_GENERATION, $event );
         return $event->getRouteReference();
     }

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/RouteReferenceGeneratorInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/RouteReferenceGeneratorInterface.php
@@ -9,20 +9,11 @@
 
 namespace eZ\Publish\Core\MVC\Symfony\Routing\Generator;
 
-use Symfony\Component\HttpFoundation\Request;
-
 /**
  * Interface for RouteReference generators.
  */
 interface RouteReferenceGeneratorInterface
 {
-    /**
-     * Injects the current request.
-     *
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     */
-    public function setRequest( Request $request = null );
-
     /**
      * Generates a RouteReference, based on the given resource and associated params.
      * If $resource is null, generated route reference will be based on current request's route and parameters.

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/RouteReferenceGeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/RouteReferenceGeneratorTest.php
@@ -16,6 +16,7 @@ use eZ\Publish\Core\MVC\Symfony\Routing\RouteReference;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class RouteReferenceGeneratorTest extends PHPUnit_Framework_TestCase
 {
@@ -38,6 +39,8 @@ class RouteReferenceGeneratorTest extends PHPUnit_Framework_TestCase
         $request = new Request();
         $request->attributes->set( '_route', $currentRouteName );
         $request->attributes->set( '_route_params', $currentRouteParams );
+        $requestStack = new RequestStack();
+        $requestStack->push( $request );
 
         $event = new RouteReferenceGenerationEvent( new RouteReference( $currentRouteName, $currentRouteParams ), $request );
         $this->dispatcher
@@ -46,7 +49,7 @@ class RouteReferenceGeneratorTest extends PHPUnit_Framework_TestCase
             ->with( MVCEvents::ROUTE_REFERENCE_GENERATION, $this->equalTo( $event ) );
 
         $generator = new RouteReferenceGenerator( $this->dispatcher );
-        $generator->setRequest( $request );
+        $generator->setRequestStack( $requestStack );
         $reference = $generator->generate();
         $this->assertInstanceOf( 'eZ\Publish\Core\MVC\Symfony\Routing\RouteReference', $reference );
         $this->assertSame( $currentRouteName, $reference->getRoute() );
@@ -63,6 +66,8 @@ class RouteReferenceGeneratorTest extends PHPUnit_Framework_TestCase
         $request = new Request();
         $request->attributes->set( '_route', $currentRouteName );
         $request->attributes->set( '_route_params', $currentRouteParams );
+        $requestStack = new RequestStack();
+        $requestStack->push( $request );
 
         $event = new RouteReferenceGenerationEvent( new RouteReference( $currentRouteName, $expectedParams ), $request );
         $this->dispatcher
@@ -71,7 +76,7 @@ class RouteReferenceGeneratorTest extends PHPUnit_Framework_TestCase
             ->with( MVCEvents::ROUTE_REFERENCE_GENERATION, $this->equalTo( $event ) );
 
         $generator = new RouteReferenceGenerator( $this->dispatcher );
-        $generator->setRequest( $request );
+        $generator->setRequestStack( $requestStack );
         $reference = $generator->generate( null, $passedParams );
         $this->assertInstanceOf( 'eZ\Publish\Core\MVC\Symfony\Routing\RouteReference', $reference );
         $this->assertSame( $currentRouteName, $reference->getRoute() );
@@ -89,6 +94,8 @@ class RouteReferenceGeneratorTest extends PHPUnit_Framework_TestCase
         $request = new Request();
         $request->attributes->set( '_route', $currentRouteName );
         $request->attributes->set( '_route_params', $currentRouteParams );
+        $requestStack = new RequestStack();
+        $requestStack->push( $request );
 
         $event = new RouteReferenceGenerationEvent( new RouteReference( $resource, $params ), $request );
         $this->dispatcher
@@ -97,7 +104,7 @@ class RouteReferenceGeneratorTest extends PHPUnit_Framework_TestCase
             ->with( MVCEvents::ROUTE_REFERENCE_GENERATION, $this->equalTo( $event ) );
 
         $generator = new RouteReferenceGenerator( $this->dispatcher );
-        $generator->setRequest( $request );
+        $generator->setRequestStack( $requestStack );
         $reference = $generator->generate( $resource, $params );
         $this->assertInstanceOf( 'eZ\Publish\Core\MVC\Symfony\Routing\RouteReference', $reference );
         $this->assertSame( $resource, $reference->getRoute() );
@@ -110,6 +117,8 @@ class RouteReferenceGeneratorTest extends PHPUnit_Framework_TestCase
         $currentRouteParams = array( 'foo' => 'bar' );
 
         $request = new Request();
+        $requestStack = new RequestStack();
+        $requestStack->push( $request );
 
         $event = new RouteReferenceGenerationEvent( new RouteReference( null, array() ), $request );
         $this->dispatcher
@@ -118,7 +127,7 @@ class RouteReferenceGeneratorTest extends PHPUnit_Framework_TestCase
             ->with( MVCEvents::ROUTE_REFERENCE_GENERATION, $this->equalTo( $event ) );
 
         $generator = new RouteReferenceGenerator( $this->dispatcher );
-        $generator->setRequest( $request );
+        $generator->setRequestStack( $requestStack );
         $reference = $generator->generate();
         $this->assertInstanceOf( 'eZ\Publish\Core\MVC\Symfony\Routing\RouteReference', $reference );
     }

--- a/eZ/Publish/Core/MVC/Symfony/Templating/GlobalHelper.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/GlobalHelper.php
@@ -12,6 +12,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Templating;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\Helper\TranslationHelper;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\RequestStackAware;
 use eZ\Publish\Core\MVC\Symfony\Routing\UrlAliasRouter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RouterInterface;
@@ -22,6 +23,8 @@ use Symfony\Component\Routing\RouterInterface;
  */
 class GlobalHelper
 {
+    use RequestStackAware;
+
     /**
      * @var \eZ\Publish\Core\MVC\ConfigResolverInterface
      */
@@ -37,10 +40,6 @@ class GlobalHelper
      */
     protected $router;
 
-    /**
-     * @var \Symfony\Component\HttpFoundation\Request
-     */
-    protected $request;
     /**
      * @var \eZ\Publish\Core\Helper\TranslationHelper
      */
@@ -60,23 +59,16 @@ class GlobalHelper
     }
 
     /**
-     * @param \Symfony\Component\HttpFoundation\Request $request
-     */
-    public function setRequest( Request $request = null )
-    {
-        $this->request = $request;
-    }
-
-    /**
      * Returns the current siteaccess.
      *
      * @return \eZ\Publish\Core\MVC\Symfony\SiteAccess|null
      */
     public function getSiteaccess()
     {
-        if ( $this->request )
+        $request = $this->getCurrentRequest();
+        if ( $request )
         {
-            return $this->request->attributes->get( 'siteaccess' );
+            return $request->attributes->get( 'siteaccess' );
         }
     }
 
@@ -87,9 +79,10 @@ class GlobalHelper
      */
     public function getViewParameters()
     {
-        if ( $this->request )
+        $request = $this->getCurrentRequest();
+        if ( $request )
         {
-            return $this->request->attributes->get( 'viewParameters' );
+            return $request->attributes->get( 'viewParameters' );
         }
     }
 
@@ -101,9 +94,10 @@ class GlobalHelper
      */
     public function getViewParametersString()
     {
-        if ( $this->request )
+        $request = $this->getCurrentRequest();
+        if ( $request )
         {
-            return $this->request->attributes->get( 'viewParametersString' );
+            return $request->attributes->get( 'viewParametersString' );
         }
     }
 
@@ -114,9 +108,10 @@ class GlobalHelper
      */
     public function getRequestedUriString()
     {
-        if ( $this->request )
+        $request = $this->getCurrentRequest();
+        if ( $request )
         {
-            return $this->request->attributes->get( 'semanticPathinfo' );
+            return $request->attributes->get( 'semanticPathinfo' );
         }
     }
 
@@ -131,16 +126,17 @@ class GlobalHelper
      */
     public function getSystemUriString()
     {
-        if ( $this->request )
+        $request = $this->getCurrentRequest();
+        if ( $request )
         {
-            if ( $this->request->attributes->get( '_route' ) === UrlAliasRouter::URL_ALIAS_ROUTE_NAME )
+            if ( $request->attributes->get( '_route' ) === UrlAliasRouter::URL_ALIAS_ROUTE_NAME )
             {
                 return $this->router
                     ->generate(
                         '_ezpublishLocation',
                         array(
-                            'locationId' => $this->request->attributes->get( 'locationId' ),
-                            'viewType' => $this->request->attributes->get( 'viewType' )
+                            'locationId' => $request->attributes->get( 'locationId' ),
+                            'viewType' => $request->attributes->get( 'viewType' )
                         )
                     );
             }

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/GlobalHelperTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/GlobalHelperTest.php
@@ -13,6 +13,7 @@ use eZ\Publish\Core\MVC\Symfony\Templating\GlobalHelper;
 use Symfony\Component\HttpFoundation\Request;
 use eZ\Publish\Core\MVC\Symfony\Routing\UrlAliasRouter;
 use PHPUnit_Framework_TestCase;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class GlobalHelperTest extends PHPUnit_Framework_TestCase
 {
@@ -63,9 +64,11 @@ class GlobalHelperTest extends PHPUnit_Framework_TestCase
     public function testGetSiteaccess()
     {
         $request = new Request();
+        $requestStack = new RequestStack();
+        $requestStack->push( $request );
         $siteAccess = $this->getMock( 'eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess' );
         $request->attributes->set( 'siteaccess', $siteAccess );
-        $this->helper->setRequest( $request );
+        $this->helper->setRequestStack( $requestStack );
 
         $this->assertSame( $siteAccess, $this->helper->getSiteaccess() );
     }
@@ -79,7 +82,9 @@ class GlobalHelperTest extends PHPUnit_Framework_TestCase
             'somethingelse'    => 'héhé-høhø'
         );
         $request->attributes->set( 'viewParameters', $viewParameters );
-        $this->helper->setRequest( $request );
+        $requestStack = new RequestStack();
+        $requestStack->push( $request );
+        $this->helper->setRequestStack( $requestStack );
 
         $this->assertSame( $viewParameters, $this->helper->getViewParameters() );
     }
@@ -89,7 +94,9 @@ class GlobalHelperTest extends PHPUnit_Framework_TestCase
         $request = Request::create( '/foo' );
         $viewParametersString = '/(foo)/bar/(toto)/tata/(somethingelse)/héhé-høhø';
         $request->attributes->set( 'viewParametersString', $viewParametersString );
-        $this->helper->setRequest( $request );
+        $requestStack = new RequestStack();
+        $requestStack->push( $request );
+        $this->helper->setRequestStack( $requestStack );
 
         $this->assertSame( $viewParametersString, $this->helper->getViewParametersString() );
     }
@@ -99,7 +106,9 @@ class GlobalHelperTest extends PHPUnit_Framework_TestCase
         $request = Request::create( '/ezdemo_site/foo/bar' );
         $semanticPathinfo = '/foo/bar';
         $request->attributes->set( 'semanticPathinfo', $semanticPathinfo );
-        $this->helper->setRequest( $request );
+        $requestStack = new RequestStack();
+        $requestStack->push( $request );
+        $this->helper->setRequestStack( $requestStack );
 
         $this->assertSame( $semanticPathinfo, $this->helper->getRequestedUriString() );
     }
@@ -110,7 +119,9 @@ class GlobalHelperTest extends PHPUnit_Framework_TestCase
         $semanticPathinfo = '/foo/bar';
         $request->attributes->set( 'semanticPathinfo', $semanticPathinfo );
         $request->attributes->set( '_route', 'someRouteName' );
-        $this->helper->setRequest( $request );
+        $requestStack = new RequestStack();
+        $requestStack->push( $request );
+        $this->helper->setRequestStack( $requestStack );
         $this->assertSame( $semanticPathinfo, $this->helper->getSystemUriString() );
     }
 
@@ -123,6 +134,8 @@ class GlobalHelperTest extends PHPUnit_Framework_TestCase
         $request->attributes->set( '_route', UrlAliasRouter::URL_ALIAS_ROUTE_NAME );
         $request->attributes->set( 'locationId', $locationId );
         $request->attributes->set( 'viewType', $viewType );
+        $requestStack = new RequestStack();
+        $requestStack->push( $request );
 
         $this->router
             ->expects( $this->once() )
@@ -130,7 +143,7 @@ class GlobalHelperTest extends PHPUnit_Framework_TestCase
             ->with( '_ezpublishLocation', array( 'locationId' => $locationId, 'viewType' => $viewType ) )
             ->will( $this->returnValue( $expectedSystemUriString ) );
 
-        $this->helper->setRequest( $request );
+        $this->helper->setRequestStack( $requestStack );
 
         $this->assertSame( $expectedSystemUriString, $this->helper->getSystemUriString() );
     }

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/RoutingExtensionTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/RoutingExtensionTest.php
@@ -12,6 +12,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests\Twig\Extension;
 use eZ\Publish\Core\MVC\Symfony\Routing\Generator\RouteReferenceGenerator;
 use eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\RoutingExtension;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Twig_Test_IntegrationTestCase;
 
 class RoutingExtensionTest extends Twig_Test_IntegrationTestCase
@@ -33,7 +34,10 @@ class RoutingExtensionTest extends Twig_Test_IntegrationTestCase
         $generator = new RouteReferenceGenerator(
             $this->getMock( 'Symfony\Component\EventDispatcher\EventDispatcherInterface' )
         );
-        $generator->setRequest( new Request() );
+        $request = new Request();
+        $requestStack = new RequestStack();
+        $requestStack->push( $request );
+        $generator->setRequestStack( $requestStack );
 
         return $generator;
     }

--- a/eZ/Publish/Core/REST/Server/Controller.php
+++ b/eZ/Publish/Core/REST/Server/Controller.php
@@ -19,11 +19,6 @@ use eZ\Publish\Core\REST\Common\RequestParser as RequestParser;
 abstract class Controller extends ContainerAware
 {
     /**
-     * @var \Symfony\Component\HttpFoundation\Request
-     */
-    protected $request;
-
-    /**
      * @var \eZ\Publish\Core\REST\Common\Input\Dispatcher
      */
     protected $inputDispatcher;
@@ -55,11 +50,6 @@ abstract class Controller extends ContainerAware
         $this->router = $router;
     }
 
-    public function setRequest( Request $request = null )
-    {
-        $this->request = $request;
-    }
-
     public function setRepository( Repository $repository )
     {
         $this->repository = $repository;
@@ -76,9 +66,9 @@ abstract class Controller extends ContainerAware
      *
      * @return string
      */
-    protected function getMediaType()
+    protected function getMediaType( Request $request )
     {
-        foreach ( $this->request->getAcceptableContentTypes() as $mimeType )
+        foreach ( $request->getAcceptableContentTypes() as $mimeType )
         {
             if ( preg_match( '(^([a-z0-9-/.]+)\+.*$)', strtolower( $mimeType ), $matches ) )
             {

--- a/eZ/Publish/Core/REST/Server/Controller/Content.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Content.php
@@ -22,6 +22,7 @@ use eZ\Publish\API\Repository\Exceptions\ContentValidationException;
 use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 use eZ\Publish\Core\REST\Server\Exceptions\ForbiddenException;
 use eZ\Publish\Core\REST\Server\Exceptions\BadRequestException;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Content controller
@@ -35,15 +36,15 @@ class Content extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\TemporaryRedirect
      */
-    public function redirectContent()
+    public function redirectContent( Request $request )
     {
-        if ( !$this->request->query->has( 'remoteId' ) )
+        if ( !$request->query->has( 'remoteId' ) )
         {
             throw new BadRequestException( "'remoteId' parameter is required." );
         }
 
         $contentInfo = $this->repository->getContentService()->loadContentInfoByRemoteId(
-            $this->request->query->get( 'remoteId' )
+            $request->query->get( 'remoteId' )
         );
 
         return new Values\TemporaryRedirect(
@@ -64,7 +65,7 @@ class Content extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\RestContent
      */
-    public function loadContent( $contentId )
+    public function loadContent( $contentId, Request $request )
     {
         $contentInfo = $this->repository->getContentService()->loadContentInfo( $contentId );
 
@@ -78,12 +79,12 @@ class Content extends RestController
 
         $contentVersion = null;
         $relations = null;
-        if ( $this->getMediaType() === 'application/vnd.ez.api.content' )
+        if ( $this->getMediaType( $request ) === 'application/vnd.ez.api.content' )
         {
             $languages = null;
-            if ( $this->request->query->has( 'languages' ) )
+            if ( $request->query->has( 'languages' ) )
             {
-                $languages = explode( ',', $this->request->query->get( 'languages' ) );
+                $languages = explode( ',', $request->query->get( 'languages' ) );
             }
 
             $contentVersion = $this->repository->getContentService()->loadContent( $contentId, $languages );
@@ -96,7 +97,7 @@ class Content extends RestController
             $contentVersion,
             $contentType,
             $relations,
-            $this->request->getPathInfo()
+            $request->getPathInfo()
         );
 
         if ( $contentInfo->mainLocationId === null )
@@ -116,12 +117,12 @@ class Content extends RestController
      * @param mixed $contentId
      * @return \eZ\Publish\Core\REST\Server\Values\RestContent
      */
-    public function updateContentMetadata( $contentId )
+    public function updateContentMetadata( $contentId, Request $request )
     {
         $updateStruct = $this->inputDispatcher->parse(
             new Message(
-                array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                $this->request->getContent()
+                array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                $request->getContent()
             )
         );
 
@@ -194,12 +195,12 @@ class Content extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\Version
      */
-    public function loadContentInVersion( $contentId, $versionNumber )
+    public function loadContentInVersion( $contentId, $versionNumber, Request $request )
     {
         $languages = null;
-        if ( $this->request->query->has( 'languages' ) )
+        if ( $request->query->has( 'languages' ) )
         {
-            $languages = explode( ',', $this->request->query->get( 'languages' ) );
+            $languages = explode( ',', $request->query->get( 'languages' ) );
         }
 
         $content = $this->repository->getContentService()->loadContent(
@@ -215,7 +216,7 @@ class Content extends RestController
             $content,
             $contentType,
             $this->repository->getContentService()->loadRelations( $content->getVersionInfo() ),
-            $this->request->getPathInfo()
+            $request->getPathInfo()
         );
 
         if ( $content->contentInfo->mainLocationId === null )
@@ -240,12 +241,12 @@ class Content extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\CreatedContent
      */
-    public function createContent()
+    public function createContent( Request $request )
     {
         $contentCreate = $this->inputDispatcher->parse(
             new Message(
-                array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                $this->request->getContent()
+                array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                $request->getContent()
             )
         );
 
@@ -268,7 +269,7 @@ class Content extends RestController
         $contentValue = null;
         $contentType = null;
         $relations = null;
-        if ( $this->getMediaType() === 'application/vnd.ez.api.content' )
+        if ( $this->getMediaType( $request ) === 'application/vnd.ez.api.content' )
         {
             $contentValue = $content;
             $contentType = $this->repository->getContentTypeService()->loadContentType(
@@ -313,9 +314,9 @@ class Content extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\ResourceCreated
      */
-    public function copyContent( $contentId )
+    public function copyContent( $contentId, Request $request )
     {
-        $destination = $this->request->headers->get( 'Destination' );
+        $destination = $request->headers->get( 'Destination' );
 
         $parentLocationParts = explode( '/', $destination );
         $copiedContent = $this->repository->getContentService()->copyContent(
@@ -339,13 +340,13 @@ class Content extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\VersionList
      */
-    public function loadContentVersions( $contentId )
+    public function loadContentVersions( $contentId, Request $request )
     {
         $contentInfo = $this->repository->getContentService()->loadContentInfo( $contentId );
 
         $versionList = new Values\VersionList(
             $this->repository->getContentService()->loadVersions( $contentInfo ),
-            $this->request->getPathInfo()
+            $request->getPathInfo()
         );
 
         if ( $contentInfo->mainLocationId === null )
@@ -461,12 +462,12 @@ class Content extends RestController
      * @throws \eZ\Publish\Core\REST\Server\Exceptions\BadRequestException
      * @return \eZ\Publish\Core\REST\Server\Values\Version
      */
-    public function updateVersion( $contentId, $versionNumber )
+    public function updateVersion( $contentId, $versionNumber, Request $request )
     {
         $contentUpdateStruct = $this->inputDispatcher->parse(
             new Message(
                 array(
-                    'Content-Type' => $this->request->headers->get( 'Content-Type' ),
+                    'Content-Type' => $request->headers->get( 'Content-Type' ),
                     'Url' => $this->router->generate(
                         'ezpublish_rest_updateVersion', array(
                             'contentId' => $contentId,
@@ -474,7 +475,7 @@ class Content extends RestController
                         )
                     )
                 ),
-                $this->request->getContent()
+                $request->getContent()
             )
         );
 
@@ -502,9 +503,9 @@ class Content extends RestController
         }
 
         $languages = null;
-        if ( $this->request->query->has( 'languages' ) )
+        if ( $request->query->has( 'languages' ) )
         {
-            $languages = explode( ',', $this->request->query->get( 'languages' ) );
+            $languages = explode( ',', $request->query->get( 'languages' ) );
         }
 
         // Reload the content to handle languages GET parameter
@@ -521,7 +522,7 @@ class Content extends RestController
             $content,
             $contentType,
             $this->repository->getContentService()->loadRelations( $content->getVersionInfo() ),
-            $this->request->getPathInfo()
+            $request->getPathInfo()
         );
     }
 
@@ -582,10 +583,10 @@ class Content extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\RelationList
      */
-    public function loadVersionRelations( $contentId, $versionNumber )
+    public function loadVersionRelations( $contentId, $versionNumber, Request $request )
     {
-        $offset = $this->request->query->has( 'offset' ) ? (int)$this->request->query->get( 'offset' ) : 0;
-        $limit = $this->request->query->has( 'limit' ) ? (int)$this->request->query->get( 'limit' ) : -1;
+        $offset = $request->query->has( 'offset' ) ? (int)$request->query->get( 'offset' ) : 0;
+        $limit = $request->query->has( 'limit' ) ? (int)$request->query->get( 'limit' ) : -1;
 
         $contentInfo = $this->repository->getContentService()->loadContentInfo( $contentId );
         $relationList = $this->repository->getContentService()->loadRelations(
@@ -602,7 +603,7 @@ class Content extends RestController
             $relationList,
             $contentId,
             $versionNumber,
-            $this->request->getPathInfo()
+            $request->getPathInfo()
         );
 
         if ( $contentInfo->mainLocationId === null )
@@ -626,7 +627,7 @@ class Content extends RestController
      * @throws \eZ\Publish\Core\REST\Common\Exceptions\NotFoundException
      * @return \eZ\Publish\Core\REST\Server\Values\RestRelation
      */
-    public function loadVersionRelation( $contentId, $versionNumber, $relationId )
+    public function loadVersionRelation( $contentId, $versionNumber, $relationId, Request $request )
     {
         $contentInfo = $this->repository->getContentService()->loadContentInfo( $contentId );
         $relationList = $this->repository->getContentService()->loadRelations(
@@ -645,13 +646,13 @@ class Content extends RestController
                 }
 
                 return new Values\CachedValue(
-                    new Values\LocationList( $relation, $this->request->getPathInfo() ),
+                    new Values\LocationList( $relation, $request->getPathInfo() ),
                     array( 'locationId' => $contentInfo->mainLocationId )
                 );
             }
         }
 
-        throw new Exceptions\NotFoundException( "Relation not found: '{$this->request->getPathInfo()}'." );
+        throw new Exceptions\NotFoundException( "Relation not found: '{$request->getPathInfo()}'." );
     }
 
     /**
@@ -665,7 +666,7 @@ class Content extends RestController
      * @throws \eZ\Publish\Core\REST\Common\Exceptions\NotFoundException
      * @return \eZ\Publish\Core\REST\Server\Values\NoContent
      */
-    public function removeRelation( $contentId, $versionNumber, $relationId )
+    public function removeRelation( $contentId, $versionNumber, $relationId, Request $request )
     {
         $versionInfo = $this->repository->getContentService()->loadVersionInfo(
             $this->repository->getContentService()->loadContentInfo( $contentId ),
@@ -692,7 +693,7 @@ class Content extends RestController
             }
         }
 
-        throw new Exceptions\NotFoundException( "Relation not found: '{$this->request->getPathInfo()}'." );
+        throw new Exceptions\NotFoundException( "Relation not found: '{$request->getPathInfo()}'." );
     }
 
     /**
@@ -705,12 +706,12 @@ class Content extends RestController
      * @throws ForbiddenException if a relation to the same content already exists
      * @return \eZ\Publish\Core\REST\Server\Values\CreatedRelation
      */
-    public function createRelation( $contentId, $versionNumber )
+    public function createRelation( $contentId, $versionNumber, Request $request )
     {
         $destinationContentId = $this->inputDispatcher->parse(
             new Message(
-                array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                $this->request->getContent()
+                array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                $request->getContent()
             )
         );
 
@@ -752,12 +753,12 @@ class Content extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\RestExecutedView
      */
-    public function createView()
+    public function createView( Request $request )
     {
         $viewInput = $this->inputDispatcher->parse(
             new Message(
-                array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                $this->request->getContent()
+                array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                $request->getContent()
             )
         );
         return new Values\RestExecutedView(

--- a/eZ/Publish/Core/REST/Server/Controller/ObjectState.php
+++ b/eZ/Publish/Core/REST/Server/Controller/ObjectState.php
@@ -21,6 +21,7 @@ use eZ\Publish\Core\REST\Common\Values\ContentObjectStates;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\REST\Server\Exceptions\ForbiddenException;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * ObjectState controller
@@ -59,15 +60,15 @@ class ObjectState extends RestController
      * @throws \eZ\Publish\Core\REST\Server\Exceptions\ForbiddenException
      * @return \eZ\Publish\Core\REST\Server\Values\CreatedObjectStateGroup
      */
-    public function createObjectStateGroup()
+    public function createObjectStateGroup( Request $request )
     {
         try
         {
             $createdStateGroup = $this->objectStateService->createObjectStateGroup(
                 $this->inputDispatcher->parse(
                     new Message(
-                        array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                        $this->request->getContent()
+                        array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                        $request->getContent()
                     )
                 )
             );
@@ -92,7 +93,7 @@ class ObjectState extends RestController
      * @throws \eZ\Publish\Core\REST\Server\Exceptions\ForbiddenException
      * @return \eZ\Publish\Core\REST\Server\Values\CreatedObjectState
      */
-    public function createObjectState( $objectStateGroupId )
+    public function createObjectState( $objectStateGroupId, Request $request )
     {
         $objectStateGroup = $this->objectStateService->loadObjectStateGroup( $objectStateGroupId );
 
@@ -102,8 +103,8 @@ class ObjectState extends RestController
                 $objectStateGroup,
                 $this->inputDispatcher->parse(
                     new Message(
-                        array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                        $this->request->getContent()
+                        array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                        $request->getContent()
                     )
                 )
             );
@@ -219,12 +220,12 @@ class ObjectState extends RestController
      * @throws \eZ\Publish\Core\REST\Server\Exceptions\ForbiddenException
      * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup
      */
-    public function updateObjectStateGroup( $objectStateGroupId )
+    public function updateObjectStateGroup( $objectStateGroupId, Request $request )
     {
         $updateStruct = $this->inputDispatcher->parse(
             new Message(
-                array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                $this->request->getContent()
+                array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                $request->getContent()
             )
         );
 
@@ -250,12 +251,12 @@ class ObjectState extends RestController
      * @throws \eZ\Publish\Core\REST\Server\Exceptions\ForbiddenException
      * @return \eZ\Publish\Core\REST\Common\Values\RestObjectState
      */
-    public function updateObjectState( $objectStateGroupId, $objectStateId )
+    public function updateObjectState( $objectStateGroupId, $objectStateId, Request $request )
     {
         $updateStruct = $this->inputDispatcher->parse(
             new Message(
-                array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                $this->request->getContent()
+                array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                $request->getContent()
             )
         );
 
@@ -311,12 +312,12 @@ class ObjectState extends RestController
      * @throws \eZ\Publish\Core\REST\Server\Exceptions\ForbiddenException
      * @return \eZ\Publish\Core\REST\Common\Values\ContentObjectStates
      */
-    public function setObjectStatesForContent( $contentId)
+    public function setObjectStatesForContent( $contentId, Request $request )
     {
         $newObjectStates = $this->inputDispatcher->parse(
             new Message(
-                array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                $this->request->getContent()
+                array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                $request->getContent()
             )
         );
 

--- a/eZ/Publish/Core/REST/Server/Controller/Role.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Role.php
@@ -23,6 +23,7 @@ use eZ\Publish\API\Repository\Values\User\RoleCreateStruct;
 use eZ\Publish\API\Repository\Values\User\RoleUpdateStruct;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Role controller
@@ -70,15 +71,15 @@ class Role extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\CreatedRole
      */
-    public function createRole()
+    public function createRole( Request $request )
     {
         return new Values\CreatedRole(
             array(
                 'role' => $this->roleService->createRole(
                     $this->inputDispatcher->parse(
                         new Message(
-                            array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                            $this->request->getContent()
+                            array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                            $request->getContent()
                         )
                     )
                 )
@@ -91,14 +92,14 @@ class Role extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\RoleList
      */
-    public function listRoles()
+    public function listRoles( Request $request )
     {
         $roles = array();
-        if ( $this->request->query->has( 'identifier' ) )
+        if ( $request->query->has( 'identifier' ) )
         {
             try
             {
-                $role = $this->roleService->loadRoleByIdentifier( $this->request->query->get( 'identifier' ) );
+                $role = $this->roleService->loadRoleByIdentifier( $request->query->get( 'identifier' ) );
                 $roles[] = $role;
             }
             catch ( APINotFoundException $e )
@@ -108,8 +109,8 @@ class Role extends RestController
         }
         else
         {
-            $offset = $this->request->query->has( 'offset' ) ? (int)$this->request->query->get( 'offset' ) : 0;
-            $limit = $this->request->query->has( 'limit' ) ? (int)$this->request->query->get( 'limit' ) : -1;
+            $offset = $request->query->has( 'offset' ) ? (int)$request->query->get( 'offset' ) : 0;
+            $limit = $request->query->has( 'limit' ) ? (int)$request->query->get( 'limit' ) : -1;
 
             $roles = array_slice(
                 $this->roleService->loadRoles(),
@@ -118,7 +119,7 @@ class Role extends RestController
             );
         }
 
-        return new Values\RoleList( $roles, $this->request->getPathInfo() );
+        return new Values\RoleList( $roles, $request->getPathInfo() );
     }
 
     /**
@@ -140,12 +141,12 @@ class Role extends RestController
      *
      * @return \eZ\Publish\API\Repository\Values\User\Role
      */
-    public function updateRole( $roleId )
+    public function updateRole( $roleId, Request $request )
     {
         $createStruct = $this->inputDispatcher->parse(
             new Message(
-                array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                $this->request->getContent()
+                array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                $request->getContent()
             )
         );
         return $this->roleService->updateRole(
@@ -177,10 +178,10 @@ class Role extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\PolicyList
      */
-    public function loadPolicies( $roleId )
+    public function loadPolicies( $roleId, Request $request )
     {
         $loadedRole = $this->roleService->loadRole( $roleId  );
-        return new Values\PolicyList( $loadedRole->getPolicies(), $this->request->getPathInfo() );
+        return new Values\PolicyList( $loadedRole->getPolicies(), $request->getPathInfo() );
     }
 
     /**
@@ -211,7 +212,7 @@ class Role extends RestController
      * @throws \eZ\Publish\Core\REST\Common\Exceptions\NotFoundException
      * @return \eZ\Publish\API\Repository\Values\User\Policy
      */
-    public function loadPolicy( $roleId, $policyId )
+    public function loadPolicy( $roleId, $policyId, Request $request )
     {
         $loadedRole = $this->roleService->loadRole( $roleId );
         foreach ( $loadedRole->getPolicies() as $policy )
@@ -220,7 +221,7 @@ class Role extends RestController
                 return $policy;
         }
 
-        throw new Exceptions\NotFoundException( "Policy not found: '{$this->request->getPathInfo()}'." );
+        throw new Exceptions\NotFoundException( "Policy not found: '{$request->getPathInfo()}'." );
     }
 
     /**
@@ -230,12 +231,12 @@ class Role extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\CreatedPolicy
      */
-    public function addPolicy( $roleId )
+    public function addPolicy( $roleId, Request $request )
     {
         $createStruct = $this->inputDispatcher->parse(
             new Message(
-                array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                $this->request->getContent()
+                array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                $request->getContent()
             )
         );
 
@@ -276,12 +277,12 @@ class Role extends RestController
      * @throws \eZ\Publish\Core\REST\Common\Exceptions\NotFoundException
      * @return \eZ\Publish\API\Repository\Values\User\Policy
      */
-    public function updatePolicy( $roleId, $policyId )
+    public function updatePolicy( $roleId, $policyId, Request $request )
     {
         $updateStruct = $this->inputDispatcher->parse(
             new Message(
-                array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                $this->request->getContent()
+                array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                $request->getContent()
             )
         );
 
@@ -304,7 +305,7 @@ class Role extends RestController
             }
         }
 
-        throw new Exceptions\NotFoundException( "Policy not found: '{$this->request->getPathInfo()}'." );
+        throw new Exceptions\NotFoundException( "Policy not found: '{$request->getPathInfo()}'." );
     }
 
     /**
@@ -316,7 +317,7 @@ class Role extends RestController
      * @throws \eZ\Publish\Core\REST\Common\Exceptions\NotFoundException
      * @return \eZ\Publish\Core\REST\Server\Values\NoContent
      */
-    public function deletePolicy( $roleId, $policyId )
+    public function deletePolicy( $roleId, $policyId, Request $request )
     {
         $role = $this->roleService->loadRole( $roleId );
 
@@ -336,7 +337,7 @@ class Role extends RestController
             return new Values\NoContent();
         }
 
-        throw new Exceptions\NotFoundException( "Policy not found: '{$this->request->getPathInfo()}'." );
+        throw new Exceptions\NotFoundException( "Policy not found: '{$request->getPathInfo()}'." );
     }
 
     /**
@@ -346,12 +347,12 @@ class Role extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\RoleAssignmentList
      */
-    public function assignRoleToUser( $userId )
+    public function assignRoleToUser( $userId, Request $request )
     {
         $roleAssignment = $this->inputDispatcher->parse(
             new Message(
-                array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                $this->request->getContent()
+                array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                $request->getContent()
             )
         );
 
@@ -378,12 +379,12 @@ class Role extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\RoleAssignmentList
      */
-    public function assignRoleToUserGroup( $groupPath )
+    public function assignRoleToUserGroup( $groupPath, Request $request )
     {
         $roleAssignment = $this->inputDispatcher->parse(
             new Message(
-                array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                $this->request->getContent()
+                array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                $request->getContent()
             )
         );
 
@@ -488,7 +489,7 @@ class Role extends RestController
      * @throws \eZ\Publish\Core\REST\Common\Exceptions\NotFoundException
      * @return \eZ\Publish\Core\REST\Server\Values\RestUserRoleAssignment
      */
-    public function loadRoleAssignmentForUser( $userId, $roleId )
+    public function loadRoleAssignmentForUser( $userId, $roleId, Request $request )
     {
         $user = $this->userService->loadUser( $userId );
         $roleAssignments = $this->roleService->getRoleAssignmentsForUser( $user );
@@ -501,7 +502,7 @@ class Role extends RestController
             }
         }
 
-        throw new Exceptions\NotFoundException( "Role assignment not found: '{$this->request->getPathInfo()}'." );
+        throw new Exceptions\NotFoundException( "Role assignment not found: '{$request->getPathInfo()}'." );
     }
 
     /**
@@ -513,7 +514,7 @@ class Role extends RestController
      * @throws \eZ\Publish\Core\REST\Common\Exceptions\NotFoundException
      * @return \eZ\Publish\Core\REST\Server\Values\RestUserGroupRoleAssignment
      */
-    public function loadRoleAssignmentForUserGroup( $groupPath, $roleId )
+    public function loadRoleAssignmentForUserGroup( $groupPath, $roleId, Request $request )
     {
         $groupLocationParts = explode( '/', $groupPath );
         $groupLocation = $this->locationService->loadLocation( array_pop( $groupLocationParts ) );
@@ -528,7 +529,7 @@ class Role extends RestController
             }
         }
 
-        throw new Exceptions\NotFoundException( "Role assignment not found: '{$this->request->getPathInfo()}'." );
+        throw new Exceptions\NotFoundException( "Role assignment not found: '{$request->getPathInfo()}'." );
     }
 
     /**
@@ -536,13 +537,13 @@ class Role extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\PolicyList
      */
-    public function listPoliciesForUser()
+    public function listPoliciesForUser( Request $request )
     {
         return new Values\PolicyList(
             $this->roleService->loadPoliciesByUserId(
-                $this->request->query->get( 'userId' )
+                $request->query->get( 'userId' )
             ),
-            $this->request->getPathInfo()
+            $request->getPathInfo()
         );
     }
 

--- a/eZ/Publish/Core/REST/Server/Controller/Section.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Section.php
@@ -20,6 +20,7 @@ use eZ\Publish\Core\REST\Server\Values\NoContent;
 
 use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\REST\Server\Exceptions\ForbiddenException;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Section controller
@@ -48,12 +49,12 @@ class Section extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\SectionList
      */
-    public function listSections()
+    public function listSections( Request $request )
     {
-        if ( $this->request->query->has( 'identifier' ) )
+        if ( $request->query->has( 'identifier' ) )
         {
             $sections = array(
-                $this->loadSectionByIdentifier()
+                $this->loadSectionByIdentifier( $request )
             );
         }
         else
@@ -61,7 +62,7 @@ class Section extends RestController
             $sections = $this->sectionService->loadSections();
         }
 
-        return new Values\SectionList( $sections, $this->request->getPathInfo() );
+        return new Values\SectionList( $sections, $request->getPathInfo() );
     }
 
     /**
@@ -69,11 +70,11 @@ class Section extends RestController
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Section
      */
-    public function loadSectionByIdentifier()
+    public function loadSectionByIdentifier( Request $request )
     {
         return $this->sectionService->loadSectionByIdentifier(
             // GET variable
-            $this->request->query->get( 'identifier' )
+            $request->query->get( 'identifier' )
         );
     }
 
@@ -83,15 +84,15 @@ class Section extends RestController
      * @throws \eZ\Publish\Core\REST\Server\Exceptions\ForbiddenException
      * @return \eZ\Publish\Core\REST\Server\Values\CreatedSection
      */
-    public function createSection()
+    public function createSection( Request $request )
     {
         try
         {
             $createdSection = $this->sectionService->createSection(
                 $this->inputDispatcher->parse(
                     new Message(
-                        array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                        $this->request->getContent()
+                        array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                        $request->getContent()
                     )
                 )
             );
@@ -128,12 +129,12 @@ class Section extends RestController
      * @throws \eZ\Publish\Core\REST\Server\Exceptions\ForbiddenException
      * @return \eZ\Publish\API\Repository\Values\Content\Section
      */
-    public function updateSection( $sectionId )
+    public function updateSection( $sectionId, Request $request )
     {
         $createStruct = $this->inputDispatcher->parse(
             new Message(
-                array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                $this->request->getContent()
+                array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                $request->getContent()
             )
         );
 

--- a/eZ/Publish/Core/REST/Server/Controller/Trash.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Trash.php
@@ -20,6 +20,7 @@ use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\Core\REST\Server\Exceptions\ForbiddenException;
 
 use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Trash controller
@@ -57,10 +58,10 @@ class Trash extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\Trash
      */
-    public function loadTrashItems()
+    public function loadTrashItems( Request $request )
     {
-        $offset = $this->request->query->has( 'offset' ) ? (int)$this->request->query->get( 'offset' ) : 0;
-        $limit = $this->request->query->has( 'limit' ) ? (int)$this->request->query->get( 'limit' ) : -1;
+        $offset = $request->query->has( 'offset' ) ? (int)$request->query->get( 'offset' ) : 0;
+        $limit = $request->query->has( 'limit' ) ? (int)$request->query->get( 'limit' ) : -1;
 
         $query = new Query();
         $query->offset = $offset >= 0 ? $offset : null;
@@ -82,7 +83,7 @@ class Trash extends RestController
 
         return new Values\Trash(
             $trashItems,
-            $this->request->getPathInfo()
+            $request->getPathInfo()
         );
     }
 
@@ -137,12 +138,12 @@ class Trash extends RestController
      * @throws \eZ\Publish\Core\REST\Server\Exceptions\ForbiddenException
      * @return \eZ\Publish\Core\REST\Server\Values\ResourceCreated
      */
-    public function restoreTrashItem( $trashItemId )
+    public function restoreTrashItem( $trashItemId, Request $request )
     {
         $requestDestination = null;
         try
         {
-            $requestDestination = $this->request->headers->get( 'Destination' );
+            $requestDestination = $request->headers->get( 'Destination' );
         }
         catch ( InvalidArgumentException $e )
         {
@@ -150,12 +151,12 @@ class Trash extends RestController
         }
 
         $parentLocation = null;
-        if ( $this->request->headers->has( 'Destination' ) )
+        if ( $request->headers->has( 'Destination' ) )
         {
             $locationPathParts = explode(
                 '/',
                 $this->requestParser->parseHref(
-                    $this->request->headers->get( 'Destination' ), 'locationPath'
+                    $request->headers->get( 'Destination' ), 'locationPath'
                 )
             );
 

--- a/eZ/Publish/Core/REST/Server/Controller/URLAlias.php
+++ b/eZ/Publish/Core/REST/Server/Controller/URLAlias.php
@@ -17,6 +17,7 @@ use eZ\Publish\Core\REST\Server\Controller as RestController;
 
 use eZ\Publish\API\Repository\URLAliasService;
 use eZ\Publish\API\Repository\LocationService;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * URLAlias controller
@@ -81,7 +82,7 @@ class URLAlias extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\URLAliasRefList
      */
-    public function listLocationURLAliases( $locationPath )
+    public function listLocationURLAliases( $locationPath, Request $request )
     {
         $locationPathParts = explode( '/', $locationPath );
 
@@ -89,12 +90,12 @@ class URLAlias extends RestController
             array_pop( $locationPathParts )
         );
 
-        $custom = $this->request->query->has( 'custom' ) && $this->request->query->get( 'custom' ) === 'false' ? false : true;
+        $custom = $request->query->has( 'custom' ) && $request->query->get( 'custom' ) === 'false' ? false : true;
 
         return new Values\CachedValue(
             new Values\URLAliasRefList(
                 $this->urlAliasService->listLocationAliases( $location, $custom ),
-                $this->request->getPathInfo()
+                $request->getPathInfo()
             ),
             array( 'locationId' => $location->id )
         );
@@ -106,12 +107,12 @@ class URLAlias extends RestController
      * @throws \eZ\Publish\Core\REST\Server\Exceptions\ForbiddenException
      * @return \eZ\Publish\Core\REST\Server\Values\CreatedURLAlias
      */
-    public function createURLAlias()
+    public function createURLAlias( Request $request )
     {
         $urlAliasCreate = $this->inputDispatcher->parse(
             new Message(
-                array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                $this->request->getContent()
+                array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                $request->getContent()
             )
         );
 

--- a/eZ/Publish/Core/REST/Server/Controller/URLWildcard.php
+++ b/eZ/Publish/Core/REST/Server/Controller/URLWildcard.php
@@ -16,6 +16,7 @@ use eZ\Publish\Core\REST\Server\Values;
 use eZ\Publish\Core\REST\Server\Controller as RestController;
 
 use eZ\Publish\API\Repository\URLWildcardService;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * URLWildcard controller
@@ -69,12 +70,12 @@ class URLWildcard extends RestController
      * @throws \eZ\Publish\Core\REST\Server\Exceptions\ForbiddenException
      * @return \eZ\Publish\Core\REST\Server\Values\CreatedURLWildcard
      */
-    public function createURLWildcard()
+    public function createURLWildcard( Request $request )
     {
         $urlWildcardCreate = $this->inputDispatcher->parse(
             new Message(
-                array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                $this->request->getContent()
+                array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                $request->getContent()
             )
         );
 

--- a/eZ/Publish/Core/REST/Server/Controller/User.php
+++ b/eZ/Publish/Core/REST/Server/Controller/User.php
@@ -33,6 +33,7 @@ use eZ\Publish\Core\REST\Server\Exceptions\ForbiddenException;
 use eZ\Publish\Core\REST\Common\Exceptions\NotFoundException;
 use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
@@ -205,7 +206,7 @@ class User extends RestController
      * @throws \eZ\Publish\Core\REST\Server\Exceptions\BadRequestException
      * @return \eZ\Publish\Core\REST\Server\Values\CreatedUserGroup
      */
-    public function createUserGroup( $groupPath )
+    public function createUserGroup( $groupPath, Request $request )
     {
         $userGroupLocation = $this->locationService->loadLocation(
             $this->extractLocationIdFromPath( $groupPath )
@@ -214,8 +215,8 @@ class User extends RestController
         $createdUserGroup = $this->userService->createUserGroup(
             $this->inputDispatcher->parse(
                 new Message(
-                    array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                    $this->request->getContent()
+                    array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                    $request->getContent()
                 )
             ),
             $this->userService->loadUserGroup(
@@ -248,7 +249,7 @@ class User extends RestController
      * @throws \eZ\Publish\Core\REST\Server\Exceptions\ForbiddenException
      * @return \eZ\Publish\Core\REST\Server\Values\CreatedUser
      */
-    public function createUser( $groupPath )
+    public function createUser( $groupPath, Request $request )
     {
         $userGroupLocation = $this->locationService->loadLocation(
             $this->extractLocationIdFromPath( $groupPath )
@@ -257,8 +258,8 @@ class User extends RestController
 
         $userCreateStruct = $this->inputDispatcher->parse(
             new Message(
-                array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                $this->request->getContent()
+                array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                $request->getContent()
             )
         );
 
@@ -295,7 +296,7 @@ class User extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\RestUserGroup
      */
-    public function updateUserGroup( $groupPath )
+    public function updateUserGroup( $groupPath, Request $request )
     {
         $userGroupLocation = $this->locationService->loadLocation(
             $this->extractLocationIdFromPath( $groupPath )
@@ -308,11 +309,11 @@ class User extends RestController
         $updateStruct = $this->inputDispatcher->parse(
             new Message(
                 array(
-                    'Content-Type' => $this->request->headers->get( 'Content-Type' ),
+                    'Content-Type' => $request->headers->get( 'Content-Type' ),
                     // @todo Needs refactoring! Temporary solution so parser has access to URL
-                    'Url' => $this->request->getPathInfo()
+                    'Url' => $request->getPathInfo()
                 ),
-                $this->request->getContent()
+                $request->getContent()
             )
         );
 
@@ -346,18 +347,18 @@ class User extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\RestUser
      */
-    public function updateUser( $userId )
+    public function updateUser( $userId, Request $request )
     {
         $user = $this->userService->loadUser( $userId );
 
         $updateStruct = $this->inputDispatcher->parse(
             new Message(
                 array(
-                    'Content-Type' => $this->request->headers->get( 'Content-Type' ),
+                    'Content-Type' => $request->headers->get( 'Content-Type' ),
                     // @todo Needs refactoring! Temporary solution so parser has access to URL
-                    'Url' => $this->request->getPathInfo()
+                    'Url' => $request->getPathInfo()
                 ),
-                $this->request->getContent()
+                $request->getContent()
             )
         );
 
@@ -441,26 +442,26 @@ class User extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\UserList|\eZ\Publish\Core\REST\Server\Values\UserRefList
      */
-    public function loadUsers()
+    public function loadUsers( Request $request )
     {
         $restUsers = array();
-        if ( $this->request->query->has( 'roleId' ) )
+        if ( $request->query->has( 'roleId' ) )
         {
-             $restUsers = $this->loadUsersAssignedToRole();
+             $restUsers = $this->loadUsersAssignedToRole( $request );
         }
-        else if ( $this->request->query->has( 'remoteId' ) )
+        else if ( $request->query->has( 'remoteId' ) )
         {
             $restUsers = array(
-                $this->loadUserByRemoteId()
+                $this->loadUserByRemoteId( $request )
             );
         }
 
-        if ( $this->getMediaType() === 'application/vnd.ez.api.userlist' )
+        if ( $this->getMediaType( $request ) === 'application/vnd.ez.api.userlist' )
         {
-            return new Values\UserList( $restUsers, $this->request->getPathInfo() );
+            return new Values\UserList( $restUsers, $request->getPathInfo() );
         }
 
-        return new Values\UserRefList( $restUsers, $this->request->getPathInfo() );
+        return new Values\UserRefList( $restUsers, $request->getPathInfo() );
     }
 
     /**
@@ -468,10 +469,10 @@ class User extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\RestUser[]
      */
-    public function loadUsersAssignedToRole()
+    public function loadUsersAssignedToRole( Request $request )
     {
         $role = $this->roleService->loadRole(
-            $this->requestParser->parseHref( $this->request->query->get( 'roleId' ), 'roleId' )
+            $this->requestParser->parseHref( $request->query->get( 'roleId' ), 'roleId' )
         );
         $roleAssignments = $this->roleService->getRoleAssignments( $role );
 
@@ -504,9 +505,9 @@ class User extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\RestUser
      */
-    public function loadUserByRemoteId()
+    public function loadUserByRemoteId( Request $request )
     {
-        $contentInfo = $this->contentService->loadContentInfoByRemoteId( $this->request->query->get( 'remoteId' ) );
+        $contentInfo = $this->contentService->loadContentInfoByRemoteId( $request->query->get( 'remoteId' ) );
         $user = $this->userService->loadUser( $contentInfo->id );
         $userLocation = $this->locationService->loadLocation( $contentInfo->mainLocationId );
         $contentType = $this->contentTypeService->loadContentType( $contentInfo->contentTypeId );
@@ -525,12 +526,12 @@ class User extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\UserGroupList|\eZ\Publish\Core\REST\Server\Values\UserGroupRefList
      */
-    public function loadUserGroups()
+    public function loadUserGroups( Request $request )
     {
         $restUserGroups = array();
-        if ( $this->request->query->has( 'id' ) )
+        if ( $request->query->has( 'id' ) )
         {
-            $userGroup = $this->userService->loadUserGroup( $this->request->query->get( 'id' ) );
+            $userGroup = $this->userService->loadUserGroup( $request->query->get( 'id' ) );
             $userGroupContentInfo = $userGroup->getVersionInfo()->getContentInfo();
             $userGroupMainLocation = $this->locationService->loadLocation( $userGroupContentInfo->mainLocationId );
             $contentType = $this->contentTypeService->loadContentType( $userGroupContentInfo->contentTypeId );
@@ -545,23 +546,23 @@ class User extends RestController
                 )
             );
         }
-        else if ( $this->request->query->has( 'roleId' ) )
+        else if ( $request->query->has( 'roleId' ) )
         {
-             $restUserGroups = $this->loadUserGroupsAssignedToRole();
+             $restUserGroups = $this->loadUserGroupsAssignedToRole( $request );
         }
-        else if ( $this->request->query->has( 'remoteId' ) )
+        else if ( $request->query->has( 'remoteId' ) )
         {
             $restUserGroups = array(
-                $this->loadUserGroupByRemoteId()
+                $this->loadUserGroupByRemoteId( $request )
             );
         }
 
-        if ( $this->getMediaType() === 'application/vnd.ez.api.usergrouplist' )
+        if ( $this->getMediaType( $request ) === 'application/vnd.ez.api.usergrouplist' )
         {
-            return new Values\UserGroupList( $restUserGroups, $this->request->getPathInfo() );
+            return new Values\UserGroupList( $restUserGroups, $request->getPathInfo() );
         }
 
-        return new Values\UserGroupRefList( $restUserGroups, $this->request->getPathInfo() );
+        return new Values\UserGroupRefList( $restUserGroups, $request->getPathInfo() );
     }
 
     /**
@@ -569,9 +570,9 @@ class User extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\RestUserGroup
      */
-    public function loadUserGroupByRemoteId()
+    public function loadUserGroupByRemoteId( Request $request )
     {
-        $contentInfo = $this->contentService->loadContentInfoByRemoteId( $this->request->query->get( 'remoteId' ) );
+        $contentInfo = $this->contentService->loadContentInfoByRemoteId( $request->query->get( 'remoteId' ) );
         $userGroup = $this->userService->loadUserGroup( $contentInfo->id );
         $userGroupLocation = $this->locationService->loadLocation( $contentInfo->mainLocationId );
         $contentType = $this->contentTypeService->loadContentType( $contentInfo->contentTypeId );
@@ -590,10 +591,10 @@ class User extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\RestUserGroup[]
      */
-    public function loadUserGroupsAssignedToRole()
+    public function loadUserGroupsAssignedToRole( Request $request )
     {
         $role = $this->roleService->loadRole(
-            $this->requestParser->parseHref( $this->request->query->get( 'roleId' ), 'roleId' )
+            $this->requestParser->parseHref( $request->query->get( 'roleId' ), 'roleId' )
         );
         $roleAssignments = $this->roleService->getRoleAssignments( $role );
 
@@ -628,13 +629,13 @@ class User extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\VersionList
      */
-    public function loadUserDrafts( $userId )
+    public function loadUserDrafts( $userId, Request $request )
     {
         $contentDrafts = $this->contentService->loadContentDrafts(
             $this->userService->loadUser( $userId )
         );
 
-        return new Values\VersionList( $contentDrafts, $this->request->getPathInfo() );
+        return new Values\VersionList( $contentDrafts, $request->getPathInfo() );
     }
 
     /**
@@ -645,7 +646,7 @@ class User extends RestController
      * @throws \eZ\Publish\Core\REST\Server\Exceptions\ForbiddenException
      * @return \eZ\Publish\Core\REST\Server\Values\ResourceCreated
      */
-    public function moveUserGroup( $groupPath )
+    public function moveUserGroup( $groupPath, Request $request )
     {
         $userGroupLocation = $this->locationService->loadLocation(
             $this->extractLocationIdFromPath( $groupPath )
@@ -656,7 +657,7 @@ class User extends RestController
         );
 
         $locationPath = $this->requestParser->parseHref(
-            $this->request->headers->get( 'Destination' ),
+            $request->headers->get( 'Destination' ),
             'groupPath'
         );
 
@@ -699,10 +700,10 @@ class User extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\UserGroupList|\eZ\Publish\Core\REST\Server\Values\UserGroupRefList
      */
-    public function loadSubUserGroups( $groupPath )
+    public function loadSubUserGroups( $groupPath, Request $request )
     {
-        $offset = $this->request->query->has( 'offset' ) ? (int)$this->request->query->get( 'offset' ) : 0;
-        $limit = $this->request->query->has( 'limit' ) ? (int)$this->request->query->get( 'limit' ) : 10;
+        $offset = $request->query->has( 'offset' ) ? (int)$request->query->get( 'offset' ) : 0;
+        $limit = $request->query->has( 'limit' ) ? (int)$request->query->get( 'limit' ) : 10;
 
         $userGroupLocation = $this->locationService->loadLocation(
             $this->extractLocationIdFromPath( $groupPath )
@@ -734,16 +735,16 @@ class User extends RestController
             );
         }
 
-        if ( $this->getMediaType() === 'application/vnd.ez.api.usergrouplist' )
+        if ( $this->getMediaType( $request ) === 'application/vnd.ez.api.usergrouplist' )
         {
             return new Values\CachedValue(
-                new Values\UserGroupList( $restUserGroups, $this->request->getPathInfo() ),
+                new Values\UserGroupList( $restUserGroups, $request->getPathInfo() ),
                 array( 'locationId' => $userGroupLocation->id )
             );
         }
 
         return new Values\CachedValue(
-            new Values\UserGroupRefList( $restUserGroups, $this->request->getPathInfo() ),
+            new Values\UserGroupRefList( $restUserGroups, $request->getPathInfo() ),
             array( 'locationId' => $userGroupLocation->id )
         );
     }
@@ -757,10 +758,10 @@ class User extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\UserGroupRefList
      */
-    public function loadUserGroupsOfUser( $userId )
+    public function loadUserGroupsOfUser( $userId, Request $request )
     {
-        $offset = $this->request->query->has( 'offset' ) ? (int)$this->request->query->get( 'offset' ) : 0;
-        $limit = $this->request->query->has( 'limit' ) ? (int)$this->request->query->get( 'limit' ) : 10;
+        $offset = $request->query->has( 'offset' ) ? (int)$request->query->get( 'offset' ) : 0;
+        $limit = $request->query->has( 'limit' ) ? (int)$request->query->get( 'limit' ) : 10;
 
         $user = $this->userService->loadUser( $userId );
         $userGroups = $this->userService->loadUserGroupsOfUser(
@@ -786,7 +787,7 @@ class User extends RestController
         }
 
         return new Values\CachedValue(
-            new Values\UserGroupRefList( $restUserGroups, $this->request->getPathInfo(), $userId ),
+            new Values\UserGroupRefList( $restUserGroups, $request->getPathInfo(), $userId ),
             array( 'locationId' => $user->contentInfo->mainLocationId )
         );
 
@@ -799,7 +800,7 @@ class User extends RestController
      *
      * @return \eZ\Publish\Core\REST\Server\Values\UserList|\eZ\Publish\Core\REST\Server\Values\UserRefList
      */
-    public function loadUsersFromGroup( $groupPath )
+    public function loadUsersFromGroup( $groupPath, Request $request )
     {
         $userGroupLocation = $this->locationService->loadLocation(
             $this->extractLocationIdFromPath( $groupPath )
@@ -809,8 +810,8 @@ class User extends RestController
             $userGroupLocation->contentId
         );
 
-        $offset = $this->request->query->has( 'offset' ) ? (int)$this->request->query->get( 'offset' ) : 0;
-        $limit = $this->request->query->has( 'limit' ) ? (int)$this->request->query->get( 'limit' ) : 10;
+        $offset = $request->query->has( 'offset' ) ? (int)$request->query->get( 'offset' ) : 0;
+        $limit = $request->query->has( 'limit' ) ? (int)$request->query->get( 'limit' ) : 10;
 
         $users = $this->userService->loadUsersOfUserGroup(
             $userGroup,
@@ -834,16 +835,16 @@ class User extends RestController
             );
         }
 
-        if ( $this->getMediaType() === 'application/vnd.ez.api.userlist' )
+        if ( $this->getMediaType( $request ) === 'application/vnd.ez.api.userlist' )
         {
             return new Values\CachedValue(
-                new Values\UserList( $restUsers, $this->request->getPathInfo() ),
+                new Values\UserList( $restUsers, $request->getPathInfo() ),
                 array( 'locationId' => $userGroupLocation->id )
             );
         }
 
         return new Values\CachedValue(
-            new Values\UserRefList( $restUsers, $this->request->getPathInfo() ),
+            new Values\UserRefList( $restUsers, $request->getPathInfo() ),
             array( 'locationId' => $userGroupLocation->id )
         );
     }
@@ -911,14 +912,14 @@ class User extends RestController
      * @throws \eZ\Publish\Core\REST\Server\Exceptions\ForbiddenException
      * @return \eZ\Publish\Core\REST\Server\Values\UserGroupRefList
      */
-    public function assignUserToUserGroup( $userId )
+    public function assignUserToUserGroup( $userId, Request $request )
     {
         $user = $this->userService->loadUser( $userId );
 
         try
         {
             $userGroupLocation = $this->locationService->loadLocation(
-                $this->extractLocationIdFromPath( $this->request->query->get( 'group' ) )
+                $this->extractLocationIdFromPath( $request->query->get( 'group' ) )
             );
         }
         catch ( APINotFoundException $e )
@@ -979,28 +980,28 @@ class User extends RestController
      * @throws \eZ\Publish\Core\Base\Exceptions\UnauthorizedException If the login or password are incorrect or invalid CSRF
      * @return Values\UserSession|Values\Conflict
      */
-    public function createSession()
+    public function createSession( Request $request )
     {
         /** @var $sessionInput \eZ\Publish\Core\REST\Server\Values\SessionInput */
         $sessionInput = $this->inputDispatcher->parse(
             new Message(
-                array( 'Content-Type' => $this->request->headers->get( 'Content-Type' ) ),
-                $this->request->getContent()
+                array( 'Content-Type' => $request->headers->get( 'Content-Type' ) ),
+                $request->getContent()
             )
         );
-        $this->request->attributes->set( 'username', $sessionInput->login );
-        $this->request->attributes->set( 'password', $sessionInput->password );
+        $request->attributes->set( 'username', $sessionInput->login );
+        $request->attributes->set( 'password', $sessionInput->password );
 
         try
         {
             $csrfToken = '';
             $csrfProvider = $this->container->get( 'form.csrf_provider', ContainerInterface::NULL_ON_INVALID_REFERENCE );
-            $session = $this->request->getSession();
+            $session = $request->getSession();
             if ( $session->isStarted() )
             {
                 if ( $csrfProvider )
                 {
-                    $csrfToken = $this->request->headers->get( 'X-CSRF-Token' );
+                    $csrfToken = $request->headers->get( 'X-CSRF-Token' );
                     if (
                         !$csrfProvider->isCsrfTokenValid(
                             $this->container->getParameter( 'ezpublish_rest.csrf_token_intention' ),
@@ -1014,7 +1015,7 @@ class User extends RestController
             }
 
             $authenticator = $this->container->get( 'ezpublish_rest.session_authenticator' );
-            $token = $authenticator->authenticate( $this->request );
+            $token = $authenticator->authenticate( $request );
             // If CSRF token has not been generated yet (i.e. session not started), we generate it now.
             // This will seamlessly start the session.
             if ( !$csrfToken )
@@ -1040,11 +1041,11 @@ class User extends RestController
         }
         catch ( AuthenticationException $e )
         {
-            throw new UnauthorizedException( "Invalid login or password", $this->request->getPathInfo() );
+            throw new UnauthorizedException( "Invalid login or password", $request->getPathInfo() );
         }
         catch ( AccessDeniedException $e )
         {
-            throw new UnauthorizedException( $e->getMessage(), $this->request->getPathInfo() );
+            throw new UnauthorizedException( $e->getMessage(), $request->getPathInfo() );
         }
     }
 
@@ -1056,11 +1057,11 @@ class User extends RestController
      * @throws \eZ\Publish\Core\REST\Common\Exceptions\NotFoundException
      * @return \eZ\Publish\Core\REST\Server\Values\UserSession
      */
-    public function refreshSession( $sessionId )
+    public function refreshSession( $sessionId, Request $request )
     {
         /** @var $session \Symfony\Component\HttpFoundation\Session\Session */
-        $session = $this->request->getSession();
-        $inputCsrf = $this->request->headers->get( 'X-CSRF-Token' );
+        $session = $request->getSession();
+        $inputCsrf = $request->headers->get( 'X-CSRF-Token' );
         if ( $session === null || !$session->isStarted() || $session->getId() != $sessionId )
         {
             throw new RestNotFoundException( "Session not valid" );
@@ -1082,7 +1083,7 @@ class User extends RestController
      * @return \eZ\Publish\Core\REST\Server\Values\NoContent
      * @throws RestNotFoundException
      */
-    public function deleteSession( $sessionId )
+    public function deleteSession( $sessionId, Request $request )
     {
         /** @var $session \Symfony\Component\HttpFoundation\Session\Session */
         $session = $this->container->get( 'session' );
@@ -1092,7 +1093,7 @@ class User extends RestController
         }
 
         return new Values\DeletedUserSession(
-            $this->container->get( 'ezpublish_rest.session_authenticator' )->logout( $this->request )
+            $this->container->get( 'ezpublish_rest.session_authenticator' )->logout( $request )
         );
     }
 

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/CachedValue.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/CachedValue.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\RequestStackAware;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
@@ -20,19 +21,14 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class CachedValue extends ValueObjectVisitor
 {
+    use RequestStackAware;
+
     /** @var ConfigResolverInterface */
     protected $configResolver;
-
-    protected $request;
 
     public function __construct( ConfigResolverInterface $configResolver )
     {
         $this->configResolver = $configResolver;
-    }
-
-    public function setRequest( Request $request = null )
-    {
-        return $this->request = $request;
     }
 
     /**
@@ -56,7 +52,8 @@ class CachedValue extends ValueObjectVisitor
         if ( $this->getParameter( 'content.ttl_cache' ) === true )
         {
             $response->setSharedMaxAge( $this->getParameter( 'content.default_ttl' ) );
-            if ( isset( $this->request ) && $this->request->headers->has( 'X-User-Hash' ) )
+            $request = $this->getCurrentRequest();
+            if ( isset( $request ) && $request->headers->has( 'X-User-Hash' ) )
             {
                 $response->setVary( 'X-User-Hash', false );
             }

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/CachedValueTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/CachedValueTest.php
@@ -18,6 +18,7 @@ use eZ\Publish\Core\REST\Server\Values\CachedValue;
 use PHPUnit_Framework_MockObject_MockObject;
 use stdClass;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class CachedValueTest extends ValueObjectVisitorBaseTest
 {
@@ -150,7 +151,12 @@ class CachedValueTest extends ValueObjectVisitorBaseTest
         $visitor = new ValueObjectVisitor\CachedValue(
             $this->getConfigProviderMock()
         );
-        $visitor->setRequest( $this->request );
+        $requestStack = new RequestStack();
+        if ( $this->request )
+        {
+            $requestStack->push( $this->request );
+        }
+        $visitor->setRequestStack( $requestStack );
         return $visitor;
     }
 


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24457

Request injection has been deprecated as of Symfony 2.4 and will be removed in 3.0.
Instead we must use RequestStack, which contains all ongoing requests (including sub-requests).

This PR fixes all `@request` injection.
It also introduces a trait, `RequestStackAware`, to ease access to the current request.
For controllers, signatures have been changed to add the request as an argument to actions, [as described in Symfony documentation](http://symfony.com/doc/current/book/controller.html#book-controller-request-argument).