### PR TITLE
define QueryParams as an associative array

### DIFF
--- a/doc/specifications/proposed/named_queries/developer_documentation.md
+++ b/doc/specifications/proposed/named_queries/developer_documentation.md
@@ -44,7 +44,11 @@ system:
                     template: "AcmeBundle:query/list/latest_articles.html.twig"
                     match:
                         QueryType\Name: 'AcmeBundle:LatestContent'
-                        QueryType\Parameter: "ContentType=article"
+                        QueryType\Parameter:
+                            ContentType:"article"
+                            Limit: 10
+                            SortBy:"name"
+                            SorDirection:"desc"
 ```
 
 ## QueryType objects


### PR DESCRIPTION
I'd say is more legible and probably could make it easy the match part working with array_keys or something instead of needing some kind of split in the ContentType=article?