### PR TITLE
Implement EZP-24572: Indexable definition for Selection field type

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchMultivaluedBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchMultivaluedBaseIntegrationTest.php
@@ -1,0 +1,785 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\API\Repository\Tests\FieldType;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Field;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalNot;
+
+/**
+ * Integration test for searching and sorting with Field criterion and Field sort clause.
+ *
+ * This test is based on SearchBaseIntegrationTest, expanding it with analogous methods to
+ * provide multivalued field data. Methods provided in SearchBaseIntegrationTest are documented
+ * there.
+ *
+ * To get the test working extend it in a concrete field type test and implement:
+ *
+ * - getValidMultivaluedSearchValueOne()
+ * - getValidMultivaluedSearchValueTwo()
+ *
+ * If needed you can override the methods that provide Field criterion target value and
+ * which by default fall back to the methods mentioned above:
+ *
+ * - getMultivaluedSearchTargetValueOne()
+ * - getMultivaluedSearchTargetValueTwo()
+ *
+ * In order to test fields additionally indexed by the field type, provide the required
+ * data by overriding method:
+ *
+ * - getAdditionallyIndexedMultivaluedFieldData()
+ *
+ * Value should contain at least two distinct values, appearing in ascending order.
+ */
+abstract class SearchMultivaluedBaseIntegrationTest extends SearchBaseIntegrationTest
+{
+    /**
+     * Get search field multivalued value One.
+     *
+     * The value must be valid for Content creation.
+     *
+     * Value should contain at least two distinct values, appearing in ascending order.
+     * Additionally, there should be no overlapping with values provided through
+     * {@link self::getValidMultivaluedSearchValuesTwo()}
+     *
+     * @return mixed
+     */
+    abstract protected function getValidMultivaluedSearchValuesOne();
+
+    /**
+     * Get search target field value One.
+     *
+     * Returns the Field criterion target value for the field value One.
+     * Default implementation falls back on {@link getValidSearchValueOne}.
+     *
+     * @return mixed
+     */
+    protected function getMultivaluedSearchTargetValuesOne()
+    {
+        return $this->getValidMultivaluedSearchValuesOne();
+    }
+
+    /**
+     * Get search field multivalued value Two.
+     *
+     * The value must be valid for Content creation.
+     *
+     * Value should contain at least two distinct values, appearing in ascending order.
+     * Additionally, there should be no overlapping with values provided through
+     * {@link self::getValidMultivaluedSearchValuesOne()}
+     *
+     * @return mixed
+     */
+    abstract protected function getValidMultivaluedSearchValuesTwo();
+
+    /**
+     * Get search target field value Two.
+     *
+     * Returns the Field criterion target value for the field value Two.
+     * Default implementation falls back on {@link getValidSearchValueTwo}.
+     *
+     * @return mixed
+     */
+    protected function getMultivaluedSearchTargetValuesTwo()
+    {
+        return $this->getValidMultivaluedSearchValuesTwo();
+    }
+
+    protected function getAdditionallyIndexedMultivaluedFieldData()
+    {
+        return array();
+    }
+
+    protected $legacyUnsupportedOperators = array(
+        Operator::EQ => "EQ",
+        Operator::IN => "IN",
+        Operator::GT => "GT",
+        Operator::GTE => "GTE",
+        Operator::LT => "LT",
+        Operator::LTE => "LTE",
+        Operator::BETWEEN => "BETWEEN",
+    );
+
+    protected function checkOperatorSupport( $operator )
+    {
+        if ( ltrim( get_class( $this->getSetupFactory() ), '\\' ) === 'eZ\\Publish\\API\\Repository\\Tests\\SetupFactory\\Legacy' )
+        {
+            if ( isset( $this->legacyUnsupportedOperators[$operator] ) )
+            {
+                $this->markTestSkipped(
+                    "Legacy Search Engine does not properly support multivalued fields " .
+                    "with '{$this->legacyUnsupportedOperators[$operator]}' operator"
+                );
+            }
+        }
+    }
+
+    /**
+     * Creates test Content and Locations and returns the context for subsequent testing
+     *
+     * Context consists of repository instance and created Content IDs.
+     *
+     * @return \eZ\Publish\API\Repository\Repository
+     */
+    public function testCreateMultivaluedTestContent()
+    {
+        $repository = $this->getRepository();
+        $fieldTypeService = $repository->getFieldTypeService();
+        $fieldType = $fieldTypeService->getFieldType( $this->getTypeName() );
+
+        if ( !$fieldType->isSearchable() )
+        {
+            $this->markTestSkipped( "Field type '{$this->getTypeName()}' is not searchable." );
+        }
+
+        $contentType = $this->testCreateContentType();
+
+        return array(
+            $repository,
+            $this->createTestSearchContent(
+                $this->getValidMultivaluedSearchValuesOne(),
+                $repository,
+                $contentType
+            )->id,
+            $this->createTestSearchContent(
+                $this->getValidMultivaluedSearchValuesTwo(),
+                $repository,
+                $contentType
+            )->id,
+        );
+    }
+
+    /**
+     * Provider method for testFind* methods.
+     *
+     * Do not use directly, use getAdditionallyIndexedFieldData() instead.
+     *
+     * @return array
+     */
+    public function findMultivaluedProvider()
+    {
+        $additionalFields = $this->getAdditionallyIndexedMultivaluedFieldData();
+        $additionalFields[] = array(
+            null,
+            $this->getMultivaluedSearchTargetValuesOne(),
+            $this->getMultivaluedSearchTargetValuesTwo(),
+        );
+        $templates = array(
+            array( true, true ),
+            array( true, false ),
+            array( false, true ),
+            array( false, false ),
+        );
+
+        $fixture = array();
+
+        foreach ( $additionalFields as $additionalField )
+        {
+            foreach ( $templates as $template )
+            {
+                array_push( $template, $additionalField[0] );
+                array_unshift( $template, $additionalField[2] );
+                array_unshift( $template, $additionalField[1] );
+
+                $fixture[] = $template;
+            }
+        }
+
+        return $fixture;
+    }
+
+    /**
+     * Tests search with EQ operator.
+     *
+     * Simplified representation:
+     *
+     *     value EQ One
+     *
+     * The result should contain Content One.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedEqualsOne( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::EQ );
+
+        foreach ( $valuesOne as $value )
+        {
+            $criteria = new Field( "data", Operator::EQ, $value );
+
+            $this->assertFindResult( $context, $criteria, true, false, $filter, $content, $modifyField );
+        }
+    }
+
+    /**
+     * Tests search with EQ operator.
+     *
+     * Simplified representation:
+     *
+     *     NOT( value EQ One )
+     *
+     * The result should contain Content Two.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedNotEqualsOne( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::EQ );
+
+        foreach ( $valuesOne as $value )
+        {
+            $criteria = new LogicalNot( new Field( "data", Operator::EQ, $value ) );
+
+            $this->assertFindResult( $context, $criteria, false, true, $filter, $content, $modifyField );
+        }
+    }
+
+    /**
+     * Tests search with IN operator.
+     *
+     * Simplified representation:
+     *
+     *     value IN [One]
+     *
+     * The result should contain Content One.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedInOne( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::IN );
+
+        $criteria = new Field( "data", Operator::IN, $valuesOne );
+
+        $this->assertFindResult( $context, $criteria, true, false, $filter, $content, $modifyField );
+    }
+
+    /**
+     * Tests search with IN operator.
+     *
+     * Simplified representation:
+     *
+     *     NOT( value IN [One] )
+     *
+     * The result should contain Content Two.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedNotInOne( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::IN );
+
+        $criteria = new LogicalNot(
+            new Field( "data", Operator::IN, $valuesOne )
+        );
+
+        $this->assertFindResult( $context, $criteria, false, true, $filter, $content, $modifyField );
+    }
+
+    /**
+     * Tests search with IN operator.
+     *
+     * Simplified representation:
+     *
+     *     value IN [One,Two]
+     *
+     * The result should contain both Content One and Content Two.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedInOneTwo( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::IN );
+
+        $criteria = new Field( "data", Operator::IN, array_merge( $valuesOne, $valuesTwo ) );
+
+        $this->assertFindResult( $context, $criteria, true, true, $filter, $content, $modifyField );
+    }
+
+    /**
+     * Tests search with IN operator.
+     *
+     * Simplified representation:
+     *
+     *     NOT( value IN [One,Two] )
+     *
+     * The result should be empty.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedNotInOneTwo( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::IN );
+
+        $criteria = new LogicalNot(
+            new Field( "data", Operator::IN, array_merge( $valuesOne, $valuesTwo ) )
+        );
+
+        $this->assertFindResult( $context, $criteria, false, false, $filter, $content, $modifyField );
+    }
+
+    /**
+     * Tests search with CONTAINS operator.
+     *
+     * Simplified representation:
+     *
+     *     value CONTAINS One
+     *
+     * The result should contain Content One.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedContainsOne( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::CONTAINS );
+
+        foreach ( $valuesOne as $value )
+        {
+            $criteria = new Field( "data", Operator::CONTAINS, $value );
+
+            $this->assertFindResult( $context, $criteria, true, false, $filter, $content, $modifyField );
+        }
+    }
+
+    /**
+     * Tests search with CONTAINS operator.
+     *
+     * Simplified representation:
+     *
+     *     NOT( value CONTAINS One )
+     *
+     * The result should contain Content Two.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedNotContainsOne( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::CONTAINS );
+
+        foreach ( $valuesOne as $value )
+        {
+            $criteria = new LogicalNot( new Field( "data", Operator::CONTAINS, $value ) );
+
+            $this->assertFindResult( $context, $criteria, false, true, $filter, $content, $modifyField );
+        }
+    }
+
+    /**
+     * Tests search with GT operator.
+     *
+     * Simplified representation:
+     *
+     *     value GT One[0]
+     *
+     * The result should contain both Content One and Content Two.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedGreaterThanOneFindsOneTwo( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::GT );
+
+        $criteria = new Field( "data", Operator::GT, reset( $valuesOne ) );
+
+        $this->assertFindResult( $context, $criteria, true, true, $filter, $content, $modifyField );
+    }
+
+    /**
+     * Tests search with GT operator.
+     *
+     * Simplified representation:
+     *
+     *     value GT One[1]
+     *
+     * The result should contain Content Two.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedGreaterThanOneFindsTwo( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::GT );
+
+        $criteria = new Field( "data", Operator::GT, end( $valuesOne ) );
+
+        $this->assertFindResult( $context, $criteria, false, true, $filter, $content, $modifyField );
+    }
+
+    /**
+     * Tests search with GT operator.
+     *
+     * Simplified representation:
+     *
+     *     NOT( value GT One[0] )
+     *
+     * The result should be empty.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedNotGreaterThanOneFindsOneTwo( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::GT );
+
+        $criteria = new LogicalNot( new Field( "data", Operator::GT, reset( $valuesOne ) ) );
+
+        $this->assertFindResult( $context, $criteria, false, false, $filter, $content, $modifyField );
+    }
+
+    /**
+     * Tests search with GT operator.
+     *
+     * Simplified representation:
+     *
+     *     NOT( value GT One[1] )
+     *
+     * The result should contain Content One.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedNotGreaterThanOneFindsTwo( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::GT );
+
+        $criteria = new LogicalNot( new Field( "data", Operator::GT, end( $valuesOne ) ) );
+
+        $this->assertFindResult( $context, $criteria, true, false, $filter, $content, $modifyField );
+    }
+
+    /**
+     * Tests search with GTE operator.
+     *
+     * Simplified representation:
+     *
+     *     value GTE One
+     *
+     * The result should contain both Content One and Content Two.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedGreaterThanOrEqualOne( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::GTE );
+
+        foreach ( $valuesOne as $value )
+        {
+            $criteria = new Field( "data", Operator::GTE, $value );
+
+            $this->assertFindResult( $context, $criteria, true, true, $filter, $content, $modifyField );
+        }
+    }
+
+    /**
+     * Tests search with GTE operator.
+     *
+     * Simplified representation:
+     *
+     *     NOT( value GTE One )
+     *
+     * The result should be empty.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedNotGreaterThanOrEqual( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::GTE );
+
+        foreach ( $valuesOne as $value )
+        {
+            $criteria = new LogicalNot( new Field( "data", Operator::GTE, $value ) );
+
+            $this->assertFindResult( $context, $criteria, false, false, $filter, $content, $modifyField );
+        }
+    }
+
+    /**
+     * Tests search with LT operator.
+     *
+     * Simplified representation:
+     *
+     *     value LT One[0]
+     *
+     * The result should be empty.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedLowerThanOneEmpty( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::LT );
+
+        $criteria = new Field( "data", Operator::LT, reset( $valuesOne ) );
+
+        $this->assertFindResult( $context, $criteria, false, false, $filter, $content, $modifyField );
+    }
+
+    /**
+     * Tests search with LT operator.
+     *
+     * Simplified representation:
+     *
+     *     value LT One[1]
+     *
+     * The result should contain Content One.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedLowerThanOneFindsOne( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::LT );
+
+        $criteria = new Field( "data", Operator::LT, end( $valuesOne ) );
+
+        $this->assertFindResult( $context, $criteria, true, false, $filter, $content, $modifyField );
+    }
+
+    /**
+     * Tests search with LT operator.
+     *
+     * Simplified representation:
+     *
+     *     NOT( value LT One[0] )
+     *
+     * The result should contain both Content One and Content Two.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedNotLowerThanOneEmpty( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::LT );
+
+        $criteria = new LogicalNot( new Field( "data", Operator::LT, reset( $valuesOne ) ) );
+
+        $this->assertFindResult( $context, $criteria, true, true, $filter, $content, $modifyField );
+    }
+
+    /**
+     * Tests search with LT operator.
+     *
+     * Simplified representation:
+     *
+     *     NOT( value LT One[1] )
+     *
+     * The result should contain Content Two.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedNotLowerThanOneFindsOne( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::LT );
+
+        $criteria = new LogicalNot( new Field( "data", Operator::LT, end( $valuesOne ) ) );
+
+        $this->assertFindResult( $context, $criteria, false, true, $filter, $content, $modifyField );
+    }
+
+    /**
+     * Tests search with LTE operator.
+     *
+     * Simplified representation:
+     *
+     *     value LTE One
+     *
+     * The result should contain Content One.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedLowerThanOrEqualOne( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::LTE );
+
+        foreach ( $valuesOne as $value )
+        {
+            $criteria = new Field( "data", Operator::LTE, $value );
+
+            $this->assertFindResult( $context, $criteria, true, false, $filter, $content, $modifyField );
+        }
+    }
+
+    /**
+     * Tests search with LTE operator.
+     *
+     * Simplified representation:
+     *
+     *     NOT( value LTE One )
+     *
+     * The result should contain Content Two.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedNotLowerThanOrEqualOne( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::LTE );
+
+        foreach ( $valuesOne as $value )
+        {
+            $criteria = new LogicalNot( new Field( "data", Operator::LTE, $value ) );
+
+            $this->assertFindResult( $context, $criteria, false, true, $filter, $content, $modifyField );
+        }
+    }
+
+    /**
+     * Tests search with BETWEEN operator.
+     *
+     * Simplified representation:
+     *
+     *     value BETWEEN [One,Two]
+     *
+     * The result should contain both Content One and Content Two.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedBetweenOneTwo( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::BETWEEN );
+
+        foreach ( $valuesOne as $valueOne )
+        {
+            foreach ( $valuesTwo as $valueTwo )
+            {
+                $criteria = new Field(
+                    "data",
+                    Operator::BETWEEN,
+                    array(
+                        $valueOne,
+                        $valueTwo,
+                    )
+                );
+
+                $this->assertFindResult( $context, $criteria, true, true, $filter, $content, $modifyField );
+            }
+        }
+    }
+
+    /**
+     * Tests search with BETWEEN operator.
+     *
+     * Simplified representation:
+     *
+     *     NOT( value BETWEEN [One,Two] )
+     *
+     * The result should contain both Content One and Content Two.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedNotBetweenOneTwo( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::BETWEEN );
+
+        foreach ( $valuesOne as $valueOne )
+        {
+            foreach ( $valuesTwo as $valueTwo )
+            {
+                $criteria = new LogicalNot(
+                    new Field(
+                        "data",
+                        Operator::BETWEEN,
+                        array(
+                            $valueOne,
+                            $valueTwo,
+                        )
+                    )
+                );
+
+                $this->assertFindResult( $context, $criteria, false, false, $filter, $content, $modifyField );
+            }
+        }
+    }
+
+    /**
+     * Tests search with BETWEEN operator.
+     *
+     * Simplified representation:
+     *
+     *     value BETWEEN [Two,One]
+     *
+     * The result should be empty.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedBetweenTwoOne( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::BETWEEN );
+
+        foreach ( $valuesOne as $valueOne )
+        {
+            foreach ( $valuesTwo as $valueTwo )
+            {
+                $criteria = new Field(
+                    "data",
+                    Operator::BETWEEN,
+                    array(
+                        $valueTwo,
+                        $valueOne,
+                    )
+                );
+
+                $this->assertFindResult( $context, $criteria, false, false, $filter, $content, $modifyField );
+            }
+        }
+    }
+
+    /**
+     * Tests search with BETWEEN operator.
+     *
+     * Simplified representation:
+     *
+     *     NOT( value BETWEEN [Two,One] )
+     *
+     * The result should contain both Content One and Content Two.
+     *
+     * @dataProvider findMultivaluedProvider
+     * @depends testCreateMultivaluedTestContent
+     */
+    public function testFindMultivaluedNotBetweenTwoOne( $valuesOne, $valuesTwo, $filter, $content, $modifyField, array $context )
+    {
+        $this->checkOperatorSupport( Operator::BETWEEN );
+
+        foreach ( $valuesOne as $valueOne )
+        {
+            foreach ( $valuesTwo as $valueTwo )
+            {
+                $criteria = new LogicalNot(
+                    new Field(
+                        "data",
+                        Operator::BETWEEN,
+                        array(
+                            $valueTwo,
+                            $valueOne,
+                        )
+                    )
+                );
+
+                $this->assertFindResult( $context, $criteria, true, true, $filter, $content, $modifyField );
+            }
+        }
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/FieldType/SelectionIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SelectionIntegrationTest.php
@@ -18,7 +18,7 @@ use eZ\Publish\API\Repository\Values\Content\Field;
  * @group integration
  * @group field-type
  */
-class SelectionIntegrationTest extends BaseIntegrationTest
+class SelectionIntegrationTest extends SearchMultivaluedBaseIntegrationTest
 {
     /**
      * Get name of tested field type
@@ -59,9 +59,11 @@ class SelectionIntegrationTest extends BaseIntegrationTest
         return array(
             'isMultiple' => true,
             'options' => array(
-                0 => 'First',
-                1 => 'Sindelfingen',
-                2 => 'Bielefeld',
+                0 => 'A first',
+                1 => 'Bielefeld',
+                2 => 'Sindelfingen',
+                3 => 'Turtles',
+                4 => 'Zombies',
             )
         );
     }
@@ -177,7 +179,7 @@ class SelectionIntegrationTest extends BaseIntegrationTest
                 'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentType',
             ),
             array(
-                new SelectionValue( array( 3 ) ),
+                new SelectionValue( array( 7 ) ),
                 'eZ\\Publish\\Core\\Base\\Exceptions\\ContentFieldValidationException',
             ),
         );
@@ -329,6 +331,63 @@ class SelectionIntegrationTest extends BaseIntegrationTest
             ),
             array(
                 new SelectionValue( array( 0 ) )
+            ),
+        );
+    }
+
+    protected function getValidSearchValueOne()
+    {
+        return array( 1 );
+    }
+
+    protected function getValidSearchValueTwo()
+    {
+        return array( 2 );
+    }
+
+    protected function getSearchTargetValueOne()
+    {
+        return 1;
+    }
+
+    protected function getSearchTargetValueTwo()
+    {
+        return 2;
+    }
+
+    protected function getAdditionallyIndexedFieldData()
+    {
+        return array(
+            array(
+                "selected_option_value",
+                "Bielefeld",
+                "Sindelfingen",
+            ),
+            array(
+                "sort_value",
+                "1",
+                "2",
+            ),
+        );
+    }
+
+    protected function getValidMultivaluedSearchValuesOne()
+    {
+        return array( 0, 1 );
+    }
+
+    protected function getValidMultivaluedSearchValuesTwo()
+    {
+        return array( 2, 3, 4 );
+    }
+
+    protected function getAdditionallyIndexedMultivaluedFieldData()
+    {
+        return array(
+            array(
+                "selected_option_value",
+                array( "A first", "Bielefeld" ),
+                array( "Sindelfingen", "Turtles", "Zombies" ),
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/BinaryFile/SearchField.php
+++ b/eZ/Publish/Core/FieldType/BinaryFile/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\BinaryFile;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/BinaryFile/SearchField.php
+++ b/eZ/Publish/Core/FieldType/BinaryFile/SearchField.php
@@ -63,17 +63,30 @@ class SearchField implements Indexable
     }
 
     /**
-     * Get name of the default field to be used for query and sort.
+     * Get name of the default field to be used for matching.
      *
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
-     * field for query and sort. Default field is typically used by Field
-     * criterion and sort clause.
+     * field for matching. Default field is typically used by Field criterion.
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "file_name";
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Checkbox/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Checkbox/SearchField.php
@@ -51,17 +51,30 @@ class SearchField implements Indexable
     }
 
     /**
-     * Get name of the default field to be used for query and sort.
+     * Get name of the default field to be used for matching.
      *
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
-     * field for query and sort. Default field is typically used by Field
-     * criterion and sort clause.
+     * field for matching. Default field is typically used by Field criterion.
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Checkbox/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Checkbox/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\Checkbox;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/Country/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Country/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\Country;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/Country/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Country/SearchField.php
@@ -51,17 +51,30 @@ class SearchField implements Indexable
     }
 
     /**
-     * Get name of the default field to be used for query and sort.
+     * Get name of the default field to be used for matching.
      *
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
-     * field for query and sort. Default field is typically used by Field
-     * criterion and sort clause.
+     * field for matching. Default field is typically used by Field criterion.
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Date/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Date/SearchField.php
@@ -58,17 +58,30 @@ class SearchField implements Indexable
     }
 
     /**
-     * Get name of the default field to be used for query and sort.
+     * Get name of the default field to be used for matching.
      *
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
-     * field for query and sort. Default field is typically used by Field
-     * criterion and sort clause.
+     * field for matching. Default field is typically used by Field criterion.
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Date/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Date/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\Date;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 use DateTime;
@@ -22,11 +23,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         // The field type stores date value as a timestamp of the start of the day in the
         // environment's timezone.

--- a/eZ/Publish/Core/FieldType/DateAndTime/SearchField.php
+++ b/eZ/Publish/Core/FieldType/DateAndTime/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\DateAndTime;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/DateAndTime/SearchField.php
+++ b/eZ/Publish/Core/FieldType/DateAndTime/SearchField.php
@@ -51,17 +51,30 @@ class SearchField implements Indexable
     }
 
     /**
-     * Get name of the default field to be used for query and sort.
+     * Get name of the default field to be used for matching.
      *
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
-     * field for query and sort. Default field is typically used by Field
-     * criterion and sort clause.
+     * field for matching. Default field is typically used by Field criterion.
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/EmailAddress/SearchField.php
+++ b/eZ/Publish/Core/FieldType/EmailAddress/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\EmailAddress;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/EmailAddress/SearchField.php
+++ b/eZ/Publish/Core/FieldType/EmailAddress/SearchField.php
@@ -51,17 +51,30 @@ class SearchField implements Indexable
     }
 
     /**
-     * Get name of the default field to be used for query and sort.
+     * Get name of the default field to be used for matching.
      *
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
-     * field for query and sort. Default field is typically used by Field
-     * criterion and sort clause.
+     * field for matching. Default field is typically used by Field criterion.
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Float/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Float/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\Float;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/Float/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Float/SearchField.php
@@ -51,17 +51,30 @@ class SearchField implements Indexable
     }
 
     /**
-     * Get name of the default field to be used for query and sort.
+     * Get name of the default field to be used for matching.
      *
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
-     * field for query and sort. Default field is typically used by Field
-     * criterion and sort clause.
+     * field for matching. Default field is typically used by Field criterion.
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/ISBN/SearchField.php
+++ b/eZ/Publish/Core/FieldType/ISBN/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\ISBN;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/ISBN/SearchField.php
+++ b/eZ/Publish/Core/FieldType/ISBN/SearchField.php
@@ -51,17 +51,30 @@ class SearchField implements Indexable
     }
 
     /**
-     * Get name of the default field to be used for query and sort.
+     * Get name of the default field to be used for matching.
      *
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
-     * field for query and sort. Default field is typically used by Field
-     * criterion and sort clause.
+     * field for matching. Default field is typically used by Field criterion.
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Image/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Image/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\Image;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/Image/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Image/SearchField.php
@@ -69,17 +69,30 @@ class SearchField implements Indexable
     }
 
     /**
-     * Get name of the default field to be used for query and sort.
+     * Get name of the default field to be used for matching.
      *
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
-     * field for query and sort. Default field is typically used by Field
-     * criterion and sort clause.
+     * field for matching. Default field is typically used by Field criterion.
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "filename";
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Integer/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Integer/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\Integer;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/Integer/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Integer/SearchField.php
@@ -51,17 +51,30 @@ class SearchField implements Indexable
     }
 
     /**
-     * Get name of the default field to be used for query and sort.
+     * Get name of the default field to be used for matching.
      *
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
-     * field for query and sort. Default field is typically used by Field
-     * criterion and sort clause.
+     * field for matching. Default field is typically used by Field criterion.
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/MapLocation/SearchField.php
+++ b/eZ/Publish/Core/FieldType/MapLocation/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\MapLocation;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -22,10 +23,11 @@ class SearchField implements Indexable
      * Get index data for field for search backend
      *
      * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/MapLocation/SearchField.php
+++ b/eZ/Publish/Core/FieldType/MapLocation/SearchField.php
@@ -60,17 +60,30 @@ class SearchField implements Indexable
     }
 
     /**
-     * Get name of the default field to be used for query and sort.
+     * Get name of the default field to be used for matching.
      *
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
-     * field for query and sort. Default field is typically used by Field
-     * criterion and sort clause.
+     * field for matching. Default field is typically used by Field criterion.
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value_address";
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Media/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Media/SearchField.php
@@ -63,17 +63,30 @@ class SearchField implements Indexable
     }
 
     /**
-     * Get name of the default field to be used for query and sort.
+     * Get name of the default field to be used for matching.
      *
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
-     * field for query and sort. Default field is typically used by Field
-     * criterion and sort clause.
+     * field for matching. Default field is typically used by Field criterion.
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "file_name";
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Media/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Media/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\Media;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/Price/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Price/SearchField.php
@@ -53,17 +53,30 @@ class SearchField implements Indexable
     }
 
     /**
-     * Get name of the default field to be used for query and sort.
+     * Get name of the default field to be used for matching.
      *
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
-     * field for query and sort. Default field is typically used by Field
-     * criterion and sort clause.
+     * field for matching. Default field is typically used by Field criterion.
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Price/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Price/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\Price;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/Relation/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Relation/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\Relation;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/Relation/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Relation/SearchField.php
@@ -51,17 +51,30 @@ class SearchField implements Indexable
     }
 
     /**
-     * Get name of the default field to be used for query and sort.
+     * Get name of the default field to be used for matching.
      *
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
-     * field for query and sort. Default field is typically used by Field
-     * criterion and sort clause.
+     * field for matching. Default field is typically used by Field criterion.
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Selection/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Selection/SearchField.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\FieldType\Selection;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
+use eZ\Publish\SPI\FieldType\Indexable;
+use eZ\Publish\SPI\Search;
+
+/**
+ * Indexable definition for Selection field type
+ */
+class SearchField implements Indexable
+{
+    /**
+     * Get index data for field for search backend
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
+    {
+        $indexes = array();
+        $values = array();
+        $fieldSettings = $fieldDefinition->fieldTypeConstraints->fieldSettings;
+        $options = $fieldSettings["options"];
+        $positionSet = array_flip( $field->value->data );
+
+        foreach ( $options as $index => $value )
+        {
+            if ( isset( $positionSet[$index] ) )
+            {
+                $values[] = $value;
+                $indexes[] = $index;
+            }
+        }
+
+        return array(
+            new Search\Field(
+                'selected_option_value',
+                $values,
+                new Search\FieldType\MultipleStringField()
+            ),
+            new Search\Field(
+                'selected_option_index',
+                $indexes,
+                new Search\FieldType\MultipleIntegerField()
+            ),
+            new Search\Field(
+                'selected_option_count',
+                count( $indexes ),
+                new Search\FieldType\IntegerField()
+            ),
+            new Search\Field(
+                'sort_value',
+                implode( "-", $indexes ),
+                new Search\FieldType\StringField()
+            ),
+        );
+    }
+
+    /**
+     * Get index field types for search backend
+     *
+     * @return \eZ\Publish\SPI\Search\FieldType[]
+     */
+    public function getIndexDefinition()
+    {
+        return array(
+            'selected_option_value' => new Search\FieldType\MultipleStringField(),
+            'selected_option_index' => new Search\FieldType\MultipleIntegerField(),
+            'selected_option_count' => new Search\FieldType\IntegerField(),
+            'sort_value' => new Search\FieldType\StringField(),
+        );
+    }
+
+    /**
+     * Get name of the default field to be used for matching.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for matching. Default field is typically used by Field criterion.
+     *
+     * @return string
+     */
+    public function getDefaultMatchField()
+    {
+        return "selected_option_index";
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return "sort_value";
+    }
+}

--- a/eZ/Publish/Core/FieldType/TextBlock/SearchField.php
+++ b/eZ/Publish/Core/FieldType/TextBlock/SearchField.php
@@ -51,17 +51,30 @@ class SearchField implements Indexable
     }
 
     /**
-     * Get name of the default field to be used for query and sort.
+     * Get name of the default field to be used for matching.
      *
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
-     * field for query and sort. Default field is typically used by Field
-     * criterion and sort clause.
+     * field for matching. Default field is typically used by Field criterion.
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/TextBlock/SearchField.php
+++ b/eZ/Publish/Core/FieldType/TextBlock/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\TextBlock;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/TextLine/SearchField.php
+++ b/eZ/Publish/Core/FieldType/TextLine/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\TextLine;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/TextLine/SearchField.php
+++ b/eZ/Publish/Core/FieldType/TextLine/SearchField.php
@@ -51,17 +51,30 @@ class SearchField implements Indexable
     }
 
     /**
-     * Get name of the default field to be used for query and sort.
+     * Get name of the default field to be used for matching.
      *
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
-     * field for query and sort. Default field is typically used by Field
-     * criterion and sort clause.
+     * field for matching. Default field is typically used by Field criterion.
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Time/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Time/SearchField.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType\Time;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
 
@@ -21,11 +22,12 @@ class SearchField implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/Time/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Time/SearchField.php
@@ -51,17 +51,30 @@ class SearchField implements Indexable
     }
 
     /**
-     * Get name of the default field to be used for query and sort.
+     * Get name of the default field to be used for matching.
      *
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
-     * field for query and sort. Default field is typically used by Field
-     * criterion and sort clause.
+     * field for matching. Default field is typically used by Field criterion.
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
     {
         return "value";
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/Unindexed.php
+++ b/eZ/Publish/Core/FieldType/Unindexed.php
@@ -42,16 +42,29 @@ class Unindexed implements Indexable
     }
 
     /**
-     * Get name of the default field to be used for query and sort.
+     * Get name of the default field to be used for matching.
      *
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
-     * field for query and sort. Default field is typically used by Field
-     * criterion and sort clause.
+     * field for matching. Default field is typically used by Field criterion.
      *
      * @return string
      */
-    public function getDefaultField()
+    public function getDefaultMatchField()
+    {
+        return null;
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
     {
         return null;
     }

--- a/eZ/Publish/Core/FieldType/Unindexed.php
+++ b/eZ/Publish/Core/FieldType/Unindexed.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\FieldType;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 
 /**
@@ -20,11 +21,12 @@ class Unindexed implements Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field )
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
     {
         return array();
     }

--- a/eZ/Publish/Core/Search/Common/FieldNameResolver.php
+++ b/eZ/Publish/Core/Search/Common/FieldNameResolver.php
@@ -135,7 +135,8 @@ class FieldNameResolver
                 $contentTypeIdentifier,
                 $fieldDefinitionIdentifier,
                 $fieldIdentifierMap[$fieldDefinitionIdentifier]["field_type_identifier"],
-                $name
+                $name,
+                false
             );
         }
 
@@ -182,7 +183,8 @@ class FieldNameResolver
             $contentTypeIdentifier,
             $fieldDefinitionIdentifier,
             $fieldMap[$contentTypeIdentifier][$fieldDefinitionIdentifier]["field_type_identifier"],
-            $name
+            $name,
+            true
         );
     }
 
@@ -194,6 +196,7 @@ class FieldNameResolver
      * @param string $fieldDefinitionIdentifier
      * @param string $fieldTypeIdentifier
      * @param string $name
+     * @param boolean $isSortField
      *
      * @return string
      */
@@ -202,7 +205,8 @@ class FieldNameResolver
         $contentTypeIdentifier,
         $fieldDefinitionIdentifier,
         $fieldTypeIdentifier,
-        $name
+        $name,
+        $isSortField
     )
     {
         // If criterion or sort clause implements CustomFieldInterface and custom field is set for
@@ -222,10 +226,17 @@ class FieldNameResolver
 
         $indexFieldType = $this->fieldRegistry->getType( $fieldTypeIdentifier );
 
-        // If $name is not given use default search field name
+        // If $name is not given use default field name
         if ( $name === null )
         {
-            $name = $indexFieldType->getDefaultField();
+            if ( $isSortField )
+            {
+                $name = $indexFieldType->getDefaultSortField();
+            }
+            else
+            {
+                $name = $indexFieldType->getDefaultMatchField();
+            }
         }
 
         $indexDefinition = $indexFieldType->getIndexDefinition();

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/FieldValueMapper/IntegerMapper.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/FieldValueMapper/IntegerMapper.php
@@ -39,6 +39,18 @@ class IntegerMapper extends FieldValueMapper
      */
     public function map( Field $field )
     {
-        return (int)$field->value;
+        return $this->convert( $field->value );
+    }
+
+    /**
+     * Convert to a proper Elasticsearch representation
+     *
+     * @param mixed $value
+     *
+     * @return string
+     */
+    protected function convert( $value )
+    {
+        return (int)$value;
     }
 }

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/FieldValueMapper/MultipleIntegerMapper.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/FieldValueMapper/MultipleIntegerMapper.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * File containing the MultipleStringMapper class
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper;
+
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType\MultipleIntegerField;
+
+/**
+ * Maps raw document field values to something Solr can index.
+ */
+class MultipleIntegerMapper extends IntegerMapper
+{
+    /**
+     * Check if field can be mapped
+     *
+     * @param Field $field
+     *
+     * @return bool
+     */
+    public function canMap( Field $field )
+    {
+        return $field->type instanceof MultipleIntegerField;
+    }
+
+    /**
+     * Map field value to a proper Solr representation
+     *
+     * @param Field $field
+     *
+     * @return array
+     */
+    public function map( Field $field )
+    {
+        $values = array();
+
+        foreach ( (array)$field->value as $value )
+        {
+            $values[] = $this->convert( $value );
+        }
+
+        return $values;
+    }
+}
+

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Mapper/StandardMapper.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Mapper/StandardMapper.php
@@ -321,7 +321,9 @@ class StandardMapper implements MapperInterface
                     }
 
                     $fieldType = $this->fieldRegistry->getType( $field->type );
-                    foreach ( $fieldType->getIndexData( $field ) as $indexField )
+                    $indexFields = $fieldType->getIndexData( $field, $fieldDefinition );
+
+                    foreach ( $indexFields as $indexField )
                     {
                         $fields[] = new Field(
                             $name = $this->fieldNameGenerator->getName(

--- a/eZ/Publish/Core/Search/Solr/Content/DocumentMapper/NativeDocumentMapper.php
+++ b/eZ/Publish/Core/Search/Solr/Content/DocumentMapper/NativeDocumentMapper.php
@@ -420,7 +420,9 @@ class NativeDocumentMapper implements DocumentMapper
                 }
 
                 $fieldType = $this->fieldRegistry->getType( $field->type );
-                foreach ( $fieldType->getIndexData( $field ) as $indexField )
+                $indexFields = $fieldType->getIndexData( $field, $fieldDefinition );
+
+                foreach ( $indexFields as $indexField )
                 {
                     if ( $indexField->value === null )
                     {

--- a/eZ/Publish/Core/Search/Tests/FieldNameResolverTest.php
+++ b/eZ/Publish/Core/Search/Tests/FieldNameResolverTest.php
@@ -428,7 +428,8 @@ class FieldNameResolverTest extends TestCase
             "content_type_identifier",
             "field_definition_identifier",
             "dummy",
-            "dummy"
+            "dummy",
+            false
         );
 
         $this->assertEquals( "custom_field_name", $customFieldName );
@@ -489,13 +490,14 @@ class FieldNameResolverTest extends TestCase
             "content_type_identifier",
             "field_definition_identifier",
             "field_type_identifier",
-            "field_name"
+            "field_name",
+            true
         );
 
         $this->assertEquals( "generated_typed_field_name", $fieldName );
     }
 
-    public function testGetIndexFieldNameDefaultField()
+    public function testGetIndexFieldNameDefaultMatchField()
     {
         $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getSearchableFieldMap" ) );
         $indexFieldType = $this->getIndexFieldTypeMock();
@@ -511,7 +513,7 @@ class FieldNameResolverTest extends TestCase
 
         $indexFieldType
             ->expects( $this->once() )
-            ->method( "getDefaultField" )
+            ->method( "getDefaultMatchField" )
             ->will(
                 $this->returnValue( "field_name" )
             );
@@ -555,16 +557,14 @@ class FieldNameResolverTest extends TestCase
             "content_type_identifier",
             "field_definition_identifier",
             "field_type_identifier",
-            null
+            null,
+            false
         );
 
         $this->assertEquals( "generated_typed_field_name", $fieldName );
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
-    public function testGetIndexFieldNameDefaultFieldThrowsRuntimeException()
+    public function testGetIndexFieldNameDefaultSortField()
     {
         $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getSearchableFieldMap" ) );
         $indexFieldType = $this->getIndexFieldTypeMock();
@@ -580,7 +580,77 @@ class FieldNameResolverTest extends TestCase
 
         $indexFieldType
             ->expects( $this->once() )
-            ->method( "getDefaultField" )
+            ->method( "getDefaultSortField" )
+            ->will(
+                $this->returnValue( "field_name" )
+            );
+
+        $indexFieldType
+            ->expects( $this->once() )
+            ->method( "getIndexDefinition" )
+            ->will(
+                $this->returnValue(
+                    array(
+                        "field_name" => $searchFieldTypeMock,
+                    )
+                )
+            );
+
+        $this->fieldNameGeneratorMock
+            ->expects( $this->once() )
+            ->method( "getName" )
+            ->with(
+                "field_name",
+                "field_definition_identifier",
+                "content_type_identifier"
+            )
+            ->will(
+                $this->returnValue( "generated_field_name" )
+            );
+
+        $this->fieldNameGeneratorMock
+            ->expects( $this->once() )
+            ->method( "getTypedName" )
+            ->with(
+                "generated_field_name",
+                $this->isInstanceOf( "eZ\\Publish\\SPI\\Search\\FieldType" )
+            )
+            ->will(
+                $this->returnValue( "generated_typed_field_name" )
+            );
+
+        $fieldName = $mockedFieldNameResolver->getIndexFieldName(
+            new ArrayObject(),
+            "content_type_identifier",
+            "field_definition_identifier",
+            "field_type_identifier",
+            null,
+            true
+        );
+
+        $this->assertEquals( "generated_typed_field_name", $fieldName );
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testGetIndexFieldNameDefaultMatchFieldThrowsRuntimeException()
+    {
+        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getSearchableFieldMap" ) );
+        $indexFieldType = $this->getIndexFieldTypeMock();
+        $searchFieldTypeMock = $this->getSearchFieldTypeMock();
+
+        $this->fieldRegistryMock
+            ->expects( $this->once() )
+            ->method( "getType" )
+            ->with( "field_type_identifier" )
+            ->will(
+                $this->returnValue( $indexFieldType )
+            );
+
+        $indexFieldType
+            ->expects( $this->once() )
+            ->method( "getDefaultMatchField" )
             ->will(
                 $this->returnValue( "non_existent_field_name" )
             );
@@ -601,7 +671,53 @@ class FieldNameResolverTest extends TestCase
             "content_type_identifier",
             "field_definition_identifier",
             "field_type_identifier",
-            null
+            null,
+            false
+        );
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testGetIndexFieldNameDefaultSortFieldThrowsRuntimeException()
+    {
+        $mockedFieldNameResolver = $this->getMockedFieldNameResolver( array( "getSearchableFieldMap" ) );
+        $indexFieldType = $this->getIndexFieldTypeMock();
+        $searchFieldTypeMock = $this->getSearchFieldTypeMock();
+
+        $this->fieldRegistryMock
+            ->expects( $this->once() )
+            ->method( "getType" )
+            ->with( "field_type_identifier" )
+            ->will(
+                $this->returnValue( $indexFieldType )
+            );
+
+        $indexFieldType
+            ->expects( $this->once() )
+            ->method( "getDefaultSortField" )
+            ->will(
+                $this->returnValue( "non_existent_field_name" )
+            );
+
+        $indexFieldType
+            ->expects( $this->once() )
+            ->method( "getIndexDefinition" )
+            ->will(
+                $this->returnValue(
+                    array(
+                        "field_name" => $searchFieldTypeMock,
+                    )
+                )
+            );
+
+        $mockedFieldNameResolver->getIndexFieldName(
+            new ArrayObject(),
+            "content_type_identifier",
+            "field_definition_identifier",
+            "field_type_identifier",
+            null,
+            true
         );
     }
 
@@ -640,7 +756,8 @@ class FieldNameResolverTest extends TestCase
             "content_type_identifier",
             "field_definition_identifier",
             "field_type_identifier",
-            "non_existent_field_name"
+            "non_existent_field_name",
+            false
         );
     }
 

--- a/eZ/Publish/Core/settings/indexable_fieldtypes.yml
+++ b/eZ/Publish/Core/settings/indexable_fieldtypes.yml
@@ -16,6 +16,7 @@ parameters:
     ezpublish.fieldType.indexable.ezinteger.class: eZ\Publish\Core\FieldType\Integer\SearchField
     ezpublish.fieldType.indexable.ezfloat.class: eZ\Publish\Core\FieldType\Float\SearchField
     ezpublish.fieldType.indexable.eztime.class: eZ\Publish\Core\FieldType\Time\SearchField
+    ezpublish.fieldType.indexable.ezselection.class: eZ\Publish\Core\FieldType\Selection\SearchField
     ezpublish.fieldType.indexable.unindexed.class: eZ\Publish\Core\FieldType\Unindexed
 
 services:
@@ -116,6 +117,11 @@ services:
         tags:
             - {name: ezpublish.fieldType.indexable, alias: ezobjectrelation}
 
+    ezpublish.fieldType.indexable.ezselection:
+        class: %ezpublish.fieldType.indexable.ezselection.class%
+        tags:
+            - {name: ezpublish.fieldType.indexable, alias: ezselection}
+
     ezpublish.fieldType.indexable.unindexed:
         class: %ezpublish.fieldType.indexable.unindexed.class%
         tags:
@@ -127,7 +133,6 @@ services:
             - {name: ezpublish.fieldType.indexable, alias: ezmultioption}
             - {name: ezpublish.fieldType.indexable, alias: ezauthor}
             - {name: ezpublish.fieldType.indexable, alias: ezsrrating}
-            - {name: ezpublish.fieldType.indexable, alias: ezselection}
             - {name: ezpublish.fieldType.indexable, alias: ezsubtreesubscription}
             - {name: ezpublish.fieldType.indexable, alias: ezobjectrelationlist}
             - {name: ezpublish.fieldType.indexable, alias: ezoption}

--- a/eZ/Publish/Core/settings/search_engines/elasticsearch/field_value_mappers.yml
+++ b/eZ/Publish/Core/settings/search_engines/elasticsearch/field_value_mappers.yml
@@ -6,6 +6,7 @@ parameters:
     ezpublish.search.elasticsearch.content.field_value_mapper.float.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\FloatMapper
     ezpublish.search.elasticsearch.content.field_value_mapper.identifier.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\IdentifierMapper
     ezpublish.search.elasticsearch.content.field_value_mapper.integer.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\IntegerMapper
+    ezpublish.search.elasticsearch.content.field_value_mapper.multiple_integer.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\MultipleIntegerMapper
     ezpublish.search.elasticsearch.content.field_value_mapper.multiple_boolean.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\MultipleBooleanMapper
     ezpublish.search.elasticsearch.content.field_value_mapper.multiple_identifier.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\MultipleIdentifierMapper
     ezpublish.search.elasticsearch.content.field_value_mapper.multiple_string.class: eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper\MultipleStringMapper
@@ -40,6 +41,11 @@ services:
 
     ezpublish.search.elasticsearch.content.field_value_mapper.identifier:
         class: %ezpublish.search.elasticsearch.content.field_value_mapper.identifier.class%
+        tags:
+            - {name: ezpublish.search.elasticsearch.content.field_value_mapper}
+
+    ezpublish.search.elasticsearch.content.field_value_mapper.multiple_integer:
+        class: %ezpublish.search.elasticsearch.content.field_value_mapper.multiple_integer.class%
         tags:
             - {name: ezpublish.search.elasticsearch.content.field_value_mapper}
 

--- a/eZ/Publish/SPI/FieldType/Indexable.php
+++ b/eZ/Publish/SPI/FieldType/Indexable.php
@@ -38,15 +38,25 @@ interface Indexable
     public function getIndexDefinition();
 
     /**
-     * Get name of the default field to be used for query and sort.
+     * Get name of the default field to be used for matching.
      *
      * As field types can index multiple fields (see MapLocation field type's
      * implementation of this interface), this method is used to define default
-     * field for query and sort. Default field is typically used by Field
-     * criterion and sort clause.
+     * field for matching. Default field is typically used by Field criterion.
      *
      * @return string
      */
-    public function getDefaultField();
+    public function getDefaultMatchField();
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField();
 }
 

