### PR TITLE
Impl EZP-24572: Implement Indexable definition for Selection field type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,7 @@ branches:
   only:
     - master
     - impl-EZP-24434-aa-core-2
+    - impl-EZP-24471-solr-multicore-tests
 
 # setup requirements for running unit/integration/behat tests
 before_script:

--- a/eZ/Publish/API/Repository/Tests/FieldType/SelectionIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SelectionIntegrationTest.php
@@ -18,7 +18,7 @@ use eZ\Publish\API\Repository\Values\Content\Field;
  * @group integration
  * @group field-type
  */
-class SelectionIntegrationTest extends BaseIntegrationTest
+class SelectionIntegrationTest extends SearchBaseIntegrationTest
 {
     /**
      * Get name of tested field type
@@ -60,8 +60,8 @@ class SelectionIntegrationTest extends BaseIntegrationTest
             'isMultiple' => true,
             'options' => array(
                 0 => 'First',
-                1 => 'Sindelfingen',
-                2 => 'Bielefeld',
+                1 => 'Bielefeld',
+                2 => 'Sindelfingen',
             )
         );
     }
@@ -329,6 +329,42 @@ class SelectionIntegrationTest extends BaseIntegrationTest
             ),
             array(
                 new SelectionValue( array( 0 ) )
+            ),
+        );
+    }
+
+    protected function getValidSearchValueOne()
+    {
+        return array( 1 );
+    }
+
+    protected function getValidSearchValueTwo()
+    {
+        return array( 2 );
+    }
+
+    protected function getSearchTargetValueOne()
+    {
+        return 1;
+    }
+
+    protected function getSearchTargetValueTwo()
+    {
+        return 2;
+    }
+
+    protected function getAdditionallyIndexedFieldData()
+    {
+        return array(
+            array(
+                "option_value",
+                "Bielefeld",
+                "Sindelfingen",
+            ),
+            array(
+                "sort_value",
+                "1",
+                "2",
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/BinaryFile/SearchField.php
+++ b/eZ/Publish/Core/FieldType/BinaryFile/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\BinaryFile;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/BinaryFile/SearchField.php
+++ b/eZ/Publish/Core/FieldType/BinaryFile/SearchField.php
@@ -72,8 +72,13 @@ class SearchField implements Indexable
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "file_name";
+    }
+
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Checkbox/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Checkbox/SearchField.php
@@ -60,8 +60,13 @@ class SearchField implements Indexable
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Checkbox/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Checkbox/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\Checkbox;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/Country/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Country/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\Country;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/Country/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Country/SearchField.php
@@ -60,8 +60,13 @@ class SearchField implements Indexable
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Date/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Date/SearchField.php
@@ -67,8 +67,13 @@ class SearchField implements Indexable
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Date/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Date/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\Date;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 use DateTime;
@@ -22,11 +23,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         // The field type stores date value as a timestamp of the start of the day in the
         // environment's timezone.

--- a/eZ/Publish/Core/FieldType/DateAndTime/SearchField.php
+++ b/eZ/Publish/Core/FieldType/DateAndTime/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\DateAndTime;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/DateAndTime/SearchField.php
+++ b/eZ/Publish/Core/FieldType/DateAndTime/SearchField.php
@@ -60,8 +60,13 @@ class SearchField implements Indexable
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/EmailAddress/SearchField.php
+++ b/eZ/Publish/Core/FieldType/EmailAddress/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\EmailAddress;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/EmailAddress/SearchField.php
+++ b/eZ/Publish/Core/FieldType/EmailAddress/SearchField.php
@@ -60,8 +60,13 @@ class SearchField implements Indexable
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Float/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Float/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\Float;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/Float/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Float/SearchField.php
@@ -60,8 +60,13 @@ class SearchField implements Indexable
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/ISBN/SearchField.php
+++ b/eZ/Publish/Core/FieldType/ISBN/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\ISBN;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/ISBN/SearchField.php
+++ b/eZ/Publish/Core/FieldType/ISBN/SearchField.php
@@ -60,8 +60,13 @@ class SearchField implements Indexable
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Image/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Image/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\Image;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/Image/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Image/SearchField.php
@@ -78,8 +78,13 @@ class SearchField implements Indexable
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "filename";
+    }
+
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Integer/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Integer/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\Integer;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/Integer/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Integer/SearchField.php
@@ -60,8 +60,13 @@ class SearchField implements Indexable
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/MapLocation/SearchField.php
+++ b/eZ/Publish/Core/FieldType/MapLocation/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\MapLocation;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -22,10 +23,11 @@ class SearchField implements Indexable
      * Get index data for field for search backend
      *
      * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/MapLocation/SearchField.php
+++ b/eZ/Publish/Core/FieldType/MapLocation/SearchField.php
@@ -69,8 +69,13 @@ class SearchField implements Indexable
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value_address";
+    }
+
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Media/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Media/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\Media;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/Media/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Media/SearchField.php
@@ -72,8 +72,13 @@ class SearchField implements Indexable
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "file_name";
+    }
+
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Price/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Price/SearchField.php
@@ -62,8 +62,13 @@ class SearchField implements Indexable
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Price/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Price/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\Price;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/Relation/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Relation/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\Relation;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/Relation/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Relation/SearchField.php
@@ -60,8 +60,13 @@ class SearchField implements Indexable
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Selection/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Selection/SearchField.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\FieldType\Selection;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
+use eZ\Publish\SPI\FieldType\Indexable;
+use eZ\Publish\SPI\Search;
+
+/**
+ * Indexable definition for Selection field type
+ */
+class SearchField implements Indexable
+{
+    /**
+     * Get index data for field for search backend
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
+    {
+        $indexes = array();
+        $values = array();
+        $fieldSettings = $fieldDefinition->fieldTypeConstraints->fieldSettings;
+        $options = $fieldSettings["options"];
+        $positionSet = array_flip( $field->value->data );
+
+        foreach ( $options as $index => $value )
+        {
+            if ( isset( $positionSet[$index] ) )
+            {
+                $values[] = $value;
+                $indexes[] = $index;
+            }
+        }
+
+        return array(
+            new Search\Field(
+                'option_value',
+                $values,
+                new Search\FieldType\MultipleStringField()
+            ),
+            new Search\Field(
+                'option_index',
+                $indexes,
+                new Search\FieldType\MultipleIntegerField()
+            ),
+            new Search\Field(
+                'option_count',
+                count( $indexes ),
+                new Search\FieldType\IntegerField()
+            ),
+            new Search\Field(
+                'sort_value',
+                implode( "-", $indexes ),
+                new Search\FieldType\StringField()
+            ),
+        );
+    }
+
+    /**
+     * Get index field types for search backend
+     *
+     * @return \eZ\Publish\SPI\Search\FieldType[]
+     */
+    public function getIndexDefinition()
+    {
+        return array(
+            'option_value' => new Search\FieldType\MultipleStringField(),
+            'option_index' => new Search\FieldType\MultipleIntegerField(),
+            'sort_value' => new Search\FieldType\StringField(),
+        );
+    }
+
+    /**
+     * Get name of the default field to be used for query and sort.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for query and sort. Default field is typically used by Field
+     * criterion and sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultMatchField()
+    {
+        return "option_index";
+    }
+
+    public function getDefaultSortField()
+    {
+        return "sort_value";
+    }
+}

--- a/eZ/Publish/Core/FieldType/TextBlock/SearchField.php
+++ b/eZ/Publish/Core/FieldType/TextBlock/SearchField.php
@@ -60,8 +60,13 @@ class SearchField implements Indexable
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/TextBlock/SearchField.php
+++ b/eZ/Publish/Core/FieldType/TextBlock/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\TextBlock;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/TextLine/SearchField.php
+++ b/eZ/Publish/Core/FieldType/TextLine/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\TextLine;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/TextLine/SearchField.php
+++ b/eZ/Publish/Core/FieldType/TextLine/SearchField.php
@@ -60,8 +60,13 @@ class SearchField implements Indexable
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Time/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Time/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\Time;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/Time/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Time/SearchField.php
@@ -60,8 +60,13 @@ class SearchField implements Indexable
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Unindexed.php
+++ b/eZ/Publish/Core/FieldType/Unindexed.php
@@ -51,7 +51,12 @@ class Unindexed implements Indexable
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
+    {
+        return null;
+    }
+
+    public function getDefaultSortField()
     {
         return null;
     }

--- a/eZ/Publish/Core/FieldType/Unindexed.php
+++ b/eZ/Publish/Core/FieldType/Unindexed.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 
 /**
@@ -20,11 +21,12 @@ class Unindexed implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array();
     }

--- a/eZ/Publish/Core/Search/Common/FieldNameResolver.php
+++ b/eZ/Publish/Core/Search/Common/FieldNameResolver.php
@@ -135,7 +135,8 @@ class FieldNameResolver
                 $contentTypeIdentifier,
                 $fieldDefinitionIdentifier,
                 $fieldIdentifierMap[$fieldDefinitionIdentifier]["field_type_identifier"],
-                $name
+                $name,
+                false
             );
         }
 
@@ -182,7 +183,8 @@ class FieldNameResolver
             $contentTypeIdentifier,
             $fieldDefinitionIdentifier,
             $fieldMap[$contentTypeIdentifier][$fieldDefinitionIdentifier]["field_type_identifier"],
-            $name
+            $name,
+            true
         );
     }
 
@@ -194,6 +196,7 @@ class FieldNameResolver
      * @param string $fieldDefinitionIdentifier
      * @param string $fieldTypeIdentifier
      * @param string $name
+     * @param boolean $isSortField
      *
      * @return string
      */
@@ -202,7 +205,8 @@ class FieldNameResolver
         $contentTypeIdentifier,
         $fieldDefinitionIdentifier,
         $fieldTypeIdentifier,
-        $name
+        $name,
+        $isSortField
     )
     {
         // If criterion or sort clause implements CustomFieldInterface and custom field is set for
@@ -222,10 +226,17 @@ class FieldNameResolver
 
         $indexFieldType = $this->fieldRegistry->getType( $fieldTypeIdentifier );
 
-        // If $name is not given use default search field name
+        // If $name is not given use default field name
         if ( $name === null )
         {
-            $name = $indexFieldType->getDefaultField();
+            if ( $isSortField )
+            {
+                $name = $indexFieldType->getDefaultSortField();
+            }
+            else
+            {
+                $name = $indexFieldType->getDefaultMatchField();
+            }
         }
 
         $indexDefinition = $indexFieldType->getIndexDefinition();

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/FieldValueMapper/IntegerMapper.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/FieldValueMapper/IntegerMapper.php
@@ -39,6 +39,18 @@ class IntegerMapper extends FieldValueMapper
      */
     public function map( Field $field )
     {
-        return (int)$field->value;
+        return $this->convert( $field->value );
+    }
+
+    /**
+     * Convert to a proper Elasticsearch representation
+     *
+     * @param mixed $value
+     *
+     * @return string
+     */
+    protected function convert( $value )
+    {
+        return (int)$value;
     }
 }

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/FieldValueMapper/MultipleIntegerMapper.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/FieldValueMapper/MultipleIntegerMapper.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * File containing the MultipleStringMapper class
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper;
+
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType\MultipleIntegerField;
+
+/**
+ * Maps raw document field values to something Solr can index.
+ */
+class MultipleIntegerMapper extends IntegerMapper
+{
+    /**
+     * Check if field can be mapped
+     *
+     * @param Field $field
+     *
+     * @return bool
+     */
+    public function canMap( Field $field )
+    {
+        return $field->type instanceof MultipleIntegerField;
+    }
+
+    /**
+     * Map field value to a proper Solr representation
+     *
+     * @param Field $field
+     *
+     * @return array
+     */
+    public function map( Field $field )
+    {
+        $values = array();
+
+        foreach ( (array)$field->value as $value )
+        {
+            $values[] = $this->convert( $value );
+        }
+
+        return $values;
+    }
+}
+

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Mapper/StandardMapper.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Mapper/StandardMapper.php
@@ -321,7 +321,9 @@ class StandardMapper implements MapperInterface
                     }
 
                     $fieldType = $this->fieldRegistry->getType( $field->type );
