### PR TITLE
EZP-24468: Changed content/download route to use fieldId

### DIFF
--- a/doc/specifications/proposed/content_download/content_download.md
+++ b/doc/specifications/proposed/content_download/content_download.md
@@ -14,9 +14,9 @@ It includes:
 
 ### Route
 
-Path: `/content/download/{contentId}/{fieldIdentifier}/{filename}`
+Path: `/content/download/{contentId}/{fieldId}/{filename}`
 
-Example: `/content/download/68/file/My-file.pdf`
+Example: `/content/download/68/64567/My-file.pdf`
 
 #### Arguments
 
@@ -24,13 +24,13 @@ Example: `/content/download/68/file/My-file.pdf`
 
   ID of the Content the field is part of
 
-- fieldIdentifier
+- fieldId
 
-  Field Definition identifier of the Binary / Media Field.
+  Field ID of the Binary / Media Field.
 
 - filename
 
-  Name of the file to send for download. Can be any valid file name.
+  Name of the file to send for download. Can be any valid file name, but defaults to the Field's value.
 
 #### Query parameters
 
@@ -41,10 +41,12 @@ Example: `/content/download/68/file/My-file.pdf`
 
 - language (optional)
 
+  > Should we keep this, given that the fileId binds to a particular language ?
+
   The language the file must be downloaded for.
   If not specified, the prioritized languages list of the matched siteaccess is used.
 
-The controller action will load the content based on the content id, and identify the field using the identifier. The
+The controller action will load the content based on the content and field id. The
 binary file referenced by the Field Value will then be streamed, using the active IO Service.
 
 It *should* also support HTTP caching, by making sure the proper headers are sent.
@@ -63,16 +65,16 @@ The [Route Reference](https://doc.ez.no/display/EZP/RouteReference) mechanism wi
 
 ##### Arguments
 
-The arguments are the same than the `ez_content_download` route.
-
-The only difference is that instead of providing the `contentId`, the route reference expects a `content`, as an API
-Content Value Object.
+The arguments are the `Content` and the Field Definition Identifier.
 
 #### REST
 An extra attribute will be added to Fields of BinaryFile/Media type: `downloadUri`. It will contain the download uri for
 the Field's contents.
 
 ## Backward compatibility
+
+> Not implemented yet
+
 Since it is common practice to copy/save file download links, it is possible that a legacy link will be used on occasions.
 This can be covered by adding a route that matches the legacy route, and redirects to the new route:
 
@@ -85,13 +87,3 @@ would be redirected to
 ```
 /content/download/123/file_field/bc.pdf?version=6
 ```
-
-
-## Options
-
-### IgorwFileServeBundle
-
-> https://github.com/igorw/IgorwFileServeBundle
-
-A package meant to replace the BinaryResponse we currently use. Supports server-side mechanism such as X-SendFile, but
-seems to be stalled a bit.

--- a/doc/specifications/proposed/content_download/content_download.md
+++ b/doc/specifications/proposed/content_download/content_download.md
@@ -39,13 +39,6 @@ Example: `/content/download/68/64567/My-file.pdf`
   The version number the file must be downloaded for. Requires the versionview permission.
   If not specified, the published version is used.
 
-- language (optional)
-
-  > Should we keep this, given that the fileId binds to a particular language ?
-
-  The language the file must be downloaded for.
-  If not specified, the prioritized languages list of the matched siteaccess is used.
-
 The controller action will load the content based on the content and field id. The
 binary file referenced by the Field Value will then be streamed, using the active IO Service.
 
@@ -85,5 +78,5 @@ This can be covered by adding a route that matches the legacy route, and redirec
 would be redirected to
 
 ```
-/content/download/123/file_field/bc.pdf?version=6
+/content/download/123/45678/bc.pdf?version=6
 ```

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ContentDownloadRouteReferenceListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ContentDownloadRouteReferenceListener.php
@@ -17,6 +17,7 @@ class ContentDownloadRouteReferenceListener implements EventSubscriberInterface
 {
     const ROUTE_NAME = 'ez_content_download';
     const OPT_FIELD_IDENTIFIER = 'fieldIdentifier';
+    const OPT_FIELD_ID = 'fieldId';
     const OPT_CONTENT = 'content';
     const OPT_CONTENT_ID = 'contentId';
     const OPT_DOWNLOAD_NAME = 'filename';
@@ -66,6 +67,9 @@ class ContentDownloadRouteReferenceListener implements EventSubscriberInterface
             $routeReference->set( self::OPT_VERSION, $options[self::OPT_VERSION] );
         }
 
+        $routeReference->remove( self::OPT_FIELD_IDENTIFIER );
+
+        $routeReference->set( self::OPT_FIELD_ID, $options[self::OPT_FIELD_ID] );
         $routeReference->set( self::OPT_CONTENT_ID, $options[self::OPT_CONTENT_ID] );
         $routeReference->set( self::OPT_DOWNLOAD_NAME, $options[self::OPT_DOWNLOAD_NAME] );
     }
@@ -84,6 +88,18 @@ class ContentDownloadRouteReferenceListener implements EventSubscriberInterface
             function ( Options $options )
             {
                 return $options[self::OPT_CONTENT]->id;
+            }
+        );
+
+        $resolver->setDefault(
+            self::OPT_FIELD_ID,
+            function ( Options $options )
+            {
+                return $this->translationHelper->getTranslatedField(
+                    $options[self::OPT_CONTENT],
+                    $options[self::OPT_FIELD_IDENTIFIER],
+                    $options[self::OPT_LANGUAGE]
+                )->id;
             }
         );
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
@@ -20,5 +20,5 @@ _ez_user_hash:
     path: /_fos_user_context_hash
 
 ez_content_download:
-    path: /content/download/{contentId}/{fieldIdentifier}/{filename}
+    path: /content/download/{contentId}/{fieldId}/{filename}
     defaults: { _controller: ezpublish.controller.content.download:downloadBinaryFileAction }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -81,7 +81,6 @@ services:
         arguments:
             - @ezpublish.api.service.content
             - @ezpublish.fieldType.ezbinaryfile.io_service
-            - @ezpublish.translation_helper
         parent: ezpublish.controller.base
 
     ezpublish.controller.page.view:

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
@@ -8,12 +8,10 @@ use eZ\Bundle\EzPublishIOBundle\BinaryStreamResponse;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Field;
-use eZ\Publish\Core\Helper\TranslationHelper;
 use eZ\Publish\Core\IO\IOService;
 use eZ\Publish\Core\MVC\Symfony\Controller\Controller;
 use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class DownloadController extends Controller
@@ -24,14 +22,10 @@ class DownloadController extends Controller
     /** @var \eZ\Publish\Core\IO\IOService */
     private $ioService;
 
-    /** @var \eZ\Publish\Core\Helper\TranslationHelper */
-    private $translationHelper;
-
-    public function __construct( ContentService $contentService, IOService $ioService, TranslationHelper $translationHelper )
+    public function __construct( ContentService $contentService, IOService $ioService )
     {
         $this->contentService = $contentService;
         $this->ioService = $ioService;
-        $this->translationHelper = $translationHelper;
     }
 
     /**


### PR DESCRIPTION
> Story: https://jira.ez.no/browse/EZP-24468
> Status: on hold

As explained in [this comment](https://jira.ez.no/browse/EZP-24468?focusedCommentId=108608&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-108608), using the `fieldDefIdentifier` in the `ez_content_download` route turned out to be a bad idea.

This PR changes the route, controller and route reference listener to use the `fieldId` instead.