### PR TITLE
EZP-24623: Implemented QueryType API

### DIFF
--- a/doc/specifications/proposed/named_queries/developer_documentation.md
+++ b/doc/specifications/proposed/named_queries/developer_documentation.md
@@ -144,26 +144,25 @@ The implementations should use Symfony's `OptionsResolver` for parameters handli
 
 ### QueryType example: latest content
 This QueryType returns a LocationQuery that searches for the 10 last published content, order by reverse
-publishing date. It accepts an optional `type` parameter, that can be set to a ContentType identifier.
-identifier:
+publishing date. It accepts an optional `type` parameter, that can be set to a ContentType identifier:
 
 ```php
-namespace AcmeBundle\Ez\QueryType;
+namespace Acme\AcmeBundle\QueryType;
 
+use eZ\Publish\Core\QueryType\QueryType;
 use eZ\Publish\API\Repository\Values\Content\Query;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class LatestContentQueryType implements QueryType
 {
-    protected function getQuery(array $parameters = [])
+    public function getQuery(array $parameters = [])
     {
-        $criteria[] = new Query\Criterion\Visibility( Query\Criterion\Visibility::VISIBLE );
+        $criteria[] = new Query\Criterion\Visibility(Query\Criterion\Visibility::VISIBLE);
         if (isset($parameters['type'])) {
             $criteria[] = new Query\Criterion\ContentTypeIdentifier($parameters['type']);
         }
 
         return new Query([
-            'criterion' => new Query\Criterion\LogicalAnd($criteria),
+            'filter' => new Query\Criterion\LogicalAnd($criteria),
             'sortClauses' => [new Query\SortClause\DatePublished()],
             'limit' => isset($parameters['limit']) ? $parameters['limit'] : 10,
         ]);
@@ -174,6 +173,14 @@ class LatestContentQueryType implements QueryType
         return 'AcmeBundle:LatestContent';
     }
 
+    /**
+     * Returns an array listing the parameters supported by the QueryType.
+     * @return array
+     */
+    public function getSupportedParameters()
+    {
+        return ['type'];
+    }
 }
 ```
 

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/QueryTypePass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/QueryTypePass.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
+
+use Exception;
+use ReflectionClass;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Processes services tagged as ezpublish.query_type, and registers them with ezpublish.query_type.registry.
+ */
+class QueryTypePass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('ezpublish.query_type.registry')) {
+            return;
+        }
+
+        $queryTypes = [];
+
+        // tagged query types
+        $taggedServiceIds = $container->findTaggedServiceIds('ezpublish.query_type');
+        foreach ($taggedServiceIds as $taggedServiceId => $tags) {
+            $queryTypeDefinition = $container->getDefinition($taggedServiceId);
+            $queryTypeClass = $queryTypeDefinition->getClass();
+
+            for ($i = 0, $count = count($tags); $i < $count; ++$i) {
+                // TODO: Check for duplicates
+                $queryTypes[$queryTypeClass::getName()] = new Reference($taggedServiceId);
+            }
+        }
+
+        // named by convention query types
+        if ($container->hasParameter('kernel.bundles')) {
+            foreach ($container->getParameter('kernel.bundles') as $bundleName => $bundleClass) {
+                $bundleReflectionClass = new ReflectionClass($bundleClass);
+                $bundleDir = dirname($bundleReflectionClass->getFileName());
+
+                $bundleQueryTypesDir = $bundleDir . DIRECTORY_SEPARATOR . 'QueryType';
+
+                if (!is_dir($bundleQueryTypesDir)) {
+                    continue;
+                }
+
+                $queryTypeServices = [];
+                $bundleQueryTypeNamespace = substr($bundleClass, 0, strrpos($bundleClass, '\\') + 1) . 'QueryType';
+                foreach (glob($bundleQueryTypesDir . DIRECTORY_SEPARATOR . '*QueryType.php') as $queryTypeFilePath) {
+                    $queryTypeFileName = basename($queryTypeFilePath, '.php');
+                    $queryTypeClassName = $bundleQueryTypeNamespace . '\\' . $queryTypeFileName;
+                    if (!class_exists($queryTypeClassName)) {
+                        throw new Exception("Expected $queryTypeClassName to be defined in $queryTypeFilePath");
+                    }
+
+                    $queryTypeReflectionClass = new ReflectionClass($queryTypeClassName);
+                    if (!$queryTypeReflectionClass->implementsInterface('eZ\Publish\Core\QueryType\QueryType')) {
+                        throw new Exception("$queryTypeClassName needs to implement eZ\\Publish\\Core\\QueryType\\QueryType");
+                    }
+
+                    $serviceId = 'ezpublish.query_type.convention.' . strtolower($bundleName) . '_' . strtolower($queryTypeFileName);
+                    $queryTypeServices[$serviceId] = new Definition($queryTypeClassName);
+
+                    $queryTypes[$queryTypeClassName::getName()] = new Reference($serviceId);
+                }
+                $container->addDefinitions($queryTypeServices);
+            }
+        }
+
+        $aggregatorDefinition = $container->getDefinition('ezpublish.query_type.registry');
+        $aggregatorDefinition->addMethodCall('addQueryTypes', [$queryTypes]);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
@@ -19,6 +19,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\FragmentPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\HttpCachePass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\IdentityDefinerPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\ImaginePass;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\QueryTypePass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\RegisterSearchEnginePass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\RegisterStorageEnginePass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\LegacyStorageEnginePass;
@@ -93,6 +94,7 @@ class EzPublishCoreBundle extends Bundle
         // Legacy Storage passes
         $container->addCompilerPass(new FieldValueConverterRegistryPass());
         $container->addCompilerPass(new RoleLimitationConverterPass());