-                    foreach ( $fieldType->getIndexData( $field ) as $indexField )
+                    $indexFields = $fieldType->getIndexData( $field, $fieldDefinition );
+
+                    foreach ( $indexFields as $indexField )
                     {
                         $fields[] = new Field(
                             $name = $this->fieldNameGenerator->getName(

--- a/eZ/Publish/Core/Search/Solr/Content/DocumentMapper/NativeDocumentMapper.php
+++ b/eZ/Publish/Core/Search/Solr/Content/DocumentMapper/NativeDocumentMapper.php
@@ -420,7 +420,9 @@ class NativeDocumentMapper implements DocumentMapper
                 }
 
                 $fieldType = $this->fieldRegistry->getType( $field->type );
-                foreach ( $fieldType->getIndexData( $field ) as $indexField )
+                $indexFields = $fieldType->getIndexData( $field, $fieldDefinition );
+
+                foreach ( $indexFields as $indexField )
                 {
                     if ( $indexField->value === null )
                     {

--- a/eZ/Publish/Core/Search/Tests/FieldNameResolverTest.php
+++ b/eZ/Publish/Core/Search/Tests/FieldNameResolverTest.php
@@ -428,7 +428,8 @@ class FieldNameResolverTest extends TestCase
             "content_type_identifier",
             "field_definition_identifier",
             "dummy",
-            "dummy"
+            "dummy",
+            false
         );
 
         $this->assertEquals( "custom_field_name", $customFieldName );
@@ -489,13 +490,14 @@ class FieldNameResolverTest extends TestCase
             "content_type_identifier",
             "field_definition_identifier",
             "field_type_identifier",
-            "field_name"
+            "field_name",
+            true
         );
 
         $this->assertEquals( "generated_typed_field_name", $fieldName );
     }
 
-    public function testGetIndexFieldNameDefaultField()
+    public function testGetIndexFieldNameDefaultMatchField()
     {
         $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getSearchableFieldMap" ) );
         $indexFieldType = $this->getIndexFieldTypeMock();
@@ -511,7 +513,7 @@ class FieldNameResolverTest extends TestCase
 
         $indexFieldType
             ->expects( $this->once() )
-            ->method( "getDefaultField" )
+            ->method( "getDefaultMatchField" )
             ->will(
                 $this->returnValue( "field_name" )
             );
@@ -555,16 +557,14 @@ class FieldNameResolverTest extends TestCase
             "content_type_identifier",
             "field_definition_identifier",
             "field_type_identifier",
-            null
+            null,
+            false
         );
 
         $this->assertEquals( "generated_typed_field_name", $fieldName );
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
-    public function testGetIndexFieldNameDefaultFieldThrowsRuntimeException()
+    public function testGetIndexFieldNameDefaultSortField()
     {
         $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getSearchableFieldMap" ) );
         $indexFieldType = $this->getIndexFieldTypeMock();
@@ -580,7 +580,77 @@ class FieldNameResolverTest extends TestCase
 
         $indexFieldType
             ->expects( $this->once() )
-            ->method( "getDefaultField" )
+            ->method( "getDefaultSortField" )
+            ->will(
+                $this->returnValue( "field_name" )
+            );
+
+        $indexFieldType
+            ->expects( $this->once() )
+            ->method( "getIndexDefinition" )
+            ->will(
+                $this->returnValue(
+                    array(
+                        "field_name" => $searchFieldTypeMock,
+                    )
+                )
+            );
+
+        $this->fieldNameGeneratorMock
+            ->expects( $this->once() )
+            ->method( "getName" )
+            ->with(
+                "field_name",
+                "field_definition_identifier",
+                "content_type_identifier"
+            )
+            ->will(
+                $this->returnValue( "generated_field_name" )
+            );
+
+        $this->fieldNameGeneratorMock
+            ->expects( $this->once() )
+            ->method( "getTypedName" )
+            ->with(
+                "generated_field_name",
+                $this->isInstanceOf( "eZ\\Publish\\SPI\\Search\\FieldType" )
+            )
+            ->will(
+                $this->returnValue( "generated_typed_field_name" )
+            );
+
+        $fieldName = $mockedFieldNameResolver->getIndexFieldName(
+            new ArrayObject(),
+            "content_type_identifier",
+            "field_definition_identifier",
+            "field_type_identifier",
+            null,
+            true
+        );
+
+        $this->assertEquals( "generated_typed_field_name", $fieldName );
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testGetIndexFieldNameDefaultMatchFieldThrowsRuntimeException()
+    {
+        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getSearchableFieldMap" ) );
+        $indexFieldType = $this->getIndexFieldTypeMock();
+        $searchFieldTypeMock = $this->getSearchFieldTypeMock();
+
+        $this->fieldRegistryMock
+            ->expects( $this->once() )
+            ->method( "getType" )
+            ->with( "field_type_identifier" )
+            ->will(
+                $this->returnValue( $indexFieldType )
+            );
+
+        $indexFieldType
+            ->expects( $this->once() )
+            ->method( "getDefaultMatchField" )
             ->will(
                 $this->returnValue( "non_existent_field_name" )
             );
@@ -601,7 +671,53 @@ class FieldNameResolverTest extends TestCase
             "content_type_identifier",
             "field_definition_identifier",
             "field_type_identifier",
-            null
+            null,
+            false
+        );
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testGetIndexFieldNameDefaultSortFieldThrowsRuntimeException()
+    {
+        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getSearchableFieldMap" ) );
+        $indexFieldType = $this->getIndexFieldTypeMock();
+        $searchFieldTypeMock = $this->getSearchFieldTypeMock();
+
+        $this->fieldRegistryMock
+            ->expects( $this->once() )
+            ->method( "getType" )
+            ->with( "field_type_identifier" )
+            ->will(
+                $this->returnValue( $indexFieldType )
+            );
+
+        $indexFieldType
+            ->expects( $this->once() )
+            ->method( "getDefaultSortField" )
+            ->will(
+                $this->returnValue( "non_existent_field_name" )
+            );
+
+        $indexFieldType
+            ->expects( $this->once() )
+            ->method( "getIndexDefinition" )
+            ->will(
+                $this->returnValue(
+                    array(
+                        "field_name" => $searchFieldTypeMock,
+                    )
+                )
+            );
+
+        $mockedFieldNameResolver->getIndexFieldName(
+            new ArrayObject(),
+            "content_type_identifier",
+            "field_definition_identifier",
+            "field_type_identifier",
+            null,
+            true
         );
     }
 
@@ -640,7 +756,8 @@ class FieldNameResolverTest extends TestCase
             "content_type_identifier",
             "field_definition_identifier",
             "field_type_identifier",
-            "non_existent_field_name"
+            "non_existent_field_name",
+            false
         );
     }
 

