### PR TITLE
Fix EZP-24444: Implement FieldDefinition form mapper for ezpage

### DIFF
--- a/eZ/Publish/Core/FieldType/Page/Type.php
+++ b/eZ/Publish/Core/FieldType/Page/Type.php
@@ -77,7 +77,7 @@ class Type extends FieldType
                 switch ( $name )
                 {
                     case 'defaultLayout':
-                        if ( !in_array( $value, $this->pageService->getAvailableZoneLayouts() ) )
+                        if ( $value !== "" && !in_array( $value, $this->pageService->getAvailableZoneLayouts() ) )
                         {
                             $validationErrors[] = new ValidationError(
                                 "Layout '{$value}' for setting '%setting%' is not available",


### PR DESCRIPTION
Need to allow empty value, when the field type is first added to the content type.

Required for FieldDefinition form mapper for ezpage: https://github.com/ezsystems/repository-forms/pull/23

https://jira.ez.no/browse/EZP-24444