### PR TITLE
Fix EZP-24390: Implement FieldDefinition form mapper for ezdatetime

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
@@ -98,6 +98,10 @@ class DateAndTimeConverter implements Converter
     {
         $useSeconds = (bool)$storageDef->dataInt2;
         $dateInterval = $this->getDateIntervalFromXML( $storageDef->dataText5 );
+        if ( !($dateInterval instanceof DateInterval) )
+        {
+            $dateInterval = new DateInterval( "P0Y" );
+        }
 
         $fieldDef->fieldTypeConstraints->fieldSettings = new FieldSettings(
             array(


### PR DESCRIPTION
Return an empty DateInterval, rather than void. Requirement for https://github.com/ezsystems/repository-forms/pull/13

https://jira.ez.no/browse/EZP-24390