--- a/eZ/Publish/Core/settings/indexable_fieldtypes.yml
+++ b/eZ/Publish/Core/settings/indexable_fieldtypes.yml
@@ -16,6 +16,7 @@ parameters:
     ezpublish.fieldType.indexable.ezinteger.class: eZ\Publish\Core\FieldType\Integer\SearchField
     ezpublish.fieldType.indexable.ezfloat.class: eZ\Publish\Core\FieldType\Float\SearchField
     ezpublish.fieldType.indexable.eztime.class: eZ\Publish\Core\FieldType\Time\SearchField
+    ezpublish.fieldType.indexable.ezselection.class: eZ\Publish\Core\FieldType\Selection\SearchField
     ezpublish.fieldType.indexable.unindexed.class: eZ\Publish\Core\FieldType\Unindexed
 
 services:
@@ -116,6 +117,11 @@ services:
         tags:
             - {name: ezpublish.fieldType.indexable, alias: ezobjectrelation}
 
+    ezpublish.fieldType.indexable.ezselection:
+        class: %ezpublish.fieldType.indexable.ezselection.class%
+        tags:
+            - {name: ezpublish.fieldType.indexable, alias: ezselection}
+
     ezpublish.fieldType.indexable.unindexed:
         class: %ezpublish.fieldType.indexable.unindexed.class%
         tags:
