### PR TITLE
EZP-24672: Implemented LocationSearch in REST

### DIFF
--- a/doc/bc/changes-6.0.md
+++ b/doc/bc/changes-6.0.md
@@ -163,6 +163,10 @@ Changes affecting version compatibility with former or future versions.
 * `eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger::purge()` is deprecated and will be removed in v6.1.
   Use `eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger::purgeForContent()` instead.
 
+* The REST resource `/content/views` is deprecated and will be removed in v6.1.
+  `/views`` replaces it.
+  Until it is removed, POST to `/content/views` will return a 301 instead of a 200, and include location header to the
+  new resource.
 
 ## Removed features
 

--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -241,6 +241,7 @@ In the content module there are the root collections objects, locations, trash a
 /content/locations                                                .                   list/find locations     .                            .
 /content/locations/<path>                                         .                   load a location         update location              delete location  copy subtree
 /content/locations/<path>/children                                .                   load children           .                            .
+/views                                                            create view         list views              .                            .
 /content/views                                                    create view         list views              .                            .
 /content/views/<ID>                                               .                   get view                .                            delete view
 /content/views/<ID>/results                                       .                   get view results        .                            .
@@ -332,7 +333,7 @@ XML Example
         <locationByPath media-type="" href="/api/ezp/v2/content/locations{?locationPath}"/>
         <trash media-type="application/vnd.ez.api.Trash+xml" href="/api/ezp/v2/content/trash"/>
         <sections media-type="application/vnd.ez.api.SectionList+xml" href="/api/ezp/v2/content/sections"/>
-        <views media-type="application/vnd.ez.api.RefList+xml" href="/api/ezp/v2/content/views"/>
+        <views media-type="application/vnd.ez.api.RefList+xml" href="/api/ezp/v2/views"/>
         <objectStateGroups media-type="application/vnd.ez.api.ObjectStateGroupList+xml" href="/api/ezp/v2/content/objectstategroups"/>
         <objectStates media-type="application/vnd.ez.api.ObjectStateList+xml" href="/api/ezp/v2/content/objectstategroups/{objectStateGroupId}/objectstates"/>
         <globalUrlAliases media-type="application/vnd.ez.api.UrlAliasRefList+xml" href="/api/ezp/v2/content/urlaliases"/>
@@ -442,7 +443,7 @@ JSON Example
                 "_media-type": "application/vnd.ez.api.UserRefList+json"
             },
             "views": {
-                "_href": "/api/ezp/v2/content/views",
+                "_href": "/api/ezp/v2/views",
                 "_media-type": "application/vnd.ez.api.RefList+json"
             },
             "refreshSession": {
@@ -790,7 +791,7 @@ List/Search Content
 ```````````````````
 :Resource: /content/objects
 :Method: GET (not implemented)
-:Description: This resource will used in future for searching content by providing a query string as alternative to posting a view to /content/views.
+:Description: This resource will be used in future for searching content by providing a query string as alternative to posting a view to /views.
 
 Load Content by remote id
 `````````````````````````
@@ -2115,7 +2116,7 @@ Views
 
 Create View
 ```````````
-:Resource: /content/views
+:Resource: /views
 :Method:  POST
 :Description: executes a query and returns view including the results
               The View_ input reflects the criteria model of the public API.
@@ -2123,9 +2124,13 @@ Create View
     :Accept:
         :application/vnd.ez.api.View+xml: the view in xml format (see View_)
         :application/vnd.ez.api.View+json: the view in json format (see View_)
+        :application/vnd.ez.api.View+xml; version=1.1: the view in xml format (see View_)
+        :application/vnd.ez.api.View+json; version=1.1: the view in json format (see View_)
     :Content-Type:
         :application/vnd.ez.api.ViewInput+xml: the view input in xml format (see View_)
         :application/vnd.ez.api.ViewInput+json: the view input in json format (see View_)
+        :application/vnd.ez.api.ViewInput+xml; version=1.1: the view input in xml format (see View_)
+        :application/vnd.ez.api.ViewInput+json; version=1.1: the view input in json format (see View_)
 :Response: 200 OK
            Note : when persistence will be implemented, it will change to 201 Created
 
@@ -2148,9 +2153,9 @@ Perform a query on images withing the media section, sorted by name, limiting re
 
 .. code:: http
 
-    POST /content/views HTTP/1.1
-    Accept: application/vnd.ez.api.View+xml
-    Content-Type: application/vnd.ez.api.ViewInput+xml
+    POST /views HTTP/1.1
+    Accept: application/vnd.ez.api.View+xml; version=1.1
+    Content-Type: application/vnd.ez.api.ViewInput+xml; version=1.1
     Content-Length: xxx
 
 .. code:: xml
@@ -2158,7 +2163,7 @@ Perform a query on images withing the media section, sorted by name, limiting re
     <?xml version="1.0" encoding="UTF-8"?>
     <ViewInput>
       <identifier>TitleView</identifier>
-      <Query>
+      <ContentQuery>
         <Criteria>
           <ContentTypeIdentifierCriterion>image</ContentTypeIdentifierCriterion>
           <SectionIdentifierCriterion>media</SectionIdentifierCriterion>
@@ -2173,26 +2178,26 @@ Perform a query on images withing the media section, sorted by name, limiting re
         <FacetBuilders>
           <contentTypeFacetBuilder/>
         </FacetBuilders>
-      </Query>
+      </ContentQuery>
     </ViewInput>
 
 .. code:: http
 
     HTTP/1.1 200 OK
