### PR TITLE
Fix EZP-24698: Role update leads to NotFoundException

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
@@ -93,7 +93,7 @@ abstract class Gateway
     /**
      * Update role.
      *
-     * @throws \eZ\Publish\Core\Base\Exceptions\NotFoundException
+     * Will not throw anything if location id is invalid.
      *
      * @param RoleUpdateStruct $role
      */

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
@@ -15,7 +15,6 @@ use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\SPI\Persistence\User\Policy;
 use eZ\Publish\SPI\Persistence\User\RoleUpdateStruct;
 use eZ\Publish\SPI\Persistence\User\Role;
-use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 
 /**
  * User Role gateway implementation using the Doctrine database.
@@ -456,7 +455,7 @@ class DoctrineDatabase extends Gateway
     /**
      * Update role.
      *
-     * @throws \eZ\Publish\Core\Base\Exceptions\NotFoundException
+     * Will not throw anything if location id is invalid.
      *
      * @param \eZ\Publish\SPI\Persistence\User\RoleUpdateStruct $role
      */
@@ -477,9 +476,11 @@ class DoctrineDatabase extends Gateway
         $statement = $query->prepare();
         $statement->execute();
 
-        if ($statement->rowCount() < 1) {
+        // Commented due to EZP-24698: Role update leads to NotFoundException
+        // Should be fixed with PDO::MYSQL_ATTR_FOUND_ROWS instead
+        /*if ($statement->rowCount() < 1) {
             throw new NotFoundException('role', $role->id);
-        }
+        }*/
     }
 
     /**


### PR DESCRIPTION
The role updating code in the Doctrine layer tries to read the row count after doing the update query. Updates have no result rows, so it always fails with a NotFoundException. Fix is simple: Don't do it. (Verified by comparing with content type code.)

https://jira.ez.no/browse/EZP-24698