### PR TITLE
Fix EZP-24621: Exception "Could not find 'Content' with identifier '[ID]'" when removing content

### DIFF
--- a/eZ/Publish/Core/SignalSlot/ContentService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentService.php
@@ -288,7 +288,6 @@ class ContentService implements ContentServiceInterface
      */
     public function deleteContent(ContentInfo $contentInfo)
     {
-        $returnValue = $this->service->deleteContent($contentInfo);
         $this->signalDispatcher->emit(
             new DeleteContentSignal(
                 array(
@@ -297,7 +296,7 @@ class ContentService implements ContentServiceInterface
             )
         );
 
-        return $returnValue;
+        return $this->service->deleteContent($contentInfo);
     }
 
     /**


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-24621

When removing content I get the exception "Could not find 'Content' with identifier '[ID]'". The problem seems to be that SignalSlot/ContentService.php `deleteContent()` first deletes the content, and then emits a `DeleteContentSignal`:
https://github.com/ezsystems/ezpublish-kernel/blob/3ab82f6adc9441b2ccf11bd21c00509f423d7c28/eZ/Publish/Core/SignalSlot/ContentService.php#L289

Later on, when this signal is received, HTTP cache is purged, and in the process `ContentService::loadContentInfo()` is called:
https://github.com/ezsystems/ezpublish-kernel/blob/3ab82f6adc9441b2ccf11bd21c00509f423d7c28/eZ/Publish/Core/MVC/Symfony/Cache/Http/InstantCachePurger.php#L69

But at this point the content no longer exists. The fix simply flips the order of delete and signal.