### PR TITLE
[WIP] Fix EZP-24685: Role UI (list, view, CRUD)

### DIFF
--- a/eZ/Publish/API/Repository/Values/User/Limitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation.php
@@ -54,4 +54,13 @@ abstract class Limitation extends ValueObject
      * @var mixed[]
      */
     public $limitationValues = array();
+
+    /**
+     * A hash of human readable limitations, using IDs or identifiers as keys.
+     *
+     * @readonly
+     *
+     * @return mixed[]
+     */
+    abstract public function limitationValuesAsText();
 }

--- a/eZ/Publish/API/Repository/Values/User/Limitation/ContentTypeLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/ContentTypeLimitation.php
@@ -23,4 +23,16 @@ class ContentTypeLimitation extends Limitation
     {
         return Limitation::CONTENTTYPE;
     }
+
+    /**
+     * A hash of human readable limitations, using IDs or identifiers as keys.
+     *
+     * @readonly
+     *
+     * @return mixed[]
+     */
+    public function limitationValuesAsText()
+    {
+        return $this->limitationValues; // TODO: load content type names
+    }
 }

--- a/eZ/Publish/API/Repository/Values/User/Limitation/SectionLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/SectionLimitation.php
@@ -23,4 +23,16 @@ class SectionLimitation extends RoleLimitation
     {
         return Limitation::SECTION;
     }
+
+    /**
+     * A hash of human readable limitations, using IDs or identifiers as keys.
+     *
+     * @readonly
+     *
+     * @return mixed[]
+     */
+    public function limitationValuesAsText()
+    {
+        return $this->limitationValues; // TODO: load section names
+    }
 }

--- a/eZ/Publish/API/Repository/Values/User/Limitation/SiteAccessLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/SiteAccessLimitation.php
@@ -23,4 +23,16 @@ class SiteAccessLimitation extends Limitation
     {
         return Limitation::SITEACCESS;
     }
+
+    /**
+     * A hash of human readable limitations, using IDs or identifiers as keys.
+     *
+     * @readonly
+     *
+     * @return mixed[]
+     */
+    public function limitationValuesAsText()
+    {
+        return $this->limitationValues; // TODO: load site access names
+    }
 }

--- a/eZ/Publish/API/Repository/Values/User/RoleAssignment.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleAssignment.php
@@ -33,4 +33,11 @@ abstract class RoleAssignment extends ValueObject
      * @return \eZ\Publish\API\Repository\Values\User\Role
      */
     abstract public function getRole();
+
+    /**
+     * Returns the type of role assignment: user or usergroup.
+     *
+     * @return string
+     */
+    abstract public function getType();
 }

--- a/eZ/Publish/Core/Repository/Values/User/UserGroupRoleAssignment.php
+++ b/eZ/Publish/Core/Repository/Values/User/UserGroupRoleAssignment.php
@@ -67,4 +67,14 @@ class UserGroupRoleAssignment extends APIUserGroupRoleAssignment
     {
         return $this->userGroup;
     }
+
+    /**
+     * Returns the type of role assignment: user or usergroup.
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return 'usergroup';
+    }
 }

--- a/eZ/Publish/Core/Repository/Values/User/UserRoleAssignment.php
+++ b/eZ/Publish/Core/Repository/Values/User/UserRoleAssignment.php
@@ -67,4 +67,14 @@ class UserRoleAssignment extends APIUserRoleAssignment
     {
         return $this->user;
     }
+
+    /**
+     * Returns the type of role assignment: user or usergroup.
+     *
+     * @return string
+     */
+    public function getType()
+    {
+        return 'user';
+    }
 }


### PR DESCRIPTION
Adds Limitation::limitationValuesAsText() and RoleAssignment::getType(), needed for Role UI. Incomplete, done to illustrate approach.

Required by Role UI https://github.com/ezsystems/PlatformUIBundle/pull/294 in order to
- Show human readable limitaton values (section names, etc). Legacy solution is https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/classes/ezpolicylimitation.php#L200
- show human readable user/usergroup names in role assignments

https://jira.ez.no/browse/EZP-24685