### PR TITLE
Implement: EZP-24486: Disable FullText search for LocationSearch

### DIFF
--- a/eZ/Publish/Core/Search/Solr/Content/DocumentMapper/NativeDocumentMapper.php
+++ b/eZ/Publish/Core/Search/Solr/Content/DocumentMapper/NativeDocumentMapper.php
@@ -628,7 +628,7 @@ class NativeDocumentMapper implements DocumentMapper
         $contentType = $this->contentTypeHandler->load(
             $content->versionInfo->contentInfo->contentTypeId
         );
-        $fieldSets = $this->mapContentFields( $content, $contentType, true );
+        $fieldSets = $this->mapContentFields( $content, $contentType, false );
         $documents = array();
 
         foreach ( $fieldSets as $languageCode => $translationFields )

--- a/eZ/Publish/Core/Search/Solr/Content/Resources/schema.xml
+++ b/eZ/Publish/Core/Search/Solr/Content/Resources/schema.xml
@@ -112,14 +112,14 @@ should not remove or drastically change the existing definitions.
     <dynamicField name="*_gl_1_coordinate" type="double" indexed="true" stored="true"/>
     <dynamicField name="*_c" type="currency" indexed="true" stored="true"/>
 
-    <field name="text" type="text" indexed="true" multiValued="true" stored="false"/>
-
     <!--
-      Index all text, html and string fields in full text index
+      Full text field is indexed through a proxy field '*_fulltext_t'.
+      This definition's wildcard should be kept longer than other dynamic fields,
+      in order for this field to match over them.
     -->
-    <copyField source="*_t" dest="text" />
-    <copyField source="*_s" dest="text" />
-    <copyField source="*_h" dest="text" />
+    <field name="text" type="text" indexed="true" multiValued="true" stored="false"/>
+    <dynamicField name="*_fulltext_t" type="text" indexed="false" stored="false"/>
+    <copyField source="*_fulltext_t" dest="text" />
 
     <!--
       This field is required since Solr 4

--- a/eZ/Publish/Core/settings/search_engines/solr/criterion_visitors.yml
+++ b/eZ/Publish/Core/settings/search_engines/solr/criterion_visitors.yml
@@ -58,7 +58,8 @@ parameters:
     ezpublish.search.solr.location.criterion_visitor.priority_between.class: eZ\Publish\Core\Search\Solr\Content\Location\CriterionVisitor\Location\PriorityBetween
     ezpublish.search.solr.location.criterion_visitor.field_in.class: eZ\Publish\Core\Search\Solr\Content\Location\CriterionVisitor\Field\FieldIn
     ezpublish.search.solr.location.criterion_visitor.field_range.class: eZ\Publish\Core\Search\Solr\Content\Location\CriterionVisitor\Field\FieldRange
-    ezpublish.search.solr.location.criterion_visitor.full_text.class: eZ\Publish\Core\Search\Solr\Content\Location\CriterionVisitor\FullText
+    # We don't support fulltext Location search out of the box
+    #ezpublish.search.solr.location.criterion_visitor.full_text.class: eZ\Publish\Core\Search\Solr\Content\Location\CriterionVisitor\FullText
     ezpublish.search.solr.location.criterion_visitor.map_location_distance_range.class: eZ\Publish\Core\Search\Solr\Content\Location\CriterionVisitor\Field\MapLocationDistanceRange
 
 services:
@@ -382,12 +383,13 @@ services:
         tags:
             - {name: ezpublish.search.solr.location.criterion_visitor}
 
-    ezpublish.search.solr.location.criterion_visitor.full_text:
-        class: %ezpublish.search.solr.location.criterion_visitor.full_text.class%
-        arguments:
-            - @ezpublish.search.common.field_name_resolver
-        tags:
-            - {name: ezpublish.search.solr.location.criterion_visitor}
+    # We don't support fulltext Location search out of the box
+    #ezpublish.search.solr.location.criterion_visitor.full_text:
+    #    class: %ezpublish.search.solr.location.criterion_visitor.full_text.class%
+    #    arguments:
+    #        - @ezpublish.search.common.field_name_resolver
+    #    tags:
+    #        - {name: ezpublish.search.solr.location.criterion_visitor}
 
     ezpublish.search.solr.location.criterion_visitor.map_location_distance_range:
         class: %ezpublish.search.solr.location.criterion_visitor.map_location_distance_range.class%


### PR DESCRIPTION
This PR resolves sub-task https://jira.ez.no/browse/EZP-24486

Schema is changed to index to fulltext `text` field over proxy field `*_fulltext_t`, which is not indexed nor stored, but is copied to it.
Location index now does not index to `text` field by omitting `*_fulltext_t` fields and not registering `FullText` criterion.