### PR TITLE
EZP-24083 do not save empty url

### DIFF
--- a/eZ/Publish/Core/FieldType/Tests/Url/UrlStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Url/UrlStorageTest.php
@@ -88,6 +88,38 @@ class UrlStorageTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(12, $field->value->data['urlId']);
     }
 
+    public function testStoreFieldDataWithEmptyUrl()
+    {
+        $versionInfo = new VersionInfo(array('versionNo' => 24));
+        $fieldValue = new FieldValue(array('externalData' => ''));
+        $field = new Field(array('id' => 42, 'value' => $fieldValue));
+        $gateway = $this->getGatewayMock();
+
+        $gateway
+            ->expects($this->never())
+            ->method('getUrlIdMap');
+
+        $gateway
+            ->expects($this->never())
+            ->method('insertUrl');
+
+        $gateway
+            ->expects($this->never())
+            ->method('linkUrl');
+
+        $storage = $this->getPartlyMockedStorage(array('getGateway'));
+        $storage
+            ->expects($this->once())
+            ->method('getGateway')
+            ->with($this->getContext())
+            ->will($this->returnValue($gateway));
+
+        $result = $storage->storeFieldData($versionInfo, $field, $this->getContext());
+
+        $this->assertFalse($result);
+        $this->assertEquals(null, $field->value->data['urlId']);
+    }
+
     public function testGetFieldData()
     {
         $versionInfo = new VersionInfo();

--- a/eZ/Publish/Core/FieldType/Url/UrlStorage.php
+++ b/eZ/Publish/Core/FieldType/Url/UrlStorage.php
@@ -47,6 +47,10 @@ class UrlStorage extends GatewayBasedStorage
         $gateway = $this->getGateway($context);
         $url = $field->value->externalData;
 
+        if (empty($url)) {
+            return false;
+        }
+
         $map = $gateway->getUrlIdMap(array($url));
 
         if (isset($map[$url])) {


### PR DESCRIPTION
This PR fixes https://jira.ez.no/browse/EZP-24083.

The issue is present when creating and/or updating content with empty ezurl field type.
In that case we end up with multiple entries in the database with url set to null and the same md5 hash.

I have added a simple check to prevent this from happening, which is consistent with behavior in the legacy stack.