### PR TITLE
Fix EZP-24533: Float FieldType has wrong default validator values

### DIFF
--- a/doc/bc/changes-6.0.md
+++ b/doc/bc/changes-6.0.md
@@ -151,6 +151,10 @@ Changes affecting version compatibility with former or future versions.
   <input type="hidden" name="_csrf_token" value="{{ csrf_token("authenticate") }}" />
   ```
 
+* Float field type `FloatValueValidator` has changed. `false` isn't considered as valid value any more for
+  `minFloatValue` and `maxFloatValue`. Use `null` instead of `false` if you want to deactivate these validators.
+  Default validator value has been changed accordingly.
+
 ## Deprecations
 
 * `eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger::purge()` is deprecated and will be removed in v6.1.

--- a/eZ/Publish/Core/FieldType/Float/Type.php
+++ b/eZ/Publish/Core/FieldType/Float/Type.php
@@ -27,11 +27,11 @@ class Type extends FieldType
         'FloatValueValidator' => array(
             'minFloatValue' => array(
                 'type' => 'float',
-                'default' => false
+                'default' => null
             ),
             'maxFloatValue' => array(
                 'type' => 'float',
-                'default' => false
+                'default' => null
             )
         )
     );
@@ -69,7 +69,7 @@ class Type extends FieldType
                 {
                     case "minFloatValue":
                     case "maxFloatValue":
-                        if ( $value !== false && !is_numeric( $value ) )
+                        if ( $value !== null && !is_numeric( $value ) )
                         {
                             $validationErrors[] = new ValidationError(
                                 "Validator parameter '%parameter%' value must be of numeric type",
@@ -124,7 +124,7 @@ class Type extends FieldType
         $validationErrors = array();
 
         if ( isset( $constraints['maxFloatValue'] ) &&
-            $constraints['maxFloatValue'] !== false && $fieldValue->value > $constraints['maxFloatValue'] )
+            $constraints['maxFloatValue'] !== null && $fieldValue->value > $constraints['maxFloatValue'] )
         {
             $validationErrors[] = new ValidationError(
                 "The value can not be higher than %size%.",
@@ -137,7 +137,7 @@ class Type extends FieldType
         }
 
         if ( isset( $constraints['minFloatValue'] ) &&
-            $constraints['minFloatValue'] !== false && $fieldValue->value < $constraints['minFloatValue'] )
+            $constraints['minFloatValue'] !== null && $fieldValue->value < $constraints['minFloatValue'] )
         {
             $validationErrors[] = new ValidationError(
                 "The value can not be lower than %size%.",

--- a/eZ/Publish/Core/FieldType/Tests/FloatTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FloatTest.php
@@ -49,11 +49,11 @@ class FloatTest extends FieldTypeTest
             "FloatValueValidator" => array(
                 "minFloatValue" => array(
                     "type" => "float",
-                    "default" => false
+                    "default" => null
                 ),
                 "maxFloatValue" => array(
                     "type" => "float",
-                    "default" => false
+                    "default" => null
                 )
             )
         );
@@ -306,7 +306,7 @@ class FloatTest extends FieldTypeTest
             array(
                 array(
                     'FloatValueValidator' => array(
-                        'minFloatValue' => false,
+                        'minFloatValue' => null,
                     )
                 )
             ),
@@ -320,7 +320,7 @@ class FloatTest extends FieldTypeTest
             array(
                 array(
                     'FloatValueValidator' => array(
-                        'maxFloatValue' => false,
+                        'maxFloatValue' => null,
                     )
                 )
             ),

--- a/eZ/Publish/Core/FieldType/Tests/FloatValueValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FloatValueValidatorTest.php
@@ -76,11 +76,11 @@ class FloatValueValidatorTest extends PHPUnit_Framework_TestCase
         $constraintsSchema = array(
             "minFloatValue" => array(
                 "type" => "float",
-                "default" => false
+                "default" => null
             ),
             "maxFloatValue" => array(
                 "type" => "float",
-                "default" => false
+                "default" => null
             )
         );
         $validator = new FloatValueValidator;
@@ -243,15 +243,15 @@ class FloatValueValidatorTest extends PHPUnit_Framework_TestCase
                     "maxFloatValue" => 2.2,
                 ),
                 array(
-                    "minFloatValue" => false,
-                    "maxFloatValue" => false
+                    "minFloatValue" => null,
+                    "maxFloatValue" => null
                 ),
                 array(
                     "minFloatValue" => -5,
-                    "maxFloatValue" => false
+                    "maxFloatValue" => null
                 ),
                 array(
-                    "minFloatValue" => false,
+                    "minFloatValue" => null,
                     "maxFloatValue" => 12.7
                 ),
                 array(

--- a/eZ/Publish/Core/FieldType/Validator.php
+++ b/eZ/Publish/Core/FieldType/Validator.php
@@ -176,7 +176,7 @@ abstract class Validator
      */
     public function __set( $name, $value )
     {
-        if ( !isset( $this->constraints[$name] ) )
+        if ( !array_key_exists( $name, $this->constraints ) )
         {
             throw new PropertyNotFound( "The constraint '{$name}' is not valid for this validator." );
         }

--- a/eZ/Publish/Core/FieldType/Validator/FloatValueValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/FloatValueValidator.php
@@ -25,18 +25,18 @@ use eZ\Publish\Core\FieldType\Value as BaseValue;
 class FloatValueValidator extends Validator
 {
     protected $constraints = array(
-        'minFloatValue' => false,
-        'maxFloatValue' => false
+        'minFloatValue' => null,
+        'maxFloatValue' => null
     );
 
     protected $constraintsSchema = array(
         "minFloatValue" => array(
             "type" => "float",
-            "default" => false
+            "default" => null
         ),
         "maxFloatValue" => array(
             "type" => "float",
-            "default" => false
+            "default" => null
         )
     );
 
@@ -50,7 +50,7 @@ class FloatValueValidator extends Validator
             {
                 case "minFloatValue":
                 case "maxFloatValue":
-                    if ( $value !== false && !is_numeric( $value ) )
+                    if ( $value !== null && !is_numeric( $value ) )
                     {
                         $validationErrors[] = new ValidationError(
                             "Validator parameter '%parameter%' value must be of numeric type",
@@ -92,7 +92,7 @@ class FloatValueValidator extends Validator
     {
         $isValid = true;
 
-        if ( $this->constraints['maxFloatValue'] !== false && $value->value > $this->constraints['maxFloatValue'] )
+        if ( $this->constraints['maxFloatValue'] !== null && $value->value > $this->constraints['maxFloatValue'] )
         {
             $this->errors[] = new ValidationError(
                 "The value can not be higher than %size%.",
@@ -104,7 +104,7 @@ class FloatValueValidator extends Validator
             $isValid = false;
         }
 
-        if ( $this->constraints['minFloatValue'] !== false && $value->value < $this->constraints['minFloatValue'] )
+        if ( $this->constraints['minFloatValue'] !== null && $value->value < $this->constraints['minFloatValue'] )
         {
             $this->errors[] = new ValidationError(
                 "The value can not be lower than %size%.",

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/FloatConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/FloatConverter.php
@@ -90,7 +90,7 @@ class FloatConverter implements Converter
      */
     public function toFieldDefinition( StorageFieldDefinition $storageDef, FieldDefinition $fieldDef )
     {
-        $validatorParameters = array( 'minFloatValue' => false, 'maxFloatValue' => false );
+        $validatorParameters = array( 'minFloatValue' => null, 'maxFloatValue' => null );
         if ( $storageDef->dataFloat4 & self::HAS_MIN_VALUE )
         {
             $validatorParameters['minFloatValue'] = $storageDef->dataFloat1;


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24533

To be compatible with Symfony Form component and NumberToLocalizedStringTransformer, we **must not** use `false` as default values, and prefer `null` instead.