@@ -127,7 +133,6 @@ services:
             - {name: ezpublish.fieldType.indexable, alias: ezmultioption}
             - {name: ezpublish.fieldType.indexable, alias: ezauthor}
             - {name: ezpublish.fieldType.indexable, alias: ezsrrating}
-            - {name: ezpublish.fieldType.indexable, alias: ezselection}
             - {name: ezpublish.fieldType.indexable, alias: ezsubtreesubscription}
             - {name: ezpublish.fieldType.indexable, alias: ezobjectrelationlist}
             - {name: ezpublish.fieldType.indexable, alias: ezoption}

--- a/eZ/Publish/Core/settings/search_engines/elasticsearch/field_value_mappers.yml
+++ b/eZ/Publish/Core/settings/search_engines/elasticsearch/field_value_mappers.yml
@@ -6,6 +6,7 @@ parameters:
     ezpublish.search.elasticsearch.content.field_value_mapper.float.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\FloatMapper
     ezpublish.search.elasticsearch.content.field_value_mapper.identifier.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\IdentifierMapper
     ezpublish.search.elasticsearch.content.field_value_mapper.integer.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\IntegerMapper
+    ezpublish.search.elasticsearch.content.field_value_mapper.multiple_integer.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\MultipleIntegerMapper
     ezpublish.search.elasticsearch.content.field_value_mapper.multiple_boolean.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\MultipleBooleanMapper
     ezpublish.search.elasticsearch.content.field_value_mapper.multiple_identifier.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\MultipleIdentifierMapper
     ezpublish.search.elasticsearch.content.field_value_mapper.multiple_string.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\MultipleStringMapper
