### PR TITLE
Fix EZP-24535: Avoid empty width/height and allow to force them

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -409,7 +409,10 @@
 {% if not ez_is_field_empty( content, field ) %}
 <figure {{ block( 'field_attributes' ) }}>
     {% set imageAlias = ez_image_alias( field, versionInfo, parameters.alias|default( 'original' ) ) %}
-    <img src="{% if imageAlias %}{{ asset( imageAlias.uri ) }}{% else %}//:0{% endif %}"{% if imageAlias.width is defined %} width="{{ imageAlias.width }}"{% endif %}{% if imageAlias.height is defined %} height="{{ imageAlias.height }}"{% endif %} alt="{{ field.value.alternativeText }}" />
+    {% set src = imageAlias ? asset( imageAlias.uri ) : "//:0" %}
+    {% set width = parameters.width is defined ? parameters.width : imageAlias.width %}
+    {% set height = parameters.height is defined ? parameters.height : imageAlias.height %}
+    <img src="{{ src }}"{% if width %} width="{{ width }}"{% endif %}{% if height %} height="{{ height }}"{% endif %} alt="{{ field.value.alternativeText }}" />
 </figure>
 {% endif %}
 {% endspaceless %}


### PR DESCRIPTION
- Avoid the width="" and the height=""
- Allow to force a height and a width manually (useful for handling the different screen densities)