### PR TITLE
EZP-24593: Add possibility to search for ContentInfo to avoid Content loading

### DIFF
--- a/doc/bc/changes-5.3.md
+++ b/doc/bc/changes-5.3.md
@@ -160,6 +160,11 @@ Changes affecting version compatibility with former or future versions.
   when deleting last version of the Content. Since Content without a version does not make sense, in
   this case `eZ\Publish\Core\Repository\ContentService::deleteContent()` should be used instead.
 
+
+* 5.3.8: $fieldFilters argument on Search service has been renamed to $languageFilter
+  Reason is to better communicate what the argument is used for. No changes
+  to it's structure is done so this is a purly cosmetic change.
+
 ## Deprecations
 
 * Method `eZ\Publish\API\Repository\RoleService::removePolicy` is deprecated in

--- a/doc/bc/changes-5.4.md
+++ b/doc/bc/changes-5.4.md
@@ -193,6 +193,15 @@ Changes affecting version compatibility with former or future versions.
   Reason is to better communicate what the argument is used for. No changes
   to it's structure is done so this is a purly cosmetic change.
 
+* 5.4.5: $languageFilter specification has changed to work as priority list of languages
+  To be able to sort on translated values in a predictable way we need to deal with
+  one language per content object at a time. This change only affects how the sort is
+  performed internally, and not which fields are returned in the case of findContent.
+  This furthermore better matches the behaviour of language lists for SiteAccess.
+  Behaviour of Search engines will be gradually changed to reflect this change, Solr first.
+  Note: Possibility to search across all languages remains, however Field SortClause will
+  for instance not work properly in this case, and we plan to start to give warnings about this.
+
 ## Deprecations
 
 * `imagemagick` siteaccess settings are now deprecated. It is mandatory to remove them.

--- a/doc/bc/changes-5.4.md
+++ b/doc/bc/changes-5.4.md
@@ -189,6 +189,10 @@ Changes affecting version compatibility with former or future versions.
   when deleting last version of the Content. Since Content without a version does not make sense, in
   this case `eZ\Publish\Core\Repository\ContentService::deleteContent()` should be used instead.
 
+* 5.4.5: $fieldFilters argument on Search service has been renamed to $languageFilter
+  Reason is to better communicate what the argument is used for. No changes
+  to it's structure is done so this is a purly cosmetic change.
+
 ## Deprecations
 
 * `imagemagick` siteaccess settings are now deprecated. It is mandatory to remove them.

--- a/eZ/Publish/API/Repository/SearchService.php
+++ b/eZ/Publish/API/Repository/SearchService.php
@@ -25,7 +25,7 @@ interface SearchService
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if query is not valid
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query $query
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter Configuration for specifying prioritized languages query will be performed on.
      *        Also used to define which field languages are loaded for the returned content.
      *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
      *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations
@@ -43,7 +43,7 @@ interface SearchService
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if there is more than than one result matching the criterions
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $filter
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter Configuration for specifying prioritized languages query will be performed on.
      *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
      *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.
@@ -68,7 +68,7 @@ interface SearchService
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if query is not valid
      *
      * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter Configuration for specifying prioritized languages query will be performed on.
      *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
      *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.

--- a/eZ/Publish/API/Repository/SearchService.php
+++ b/eZ/Publish/API/Repository/SearchService.php
@@ -22,19 +22,18 @@ interface SearchService
     /**
      * Finds content objects for the given query.
      *
-     * @todo define structs for the field filters
-     *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if query is not valid
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query $query
-     * @param array $fieldFilters - a map of filters for the returned fields.
+     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     *        Also used to define which field languages are loaded for the returned content.
      *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
      *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
      */
-    public function findContent(Query $query, array $fieldFilters = array(), $filterOnUserPermissions = true);
+    public function findContent(Query $query, array $languageFilter = array(), $filterOnUserPermissions = true);
 
     /**
      * Performs a query for a single content object.
@@ -43,17 +42,15 @@ interface SearchService
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if criterion is not valid
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if there is more than than one result matching the criterions
      *
-     * @todo define structs for the field filters
-     *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $filter
-     * @param array $fieldFilters - a map of filters for the returned fields.
+     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
      *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
      *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content
      */
-    public function findSingle(Criterion $filter, array $fieldFilters = array(), $filterOnUserPermissions = true);
+    public function findSingle(Criterion $filter, array $languageFilter = array(), $filterOnUserPermissions = true);
 
     /**
      * Suggests a list of values for the given prefix.
@@ -71,12 +68,12 @@ interface SearchService
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if query is not valid
      *
      * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
-     * @param array $fieldFilters - a map of filters for the returned fields.
+     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
      *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
      *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
      */
-    public function findLocations(LocationQuery $query, array $fieldFilters = array(), $filterOnUserPermissions = true);
+    public function findLocations(LocationQuery $query, array $languageFilter = array(), $filterOnUserPermissions = true);
 }

--- a/eZ/Publish/API/Repository/SearchService.php
+++ b/eZ/Publish/API/Repository/SearchService.php
@@ -36,6 +36,26 @@ interface SearchService
     public function findContent(Query $query, array $languageFilter = array(), $filterOnUserPermissions = true);
 
     /**
+     * Finds contentInfo objects for the given query.
+     *
+     * This method works just like findContent, however does not load the full Content Objects. This means
+     * it can be more efficient for use cases where you don't need the full Content. Also including use cases
+     * where content will be loaded by separate code, like an ESI based sub requests that takes content ID as input.
+     *
+     * @since 5.4.5
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if query is not valid
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param array $languageFilter - a map of filters for the returned fields.
+     *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
+     *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations
+     * @param bool $filterOnUserPermissions if true (default) only the objects which is the user allowed to read are returned.
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
+     */
+    public function findContentInfo(Query $query, array $languageFilter = array(), $filterOnUserPermissions = true);
+
+    /**
      * Performs a query for a single content object.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the object was not found by the query or due to permissions

--- a/eZ/Publish/API/Repository/Tests/SearchServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceAuthorizationTest.php
@@ -117,7 +117,7 @@ class SearchServiceAuthorizationTest extends BaseTest
     /**
      * Test for the findContent() method, verifying disabling permissions.
      *
-     * @see \eZ\Publish\API\Repository\ContentService::findContent($query, $fieldFilters, $filterOnUserPermissions)
+     * @see \eZ\Publish\API\Repository\ContentService::findContent($query, $languageFilter, $filterOnUserPermissions)
      * @depends eZ\Publish\API\Repository\Tests\SearchServiceAuthorizationTest::testFindContent
      */
     public function testFindContentWithUserPermissionFilter()
@@ -154,7 +154,7 @@ class SearchServiceAuthorizationTest extends BaseTest
     /**
      * Test for the findSingle() method disabling permission filtering.
      *
-     * @see \eZ\Publish\API\Repository\ContentService::findSingle($query, $fieldFilters, $filterOnUserPermissions)
+     * @see \eZ\Publish\API\Repository\ContentService::findSingle($query, $languageFilter, $filterOnUserPermissions)
      * @depends eZ\Publish\API\Repository\Tests\SearchServiceAuthorizationTest::testFindContent
      */
     public function testFindSingleWithUserPermissionFilter()
@@ -184,7 +184,7 @@ class SearchServiceAuthorizationTest extends BaseTest
     /**
      * Test for the findSingle() method.
      *
-     * @see \eZ\Publish\API\Repository\ContentService::findSingle($query, $fieldFilters, $filterOnUserPermissions)
+     * @see \eZ\Publish\API\Repository\ContentService::findSingle($query, $languageFilter, $filterOnUserPermissions)
      * @expectedException \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @depends eZ\Publish\API\Repository\Tests\SearchServiceAuthorizationTest::testFindContent
      */

