### PR TITLE
Fix EZP-24691: Move scope change to event so legacy-bridge can build …

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Console/Application.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Console/Application.php
@@ -10,14 +10,10 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Console;
 
-use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
-use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
-use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application as BaseApplication;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * eZ Publish console application.
@@ -25,35 +21,11 @@ use Symfony\Component\Console\Input\InputOption;
  */
 class Application extends BaseApplication
 {
-    /**
-     * @var string
-     */
-    private $siteAccessName;
-
     public function __construct(KernelInterface $kernel)
     {
         parent::__construct($kernel);
         $this->getDefinition()->addOption(
             new InputOption('--siteaccess', null, InputOption::VALUE_OPTIONAL, 'SiteAccess to use for operations. If not provided, default siteaccess will be used')
         );
-    }
-
-    public function doRun(InputInterface $input, OutputInterface $output)
-    {
-        $this->siteAccessName = $input->getParameterOption('--siteaccess', null);
-
-        return parent::doRun($input, $output);
-    }
-
-    protected function registerCommands()
-    {
-        parent::registerCommands();
-
-        $container = $this->getKernel()->getContainer();
-        $siteAccess = $container->get('ezpublish.siteaccess');
-        $siteAccess->name = $this->siteAccessName ?: $container->getParameter('ezpublish.siteaccess.default');
-        $siteAccess->matchingType = 'cli';
-        $eventDispatcher = $container->get('event_dispatcher');
-        $eventDispatcher->dispatch(MVCEvents::CONFIG_SCOPE_CHANGE, new ScopeChangeEvent($siteAccess));
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ConsoleCommandListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ConsoleCommandListener.php
@@ -16,7 +16,6 @@ use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
-use Symfony\Component\DependencyInjection\ContainerAware;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ConsoleCommandListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ConsoleCommandListener.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * File containing the ConsoleCommandListener class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\EventListener;
+
+use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
+use eZ\Publish\Core\MVC\Symfony\MVCEvents;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * ConsoleCommandListener match listener.
+ */
+class ConsoleCommandListener extends ContainerAware implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            ConsoleEvents::COMMAND => [
+                ['onConsoleCommand', -1],
+            ],
+        ];
+    }
+
+    public function onConsoleCommand(ConsoleCommandEvent $event)
+    {
+        $siteAccessName = $event->getInput()->getParameterOption('--siteaccess', null);
+
+        $siteAccess = $this->container->get('ezpublish.siteaccess');
+        $siteAccess->name = $siteAccessName ?: $this->container->getParameter('ezpublish.siteaccess.default');
+        $siteAccess->matchingType = 'cli';
+
+        $eventDispatcher = $this->container->get('event_dispatcher');
+        $eventDispatcher->dispatch(MVCEvents::CONFIG_SCOPE_CHANGE, new ScopeChangeEvent($siteAccess));
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -59,8 +59,9 @@ services:
 
     ezpublish.console_event_listener:
         class: %ezpublish.console_event_listener.class%
+        arguments: [%ezpublish.siteaccess.default.name%, @event_dispatcher]
         calls:
-            - [setContainer, [@service_container]]
+            - [setSiteAccess, [@ezpublish.siteaccess]]
         tags:
             - { name: kernel.event_subscriber }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -6,6 +6,7 @@ parameters:
     ezpublish.config.default_scope: ezsettings
     ezpublish.config.dynamic_setting.parser.class: eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\DynamicSettingParser
     ezpublish.config.complex_setting_value.resolver.class: eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ComplexSettings\ComplexSettingValueResolver
+    ezpublish.console_event_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\ConsoleCommandListener
     ezpublish.controller.base.class: eZ\Publish\Core\MVC\Symfony\Controller\Controller
     ezpublish.controller.content.view.class: eZ\Publish\Core\MVC\Symfony\Controller\Content\ViewController
     ezpublish.controller.content.preview.class: eZ\Publish\Core\MVC\Symfony\Controller\Content\PreviewController
@@ -55,6 +56,13 @@ services:
 
     ezpublish.config.complex_setting_value.resolver:
         class: %ezpublish.config.complex_setting_value.resolver.class%
+
+    ezpublish.console_event_listener:
+        class: %ezpublish.console_event_listener.class%
+        calls:
+            - [setContainer, [@service_container]]
+        tags:
+            - { name: kernel.event_subscriber }
 
     ezpublish.controller.base:
         class: %ezpublish.controller.base.class%


### PR DESCRIPTION
…the correct cli kernel

Moving setting the siteaccess and performing scope change to an ConsoleEvents::COMMAND listener will allow legacy bundle to inject the correct legacy kernel handler.

Goes together with https://github.com/ezsystems/LegacyBridge/pull/31