### PR TITLE
Implement EZP-24558: Solr: extract core filtering logic into dedicated service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ branches:
     - master
     - impl-EZP-24434-aa-core-2
     - fix-EZP-24556-solr-customfield
+    - impl-EZP-24558-extract-core-filter
 
 # setup requirements for running unit/integration/behat tests
 before_script:

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/CoreFilter.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/CoreFilter.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Search\Solr\Content\Gateway;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+
+/**
+ * Core filter applies conditions on a query object ensuring matching of correct
+ * document across multiple Solr indexes.
+ */
+abstract class CoreFilter
+{
+    /**
+     * Applies conditions on the $query using given $languageSettings.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param array $languageSettings
+     */
+    abstract public function apply( Query $query, array $languageSettings );
+}

--- a/eZ/Publish/Core/Search/Solr/Content/Gateway/CoreFilter/NativeCoreFilter.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Gateway/CoreFilter/NativeCoreFilter.php
@@ -1,0 +1,292 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Search\Solr\Content\Gateway\CoreFilter;
+
+use eZ\Publish\Core\Search\Solr\Content\Gateway\CoreFilter;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalNot;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOr;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\CustomField;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointResolver;
+
+/**
+ * Native core filter handles:
+ *
+ * - search type (Content and Location)
+ * - prioritized languages fallback
+ * - always available language fallback
+ * - main language search
+ */
+class NativeCoreFilter extends CoreFilter
+{
+    /**
+     * Name of the Solr backend field holding document type identifier
+     * ('content' or 'location').
+     *
+     * @access private
+     *
+     * @var string
+     */
+    const FIELD_DOCUMENT_TYPE = "document_type_id";
+
+    /**
+     * Name of the Solr backend field holding list of all translation's Content
+     * language codes.
+     *
+     * @access private
+     *
+     * @var string
+     */
+    const FIELD_LANGUAGES = "language_code_ms";
+
+    /**
+     * Name of the Solr backend field holding language code of the indexed
+     * translation.
+     *
+     * @access private
+     *
+     * @var string
+     */
+    const FIELD_LANGUAGE = "meta_indexed_language_code_s";
+
+    /**
+     * Name of the Solr backend field indicating if the indexed translation
+     * is in the main language.
+     *
+     * @access private
+     *
+     * @var string
+     */
+    const FIELD_IS_MAIN_LANGUAGE = "meta_indexed_is_main_translation_b";
+
+    /**
+     * Name of the Solr backend field indicating if the indexed translation
+     * is always available.
+     *
+     * @access private
+     *
+     * @var string
+     */
+    const FIELD_IS_ALWAYS_AVAILABLE = "meta_indexed_is_main_translation_and_always_available_b";
+
+    /**
+     * Name of the Solr backend field indicating if the indexed document is
+     * located in the main translations index.
+     *
+     * @access private
+     *
+     * @var string
+     */
+    const FIELD_IS_MAIN_LANGUAGES_INDEX = "meta_indexed_main_translation_b";
+
+    /**
+     * Indicates presence of main languages index.
+     *
+     * @var boolean
+     */
+    private $hasMainLanguagesEndpoint;
+
+    public function __construct( EndpointResolver $endpointResolver )
+    {
+        $this->hasMainLanguagesEndpoint = (
+            $endpointResolver->getMainLanguagesEndpoint() !== null
+        );
+    }
+
+    public function apply( Query $query, array $languageSettings )
+    {
+        $languages = (
+            empty( $languageSettings["languages"] ) ?
+                array() :
+                $languageSettings["languages"]
+        );
+        $useAlwaysAvailable = (
+            !isset( $languageSettings["useAlwaysAvailable"] ) ||
+            $languageSettings["useAlwaysAvailable"] === true
+        );
+
+        $documentType = "content";
+        if ( $query instanceof LocationQuery )
+        {
+            $documentType = "location";
+        }
+
+        $query->filter = new LogicalAnd(
+            array(
+                new CustomField( self::FIELD_DOCUMENT_TYPE, Operator::EQ, $documentType ),
+                $query->filter,
+                $this->getCoreCriterion( $languages, $useAlwaysAvailable )
+            )
+        );
+    }
+
+    /**
+     * Returns a filtering condition for the given language settings.
+     *
+     * The condition ensures the same Content will be matched only once across all
+     * targeted translation endpoints.
+     *
+     * @param string[] $languageCodes
+     * @param boolean $useAlwaysAvailable
+     *
+     * @return string
+     */
+    private function getCoreCriterion( array $languageCodes, $useAlwaysAvailable )
+    {
+        // Handle languages if given
+        if ( !empty( $languageCodes ) )
+        {
+            // Get condition for prioritized languages fallback
+            $filter = $this->getLanguageFilter( $languageCodes );
+
+            // Handle always available fallback if used
+            if ( $useAlwaysAvailable )
+            {
+                // Combine conditions with OR
+                $filter = new LogicalOr(
+                    array(
+                        $filter,
+                        $this->getAlwaysAvailableFilter( $languageCodes )
+                    )
+                );
+            }
+
+            // Return languages condition
+            return $filter;
+        }
+
+        // Otherwise search only main languages
+        return new CustomField( self::FIELD_IS_MAIN_LANGUAGE, Operator::EQ, true );
+    }
+
+    /**
+     * Returns criteria for prioritized languages fallback.
+     *
+     * @param string[] $languageCodes
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion
+     */
+    private function getLanguageFilter( array $languageCodes )
+    {
+        $languageFilters = array();
+
+        foreach ( $languageCodes as $languageCode )
+        {
+            // Include language
+            $condition = new CustomField( self::FIELD_LANGUAGE, Operator::EQ, $languageCode );
+            // Get list of excluded languages
+            $excluded = $this->getExcludedLanguageCodes( $languageCodes, $languageCode );
+
+            // Combine if list is not empty
+            if ( !empty( $excluded ) )
+            {
+                $condition = new LogicalAnd(
+                    array(
+                        $condition,
+                        new LogicalNot(
+                            new CustomField( self::FIELD_LANGUAGES, Operator::IN, $excluded )
+                        ),
+                    )
+                );
+            }
+
+            $languageFilters[] = $condition;
+        }
+
+        // Combine language fallback conditions with OR
+        if ( count( $languageFilters ) > 1 )
+        {
+            $languageFilters = array( new LogicalOr( $languageFilters ) );
+        }
+
+        // Exclude main languages index if used
+        if ( $this->hasMainLanguagesEndpoint )
+        {
+            $languageFilters[] = new LogicalNot(
+                new CustomField( self::FIELD_IS_MAIN_LANGUAGES_INDEX, Operator::EQ, true )
+            );
+        }
+
+        // Combine conditions
+        if ( count( $languageFilters ) > 1 )
+        {
+            return new LogicalAnd( $languageFilters );
+        }
+
+        return reset( $languageFilters );
+    }
+
+    /**
+     * Returns criteria for always available translation fallback.
+     *
+     * @param string[] $languageCodes
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion
+     */
+    private function getAlwaysAvailableFilter( array $languageCodes )
+    {
+        $conditions = array(
+            // Include always available main language translations
+            new CustomField(
+                self::FIELD_IS_ALWAYS_AVAILABLE,
+                Operator::EQ,
+                true
+            ),
+            // Exclude all given languages
+            new LogicalNot(
+                new CustomField( self::FIELD_LANGUAGES, Operator::IN, $languageCodes )
+            ),
+        );
+
+        // Include only from main languages index if used
+        if ( $this->hasMainLanguagesEndpoint )
+        {
+            $conditions[] = new CustomField(
+                self::FIELD_IS_MAIN_LANGUAGES_INDEX,
+                Operator::EQ,
+                true
+            );
+        }
+
+        // Combine conditions
+        return new LogicalAnd( $conditions );
+    }
+
+    /**
+     * Returns a list of language codes to be excluded when matching translation in given
+     * $selectedLanguageCode.
+     *
+     * If $selectedLanguageCode is omitted, all languages will be returned.
+     *
+     * @param string[] $languageCodes
+     * @param null|string $selectedLanguageCode
+     *
+     * @return string[]
+     */
+    private function getExcludedLanguageCodes( array $languageCodes, $selectedLanguageCode = null )
+    {
+        $excludedLanguageCodes = array();
+
+        foreach ( $languageCodes as $languageCode )
+        {
+            if ( $selectedLanguageCode !== null && $languageCode === $selectedLanguageCode )
+            {
+                break;
+            }
+
+            $excludedLanguageCodes[] = $languageCode;
+        }
+
+        return $excludedLanguageCodes;
+    }
+}

