### PR TITLE
[WIP investigation] Add checks to users injected to UserWrapped to avoid recursion

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
@@ -13,6 +13,7 @@ use eZ\Publish\API\Repository\Values\User\User as APIUser;
 use Symfony\Component\Security\Core\User\AdvancedUserInterface;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\UserInterface as CoreUserInterface;
+use InvalidArgumentException;
 
 /**
  * This class represents a UserWrapped object.
@@ -37,7 +38,7 @@ class UserWrapped implements UserInterface, EquatableInterface
 
     public function __construct( CoreUserInterface $wrappedUser, APIUser $apiUser )
     {
-        $this->wrappedUser = $wrappedUser;
+        $this->setWrappedUser( $wrappedUser );
         $this->apiUser = $apiUser;
     }
 
@@ -83,10 +84,17 @@ class UserWrapped implements UserInterface, EquatableInterface
     }
 
     /**
+     * @throws InvalidArgumentException If $wrappedUser is instance of self
+     *
      * @param \Symfony\Component\Security\Core\User\UserInterface $wrappedUser
      */
     public function setWrappedUser( CoreUserInterface $wrappedUser )
     {
+        if ( $wrappedUser instanceOf UserWrapped )
+        {
+            throw new InvalidArgumentException( "Injecting UserWrapped to itself is not allowed to avoid recursion" );
+        }
+
         $this->wrappedUser = $wrappedUser;
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
@@ -94,6 +94,10 @@ class UserWrapped implements UserInterface, EquatableInterface
         {
             throw new InvalidArgumentException( "Injecting UserWrapped to itself is not allowed to avoid recursion" );
         }
+        else if ( $wrappedUser instanceOf User )
+        {
+            throw new InvalidArgumentException( "Injecting User into UserWrapped causes duplication of APIUser, not wanted for session serialization" );
+        }
 
         $this->wrappedUser = $wrappedUser;
     }


### PR DESCRIPTION
- [x] Throw InvalidArgumentException on injecting of self to avoid recursion
- [x] Throw InvalidArgumentException on injecting of User to avoid duplication of API User (as it is a large object which should not be in Session in the first place)
- [ ] Test with SSO setup to get trace of when recursion happens *(if tests don't reveal any clues)*