### PR TITLE
Renamed SearchHit::$contentTranslation to $matchedTranslation

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php
@@ -1663,7 +1663,7 @@ class SearchServiceLocationTest extends BaseTest
             $property->setAccessible(true);
             $property->setValue($hit, null);
 
-            $property = new \ReflectionProperty(get_class($hit), 'contentTranslation');
+            $property = new \ReflectionProperty(get_class($hit), 'matchedTranslation');
             $property->setAccessible(true);
             $property->setValue($hit, null);
         }

--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -4479,7 +4479,7 @@ class SearchServiceTest extends BaseTest
             $property->setAccessible(true);
             $property->setValue($hit, null);
 
-            $property = new \ReflectionProperty(get_class($hit), 'contentTranslation');
+            $property = new \ReflectionProperty(get_class($hit), 'matchedTranslation');
             $property->setAccessible(true);
             $property->setValue($hit, null);
         }

--- a/eZ/Publish/API/Repository/Tests/SearchServiceTranslationLanguageFallbackTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTranslationLanguageFallbackTest.php
@@ -1454,7 +1454,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
             );
             $this->assertEquals(
                 $translationLanguageCode,
-                $searchResult->searchHits[$index]->contentTranslation
+                $searchResult->searchHits[$index]->matchedTranslation
             );
         }
     }
@@ -1510,7 +1510,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
             );
             $this->assertEquals(
                 $translationLanguageCode,
-                $searchResult->searchHits[$index]->contentTranslation
+                $searchResult->searchHits[$index]->matchedTranslation
             );
         }
     }
@@ -1562,7 +1562,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
             );
             $this->assertEquals(
                 $translationLanguageCode,
-                $searchResult->searchHits[$index]->contentTranslation
+                $searchResult->searchHits[$index]->matchedTranslation
             );
         }
 
@@ -1582,7 +1582,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
             );
             $this->assertEquals(
                 $translationLanguageCode,
-                $searchResult->searchHits[$realIndex]->contentTranslation
+                $searchResult->searchHits[$realIndex]->matchedTranslation
             );
         }
     }

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/CustomFieldBetween.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Elasticsearch/CustomFieldBetween.php
@@ -15,7 +15,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
       ),
        'score' => 1,
        'index' => null,
-       'contentTranslation' => null,
+       'matchedTranslation' => null,
        'highlight' => null,
     )),
     1 =>
@@ -27,7 +27,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
       ),
        'score' => 1,
        'index' => null,
-       'contentTranslation' => null,
+       'matchedTranslation' => null,
        'highlight' => null,
     )),
     2 =>
@@ -39,7 +39,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
       ),
        'score' => 1,
        'index' => null,
-       'contentTranslation' => null,
+       'matchedTranslation' => null,
        'highlight' => null,
     )),
     3 =>
@@ -51,7 +51,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
       ),
        'score' => 1,
        'index' => null,
-       'contentTranslation' => null,
+       'matchedTranslation' => null,
        'highlight' => null,
     )),
   ),

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/CustomFieldBetween.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/CustomFieldBetween.php
@@ -15,7 +15,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
       ),
        'score' => 1,
        'index' => null,
-       'contentTranslation' => null,
+       'matchedTranslation' => null,
        'highlight' => null,
     )),
     1 =>
@@ -27,7 +27,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
       ),
        'score' => 1,
        'index' => null,
-       'contentTranslation' => null,
+       'matchedTranslation' => null,
        'highlight' => null,
     )),
     2 =>
@@ -39,7 +39,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
       ),
        'score' => 1,
        'index' => null,
-       'contentTranslation' => null,
+       'matchedTranslation' => null,
        'highlight' => null,
     )),
     3 =>
@@ -51,7 +51,7 @@ return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state
       ),
        'score' => 1,
        'index' => null,
-       'contentTranslation' => null,
+       'matchedTranslation' => null,
        'highlight' => null,
     )),
   ),

--- a/eZ/Publish/API/Repository/Values/Content/Search/SearchHit.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/SearchHit.php
@@ -43,7 +43,7 @@ class SearchHit extends ValueObject
      *
      * @var string
      */
-    public $contentTranslation;
+    public $matchedTranslation;
 
     /**
      * A representation of the search hit including highlighted terms.


### PR DESCRIPTION
Review together with https://github.com/ezsystems/ezplatform-solr-search-engine/pull/12

One of the remaining points from the workshop.

Initially the idea was for this to be plural (an array of strings), containing the array of matched language codes. Since we can't achieve that ATM the property is kept as string.