--- a/eZ/Publish/API/Repository/Tests/SearchServiceFieldFiltersTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceFieldFiltersTest.php
@@ -201,14 +201,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $searchService = $repository->getSearchService();
 
         // The content will be found, but field filtering in the service will cause the exception.
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchService->findContent($query, $fieldFilters);
+        $searchService->findContent($query, $languageFilter);
     }
 
     /**
@@ -241,7 +241,7 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
                 'eng-US',
@@ -249,7 +249,7 @@ class SearchServiceFieldFiltersTest extends BaseTest
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -283,14 +283,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -323,14 +323,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-US',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content2->id, $searchResult->searchHits[0]->valueObject->id);
@@ -363,14 +363,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(0, $searchResult->totalCount);
     }
@@ -405,13 +405,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -448,13 +448,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-US',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -491,13 +491,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -531,13 +531,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -570,13 +570,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(0, $searchResult->totalCount);
     }
@@ -699,7 +699,7 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
                 'eng-US',
@@ -707,7 +707,7 @@ class SearchServiceFieldFiltersTest extends BaseTest
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -739,14 +739,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content2->id, $searchResult->searchHits[0]->valueObject->id);
@@ -777,14 +777,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-US',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -815,14 +815,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(0, $searchResult->totalCount);
     }
@@ -855,13 +855,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -896,13 +896,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-US',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -937,13 +937,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -975,13 +975,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -1012,13 +1012,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(0, $searchResult->totalCount);
     }
@@ -1051,7 +1051,7 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
                 'eng-US',
@@ -1059,7 +1059,7 @@ class SearchServiceFieldFiltersTest extends BaseTest
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -1091,14 +1091,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content2->id, $searchResult->searchHits[0]->valueObject->id);
@@ -1129,14 +1129,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-US',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -1167,14 +1167,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(0, $searchResult->totalCount);
     }
@@ -1207,13 +1207,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -1248,13 +1248,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-US',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -1289,13 +1289,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -1327,13 +1327,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -1364,13 +1364,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(0, $searchResult->totalCount);
     }
@@ -1591,7 +1591,7 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
                 'eng-US',
@@ -1599,7 +1599,7 @@ class SearchServiceFieldFiltersTest extends BaseTest
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -1639,14 +1639,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content2->id, $searchResult->searchHits[0]->valueObject->id);
@@ -1685,14 +1685,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-US',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -1731,14 +1731,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(0, $searchResult->totalCount);
     }
@@ -1775,13 +1775,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -1820,13 +1820,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-US',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -1865,13 +1865,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -1906,13 +1906,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -1947,13 +1947,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(0, $searchResult->totalCount);
     }
@@ -1990,7 +1990,7 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
                 'eng-US',
@@ -1998,7 +1998,7 @@ class SearchServiceFieldFiltersTest extends BaseTest
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -2034,14 +2034,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content2->id, $searchResult->searchHits[0]->valueObject->id);
@@ -2076,14 +2076,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-US',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -2118,14 +2118,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(0, $searchResult->totalCount);
     }
@@ -2162,13 +2162,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -2207,13 +2207,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-US',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -2252,13 +2252,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -2294,13 +2294,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -2335,13 +2335,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(0, $searchResult->totalCount);
     }
@@ -2581,7 +2581,7 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
                 'eng-US',
@@ -2589,7 +2589,7 @@ class SearchServiceFieldFiltersTest extends BaseTest
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -2641,14 +2641,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -2699,14 +2699,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-US',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content2->id, $searchResult->searchHits[0]->valueObject->id);
@@ -2757,14 +2757,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(0, $searchResult->totalCount);
     }
@@ -2826,13 +2826,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -2896,13 +2896,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-US',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -2966,13 +2966,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -3026,13 +3026,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -3085,13 +3085,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(0, $searchResult->totalCount);
     }
@@ -3220,7 +3220,7 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
                 'eng-US',
@@ -3228,7 +3228,7 @@ class SearchServiceFieldFiltersTest extends BaseTest
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -3266,14 +3266,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content2->id, $searchResult->searchHits[0]->valueObject->id);
@@ -3310,14 +3310,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-US',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -3354,14 +3354,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(0, $searchResult->totalCount);
     }
@@ -3400,13 +3400,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -3447,13 +3447,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-US',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -3494,13 +3494,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -3538,13 +3538,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -3581,13 +3581,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(0, $searchResult->totalCount);
     }
@@ -3622,7 +3622,7 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
                 'eng-US',
@@ -3630,7 +3630,7 @@ class SearchServiceFieldFiltersTest extends BaseTest
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -3664,14 +3664,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content2->id, $searchResult->searchHits[0]->valueObject->id);
@@ -3704,14 +3704,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-US',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -3744,14 +3744,14 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
             'useAlwaysAvailable' => false,
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(0, $searchResult->totalCount);
     }
@@ -3786,13 +3786,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-GB',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -3829,13 +3829,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'eng-US',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -3872,13 +3872,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(2, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -3912,13 +3912,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(1, $searchResult->totalCount);
         $this->assertEquals($content1->id, $searchResult->searchHits[0]->valueObject->id);
@@ -3951,13 +3951,13 @@ class SearchServiceFieldFiltersTest extends BaseTest
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
 
-        $fieldFilters = array(
+        $languageFilter = array(
             'languages' => array(
                 'ger-DE',
             ),
         );
 
-        $searchResult = $searchService->findContent($query, $fieldFilters);
+        $searchResult = $searchService->findContent($query, $languageFilter);
 
         $this->assertEquals(0, $searchResult->totalCount);
     }

--- a/eZ/Publish/Core/REST/Client/ContentService.php
+++ b/eZ/Publish/Core/REST/Client/ContentService.php
@@ -556,16 +556,14 @@ class ContentService implements APIContentService, Sessionable
     /**
      * Finds content objects for the given query.
      *
-     * @todo define structs for the field filters
-     *
      * @param \eZ\Publish\API\Repository\Values\Content\Query $query
-     * @param array $fieldFilters - a map of filters for the returned fields.
+     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\SearchResult
      */
-    public function findContent(Query $query, array $fieldFilters, $filterOnUserPermissions = true)
+    public function findContent(Query $query, array $languageFilter, $filterOnUserPermissions = true)
     {
         throw new \Exception('@todo: Implement.');
     }
@@ -576,16 +574,14 @@ class ContentService implements APIContentService, Sessionable
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the object was not found by the query or due to permissions
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the query would return more than one result
      *
-     * @todo define structs for the field filters
-     *
      * @param \eZ\Publish\API\Repository\Values\Content\Query $query
-     * @param array $fieldFilters - a map of filters for the returned fields.
+     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content
      */
-    public function findSingle(Query $query, array $fieldFilters, $filterOnUserPermissions = true)
+    public function findSingle(Query $query, array $languageFilter, $filterOnUserPermissions = true)
     {
         throw new \Exception('@todo: Implement.');
     }

--- a/eZ/Publish/Core/REST/Client/ContentService.php
+++ b/eZ/Publish/Core/REST/Client/ContentService.php
@@ -557,7 +557,7 @@ class ContentService implements APIContentService, Sessionable
      * Finds content objects for the given query.
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query $query
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter Configuration for specifying prioritized languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.
      *
@@ -575,7 +575,7 @@ class ContentService implements APIContentService, Sessionable
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the query would return more than one result
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query $query
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter Configuration for specifying prioritized languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.
      *

--- a/eZ/Publish/Core/Repository/SearchService.php
+++ b/eZ/Publish/Core/Repository/SearchService.php
@@ -93,19 +93,17 @@ class SearchService implements SearchServiceInterface
     /**
      * Finds content objects for the given query.
      *
-     * @todo define structs for the field filters
-     *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if query is not valid
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query $query
-     * @param array $fieldFilters - a map of filters for the returned fields.
+     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
      *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
      *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations.
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
      */
