### PR TITLE
EZP-24564: REST UserSession expects csrf as string

### DIFF
--- a/eZ/Publish/Core/REST/Server/Controller/User.php
+++ b/eZ/Publish/Core/REST/Server/Controller/User.php
@@ -1025,7 +1025,7 @@ class User extends RestController
             {
                 $csrfToken = $csrfTokenManager->getToken(
                     $this->container->getParameter( 'ezpublish_rest.csrf_token_intention' )
-                );
+                )->getValue();
             }
 
             return new Values\UserSession(


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-24564

Makes sure that the REST User Controller sets the UserSession's CSRF token as a string and not an object.