### PR TITLE
[Spec] Added clarifications on Persisted Queries

### DIFF
--- a/doc/specifications/proposed/named_queries/index.md
+++ b/doc/specifications/proposed/named_queries/index.md
@@ -14,6 +14,19 @@ ContentType identifier...
 In the initial version, QueryType objects can be created as PHP classes. The main use-case is to allow developers
 to ease implementation of content / location lists in sites implementations, by defining QueryTypes inside bundles.
 
+### Differences from Persisted Queries
+
+When `Views` were added to REST API there was the intention to allow these to be persisted at some point *(after UI were moved to Platform Stack)*.
+And while there are no own specification for it yet, these are the main differences between the two:
+- Persisted Queries serves as Editorial Queries/Search to drive possible future features like reuse in content, blocks, and plainly sharing link to a search result to co workers or public.
+- Named Queries on the other side is a DX feature for developer to provided queries for reuse in code, and aim to make eZ Platform much easier to work with by exposing the power of `filtering` content directly from templates.
+- Persisted Queries, unlike Named Queries, will by it's nature be possible to be retrieve and created from PHP Repository API, and hence also REST API which will need to distinguishing these two from each other for API use and in extension UI's exposing such editing functionality.
+- Persisted Queries could allow the Repository to keep track of hits internally in the future, ala how JIRA works with filters. This will allow more advance cache clearing logic to aim for editor never having to take care about cache.
+- Persisted Queries being editorial and not a DX feature like Named Query, meaning editor might change it completely at any moment, and also for cache reasons mentioned above this means it most likely won't support dynamic parameters beyond limit, offset and viewMode *(does not belong to Query, rather view and would be exposed by embeds and blocks)*.
+
+However Persisted Queries are a non-goal of this spec and feature, this section is merely to make it's relation more clear as there are many possible overlaps in feature-set for Queries and Views.
+
+
 ## Chapters
 
 ### [Query Type API](query_type_api.md)


### PR DESCRIPTION
Review ping @bdunogier, @pspanja.

BD: As you mentioned we could support dynamic parameters on Persisted Queries, I added a section on that as I think it will to easily break down. And while I did not go into it in details, I kind of view Named Queries *(like you seem to do from spec also)* as being two parts: a factory; The Type; aka Query Type, and the corresponding Value; __potentially__ the Query object it returns as a result. While Persisted Queries is just a Value, no factories involved. Except maybe for structs like newContentQueryCreateStruct(), which will for the most part look like a Query Value but w/o limit and offset for instance. But unsure if that first with how you see things? *side: hmm, maybe I should just do a proposed spec to make it more clear* :P 