-    public function findContent(Query $query, array $fieldFilters = array(), $filterOnUserPermissions = true)
+    public function findContent(Query $query, array $languageFilter = array(), $filterOnUserPermissions = true)
     {
         if (!is_int($query->offset)) {
             throw new InvalidArgumentType(
@@ -135,16 +133,16 @@ class SearchService implements SearchServiceInterface
             return new SearchResult(array('time' => 0, 'totalCount' => 0));
         }
 
-        $result = $this->searchHandler->findContent($query, $fieldFilters);
+        $result = $this->searchHandler->findContent($query, $languageFilter);
 
         $contentService = $this->repository->getContentService();
         foreach ($result->searchHits as $hit) {
             $hit->valueObject = $contentService->internalLoadContent(
                 $hit->valueObject->id,
-                (!empty($fieldFilters['languages']) ? $fieldFilters['languages'] : null),
+                (!empty($languageFilter['languages']) ? $languageFilter['languages'] : null),
                 null,
                 false,
-                (isset($fieldFilters['useAlwaysAvailable']) ? $fieldFilters['useAlwaysAvailable'] : true)
+                (isset($languageFilter['useAlwaysAvailable']) ? $languageFilter['useAlwaysAvailable'] : true)
             );
         }
 
@@ -237,17 +235,15 @@ class SearchService implements SearchServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if criterion is not valid
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if there is more than one result matching the criterions
      *
-     * @todo define structs for the field filters
-     *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $filter
-     * @param array $fieldFilters - a map of filters for the returned fields.
+     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
      *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
      *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations.
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content
      */
-    public function findSingle(Criterion $filter, array $fieldFilters = array(), $filterOnUserPermissions = true)
+    public function findSingle(Criterion $filter, array $languageFilter = array(), $filterOnUserPermissions = true)
     {
         $this->validateContentCriteria(array($filter), '$filter');
 
@@ -255,14 +251,14 @@ class SearchService implements SearchServiceInterface
             throw new NotFoundException('Content', '*');
         }
 
-        $contentInfo = $this->searchHandler->findSingle($filter, $fieldFilters);
+        $contentInfo = $this->searchHandler->findSingle($filter, $languageFilter);
 
         return $this->repository->getContentService()->internalLoadContent(
             $contentInfo->id,
-            (!empty($fieldFilters['languages']) ? $fieldFilters['languages'] : null),
+            (!empty($languageFilter['languages']) ? $languageFilter['languages'] : null),
             null,
             false,
-            (isset($fieldFilters['useAlwaysAvailable']) ? $fieldFilters['useAlwaysAvailable'] : true)
+            (isset($languageFilter['useAlwaysAvailable']) ? $languageFilter['useAlwaysAvailable'] : true)
         );
     }
 
@@ -284,14 +280,14 @@ class SearchService implements SearchServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if query is not valid
      *
      * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
-     * @param array $fieldFilters - a map of filters for the returned fields.
+     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
      *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
      *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
      */
-    public function findLocations(LocationQuery $query, array $fieldFilters = array(), $filterOnUserPermissions = true)
+    public function findLocations(LocationQuery $query, array $languageFilter = array(), $filterOnUserPermissions = true)
     {
         if (!is_int($query->offset)) {
             throw new InvalidArgumentType(
@@ -318,7 +314,7 @@ class SearchService implements SearchServiceInterface
             return new SearchResult(array('time' => 0, 'totalCount' => 0));
         }
 
-        $result = $this->locationSearchHandler->findLocations($query, $fieldFilters);
+        $result = $this->locationSearchHandler->findLocations($query, $languageFilter);
 
         foreach ($result->searchHits as $hit) {
             $hit->valueObject = $this->domainMapper->buildLocationDomainObject(

--- a/eZ/Publish/Core/Repository/SearchService.php
+++ b/eZ/Publish/Core/Repository/SearchService.php
@@ -105,6 +105,67 @@ class SearchService implements SearchServiceInterface
      */
     public function findContent(Query $query, array $languageFilter = array(), $filterOnUserPermissions = true)
     {
+        $contentService = $this->repository->getContentService();
+        $result = $this->internalFindContentInfo($query, $languageFilter, $filterOnUserPermissions);
+        foreach ($result->searchHits as $hit) {
+            // As we get ContentInfo from SPI, we need to load full content (avoids getting stale content data)
+            $hit->valueObject = $contentService->internalLoadContent(
+                $hit->valueObject->id,
+                (!empty($languageFilter['languages']) ? $languageFilter['languages'] : null),
+                null,
+                false,
+                (isset($languageFilter['useAlwaysAvailable']) ? $languageFilter['useAlwaysAvailable'] : true)
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * Finds contentInfo objects for the given query.
+     *
+     * @see SearchServiceInterface::findContentInfo()
+     *
+     * @since 5.4.5
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if query is not valid
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param array $languageFilter - a map of filters for the returned fields.
+     *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
+     *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations.
+     * @param bool $filterOnUserPermissions if true (default) only the objects which is the user allowed to read are returned.
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
+     */
+    public function findContentInfo(Query $query, array $languageFilter = array(), $filterOnUserPermissions = true)
+    {
+        $result = $this->internalFindContentInfo($query, $languageFilter, $filterOnUserPermissions);
+        foreach ($result->searchHits as $hit) {
+            $hit->valueObject = $this->domainMapper->buildContentInfoDomainObject(
+                $hit->valueObject
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * Finds SPI content info objects for the given query.
+     *
+     * Internal for use by {@link findContent} and {@link findContentInfo}.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if query is not valid
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param array $languageFilter - a map of filters for the returned fields.
+     *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
+     *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations.
+     * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult With "raw" SPI contentInfo objects in result
+     */
+    protected function internalFindContentInfo(Query $query, array $languageFilter = array(), $filterOnUserPermissions = true)
+    {
         if (!is_int($query->offset)) {
             throw new InvalidArgumentType(
                 '$query->offset',
@@ -133,20 +194,7 @@ class SearchService implements SearchServiceInterface
             return new SearchResult(array('time' => 0, 'totalCount' => 0));
         }
 
-        $result = $this->searchHandler->findContent($query, $languageFilter);
-
-        $contentService = $this->repository->getContentService();
-        foreach ($result->searchHits as $hit) {
-            $hit->valueObject = $contentService->internalLoadContent(
-                $hit->valueObject->id,
-                (!empty($languageFilter['languages']) ? $languageFilter['languages'] : null),
-                null,
-                false,
-                (isset($languageFilter['useAlwaysAvailable']) ? $languageFilter['useAlwaysAvailable'] : true)
-            );
-        }
-
-        return $result;
+        return $this->searchHandler->findContent($query, $languageFilter);
     }
 
     /**

--- a/eZ/Publish/Core/Repository/SearchService.php
+++ b/eZ/Publish/Core/Repository/SearchService.php
@@ -96,7 +96,7 @@ class SearchService implements SearchServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if query is not valid
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query $query
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter Configuration for specifying prioritized languages query will be performed on.
      *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
      *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations.
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.
@@ -236,7 +236,7 @@ class SearchService implements SearchServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if there is more than one result matching the criterions
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $filter
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter Configuration for specifying prioritized languages query will be performed on.
      *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
      *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations.
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.
@@ -280,7 +280,7 @@ class SearchService implements SearchServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if query is not valid
      *
      * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter Configuration for specifying prioritized languages query will be performed on.
      *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
      *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
@@ -284,14 +284,14 @@ class SearchTest extends BaseServiceMockTest
 
         $serviceQuery = new Query();
         $handlerQuery = new Query(array('filter' => new Criterion\MatchAll(), 'limit' => 10));
-        $fieldFilters = array();
+        $languageFilter = array();
         $spiContentInfo = new SPIContentInfo();
         $contentMock = $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\Content\\Content');
 
         /* @var \PHPUnit_Framework_MockObject_MockObject $searchHandlerMock */
         $searchHandlerMock->expects($this->once())
             ->method('findContent')
-            ->with($this->equalTo($handlerQuery), $this->equalTo($fieldFilters))
+            ->with($this->equalTo($handlerQuery), $this->equalTo($languageFilter))
             ->will(
                 $this->returnValue(
                     new SearchResult(
@@ -308,7 +308,7 @@ class SearchTest extends BaseServiceMockTest
             ->method('internalLoadContent')
             ->will($this->returnValue($contentMock));
 
-        $result = $service->findContent($serviceQuery, $fieldFilters, false);
+        $result = $service->findContent($serviceQuery, $languageFilter, false);
 
         $this->assertEquals(
             new SearchResult(
@@ -363,14 +363,14 @@ class SearchTest extends BaseServiceMockTest
             ->disableOriginalConstructor()
             ->getMock();
         $query = new Query(array('filter' => $criterionMock, 'limit' => 10));
-        $fieldFilters = array();
+        $languageFilter = array();
         $spiContentInfo = new SPIContentInfo();
         $contentMock = $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\Content\\Content');
 
         /* @var \PHPUnit_Framework_MockObject_MockObject $searchHandlerMock */
         $searchHandlerMock->expects($this->once())
             ->method('findContent')
-            ->with($this->equalTo($query), $this->equalTo($fieldFilters))
+            ->with($this->equalTo($query), $this->equalTo($languageFilter))
             ->will(
                 $this->returnValue(
                     new SearchResult(
@@ -395,7 +395,7 @@ class SearchTest extends BaseServiceMockTest
             ->with($criterionMock)
             ->will($this->returnValue(true));
 
-        $result = $service->findContent($query, $fieldFilters, true);
+        $result = $service->findContent($query, $languageFilter, true);
 
         $this->assertEquals(
             new SearchResult(
@@ -596,7 +596,7 @@ class SearchTest extends BaseServiceMockTest
                 )
             );
 
-        $fieldFilters = array();
+        $languageFilter = array();
         $spiContentInfo = new SPIContentInfo();
         $contentMock = $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\Content\\Content');
         $domainMapperMock->expects($this->never())
@@ -631,7 +631,7 @@ class SearchTest extends BaseServiceMockTest
                 )
             );
 
-        $result = $service->findContent(new Query(), $fieldFilters, false);
+        $result = $service->findContent(new Query(), $languageFilter, false);
 
         $this->assertEquals(
             new SearchResult(
@@ -765,14 +765,14 @@ class SearchTest extends BaseServiceMockTest
             ->with($criterionMock)
             ->will($this->returnValue(true));
 
-        $fieldFilters = array();
+        $languageFilter = array();
         $spiContentInfo = new SPIContentInfo();
         $contentMock = $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\Content\\Content');
 
         /* @var \PHPUnit_Framework_MockObject_MockObject $searchHandlerMock */
         $searchHandlerMock->expects($this->once())
             ->method('findSingle')
-            ->with($this->equalTo($criterionMock), $this->equalTo($fieldFilters))
+            ->with($this->equalTo($criterionMock), $this->equalTo($languageFilter))
             ->will($this->returnValue($spiContentInfo));
 
         $domainMapperMock->expects($this->never())
@@ -783,7 +783,7 @@ class SearchTest extends BaseServiceMockTest
             ->method('internalLoadContent')
             ->will($this->returnValue($contentMock));
 
-        $result = $service->findSingle($criterionMock, $fieldFilters, true);
+        $result = $service->findSingle($criterionMock, $languageFilter, true);
 
         $this->assertEquals($contentMock, $result);
     }

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Common/CriterionVisitor/LogicalAnd.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Common/CriterionVisitor/LogicalAnd.php
@@ -36,17 +36,17 @@ class LogicalAnd extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         /* @var $criterion \eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOperator */
         return array(
             'and' => array_map(
-                function ($value) use ($dispatcher, $fieldFilters) {
-                    return $dispatcher->dispatch($value, Dispatcher::CONTEXT_FILTER, $fieldFilters);
+                function ($value) use ($dispatcher, $languageFilter) {
+                    return $dispatcher->dispatch($value, Dispatcher::CONTEXT_FILTER, $languageFilter);
                 },
                 $criterion->criteria
             ),
@@ -58,19 +58,19 @@ class LogicalAnd extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         /* @var $criterion \eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOperator */
         return array(
             'bool' => array(
                 'must' => array(
                     array_map(
-                        function ($value) use ($dispatcher, $fieldFilters) {
-                            return $dispatcher->dispatch($value, Dispatcher::CONTEXT_QUERY, $fieldFilters);
+                        function ($value) use ($dispatcher, $languageFilter) {
+                            return $dispatcher->dispatch($value, Dispatcher::CONTEXT_QUERY, $languageFilter);
                         },
                         $criterion->criteria
                     ),

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Common/CriterionVisitor/LogicalNot.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Common/CriterionVisitor/LogicalNot.php
@@ -52,17 +52,17 @@ class LogicalNot extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $this->validateCriterionInput($criterion);
 
         /* @var $criterion \eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOperator */
         return array(
-            'not' => $dispatcher->dispatch($criterion->criteria[0], Dispatcher::CONTEXT_FILTER, $fieldFilters),
+            'not' => $dispatcher->dispatch($criterion->criteria[0], Dispatcher::CONTEXT_FILTER, $languageFilter),
         );
     }
 
@@ -71,11 +71,11 @@ class LogicalNot extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $this->validateCriterionInput($criterion);
 
@@ -85,7 +85,7 @@ class LogicalNot extends CriterionVisitor
                 'must_not' => $dispatcher->dispatch(
                     $criterion->criteria[0],
                     Dispatcher::CONTEXT_FILTER,
-                    $fieldFilters
+                    $languageFilter
                 ),
             ),
         );

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Common/CriterionVisitor/LogicalOr.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Common/CriterionVisitor/LogicalOr.php
@@ -36,17 +36,17 @@ class LogicalOr extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         /* @var $criterion \eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOperator */
         return array(
             'or' => array_map(
-                function ($value) use ($dispatcher, $fieldFilters) {
-                    return $dispatcher->dispatch($value, Dispatcher::CONTEXT_FILTER, $fieldFilters);
+                function ($value) use ($dispatcher, $languageFilter) {
+                    return $dispatcher->dispatch($value, Dispatcher::CONTEXT_FILTER, $languageFilter);
                 },
                 $criterion->criteria
             ),
@@ -58,18 +58,18 @@ class LogicalOr extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         /* @var $criterion \eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOperator */
         return array(
             'bool' => array(
                 'should' => array_map(
-                    function ($value) use ($dispatcher, $fieldFilters) {
-                        return $dispatcher->dispatch($value, Dispatcher::CONTEXT_FILTER, $fieldFilters);
+                    function ($value) use ($dispatcher, $languageFilter) {
+                        return $dispatcher->dispatch($value, Dispatcher::CONTEXT_FILTER, $languageFilter);
                     },
                     $criterion->criteria
                 ),

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Common/CriterionVisitor/MatchAll.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Common/CriterionVisitor/MatchAll.php
@@ -37,11 +37,11 @@ class MatchAll extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'match_all' => new ArrayObject(),

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Common/CriterionVisitor/MatchNone.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Common/CriterionVisitor/MatchNone.php
@@ -36,11 +36,11 @@ class MatchNone extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'terms' => array(
@@ -54,11 +54,11 @@ class MatchNone extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'terms' => array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor.php
@@ -33,14 +33,14 @@ abstract class CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed Hash representation of Elasticsearch filter abstract syntax tree
      */
     abstract public function visitFilter(
         Criterion $criterion,
         CriterionVisitorDispatcher $dispatcher,
-        array $fieldFilters
+        array $languageFilter
     );
 
     /**
@@ -50,13 +50,13 @@ abstract class CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed Hash representation of Elasticsearch query abstract syntax tree
      */
-    public function visitQuery(Criterion $criterion, CriterionVisitorDispatcher $dispatcher, array $fieldFilters)
+    public function visitQuery(Criterion $criterion, CriterionVisitorDispatcher $dispatcher, array $languageFilter)
     {
-        return $this->visitFilter($criterion, $dispatcher, $fieldFilters);
+        return $this->visitFilter($criterion, $dispatcher, $languageFilter);
     }
 
     /**

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/ContentIdIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/ContentIdIn.php
@@ -42,11 +42,11 @@ class ContentIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'ids' => array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/ContentTypeGroupIdIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/ContentTypeGroupIdIn.php
@@ -42,11 +42,11 @@ class ContentTypeGroupIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         if (count($criterion->value) > 1) {
             $filter = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/ContentTypeIdIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/ContentTypeIdIn.php
@@ -42,11 +42,11 @@ class ContentTypeIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         if (count($criterion->value) > 1) {
             $filter = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/ContentTypeIdentifierIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/ContentTypeIdentifierIn.php
@@ -60,11 +60,11 @@ class ContentTypeIdentifierIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         if (count($criterion->value) > 1) {
             $idList = array();

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/CustomField.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/CustomField.php
@@ -34,11 +34,11 @@ abstract class CustomField extends FieldFilterBase
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $query = array(
             'bool' => array(
@@ -47,7 +47,7 @@ abstract class CustomField extends FieldFilterBase
             ),
         );
 
-        $fieldFilter = $this->getFieldFilter($fieldFilters);
+        $fieldFilter = $this->getFieldFilter($languageFilter);
 
         if ($fieldFilter === null) {
             $query = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/CustomField/CustomFieldIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/CustomField/CustomFieldIn.php
@@ -70,11 +70,11 @@ class CustomFieldIn extends CustomField
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $filter = array(
             'nested' => array(
@@ -90,7 +90,7 @@ class CustomFieldIn extends CustomField
             ),
         );
 
-        $fieldFilter = $this->getFieldFilter($fieldFilters);
+        $fieldFilter = $this->getFieldFilter($languageFilter);
 
         if ($fieldFilter !== null) {
             $filter['nested']['filter'] = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/CustomField/CustomFieldRange.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/CustomField/CustomFieldRange.php
@@ -75,11 +75,11 @@ class CustomFieldRange extends CustomField
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $filter = array(
             'nested' => array(
@@ -90,7 +90,7 @@ class CustomFieldRange extends CustomField
             ),
         );
 
-        $fieldFilter = $this->getFieldFilter($fieldFilters);
+        $fieldFilter = $this->getFieldFilter($languageFilter);
 
         if ($fieldFilter !== null) {
             $filter['nested']['filter'] = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/DateMetadata/ModifiedIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/DateMetadata/ModifiedIn.php
@@ -43,11 +43,11 @@ class ModifiedIn extends DateMetadata
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         if (count($criterion->value) > 1) {
             $that = $this;

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/DateMetadata/ModifiedRange.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/DateMetadata/ModifiedRange.php
@@ -46,11 +46,11 @@ class ModifiedRange extends DateMetadata
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $start = $this->getNativeTime($criterion->value[0]);
         $end = isset($criterion->value[1]) ? $this->getNativeTime($criterion->value[1]) : null;

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/DateMetadata/PublishedIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/DateMetadata/PublishedIn.php
@@ -43,11 +43,11 @@ class PublishedIn extends DateMetadata
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         if (count($criterion->value) > 1) {
             $that = $this;

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/DateMetadata/PublishedRange.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/DateMetadata/PublishedRange.php
@@ -46,11 +46,11 @@ class PublishedRange extends DateMetadata
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $start = $this->getNativeTime($criterion->value[0]);
         $end = isset($criterion->value[1]) ? $this->getNativeTime($criterion->value[1]) : null;

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/DepthIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/DepthIn.php
@@ -66,11 +66,11 @@ class DepthIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'nested' => array(
@@ -85,11 +85,11 @@ class DepthIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'nested' => array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/DepthRange.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/DepthRange.php
@@ -45,11 +45,11 @@ class DepthRange extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $start = $criterion->value[0];
         $end = isset($criterion->value[1]) ? $criterion->value[1] : null;
@@ -71,11 +71,11 @@ class DepthRange extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $start = $criterion->value[0];
         $end = isset($criterion->value[1]) ? $criterion->value[1] : null;

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/Field/FieldIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/Field/FieldIn.php
@@ -91,11 +91,11 @@ class FieldIn extends Field
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $filter = array(
             'nested' => array(
@@ -106,9 +106,9 @@ class FieldIn extends Field
             ),
         );
 
-        $fieldFilter = $this->getFieldFilter($fieldFilters);
+        $fieldFilter = $this->getFieldFilter($languageFilter);
 
-        if ($fieldFilters !== null) {
+        if ($languageFilter !== null) {
             $filter['nested']['filter'] = array(
                 'bool' => array(
                     'must' => array(
@@ -129,13 +129,13 @@ class FieldIn extends Field
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
-        $fieldFilter = $this->getFieldFilter($fieldFilters);
+        $fieldFilter = $this->getFieldFilter($languageFilter);
 
         if ($fieldFilter === null) {
             $query = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/Field/FieldRange.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/Field/FieldRange.php
@@ -89,11 +89,11 @@ class FieldRange extends Field
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $filter = array(
             'nested' => array(
@@ -104,7 +104,7 @@ class FieldRange extends Field
             ),
         );
 
-        $fieldFilter = $this->getFieldFilter($fieldFilters);
+        $fieldFilter = $this->getFieldFilter($languageFilter);
 
         if ($fieldFilter !== null) {
             $filter['nested']['filter'] = array(
@@ -125,11 +125,11 @@ class FieldRange extends Field
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $query = array(
             'bool' => array(
@@ -138,7 +138,7 @@ class FieldRange extends Field
             ),
         );
 
-        $fieldFilter = $this->getFieldFilter($fieldFilters);
+        $fieldFilter = $this->getFieldFilter($languageFilter);
 
         if ($fieldFilter === null) {
             $query = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/Field/MapLocationDistanceRange.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/Field/MapLocationDistanceRange.php
@@ -132,11 +132,11 @@ class MapLocationDistanceRange extends Field
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $filter = array(
             'nested' => array(
@@ -147,9 +147,9 @@ class MapLocationDistanceRange extends Field
             ),
         );
 
-        $fieldFilter = $this->getFieldFilter($fieldFilters);
+        $fieldFilter = $this->getFieldFilter($languageFilter);
 
-        if ($fieldFilters !== null) {
+        if ($languageFilter !== null) {
             $filter['nested']['filter'] = array(
                 'and' => array(
                     $fieldFilter,
@@ -168,11 +168,11 @@ class MapLocationDistanceRange extends Field
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $query = array(
             'filtered' => array(
@@ -182,7 +182,7 @@ class MapLocationDistanceRange extends Field
             ),
         );
 
-        $fieldFilter = $this->getFieldFilter($fieldFilters);
+        $fieldFilter = $this->getFieldFilter($languageFilter);
 
         if ($fieldFilter === null) {
             $query = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/FieldFilterBase.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/FieldFilterBase.php
@@ -19,30 +19,30 @@ use eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitor;
 abstract class FieldFilterBase extends CriterionVisitor
 {
     /**
-     * Returns filter condition for the given $fieldFilters.
+     * Returns filter condition for the given $languageFilter.
      *
      * Filter is to be used by both query and filter visiting, as it should not impact scoring.
      * Null will be returned if nothing is found to be filtered.
      *
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return array|null
      */
-    protected function getFieldFilter(array $fieldFilters)
+    protected function getFieldFilter(array $languageFilter)
     {
         $filter = null;
 
         // Only 'languages' and 'useAlwaysAvailable' are available,
         // latter making sense only when former is set.
-        if (!empty($fieldFilters['languages'])) {
+        if (!empty($languageFilter['languages'])) {
             // For 'terms' filter caching is enabled by default
             $filter = array(
                 'terms' => array(
-                    'fields_doc.meta_language_code_s' => $fieldFilters['languages'],
+                    'fields_doc.meta_language_code_s' => $languageFilter['languages'],
                 ),
             );
 
-            if (!isset($fieldFilters['useAlwaysAvailable']) || $fieldFilters['useAlwaysAvailable'] === true) {
+            if (!isset($languageFilter['useAlwaysAvailable']) || $languageFilter['useAlwaysAvailable'] === true) {
                 $filter = array(
                     'or' => array(
                         // Enabling caching requires filters to be wrapped in 'filters' element
@@ -69,23 +69,23 @@ abstract class FieldFilterBase extends CriterionVisitor
      * TODO: should really work something like this, but also
      * needs update to the UrlAliasService etc.
      *
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return array|null
      */
-    protected function getTodoFieldFilter(array $fieldFilters)
+    protected function getTodoFieldFilter(array $languageFilter)
     {
         $translationFilter = null;
 
-        if (!empty($fieldFilters['languages'])) {
+        if (!empty($languageFilter['languages'])) {
             $translationFilter = array(
                 'terms' => array(
-                    'fields_doc.meta_language_code_s' => $fieldFilters['languages'],
+                    'fields_doc.meta_language_code_s' => $languageFilter['languages'],
                 ),
             );
 
-            if (isset($fieldFilters['defaultTranslationToMainLanguage'])) {
-                switch ($fieldFilters['defaultTranslationToMainLanguage']) {
+            if (isset($languageFilter['defaultTranslationToMainLanguage'])) {
+                switch ($languageFilter['defaultTranslationToMainLanguage']) {
                     case true:
                         $translationFilter = array(
                             'or' => array(
@@ -125,7 +125,7 @@ abstract class FieldFilterBase extends CriterionVisitor
                         throw new \RuntimeException(
                             "Invalid value for 'defaultTranslationToMainLanguage' field filter: expected one of: " .
                             "true, 'use_always_available', false, got: " .
-                            var_export($fieldFilters['defaultTranslationToMainLanguage'], true)
+                            var_export($languageFilter['defaultTranslationToMainLanguage'], true)
                         );
                 }
             }

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/FullText.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/FullText.php
@@ -111,11 +111,11 @@ class FullText extends FieldFilterBase
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $filter = array(
             'nested' => array(
@@ -126,9 +126,9 @@ class FullText extends FieldFilterBase
             ),
         );
 
-        $fieldFilter = $this->getFieldFilter($fieldFilters);
+        $fieldFilter = $this->getFieldFilter($languageFilter);
 
-        if ($fieldFilters !== null) {
+        if ($languageFilter !== null) {
             $filter['nested']['filter'] = array(
                 'bool' => array(
                     'must' => array(
@@ -149,13 +149,13 @@ class FullText extends FieldFilterBase
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
-        $fieldFilter = $this->getFieldFilter($fieldFilters);
+        $fieldFilter = $this->getFieldFilter($languageFilter);
 
         if ($fieldFilter === null) {
             $query = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/LanguageCodeIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/LanguageCodeIn.php
@@ -66,11 +66,11 @@ class LanguageCodeIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $filter = $this->getCondition($criterion);
 
@@ -96,11 +96,11 @@ class LanguageCodeIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $filter = $this->getCondition($criterion);
 

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/LocationIdIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/LocationIdIn.php
@@ -66,11 +66,11 @@ class LocationIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'nested' => array(
@@ -85,11 +85,11 @@ class LocationIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'nested' => array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/LocationRemoteIdIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/LocationRemoteIdIn.php
@@ -66,11 +66,11 @@ class LocationRemoteIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'nested' => array(
@@ -85,11 +85,11 @@ class LocationRemoteIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'nested' => array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/ObjectStateIdIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/ObjectStateIdIn.php
@@ -42,11 +42,11 @@ class ObjectStateIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         if (count($criterion->value) > 1) {
             $filter = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/ParentLocationIdIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/ParentLocationIdIn.php
@@ -66,11 +66,11 @@ class ParentLocationIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'nested' => array(
@@ -85,11 +85,11 @@ class ParentLocationIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'nested' => array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/RemoteIdIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/RemoteIdIn.php
@@ -42,11 +42,11 @@ class RemoteIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         if (count($criterion->value) > 1) {
             $filter = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/SectionIdIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/SectionIdIn.php
@@ -42,11 +42,11 @@ class SectionIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         if (count($criterion->value) > 1) {
             $filter = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/SubtreeIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/SubtreeIn.php
@@ -65,11 +65,11 @@ class SubtreeIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'nested' => array(
@@ -86,11 +86,11 @@ class SubtreeIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'nested' => array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/UserMetadataIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/UserMetadataIn.php
@@ -45,11 +45,11 @@ class UserMetadataIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         switch ($criterion->target) {
             case Criterion\UserMetadata::MODIFIER:

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/Visibility.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/Visibility.php
@@ -49,11 +49,11 @@ class Visibility extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'nested' => array(
@@ -72,11 +72,11 @@ class Visibility extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'nested' => array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitorDispatcher.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitorDispatcher.php
@@ -75,11 +75,11 @@ class CriterionVisitorDispatcher
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param string $context
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return string
      */
-    public function dispatch(Criterion $criterion, $context, array $fieldFilters = array())
+    public function dispatch(Criterion $criterion, $context, array $languageFilter = array())
     {
         if (!isset($this->contextMethodMap[$context])) {
             throw new RuntimeException(
@@ -89,7 +89,7 @@ class CriterionVisitorDispatcher
 
         foreach ($this->visitors as $visitor) {
             if ($visitor->canVisit($criterion)) {
-                return $visitor->{ $this->contextMethodMap[$context] }($criterion, $this, $fieldFilters);
+                return $visitor->{ $this->contextMethodMap[$context] }($criterion, $this, $languageFilter);
             }
         }
 

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Gateway.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Gateway.php
@@ -37,11 +37,11 @@ abstract class Gateway
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query $query
      * @param string $type
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    abstract public function find(Query $query, $type, array $fieldFilters = array());
+    abstract public function find(Query $query, $type, array $languageFilter = array());
 
     /**
      * Finds and returns documents of a given $type for a given $query string.

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Gateway/Native.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Gateway/Native.php
@@ -159,11 +159,11 @@ class Native extends Gateway
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query $query
      * @param string $type
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function find(Query $query, $type, array $fieldFilters = array())
+    public function find(Query $query, $type, array $languageFilter = array())
     {
         $aggregationList = array_map(
             array($this->facetBuilderVisitor, 'visit'),
@@ -182,14 +182,14 @@ class Native extends Gateway
                         $this->criterionVisitorDispatcher->dispatch(
                             $query->query,
                             CriterionVisitorDispatcher::CONTEXT_QUERY,
-                            $fieldFilters
+                            $languageFilter
                         ),
                     ),
                     'filter' => array(
                         $this->criterionVisitorDispatcher->dispatch(
                             $query->filter,
                             CriterionVisitorDispatcher::CONTEXT_FILTER,
-                            $fieldFilters
+                            $languageFilter
                         ),
                     ),
                 ),

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Handler.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Handler.php
@@ -63,7 +63,7 @@ class Handler implements SearchHandlerInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if Query criterion is not applicable to its target
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query $query
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter Configuration for specifying prioritized languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
@@ -86,7 +86,7 @@ class Handler implements SearchHandlerInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if there is more than than one result matching the criterions
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $filter
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter Configuration for specifying prioritized languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      *
      * @return \eZ\Publish\SPI\Persistence\Content

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Handler.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Handler.php
@@ -60,22 +60,20 @@ class Handler implements SearchHandlerInterface
     /**
      * Finds content objects for the given query.
      *
-     * @todo define structs for the field filters
-     *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if Query criterion is not applicable to its target
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query $query
-     * @param array $fieldFilters - a map of filters for the returned fields.
+     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
      */
-    public function findContent(Query $query, array $fieldFilters = array())
+    public function findContent(Query $query, array $languageFilter = array())
     {
         $query->filter = $query->filter ?: new Criterion\MatchAll();
         $query->query = $query->query ?: new Criterion\MatchAll();
 
-        $data = $this->gateway->find($query, $this->documentTypeName, $fieldFilters);
+        $data = $this->gateway->find($query, $this->documentTypeName, $languageFilter);
 
         return $this->extractor->extract($data);
     }
@@ -87,21 +85,19 @@ class Handler implements SearchHandlerInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if Criterion is not applicable to its target
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if there is more than than one result matching the criterions
      *
-     * @todo define structs for the field filters
-     *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $filter
-     * @param array $fieldFilters - a map of filters for the returned fields.
+     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      *
      * @return \eZ\Publish\SPI\Persistence\Content
      */
-    public function findSingle(Criterion $filter, array $fieldFilters = array())
+    public function findSingle(Criterion $filter, array $languageFilter = array())
     {
         $query = new Query();
         $query->filter = $filter;
         $query->offset = 0;
         $query->limit = 1;
-        $result = $this->findContent($query, $fieldFilters);
+        $result = $this->findContent($query, $languageFilter);
 
         if (!$result->totalCount) {
             throw new NotFoundException(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/ContentIdIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/ContentIdIn.php
@@ -42,11 +42,11 @@ class ContentIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'terms' => array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/ContentTypeGroupIdIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/ContentTypeGroupIdIn.php
@@ -42,11 +42,11 @@ class ContentTypeGroupIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         if (count($criterion->value) > 1) {
             $filter = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/ContentTypeIdIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/ContentTypeIdIn.php
@@ -42,11 +42,11 @@ class ContentTypeIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         if (count($criterion->value) > 1) {
             $filter = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/ContentTypeIdentifierIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/ContentTypeIdentifierIn.php
@@ -60,11 +60,11 @@ class ContentTypeIdentifierIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         if (count($criterion->value) > 1) {
             $idList = array();

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/DateMetadata/ModifiedIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/DateMetadata/ModifiedIn.php
@@ -43,11 +43,11 @@ class ModifiedIn extends DateMetadata
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         if (count($criterion->value) > 1) {
             $that = $this;

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/DateMetadata/ModifiedRange.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/DateMetadata/ModifiedRange.php
@@ -46,11 +46,11 @@ class ModifiedRange extends DateMetadata
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $start = $this->getNativeTime($criterion->value[0]);
         $end = isset($criterion->value[1]) ? $this->getNativeTime($criterion->value[1]) : null;

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/DateMetadata/PublishedIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/DateMetadata/PublishedIn.php
@@ -43,11 +43,11 @@ class PublishedIn extends DateMetadata
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         if (count($criterion->value) > 1) {
             $that = $this;

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/DateMetadata/PublishedRange.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/DateMetadata/PublishedRange.php
@@ -46,11 +46,11 @@ class PublishedRange extends DateMetadata
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $start = $this->getNativeTime($criterion->value[0]);
         $end = isset($criterion->value[1]) ? $this->getNativeTime($criterion->value[1]) : null;

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/LanguageCodeIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/LanguageCodeIn.php
@@ -66,11 +66,11 @@ class LanguageCodeIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $filter = $this->getCondition($criterion);
 
@@ -96,11 +96,11 @@ class LanguageCodeIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $filter = $this->getCondition($criterion);
 

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/Location/DepthIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/Location/DepthIn.php
@@ -44,11 +44,11 @@ class DepthIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'terms' => array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/Location/DepthRange.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/Location/DepthRange.php
@@ -47,11 +47,11 @@ class DepthRange extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $start = $criterion->value[0];
         $end = isset($criterion->value[1]) ? $criterion->value[1] : null;

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/Location/IsMainLocation.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/Location/IsMainLocation.php
@@ -38,11 +38,11 @@ class IsMainLocation extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'term' => array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/Location/PriorityIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/Location/PriorityIn.php
@@ -44,11 +44,11 @@ class PriorityIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'terms' => array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/Location/PriorityRange.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/Location/PriorityRange.php
@@ -47,11 +47,11 @@ class PriorityRange extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         $start = $criterion->value[0];
         $end = isset($criterion->value[1]) ? $criterion->value[1] : null;

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/LocationIdIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/LocationIdIn.php
@@ -42,11 +42,11 @@ class LocationIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         if (count($criterion->value) > 1) {
             $filter = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/LocationRemoteIdIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/LocationRemoteIdIn.php
@@ -42,11 +42,11 @@ class LocationRemoteIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         if (count($criterion->value) > 1) {
             $filter = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/ObjectStateIdIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/ObjectStateIdIn.php
@@ -40,11 +40,11 @@ class ObjectStateIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         if (count($criterion->value) > 1) {
             $filter = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/ParentLocationIdIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/ParentLocationIdIn.php
@@ -42,11 +42,11 @@ class ParentLocationIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         if (count($criterion->value) > 1) {
             $filter = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/RemoteIdIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/RemoteIdIn.php
@@ -42,11 +42,11 @@ class RemoteIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         if (count($criterion->value) > 1) {
             $filter = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/SectionIdIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/SectionIdIn.php
@@ -42,11 +42,11 @@ class SectionIdIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         if (count($criterion->value) > 1) {
             $filter = array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/SubtreeIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/SubtreeIn.php
@@ -65,11 +65,11 @@ class SubtreeIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'or' => $this->getCondition($criterion),
@@ -81,11 +81,11 @@ class SubtreeIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitQuery(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'bool' => array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/UserMetadataIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/UserMetadataIn.php
@@ -45,11 +45,11 @@ class UserMetadataIn extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         switch ($criterion->target) {
             case Criterion\UserMetadata::MODIFIER:

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/Visibility.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/Visibility.php
@@ -37,11 +37,11 @@ class Visibility extends CriterionVisitor
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param \eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher $dispatcher
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return mixed
      */
-    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $fieldFilters)
+    public function visitFilter(Criterion $criterion, Dispatcher $dispatcher, array $languageFilter)
     {
         return array(
             'term' => array(

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/Handler.php
@@ -77,7 +77,7 @@ class Handler implements SearchHandlerInterface
      * Finds Locations for the given $query.
      *
      * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter Configuration for specifying prioritized languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/Handler.php
@@ -77,12 +77,12 @@ class Handler implements SearchHandlerInterface
      * Finds Locations for the given $query.
      *
      * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
-     * @param array $fieldFilters - a map of filters for the returned fields.
+     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
      */
-    public function findLocations(LocationQuery $query, array $fieldFilters = array())
+    public function findLocations(LocationQuery $query, array $languageFilter = array())
     {
         $query->filter = $query->filter ?: new Criterion\MatchAll();
         $query->query = $query->query ?: new Criterion\MatchAll();

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriteriaConverter.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriteriaConverter.php
@@ -53,18 +53,18 @@ class CriteriaConverter
      *
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
     public function convertCriteria(
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters = array()
+        array $languageFilter = array()
     ) {
         foreach ($this->handlers as $handler) {
             if ($handler->accept($criterion)) {
-                return $handler->handle($this, $query, $criterion, $fieldFilters);
+                return $handler->handle($this, $query, $criterion, $languageFilter);
             }
         }
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler.php
@@ -66,13 +66,13 @@ abstract class CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      */
     abstract public function handle(
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     );
 
     /**

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentId.php
@@ -40,7 +40,7 @@ class ContentId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -48,7 +48,7 @@ class ContentId extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         return $query->expr->in(
             $this->dbHandler->quoteColumn('id', 'ezcontentobject'),

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeGroupId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeGroupId.php
@@ -40,7 +40,7 @@ class ContentTypeGroupId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -48,7 +48,7 @@ class ContentTypeGroupId extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $subSelect = $query->subSelect();
         $subSelect

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeId.php
@@ -40,7 +40,7 @@ class ContentTypeId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -48,7 +48,7 @@ class ContentTypeId extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         return $query->expr->in(
             $this->dbHandler->quoteColumn('contentclass_id', 'ezcontentobject'),

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeIdentifier.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeIdentifier.php
@@ -64,7 +64,7 @@ class ContentTypeIdentifier extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -72,7 +72,7 @@ class ContentTypeIdentifier extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $idList = array();
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/DateMetadata.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/DateMetadata.php
@@ -41,7 +41,7 @@ class DateMetadata extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -49,7 +49,7 @@ class DateMetadata extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $column = $this->dbHandler->quoteColumn(
             $criterion->target === Criterion\DateMetadata::MODIFIED ? 'modified' : 'published',

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/Field.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/Field.php
@@ -139,7 +139,7 @@ class Field extends FieldBase
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -147,7 +147,7 @@ class Field extends FieldBase
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $fieldsInformation = $this->getFieldsInformation($criterion->target);
 
@@ -193,7 +193,7 @@ class Field extends FieldBase
             )
         );
 
-        $this->addFieldFiltersConditions($subSelect, $fieldFilters);
+        $this->addFieldFiltersConditions($subSelect, $languageFilter);
 
         return $query->expr->in(
             $this->dbHandler->quoteColumn('id', 'ezcontentobject'),

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldBase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldBase.php
@@ -47,24 +47,24 @@ abstract class FieldBase extends CriterionHandler
     }
 
     /**
-     * Returns the bitmask for the list languages in given $fieldFilters.
+     * Returns the bitmask for the list languages in given $languageFilter.
      *
-     * The method will return null if no languages are contained in $fieldFilters.
+     * The method will return null if no languages are contained in $languageFilter.
      * Note: 'useAlwaysAvailable' filter is ignored here.
      *
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return null|int
      */
-    protected function getFieldFiltersLanguageMask(array $fieldFilters)
+    protected function getFieldFiltersLanguageMask(array $languageFilter)
     {
-        if (empty($fieldFilters['languages'])) {
+        if (empty($languageFilter['languages'])) {
             return null;
         }
 
         $mask = 0;
 
-        foreach ($fieldFilters['languages'] as $languageCode) {
+        foreach ($languageFilter['languages'] as $languageCode) {
             $mask |= $this->languageHandler->loadByLanguageCode($languageCode)->id;
         }
 
@@ -77,19 +77,19 @@ abstract class FieldBase extends CriterionHandler
      * Conditions are combined with existing ones using logical AND operator.
      *
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param array $fieldFilters
+     * @param array $languageFilter
      */
-    protected function addFieldFiltersConditions(SelectQuery $query, array $fieldFilters)
+    protected function addFieldFiltersConditions(SelectQuery $query, array $languageFilter)
     {
-        $languageMask = $this->getFieldFiltersLanguageMask($fieldFilters);
+        $languageMask = $this->getFieldFiltersLanguageMask($languageFilter);
 
-        // Only apply if languages are defined in $fieldFilters;
+        // Only apply if languages are defined in $languageFilter;
         // 'useAlwaysAvailable' does not make sense on its own
         if ($languageMask === null) {
             return;
         }
 
-        // Condition for the language part of $fieldFilters
+        // Condition for the language part of $languageFilter
         $languageMaskExpression = $query->expr->gt(
             $query->expr->bitAnd(
                 $this->dbHandler->quoteColumn('language_id', 'ezcontentobject_attribute'),
@@ -101,8 +101,8 @@ abstract class FieldBase extends CriterionHandler
         // If 'useAlwaysAvailable' is set to true, additionally factor in condition for the
         // Content's main language that is marked as always available
         if (
-            !isset($fieldFilters['useAlwaysAvailable'])
-            || $fieldFilters['useAlwaysAvailable'] === true
+            !isset($languageFilter['useAlwaysAvailable'])
+            || $languageFilter['useAlwaysAvailable'] === true
         ) {
             $query->where(
                 $query->expr->lOr(

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldRelation.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldRelation.php
@@ -74,7 +74,7 @@ class FieldRelation extends FieldBase
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      *
@@ -84,7 +84,7 @@ class FieldRelation extends FieldBase
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $column = $this->dbHandler->quoteColumn('to_contentobject_id', 'ezcontentobject_link');
         $fieldDefinitionIds = $this->getFieldDefinitionsIds($criterion->target);

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FullText.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FullText.php
@@ -227,7 +227,7 @@ class FullText extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -235,7 +235,7 @@ class FullText extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $subSelect = $query->subSelect();
         $subSelect

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LanguageCode.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LanguageCode.php
@@ -59,7 +59,7 @@ class LanguageCode extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -67,7 +67,7 @@ class LanguageCode extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $languages = array_flip($criterion->value);
         /* @var $criterion \eZ\Publish\API\Repository\Values\Content\Query\Criterion\LanguageCode */

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalAnd.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalAnd.php
@@ -40,7 +40,7 @@ class LogicalAnd extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -48,11 +48,11 @@ class LogicalAnd extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $subexpressions = array();
         foreach ($criterion->criteria as $subCriterion) {
-            $subexpressions[] = $converter->convertCriteria($query, $subCriterion, $fieldFilters);
+            $subexpressions[] = $converter->convertCriteria($query, $subCriterion, $languageFilter);
         }
 
         return $query->expr->lAnd($subexpressions);

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalNot.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalNot.php
@@ -40,7 +40,7 @@ class LogicalNot extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -48,10 +48,10 @@ class LogicalNot extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         return $query->expr->not(
-            $converter->convertCriteria($query, $criterion->criteria[0], $fieldFilters)
+            $converter->convertCriteria($query, $criterion->criteria[0], $languageFilter)
         );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalOr.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalOr.php
@@ -40,7 +40,7 @@ class LogicalOr extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -48,11 +48,11 @@ class LogicalOr extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $subexpressions = array();
         foreach ($criterion->criteria as $subCriterion) {
-            $subexpressions[] = $converter->convertCriteria($query, $subCriterion, $fieldFilters);
+            $subexpressions[] = $converter->convertCriteria($query, $subCriterion, $languageFilter);
         }
 
         return $query->expr->lOr($subexpressions);

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MapLocationDistance.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MapLocationDistance.php
@@ -100,7 +100,7 @@ class MapLocationDistance extends FieldBase
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -108,7 +108,7 @@ class MapLocationDistance extends FieldBase
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $fieldDefinitionIds = $this->getFieldDefinitionIds($criterion->target);
         $subSelect = $query->subSelect();
@@ -235,7 +235,7 @@ class MapLocationDistance extends FieldBase
                 )
             );
 
-        $this->addFieldFiltersConditions($subSelect, $fieldFilters);
+        $this->addFieldFiltersConditions($subSelect, $languageFilter);
 
         return $query->expr->in(
             $this->dbHandler->quoteColumn('id', 'ezcontentobject'),

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MatchAll.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MatchAll.php
@@ -40,7 +40,7 @@ class MatchAll extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -48,7 +48,7 @@ class MatchAll extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         return $query->bindValue('1');
     }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MatchNone.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MatchNone.php
@@ -38,7 +38,7 @@ class MatchNone extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -46,7 +46,7 @@ class MatchNone extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         return $query->expr->not($query->bindValue('1'));
     }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ObjectStateId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ObjectStateId.php
@@ -45,7 +45,7 @@ class ObjectStateId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -53,7 +53,7 @@ class ObjectStateId extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $subSelect = $query->subSelect();
         $subSelect

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/RemoteId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/RemoteId.php
@@ -40,7 +40,7 @@ class RemoteId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -48,7 +48,7 @@ class RemoteId extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         return $query->expr->in(
             $this->dbHandler->quoteColumn('remote_id', 'ezcontentobject'),

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/SectionId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/SectionId.php
@@ -40,7 +40,7 @@ class SectionId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -48,7 +48,7 @@ class SectionId extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         return $query->expr->in(
             $this->dbHandler->quoteColumn('section_id', 'ezcontentobject'),

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/UserMetadata.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/UserMetadata.php
@@ -41,7 +41,7 @@ class UserMetadata extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -49,7 +49,7 @@ class UserMetadata extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         switch ($criterion->target) {
             case Criterion\UserMetadata::MODIFIER:

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway.php
@@ -27,7 +27,7 @@ abstract class Gateway
      * @param int $offset
      * @param int $limit
      * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sort
-     * @param array $fieldFilters
+     * @param array $languageFilter
      * @param bool $doCount
      *
      * @return mixed[][]
@@ -37,7 +37,7 @@ abstract class Gateway
         $offset,
         $limit,
         array $sort = null,
-        array $fieldFilters = array(),
+        array $languageFilter = array(),
         $doCount = true
     );
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Depth.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Depth.php
@@ -41,7 +41,7 @@ class Depth extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -49,7 +49,7 @@ class Depth extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $table = $this->getUniqueTableName();
         $column = $this->dbHandler->quoteColumn('depth', $table);

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/LocationId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/LocationId.php
@@ -40,7 +40,7 @@ class LocationId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -48,7 +48,7 @@ class LocationId extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $subSelect = $query->subSelect();
         $subSelect

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/LocationPriority.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/LocationPriority.php
@@ -40,7 +40,7 @@ class LocationPriority extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -48,7 +48,7 @@ class LocationPriority extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $subSelect = $query->subSelect();
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/LocationRemoteId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/LocationRemoteId.php
@@ -40,7 +40,7 @@ class LocationRemoteId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -48,7 +48,7 @@ class LocationRemoteId extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $subSelect = $query->subSelect();
         $subSelect

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/ParentLocationId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/ParentLocationId.php
@@ -40,7 +40,7 @@ class ParentLocationId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -48,7 +48,7 @@ class ParentLocationId extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $subSelect = $query->subSelect();
         $subSelect

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/PermissionSubtree.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/PermissionSubtree.php
@@ -41,7 +41,7 @@ class PermissionSubtree extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -49,7 +49,7 @@ class PermissionSubtree extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $table = 'permission_subtree';
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Subtree.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Subtree.php
@@ -40,7 +40,7 @@ class Subtree extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -48,7 +48,7 @@ class Subtree extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $table = $this->getUniqueTableName();
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Visibility.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Visibility.php
@@ -45,7 +45,7 @@ class Visibility extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -53,7 +53,7 @@ class Visibility extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $subSelect = $query->subSelect();
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -71,7 +71,7 @@ class DoctrineDatabase extends Gateway
      * @param int $offset
      * @param int $limit
      * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sort
-     * @param array $fieldFilters
+     * @param array $languageFilter
      * @param bool $doCount
      *
      * @return mixed[][]
@@ -81,10 +81,10 @@ class DoctrineDatabase extends Gateway
         $offset,
         $limit,
         array $sort = null,
-        array $fieldFilters = array(),
+        array $languageFilter = array(),
         $doCount = true
     ) {
-        $count = $doCount ? $this->getResultCount($criterion, $fieldFilters) : null;
+        $count = $doCount ? $this->getResultCount($criterion, $languageFilter) : null;
 
         if (!$doCount && $limit === 0) {
             throw new \RuntimeException('Invalid query, can not disable count and request 0 items at the same time');
@@ -94,7 +94,7 @@ class DoctrineDatabase extends Gateway
             return array('count' => $count, 'rows' => array());
         }
 
-        $contentInfoList = $this->getContentInfoList($criterion, $sort, $offset, $limit, $fieldFilters);
+        $contentInfoList = $this->getContentInfoList($criterion, $sort, $offset, $limit, $languageFilter);
 
         return array(
             'count' => $count,
@@ -107,14 +107,14 @@ class DoctrineDatabase extends Gateway
      *
      * @param Criterion $filter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return string
      */
-    protected function getQueryCondition(Criterion $filter, SelectQuery $query, $fieldFilters)
+    protected function getQueryCondition(Criterion $filter, SelectQuery $query, $languageFilter)
     {
         $condition = $query->expr->lAnd(
-            $this->criteriaConverter->convertCriteria($query, $filter, $fieldFilters),
+            $this->criteriaConverter->convertCriteria($query, $filter, $languageFilter),
             $query->expr->eq(
                 'ezcontentobject.status',
                 ContentInfo::STATUS_PUBLISHED
@@ -133,11 +133,11 @@ class DoctrineDatabase extends Gateway
      *
      * @param Criterion $filter
      * @param array $sort
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return int
      */
-    protected function getResultCount(Criterion $filter, $fieldFilters)
+    protected function getResultCount(Criterion $filter, $languageFilter)
     {
         $query = $this->handler->createSelectQuery();
 
@@ -152,7 +152,7 @@ class DoctrineDatabase extends Gateway
             );
 
         $query->where(
-            $this->getQueryCondition($filter, $query, $fieldFilters)
+            $this->getQueryCondition($filter, $query, $languageFilter)
         );
 
         $statement = $query->prepare();
@@ -168,11 +168,11 @@ class DoctrineDatabase extends Gateway
      * @param array $sort
      * @param mixed $offset
      * @param mixed $limit
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return int[]
      */
-    protected function getContentInfoList(Criterion $filter, $sort, $offset, $limit, $fieldFilters)
+    protected function getContentInfoList(Criterion $filter, $sort, $offset, $limit, $languageFilter)
     {
         $query = $this->handler->createSelectQuery();
         $query->selectDistinct(
@@ -212,7 +212,7 @@ class DoctrineDatabase extends Gateway
         }
 
         $query->where(
-            $this->getQueryCondition($filter, $query, $fieldFilters)
+            $this->getQueryCondition($filter, $query, $languageFilter)
         );
 
         if ($sort !== null) {

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/ExceptionConversion.php
@@ -46,7 +46,7 @@ class ExceptionConversion extends Gateway
      * @param int $offset
      * @param int|null $limit
      * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sort
-     * @param array $fieldFilters
+     * @param array $languageFilter
      * @param bool $doCount
      *
      * @throws \RuntimeException
@@ -58,11 +58,11 @@ class ExceptionConversion extends Gateway
         $offset = 0,
         $limit = null,
         array $sort = null,
-        array $fieldFilters = array(),
+        array $languageFilter = array(),
         $doCount = true
     ) {
         try {
-            return $this->innerGateway->find($criterion, $offset, $limit, $sort, $fieldFilters, $doCount);
+            return $this->innerGateway->find($criterion, $offset, $limit, $sort, $languageFilter, $doCount);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {

--- a/eZ/Publish/Core/Search/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Handler.php
@@ -76,7 +76,7 @@ class Handler implements SearchHandlerInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if Query criterion is not applicable to its target
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query $query
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter Configuration for specifying prioritized languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
@@ -126,7 +126,7 @@ class Handler implements SearchHandlerInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if there is more than than one result matching the criterions
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $filter
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter Configuration for specifying prioritized languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      *
      * @return \eZ\Publish\SPI\Persistence\Content\ContentInfo

--- a/eZ/Publish/Core/Search/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Handler.php
@@ -73,17 +73,15 @@ class Handler implements SearchHandlerInterface
     /**
      * Finds content objects for the given query.
      *
-     * @todo define structs for the field filters
-     *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if Query criterion is not applicable to its target
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query $query
-     * @param array $fieldFilters - a map of filters for the returned fields.
+     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
      */
-    public function findContent(Query $query, array $fieldFilters = array())
+    public function findContent(Query $query, array $languageFilter = array())
     {
         $start = microtime(true);
         $query->filter = $query->filter ?: new Criterion\MatchAll();
@@ -102,7 +100,7 @@ class Handler implements SearchHandlerInterface
             $query->offset,
             $query->limit,
             $query->sortClauses,
-            $fieldFilters,
+            $languageFilter,
             $query->performCount
         );
 
@@ -127,15 +125,13 @@ class Handler implements SearchHandlerInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if Criterion is not applicable to its target
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if there is more than than one result matching the criterions
      *
-     * @todo define structs for the field filters
-     *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $filter
-     * @param array $fieldFilters - a map of filters for the returned fields.
+     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      *
      * @return \eZ\Publish\SPI\Persistence\Content\ContentInfo
      */
-    public function findSingle(Criterion $filter, array $fieldFilters = array())
+    public function findSingle(Criterion $filter, array $languageFilter = array())
     {
         $searchQuery = new Query();
         $searchQuery->filter = $filter;
@@ -144,7 +140,7 @@ class Handler implements SearchHandlerInterface
         $searchQuery->limit = 2;// Because we optimize away the count query below
         $searchQuery->performCount = true;
         $searchQuery->sortClauses = null;
-        $result = $this->findContent($searchQuery, $fieldFilters);
+        $result = $this->findContent($searchQuery, $languageFilter);
 
         if (empty($result->searchHits)) {
             throw new NotFoundException('Content', 'findSingle() found no content for given $criterion');

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/Depth.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/Depth.php
@@ -41,7 +41,7 @@ class Depth extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -49,7 +49,7 @@ class Depth extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $column = $this->dbHandler->quoteColumn('depth', 'ezcontentobject_tree');
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/IsMainLocation.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/IsMainLocation.php
@@ -41,7 +41,7 @@ class IsMainLocation extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -49,7 +49,7 @@ class IsMainLocation extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $idColumn = $this->dbHandler->quoteColumn('node_id', 'ezcontentobject_tree');
         $mainIdColumn = $this->dbHandler->quoteColumn('main_node_id', 'ezcontentobject_tree');

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/Priority.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/Priority.php
@@ -41,7 +41,7 @@ class Priority extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -49,7 +49,7 @@ class Priority extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $column = $this->dbHandler->quoteColumn('priority');
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/LocationId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/LocationId.php
@@ -40,7 +40,7 @@ class LocationId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -48,7 +48,7 @@ class LocationId extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         return $query->expr->in(
             $this->dbHandler->quoteColumn('node_id', 'ezcontentobject_tree'),

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/LocationRemoteId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/LocationRemoteId.php
@@ -40,7 +40,7 @@ class LocationRemoteId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -48,7 +48,7 @@ class LocationRemoteId extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         return $query->expr->in(
             $this->dbHandler->quoteColumn('remote_id', 'ezcontentobject_tree'),

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/ParentLocationId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/ParentLocationId.php
@@ -40,7 +40,7 @@ class ParentLocationId extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -48,7 +48,7 @@ class ParentLocationId extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         return $query->expr->in(
             $this->dbHandler->quoteColumn('parent_node_id', 'ezcontentobject_tree'),

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Subtree.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Subtree.php
@@ -41,7 +41,7 @@ class Subtree extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -49,7 +49,7 @@ class Subtree extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $statements = array();
         foreach ($criterion->value as $pattern) {

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Visibility.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Visibility.php
@@ -42,7 +42,7 @@ class Visibility extends CriterionHandler
      * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
      * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion$criterion
-     * @param array $fieldFilters
+     * @param array $languageFilter
      *
      * @return \eZ\Publish\Core\Persistence\Database\Expression
      */
@@ -50,7 +50,7 @@ class Visibility extends CriterionHandler
         CriteriaConverter $converter,
         SelectQuery $query,
         Criterion $criterion,
-        array $fieldFilters
+        array $languageFilter
     ) {
         $column = $this->dbHandler->quoteColumn('is_invisible', 'ezcontentobject_tree');
 

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Handler.php
@@ -54,7 +54,7 @@ class Handler implements LocationSearchHandler
     /**
      * @see \eZ\Publish\SPI\Search\Content\Location\Handler::findLocations
      */
-    public function findLocations(LocationQuery $query, array $fieldFilters = array())
+    public function findLocations(LocationQuery $query, array $languageFilter = array())
     {
         $start = microtime(true);
         $query->filter = $query->filter ?: new Criterion\MatchAll();

--- a/eZ/Publish/Core/SignalSlot/SearchService.php
+++ b/eZ/Publish/Core/SignalSlot/SearchService.php
@@ -67,6 +67,27 @@ class SearchService implements SearchServiceInterface
     }
 
     /**
+     * Finds contentInfo objects for the given query.
+     *
+     * @see SearchServiceInterface::findContentInfo()
+     *
+     * @since 5.4.5
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if query is not valid
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     * @param array $languageFilter - a map of filters for the returned fields.
+     *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
+     *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations.
+     * @param bool $filterOnUserPermissions if true (default) only the objects which is the user allowed to read are returned.
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
+     */
+    public function findContentInfo(Query $query, array $languageFilter = array(), $filterOnUserPermissions = true)
+    {
+        return $this->service->findContentInfo($query, $languageFilter, $filterOnUserPermissions);
+    }
+
+    /**
      * Performs a query for a single content object.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the object was not found by the query or due to permissions

--- a/eZ/Publish/Core/SignalSlot/SearchService.php
+++ b/eZ/Publish/Core/SignalSlot/SearchService.php
@@ -55,7 +55,7 @@ class SearchService implements SearchServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if query is not valid
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query $query
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter Configuration for specifying prioritized languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.
      *
@@ -74,7 +74,7 @@ class SearchService implements SearchServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if there is more than than one result matching the criterions
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $filter
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter Configuration for specifying prioritized languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.
      *
@@ -104,7 +104,7 @@ class SearchService implements SearchServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if query is not valid
      *
      * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter Configuration for specifying prioritized languages query will be performed on.
      *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
      *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.

--- a/eZ/Publish/Core/SignalSlot/SearchService.php
+++ b/eZ/Publish/Core/SignalSlot/SearchService.php
@@ -52,20 +52,18 @@ class SearchService implements SearchServiceInterface
     /**
      * Finds content objects for the given query.
      *
-     * @todo define structs for the field filters
-     *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if query is not valid
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query $query
-     * @param array $fieldFilters - a map of filters for the returned fields.
+     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
      */
-    public function findContent(Query $query, array $fieldFilters = array(), $filterOnUserPermissions = true)
+    public function findContent(Query $query, array $languageFilter = array(), $filterOnUserPermissions = true)
     {
-        return $this->service->findContent($query, $fieldFilters, $filterOnUserPermissions);
+        return $this->service->findContent($query, $languageFilter, $filterOnUserPermissions);
     }
 
     /**
@@ -75,18 +73,16 @@ class SearchService implements SearchServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if criterion is not valid
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if there is more than than one result matching the criterions
      *
-     * @todo define structs for the field filters
-     *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $filter
-     * @param array $fieldFilters - a map of filters for the returned fields.
+     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content
      */
-    public function findSingle(Criterion $filter, array $fieldFilters = array(), $filterOnUserPermissions = true)
+    public function findSingle(Criterion $filter, array $languageFilter = array(), $filterOnUserPermissions = true)
     {
-        return $this->service->findSingle($filter, $fieldFilters, $filterOnUserPermissions);
+        return $this->service->findSingle($filter, $languageFilter, $filterOnUserPermissions);
     }
 
     /**
@@ -108,15 +104,15 @@ class SearchService implements SearchServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if query is not valid
      *
      * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
-     * @param array $fieldFilters - a map of filters for the returned fields.
+     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
      *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
      *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations
      * @param bool $filterOnUserPermissions if true only the objects which is the user allowed to read are returned.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
      */
-    public function findLocations(LocationQuery $query, array $fieldFilters = array(), $filterOnUserPermissions = true)
+    public function findLocations(LocationQuery $query, array $languageFilter = array(), $filterOnUserPermissions = true)
     {
-        return $this->service->findLocations($query, $fieldFilters, $filterOnUserPermissions);
+        return $this->service->findLocations($query, $languageFilter, $filterOnUserPermissions);
     }
 }

--- a/eZ/Publish/Core/SignalSlot/Tests/SearchServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/SearchServiceTest.php
@@ -11,6 +11,7 @@
 namespace eZ\Publish\Core\SignalSlot\Tests;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Visibility;
 use eZ\Publish\Core\SignalSlot\SignalDispatcher;
@@ -53,6 +54,16 @@ class SearchServiceTest extends ServiceTest
                 0,
             ),
             array(
+                'findContentInfo',
+                array(
+                    new Query(),
+                    $languageFilter,
+                    false,
+                ),
+                new SearchResult(array('totalCount' => 0)),
+                0,
+            ),
+            array(
                 'findSingle',
                 array(
                     $criterion,
@@ -60,6 +71,16 @@ class SearchServiceTest extends ServiceTest
                     false,
                 ),
                 $content,
+                0,
+            ),
+            array(
+                'findLocations',
+                array(
+                    new LocationQuery(),
+                    $languageFilter,
+                    false,
+                ),
+                new SearchResult(array('totalCount' => 0)),
                 0,
             ),
             array(

--- a/eZ/Publish/Core/SignalSlot/Tests/SearchServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/SearchServiceTest.php
@@ -32,7 +32,7 @@ class SearchServiceTest extends ServiceTest
 
     public function serviceProvider()
     {
-        $fieldFilters = array('languages' => array('fre-FR'));
+        $languageFilter = array('languages' => array('fre-FR'));
         $content = $this->getContent(
             $this->getVersionInfo(
                 $this->getContentInfo(42, md5(__METHOD__)),
@@ -46,7 +46,7 @@ class SearchServiceTest extends ServiceTest
                 'findContent',
                 array(
                     new Query(),
-                    $fieldFilters,
+                    $languageFilter,
                     false,
                 ),
                 new SearchResult(array('totalCount' => 0)),
@@ -56,7 +56,7 @@ class SearchServiceTest extends ServiceTest
                 'findSingle',
                 array(
                     $criterion,
-                    $fieldFilters,
+                    $languageFilter,
                     false,
                 ),
                 $content,

--- a/eZ/Publish/Core/SignalSlot/Tests/ServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ServiceTest.php
@@ -31,10 +31,10 @@ abstract class ServiceTest extends PHPUnit_Framework_TestCase
      * @param mixed $innerService mock of the inner service used by the signal
      * slot one used to test whether the original method is called is correctly
      * called.
-     * @param eZ\Publish\Core\SignalSlot\SignalDispatcher $dispatcher mock of
+     * @param \eZ\Publish\Core\SignalSlot\SignalDispatcher $dispatcher mock of
      * the dispatcher used to test whether the emit method is correctly called
      *
-     * @return an instance of the SignalSlot service
+     * @return object An instance of the SignalSlot service
      */
     abstract protected function getSignalSlotService($innerService, SignalDispatcher $dispatcher);
 

--- a/eZ/Publish/SPI/Search/Content/Handler.php
+++ b/eZ/Publish/SPI/Search/Content/Handler.php
@@ -26,7 +26,7 @@ interface Handler
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if Query criterion is not applicable to its target
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query $query
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter Configuration for specifying prioritized languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult With ContentInfo as SearchHit->valueObject
@@ -41,7 +41,7 @@ interface Handler
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if there is more than than one result matching the criterions
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $filter
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter Configuration for specifying prioritized languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      *
      * @return \eZ\Publish\SPI\Persistence\Content\ContentInfo

--- a/eZ/Publish/SPI/Search/Content/Handler.php
+++ b/eZ/Publish/SPI/Search/Content/Handler.php
@@ -23,17 +23,15 @@ interface Handler
     /**
      * Finds content objects for the given query.
      *
-     * @todo define structs for the field filters
-     *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if Query criterion is not applicable to its target
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query $query
-     * @param array $fieldFilters - a map of filters for the returned fields.
+     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult With ContentInfo as SearchHit->valueObject
      */
-    public function findContent(Query $query, array $fieldFilters = array());
+    public function findContent(Query $query, array $languageFilter = array());
 
     /**
      * Performs a query for a single content object.
@@ -42,15 +40,13 @@ interface Handler
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if Criterion is not applicable to its target
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if there is more than than one result matching the criterions
      *
-     * @todo define structs for the field filters
-     *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $filter
-     * @param array $fieldFilters - a map of filters for the returned fields.
+     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      *
      * @return \eZ\Publish\SPI\Persistence\Content\ContentInfo
      */
-    public function findSingle(Criterion $filter, array $fieldFilters = array());
+    public function findSingle(Criterion $filter, array $languageFilter = array());
 
     /**
      * Suggests a list of values for the given prefix.

--- a/eZ/Publish/SPI/Search/Content/Location/Handler.php
+++ b/eZ/Publish/SPI/Search/Content/Location/Handler.php
@@ -22,12 +22,12 @@ interface Handler
      * Finds locations for the given $query.
      *
      * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
-     * @param array $fieldFilters - a map of filters for the returned fields.
+     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult With Location as SearchHit->valueObject
      */
-    public function findLocations(LocationQuery $query, array $fieldFilters = array());
+    public function findLocations(LocationQuery $query, array $languageFilter = array());
 
     /**
      * Indexes a Location in the index storage.

--- a/eZ/Publish/SPI/Search/Content/Location/Handler.php
+++ b/eZ/Publish/SPI/Search/Content/Location/Handler.php
@@ -22,7 +22,7 @@ interface Handler
      * Finds locations for the given $query.
      *
      * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
-     * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
+     * @param array $languageFilter Configuration for specifying prioritized languages query will be performed on.
      *        Currently supported: <code>array("languages" => array(<language1>,..))</code>.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult With Location as SearchHit->valueObject


### PR DESCRIPTION
With introduction of Solr support in next release, this adds possibility to search for ContentInfo and hence only hitting the Solr backend to produce the search result., just like findLocations.

- [x] for 5.3+ change fieldFilter to languageFilter to make more clear
- [x] for 5.4+ document languages being a priority flag
- [x] for 5.4+ add ability to search for content info
- [x] rebase for PSR-2 change

https://jira.ez.no/browse/EZP-24593