@@ -40,6 +41,11 @@ services:
 
     ezpublish.search.elasticsearch.content.field_value_mapper.identifier:
         class: %ezpublish.search.elasticsearch.content.field_value_mapper.identifier.class%
+        tags:
+            - {name: ezpublish.search.elasticsearch.content.field_value_mapper}
+
+    ezpublish.search.elasticsearch.content.field_value_mapper.multiple_integer:
+        class: %ezpublish.search.elasticsearch.content.field_value_mapper.multiple_integer.class%
         tags:
             - {name: ezpublish.search.elasticsearch.content.field_value_mapper}
 

--- a/eZ/Publish/SPI/FieldType/Indexable.php
+++ b/eZ/Publish/SPI/FieldType/Indexable.php
@@ -47,6 +47,13 @@ interface Indexable
      *
      * @return string
      */
-    public function getDefaultField();
+    public function getDefaultMatchField();
+
+    /**
+     *
+     *
+     * @return string
+     */
+    public function getDefaultSortField();
 }
 

--- a/eZ/Publish/SPI/FieldType/Indexable.php
+++ b/eZ/Publish/SPI/FieldType/Indexable.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\SPI\FieldType;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 
 /**
  * The field type interface which all field types have to implement to be
@@ -22,11 +23,12 @@ interface Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field );
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition );
 
     /**
      * Get index field types for search backend


### PR DESCRIPTION
#### This PR resolves https://jira.ez.no/browse/EZP-24572
#### Based on https://github.com/ezsystems/ezpublish-kernel/pull/1322

This implements `Indexable` definition for `Selection` field type. Doing so required some changes to the `Indexable` interface:

1. `getFieldData()` now receives SPI FieldDefinition as a second parameter.

  In Selection field type case the field definition is used to index option labels.

2. New method `getDefaultSortField()` is added, `getDefaultField()` is renamed to `getDefaultMatchField()`.

  As Selection field type must index in a multivalued field, which can't be used for sort, a separate field for sort is required.

Indexed data:

1. `option_value`, a list of selected options labels
2. `option_index`, a list of selected options indexes
3. `option_count`, count of selected options
4. `sort_value`, list of selected options indexes concatenated with `-` and used for sorting