### PR TITLE
Implement commit() instead of setCommit()

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -4365,6 +4365,8 @@ class ContentServiceTest extends BaseContentServiceTest
             throw $e;
         }
 
+        $this->refreshSearch($repository);
+
         // This will contain the admin user and the new child location
         $locations = $locationService->loadLocationChildren(
             $locationService->loadLocation($locationId)

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
@@ -249,7 +249,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
 
         $contentType = $this->testCreateContentType();
 
-        return array(
+        $context = array(
             $repository,
             $this->createTestSearchContent(
                 $this->getValidSearchValueOne(),
@@ -262,6 +262,10 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
                 $contentType
             )->id,
         );
+
+        $this->refreshSearch($repository);
+
+        return $context;
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchMultivaluedBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchMultivaluedBaseIntegrationTest.php
@@ -141,7 +141,7 @@ abstract class SearchMultivaluedBaseIntegrationTest extends SearchBaseIntegratio
 
         $contentType = $this->testCreateContentType();
 
-        return array(
+        $context = array(
             $repository,
             $this->createTestSearchContent(
                 $this->getValidMultivaluedSearchValuesOne(),
@@ -154,6 +154,10 @@ abstract class SearchMultivaluedBaseIntegrationTest extends SearchBaseIntegratio
                 $contentType
             )->id,
         );
+
+        $this->refreshSearch($repository);
+
+        return $context;
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/LocationServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceAuthorizationTest.php
@@ -360,6 +360,8 @@ class LocationServiceAuthorizationTest extends BaseTest
         // Set current user to newly created user again, and try to delete $firstLocation
         $repository->setCurrentUser($user);
 
+        $this->refreshSearch($repository);
+
         // This call will fail with an "UnauthorizedException" because user does not have
         // permission to delete $secondLocation which is in the subtree of the $firstLocation
         $locationService->deleteLocation($firstLocation);

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -1054,6 +1054,9 @@ class LocationServiceTest extends BaseTest
                 $hiddenLocation->id
             )
         );
+
+        $this->refreshSearch($repository);
+
         foreach ($locationService->loadLocationChildren($hiddenLocation)->locations as $child) {
             $this->assertSubtreeProperties(
                 array('invisible' => true),
@@ -1122,6 +1125,9 @@ class LocationServiceTest extends BaseTest
                 $unHiddenLocation->id
             )
         );
+
+        $this->refreshSearch($repository);
+
         foreach ($locationService->loadLocationChildren($unHiddenLocation)->locations as $child) {
             $this->assertSubtreeProperties(
                 array('invisible' => false),
@@ -1168,6 +1174,9 @@ class LocationServiceTest extends BaseTest
                 $unHiddenHigherLocation->id
             )
         );
+
+        $this->refreshSearch($repository);
+
         foreach ($locationService->loadLocationChildren($unHiddenHigherLocation)->locations as $child) {
             $this->assertSubtreeProperties(
                 array('invisible' => false),
@@ -1271,6 +1280,8 @@ class LocationServiceTest extends BaseTest
 
         // Delete the user group location
         $locationService->deleteLocation($location);
+
+        $this->refreshSearch($repository);
 
         // Reload parent location
         $parentLocation = $locationService->loadLocation(
@@ -1452,6 +1463,8 @@ class LocationServiceTest extends BaseTest
             $beforeIds[] = $properties['id'];
         }
 
+        $this->refreshSearch($repository);
+
         // Load Subtree properties after copy
         $actual = $this->loadSubtreeProperties($copiedLocation);
 
@@ -1507,6 +1520,8 @@ class LocationServiceTest extends BaseTest
             $newParentLocation
         );
         /* END: Use Case */
+
+        $this->refreshSearch($repository);
 
         $childCountAfter = $locationService->getLocationChildCount($locationService->loadLocation($demoDesignLocationId));
 
@@ -1649,6 +1664,8 @@ class LocationServiceTest extends BaseTest
         $movedLocation = $locationService->loadLocation($mediaLocationId);
         /* END: Use Case */
 
+        $this->refreshSearch($repository);
+
         // Load Subtree properties after move
         $actual = $this->loadSubtreeProperties($movedLocation);
 
@@ -1702,6 +1719,8 @@ class LocationServiceTest extends BaseTest
         // Reload new parent location
         $newParentLocation = $locationService->loadLocation($demoDesignLocationId);
         /* END: Use Case */
+
+        $this->refreshSearch($repository);
 
         // Load Subtree properties after move
         $actual = $this->loadLocationProperties($newParentLocation);
@@ -1758,6 +1777,8 @@ class LocationServiceTest extends BaseTest
         // Reload old parent location
         $oldParentLocation = $locationService->loadLocation($oldParentLocationId);
         /* END: Use Case */
+
+        $this->refreshSearch($repository);
 
         // Load Subtree properties after move
         $actual = $this->loadLocationProperties($oldParentLocation);

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP20018LanguageTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP20018LanguageTest.php
@@ -56,6 +56,8 @@ class EZP20018LanguageTest extends BaseTest
         $contentService->publishVersion(
             $draft->getVersionInfo()
         );
+
+        $this->refreshSearch($repository);
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP20018ObjectStateTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP20018ObjectStateTest.php
@@ -26,23 +26,27 @@ class EZP20018ObjectStateTest extends BaseTest
      */
     public function testSearchForNonUsedObjectState()
     {
+        $repository = $this->getRepository();
+
         $query = new Query();
         $query->filter = new ObjectStateId(2);
-        $results1 = $this->getRepository()->getSearchService()->findContent($query);
+        $results1 = $repository->getSearchService()->findContent($query);
 
         $this->assertEquals(0, $results1->totalCount);
         $this->assertCount(0, $results1->searchHits);
 
         // Assign and make sure it updates
-        $stateService = $this->getRepository()->getObjectStateService();
+        $stateService = $repository->getObjectStateService();
 
         $stateService->setContentState(
-            $this->getRepository()->getContentService()->loadContentInfo(52),
+            $repository->getContentService()->loadContentInfo(52),
             $stateService->loadObjectStateGroup(2),
             $stateService->loadObjectState(2)
         );
 
-        $results2 = $this->getRepository()->getSearchService()->findContent($query);
+        $this->refreshSearch($repository);
+
+        $results2 = $repository->getSearchService()->findContent($query);
 
         $this->assertEquals(1, $results2->totalCount);
         $this->assertCount($results2->totalCount, $results2->searchHits);
@@ -53,24 +57,28 @@ class EZP20018ObjectStateTest extends BaseTest
      */
     public function testSearchForUsedObjectState()
     {
+        $repository = $this->getRepository();
+
         $query = new Query();
         $query->filter = new ObjectStateId(1);
         $query->limit = 50;
-        $results1 = $this->getRepository()->getSearchService()->findContent($query);
+        $results1 = $repository->getSearchService()->findContent($query);
 
         $this->assertEquals(18, $results1->totalCount);
         $this->assertEquals($results1->totalCount, count($results1->searchHits));
 
         // Assign and make sure it updates
-        $stateService = $this->getRepository()->getObjectStateService();
+        $stateService = $repository->getObjectStateService();
 
         $stateService->setContentState(
-            $this->getRepository()->getContentService()->loadContentInfo(52),
+            $repository->getContentService()->loadContentInfo(52),
             $stateService->loadObjectStateGroup(2),
             $stateService->loadObjectState(2)
         );
 
-        $results2 = $this->getRepository()->getSearchService()->findContent($query);
+        $this->refreshSearch($repository);
+
+        $results2 = $repository->getSearchService()->findContent($query);
 
         $this->assertEquals(17, $results2->totalCount);
         $this->assertCount($results2->totalCount, $results2->searchHits);

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP20018VisibilityTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP20018VisibilityTest.php
@@ -26,19 +26,23 @@ class EZP20018VisibilityTest extends BaseTest
      */
     public function testSearchForHiddenContent()
     {
+        $repository = $this->getRepository();
+
         $query = new Query();
         $query->filter = new Visibility(Visibility::HIDDEN);
-        $results1 = $this->getRepository()->getSearchService()->findContent($query);
+        $results1 = $repository->getSearchService()->findContent($query);
 
         $this->assertEquals(0, $results1->totalCount);
         $this->assertCount(0, $results1->searchHits);
 
          // Hide "Images" Folder
-        $locationService = $this->getRepository()->getLocationService();
+        $locationService = $repository->getLocationService();
         $locationService->hideLocation($locationService->loadLocation(54));
 
+        $this->refreshSearch($repository);
+
         // Assert updated values
-        $results2 = $this->getRepository()->getSearchService()->findContent($query);
+        $results2 = $repository->getSearchService()->findContent($query);
 
         $this->assertEquals(1, $results2->totalCount);
         $this->assertCount(1, $results2->searchHits);
@@ -49,20 +53,24 @@ class EZP20018VisibilityTest extends BaseTest
      */
     public function testSearchForVisibleContent()
     {
+        $repository = $this->getRepository();
+
         $query = new Query();
         $query->filter = new Visibility(Visibility::VISIBLE);
         $query->limit = 50;
-        $results1 = $this->getRepository()->getSearchService()->findContent($query);
+        $results1 = $repository->getSearchService()->findContent($query);
 
         $this->assertEquals(18, $results1->totalCount);
         $this->assertEquals($results1->totalCount, count($results1->searchHits));
 
          // Hide "Images" Folder
-        $locationService = $this->getRepository()->getLocationService();
+        $locationService = $repository->getLocationService();
         $locationService->hideLocation($locationService->loadLocation(54));
 
+        $this->refreshSearch($repository);
+
         // Assert updated values
-        $results2 = $this->getRepository()->getSearchService()->findContent($query);
+        $results2 = $repository->getSearchService()->findContent($query);
 
         $this->assertEquals($results1->totalCount - 1, $results2->totalCount);
         $this->assertEquals($results2->totalCount, count($results2->searchHits));

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP21069Test.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP21069Test.php
@@ -83,6 +83,8 @@ class EZP21069Test extends BaseTest
             )->versionInfo,
             $contentDraftStruct
         );
+
+        $this->refreshSearch($repository);
     }
 
     public function testSearchOnPreviousAttributeContentGivesNoResult()

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP21906SearchOneContentMultipleLocationsTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP21906SearchOneContentMultipleLocationsTest.php
@@ -60,6 +60,8 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
         $locationService->createLocation($feedbackFormContentInfo, $locationCreateStruct1);
         $locationCreateStruct2 = $locationService->newLocationCreateStruct($locationsFolder2[0]->id);
         $locationService->createLocation($feedbackFormContentInfo, $locationCreateStruct2);
+
+        $this->refreshSearch($repository);
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php
@@ -84,6 +84,8 @@ class SearchServiceLocationTest extends BaseTest
         $draft = $contentService->createContent($createStruct, array($locationCreateStruct));
         $content = $contentService->publishVersion($draft->getVersionInfo());
 
+        $this->refreshSearch($repository);
+
         return $content;
     }
 
@@ -968,6 +970,8 @@ class SearchServiceLocationTest extends BaseTest
         $draft = $contentService->createContent($createStruct, array($locationCreateStruct));
         $tree = $contentService->publishVersion($draft->getVersionInfo());
 
+        $this->refreshSearch($repository);
+
         $query = new LocationQuery(
             array(
                 'filter' => new Criterion\LogicalAnd(
@@ -1046,6 +1050,8 @@ class SearchServiceLocationTest extends BaseTest
 
         $draft = $contentService->createContent($createStruct, array($locationCreateStruct));
         $tree = $contentService->publishVersion($draft->getVersionInfo());
+
+        $this->refreshSearch($repository);
 
         $query = new LocationQuery(
             array(
@@ -1142,6 +1148,8 @@ class SearchServiceLocationTest extends BaseTest
         $draft = $contentService->createContent($createStruct, array($locationCreateStruct));
         $mushrooms = $contentService->publishVersion($draft->getVersionInfo());
 
+        $this->refreshSearch($repository);
+
         $query = new LocationQuery(
             array(
                 'filter' => new Criterion\LogicalAnd(
@@ -1236,6 +1244,8 @@ class SearchServiceLocationTest extends BaseTest
 
         $draft = $contentService->createContent($createStruct, array($locationCreateStruct));
         $mushrooms = $contentService->publishVersion($draft->getVersionInfo());
+
+        $this->refreshSearch($repository);
 
         $wellInVodice = array(
             'latitude' => 43.756825,
@@ -1353,6 +1363,8 @@ class SearchServiceLocationTest extends BaseTest
         $draft = $contentService->createContent($createStruct, array($locationCreateStruct));
         $mushrooms = $contentService->publishVersion($draft->getVersionInfo());
 
+        $this->refreshSearch($repository);
+
         $well = array(
             'latitude' => 43.756825,
             'longitude' => 15.775074,
@@ -1453,6 +1465,8 @@ class SearchServiceLocationTest extends BaseTest
         $draft = $contentService->createContent($createStruct, array($locationCreateStruct));
         $tree = $contentService->publishVersion($draft->getVersionInfo());
 
+        $this->refreshSearch($repository);
+
         $distanceCriterion = new Criterion\MapLocationDistance(
             'maplocation',
             Criterion\Operator::LTE,
@@ -1550,6 +1564,8 @@ class SearchServiceLocationTest extends BaseTest
 
         $draft = $contentService->createContent($createStruct, array($locationCreateStruct));
         $mushrooms = $contentService->publishVersion($draft->getVersionInfo());
+
+        $this->refreshSearch($repository);
 
         $well = array(
             'latitude' => 43.756825,

--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -1093,6 +1093,8 @@ class SearchServiceTest extends BaseTest
         $draft = $contentService->createContent($createStruct);
         $content = $contentService->publishVersion($draft->getVersionInfo());
 
+        $this->refreshSearch($repository);
+
         return $content;
     }
 
@@ -1688,6 +1690,8 @@ class SearchServiceTest extends BaseTest
 
         $draft = $contentService->createContent($createStruct);
         $content = $contentService->publishVersion($draft->getVersionInfo());
+
+        $this->refreshSearch($repository);
 
         return $content;
     }
@@ -2735,6 +2739,8 @@ class SearchServiceTest extends BaseTest
         $draft = $contentService->createContent($createStruct);
         $tree = $contentService->publishVersion($draft->getVersionInfo());
 
+        $this->refreshSearch($repository);
+
         $query = new Query(
             array(
                 'filter' => new Criterion\LogicalAnd(
@@ -2812,6 +2818,8 @@ class SearchServiceTest extends BaseTest
 
         $draft = $contentService->createContent($createStruct);
         $tree = $contentService->publishVersion($draft->getVersionInfo());
+
+        $this->refreshSearch($repository);
 
         $query = new Query(
             array(
@@ -2907,6 +2915,8 @@ class SearchServiceTest extends BaseTest
         $draft = $contentService->createContent($createStruct);
         $mushrooms = $contentService->publishVersion($draft->getVersionInfo());
 
+        $this->refreshSearch($repository);
+
         $query = new Query(
             array(
                 'filter' => new Criterion\LogicalAnd(
@@ -2976,6 +2986,8 @@ class SearchServiceTest extends BaseTest
 
         $draft = $contentService->createContent($createStruct);
         $polarBear = $contentService->publishVersion($draft->getVersionInfo());
+
+        $this->refreshSearch($repository);
 
         $query = new Query(
             array(
@@ -3070,6 +3082,8 @@ class SearchServiceTest extends BaseTest
 
         $draft = $contentService->createContent($createStruct);
         $mushrooms = $contentService->publishVersion($draft->getVersionInfo());
+
+        $this->refreshSearch($repository);
 
         $wellInVodice = array(
             'latitude' => 43.756825,
@@ -3186,6 +3200,8 @@ class SearchServiceTest extends BaseTest
         $draft = $contentService->createContent($createStruct);
         $mushrooms = $contentService->publishVersion($draft->getVersionInfo());
 
+        $this->refreshSearch($repository);
+
         $well = array(
             'latitude' => 43.756825,
             'longitude' => 15.775074,
@@ -3290,6 +3306,8 @@ class SearchServiceTest extends BaseTest
         $draft = $contentService->createContent($createStruct);
         $tree = $contentService->publishVersion($draft->getVersionInfo());
 
+        $this->refreshSearch($repository);
+
         $distanceCriterion = new Criterion\MapLocationDistance(
             'maplocation',
             Criterion\Operator::LTE,
@@ -3392,6 +3410,8 @@ class SearchServiceTest extends BaseTest
         $draft = $contentService->createContent($createStruct);
         $mushrooms = $contentService->publishVersion($draft->getVersionInfo());
 
+        $this->refreshSearch($repository);
+
         $well = array(
             'latitude' => 43.756825,
             'longitude' => 15.775074,
@@ -3466,6 +3486,8 @@ class SearchServiceTest extends BaseTest
             $locationService->newLocationCreateStruct($designLocationId)
         );
 
+        $this->refreshSearch($repository);
+
         $query = new LocationQuery(
             array(
                 'filter' => new Criterion\LogicalAnd(
@@ -3507,6 +3529,8 @@ class SearchServiceTest extends BaseTest
             $contentService->loadContentInfo($partnersContentId),
             $locationService->newLocationCreateStruct($designLocationId)
         );
+
+        $this->refreshSearch($repository);
 
         $query = new LocationQuery(
             array(
@@ -3551,6 +3575,8 @@ class SearchServiceTest extends BaseTest
             $locationService->newLocationCreateStruct($designLocationId)
         );
 
+        $this->refreshSearch($repository);
+
         $query = new LocationQuery(
             array(
                 'filter' => new Criterion\ParentLocationId($designLocationId),
@@ -3591,6 +3617,8 @@ class SearchServiceTest extends BaseTest
             $contentService->loadContentInfo($partnersContentId),
             $locationService->newLocationCreateStruct($designLocationId)
         );
+
+        $this->refreshSearch($repository);
 
         $query = new LocationQuery(
             array(
@@ -3638,6 +3666,8 @@ class SearchServiceTest extends BaseTest
         $location1 = $locationService->createLocation($content->contentInfo, $locationCreateStruct);
         $locationCreateStruct = $repository->getLocationService()->newLocationCreateStruct(5);
         $location2 = $locationService->createLocation($content->contentInfo, $locationCreateStruct);
+
+        $this->refreshSearch($repository);
 
         $query = new LocationQuery(
             array(
@@ -4033,6 +4063,8 @@ class SearchServiceTest extends BaseTest
         $draft = $contentService->createContent($createStruct, array($locationCreateStruct));
         $content = $contentService->publishVersion($draft->getVersionInfo());
         $contentTypeService->createContentTypeDraft($contentType);
+
+        $this->refreshSearch($repository);
 
         return $content;
     }

--- a/eZ/Publish/API/Repository/Tests/SearchServiceTranslationLanguageFallbackTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTranslationLanguageFallbackTest.php
@@ -153,7 +153,7 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
 
         $contentType = $this->createTestContentType();
 
-        return array(
+        $context = array(
             $repository,
             array(
                 1 => $this->createContent(
@@ -194,6 +194,10 @@ class SearchServiceTranslationLanguageFallbackTest extends BaseTest
                 ),
             ),
         );
+
+        $this->refreshSearch($repository);
+
+        return $context;
     }
 
     public function testCreateTestContent()

--- a/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
@@ -156,6 +156,8 @@ class TrashServiceTest extends BaseTrashServiceTest
 
         $this->createTrashItem();
 
+        $this->refreshSearch($repository);
+
         $this->assertEquals(
             $childCount - 1,
             $locationService->getLocationChildCount($location)
@@ -374,12 +376,16 @@ class TrashServiceTest extends BaseTrashServiceTest
 
         $trashItem = $this->createTrashItem();
 
+        $this->refreshSearch($repository);
+
         /* BEGIN: Use Case */
         $childCount = $locationService->getLocationChildCount($location);
 
         // Recover location with new location
         $trashService->recover($trashItem);
         /* END: Use Case */
+
+        $this->refreshSearch($repository);
 
         $this->assertEquals(
             $childCount + 1,
@@ -424,6 +430,8 @@ class TrashServiceTest extends BaseTrashServiceTest
         // Recover location with new location
         $trashService->recover($trashItem, $newParentLocation);
         /* END: Use Case */
+
+        $this->refreshSearch($repository);
 
         $this->assertEquals(
             $childCount + 1,

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -247,6 +247,8 @@ class UserServiceTest extends BaseTest
         /* BEGIN: Use Case */
         $this->createUserGroupVersion1();
 
+        $this->refreshSearch($repository);
+
         // This should be one greater than before
         $subGroupCount = $userService->loadUserGroup($mainGroupId)->subGroupCount;
         /* END: Use Case */
@@ -455,6 +457,8 @@ class UserServiceTest extends BaseTest
         // Reload the user group to get an updated $parentId
         $userGroup = $userService->loadUserGroup($userGroup->id);
 
+        $this->refreshSearch($repository);
+
         // The returned array will no contain $userGroup
         $subUserGroups = $userService->loadSubUserGroups(
             $membersUserGroup
@@ -495,6 +499,8 @@ class UserServiceTest extends BaseTest
 
         // Move user group from "Users" to "Members"
         $userService->moveUserGroup($userGroup, $membersUserGroup);
+
+        $this->refreshSearch($repository);
 
         // Reload the user group to get an updated $subGroupCount
         $membersUserGroupUpdated = $userService->loadUserGroup($membersGroupId);
@@ -1610,6 +1616,8 @@ class UserServiceTest extends BaseTest
 
         /* BEGIN: Use Case */
         $this->createUserVersion1();
+
+        $this->refreshSearch($repository);
 
         // This array will contain the email of the newly created "Editor" user
         $email = array();


### PR DESCRIPTION
Review together with https://github.com/ezsystems/ezplatform-solr-search-engine/pull/13

This adds call to the `SearchHandler::commit()` method for all tests that create or modify Content/Locations and require them to be available for search.

Since quite some non-search implementation uses search internally, this also exposes all of those, that is it exposes the places where asynchronous/delayed nature of indexing gets in the way of "optimal" behavior.

While I think this way of calling `SearchHandler::commit()` to make data available for tests is justified for `SearchService::find*` methods, the behavior is hard to explain on other places, like `LocationService::loadLocationChildren()`, `TrashService::recover()`, `UserService::moveUserGroup()` and others.

For these I propose implementing internal storage-based simplified search engine. This would be quite reachable since it would basically be a subset of current Legacy search engine. Not implementing support for language filters and field criteria and sort clauses would get us rid of most of the causes of bad performance and such engine would probably perform quite well.

Additionally it would be useful in indexing slots, where currently some reindexing is sub-optimal because we don't have a simple way to fetch correct data for reindexing (and can't use search implementation because of its async nature).