### PR TITLE
Fix EZP-24442: Implement FieldDefinition form mapper for ezimage

### DIFF
--- a/eZ/Publish/Core/FieldType/Image/Type.php
+++ b/eZ/Publish/Core/FieldType/Image/Type.php
@@ -29,7 +29,7 @@ class Type extends FieldType
         "FileSizeValidator" => array(
             'maxFileSize' => array(
                 'type' => 'int',
-                'default' => false,
+                'default' => null,
             )
         )
     );
@@ -223,7 +223,7 @@ class Type extends FieldType
             switch ( $validatorIdentifier )
             {
                 case 'FileSizeValidator':
-                    if ( !isset( $parameters['maxFileSize'] ) )
+                    if ( !array_key_exists( 'maxFileSize', $parameters ) )
                     {
                         $validationErrors[] = new ValidationError(
                             "Validator %validator% expects parameter %parameter% to be set.",
@@ -236,7 +236,7 @@ class Type extends FieldType
                         );
                         break;
                     }
-                    if ( !is_int( $parameters['maxFileSize'] ) && $parameters['maxFileSize'] !== false )
+                    if ( !is_int( $parameters['maxFileSize'] ) && $parameters['maxFileSize'] !== null )
                     {
                         $validationErrors[] = new ValidationError(
                             "Validator %validator% expects parameter %parameter% to be of %type%.",

--- a/eZ/Publish/Core/FieldType/Tests/ImageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageTest.php
@@ -72,7 +72,7 @@ class ImageTest extends FieldTypeTest
             "FileSizeValidator" => array(
                 'maxFileSize' => array(
                     'type' => 'int',
-                    'default' => false,
+                    'default' => null,
                 )
             )
         );

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
@@ -250,7 +250,7 @@ EOT;
                     'FileSizeValidator' => array(
                         'maxFileSize' => ( $storageDef->dataInt1 != 0
                             ? (int)$storageDef->dataInt1 * 1024 * 1024
-                            : false ),
+                            : null ),
                     )
                 )
             )


### PR DESCRIPTION
Flipped byte/megabyte conversion in the converter, this seems to have been backwards originally.
Edit: I reverted this flip. It's not backwards, it's just that ezimage is meant to have the max file size in bytes, not MB.

What remains of the fix is to use `null` rather than `false`, same as for binaryfile and media.

Requirement for ezimage form mapper: https://github.com/ezsystems/repository-forms/pull/24

https://jira.ez.no/browse/EZP-24442