-    Location: /content/views/view1234
-    Content-Type: application/vnd.ez.api.View+xml
+    Location: /views/view1234
+    Content-Type: application/vnd.ez.api.View+xml; version=1.1
     Content-Length: xxx
 
 .. code:: xml
 
     <?xml version="1.0" encoding="UTF-8"?>
-    <View href="/content/views/TitleView" media-type="application/vnd.ez.api.View+xml">
+    <View href="/views/TitleView" media-type="application/vnd.ez.api.View+xml; version=1.1">
       <identifier>TitleView</identifier>
       <User href="/user/users/14" media-type="vnd.ez.api.User+xml"/>
       <public>false</public>
-      <Query>
+      <LocationQuery>
         <Criteria>
-          <FullTextCriterion>Title</FullTextCriterion>
+          <ParentLocationIdCriterion>2</ParentLocationIdCriterion>
         </Criteria>
         <limit>10</limit>
         <offset>0</offset>
@@ -2204,65 +2209,30 @@ Perform a query on images withing the media section, sorted by name, limiting re
         <FacetBuilders>
           <contentTypeFacetBuilder/>
         </FacetBuilders>
-      </Query>
+      </LocationQuery>
       <Result href="/content/views/view1234/results"
         media-type="application/vnd.ez.api.ViewResult+xml" count="34" time="31" maxScore="1.0">
         <searchHits>
           <searchHit score="1.0" index="installid1234567890">
             <hightlight/>
             <value>
-              <Content href="/content/objects/23" id="23"
-                media-type="application/vnd.ez.api.Content+xml" remoteId="qwert123"
-                xmlns:p="http://ez.no/API/Values" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:schemaLocation="http://ez.no/API/Values Content.xsd ">
-                <ContentType href="/content/types/10"
-                  media-type="application/vnd.ez.api.ContentType+xml" />
-                <Name>Name</Name>
-                <Versions href="/content/objects/23/versions" media-type="application/vnd.ez.api.VersionList+xml" />
-                <CurrentVersion href="/content/objects/23/currentversion"
-                  media-type="application/vnd.ez.api.Version+xml">
-                  <Version href="/content/objects/23/versions/2"
-                    media-type="application/vnd.ez.api.Version+xml">
-                    <VersionInfo>
-                      <id>123</id>
-                      <versionNo>2</versionNo>
-                      <status>PUBLISHED</status>
-                      <modificationDate>2001-12-31T12:00:00</modificationDate>
-                      <creator href="/user/users/14" media-type="application/vnd.ez.api.User+xml" />
-                      <creationDate>2001-12-31T12:00:00</creationDate>
-                      <initialLanguageCode>eng-UK</initialLanguageCode>
-                      <Content href="/content/objects/23"
-                        media-type="application/vnd.ez.api.ContentInfo+xml" />
-                    </VersionInfo>
-                    <Fields>
-                      <field>
-                        <id>1234</id>
-                        <fieldDefinitionIdentifier>title</fieldDefinitionIdentifier>
-                        <languageCode>eng-UK</languageCode>
-                        <fieldValue>Title</fieldValue>
-                      </field>
-                      <field>
-                        <id>1235</id>
-                        <fieldDefinitionIdentifier>summary
-                        </fieldDefinitionIdentifier>
-                        <languageCode>eng-UK</languageCode>
-                        <fieldValue>This is a summary</fieldValue>
-                      </field>
-                    </Fields>
-                    <Relations />
-                  </Version>
-                </CurrentVersion>
-                <Section href="/content/objects/23/section" media-type="application/vnd.ez.api.Section+xml" />
-                <MainLocation href="/content/objects/23/mainlocation"
-                  media-type="application/vnd.ez.api.Location+xml" />
-                <Locations href="/content/objects/23/locations"
-                  media-type="application/vnd.ez.api.LocationList+xml" />
-                <Owner href="/user/users/14" media-type="application/vnd.ez.api.User+xml" />
-                <PublishDate>2001-12-31T12:00:00</PublishDate>
-                <LastModificationDate>2001-12-31T12:00:00</LastModificationDate>
-                <MainLanguageCode>eng-UK</MainLanguageCode>
-                <AlwaysAvailable>true</AlwaysAvailable>
-              </Content>
+              <Location media-type="application/vnd.ez.api.Location+xml" href="/api/ezp/v2/content/locations/1/2">
+                <id>2</id>
+                <priority>0</priority>
+                <hidden>false</hidden>
+                <invisible>false</invisible>
+                <ParentLocation media-type="application/vnd.ez.api.Location+xml" href="/api/ezp/v2/content/locations/1"/>
+                <pathString>/1/2/</pathString>
+                <depth>1</depth>
+                <childCount>8</childCount>
+                <remoteId>f3e90596361e31d496d4026eb624c983</remoteId>
+                <Children media-type="application/vnd.ez.api.LocationList+xml" href="/api/ezp/v2/content/locations/1/2/children"/>
+                <Content media-type="application/vnd.ez.api.Content+xml" href="/api/ezp/v2/content/objects/57"/>
+                <sortField>PRIORITY</sortField>
+                <sortOrder>ASC</sortOrder>
+                <UrlAliases media-type="application/vnd.ez.api.UrlAliasRefList+xml" href="/api/ezp/v2/content/locations/1/2/urlaliases"/>
+              </Location>
+
             </value>
           </searchHit>
           ....
@@ -2290,6 +2260,39 @@ Perform a query on images withing the media section, sorted by name, limiting re
       </Result>
     </View>
 
