### PR TITLE
Fill width and height in image variations

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGenerator.php
@@ -143,7 +143,9 @@ class AliasGenerator implements VariationHandler
                 'fileName'     => $aliasInfo->getFilename(),
                 'dirPath'      => $aliasInfo->getPath(),
                 'uri'          => $aliasInfo->getPathname(),
-                'imageId'      => $imageValue->imageId
+                'imageId'      => $imageValue->imageId,
+                'width'        => $imageValue->width,
+                'height'       => $imageValue->height
             )
         );
     }


### PR DESCRIPTION
Now, images displayed with "ez_image_alias" will have width and height in HTML, according to content_fields.html.twig : 
img src="Home-page.png" width="112" height="113" alt=""