### PR TITLE
EZP-24468: expose content/download url over REST 

### DIFF
--- a/doc/bc/changes-6.0.md
+++ b/doc/bc/changes-6.0.md
@@ -141,6 +141,11 @@ Changes affecting version compatibility with former or future versions.
 * SiteAccess service (`ezpublish.siteaccess`) is not synchronized any more.
   Synchronized services are deprecated as of Symfony 2.7.
 
+* The Values for `BinaryFile` and `Media` FieldType now expose the content/download URL as the `url` property.
+  Before, it contained the physical path to the file, e.g. `var/site/storage/original/...`. Since this path isn't
+  allowed to pass through the rewrite rules for security, it was not usable.
+  This also affects REST, that will now expose a valid HTTP download URL.
+
 ## Deprecations
 
 * `eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger::purge()` is deprecated and will be removed in v6.1.

--- a/doc/specifications/proposed/content_download/content_download.md
+++ b/doc/specifications/proposed/content_download/content_download.md
@@ -39,10 +39,10 @@ Example: `/content/download/68/file/My-file.pdf`
   The version number the file must be downloaded for. Requires the versionview permission.
   If not specified, the published version is used.
 
-- language (optional)
+- inLanguage (optional)
 
-  The language the file must be downloaded for.
-  If not specified, the prioritized languages list of the matched siteaccess is used.
+  The language the file should be downloaded in.
+  If not specified, the most prioritized language for the siteaccess will be used.
 
 The controller action will load the content based on the content id, and identify the field using the identifier. The
 binary file referenced by the Field Value will then be streamed, using the active IO Service.
@@ -69,10 +69,24 @@ The only difference is that instead of providing the `contentId`, the route refe
 Content Value Object.
 
 #### REST
-An extra attribute will be added to Fields of BinaryFile/Media type: `downloadUri`. It will contain the download uri for
-the Field's contents.
+
+> Story: EZP-24468
+
+For various reasons (cache handling, layering), REST uses a special download URL, based on the fieldId:
+
+```
+/content/download/{contentId}/{fieldId}
+```
+
+Based on the fieldId, and independently from the siteaccess, it will use the language switcher's mechanisms, and redirect
+to the relevant `ez_content_download` route.
+
+This URL, with the HTTP post, is available via the `url` property of BinaryFile and Media fields.
 
 ## Backward compatibility
+
+> Status: TODO
+
 Since it is common practice to copy/save file download links, it is possible that a legacy link will be used on occasions.
 This can be covered by adding a route that matches the legacy route, and redirects to the new route:
 
@@ -91,6 +105,7 @@ would be redirected to
 
 ### IgorwFileServeBundle
 
