### PR TITLE
Added 6.0.x alias to dev-master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,9 @@
         "process-timeout": 3000
     },
     "extra": {
+        "branch-alias": {
+            "dev-master": "6.0.x-dev"
+        },
         "ezpublish-legacy-dir": "vendor/ezsystems/ezpublish-legacy"
     }
 }


### PR DESCRIPTION
This change will allow to use `~6.0@dev` as dependency instead of hardcoding `dev-master`.
The same needs to be done in other packages (e.g. repository-forms, demobundle...)

Ping @andrerom @bdunogier @pspanja @glye 