### PR TITLE
EZP-24499: loading Content with many languages & attributes & locations leads to high memory usage

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase/QueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase/QueryBuilder.php
@@ -90,13 +90,13 @@ class QueryBuilder
             $this->dbHandler->aliasedColumn( $query, 'main_node_id', 'ezcontentobject_tree' )
         )->from(
             $this->dbHandler->quoteTable( 'ezcontentobject' )
-        )->leftJoin(
+        )->innerJoin(
             $this->dbHandler->quoteTable( 'ezcontentobject_version' ),
             $query->expr->eq(
                 $this->dbHandler->quoteColumn( 'contentobject_id', 'ezcontentobject_version' ),
                 $this->dbHandler->quoteColumn( 'id', 'ezcontentobject' )
             )
-        )->leftJoin(
+        )->innerJoin(
             $this->dbHandler->quoteTable( 'ezcontentobject_attribute' ),
             $query->expr->lAnd(
                 $query->expr->eq(
@@ -108,20 +108,9 @@ class QueryBuilder
                     $this->dbHandler->quoteColumn( 'version', 'ezcontentobject_version' )
                 )
             )
-        )->leftJoin(
-            $this->dbHandler->quoteTable( 'ezcontentobject_tree' ),
-            $query->expr->eq(
-                $this->dbHandler->quoteColumn( 'contentobject_id', 'ezcontentobject_tree' ),
-                $this->dbHandler->quoteColumn( 'contentobject_id', 'ezcontentobject_version' )
-            )
-        )
-        // @todo: Joining with ezcontentobject_name is probably a VERY bad way to gather that information
-        // since it creates an additional cartesian product with translations.
-        ->leftJoin(
+        )->innerJoin(
             $this->dbHandler->quoteTable( 'ezcontentobject_name' ),
             $query->expr->lAnd(
-                // ezcontentobject_name.content_translation is also part of the PK but can't be
-                // easily joined with something at this level
                 $query->expr->eq(
                     $this->dbHandler->quoteColumn( 'contentobject_id', 'ezcontentobject_name' ),
                     $this->dbHandler->quoteColumn( 'contentobject_id', 'ezcontentobject_version' )
@@ -129,6 +118,22 @@ class QueryBuilder
                 $query->expr->eq(
                     $this->dbHandler->quoteColumn( 'content_version', 'ezcontentobject_name' ),
                     $this->dbHandler->quoteColumn( 'version', 'ezcontentobject_version' )
+                ),
+                $query->expr->eq(
+                    $this->dbHandler->quoteColumn( 'content_translation', 'ezcontentobject_name' ),
+                    $this->dbHandler->quoteColumn( 'language_code', 'ezcontentobject_attribute' )
+                )
+            )
+        )->leftJoin(
+            $this->dbHandler->quoteTable( 'ezcontentobject_tree' ),
+            $query->expr->lAnd(
+                $query->expr->eq(
+                    $this->dbHandler->quoteColumn( "contentobject_id", "ezcontentobject_tree" ),
+                    $this->dbHandler->quoteColumn( "id", "ezcontentobject" )
+                ),
+                $query->expr->eq(
+                    $this->dbHandler->quoteColumn( "main_node_id", "ezcontentobject_tree" ),
+                    $this->dbHandler->quoteColumn( "node_id", "ezcontentobject_tree" )
                 )
             )
         );

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Gateway/DoctrineDatabaseTest.php
@@ -741,7 +741,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
 
         $this->assertValuesInRows(
             'ezcontentobject_attribute_language_id',
-            array( '2' ),
+            array( '2', '4' ),
             $res
         );
     }
@@ -822,7 +822,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
         );
         $this->assertValuesInRows(
             'ezcontentobject_attribute_language_id',
-            array( '2' ),
+            array( '4' ),
             $res
         );
         $this->assertEquals(

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/_fixtures/contentobjects.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/_fixtures/contentobjects.php
@@ -19161,7 +19161,7 @@ keywords=cms, publish, e-commerce, content management, development framework',
       'data_type_string' => 'ezsrrating',
       'id' => '4000',
       'language_code' => 'eng-GB',
-      'language_id' => '2',
+      'language_id' => '4',
       'sort_key_int' => '0',
       'sort_key_string' => '',
       'version' => '2',
@@ -30394,6 +30394,15 @@ keywords=cms, publish, e-commerce, content management, development framework',
       'language_id'=>3,
       'name'=>'Something',
       'real_translation'=>'eng-US'
+    ),
+
+    array(
+        'content_translation'=>'eng-GB',
+        'content_version'=>2,
+        'contentobject_id'=>226,
+        'language_id'=>4,
+        'name'=>'Something',
+        'real_translation'=>'eng-GB'
     ),
 
     array(

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/_fixtures/extract_content_from_rows.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/_fixtures/extract_content_from_rows.php
@@ -28,7 +28,7 @@ return array (
     'ezcontentobject_attribute_contentclassattribute_id' => '194',
     'ezcontentobject_attribute_data_type_string' => 'ezsrrating',
     'ezcontentobject_attribute_language_code' => 'eng-GB',
-    'ezcontentobject_attribute_language_id' => '2',
+    'ezcontentobject_attribute_language_id' => '4',
     'ezcontentobject_attribute_version' => '2',
     'ezcontentobject_attribute_data_float' => '0.0',
     'ezcontentobject_attribute_data_int' => NULL,
@@ -36,7 +36,7 @@ return array (
     'ezcontentobject_attribute_sort_key_int' => '0',
     'ezcontentobject_attribute_sort_key_string' => '',
     'ezcontentobject_name_name' => 'Something',
-    'ezcontentobject_name_content_translation' => 'eng-US',
+    'ezcontentobject_name_content_translation' => 'eng-GB',
     'ezcontentobject_tree_main_node_id' => '228',
   ),
   1 =>

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/_fixtures/extract_content_from_rows_result.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/_fixtures/extract_content_from_rows_result.php
@@ -13,7 +13,7 @@ $content->fields = array();
 
 $versionInfo = new VersionInfo();
 $versionInfo->id = 676;
-$versionInfo->names = array( 'eng-US' => 'Something' );
+$versionInfo->names = array( 'eng-US' => 'Something', 'eng-GB' => 'Something' );
 $versionInfo->versionNo = 2;
 $versionInfo->modificationDate = 1313061404;
 $versionInfo->creatorId = 14;


### PR DESCRIPTION
issue: https://jira.ez.no/browse/EZP-24499

The SQL in Legacy Content GateWay QueryBuilder has a query which does not correctly filter out the languages we are not interested in, leading mysql to transfer way to many rows *(160k reported in issue)* for the data we need. This causes a lot of unneeded processing making it slow on both mysql and php side. It also causes unneeded network transfer and memory use on server, client and php side, causing memory limit issues in worst cases like the once reported.

Contains two commits:
- fix for fixtures, 25c7cb0b6f9c1b7bcb1a3aa8b8cf07ca4b50a409 introduced issue as it was lacking name table and using wrong language_id for eng-GB, fixing this to be closer to real database caused the issue reported here to be detected by the tests. `testLoadWithSingleTranslation` got 2 rows instead of 1 as expected
- Patch to fix the issue is a adjusted patch of what @pspanja proposed in #1306, it makes sure to use inner join so anything not matching is not included in result

closes #1306

@flovntp Could you/customer please test this, no big database to test this against here to verify it works just as well as the patch you proposed.