### PR TITLE
Fix EZP-24539: Avoid expensive sorting sql when not needed in Search

### DIFF
--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -85,7 +85,7 @@ class DoctrineDatabase extends Gateway
         $doCount = true
     )
     {
-        $count = $doCount ? $this->getResultCount( $criterion, $sort, $fieldFilters ) : null;
+        $count = $doCount ? $this->getResultCount( $criterion, null, $fieldFilters ) : null;
 
         if ( !$doCount && $limit === 0 )
         {

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -85,7 +85,7 @@ class DoctrineDatabase extends Gateway
         $doCount = true
     )
     {
-        $count = $doCount ? $this->getResultCount( $criterion, null, $fieldFilters ) : null;
+        $count = $doCount ? $this->getResultCount( $criterion, $fieldFilters ) : null;
 
         if ( !$doCount && $limit === 0 )
         {
@@ -139,7 +139,7 @@ class DoctrineDatabase extends Gateway
      * @param array $fieldFilters
      * @return int
      */
-    protected function getResultCount( Criterion $filter, $sort, $fieldFilters )
+    protected function getResultCount( Criterion $filter, $fieldFilters )
     {
         $query = $this->handler->createSelectQuery();
 
@@ -152,12 +152,6 @@ class DoctrineDatabase extends Gateway
                 'ezcontentobject.id',
                 'ezcontentobject_version.contentobject_id'
             );
-
-        // Should be possible to remove it now, since Field sort clauses do not filter any more
-        if ( $sort !== null )
-        {
-            $this->sortClauseConverter->applyJoin( $query, $sort );
-        }
 
         $query->where(
             $this->getQueryCondition( $filter, $query, $fieldFilters )

--- a/eZ/Publish/Core/Search/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Handler.php
@@ -144,6 +144,7 @@ class Handler implements SearchHandlerInterface
         $searchQuery->offset = 0;
         $searchQuery->limit  = 2;// Because we optimize away the count query below
         $searchQuery->performCount = true;
+        $searchQuery->sortClauses = null;
         $result = $this->findContent( $searchQuery, $fieldFilters );
 
         if ( empty( $result->searchHits ) )


### PR DESCRIPTION
Optimize sorted search queries by about 50%.

Sorting should not be required when just counting the results. Skipping the sort part of this query reduces the overall runtime for field sorted queries to the SPI by almost 50%.