### PR TITLE
Fix EZP-24557: Solr search engine: DateModified sort clause is not supported with Content Search

### DIFF
--- a/eZ/Publish/Core/Search/Solr/Content/Location/SortClauseVisitor/DateModified.php
+++ b/eZ/Publish/Core/Search/Solr/Content/Location/SortClauseVisitor/DateModified.php
@@ -12,13 +12,13 @@ namespace eZ\Publish\Core\Search\Solr\Content\Location\SortClauseVisitor;
 use eZ\Publish\Core\Search\Solr\Content\SortClauseVisitor;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 
-/**DateModified
+/**
  * Visits the sortClause tree into a Solr query
  */
 class DateModified extends SortClauseVisitor
 {
     /**
-     * CHeck if visitor is applicable to current sortClause
+     * Check if visitor is applicable to current sortClause
      *
      * @param SortClause $sortClause
      *

--- a/eZ/Publish/Core/Search/Solr/Content/SortClauseVisitor/Aggregate.php
+++ b/eZ/Publish/Core/Search/Solr/Content/SortClauseVisitor/Aggregate.php
@@ -21,16 +21,14 @@ class Aggregate extends SortClauseVisitor
     /**
      * Array of available visitors
      *
-     * @var array
+     * @var \eZ\Publish\Core\Search\Solr\Content\SortClauseVisitor[]
      */
     protected $visitors = array();
 
     /**
-     * COnstruct from optional visitor array
+     * Construct from optional visitor array
      *
-     * @param array $visitors
-     *
-     * @return void
+     * @param \eZ\Publish\Core\Search\Solr\Content\SortClauseVisitor[] $visitors
      */
     public function __construct( array $visitors = array() )
     {
@@ -43,9 +41,7 @@ class Aggregate extends SortClauseVisitor
     /**
      * Adds visitor
      *
-     * @param FieldValueVisitor $visitor
-     *
-     * @return void
+     * @param \eZ\Publish\Core\Search\Solr\Content\SortClauseVisitor $visitor
      */
     public function addVisitor( SortClauseVisitor $visitor )
     {
@@ -53,9 +49,9 @@ class Aggregate extends SortClauseVisitor
     }
 
     /**
-     * CHeck if visitor is applicable to current sortClause
+     * Checks if visitor is applicable to current sortClause
      *
-     * @param SortClause $sortClause
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
      *
      * @return boolean
      */
@@ -65,7 +61,9 @@ class Aggregate extends SortClauseVisitor
     }
 
     /**
-     * Map field value to a proper Solr representation
+     * Maps sort clause to a proper Solr representation
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException If visitor is not found
      *
      * @param SortClause $sortClause
      *

--- a/eZ/Publish/Core/Search/Solr/Content/SortClauseVisitor/DateModified.php
+++ b/eZ/Publish/Core/Search/Solr/Content/SortClauseVisitor/DateModified.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * File containing the SortClauseVisitor\DateModified class
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Search\Solr\Content\SortClauseVisitor;
+
+use eZ\Publish\Core\Search\Solr\Content\SortClauseVisitor;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+
+/**
+ * Visits the sortClause tree into a Solr query
+ */
+class DateModified extends SortClauseVisitor
+{
+    /**
+     * Check if visitor is applicable to current sortClause
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
+     *
+     * @return boolean
+     */
+    public function canVisit( SortClause $sortClause )
+    {
+        return $sortClause instanceof SortClause\DateModified;
+    }
+
+    /**
+     * Map field value to a proper Solr representation
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
+     *
+     * @return string
+     */
+    public function visit( SortClause $sortClause )
+    {
+        return 'modified_dt' . $this->getDirection( $sortClause );
+    }
+}

--- a/eZ/Publish/Core/settings/search_engines/solr/sort_clause_visitors.yml
+++ b/eZ/Publish/Core/settings/search_engines/solr/sort_clause_visitors.yml
@@ -9,6 +9,7 @@ parameters:
     ezpublish.search.solr.content.sort_clause_visitor.section_identifier.class: eZ\Publish\Core\Search\Solr\Content\SortClauseVisitor\SectionIdentifier
     ezpublish.search.solr.content.sort_clause_visitor.section_name.class: eZ\Publish\Core\Search\Solr\Content\SortClauseVisitor\SectionName
     ezpublish.search.solr.content.sort_clause_visitor.date_published.class: eZ\Publish\Core\Search\Solr\Content\SortClauseVisitor\DatePublished
+    ezpublish.search.solr.content.sort_clause_visitor.date_modified.class: eZ\Publish\Core\Search\Solr\Content\SortClauseVisitor\DateModified
     ezpublish.search.solr.content.sort_clause_visitor.map_location_distance.class: eZ\Publish\Core\Search\Solr\Content\SortClauseVisitor\MapLocationDistance
     # Location search
     ezpublish.search.solr.location.sort_clause_visitor.content_id.class: eZ\Publish\Core\Search\Solr\Content\Location\SortClauseVisitor\ContentId
@@ -72,6 +73,11 @@ services:
 
     ezpublish.search.solr.content.sort_clause_visitor.date_published:
         class: %ezpublish.search.solr.content.sort_clause_visitor.date_published.class%
+        tags:
+            - {name: ezpublish.search.solr.content.sort_clause_visitor}
+
+    ezpublish.search.solr.content.sort_clause_visitor.date_modified:
+        class: %ezpublish.search.solr.content.sort_clause_visitor.date_modified.class%
         tags:
             - {name: ezpublish.search.solr.content.sort_clause_visitor}
 


### PR DESCRIPTION
> Review dependency graph
> * https://github.com/ezsystems/ezpublish-kernel/pull/1305 Main languages core
>  * https://github.com/ezsystems/ezpublish-kernel/pull/1322 Multicore tests
>    * https://github.com/ezsystems/ezpublish-kernel/pull/1326 Complete CustomField support
>       * https://github.com/ezsystems/ezpublish-kernel/pull/1327 Extract CoreFilter service
>       * https://github.com/ezsystems/ezpublish-kernel/pull/1333 Indexable Selection
>          * https://github.com/ezsystems/ezpublish-kernel/pull/1334 Indexable RelationList
> * **https://github.com/ezsystems/ezpublish-kernel/pull/1329 DateModified sort clause**

#### This PR resolves https://jira.ez.no/browse/EZP-24557

This implements Content Search visitor for `DateModified` sort clause. Tests are already present, but were skipped without the implementation.

Additionally this fixes some docblocks.