### PR TITLE
EZP-24704: Solr: Implement native result extractor

### DIFF
--- a/eZ/Publish/Core/Search/Common/Slot/AbstractSubtree.php
+++ b/eZ/Publish/Core/Search/Common/Slot/AbstractSubtree.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\Search\Common\Slot;
+
+use eZ\Publish\Core\Search\Common\Slot;
+
+/**
+ * A base Search Engine slot providing indexing of the subtree.
+ */
+abstract class AbstractSubtree extends Slot
+{
+    protected function indexSubtree($locationId)
+    {
+        $contentHandler = $this->persistenceHandler->contentHandler();
+        $locationHandler = $this->persistenceHandler->locationHandler();
+
+        $processedContentIdSet = array();
+        $subtreeIds = $locationHandler->loadSubtreeIds($locationId);
+
+        foreach ($subtreeIds as $locationId => $contentId) {
+            $this->searchHandler->indexLocation(
+                $locationHandler->load($locationId)
+            );
+
+            if (isset($processedContentIdSet[$contentId])) {
+                continue;
+            }
+
+            $this->searchHandler->indexContent(
+                $contentHandler->load(
+                    $contentId,
+                    $contentHandler->loadContentInfo($contentId)->currentVersionNo
+                )
+            );
+
+            // Content could be found in multiple Locations of the subtree,
+            // but we need to (re)index it only once
+            $processedContentIdSet[$contentId] = true;
+        }
+    }
+}

--- a/eZ/Publish/Core/Search/Common/Slot/HideLocation.php
+++ b/eZ/Publish/Core/Search/Common/Slot/HideLocation.php
@@ -16,7 +16,7 @@ use eZ\Publish\Core\Search\Common\Slot;
 /**
  * A Search Engine slot handling HideLocationSignal.
  */
-class HideLocation extends Slot
+class HideLocation extends AbstractSubtree
 {
     /**
      * Receive the given $signal and react on it.
@@ -29,15 +29,6 @@ class HideLocation extends Slot
             return;
         }
 
-        $this->searchHandler->indexContent(
-            $this->persistenceHandler->contentHandler()->load(
-                $signal->contentId,
-                $signal->currentVersionNo
-            )
-        );
-
-        $this->searchHandler->indexLocation(
-            $this->persistenceHandler->locationHandler()->load($signal->locationId)
-        );
+        $this->indexSubtree($signal->locationId);
     }
 }

--- a/eZ/Publish/Core/Search/Common/Slot/MoveSubtree.php
+++ b/eZ/Publish/Core/Search/Common/Slot/MoveSubtree.php
@@ -16,7 +16,7 @@ use eZ\Publish\Core\Search\Common\Slot;
 /**
  * A Search Engine slot handling MoveSubtreeSignal.
  */
-class MoveSubtree extends Slot
+class MoveSubtree extends AbstractSubtree
 {
     /**
      * Receive the given $signal and react on it.
@@ -30,35 +30,5 @@ class MoveSubtree extends Slot
         }
 
         $this->indexSubtree($signal->locationId);
-    }
-
-    protected function indexSubtree($locationId)
-    {
-        $contentHandler = $this->persistenceHandler->contentHandler();
-        $locationHandler = $this->persistenceHandler->locationHandler();
-
-        $processedContentIdSet = array();
-        $subtreeIds = $locationHandler->loadSubtreeIds($locationId);
-
-        foreach ($subtreeIds as $locationId => $contentId) {
-            $this->searchHandler->indexLocation(
-                $locationHandler->load($locationId)
-            );
-
-            if (isset($processedContentIdSet[$contentId])) {
-                continue;
-            }
-
-            $this->searchHandler->indexContent(
-                $contentHandler->load(
-                    $contentId,
-                    $contentHandler->loadContentInfo($contentId)->currentVersionNo
-                )
-            );
-
-            // Content could be found in multiple Locations of the subtree,
-            // but we need to (re)index it only once
-            $processedContentIdSet[$contentId] = true;
-        }
     }
 }

--- a/eZ/Publish/Core/Search/Common/Slot/MoveUserGroup.php
+++ b/eZ/Publish/Core/Search/Common/Slot/MoveUserGroup.php
@@ -16,7 +16,7 @@ use eZ\Publish\Core\Search\Common\Slot;
 /**
  * A Search Engine slot handling MoveUserGroupSignal.
  */
-class MoveUserGroup extends MoveSubtree
+class MoveUserGroup extends AbstractSubtree
 {
     /**
      * Receive the given $signal and react on it.

--- a/eZ/Publish/Core/Search/Common/Slot/UnhideLocation.php
+++ b/eZ/Publish/Core/Search/Common/Slot/UnhideLocation.php
@@ -16,7 +16,7 @@ use eZ\Publish\Core\Search\Common\Slot;
 /**
  * A Search Engine slot handling UnhideLocationSignal.
  */
-class UnhideLocation extends Slot
+class UnhideLocation extends AbstractSubtree
 {
     /**
      * Receive the given $signal and react on it.
@@ -29,15 +29,6 @@ class UnhideLocation extends Slot
             return;
         }
 
-        $this->searchHandler->indexContent(
-            $this->persistenceHandler->contentHandler()->load(
-                $signal->contentId,
-                $signal->currentVersionNo
-            )
-        );
-
-        $this->searchHandler->indexLocation(
-            $this->persistenceHandler->locationHandler()->load($signal->locationId)
-        );
+        $this->indexSubtree($signal->locationId);
     }
 }


### PR DESCRIPTION
> ##### This PR resolves https://jira.ez.no/browse/EZP-24704
> ##### Review together with https://github.com/ezsystems/ezplatform-solr-search-engine/pull/10

`HideLocation` and `UnhideLocation` search engine slots are fixed so that the whole subtree is reindexed. Reindexing everything is a bit of an overkill, since it should not be required to reindex sub-subtrees where the root Location is already hidden.

That behavior should be revisited in the future, and is maybe another argument in favor of internal storage-based simplified search engine, which would here enable much simpler loading of data for reindexing.