+> Status: considered, but not done
 > https://github.com/igorw/IgorwFileServeBundle
 
 A package meant to replace the BinaryResponse we currently use. Supports server-side mechanism such as X-SendFile, but

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/BinaryContentDownloadPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/BinaryContentDownloadPass.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Injects the downloadUrlGenerator into the binary fieldtype external storage services.
+ */
+class BinaryContentDownloadPass implements CompilerPassInterface
+{
+    public function process( ContainerBuilder $container )
+    {
+        if ( !$container->has( 'ezpublish.fieldType.ezbinarybase.download_url_generator' ) )
+            return;
+
+        $downloadUrlReference = new Reference( 'ezpublish.fieldType.ezbinarybase.download_url_generator' );
+
+        $this->addCall( $container, $downloadUrlReference, 'ezpublish.fieldType.ezmedia.externalStorage' );
+        $this->addCall( $container, $downloadUrlReference, 'ezpublish.fieldType.ezbinaryfile.externalStorage' );
+    }
+
+    private function addCall( ContainerBuilder $container, Reference $reference, $targetServiceName )
+    {
+        if ( !$container->has( $targetServiceName ) )
+            return;
+
+        $definition = $container->findDefinition( $targetServiceName );
+        $definition->addMethodCall( 'setDownloadUrlGenerator', array( $reference ) );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ContentDownloadRouteReferenceListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ContentDownloadRouteReferenceListener.php
@@ -7,6 +7,7 @@ namespace eZ\Bundle\EzPublishCoreBundle\EventListener;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\Core\Helper\TranslationHelper;
 use eZ\Publish\Core\MVC\Symfony\Event\RouteReferenceGenerationEvent;
+use eZ\Publish\Core\MVC\Symfony\EventListener\LanguageSwitchListener;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use InvalidArgumentException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -20,7 +21,9 @@ class ContentDownloadRouteReferenceListener implements EventSubscriberInterface
     const OPT_CONTENT = 'content';
     const OPT_CONTENT_ID = 'contentId';
     const OPT_DOWNLOAD_NAME = 'filename';
-    const OPT_LANGUAGE = 'language';
+    const OPT_DOWNLOAD_LANGUAGE = 'inLanguage';
+    const OPT_SITEACCESS_LANGUAGE = 'language';
+    const OPT_SITEACCESS = 'siteaccess';
     const OPT_VERSION = 'version';
 
     /** @var \eZ\Publish\Core\Helper\TranslationHelper */
@@ -56,9 +59,9 @@ class ContentDownloadRouteReferenceListener implements EventSubscriberInterface
         $this->configureOptions( $resolver );
         $options = $resolver->resolve( $options );
 
-        if ( isset( $options[self::OPT_LANGUAGE]) )
+        if ( isset( $options[self::OPT_DOWNLOAD_LANGUAGE]) )
         {
-            $routeReference->set( self::OPT_LANGUAGE, $options[self::OPT_LANGUAGE] );
+            $routeReference->set( self::OPT_DOWNLOAD_LANGUAGE, $options[self::OPT_DOWNLOAD_LANGUAGE] );
         }
 
         if ( isset( $options[self::OPT_VERSION] ) )
@@ -76,9 +79,19 @@ class ContentDownloadRouteReferenceListener implements EventSubscriberInterface
     protected function configureOptions( OptionsResolver $resolver )
     {
         $resolver->setRequired( [ self::OPT_CONTENT, self::OPT_FIELD_IDENTIFIER ] );
-        $resolver->setDefaults( [ self::OPT_VERSION => null, self::OPT_LANGUAGE => null ] );
+
+        $resolver->setDefaults(
+            [
+                self::OPT_VERSION => null,
+                self::OPT_DOWNLOAD_LANGUAGE => null,
+                self::OPT_SITEACCESS_LANGUAGE => null,
+                self::OPT_SITEACCESS => null
+            ]
+        );
+
         $resolver->setAllowedTypes( self::OPT_CONTENT, 'eZ\Publish\API\Repository\Values\Content\Content' );
         $resolver->setAllowedTypes( self::OPT_FIELD_IDENTIFIER, 'string' );
+
         $resolver->setDefault(
             self::OPT_CONTENT_ID,
             function ( Options $options )
@@ -94,7 +107,7 @@ class ContentDownloadRouteReferenceListener implements EventSubscriberInterface
                 $field = $this->translationHelper->getTranslatedField(
                     $options[self::OPT_CONTENT],
                     $options[self::OPT_FIELD_IDENTIFIER],
-                    $options[self::OPT_LANGUAGE]
+                    $options[self::OPT_DOWNLOAD_LANGUAGE]
                 );
                 if ( !$field instanceof Field )
                 {

--- a/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
@@ -10,6 +10,7 @@
 namespace eZ\Bundle\EzPublishCoreBundle;
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\AsseticPass;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\BinaryContentDownloadPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\ComplexSettingsPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\ConfigResolverParameterPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\FieldTypeParameterProviderRegistryPass;
@@ -83,6 +84,7 @@ class EzPublishCoreBundle extends Bundle
             ),
             PassConfig::TYPE_BEFORE_REMOVING
         );
+        $container->addCompilerPass( new BinaryContentDownloadPass() );
 
         // Storage passes
         $container->addCompilerPass( new ExternalStorageRegistryPass );

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -60,6 +60,7 @@ parameters:
 
     # BinaryFile
     ezpublish.fieldType.ezbinaryfile.pathGenerator.class: eZ\Publish\Core\FieldType\BinaryBase\PathGenerator\LegacyPathGenerator
+    ezpublish.fieldType.ezbinarybase.downloadUrlGenerator.class: eZ\Publish\Core\MVC\Symfony\FieldType\BinaryBase\ContentDownloadUrlGenerator
 
 services:
     # Parameter providers
@@ -293,3 +294,8 @@ services:
 
     ezpublish.fieldType.ezbinaryfile.pathGenerator:
         class: %ezpublish.fieldType.ezbinaryfile.pathGenerator.class%
+
+    # Will be added to binaryfile & mediafile external storage handlers by a compiler pass
+    ezpublish.fieldType.ezbinarybase.download_url_generator:
+        class: %ezpublish.fieldType.ezbinarybase.downloadUrlGenerator.class%
+        arguments: [@router]

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
@@ -22,3 +22,7 @@ _ez_user_hash:
 ez_content_download:
     path: /content/download/{contentId}/{fieldIdentifier}/{filename}
     defaults: { _controller: ezpublish.controller.content.download:downloadBinaryFileAction }
+
+ez_content_download_field_id:
+    path: /content/download/{contentId}/{fieldId}
+    defaults: { _controller: ezpublish.controller.content.download_redirection:redirectToContentDownloadAction }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -9,6 +9,7 @@ parameters:
     ezpublish.controller.content.view.class: eZ\Publish\Core\MVC\Symfony\Controller\Content\ViewController
     ezpublish.controller.content.preview.class: eZ\Publish\Core\MVC\Symfony\Controller\Content\PreviewController
     ezpublish.controller.content.download.class: eZ\Publish\Core\MVC\Symfony\Controller\Content\DownloadController
+    ezpublish.controller.content.download_redirection.class: eZ\Publish\Core\MVC\Symfony\Controller\Content\DownloadRedirectionController
     ezpublish.controller.page.view.class: eZ\Bundle\EzPublishCoreBundle\Controller\PageController
 
     # Param converters
@@ -82,6 +83,16 @@ services:
             - @ezpublish.api.service.content
             - @ezpublish.fieldType.ezbinaryfile.io_service
             - @ezpublish.translation_helper
+            - @router
+            - @ezpublish.route_reference.generator
+        parent: ezpublish.controller.base
+
+    ezpublish.controller.content.download_redirection:
+        class: %ezpublish.controller.content.download_redirection.class%
+        arguments:
+            - @ezpublish.api.service.content
+            - @router
+            - @ezpublish.route_reference.generator
         parent: ezpublish.controller.base
 
     ezpublish.controller.page.view:

--- a/eZ/Publish/API/Repository/Tests/FieldType/BinaryFileIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/BinaryFileIntegrationTest.php
@@ -353,17 +353,18 @@ class BinaryFileIntegrationTest extends FileSearchBaseIntegrationTest
     public function provideToHashData()
     {
         $fixture = $this->getFixtureData();
-        $fixture['create']['downloadCount'] = 0;
-        $fixture['create']['uri'] = $fixture['create']['inputUri'];
-        $fixture['create']['path'] = $fixture['create']['inputUri'];
+        $expected = $fixture['create'];
+        $expected['downloadCount'] = 0;
+        $expected['uri'] = $expected['inputUri'];
+        $expected['path'] = $expected['inputUri'];
 
         $fieldValue = $this->getValidCreationFieldData();
-        $fieldValue->uri = $fixture['create']['uri'];
+        $fieldValue->uri = $expected['uri'];
 
         return array(
             array(
                 $fieldValue,
-                $fixture['create'],
+                $expected,
             ),
         );
     }

--- a/eZ/Publish/API/Repository/Tests/FieldType/MediaIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/MediaIntegrationTest.php
@@ -366,24 +366,25 @@ class MediaIntegrationTest extends FileSearchBaseIntegrationTest
     public function provideToHashData()
     {
         $fixture = $this->getFixtureData();
+        $expected = $fixture['create'];
 
-        $fixture['create']['uri'] = $fixture['create']['inputUri'];
-        $fixture['create']['path'] = $fixture['create']['inputUri'];
+        $expected['uri'] = $expected['inputUri'];
+        $expected['path'] = $expected['inputUri'];
 
         // Defaults set by type
-        $fixture['create']['hasController'] = false;
-        $fixture['create']['autoplay'] = false;
-        $fixture['create']['loop'] = false;
-        $fixture['create']['width'] = 0;
-        $fixture['create']['height'] = 0;
+        $expected['hasController'] = false;
+        $expected['autoplay'] = false;
+        $expected['loop'] = false;
+        $expected['width'] = 0;
+        $expected['height'] = 0;
 
         $fieldValue = $this->getValidCreationFieldData();
-        $fieldValue->uri = $fixture['create']['uri'];
+        $fieldValue->uri = $expected['uri'];
 
         return array(
             array(
                 $fieldValue,
-                $fixture['create'],
+                $expected,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage.php
@@ -31,10 +31,11 @@ class BinaryBaseStorage extends GatewayBasedStorage
     /** @var \eZ\Publish\SPI\FieldType\BinaryBase\PathGenerator */
     protected $pathGenerator;
 
-    /**
-     * @var \eZ\Publish\SPI\IO\MimeTypeDetector
-     */
+    /** @var \eZ\Publish\SPI\IO\MimeTypeDetector */
     protected $mimeTypeDetector;
+
+    /** @var PathGenerator */
+    protected $downloadUrlGenerator;
 
     /**
      * Construct from gateways
@@ -50,6 +51,14 @@ class BinaryBaseStorage extends GatewayBasedStorage
         $this->IOService = $IOService;
         $this->pathGenerator = $pathGenerator;
         $this->mimeTypeDetector = $mimeTypeDetector;
+    }
+
+    /**
+     * @param PathGenerator $downloadUrlGenerator
+     */
+    public function setDownloadUrlGenerator( PathGenerator $downloadUrlGenerator )
+    {
+        $this->downloadUrlGenerator = $downloadUrlGenerator;
     }
 
     public function storeFieldData( VersionInfo $versionInfo, Field $field, array $context )
@@ -80,7 +89,9 @@ class BinaryBaseStorage extends GatewayBasedStorage
             $binaryFile = $this->IOService->createBinaryFile( $createStruct );
             $storedValue['id'] = $binaryFile->id;
             $storedValue['mimeType'] = $createStruct->mimeType;
-            $storedValue['uri'] = $binaryFile->uri;
+            $storedValue['uri'] = isset( $this->downloadUrlGenerator ) ?
+                $this->downloadUrlGenerator->getStoragePathForField( $field, $versionInfo ) :
+                $binaryFile->uri;
         }
 
         $field->value->externalData = $storedValue;
@@ -140,7 +151,9 @@ class BinaryBaseStorage extends GatewayBasedStorage
         {
             $binaryFile = $this->IOService->loadBinaryFile( $field->value->externalData['id'] );
             $field->value->externalData['fileSize'] = $binaryFile->size;
-            $field->value->externalData['uri'] = $binaryFile->uri;
+            $field->value->externalData['uri'] = isset( $this->downloadUrlGenerator ) ?
+                $this->downloadUrlGenerator->getStoragePathForField( $field, $versionInfo ) :
+                $binaryFile->uri;
         }
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/BinaryFileTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/BinaryFileTest.php
@@ -339,7 +339,7 @@ class BinaryFileTest extends BinaryBaseTest
                     'fileSize' => 2342,
                     'downloadCount' => 0,
                     'mimeType' => 'application/pdf',
-                    'uri' => 'http://some/file/here',
+                    'uri' => 'http://some/file/here'
                 )
             ),
         );

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
@@ -12,7 +12,6 @@ use eZ\Publish\Core\IO\IOService;
 use eZ\Publish\Core\MVC\Symfony\Controller\Controller;
 use InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class DownloadController extends Controller
@@ -54,7 +53,7 @@ class DownloadController extends Controller
 
         $field = $this->translationHelper->getTranslatedField(
             $content, $fieldIdentifier,
-            $request->query->has( 'language' ) ? $request->query->get( 'language' ) : null
+            $request->query->has( 'inLanguage' ) ? $request->query->get( 'inLanguage' ) : null
         );
         if ( !$field instanceof Field )
         {

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadRedirectionController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadRedirectionController.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Controller\Content;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\MVC\Symfony\Controller\Controller;
+use eZ\Publish\Core\MVC\Symfony\Routing\Generator\RouteReferenceGenerator;
+use InvalidArgumentException;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouterInterface;
+
+class DownloadRedirectionController extends Controller
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /** @var \Symfony\Component\Routing\RouterInterface */
+    private $router;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\Routing\Generator\RouteReferenceGenerator */
+    private $routeReferenceGenerator;
+
+    public function __construct( ContentService $contentService, RouterInterface $router, RouteReferenceGenerator $routeReferenceGenerator )
+    {
+        $this->contentService = $contentService;
+        $this->router = $router;
+        $this->routeReferenceGenerator = $routeReferenceGenerator;
+    }
+
+    /**
+     * Used by the REST API to reference downloadable files.
+     * It redirects (permanently) to the standard ez_content_download route, based on the language of the field
+     * passed as an argument, using the language switcher
+     *
+     * @param mixed $contentId
+     * @param int $fieldId
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *
+     * @return \Symfony\Component\HttpFoundation\RedirectResponse
+     */
+    public function redirectToContentDownloadAction( $contentId, $fieldId, Request $request )
+    {
+        $content = $this->contentService->loadContent( $contentId );
+        $field = $this->findFieldInContent( $fieldId, $content );
+
+        $params = array(
+            'content' => $content,
+            'fieldIdentifier' => $field->fieldDefIdentifier,
+            'language' => $field->languageCode
+        );
+
+        if ( $request->query->has( 'version' ) )
+        {
+            $params['version'] = $request->query->get( 'version' );
+        }
+
+        $downloadUrl = $this->router->generate(
+            $this->routeReferenceGenerator->generate(
+                'ez_content_download',
+                $params
+            )
+        );
+
+        return new RedirectResponse( $downloadUrl, 301 );
+    }
+
+    /**
+     * Finds the field with id $fieldId in $content
+     *
+     * @param int $fieldId
+     * @param Content $content
+     *
+     * @return Field
+     */
+    protected function findFieldInContent( $fieldId, Content $content )
+    {
+        foreach ( $content->getFields() as $field )
+        {
+            if ( $field->id == $fieldId )
+            {
+                return $field;
+            }
+        }
+        throw new InvalidArgumentException( "Field with id $fieldId not found in Content with id {$content->id}" );
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/BinaryBase/ContentDownloadUrlGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/BinaryBase/ContentDownloadUrlGenerator.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\FieldType\BinaryBase;
+
+use eZ\Publish\SPI\FieldType\BinaryBase\PathGenerator;
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+use Symfony\Component\Routing\RouterInterface;
+
+class ContentDownloadUrlGenerator extends PathGenerator
+{
+    /** @var \Symfony\Component\Routing\RouterInterface */
+    private $router;
+
+    public function __construct( RouterInterface $router )
+    {
+        $this->router = $router;
+    }
+
+    public function getStoragePathForField( Field $field, VersionInfo $versionInfo )
+    {
+        return $this->router->generate(
+            'ez_content_download_field_id',
+            array(
+                'contentId' => $versionInfo->contentInfo->id,
+                'fieldId' => $field->id
+            )
+        );
+    }
+}

--- a/eZ/Publish/Core/REST/Common/FieldTypeProcessor/BinaryProcessor.php
+++ b/eZ/Publish/Core/REST/Common/FieldTypeProcessor/BinaryProcessor.php
@@ -40,8 +40,10 @@ class BinaryProcessor extends BinaryInputProcessor
             return $outgoingValueHash;
         }
 
+        $outgoingValueHash['uri'] = $this->generateUrl( $outgoingValueHash['uri'] );
+
         // url is kept for BC, but uri is the right one
-        $outgoingValueHash['uri'] = $outgoingValueHash['url'] = $this->generateUrl( $outgoingValueHash['uri'] );
+        $outgoingValueHash['url'] = $outgoingValueHash['uri'];
 
         return $outgoingValueHash;
     }

--- a/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/BinaryProcessorTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/BinaryProcessorTest.php
@@ -33,7 +33,7 @@ class BinaryProcessorTest extends BinaryInputProcessorTest
         $this->assertEquals(
             array(
                 'url' => $expectedUri,
-                'uri' => $expectedUri
+                'uri' => $expectedUri,
             ),
             $outputHash
         );

--- a/eZ/Publish/Core/settings/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/fieldtype_external_storages.yml
@@ -44,7 +44,6 @@ services:
             - @ezpublish.fieldType.ezbinaryfile.io_service
             - @ezpublish.fieldType.ezbinaryfile.pathGenerator
             - @ezpublish.core.io.mimeTypeDetector
-            - @?logger
         tags:
             - {name: ezpublish.fieldType.externalStorageHandler, alias: ezmedia}
 

--- a/eZ/Publish/SPI/Tests/FieldType/BinaryFileIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BinaryFileIntegrationTest.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\SPI\Tests\FieldType;
 
+use eZ\Publish\Core\MVC\Symfony\FieldType\BinaryBase\ContentDownloadUrlGenerator;
 use eZ\Publish\Core\Persistence\Legacy;
 use eZ\Publish\Core\FieldType;
 use eZ\Publish\SPI\Persistence\Content;

--- a/eZ/Publish/SPI/Tests/FieldType/MediaIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/MediaIntegrationTest.php
@@ -80,7 +80,7 @@ class MediaIntegrationTest extends FileBaseIntegrationTest
                     'LegacyStorage' => new FieldType\Media\MediaStorage\Gateway\LegacyStorage(),
                 ),
                 $this->ioService = self::$container->get( "ezpublish.fieldType.ezbinaryfile.io_service" ),
-                new FieldType\BinaryBase\PathGenerator\LegacyPathGenerator(),
+                $legacyPathGenerator = new FieldType\BinaryBase\PathGenerator\LegacyPathGenerator(),
                 new FileInfo()
             )
         );


### PR DESCRIPTION
> Alternative for #1299 
> [EZP-24468](http://jira.ez.no/browse/EZP-24468)

With this approach, we use a different route for REST content/download urls. That route is based on the fieldId instead of the fieldDefIdentifier, but does a permanent redirect to fieldDefIdentifier.

This has several advantages:
- since REST doesn't know about siteaccesses/languages mapping, we can take care of that part when redirecting
- it allows us to store this REST content/download URI into the SPI cache, and avoid putting a field Def Identifier there (even though it actually is there in every field, in the Version)
- it separates layers better, even if it is not perfect

### Things to do
- [x] Update speicification
- [x] Implement REST download route + controller
- [x] Implement language switcher based language route generation
- [x] Rename `language` parameter as it is used by the LanguageSwitcher (: `inLanguage`)
- [x] Refactor new controller action to another controller
- [x] Add route generation to BinaryBase ExternalStorage.
- [x] Fix tests
- [x] Update spec with the `downloadUrl` removal