--- a/eZ/Publish/Core/settings/search_engines/solr.yml
+++ b/eZ/Publish/Core/settings/search_engines/solr.yml
@@ -11,6 +11,7 @@ parameters:
     ezpublish.search.solr.content.gateway.native.class: eZ\Publish\Core\Search\Solr\Content\Gateway\Native
     ezpublish.search.solr.content.gateway.endpoint_registry.class: eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointRegistry
     ezpublish.search.solr.content.gateway.endpoint_resolver.native.class: eZ\Publish\Core\Search\Solr\Content\Gateway\EndpointResolver\NativeEndpointResolver
+    ezpublish.search.solr.content.gateway.core_filter.native.class: eZ\Publish\Core\Search\Solr\Content\Gateway\CoreFilter\NativeCoreFilter
     ezpublish.spi.search.solr.content_handler.class: eZ\Publish\Core\Search\Solr\Content\Handler
     ezpublish.search.solr.content.document_mapper.native.class: eZ\Publish\Core\Search\Solr\Content\DocumentMapper\NativeDocumentMapper
     ezpublish.search.solr.result_extractor.loading.class: eZ\Publish\Core\Search\Solr\Content\ResultExtractor\LoadingResultExtractor
@@ -51,6 +52,22 @@ services:
     ezpublish.search.solr.content.gateway.endpoint_resolver.location:
         alias: ezpublish.search.solr.content.gateway.endpoint_resolver.native.location
 