+
+Create View
+```````````
+:Resource: /content/views
+:Method:  POST
+:Description: Executes a query and returns view including the results.
+              The View_ input reflects the criteria model of the public API.
+              Will respond with a 301, as the resource has been moved to /views (Platform 1.0)
+:Headers:
+    :Accept:
+        :application/vnd.ez.api.View+xml: the view in xml format (see View_)
+        :application/vnd.ez.api.View+json: the view in json format (see View_)
+        :application/vnd.ez.api.View+xml; version=1.1: the view in xml format (see View_)
+        :application/vnd.ez.api.View+json; version=1.1: the view in json format (see View_)
+    :Content-Type:
+        :application/vnd.ez.api.ViewInput+xml: the view input in xml format (see View_)
+        :application/vnd.ez.api.ViewInput+json: the view input in json format (see View_)
+        :application/vnd.ez.api.ViewInput+xml; version=1.1: the view input in xml format (see View_)
+        :application/vnd.ez.api.ViewInput+json; version=1.1: the view input in json format (see View_)
+:Response: 301 Moved Permanently
+
+.. code:: http
+
+          HTTP/1.1 301 Moved Permanently
+          ETag: "<new etag>"
+          Content-Type: <depending on accept header>
+          Content-Length: <length>
+          Location: /views
+.. parsed-literal::
+View_
+
+:Error codes:
+    :400: If the Input does not match the input schema definition, In this case the response contains an ErrorMessage_
 
 List views
 ``````````
@@ -7313,7 +7316,7 @@ View XML Schema
         </xsd:complexContent>
       </xsd:complexType>
 
-      <xsd:complexType name="facetTyoe">
+      <xsd:complexType name="facetType">
         <xsd:choice>
           <xsd:element name="sectionFacet" type="sectionFacetType" />
           <xsd:element name="locationFacet" type="locationFacetType" />
@@ -7380,7 +7383,10 @@ View XML Schema
               <xsd:element name="identifier" type="xsd:string" />
               <xsd:element name="User" type="ref" />
               <xsd:element name="public" type="xsd:boolean" />
-              <xsd:element name="Query" type="queryType" />
+              <xsd:any minOccurs="1" maxOccurs="1">
+                <xsd:element name="ContentQuery" type="queryType" />
+                <xsd:element name="LocationQuery" type="queryType" />
+              </xsd:any>
               <xsd:element name="Result" type="resultType" />
             </xsd:all>
           </xsd:extension>

--- a/eZ/Bundle/EzPublishRestBundle/EventListener/RequestListener.php
+++ b/eZ/Bundle/EzPublishRestBundle/EventListener/RequestListener.php
@@ -14,7 +14,6 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
  * REST request listener.
@@ -55,10 +54,6 @@ class RequestListener implements EventSubscriberInterface
     public function onKernelRequest(GetResponseEvent $event)
     {
         $isRestRequest = true;
-
-        if ($event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST) {
-            $isRestRequest = false;
-        }
 
         if (!$this->hasRestPrefix($event->getRequest())) {
             $isRestRequest = false;

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
@@ -31,7 +31,10 @@ parameters:
     ezpublish_rest.input.parser.SessionInput.class: eZ\Publish\Core\REST\Server\Input\Parser\SessionInput
     ezpublish_rest.input.parser.VersionUpdate.class: eZ\Publish\Core\REST\Server\Input\Parser\VersionUpdate
     ezpublish_rest.input.parser.ViewInput.class: eZ\Publish\Core\REST\Server\Input\Parser\ViewInput
+    ezpublish_rest.input.parser.ViewInputOneDotOne.class: eZ\Publish\Core\REST\Server\Input\Parser\ViewInputOneDotOne
 
+    ezpublish_rest.input.parser.internal.ContentQuery.class: eZ\Publish\Core\REST\Server\Input\Parser\ContentQuery
+    ezpublish_rest.input.parser.internal.LocationQuery.class: eZ\Publish\Core\REST\Server\Input\Parser\LocationQuery
     ezpublish_rest.input.parser.internal.criterion.ContentId.class: eZ\Publish\Core\REST\Server\Input\Parser\Criterion\ContentId
     ezpublish_rest.input.parser.internal.criterion.ContentRemoteId.class: eZ\Publish\Core\REST\Server\Input\Parser\Criterion\ContentRemoteId
     ezpublish_rest.input.parser.internal.criterion.ContentTypeGroupId.class: eZ\Publish\Core\REST\Server\Input\Parser\Criterion\ContentTypeGroupId
@@ -346,6 +349,12 @@ services:
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.ViewInput }
 
+    ezpublish_rest.input.parser.ViewInputOnedotOne:
+        parent: ezpublish_rest.input.parser
+        class: %ezpublish_rest.input.parser.ViewInputOneDotOne.class%
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: "application/vnd.ez.api.ViewInput; version=1.1" }
+
     ezpublish_rest.input.parser.VersionUpdate:
         parent: ezpublish_rest.input.parser
         class: %ezpublish_rest.input.parser.VersionUpdate.class%
@@ -356,6 +365,18 @@ services:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.VersionUpdate }
 
     # internal Media-Types
+    ezpublish_rest.input.parser.internal.criterion.ContentQuery:
+        parent: ezpublish_rest.input.parser
+        class: %ezpublish_rest.input.parser.internal.ContentQuery.class%
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.ContentQuery }
+
+    ezpublish_rest.input.parser.internal.criterion.LocationQuery:
+        parent: ezpublish_rest.input.parser
+        class: %ezpublish_rest.input.parser.internal.LocationQuery.class%
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.LocationQuery }
+
     ezpublish_rest.input.parser.internal.criterion.ContentId:
         parent: ezpublish_rest.input.parser
         class: %ezpublish_rest.input.parser.internal.criterion.ContentId.class%

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
@@ -223,31 +223,37 @@ ezpublish_rest_binaryContent_getImageVariation:
 
 # Views
 
-
-ezpublish_rest_createView:
+# Deprecated in favour of /views from Platform 1.0
+ezpublish_rest_createContentView:
     path: /content/views
     defaults:
         _controller: ezpublish_rest.controller.content:createView
     methods: [POST]
 
-ezpublish_rest_listView:
-    path: /content/views
+# Views, Platform 1.0
+ezpublish_rest_views_create:
+    path: /views
     defaults:
-        _controller: ezpublish_rest.controller.content:listView
+        _controller: ezpublish_rest.controller.views:createView
+    methods: [POST]
+
+ezpublish_rest_views_list:
+    path: /views
+    defaults:
+        _controller: ezpublish_rest.controller.views:listView
     methods: [GET]
 
-ezpublish_rest_getView:
-    path : /content/views/{viewId}
+ezpublish_rest_views_load:
+    path : /views/{viewId}
     defaults:
-        _controller: ezpublish_rest.controller.content:getView
+        _controller: ezpublish_rest.controller.views:getView
     methods: [GET]
 
-ezpublish_rest_loadViewResults:
-    path: /content/views/{viewId}/results
+ezpublish_rest_views_load_results:
+    path: /views/{viewId}/results
     defaults:
-        _controller: ezpublish_rest.controller.content:loadViewResults
+        _controller: ezpublish_rest.controller.views:loadViewResults
     methods: [GET]
-
 # Object states
 
 

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
@@ -20,6 +20,7 @@ parameters:
     ezpublish_rest.controller.url_alias.class: eZ\Publish\Core\REST\Server\Controller\URLAlias
     ezpublish_rest.controller.options.class: eZ\Publish\Core\REST\Server\Controller\Options
     ezpublish_rest.controller.services.class: eZ\Publish\Core\REST\Server\Controller\Services
+    ezpublish_rest.controller.views.class: eZ\Publish\Core\REST\Server\Controller\Views
 
     ezpublish_rest.factory.class: eZ\Bundle\EzPublishRestBundle\ApiLoader\Factory
     ezpublish_rest.request_parser.class: eZ\Bundle\EzPublishRestBundle\RequestParser\Router
@@ -209,6 +210,12 @@ services:
         arguments:
             - @ezpublish.api.service.url_alias
             - @ezpublish.api.service.location
+
+    ezpublish_rest.controller.views:
+        class: %ezpublish_rest.controller.views.class%
+        parent: ezpublish_rest.controller.base
+        arguments:
+            - @ezpublish.api.service.search
 
     ezpublish_rest.request_listener:
         class: %ezpublish_rest.request_listener.class%

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -82,6 +82,7 @@ parameters:
     # Location
     ezpublish_rest.output.value_object_visitor.LocationList.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\LocationList
     ezpublish_rest.output.value_object_visitor.RestLocation.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\RestLocation
+    ezpublish_rest.output.value_object_visitor.Location.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\Location
     ezpublish_rest.output.value_object_visitor.CreatedLocation.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\CreatedLocation
     ezpublish_rest.output.value_object_visitor.LocationCreateStruct.class: eZ\Publish\Core\REST\Client\Output\ValueObjectVisitor\LocationCreateStruct
     ezpublish_rest.output.value_object_visitor.LocationUpdateStruct.class: eZ\Publish\Core\REST\Client\Output\ValueObjectVisitor\LocationUpdateStruct
@@ -625,6 +626,13 @@ services:
         class: %ezpublish_rest.output.value_object_visitor.RestLocation.class%
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Values\RestLocation }
+
+    ezpublish_rest.output.value_object_visitor.Location:
+        parent: ezpublish_rest.output.value_object_visitor.base
+        class: %ezpublish_rest.output.value_object_visitor.Location.class%
+        tags:
+            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\Content\Location }
+        arguments: [@ezpublish.api.service.location]
 
     ezpublish_rest.output.value_object_visitor.LocationList:
         parent: ezpublish_rest.output.value_object_visitor.base

--- a/eZ/Bundle/EzPublishRestBundle/Tests/EventListener/RequestListenerTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/EventListener/RequestListenerTest.php
@@ -33,7 +33,7 @@ class RequestListenerTest extends EventListenerTest
         $event = $this->getEvent(self::REST_PREFIX . '/', HttpKernelInterface::SUB_REQUEST);
         $this->getEventListener()->onKernelRequest($event);
 
-        self::assertFalse(
+        self::assertTrue(
             $event->getRequest()->attributes->get('is_rest_request')
         );
     }

--- a/eZ/Publish/Core/REST/Common/Input/Dispatcher.php
+++ b/eZ/Publish/Core/REST/Common/Input/Dispatcher.php
@@ -85,6 +85,15 @@ class Dispatcher
         }
 
         $media = $contentTypeParts[0];
+
+        // add version if given
+        if (count($mediaTypeParts) > 1) {
+            $parameters = $this->parseParameters(trim($mediaTypeParts[1]));
+            if (isset($parameters['version'])) {
+                $media .= '; version=' . $parameters['version'];
+            }
+        }
+
         $format = $contentTypeParts[1];
 
         if (!isset($this->handlers[$format])) {
@@ -106,5 +115,16 @@ class Dispatcher
         }
 
         return $this->parsingDispatcher->parse($rootNodeArray, $media);
+    }
+
+    private function parseParameters($mediaTypePart)
+    {
+        $parameters = [];
+        foreach (explode(',', $mediaTypePart) as $parameterString) {
+            list($parameterName, $parameterValue) = explode('=', $parameterString);
+            $parameters[$parameterName] = $parameterValue;
+        }
+
+        return $parameters;
     }
 }

--- a/eZ/Publish/Core/REST/Common/Tests/Input/ParsingDispatcherTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Input/ParsingDispatcherTest.php
@@ -31,11 +31,7 @@ class ParsingDispatcherTest extends PHPUnit_Framework_TestCase
     public function testParse()
     {
         $parser = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Input\\Parser');
-        $dispatcher = new Common\Input\ParsingDispatcher(
-            array(
-                'text/html' => $parser,
-            )
-        );
+        $dispatcher = new Common\Input\ParsingDispatcher(['text/html' => $parser]);
 
         $parser
             ->expects($this->at(0))
@@ -52,11 +48,7 @@ class ParsingDispatcherTest extends PHPUnit_Framework_TestCase
     public function testParseStripFormat()
     {
         $parser = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Input\\Parser');
-        $dispatcher = new Common\Input\ParsingDispatcher(
-            array(
-                'text/html' => $parser,
-            )
-        );
+        $dispatcher = new Common\Input\ParsingDispatcher(['text/html' => $parser]);
 
         $parser
             ->expects($this->at(0))

--- a/eZ/Publish/Core/REST/Server/Controller/Views.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Views.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Controller;
+
+use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\Core\REST\Server\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use eZ\Publish\Core\REST\Common\Message;
+use eZ\Publish\Core\REST\Server\Values;
+
+/**
+ * Controller for Repository Views (Search, mostly).
+ */
+class Views extends Controller
+{
+    /**
+     * @var \eZ\Publish\API\Repository\SearchService
+     */
+    private $searchService;
+
+    public function __construct(SearchService $searchService)
+    {
+        $this->searchService = $searchService;
+    }
+    /**
+     * Creates and executes a content view.
+     *
+     * @return \eZ\Publish\Core\REST\Server\Values\RestExecutedView
+     */
+    public function createView(Request $request)
+    {
+        $viewInput = $this->inputDispatcher->parse(
+            new Message(
+                array('Content-Type' => $request->headers->get('Content-Type')),
+                $request->getContent()
+            )
+        );
+
+        if ($viewInput->query instanceof LocationQuery) {
+            $method = 'findLocations';
+        } else {
+            $method = 'findContent';
+        }
+
+        return new Values\RestExecutedView(
+            array(
+                'identifier' => $viewInput->identifier,
+                'searchResults' => $this->searchService->$method($viewInput->query),
+            )
+        );
+    }
+
+    /**
+     * List content views.
+     *
+     * @return NotImplementedException;
+     */
+    public function listView()
+    {
+        return new NotImplementedException('ezpublish_rest.controller.content:listView');
+    }
+
+    /**
+     * Get a content view.
+     *
+     * @return NotImplementedException;
+     */
+    public function getView()
+    {
+        return new NotImplementedException('ezpublish_rest.controller.content:getView');
+    }
+
+    /**
+     * Get a content view results.
+     *
+     * @return NotImplementedException;
+     */
+    public function loadViewResults()
+    {
+        return new NotImplementedException('ezpublish_rest.controller.content:loadViewResults');
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ContentQuery.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ContentQuery.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * File containing the ViewInput parser class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\REST\Server\Input\Parser;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\Core\REST\Server\Input\Parser\Query as QueryParser;
+
+/**
+ * Parser for ViewInput.
+ */
+class ContentQuery extends QueryParser
+{
+    protected function buildQuery()
+    {
+        return new Query();
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Input/Parser/LocationQuery.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/LocationQuery.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * File containing the ViewInput parser class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\REST\Server\Input\Parser;
+
+use eZ\Publish\API\Repository\Values\Content\LocationQuery as LocationQueryValueObject;
+use eZ\Publish\Core\REST\Server\Input\Parser\Query as QueryParser;
+
+/**
+ * Parser for LocationQuery.
+ */
+class LocationQuery extends QueryParser
+{
+    protected function buildQuery()
+    {
+        return new LocationQueryValueObject();
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Query.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Query.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\REST\Server\Input\Parser;
+
+use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
+use eZ\Publish\Core\REST\Server\Input\Parser\Criterion as CriterionParser;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd as LogicalAndCriterion;
+
+/**
+ * Content/Location Query Parser.
+ */
+abstract class Query extends CriterionParser
+{
+    /**
+     * Parses input structure to a Query.
+     *
+     * @param array $data
+     * @param \eZ\Publish\Core\REST\Common\Input\ParsingDispatcher $parsingDispatcher
+     *
+     * @throws \eZ\Publish\Core\REST\Common\Exceptions\Parser
+     *
+     * @return \eZ\Publish\Core\REST\Server\Values\RestViewInput
+     */
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher)
+    {
+        $query = $this->buildQuery();
+
+        // Criteria
+        // -- FullTextCriterion
+        if (array_key_exists('Criteria', $data) && is_array($data['Criteria'])) {
+            $criteria = array();
+            foreach ($data['Criteria'] as $criterionName => $criterionData) {
+                $criteria[] = $this->dispatchCriterion($criterionName, $criterionData, $parsingDispatcher);
+            }
+
+            if (count($criteria) === 1) {
+                $query->filter = $criteria[0];
+            } else {
+                $query->filter = new LogicalAndCriterion($criteria);
+            }
+        }
+
+        // limit
+        if (array_key_exists('limit', $data)) {
+            $query->limit = (int)$data['limit'];
+        }
+
+        // offset
+        if (array_key_exists('offset', $data)) {
+            $query->offset = (int)$data['offset'];
+        }
+
+        // SortClauses
+        // -- SortClause
+        // ---- SortField
+        if (array_key_exists('SortClauses', $data)) {
+        }
+
+        // FacetBuilders
+        // -- contentTypeFacetBuilder
+        if (array_key_exists('FacetBuilders', $data)) {
+        }
+
+        return $query;
+    }
+
+    /**
+     * Builds and returns the Query (Location or Content object).
+     * @return \eZ\Publish\API\Repository\Values\Content\Query
+     */
+    abstract protected function buildQuery();
+}

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ViewInputOneDotOne.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ViewInputOneDotOne.php
@@ -10,16 +10,16 @@
  */
 namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
+use eZ\Publish\Core\REST\Server\Input\Parser\Criterion as CriterionParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\Core\REST\Server\Values\RestViewInput;
-use eZ\Publish\Core\REST\Common\Input\BaseParser;
 
 /**
- * Parser for ViewInput.
+ * Parser for ViewInput 1.1.
  */
-class ViewInput extends BaseParser
+class ViewInputOneDotOne extends CriterionParser
 {
     /**
      * Parses input structure to a RestViewInput struct.
@@ -42,11 +42,21 @@ class ViewInput extends BaseParser
         $restViewInput->identifier = $data['identifier'];
 
         // query
-        if (!array_key_exists('Query', $data) || !is_array($data['Query'])) {
-            throw new Exceptions\Parser('Missing <Query> attribute for <ViewInput>.');
+        if (array_key_exists('ContentQuery', $data) && is_array($data['ContentQuery'])) {
+            $queryData = $data['ContentQuery'];
+            $queryMediaType = 'application/vnd.ez.api.internal.ContentQuery';
         }
 
-        $restViewInput->query = $parsingDispatcher->parse($data['Query'], 'application/vnd.ez.api.internal.ContentQuery');
+        if (array_key_exists('LocationQuery', $data) && is_array($data['LocationQuery'])) {
+            $queryData = $data['LocationQuery'];
+            $queryMediaType = 'application/vnd.ez.api.internal.LocationQuery';
+        }
+
+        if (!isset($queryMediaType) || !isset($queryData)) {
+            throw new Exceptions\Parser('Missing <ContentQuery> or <LocationQuery> attribute for <ViewInput>.');
+        }
+
+        $restViewInput->query = $parsingDispatcher->parse($queryData, $queryMediaType);
 
         return $restViewInput;
     }

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Location.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Location.php
@@ -1,0 +1,153 @@
+<?php
+
+/**
+ * File containing the RestLocation ValueObjectVisitor class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Values\RestContent as RestContentValue;
+
+/**
+ * Location value object visitor.
+ */
+class Location extends ValueObjectVisitor
+{
+    /**
+     * @var \eZ\Publish\API\Repository\LocationService
+     */
+    private $locationService;
+
+    public function __construct(LocationService $locationService)
+    {
+        $this->locationService = $locationService;
+    }
+
+    /**
+     * Visit struct returned by controllers.
+     *
+     * @param \eZ\Publish\Core\REST\Common\Output\Visitor $visitor
+     * @param \eZ\Publish\Core\REST\Common\Output\Generator $generator
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $location
+     */
+    public function visit(Visitor $visitor, Generator $generator, $location)
+    {
+        $generator->startObjectElement('Location');
+        $visitor->setHeader('Content-Type', $generator->getMediaType('Location'));
+        $visitor->setHeader('Accept-Patch', $generator->getMediaType('LocationUpdate'));
+
+        $generator->startAttribute(
+            'href',
+            $this->router->generate(
+                'ezpublish_rest_loadLocation',
+                array('locationPath' => trim($location->pathString, '/'))
+            )
+        );
+        $generator->endAttribute('href');
+
+        $generator->startValueElement('id', $location->id);
+        $generator->endValueElement('id');
+
+        $generator->startValueElement('priority', $location->priority);
+        $generator->endValueElement('priority');
+
+        $generator->startValueElement(
+            'hidden',
+            $this->serializeBool($generator, $location->hidden)
+        );
+        $generator->endValueElement('hidden');
+
+        $generator->startValueElement(
+            'invisible',
+            $this->serializeBool($generator, $location->invisible)
+        );
+        $generator->endValueElement('invisible');
+
+        $generator->startObjectElement('ParentLocation', 'Location');
+        if (trim($location->pathString, '/') !== '1') {
+            $generator->startAttribute(
+                'href',
+                $this->router->generate(
+                    'ezpublish_rest_loadLocation',
+                    array(
+                        'locationPath' => implode('/', array_slice($location->path, 0, count($location->path) - 1)),
+                    )
+                )
+            );
+            $generator->endAttribute('href');
+        }
+        $generator->endObjectElement('ParentLocation');
+
+        $generator->startValueElement('pathString', $location->pathString);
+        $generator->endValueElement('pathString');
+
+        $generator->startValueElement('depth', $location->depth);
+        $generator->endValueElement('depth');
+
+        $generator->startValueElement('childCount', $this->locationService->getLocationChildCount($location));
+        $generator->endValueElement('childCount');
+
+        $generator->startValueElement('remoteId', $location->remoteId);
+        $generator->endValueElement('remoteId');
+
+        $generator->startObjectElement('Children', 'LocationList');
+        $generator->startAttribute(
+            'href',
+            $this->router->generate(
+                'ezpublish_rest_loadLocationChildren',
+                array(
+                    'locationPath' => trim($location->pathString, '/'),
+                )
+            )
+        );
+        $generator->endAttribute('href');
+        $generator->endObjectElement('Children');
+
+        $generator->startObjectElement('Content');
+        $generator->startAttribute(
+            'href',
+            $this->router->generate('ezpublish_rest_loadContent', array('contentId' => $location->contentId))
+        );
+        $generator->endAttribute('href');
+        $generator->endObjectElement('Content');
+
+        $generator->startValueElement('sortField', $this->serializeSortField($location->sortField));
+        $generator->endValueElement('sortField');
+
+        $generator->startValueElement('sortOrder', $this->serializeSortOrder($location->sortOrder));
+        $generator->endValueElement('sortOrder');
+
+        $generator->startObjectElement('UrlAliases', 'UrlAliasRefList');
+        $generator->startAttribute(
+            'href',
+            $this->router->generate(
+                'ezpublish_rest_listLocationURLAliases',
+                array('locationPath' => trim($location->pathString, '/'))
+            )
+        );
+        $generator->endAttribute('href');
+        $generator->endObjectElement('UrlAliases');
+
+        $generator->startObjectElement('ContentInfo', 'ContentInfo');
+        $generator->startAttribute(
+            'href',
+            $this->router->generate(
+                'ezpublish_rest_loadContent',
+                array('contentId' => $location->contentId)
+            )
+        );
+        $generator->endAttribute('href');
+        $visitor->visitValueObject(new RestContentValue($location->contentInfo));
+        $generator->endObjectElement('ContentInfo');
+
+        $generator->endObjectElement('Location');
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Root.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Root.php
@@ -172,7 +172,7 @@ class Root extends ValueObjectVisitor
 
         // Content views
         $generator->startObjectElement('views', 'RefList');
-        $generator->startAttribute('href', $this->router->generate('ezpublish_rest_createView'));
+        $generator->startAttribute('href', $this->router->generate('ezpublish_rest_views_create'));
         $generator->endAttribute('href');
         $generator->endObjectElement('views');
 

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ViewInputOneDotOneTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ViewInputOneDotOneTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * File containing the SessionInputTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
+
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\Core\REST\Server\Input\Parser\ViewInputOneDotOne;
+use eZ\Publish\Core\REST\Server\Values\RestViewInput;
+
+class ViewInputOneDotOneTest extends BaseTest
+{
+    /**
+     * Tests the ViewInput parser.
+     */
+    public function testParseContentQuery()
+    {
+        $inputArray = array(
+            'identifier' => 'Query identifier',
+            'ContentQuery' => [],
+        );
+
+        $parser = $this->getParser();
+        $parsingDispatcher = $this->getParsingDispatcherMock();
+        $parsingDispatcher
+            ->expects($this->once())
+            ->method('parse')
+            ->with($inputArray['ContentQuery'], 'application/vnd.ez.api.internal.ContentQuery')
+            ->will($this->returnValue(new Query()));
+
+        $result = $parser->parse($inputArray, $parsingDispatcher);
+
+        $expectedViewInput = new RestViewInput();
+        $expectedViewInput->identifier = 'Query identifier';
+        $expectedViewInput->query = new Query();
+
+        $this->assertEquals($expectedViewInput, $result, 'RestViewInput not created correctly.');
+    }
+
+    /**
+     * Tests the ViewInput parser.
+     */
+    public function testParseLocationQuery()
+    {
+        $inputArray = array(
+            'identifier' => 'Query identifier',
+            'LocationQuery' => [],
+        );
+
+        $parser = $this->getParser();
+        $parsingDispatcher = $this->getParsingDispatcherMock();
+        $parsingDispatcher
+            ->expects($this->once())
+            ->method('parse')
+            ->with($inputArray['LocationQuery'], 'application/vnd.ez.api.internal.LocationQuery')
+            ->will($this->returnValue(new LocationQuery()));
+
+        $result = $parser->parse($inputArray, $parsingDispatcher);
+
+        $expectedViewInput = new RestViewInput();
+        $expectedViewInput->identifier = 'Query identifier';
+        $expectedViewInput->query = new LocationQuery();
+
+        $this->assertEquals($expectedViewInput, $result, 'RestViewInput not created correctly.');
+    }
+
+    /**
+     * @expectedException \eZ\Publish\Core\REST\Common\Exceptions\Parser
+     */
+    public function testThrowsExceptionOnMissingIdentifier()
+    {
+        $inputArray = ['Query' => []];
+        $this->getParser()->parse($inputArray, $this->getParsingDispatcherMock());
+    }
+
+    /**
+     * @expectedException \eZ\Publish\Core\REST\Common\Exceptions\Parser
+     */
+    public function testThrowsExceptionOnMissingQuery()
+    {
+        $inputArray = ['identifier' => 'foo'];
+        $this->getParser()->parse($inputArray, $this->getParsingDispatcherMock());
+    }
+
+    /**
+     * Returns the session input parser.
+     *
+     * @return \eZ\Publish\Core\REST\Server\Input\Parser\ViewInput
+     */
+    protected function internalGetParser()
+    {
+        return new ViewInputOneDotOne();
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ViewInputTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ViewInputTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * File containing the SessionInputTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\Core\REST\Server\Input\Parser\ViewInput;
+use eZ\Publish\Core\REST\Server\Values\RestViewInput;
+
+class ViewInputTest extends BaseTest
+{
+    /**
+     * Tests the ViewInput parser.
+     */
+    public function testParse()
+    {
+        $inputArray = array(
+            'identifier' => 'Query identifier',
+            'Query' => [],
+        );
+
+        $parser = $this->getParser();
+        $parsingDispatcher = $this->getParsingDispatcherMock();
+        $parsingDispatcher
+            ->expects($this->once())
+            ->method('parse')
+            ->with($inputArray['Query'], 'application/vnd.ez.api.internal.ContentQuery')
+            ->will($this->returnValue(new Query()));
+
+        $result = $parser->parse($inputArray, $parsingDispatcher);
+
+        $expectedViewInput = new RestViewInput();
+        $expectedViewInput->identifier = 'Query identifier';
+        $expectedViewInput->query = new Query();
+
+        $this->assertEquals($expectedViewInput, $result, 'RestViewInput not created correctly.');
+    }
+
+    /**
+     * @expectedException \eZ\Publish\Core\REST\Common\Exceptions\Parser
+     */
+    public function testThrowsExceptionOnMissingIdentifier()
+    {
+        $inputArray = ['Query' => []];
+        $this->getParser()->parse($inputArray, $this->getParsingDispatcherMock());
+    }
+
+    /**
+     * @expectedException \eZ\Publish\Core\REST\Common\Exceptions\Parser
+     */
+    public function testThrowsExceptionOnMissingQuery()
+    {
+        $inputArray = ['identifier' => 'foo'];
+        $this->getParser()->parse($inputArray, $this->getParsingDispatcherMock());
+    }
+
+    /**
+     * Returns the session input parser.
+     *
+     * @return \eZ\Publish\Core\REST\Server\Input\Parser\ViewInput
+     */
+    protected function internalGetParser()
+    {
+        return new ViewInput();
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestExecutedViewTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestExecutedViewTest.php
@@ -10,16 +10,19 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\Repository\Values\Content;
 use eZ\Publish\Core\REST\Server\Values\RestExecutedView;
+use eZ\Publish\Core\Repository\Values\Content as ApiValues;
 
 class RestExecutedViewTest extends ValueObjectVisitorBaseTest
 {
     /**
-     * Test the RestRelation visitor.
+     * Test the RestExecutedView visitor.
      *
      * @return \DOMDocument
      */
@@ -33,17 +36,22 @@ class RestExecutedViewTest extends ValueObjectVisitorBaseTest
         $view = new RestExecutedView(
             array(
                 'identifier' => 'test_view',
-                'searchResults' => new SearchResult(),
+                'searchResults' => new SearchResult([
+                    'searchHits' => [
+                        $this->buildContentSearchHit(),
+                        $this->buildLocationSearchHit(),
+                    ],
+                ]),
             )
         );
 
         $this->addRouteExpectation(
-            'ezpublish_rest_getView',
+            'ezpublish_rest_views_load',
             array('viewId' => $view->identifier),
             "/content/views/{$view->identifier}"
         );
         $this->addRouteExpectation(
-            'ezpublish_rest_loadViewResults',
+            'ezpublish_rest_views_load_results',
             array('viewId' => $view->identifier),
             "/content/views/{$view->identifier}/results"
         );
@@ -128,5 +136,25 @@ class RestExecutedViewTest extends ValueObjectVisitorBaseTest
     public function getContentTypeServiceMock()
     {
         return $this->getMock('eZ\\Publish\\API\\Repository\\ContentTypeService');
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchHit
+     */
+    protected function buildContentSearchHit()
+    {
+        return new SearchHit([
+            'valueObject' => new ApiValues\Content([
+                'versionInfo' => new Content\VersionInfo(['contentInfo' => new ContentInfo()]),
+            ]),
+        ]);
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchHit
+     */
+    protected function buildLocationSearchHit()
+    {
+        return new SearchHit(['valueObject' => new ApiValues\Location()]);
     }
 }

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RootTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RootTest.php
@@ -81,7 +81,7 @@ class RootTest extends ValueObjectVisitorBaseTest
         );
         $this->addRouteExpectation('ezpublish_rest_loadTrashItems', array(), '/content/trash');
         $this->addRouteExpectation('ezpublish_rest_listSections', array(), '/content/sections');
-        $this->addRouteExpectation('ezpublish_rest_createView', array(), '/content/views');
+        $this->addRouteExpectation('ezpublish_rest_views_create', array(), '/views');
         $this->addRouteExpectation('ezpublish_rest_loadObjectStateGroups', array(), '/content/objectstategroups');
         $this->addTemplatedRouteExpectation(
             'ezpublish_rest_loadObjectStates',
@@ -675,7 +675,7 @@ class RootTest extends ValueObjectVisitorBaseTest
                 'tag' => 'views',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.RefList+xml',
-                    'href' => '/content/views',
+                    'href' => '/views',
                 ),
             ),
             $result,


### PR DESCRIPTION
> Implements https://jira.ez.no/browse/EZP-24671
> Status: ready for review

Adds handling of versions in Input parsing dispatcher. The input_parser service tag has an optional 'version' attribute. 

The ViewInput input parser has two classes, one for 1.0, one for 1.1. The one for 1.0 is the one used until now. The other one accepts either LocationQuery and ContentQuery.

The OutputVisitor for an ExecutedView has been modified to accept Content, Location or ContentInfo. ContentInfo search isn't implemented yet (see Controller method).

## TODO
- [x] Merge matching specification changes
- [x] Update unit tests
- [x] Test the new features a bit (version)
- [x] Consider integrating ContentInfo search, but it could deserve a bit more thinking