### PR TITLE
EZP-24573: Implement Indexable interface for RelationList

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/RelationListIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/RelationListIntegrationTest.php
@@ -22,7 +22,7 @@ use eZ\Publish\API\Repository\Values\Content\Content;
  * @group integration
  * @group field-type
  */
-class RelationListFieldTypeIntegrationTest extends RelationBaseIntegrationTest
+class RelationListFieldTypeIntegrationTest extends RelationSearchMultivaluedBaseIntegrationTest
 {
     /**
      * Get name of tested field type
@@ -397,5 +397,45 @@ class RelationListFieldTypeIntegrationTest extends RelationBaseIntegrationTest
                 $this->getValidCreationFieldData()
             ),
         );
+    }
+
+    protected function checkSearchEngineSupport()
+    {
+        if ( ltrim( get_class( $this->getSetupFactory() ), '\\' ) === 'eZ\\Publish\\API\\Repository\\Tests\\SetupFactory\\Legacy' )
+        {
+            $this->markTestSkipped(
+                "'ezobjectrelationlist' field type is not searchable with Legacy Search Engine"
+            );
+        }
+    }
+
+    protected function getValidSearchValueOne()
+    {
+        return array( 11 );
+    }
+
+    protected function getValidSearchValueTwo()
+    {
+        return array( 12 );
+    }
+
+    protected function getSearchTargetValueOne()
+    {
+        return 11;
+    }
+
+    protected function getSearchTargetValueTwo()
+    {
+        return 12;
+    }
+
+    protected function getValidMultivaluedSearchValuesOne()
+    {
+        return array( 11, 12 );
+    }
+
+    protected function getValidMultivaluedSearchValuesTwo()
+    {
+        return array( 13, 14 );
     }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/RelationSearchMultivaluedBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/RelationSearchMultivaluedBaseIntegrationTest.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\API\Repository\Tests\FieldType;
+
+use eZ\Publish\Core\Repository\Values\Content\Relation;
+use eZ\Publish\API\Repository\Values\Content\Content;
+
+/**
+ * Base integration test for field types handling content relations.
+ *
+ * @group integration
+ * @group field-type
+ * @group relation
+ */
+abstract class RelationSearchMultivaluedBaseIntegrationTest extends SearchMultivaluedBaseIntegrationTest
+{
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Relation[]
+     */
+    abstract public function getCreateExpectedRelations( Content $content );
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Relation[]
+     */
+    abstract public function getUpdateExpectedRelations( Content $content );
+
+    /**
+     * Tests relation processing on field create.
+     */
+    public function testCreateContentRelationsProcessedCorrect()
+    {
+        $content = $this->createContent( $this->getValidCreationFieldData() );
+
+        $this->assertEquals(
+            $this->normalizeRelations(
+                $this->getCreateExpectedRelations( $content )
+            ),
+            $this->normalizeRelations(
+                $this->getRepository()->getContentService()->loadRelations( $content->versionInfo )
+            )
+        );
+    }
+
+    /**
+     * Tests relation processing on field update.
+     */
+    public function testUpdateContentRelationsProcessedCorrect()
+    {
+        $content = $this->updateContent( $this->getValidUpdateFieldData() );
+
+        $this->assertEquals(
+            $this->normalizeRelations(
+                $this->getUpdateExpectedRelations( $content )
+            ),
+            $this->normalizeRelations(
+                $this->getRepository()->getContentService()->loadRelations( $content->versionInfo )
+            )
+        );
+    }
+
+    /**
+     * Normalizes given $relations for easier comparison.
+     *
+     * @param \eZ\Publish\Core\Repository\Values\Content\Relation[] $relations
+     *
+     * @return \eZ\Publish\Core\Repository\Values\Content\Relation[]
+     */
+    protected function normalizeRelations( array $relations )
+    {
+        usort(
+            $relations,
+            function ( Relation $a, Relation $b )
+            {
+                if ( $a->type == $b->type )
+                {
+                    return $a->destinationContentInfo->id < $b->destinationContentInfo->id ? 1 : -1;
+                }
+                return $a->type < $b->type ? 1 : -1;
+            }
+        );
+        $normalized = array_map(
+            function ( Relation $relation )
+            {
+                $newRelation = new Relation(
+                    array(
+                        "id" => null,
+                        "sourceFieldDefinitionIdentifier" => $relation->sourceFieldDefinitionIdentifier,
+                        "type" => $relation->type,
+                        "sourceContentInfo" => $relation->sourceContentInfo,
+                        "destinationContentInfo" => $relation->destinationContentInfo
+                    )
+                );
+                return $newRelation;
+            },
+            $relations
+        );
+
+        return $normalized;
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
@@ -168,6 +168,14 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
         return array();
     }
 
+    /**
+     * Used to control test execution by search engine
+     */
+    protected function checkSearchEngineSupport()
+    {
+        // Does nothing by default, override in a concrete test case as needed
+    }
+
     protected function checkCustomFieldsSupport()
     {
         if ( ltrim( get_class( $this->getSetupFactory() ), '\\' ) === 'eZ\\Publish\\API\\Repository\\Tests\\SetupFactory\\Legacy' )
@@ -238,6 +246,8 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
         {
             $this->markTestSkipped( "Field type '{$this->getTypeName()}' is not searchable." );
         }
+
+        $this->checkSearchEngineSupport();
 
         $contentType = $this->testCreateContentType();
 

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchMultivaluedBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchMultivaluedBaseIntegrationTest.php
@@ -139,6 +139,8 @@ abstract class SearchMultivaluedBaseIntegrationTest extends SearchBaseIntegratio
             $this->markTestSkipped( "Field type '{$this->getTypeName()}' is not searchable." );
         }
 
+        $this->checkSearchEngineSupport();
+
         $contentType = $this->testCreateContentType();
 
         return array(

--- a/eZ/Publish/Core/FieldType/RelationList/SearchField.php
+++ b/eZ/Publish/Core/FieldType/RelationList/SearchField.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\FieldType\RelationList;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
+use eZ\Publish\SPI\FieldType\Indexable;
+use eZ\Publish\SPI\Search;
+
+/**
+ * Indexable definition for RelationList field type
+ */
+class SearchField implements Indexable
+{
+    /**
+     * Get index data for field for search backend
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    public function getIndexData( Field $field, FieldDefinition $fieldDefinition )
+    {
+        return array(
+            new Search\Field(
+                'value',
+                $field->value->data["destinationContentIds"],
+                new Search\FieldType\MultipleStringField()
+            ),
+            new Search\Field(
+                'sort_value',
+                implode( "-", $field->value->data["destinationContentIds"] ),
+                new Search\FieldType\StringField()
+            ),
+        );
+    }
+
+    /**
+     * Get index field types for search backend
+     *
+     * @return \eZ\Publish\SPI\Search\FieldType[]
+     */
+    public function getIndexDefinition()
+    {
+        return array(
+            'value' => new Search\FieldType\MultipleStringField(),
+            'sort_value' => new Search\FieldType\StringField(),
+        );
+    }
+
+    /**
+     * Get name of the default field to be used for matching.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for matching. Default field is typically used by Field criterion.
+     *
+     * @return string
+     */
+    public function getDefaultMatchField()
+    {
+        return "value";
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return "sort_value";
+    }
+}

--- a/eZ/Publish/Core/settings/indexable_fieldtypes.yml
+++ b/eZ/Publish/Core/settings/indexable_fieldtypes.yml
@@ -17,6 +17,7 @@ parameters:
     ezpublish.fieldType.indexable.ezfloat.class: eZ\Publish\Core\FieldType\Float\SearchField
     ezpublish.fieldType.indexable.eztime.class: eZ\Publish\Core\FieldType\Time\SearchField
     ezpublish.fieldType.indexable.ezselection.class: eZ\Publish\Core\FieldType\Selection\SearchField
+    ezpublish.fieldType.indexable.ezobjectrelationlist.class: eZ\Publish\Core\FieldType\RelationList\SearchField
     ezpublish.fieldType.indexable.unindexed.class: eZ\Publish\Core\FieldType\Unindexed
 
 services:
@@ -122,6 +123,11 @@ services:
         tags:
             - {name: ezpublish.fieldType.indexable, alias: ezselection}
 
+    ezpublish.fieldType.indexable.ezobjectrelationlist:
+        class: %ezpublish.fieldType.indexable.ezobjectrelationlist.class%
+        tags:
+            - {name: ezpublish.fieldType.indexable, alias: ezobjectrelationlist}
+
     ezpublish.fieldType.indexable.unindexed:
         class: %ezpublish.fieldType.indexable.unindexed.class%
         tags:
@@ -134,7 +140,6 @@ services:
             - {name: ezpublish.fieldType.indexable, alias: ezauthor}
             - {name: ezpublish.fieldType.indexable, alias: ezsrrating}
             - {name: ezpublish.fieldType.indexable, alias: ezsubtreesubscription}
-            - {name: ezpublish.fieldType.indexable, alias: ezobjectrelationlist}
             - {name: ezpublish.fieldType.indexable, alias: ezoption}
             - {name: ezpublish.fieldType.indexable, alias: ezpage}
             - {name: ezpublish.fieldType.indexable, alias: ezcomcomments}


### PR DESCRIPTION
#### This PR resolves https://jira.ez.no/browse/EZP-24573

This implements `Indexable` definition for `RelationList` field type.

Only a list of related Content IDs is indexed.