+    ezpublish.search.solr.content.gateway.core_filter.native.content:
+        class: %ezpublish.search.solr.content.gateway.core_filter.native.class%
+        arguments:
+            - @ezpublish.search.solr.content.gateway.endpoint_resolver.native.content
+
+    ezpublish.search.solr.content.gateway.core_filter.native.location:
+        class: %ezpublish.search.solr.content.gateway.core_filter.native.class%
+        arguments:
+            - @ezpublish.search.solr.content.gateway.endpoint_resolver.native.location
+
+    ezpublish.search.solr.content.gateway.core_filter.content:
+        alias: ezpublish.search.solr.content.gateway.core_filter.native.content
+
+    ezpublish.search.solr.content.gateway.core_filter.location:
+        alias: ezpublish.search.solr.content.gateway.core_filter.native.location
+
     ezpublish.search.solr.content.document_mapper.native:
         class: %ezpublish.search.solr.content.document_mapper.native.class%
         arguments:
@@ -81,6 +98,7 @@ services:
             - @ezpublish.search.solr.content.gateway.client.http.stream
             - @ezpublish.search.solr.content.gateway.endpoint_resolver.content
             - @ezpublish.search.solr.content.gateway.endpoint_registry
+            - @ezpublish.search.solr.content.gateway.core_filter.content
             - @ezpublish.search.solr.content.criterion_visitor.aggregate
             - @ezpublish.search.solr.content.sort_clause_visitor.aggregate
             - @ezpublish.search.solr.content.facet_builder_visitor.aggregate
@@ -105,6 +123,7 @@ services:
             - @ezpublish.search.solr.content.gateway.client.http.stream
             - @ezpublish.search.solr.content.gateway.endpoint_resolver.location
             - @ezpublish.search.solr.content.gateway.endpoint_registry
+            - @ezpublish.search.solr.content.gateway.core_filter.location
             - @ezpublish.search.solr.location.criterion_visitor.aggregate
             - @ezpublish.search.solr.location.sort_clause_visitor.aggregate
             - @ezpublish.search.solr.location.facet_builder_visitor.aggregate


### PR DESCRIPTION
> Review dependency graph
> * https://github.com/ezsystems/ezpublish-kernel/pull/1305 Main languages core
>  * https://github.com/ezsystems/ezpublish-kernel/pull/1322 Multicore tests
>    * https://github.com/ezsystems/ezpublish-kernel/pull/1326 Complete CustomField support
>       * **https://github.com/ezsystems/ezpublish-kernel/pull/1327 Extract CoreFilter service**
>       * https://github.com/ezsystems/ezpublish-kernel/pull/1333 Indexable Selection
>          * https://github.com/ezsystems/ezpublish-kernel/pull/1334 Indexable RelationList
> * https://github.com/ezsystems/ezpublish-kernel/pull/1329 DateModified sort clause

#### This PR resolves https://jira.ez.no/browse/EZP-24558
#### Based on https://github.com/ezsystems/ezpublish-kernel/pull/1326

This extracts core filtering logic into a separate `CoreFilter` service. Native implementation of this service handles:

1. search type (Content and Location)
2. prioritized languages fallback
3. always available language fallback
4. main language search

Filtering condition is now applied to the given `Query` object, using `CustomField` criteria.