+        $container->addCompilerPass(new QueryTypePass());
 
         $securityExtension = $container->getExtension('security');
         $securityExtension->addSecurityListenerFactory(new HttpBasicFactory());

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -175,3 +175,6 @@ services:
         arguments: [@translator]
         tags:
             - { name: kernel.event_subscriber }
+
+    ezpublish.query_type.registry:
+        class: eZ\Publish\Core\QueryType\ArrayQueryTypeRegistry

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/QueryTypePassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/QueryTypePassTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * File containing the BlockViewPassTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\QueryTypePass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class QueryTypePassTest extends AbstractCompilerPassTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->setDefinition('ezpublish.query_type.registry', new Definition());
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new QueryTypePass());
+    }
+
+    public function testRegisterTaggedQueryType()
+    {
+        $def = new Definition();
+        $def->addTag('ezpublish.query_type');
+        $def->setClass('eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub\QueryTypeBundle\QueryType\TestQueryType');
+        $serviceId = 'test.query_type';
+        $this->setDefinition($serviceId, $def);
+
+        $this->compile();
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'ezpublish.query_type.registry',
+            'addQueryTypes',
+            [['Test:Test' => new Reference($serviceId)]]
+        );
+    }
+
+    public function testConventionQueryType()
+    {
+        $this->setParameter('kernel.bundles', ['QueryTypeBundle' => 'eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub\QueryTypeBundle\QueryTypeBundle']);
+
+        $this->compile();
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'ezpublish.query_type.registry',
+            'addQueryTypes',
+            [['Test:Test' => new Reference('ezpublish.query_type.convention.querytypebundle_testquerytype')]]
+        );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/QueryTypeBundle/QueryType/TestQueryType.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/QueryTypeBundle/QueryType/TestQueryType.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub\QueryTypeBundle\QueryType;
+
+use eZ\Publish\Core\QueryType\QueryType;
+
+class TestQueryType implements QueryType
+{
+    public function getQuery(array $parameters = [])
+    {
+    }
+
+    public function getSupportedParameters()
+    {
+    }
+
+    public static function getName()
+    {
+        return 'Test:Test';
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/QueryTypeBundle/QueryTypeBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/QueryTypeBundle/QueryTypeBundle.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * File containing the EzPublishCoreBundle class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub\QueryTypeBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class QueryTypeBundle extends Bundle
+{
+}

--- a/eZ/Publish/Core/QueryType/ArrayQueryTypeRegistry.php
+++ b/eZ/Publish/Core/QueryType/ArrayQueryTypeRegistry.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\QueryType;
+
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+
+/**
+ * A QueryType registry based on an array.
+ */
+class ArrayQueryTypeRegistry
+{
+    /** @var QueryType[] */
+    private $registry = [];
+
+    public function addQueryType($name, QueryType $queryType)
+    {
+        $this->registry[$name] = $queryType;
+    }
+
+    public function addQueryTypes(array $queryTypes)
+    {
+        $this->registry += $queryTypes;
+    }
+
+    public function getQueryType($name)
+    {
+        if (!isset($this->registry[$name])) {
+            throw new InvalidArgumentException('QueryType name', 'No QueryType found with that name');
+        }
+
+        return $this->registry[$name];
+    }
+}

--- a/eZ/Publish/Core/QueryType/OptionsResolverBasedQueryType.php
+++ b/eZ/Publish/Core/QueryType/OptionsResolverBasedQueryType.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\QueryType;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * An abstract QueryType class that facilitates parameters handling.
+ * It uses Symfony's [OptionsResolver](http://symfony.com/doc/current/components/options_resolver.html).
+ *
+ * The interface's `getQuery()` method is implemented as final in the abstract class. Instead, you need to implement the
+ * `doGetQuery()` abstract method. It receives the `$parameters` array after it has been processed using the OptionsResolver.
+ *
+ * In addition, you must implement the `configureOptions` abstract method. It receives an OptionsResolver, and configures
+ * it for the QueryType's supported parameters.
+ */
+abstract class OptionsResolverBasedQueryType
+{
+    /** @var OptionsResolver */
+    private $resolver;
+
+    /**
+     * Configures the OptionsResolver for the QueryType.
+     *
+     * Example:
+     * ```php
+     * // type is required
+     * $resolver->setRequired('type');
+     * // limit is optional, and has a default value of 10
+     * $resolver->setDefault('limit', 10);
+     * ```
+     *
+     * @param OptionsResolver $optionsResolver
+     */
+    abstract protected function configureOptions(OptionsResolver $optionsResolver);
+
+    /**
+     * Builds and returns the Query object.
+     *
+     * The parameters array is processed with the OptionsResolver, meaning that it has been validated, and contains
+     * the default values when applicable.
+     *
+     * @param array $parameters The QueryType parameters, pre-processed by the OptionsResolver
+     *
+     * @return Query
+     */
+    abstract protected function doGetQuery(array $parameters);
+
+    final public function getSupportedParameters()
+    {
+        return $this->getResolver()->getDefinedOptions();
+    }
+
+    final public function getQuery(array $parameters = [])
+    {
+        return $this->doGetQuery(
+            $this->getResolver()->resolve($parameters)
+        );
+    }
+
+    /**
+     * Builds the resolver, and configures it using configureOptions().
+     *
+     * @return OptionsResolver
+     */
+    private function getResolver()
+    {
+        if ($this->resolver === null) {
+            $this->resolver = new OptionsResolver();
+            $this->configureOptions($this->resolver);
+        }
+
+        return $this->resolver;
+    }
+}

--- a/eZ/Publish/Core/QueryType/QueryType.php
+++ b/eZ/Publish/Core/QueryType/QueryType.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\QueryType;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+
+/**
+ * A QueryType is a pre-defined content or location query.
+ *
+ * QueryTypes must be registered with the service container using the `ezpublish.query_type` service tag.
+ */
+interface QueryType
+{
+    /**
+     * Builds and returns the Query object.
+     *
+     * @param array $parameters A hash of parameters that will be used to build the Query
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Query
+     */
+    public function getQuery(array $parameters = []);
+
+    /**
+     * Returns an array listing the parameters supported by the QueryType.
+     *
+     * @return array
+     */
+    public function getSupportedParameters();
+
+    /**
+     * Returns the QueryType name.
+     *
+     * @return string
+     */
+    public static function getName();
+}

--- a/eZ/Publish/Core/QueryType/QueryTypeRegistry.php
+++ b/eZ/Publish/Core/QueryType/QueryTypeRegistry.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\QueryType;
+
+/**
+ * Registry of QueryType objects.
+ */
+interface QueryTypeRegistry
+{
+    /**
+     * Registers $queryType as $name.
+     *
+     * @param string $name
+     * @param \eZ\Publish\Core\QueryType\QueryType $queryType
+     */
+    public function addQueryType($name, QueryType $queryType);
+
+    /**
+     * Registers QueryTypes from the $queryTypes array.
+     *
+     * @param \eZ\Publish\Core\QueryType\QueryType[] $queryTypes An array of QueryTypes, with their name as the index
+     */
+    public function addQueryTypes(array $queryTypes);
+
+    /**
+     * Get the QueryType $name.
+     *
+     * @param string $name
+     *
+     * @return \eZ\Publish\Core\QueryType\QueryType
+     */
+    public function getQueryType($name);
+}


### PR DESCRIPTION
> Status: ready for review
> Story: https://jira.ez.no/browse/EZP-24623

The namespace is `eZ/Publish/Core/QueryType`.

Contains:
- The `QueryType` interface,
- `OptionsResolverBasedQueryType` abstract class,
- The `QueryTypeRegistry`,
- The compiler pass that registers services tagged as `ezpublish.query_type` with the Registry.

### Todo
- [x] Rebase master
- [x] Confirm the namespace
- [x] Add a couple tests
- [x] Add an interface for the `QueryTypeRegistry` (`QueryTypeRegistry` is actually the right name. But then how do we name the other one ? `ArrayQueryTypeRegistry` (it uses an array after all) ?