### PR TITLE
[WIP][VersionState] Possible interface for VersionStates

### DIFF
--- a/eZ/Publish/API/Repository/Repository.php
+++ b/eZ/Publish/API/Repository/Repository.php
@@ -163,6 +163,13 @@ interface Repository
     public function getObjectStateService();
 
     /**
+     * Get VersionStateService
+     *
+     * @return \eZ\Publish\API\Repository\VersionStateService
+     */
+    public function getVersionStateService();
+
+    /**
      * Get RoleService
      *
      * @return \eZ\Publish\API\Repository\RoleService

--- a/eZ/Publish/API/Repository/Values/VersionState/VersionState.php
+++ b/eZ/Publish/API/Repository/Values/VersionState/VersionState.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * File containing the VersionState class
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\API\Repository\Values\VersionState;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * This class represents a version state value
+ *
+ * @property-read mixed $id the id of the content type group
+ * @property-read string $identifier the identifier of the content type group
+ * @property-read string $defaultLanguageCode the default language of the version state group names and description used for fallback.
+ * @property-read string[] $languageCodes the available languages
+ */
+abstract class VersionState extends ValueObject
+{
+    /**
+     * Primary key
+     *
+     * @var mixed
+     */
+    protected $id;
+
+    /**
+     * Readable string identifier of the version state
+     *
+     * @var string
+     */
+    protected $identifier;
+
+    /**
+     * The default language code
+     *
+     * @var string
+     */
+    protected $defaultLanguageCode;
+
+    /**
+     * The available language codes for names an descriptions
+     *
+     * @var string[]
+     */
+    protected $languageCodes;
+
+    /**
+     * This method returns the human readable name in all provided languages
+     * of the content type
+     *
+     * The structure of the return value is:
+     * <code>
+     * array( 'eng' => '<name_eng>', 'de' => '<name_de>' );
+     * </code>
+     *
+     * @return string[]
+     */
+    abstract public function getNames();
+
+    /**
+     * This method returns the name of the content type in the given language
+     *
+     * @param string $languageCode
+     *
+     * @return string the name for the given language or null if none exists.
+     */
+    abstract public function getName( $languageCode );
+
+    /**
+     * This method returns the human readable description of the content type
+     *
+     * The structure of this field is:
+     * <code>
+     * array( 'eng' => '<description_eng>', 'de' => '<description_de>' );
+     * </code>
+     *
+     * @return string[]
+     */
+    abstract public function getDescriptions();
+
+    /**
+     * This method returns the name of the content type in the given language
+     *
+     * @param string $languageCode
+     *
+     * @return string the description for the given language or null if none exists.
+     */
+    abstract public function getDescription( $languageCode );
+}

--- a/eZ/Publish/API/Repository/Values/VersionState/VersionStateCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/VersionState/VersionStateCreateStruct.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * File containing the VersionStateCreateStruct class
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\API\Repository\Values\VersionState;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * This class represents a value for creating version states
+ *
+ */
+class VersionStateCreateStruct extends ValueObject
+{
+    /**
+     * Readable unique string identifier of a group
+     *
+     * @required
+     *
+     * @var string
+     */
+    public $identifier;
+
+    /**
+     * The default language code
+     *
+     * @required
+     *
+     * @var string
+     */
+    public $defaultLanguageCode;
+
+     /**
+     * An array of names with languageCode keys
+     *
+     * @required - at least one name in the main language is required
+     *
+     * @var string[]
+     */
+    public $names;
+
+    /**
+     * An array of descriptions with languageCode keys
+     *
+     * @var string[]
+     */
+    public $descriptions;
+
+}

--- a/eZ/Publish/API/Repository/Values/VersionState/VersionStateUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/VersionState/VersionStateUpdateStruct.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * File containing the VersionStateUpdateStruct class
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\API\Repository\Values\VersionState;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * This class represents a value for updating version states
+ */
+class VersionStateUpdateStruct extends ValueObject
+{
+    /**
+     * Readable unique string identifier of a group
+     *
+     * @var string
+     */
+    public $identifier;
+
+    /**
+     * The default language code
+     *
+     * @var string
+     */
+    public $defaultLanguageCode;
+
+     /**
+     * An array of names with languageCode keys
+     *
+     * @var string[]
+     */
+    public $names;
+
+    /**
+     * An array of descriptions with languageCode keys
+     *
+     * @var string[]
+     */
+    public $descriptions;
+
+}

