### PR TITLE
Fix EZP-24449: Implement FieldDefinition form mapper for RichText

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/RichTextIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/RichTextIntegrationTest.php
@@ -133,10 +133,6 @@ EOT
                 'type' => 'int',
                 'default' => 10,
             ),
-            'tagPreset' => array(
-                'type' => 'choice',
-                'default' => RichTextType::TAG_PRESET_DEFAULT,
-            )
         );
     }
 
@@ -149,7 +145,6 @@ EOT
     {
         return array(
             'numRows' => 0,
-            'tagPreset' => RichTextType::TAG_PRESET_DEFAULT,
         );
     }
 

--- a/eZ/Publish/Core/FieldType/RichText/Type.php
+++ b/eZ/Publish/Core/FieldType/RichText/Type.php
@@ -26,16 +26,6 @@ use RuntimeException;
 class Type extends FieldType
 {
     /**
-     * Default preset of tags available in online editor
-     */
-    const TAG_PRESET_DEFAULT = 0;
-
-    /**
-     * Preset of tags for online editor intended for simple formatting options
-     */
-    const TAG_PRESET_SIMPLE_FORMATTING = 1;
-
-    /**
      * List of settings available for this FieldType
      *
      * The key is the setting name, and the value is the default value for this setting
@@ -47,10 +37,6 @@ class Type extends FieldType
             "type" => "int",
             "default" => 10
         ),
-        "tagPreset" => array(
-            "type" => "choice",
-            "default" => self::TAG_PRESET_DEFAULT
-        )
     );
 
     /**
@@ -354,23 +340,6 @@ class Type extends FieldType
                         {
                             $validationErrors[] = new ValidationError(
                                 "Setting '%setting%' value must be of integer type",
-                                null,
-                                array(
-                                    "setting" => $name
-                                ),
-                                "[$name]"
-                            );
-                        }
-                        break;
-                    case "tagPreset":
-                        $definedTagPresets = array(
-                            self::TAG_PRESET_DEFAULT,
-                            self::TAG_PRESET_SIMPLE_FORMATTING
-                        );
-                        if ( !in_array( $value, $definedTagPresets, true ) )
-                        {
-                            $validationErrors[] = new ValidationError(
-                                "Setting '%setting%' is of unknown tag preset",
                                 null,
                                 array(
                                     "setting" => $name

--- a/eZ/Publish/Core/FieldType/Tests/RichTextTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichTextTest.php
@@ -88,10 +88,6 @@ class RichTextTest extends PHPUnit_Framework_TestCase
                     "type" => "int",
                     "default" => 10
                 ),
-                "tagPreset" => array(
-                    "type" => "choice",
-                    "default" => RichTextType::TAG_PRESET_DEFAULT
-                ),
             ),
             $fieldType->getSettingsSchema(),
             "The settings schema does not match what is expected."

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RichTextConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RichTextConverter.php
@@ -62,7 +62,6 @@ class RichTextConverter implements Converter
     public function toStorageFieldDefinition( FieldDefinition $fieldDefinition, StorageFieldDefinition $storageDefinition )
     {
         $storageDefinition->dataInt1 = $fieldDefinition->fieldTypeConstraints->fieldSettings['numRows'];
-        $storageDefinition->dataText2 = $fieldDefinition->fieldTypeConstraints->fieldSettings['tagPreset'];
     }
 
     /**
@@ -76,7 +75,6 @@ class RichTextConverter implements Converter
         $fieldDefinition->fieldTypeConstraints->fieldSettings = new FieldSettings(
             array(
                 'numRows' => $storageDefinition->dataInt1,
-                'tagPreset' => $storageDefinition->dataText2
             )
         );
 

--- a/eZ/Publish/Core/REST/Common/FieldTypeProcessor/RichTextProcessor.php
+++ b/eZ/Publish/Core/REST/Common/FieldTypeProcessor/RichTextProcessor.php
@@ -40,43 +40,4 @@ class RichTextProcessor extends FieldTypeProcessor
 
         return $outgoingValueHash;
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function preProcessFieldSettingsHash( $incomingSettingsHash )
-    {
-        if ( isset( $incomingSettingsHash["tagPreset"] ) )
-        {
-            switch ( $incomingSettingsHash["tagPreset"] )
-            {
-                case 'TAG_PRESET_DEFAULT':
-                    $incomingSettingsHash["tagPreset"] = Type::TAG_PRESET_DEFAULT;
-                    break;
-                case 'TAG_PRESET_SIMPLE_FORMATTING':
-                    $incomingSettingsHash["tagPreset"] = Type::TAG_PRESET_SIMPLE_FORMATTING;
-            }
-        }
-        return $incomingSettingsHash;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function postProcessFieldSettingsHash( $outgoingSettingsHash )
-    {
-        if ( isset( $outgoingSettingsHash["tagPreset"] ) )
-        {
-            switch ( $outgoingSettingsHash["tagPreset"] )
-            {
-                case Type::TAG_PRESET_DEFAULT:
-                    $outgoingSettingsHash["tagPreset"] = 'TAG_PRESET_DEFAULT';
-                    break;
-                case Type::TAG_PRESET_SIMPLE_FORMATTING:
-                    $outgoingSettingsHash["tagPreset"] = 'TAG_PRESET_SIMPLE_FORMATTING';
-            }
-        }
-
-        return $outgoingSettingsHash;
-    }
 }

--- a/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/RichTextProcessorTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/RichTextProcessorTest.php
@@ -15,53 +15,6 @@ use DOMDocument;
 
 class RichTextProcessorTest extends PHPUnit_Framework_TestCase
 {
-    protected $constants = array(
-        "TAG_PRESET_DEFAULT",
-        "TAG_PRESET_SIMPLE_FORMATTING"
-    );
-
-    public function fieldSettingsHashes()
-    {
-        return array_map(
-            function ( $constantName )
-            {
-                return array(
-                    array( "tagPreset" => $constantName ),
-                    array( "tagPreset" => constant( "eZ\\Publish\\Core\\FieldType\\RichText\\Type::{$constantName}" ) )
-                );
-            },
-            $this->constants
-        );
-    }
-
-    /**
-     * @covers \eZ\Publish\Core\REST\Common\FieldTypeProcessor\RichTextProcessor::preProcessFieldSettingsHash
-     * @dataProvider fieldSettingsHashes
-     */
-    public function testPreProcessFieldSettingsHash( $inputSettings, $outputSettings )
-    {
-        $processor = $this->getProcessor();
-
-        $this->assertEquals(
-            $outputSettings,
-            $processor->preProcessFieldSettingsHash( $inputSettings )
-        );
-    }
-
-    /**
-     * @covers \eZ\Publish\Core\REST\Common\FieldTypeProcessor\RichTextProcessor::postProcessFieldSettingsHash
-     * @dataProvider fieldSettingsHashes
-     */
-    public function testPostProcessFieldSettingsHash( $outputSettings, $inputSettings )
-    {
-        $processor = $this->getProcessor();
-
-        $this->assertEquals(
-            $outputSettings,
-            $processor->postProcessFieldSettingsHash( $inputSettings )
-        );
-    }
-
     public function testPostProcessValueHash()
     {
         $processor = $this->getProcessor();

--- a/eZ/Publish/SPI/Tests/FieldType/RichTextIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/RichTextIntegrationTest.php
@@ -114,7 +114,6 @@ class RichTextIntegrationTest extends BaseIntegrationTest
                         'fieldSettings' => new FieldSettings(
                             array(
                                 'numRows' => 0,
-                                'tagPreset' => null,
                             )
                         )
                     )


### PR DESCRIPTION
Removed tag preset field type setting, as discussed in https://github.com/ezsystems/repository-forms/pull/21

https://jira.ez.no/browse/EZP-24449