### PR TITLE
[WIP] Fix wrong request context in CORS preflight request matching

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Routing/DefaultRouter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Routing/DefaultRouter.php
@@ -72,6 +72,7 @@ class DefaultRouter extends Router implements RequestMatcherInterface, SiteAcces
 
     public function matchRequest( Request $request )
     {
+        $this->getContext()->fromRequest( $request );
         return $this->match( $request->attributes->get( 'semanticPathinfo', $request->getPathInfo() ) );
     }
 


### PR DESCRIPTION
Context:
Add this to your configuration:

```
nelmio_cors:
    defaults:
        allow_origin: ['*']
```

Then, when doing a CORS preflight OPTIONS request with an "Origin" header, the nelmio CorsBundle intercepts the request and checks for allowed methods. But the request context used is the default one ("GET") and the route is not matched, resulting in a "405 Method Not Allowed".

```
> OPTIONS /api/ezp/v2/user/sessions HTTP/1.1
> User-Agent: curl/7.38.0
> Host: dev.local
> Accept: */*
> Access-Control-Request-Method: POST
> Access-Control-Request-Headers: content-type
> Origin: http://localhost
>
< HTTP/1.1 405 Method Not Allowed
< Date: Wed, 24 Jun 2015 12:03:09 GMT
< Server: Apache/2.2.16 (Debian)
< X-Powered-By: PHP/5.4.42-1~dotdeb+6.4
< Cache-Control: no-cache
< Access-Control-Allow-Credentials: true
< Access-Control-Allow-Headers: authorization, accept, content-type, x-csrf-token, destination, x-siteaccess
< Access-Control-Max-Age: 60
< Access-Control-Allow-Origin: http://localhost
< X-Cache-Debug: 1
< Vary: Cookie,Accept-Encoding,Authorization
< Content-Length: 0
< Content-Type: text/html; charset=UTF-8
```

Fix this by feeding the router context with the request's one.

NOTE: it may not be the best place to patch, but it works (c)

TODO:
- [ ] create a JIRA issue
- [ ] add specific rest
