### PR TITLE
Fix EZP-24562: quotes in urlAlias cause twig's path() to break html

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
@@ -2,6 +2,12 @@ parameters:
     # Redefining the default router class to implement the RequestMatcherInterface
     router.class: eZ\Bundle\EzPublishCoreBundle\Routing\DefaultRouter
     ezpublish.default_router.non_siteaccess_aware_routes: ['_assetic_', '_wdt', '_profiler', '_configurator_']
+    # characters that may require encoding in the urlalias generator
+    ezpublish.urlalias_generator.charmap:
+        "\"" : "%22"
+        "'" : "%27"
+        "<" : "%3C"
+        ">" : "%3E"
 
     ezpublish.chain_router.class: eZ\Publish\Core\MVC\Symfony\Routing\ChainRouter
     ezpublish.url_generator.base.class: eZ\Publish\Core\MVC\Symfony\Routing\Generator
@@ -57,7 +63,11 @@ services:
 
     ezpublish.urlalias_generator:
         class: %ezpublish.urlalias_generator.class%
-        arguments: [@ezpublish.api.repository, @router.default, @ezpublish.config.resolver]
+        arguments:
+            - @ezpublish.api.repository
+            - @router.default
+            - @ezpublish.config.resolver
+            - %ezpublish.urlalias_generator.charmap%
         parent: ezpublish.url_generator.base
 
     ezpublish.siteaccess.matcher_builder:

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -55,11 +55,20 @@ class UrlAliasGenerator extends Generator
      */
     private $configResolver;
 
-    public function __construct( Repository $repository, RouterInterface $defaultRouter, ConfigResolverInterface $configResolver )
+    /**
+     * Array of characters that are potentially unsafe for output for (x)html, json, etc,
+     * and respective url-encoded value
+     *
+     * @var array
+     */
+    private $unsafeCharMap;
+
+    public function __construct( Repository $repository, RouterInterface $defaultRouter, ConfigResolverInterface $configResolver , array $unsafeCharMap = array() )
     {
         $this->repository = $repository;
         $this->defaultRouter = $defaultRouter;
         $this->configResolver = $configResolver;
+        $this->unsafeCharMap = $unsafeCharMap;
     }
 
     /**
@@ -130,7 +139,9 @@ class UrlAliasGenerator extends Generator
         }
 
         $path = $path ?: '/';
-        return $path . $queryString;
+
+        // replace potentially unsafe characters with url-encoded counterpart
+        return strtr( $path . $queryString, $this->unsafeCharMap );
     }
 
     /**

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
@@ -86,10 +86,17 @@ class UrlAliasGeneratorTest extends PHPUnit_Framework_TestCase
             ->method( 'getLocationService' )
             ->will( $this->returnValue( $this->locationService ) );
 
+        $urlAliasCharmap = array(
+            '"' => '%22',
+            "'" => '%27',
+            '<' => '%3C',
+            '>' => '%3E',
+        );
         $this->urlAliasGenerator = new UrlAliasGenerator(
             $this->repository,
             $this->router,
-            $this->configResolver
+            $this->configResolver,
+            $urlAliasCharmap
         );
         $this->urlAliasGenerator->setLogger( $this->logger );
         $this->urlAliasGenerator->setSiteAccessRouter( $this->siteAccessRouter );
@@ -223,6 +230,11 @@ class UrlAliasGeneratorTest extends PHPUnit_Framework_TestCase
                 new URLAlias( array( 'path' => '/foo/bar' ) ),
                 array( 'some' => 'thing', 'truc' => 'muche' ),
                 '/foo/bar?some=thing&truc=muche'
+            ),
+            array(
+                new UrlAlias( array( 'path' => '/special-chars-"<>\'' ) ),
+                array(),
+                '/special-chars-%22%3C%3E%27',
             ),
         );
     }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24562

#### Problem ####
When using `urlalias_iri` legacy transformation group, url aliases can be created with single/quotes, for example.

Symfony's RoutingExtension for twig, which implements `{{ path() }}`, has it's own method for determining wether an url is potentially unsafe, in which case it can be html-encoded.

However, this is not compatible with eZ Publish's simple `path(location)` . ref:
https://github.com/symfony/TwigBridge/blob/master/Extension/RoutingExtension.php#L75

#### Solution ####
In the UrlAliasGenerator, manually replace potentially unsafe characters with their url-encoded counterpart (not html-encoded, so that it is always a valid url)