--- a/eZ/Publish/SPI/FieldType/Indexable.php
+++ b/eZ/Publish/SPI/FieldType/Indexable.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\SPI\FieldType;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 
 /**
  * The field type interface which all field types have to implement to be
@@ -22,11 +23,12 @@ interface Indexable
     /**
      * Get index data for field for search backend
      *
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
      *
      * @return \eZ\Publish\SPI\Search\Field[]
      */
-    public function getIndexData( Field $field );
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition );
 
     /**
      * Get index field types for search backend


### PR DESCRIPTION
> Review dependency graph
> * https://github.com/ezsystems/ezpublish-kernel/pull/1305 Main languages core
>  * https://github.com/ezsystems/ezpublish-kernel/pull/1322 Multicore tests
>    * https://github.com/ezsystems/ezpublish-kernel/pull/1326 Complete CustomField support
>       * https://github.com/ezsystems/ezpublish-kernel/pull/1327 Extract CoreFilter service
>       * **https://github.com/ezsystems/ezpublish-kernel/pull/1333 Indexable Selection**
>          * https://github.com/ezsystems/ezpublish-kernel/pull/1334 Indexable RelationList
> * https://github.com/ezsystems/ezpublish-kernel/pull/1329 DateModified sort clause

#### This PR resolves https://jira.ez.no/browse/EZP-24572
#### Based on https://github.com/ezsystems/ezpublish-kernel/pull/1326

This implements `Indexable` definition for `Selection` field type. Doing so required some changes to the `Indexable` interface:

1. `getFieldData()` now receives SPI FieldDefinition as a second parameter.

  In Selection field type case the field definition is used to index option labels.

2. New method `getDefaultSortField()` is added, `getDefaultField()` is renamed to `getDefaultMatchField()`.

  As Selection field type must index in a multivalued field, which can't be used for sort, a separate field for sort is required.

Indexed data:

1. `option_value`, a list of selected options labels
2. `option_index`, a list of selected options indexes
3. `option_count`, count of selected options
4. `sort_value`, list of selected options indexes concatenated with `-` and used for sorting

#### Behavior of search on multivalued field values 

Behavior is the same to what is natural to Solr (and similar). It is possible to do ranges on a multivalued field. It is also possible to assert `equals` to a single value in a multivalued field.

#### Tests

New test case based on existing `SearchBaseIntegrationTest` is implemented. The test case deals with multivalued field values, in addition to the single-valued field values, inherited from the base test.

#### Legacy Search Engine

Legacy Search Engine does not properly support all operators with multivalued field values. It would be possible to improve upon this, but probably with some performance impact. I decided rather to skip tests instead, unless explicitly requested.