### PR TITLE
Fix EZP-24548: [API/IO] Wrong image url prefix when image is not found

### DIFF
--- a/eZ/Publish/Core/IO/Tests/TolerantIOServiceTest.php
+++ b/eZ/Publish/Core/IO/Tests/TolerantIOServiceTest.php
@@ -40,6 +40,27 @@ class TolerantIOServiceTest extends IOServiceTest
     }
 
     /**
+     * @covers \eZ\Publish\Core\IO\TolerantIOService::createMissingBinaryFile
+     */
+    public function testCreateMissingBinaryFile()
+    {
+        $id = 'id.ext';
+        $prefixedUri = $this->getPrefixedUri( $id );
+
+        $this->binarydataHandlerMock
+            ->expects( $this->once() )
+            ->method( 'getUri' )
+            ->with( $prefixedUri )
+            ->will( $this->returnValue( "/$prefixedUri" ) );
+
+        $binaryFile = parent::testLoadBinaryFileNotFound();
+        self::assertEquals(
+            new MissingBinaryFile( array( 'id' => 'id.ext', 'uri' => "/$prefixedUri" ) ),
+            $binaryFile
+        );
+    }
+
+    /**
      * Overridden to change the expected exception (none)
      * @covers \eZ\Publish\Core\IO\IOService::deleteBinaryFile
      */

--- a/eZ/Publish/Core/IO/TolerantIOService.php
+++ b/eZ/Publish/Core/IO/TolerantIOService.php
@@ -128,7 +128,7 @@ class TolerantIOService extends IOService
         return new MissingBinaryFile(
             array(
                 'id' => $binaryFileId,
-                'uri' => $this->binarydataHandler->getUri( $binaryFileId )
+                'uri' => $this->binarydataHandler->getUri( $this->getPrefixedUri( $binaryFileId ) ),
             )
         );
     }


### PR DESCRIPTION
A simple fix and test for what I believe is a bug in the TolerantIOService. The bug causes wrong URIs to be rendered in img src attributes when the image does not exist on the filesystem, e.g. without the standard "images" prefix. That becomes a problem when the view is cached with that wrong img URI and the image is then added at the correct path afterwards.

No jira issue because it wouldn't let me register.

## TODO
- [x] Rebase commits

Issue: https://jira.ez.no/browse/EZP-24548