### PR TITLE
Fix EZP-24614: "default" is not a siteaccess. Fix a configResolver failure

### DIFF
--- a/eZ/Bundle/PlatformInstallerBundle/src/Resources/config_templates/clean/ezpublish.yml
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Resources/config_templates/clean/ezpublish.yml
@@ -24,7 +24,7 @@ ezpublish:
     siteaccess:
         # Available siteaccesses
         list:
-            - default
+            - site
         # Siteaccess groups. Use them to group common settings.
         groups:
             site_group: [site]


### PR DESCRIPTION

Exemple of failure: That is impossible ( in DEV mode ) to edit a Content Type.
It works in PROD (because the Notice is not triggered) 
but 
https://github.com/ezsystems/PlatformUIBundle/blob/master/Controller/ContentTypeController.php#L150
The array is still empty..

```
CRITICAL - Uncaught PHP Exception Symfony\Component\Debug\Exception\ContextErrorException: "Notice: Undefined offset: 0" at wwwroot/vendor/ezsystems/platform-ui-bundle/Controller/ContentTypeController.php line 150 
```
