### PR TITLE
Fix EZP-23784: Improve Location handling in preview part 2

### DIFF
--- a/eZ/Publish/Core/Helper/PreviewLocationProvider.php
+++ b/eZ/Publish/Core/Helper/PreviewLocationProvider.php
@@ -50,12 +50,13 @@ class PreviewLocationProvider
      *
      * If the content doesn't have a location nor a location draft, null is returned.
      *
-     * @param mixed $contentInfo
+     * @param mixed $contentId
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Location|null
      */
     public function loadMainLocation( $contentId )
     {
+        $location = null;
         $contentInfo = $this->contentService->loadContentInfo( $contentId );
 
         // mainLocationId already exists, content has been published at least once.
@@ -64,22 +65,22 @@ class PreviewLocationProvider
             $location = $this->locationService->loadLocation( $contentInfo->mainLocationId );
         }
         // New Content, never published, create a virtual location object.
-        else
+        else if ( !$contentInfo->published )
         {
-            // @todo In future releases this will be a full draft location when this feature
-            // is implemented. Or it might return null when content does not have location,
-            // but for now we can't detect that so we return a virtual draft location
+            // In cases content is missing locations this will return empty array
             $parentLocations = $this->locationHandler->loadParentLocationsForDraftContent( $contentInfo->id );
-            if ( count( $parentLocations ) === 0 )
+            if ( empty( $parentLocations ) )
             {
                 return null;
             }
+
             $location = new Location(
                 array(
                     'contentInfo' => $contentInfo,
                     'status' => Location::STATUS_DRAFT,
                     'parentLocationId' => $parentLocations[0]->id,
-                    'depth' => $parentLocations[0]->depth + 1
+                    'depth' => $parentLocations[0]->depth + 1,
+                    'pathString' => $parentLocations[0]->pathString . '/x'
                 )
             );
         }

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Controller\Content;
 
 use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Location;
@@ -66,6 +67,9 @@ class PreviewController
         $this->locationProvider = $locationProvider;
     }
 
+    /**
+     * @throws NotImplementedException If Content is missing location as this is not supported in current version
+     */
     public function previewContentAction( Request $request, $contentId, $versionNo, $language, $siteAccessName = null )
     {
         $this->previewHelper->setPreviewActive( true );
@@ -74,6 +78,12 @@ class PreviewController
         {
             $content = $this->contentService->loadContent( $contentId, array( $language ), $versionNo );
             $location = $this->locationProvider->loadMainLocation( $contentId );
+
+            if ( !$location instanceof Location )
+            {
+                throw new NotImplementedException( "Preview for content without locations" );
+            }
+
             $this->previewHelper->setPreviewedContent( $content );
             $this->previewHelper->setPreviewedLocation( $location );
         }

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Controller\Content;
 
 use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\MVC\Symfony\Controller\Controller;
@@ -406,8 +407,10 @@ class ViewController extends Controller
      * @param string $viewType
      * @param boolean $layout
      * @param array $params
+     *
+     * @return string
      */
-    protected function renderLocation( $location, $viewType, $layout = false, array $params = array() )
+    protected function renderLocation( Location $location, $viewType, $layout = false, array $params = array() )
     {
         return $this->viewManager->renderLocation( $location, $viewType, $params + array( 'noLayout' => !$layout ) );
     }
@@ -419,8 +422,10 @@ class ViewController extends Controller
      * @param string $viewType
      * @param boolean $layout
      * @param array $params
+     *
+     * @return string
      */
-    protected function renderContent( $content, $viewType, $layout = false, array $params = array() )
+    protected function renderContent( Content $content, $viewType, $layout = false, array $params = array() )
     {
         return $this->viewManager->renderContent( $content, $viewType, $params + array( 'noLayout' => !$layout ) );
     }


### PR DESCRIPTION
issue: https://jira.ez.no/browse/EZP-23784

Just a small enhancement to what was done in #1113 to:
- adds a somewhat correct pathString
- cleans up the code a bit to mainly throw NotImplemented when Content has no locations

Intend to backport this and #1113 to 5.4 for the customer that has some issues around this to see if it solves their problem, or not.

review ping @bdunogier @lolautruche 