--- a/eZ/Publish/API/Repository/VersionStateService.php
+++ b/eZ/Publish/API/Repository/VersionStateService.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * File containing the eZ\Publish\API\Repository\VersionStateService interface.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ * @package eZ\Publish\API\Repository
+ */
+
+namespace eZ\Publish\API\Repository;
+
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use eZ\Publish\API\Repository\Values\VersionState\VersionStateUpdateStruct;
+use eZ\Publish\API\Repository\Values\VersionState\VersionStateCreateStruct;
+use eZ\Publish\API\Repository\Values\VersionState\VersionState;
+
+/**
+ * VersionStateService service
+ *
+ * @package eZ\Publish\API\Repository
+ */
+interface VersionStateService
+{
+    /**
+     * This method returns the ordered list of version states
+     *
+     * @return \eZ\Publish\API\Repository\Values\VersionState\VersionState[]
+     */
+    public function loadVersionStates();
+
+    /**
+     * Creates a new version state in the given group.
+     *
+     * Note: in current kernel: If it is the first state all content versions will
+     * set to this state.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to create an version state
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the version state with provided identifier already exists
+     *
+     * @param \eZ\Publish\API\Repository\Values\VersionState\VersionStateCreateStruct $VersionStateCreateStruct
+     *
+     * @return \eZ\Publish\API\Repository\Values\VersionState\VersionState
+     */
+    public function createVersionState( VersionStateCreateStruct $VersionStateCreateStruct );
+
+    /**
+     * Loads an version state
+     *
+     * @param mixed $stateId
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the state was not found
+     *
+     * @return \eZ\Publish\API\Repository\Values\VersionState\VersionState
+     */
+    public function loadVersionState( $stateId );
+
+    /**
+     * Updates an version state
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to update an version state
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the version state with provided identifier already exists
+     *
+     * @param \eZ\Publish\API\Repository\Values\VersionState\VersionState $VersionState
+     * @param \eZ\Publish\API\Repository\Values\VersionState\VersionStateUpdateStruct $VersionStateUpdateStruct
+     *
+     * @return \eZ\Publish\API\Repository\Values\VersionState\VersionState
+     */
+    public function updateVersionState( VersionState $VersionState, VersionStateUpdateStruct $VersionStateUpdateStruct );
+
+    /**
+     * Deletes a version state. The state of the content versions is reset to the
+     * first version state in the group.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to delete an version state
+     *
+     * @param \eZ\Publish\API\Repository\Values\VersionState\VersionState $VersionState
+     */
+    public function deleteVersionState( VersionState $VersionState );
+
+    /**
+     * Sets the version-state of a state group to $state for the given content.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to change the version state
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\API\Repository\Values\VersionState\VersionState $VersionState
+     */
+    public function setVersionState( VersionInfo $versionInfo, VersionState $VersionState );
+
+    /**
+     * Gets the version-state of version identified by $contentId.
+     *
+     * The $state is the id of the state within one group.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
+     *
+     * @return \eZ\Publish\API\Repository\Values\VersionState\VersionState
+     */
+    public function getVersionState( VersionInfo $versionInfo );
+
+    /**
+     * Returns the number of versions which are in this state
+     *
+     * @param \eZ\Publish\API\Repository\Values\VersionState\VersionState $VersionState
+     *
+     * @return int
+     */
+    public function getVersionCount( VersionState $VersionState );
+
+    /**
+     * Instantiates a new version State Create Struct and sets $identifier in it.
+     *
+     * @param string $identifier
+     *
+     * @return \eZ\Publish\API\Repository\Values\VersionState\VersionStateCreateStruct
+     */
+    public function newVersionStateCreateStruct( $identifier );
+
+    /**
+     * Instantiates a new version State Update Struct.
+     *
+     * @return \eZ\Publish\API\Repository\Values\VersionState\VersionStateUpdateStruct
+     */
+    public function newVersionStateUpdateStruct();
+}


### PR DESCRIPTION
Skipped groupes as it does not seem to make sense for a version to be in two
"workflows" at the same time.
However being in different workflows might make sense (one for articles and different one for blogs).

But open for feedback, not having groups might prevent some advance use cases so might make sense to keep.

Todo:
- [ ] Instead add Workspaces and tie version states to a given workspace _(TBD: need to identify how later edits to a draft is handled, is it sent back to beginning of que leaving two drafts of same content in the que? Are they merged once reaching the same state? With so many versions we should add version comments, revisions probably not needed as long as several versions are allowed and they keep track of parent/original version no)_
  - Alt: Each state is potentially a workspace, you promote something to next workspace, and someone accepts it and merges the changes into the version already in the workspace  if there is one.
  - Either way publish and archive should be system workspaces that have special meaning, everything else is drafts in some state.
