### PR TITLE
Fix EZP-24701: Role versioning

### DIFF
--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -1766,7 +1766,7 @@ CREATE TABLE `ezrole` (
   `name` varchar(255) NOT NULL DEFAULT '',
   `value` char(1) DEFAULT NULL,
   `version` int(11) DEFAULT '0',
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`,`version`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/data/updates/6.0/mysql.sql
+++ b/data/updates/6.0/mysql.sql
@@ -1,0 +1,10 @@
+--
+-- The `ezrole` table has changed. `version` has been added to the primary key, after the `id`. This is because role
+-- drafts are now handled differently. A draft now has the same `id` as the published role, and `version` decides which
+-- is which. You should make sure you don't have any role drafts in the database when upgrading. To find drafts, select
+-- entries in the `ezrole` table where `version` is not zero. Before this change, the `version` of a draft equals the
+-- `id` of the role. The safe way to get rid of stray role drafts is to edit the role in question, and then cancel
+-- editing.
+--
+
+ALTER TABLE ezrole DROP PRIMARY KEY, ADD PRIMARY KEY(id,version);

--- a/data/updates/6.0/postgres.sql
+++ b/data/updates/6.0/postgres.sql
@@ -1,0 +1,10 @@
+--
+-- The `ezrole` table has changed. `version` has been added to the primary key, after the `id`. This is because role
+-- drafts are now handled differently. A draft now has the same `id` as the published role, and `version` decides which
+-- is which. You should make sure you don't have any role drafts in the database when upgrading. To find drafts, select
+-- entries in the `ezrole` table where `version` is not zero. Before this change, the `version` of a draft equals the
+-- `id` of the role. The safe way to get rid of stray role drafts is to edit the role in question, and then cancel
+-- editing.
+--
+
+ALTER TABLE ezrole DROP CONSTRAINT ezrole_pkey, ADD CONSTRAINT ezrole_pkey PRIMARY KEY (id,version);

--- a/doc/bc/changes-6.0.md
+++ b/doc/bc/changes-6.0.md
@@ -158,6 +158,13 @@ Changes affecting version compatibility with former or future versions.
 * `eZ\Publish\API\Repository\Values\ValueObject\SearchHit` has a new property `$matchedTranslation`,
   which will hold language code of the Content translation that matched the search query.
 
+* Role draft functionality has been added, which has led to some API changes:
+  `eZ/Publish/API/Repository/RoleService::createRole` now returns a `eZ/Publish/API/Repository/Values/User/RoleDraft`.
+  New methods have been added to `eZ/Publish/API/Repository/RoleService`: `createRoleDraft`, `loadRoleDraft`,
+  `updateRoleDraft`, `addPolicyByRoleDraft`, `removePolicyByRoleDraft`, `deleteRoleDraft`, and `publishRoleDraft`.
+  `eZ/Publish/API/Repository/Values/User/Role` now has a `status` property, which may be one of `Role::STATUS_DEFINED`
+   or `Role::STATUS_DRAFT`.
+
 ## Deprecations
 
 * `eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger::purge()` is deprecated and will be removed in v6.1.
@@ -167,6 +174,9 @@ Changes affecting version compatibility with former or future versions.
   `/views`` replaces it.
   Until it is removed, POST to `/content/views` will return a 301 instead of a 200, and include location header to the
   new resource.
+
+* Some methods have been deprecated in `eZ/Publish/API/Repository/RoleService`: `updateRole`, `addPolicy`,
+  `removePolicy`, `deletePolicy`, and `updatePolicy`. Use the corresponding `*Draft` and `*ByRoleDraft` methods instead.
 
 ## Removed features
 

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
@@ -754,11 +754,35 @@ ezpublish_rest_loadRole:
     requirements:
         roleId: \d+
 
+ezpublish_rest_loadRoleDraft:
+    path: /user/roles/{roleId}/draft
+    defaults:
+        _controller: ezpublish_rest.controller.role:loadRoleDraft
+    methods: [GET]
+    requirements:
+        roleId: \d+
+
 ezpublish_rest_updateRole:
     path: /user/roles/{roleId}
     defaults:
         _controller: ezpublish_rest.controller.role:updateRole
     methods: [PATCH]
+    requirements:
+        roleId: \d+
+
+ezpublish_rest_updateRoleDraft:
+    path: /user/roles/{roleId}/draft
+    defaults:
+        _controller: ezpublish_rest.controller.role:updateRoleDraft
+    methods: [PATCH]
+    requirements:
+        roleId: \d+
+
+ezpublish_rest_publishRoleDraft:
+    path: /user/roles/{roleId}/draft
+    defaults:
+        _controller: ezpublish_rest.controller.role:publishRoleDraft
+    methods: [PUBLISH]
     requirements:
         roleId: \d+
 

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RoleTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RoleTest.php
@@ -34,7 +34,12 @@ class RoleTest extends RESTFunctionalTestCase
   </descriptions>
 </RoleInput>
 XML;
-        $request = $this->createHttpRequest('POST', '/api/ezp/v2/user/roles', 'RoleInput+xml', 'Role+json');
+        $request = $this->createHttpRequest(
+            'POST',
+            '/api/ezp/v2/user/roles?publish=true',
+            'RoleInput+xml',
+            'Role+json'
+        );
         $request->setContent($xml);
         $response = $this->sendHttpRequest($request);
 

--- a/eZ/Publish/API/Repository/RoleService.php
+++ b/eZ/Publish/API/Repository/RoleService.php
@@ -32,9 +32,9 @@ interface RoleService
      * @since 6.0
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists or if limitation of the
-     *                                                                        same type is repeated in the policy create struct or if
-     *                                                                        limitation is not allowed on module/function
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     *         if the name of the role already exists or if limitation of the same type
+     *         is repeated in the policy create struct or if limitation is not allowed on module/function
      * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a policy limitation in the $roleCreateStruct is not valid
      *
      * @param \eZ\Publish\API\Repository\Values\User\RoleCreateStruct $roleCreateStruct

--- a/eZ/Publish/API/Repository/RoleService.php
+++ b/eZ/Publish/API/Repository/RoleService.php
@@ -16,6 +16,7 @@ use eZ\Publish\API\Repository\Values\User\RoleUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\PolicyCreateStruct;
 use eZ\Publish\API\Repository\Values\User\Role;
 use eZ\Publish\API\Repository\Values\User\RoleCreateStruct;
+use eZ\Publish\API\Repository\Values\User\RoleDraft;
 use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\User\UserGroup;
@@ -26,7 +27,143 @@ use eZ\Publish\API\Repository\Values\User\UserGroup;
 interface RoleService
 {
     /**
+     * Creates a new RoleDraft.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists or if limitation of the
+     *                                                                        same type is repeated in the policy create struct or if
+     *                                                                        limitation is not allowed on module/function
+     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a policy limitation in the $roleCreateStruct is not valid
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleCreateStruct $roleCreateStruct
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
+     */
+    public function createRoleDraft(RoleCreateStruct $roleCreateStruct);
+
+    /**
+     * Creates a new RoleDraft for existing Role.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the Role already has a Role Draft that will need to be removed first
+     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a policy limitation in the $roleCreateStruct is not valid
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Role $role
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
+     */
+    public function createRoleDraftByRole(Role $role);
+
+    /**
+     * Loads a role for the given id.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read this role
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a role with the given name was not found
+     *
+     * @param mixed $id
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
+     */
+    public function loadRoleDraft($id);
+
+    /**
+     * Updates the properties of a role draft.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a role
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
+     * @param \eZ\Publish\API\Repository\Values\User\RoleUpdateStruct $roleUpdateStruct
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
+     */
+    public function updateRoleDraft(RoleDraft $roleDraft, RoleUpdateStruct $roleUpdateStruct);
+
+    /**
+     * Adds a new policy to the role draft.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to add  a policy
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if limitation of the same type is repeated in policy create
+     *                                                                        struct or if limitation is not allowed on module/function
+     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a limitation in the $policyCreateStruct is not valid
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
+     * @param \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct $policyCreateStruct
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
+     */
+    public function addPolicyByRoleDraft(RoleDraft $roleDraft, PolicyCreateStruct $policyCreateStruct);
+
+    /**
+     * Removes a policy from a role draft
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if policy does not belong to the given role draft
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
+     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to remove from the role
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft the updated role
+     */
+    public function removePolicyByRoleDraft(RoleDraft $roleDraft, Policy $policy);
+
+    /**
+     * Updates the limitations of a policy. The module and function cannot be changed and
+     * the limitations are replaced by the ones in $roleUpdateStruct.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a policy
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if limitation of the same type is repeated in policy update
+     *                                                                        struct or if limitation is not allowed on module/function
+     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a limitation in the $policyUpdateStruct is not valid
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
+     * @param \eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct $policyUpdateStruct
+     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\Policy
+     */
+    public function updatePolicyByRoleDraft(RoleDraft $roleDraft, Policy $policy, PolicyUpdateStruct $policyUpdateStruct);
+
+    /**
+     * Deletes the given role.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to delete this role
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
+     */
+    public function deleteRoleDraft(RoleDraft $roleDraft);
+
+    /**
+     * Publishes a given Role draft.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to delete this role
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
+     */
+    public function publishRoleDraft(RoleDraft $roleDraft);
+
+    /**
      * Creates a new Role.
+     *
+     * @deprecated since 6.0, use {@see createRoleDraft}
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists or if limitation of the
@@ -43,6 +180,8 @@ interface RoleService
     /**
      * Updates the name of the role.
      *
+     * @deprecated since 6.0, use {@see createRoleDraft}
+     *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a role
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists
      *
@@ -55,6 +194,8 @@ interface RoleService
 
     /**
      * Adds a new policy to the role.
+     *
+     * @deprecated since 6.0, use {@see addPolicyByRoleDraft}
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to add  a policy
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if limitation of the same type is repeated in policy create
@@ -71,7 +212,7 @@ interface RoleService
     /**
      * removes a policy from the role.
      *
-     * @deprecated since 5.3, use {@link deletePolicy()} instead.
+     * @deprecated since 5.3, use {@link removePolicyByRoleDraft()} instead.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if policy does not belong to the given role
@@ -86,6 +227,8 @@ interface RoleService
     /**
      * Deletes a policy.
      *
+     * @deprecated since 6.0, use {@link removePolicyByRoleDraft()} instead.
+     *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
      *
      * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to delete
@@ -95,6 +238,8 @@ interface RoleService
     /**
      * Updates the limitations of a policy. The module and function cannot be changed and
      * the limitations are replaced by the ones in $roleUpdateStruct.
+     *
+     * @deprecated since 6.0, use {@link updatePolicyByRoleDraft()} instead.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a policy
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if limitation of the same type is repeated in policy update

--- a/eZ/Publish/API/Repository/RoleService.php
+++ b/eZ/Publish/API/Repository/RoleService.php
@@ -64,7 +64,7 @@ interface RoleService
      * @since 6.0
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read this role
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a role with the given name was not found
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a role with the given id was not found
      *
      * @param mixed $id
      *
@@ -78,7 +78,7 @@ interface RoleService
      * @since 6.0
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the identifier of the role already exists
      *
      * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
      * @param \eZ\Publish\API\Repository\Values\User\RoleUpdateStruct $roleUpdateStruct
@@ -105,7 +105,7 @@ interface RoleService
     public function addPolicyByRoleDraft(RoleDraft $roleDraft, PolicyCreateStruct $policyCreateStruct);
 
     /**
-     * Removes a policy from a role draft
+     * Removes a policy from a role draft.
      *
      * @since 6.0
      *
@@ -180,7 +180,7 @@ interface RoleService
     /**
      * Updates the name of the role.
      *
-     * @deprecated since 6.0, use {@see createRoleDraft}
+     * @deprecated since 6.0, use {@see updateRoleDraft}
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a role
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists
@@ -210,7 +210,7 @@ interface RoleService
     public function addPolicy(Role $role, PolicyCreateStruct $policyCreateStruct);
 
     /**
-     * removes a policy from the role.
+     * Removes a policy from the role.
      *
      * @deprecated since 5.3, use {@link removePolicyByRoleDraft()} instead.
      *

--- a/eZ/Publish/API/Repository/RoleService.php
+++ b/eZ/Publish/API/Repository/RoleService.php
@@ -41,7 +41,7 @@ interface RoleService
      *
      * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
      */
-    public function createRoleDraft(RoleCreateStruct $roleCreateStruct);
+    public function createRole(RoleCreateStruct $roleCreateStruct);
 
     /**
      * Creates a new RoleDraft for existing Role.
@@ -56,7 +56,7 @@ interface RoleService
      *
      * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
      */
-    public function createRoleDraftByRole(Role $role);
+    public function createRoleDraft(Role $role);
 
     /**
      * Loads a role for the given id.
@@ -159,23 +159,6 @@ interface RoleService
      * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
      */
     public function publishRoleDraft(RoleDraft $roleDraft);
-
-    /**
-     * Creates a new Role.
-     *
-     * @deprecated since 6.0, use {@see createRoleDraft}
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists or if limitation of the
-     *                                                                        same type is repeated in the policy create struct or if
-     *                                                                        limitation is not allowed on module/function
-     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a policy limitation in the $roleCreateStruct is not valid
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\RoleCreateStruct $roleCreateStruct
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
-     */
-    public function createRole(RoleCreateStruct $roleCreateStruct);
 
     /**
      * Updates the name of the role.

--- a/eZ/Publish/API/Repository/RoleService.php
+++ b/eZ/Publish/API/Repository/RoleService.php
@@ -59,12 +59,12 @@ interface RoleService
     public function createRoleDraft(Role $role);
 
     /**
-     * Loads a role for the given id.
+     * Loads a RoleDraft for the given id.
      *
      * @since 6.0
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read this role
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a role with the given id was not found
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a RoleDraft with the given id was not found
      *
      * @param mixed $id
      *
@@ -73,12 +73,12 @@ interface RoleService
     public function loadRoleDraft($id);
 
     /**
-     * Updates the properties of a role draft.
+     * Updates the properties of a RoleDraft.
      *
      * @since 6.0
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the identifier of the role already exists
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the identifier of the RoleDraft already exists
      *
      * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
      * @param \eZ\Publish\API\Repository\Values\User\RoleUpdateStruct $roleUpdateStruct
@@ -88,7 +88,7 @@ interface RoleService
     public function updateRoleDraft(RoleDraft $roleDraft, RoleUpdateStruct $roleUpdateStruct);
 
     /**
-     * Adds a new policy to the role draft.
+     * Adds a new policy to the RoleDraft.
      *
      * @since 6.0
      *
@@ -105,17 +105,17 @@ interface RoleService
     public function addPolicyByRoleDraft(RoleDraft $roleDraft, PolicyCreateStruct $policyCreateStruct);
 
     /**
-     * Removes a policy from a role draft.
+     * Removes a policy from a RoleDraft.
      *
      * @since 6.0
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if policy does not belong to the given role draft
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if policy does not belong to the given RoleDraft
      *
      * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
-     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to remove from the role
+     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to remove from the RoleDraft
      *
-     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft the updated role
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft the updated RoleDraft
      */
     public function removePolicyByRoleDraft(RoleDraft $roleDraft, Policy $policy);
 
@@ -139,22 +139,22 @@ interface RoleService
     public function updatePolicyByRoleDraft(RoleDraft $roleDraft, Policy $policy, PolicyUpdateStruct $policyUpdateStruct);
 
     /**
-     * Deletes the given role.
+     * Deletes the given RoleDraft.
      *
      * @since 6.0
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to delete this role
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to delete this RoleDraft
      *
      * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
      */
     public function deleteRoleDraft(RoleDraft $roleDraft);
 
     /**
-     * Publishes a given Role draft.
+     * Publishes the given RoleDraft.
      *
      * @since 6.0
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to delete this role
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to publish this RoleDraft
      *
      * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
      */

--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceAuthorizationTest.php
@@ -45,7 +45,7 @@ class ContentTypeServiceAuthorizationTest extends BaseContentTypeServiceTest
         // $creatorId is the ID of the administrator user
         $groupCreate->creatorId = $creatorId;
         $groupCreate->creationDate = $this->createDateTime();
-        /* @todo uncomment when support for multilingual names and descriptions is added
+        /* @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         $groupCreate->mainLanguageCode = 'ger-DE';
         $groupCreate->names = array( 'eng-GB' => 'A name.' );
         $groupCreate->descriptions = array( 'eng-GB' => 'A description.' );
@@ -86,7 +86,7 @@ class ContentTypeServiceAuthorizationTest extends BaseContentTypeServiceTest
         // $modifierId is the ID of a random user
         $groupUpdate->modifierId = $modifierId;
         $groupUpdate->modificationDate = $this->createDateTime();
-        /* @todo uncomment when support for multilingual names and descriptions is added
+        /* @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         $groupUpdate->mainLanguageCode = 'eng-GB';
 
         $groupUpdate->names = array(

--- a/eZ/Publish/API/Repository/Tests/RoleServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/RoleServiceAuthorizationTest.php
@@ -618,7 +618,9 @@ class RoleServiceAuthorizationTest extends BaseTest
         $roleCreate->addPolicy($policyCreate);
 
         // Create a new role instance.
-        $role = $roleService->createRole($roleCreate);
+        $roleDraft = $roleService->createRole($roleCreate);
+        $roleService->publishRoleDraft($roleDraft);
+        $role = $roleService->loadRole($roleDraft->id);
         /* END: Inline */
 
         return $role;

--- a/eZ/Publish/API/Repository/Tests/RoleServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/RoleServiceAuthorizationTest.php
@@ -152,7 +152,7 @@ class RoleServiceAuthorizationTest extends BaseTest
         // Get a new role update struct and set new values
         $roleUpdateStruct = $roleService->newRoleUpdateStruct();
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleUpdateStruct->mainLanguageCode = 'eng-US';
 
         // This call will fail with an "UnauthorizedException"
@@ -612,7 +612,7 @@ class RoleServiceAuthorizationTest extends BaseTest
         // Get a role create struct instance and set properties
         $roleCreate = $roleService->newRoleCreateStruct('testRole');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-GB';
 
         $roleCreate->addPolicy($policyCreate);

--- a/eZ/Publish/API/Repository/Tests/RoleServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/RoleServiceTest.php
@@ -109,7 +109,7 @@ class RoleServiceTest extends BaseTest
         $roleService = $repository->getRoleService();
         $roleCreate = $roleService->newRoleCreateStruct('roleName');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $role = $roleService->createRole($roleCreate);
@@ -137,7 +137,7 @@ class RoleServiceTest extends BaseTest
         $roleService = $repository->getRoleService();
         $roleCreate = $roleService->newRoleCreateStruct('roleName');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $role = $roleService->createRoleDraft($roleCreate);
@@ -166,7 +166,7 @@ class RoleServiceTest extends BaseTest
         $roleService = $repository->getRoleService();
         $roleCreate = $roleService->newRoleCreateStruct('Editor');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         // This call will fail with an InvalidArgumentException, because Editor exists
@@ -191,7 +191,7 @@ class RoleServiceTest extends BaseTest
         $roleService = $repository->getRoleService();
         $roleCreate = $roleService->newRoleCreateStruct('Editor');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         // This call will fail with an InvalidArgumentException, because Editor exists
@@ -216,7 +216,7 @@ class RoleServiceTest extends BaseTest
         // Create new role create struct
         $roleCreate = $roleService->newRoleCreateStruct('Lumberjack');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         // Create new subtree limitation
@@ -255,7 +255,7 @@ class RoleServiceTest extends BaseTest
         // Create new role create struct
         $roleCreate = $roleService->newRoleCreateStruct('Lumberjack');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         // Create new subtree limitation
@@ -296,7 +296,7 @@ class RoleServiceTest extends BaseTest
 
         $roleCreate = $roleService->newRoleCreateStruct('roleName');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $createdRoleId = $roleService->createRole($roleCreate)->id;
@@ -332,7 +332,7 @@ class RoleServiceTest extends BaseTest
 
         $roleCreate = $roleService->newRoleCreateStruct('roleName');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $createdRoleId = $roleService->createRoleDraft($roleCreate)->id;
@@ -365,7 +365,7 @@ class RoleServiceTest extends BaseTest
         $roleService = $repository->getRoleService();
         $roleCreate = $roleService->newRoleCreateStruct('roleName');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $roleId = $roleService->createRole($roleCreate)->id;
@@ -393,7 +393,7 @@ class RoleServiceTest extends BaseTest
         $roleService = $repository->getRoleService();
         $roleCreate = $roleService->newRoleCreateStruct('roleName');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $roleId = $roleService->createRoleDraft($roleCreate)->id;
@@ -465,7 +465,7 @@ class RoleServiceTest extends BaseTest
         $roleService = $repository->getRoleService();
         $roleCreate = $roleService->newRoleCreateStruct('roleName');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $roleService->createRole($roleCreate);
@@ -515,7 +515,7 @@ class RoleServiceTest extends BaseTest
         $roleService = $repository->getRoleService();
         $roleCreate = $roleService->newRoleCreateStruct('roleName');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $role = $roleService->createRole($roleCreate);
@@ -601,7 +601,7 @@ class RoleServiceTest extends BaseTest
         $roleService = $repository->getRoleService();
         $roleCreate = $roleService->newRoleCreateStruct('newRole');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $role = $roleService->createRole($roleCreate);
@@ -633,7 +633,7 @@ class RoleServiceTest extends BaseTest
         $roleService = $repository->getRoleService();
         $roleCreate = $roleService->newRoleCreateStruct('newRole');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $role = $roleService->createRoleDraft($roleCreate);
@@ -665,7 +665,7 @@ class RoleServiceTest extends BaseTest
         $roleService = $repository->getRoleService();
         $roleCreate = $roleService->newRoleCreateStruct('newRole');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $role = $roleService->createRole($roleCreate);
@@ -693,7 +693,7 @@ class RoleServiceTest extends BaseTest
         $roleService = $repository->getRoleService();
         $roleCreate = $roleService->newRoleCreateStruct('newRole');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $role = $roleService->createRoleDraft($roleCreate);
@@ -721,7 +721,7 @@ class RoleServiceTest extends BaseTest
         $roleService = $repository->getRoleService();
         $roleCreate = $roleService->newRoleCreateStruct('newRole');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $role = $roleService->createRole($roleCreate);
@@ -747,7 +747,7 @@ class RoleServiceTest extends BaseTest
         $roleService = $repository->getRoleService();
         $roleCreate = $roleService->newRoleCreateStruct('newRole');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $role = $roleService->createRoleDraft($roleCreate);
@@ -813,7 +813,7 @@ class RoleServiceTest extends BaseTest
 
         $roleCreate = $roleService->newRoleCreateStruct('newRole');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $role = $roleService->createRole($roleCreate);
@@ -873,7 +873,7 @@ class RoleServiceTest extends BaseTest
 
         $roleCreate = $roleService->newRoleCreateStruct('newRole');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $role = $roleService->createRoleDraft($roleCreate);
@@ -934,7 +934,7 @@ class RoleServiceTest extends BaseTest
 
         $roleCreate = $roleService->newRoleCreateStruct('newRole');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $role = $roleService->createRole($roleCreate);
@@ -975,7 +975,7 @@ class RoleServiceTest extends BaseTest
 
         $roleCreate = $roleService->newRoleCreateStruct('newRole');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $role = $roleService->createRoleDraft($roleCreate);
@@ -1052,7 +1052,7 @@ class RoleServiceTest extends BaseTest
 
         $roleCreate = $roleService->newRoleCreateStruct('Lumberjack');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $role = $roleService->createRole($roleCreate);
@@ -1091,7 +1091,7 @@ class RoleServiceTest extends BaseTest
 
         $roleCreate = $roleService->newRoleCreateStruct('Lumberjack');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $role = $roleService->createRoleDraft($roleCreate);
@@ -1129,7 +1129,7 @@ class RoleServiceTest extends BaseTest
         // Instantiate a new create struct
         $roleCreate = $roleService->newRoleCreateStruct('newRole');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         // Add some role policies
@@ -1186,7 +1186,7 @@ class RoleServiceTest extends BaseTest
         // Instantiate a new create struct
         $roleCreate = $roleService->newRoleCreateStruct('newRole');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         // Add some role policies
@@ -1278,7 +1278,7 @@ class RoleServiceTest extends BaseTest
         // Instantiate a role create and add the policy create
         $roleCreate = $roleService->newRoleCreateStruct('myRole');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $roleCreate->addPolicy($policyCreate);
@@ -1407,7 +1407,7 @@ class RoleServiceTest extends BaseTest
         // Instantiate a role create and add the policy create
         $roleCreate = $roleService->newRoleCreateStruct('myRole');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $roleCreate->addPolicy($policyCreate);
@@ -1455,7 +1455,7 @@ class RoleServiceTest extends BaseTest
         // Instantiate a new role create
         $roleCreate = $roleService->newRoleCreateStruct('newRole');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         // Create a new role with two policies
@@ -1492,7 +1492,7 @@ class RoleServiceTest extends BaseTest
         // Instantiate a new role create
         $roleCreate = $roleService->newRoleCreateStruct('newRole');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         // Create a new role with two policies
@@ -1530,7 +1530,7 @@ class RoleServiceTest extends BaseTest
         // Instantiate a new role create
         $roleCreate = $roleService->newRoleCreateStruct('newRole');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         // Create a new role with two policies
@@ -1927,7 +1927,7 @@ class RoleServiceTest extends BaseTest
         // Instantiate a role create and add some policies
         $roleCreate = $roleService->newRoleCreateStruct('Example Role');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $roleCreate->addPolicy(
@@ -2338,7 +2338,7 @@ class RoleServiceTest extends BaseTest
         // Instantiate a role create and add some policies
         $roleCreate = $roleService->newRoleCreateStruct('Example Role');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $roleCreate->addPolicy(
@@ -2392,7 +2392,7 @@ class RoleServiceTest extends BaseTest
         // Instantiate a role create and add some policies
         $roleCreate = $roleService->newRoleCreateStruct('User Role');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $roleCreate->addPolicy(
@@ -2472,7 +2472,7 @@ class RoleServiceTest extends BaseTest
         $roleService = $repository->getRoleService();
         $roleCreate = $roleService->newRoleCreateStruct('newRole');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $roleDraft = $roleService->createRoleDraft($roleCreate);
@@ -2510,7 +2510,7 @@ class RoleServiceTest extends BaseTest
         $roleService = $repository->getRoleService();
         $roleCreate = $roleService->newRoleCreateStruct('newRole');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreate->mainLanguageCode = 'eng-US';
 
         $roleDraft = $roleService->createRoleDraft($roleCreate);

--- a/eZ/Publish/API/Repository/Values/User/Role.php
+++ b/eZ/Publish/API/Repository/Values/User/Role.php
@@ -23,7 +23,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 abstract class Role extends ValueObject
 {
     /**
-     * ID of the user rule.
+     * ID of the user role.
      *
      * @var mixed
      */
@@ -36,6 +36,34 @@ abstract class Role extends ValueObject
      * @var string
      */
     protected $identifier;
+
+    /**
+     * Creation date of the content type.
+     *
+     * @var \DateTime
+     */
+    protected $creationDate;
+
+    /**
+     * Modification date of the content type.
+     *
+     * @var \DateTime
+     */
+    protected $modificationDate;
+
+    /**
+     * Creator user id of the content type.
+     *
+     * @var mixed
+     */
+    protected $creatorId;
+
+    /**
+     * Modifier user id of the content type.
+     *
+     * @var mixed
+     */
+    protected $modifierId;
 
     /**
      * Returns the list of policies of this role.

--- a/eZ/Publish/API/Repository/Values/User/Role.php
+++ b/eZ/Publish/API/Repository/Values/User/Role.php
@@ -55,34 +55,6 @@ abstract class Role extends ValueObject
     protected $status;
 
     /**
-     * Creation date of the role.
-     *
-     * @var \DateTime
-     */
-    protected $creationDate;
-
-    /**
-     * Modification date of the role.
-     *
-     * @var \DateTime
-     */
-    protected $modificationDate;
-
-    /**
-     * Creator user id of the role.
-     *
-     * @var mixed
-     */
-    protected $creatorId;
-
-    /**
-     * Modifier user id of the role.
-     *
-     * @var mixed
-     */
-    protected $modifierId;
-
-    /**
      * Returns the list of policies of this role.
      *
      * @return \eZ\Publish\API\Repository\Values\User\Policy[]

--- a/eZ/Publish/API/Repository/Values/User/Role.php
+++ b/eZ/Publish/API/Repository/Values/User/Role.php
@@ -23,6 +23,16 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 abstract class Role extends ValueObject
 {
     /**
+     * @var int Status constant for defined (aka "published") role
+     */
+    const STATUS_DEFINED = 0;
+
+    /**
+     * @var int Status constant for draft (aka "temporary") role
+     */
+    const STATUS_DRAFT = 1;
+
+    /**
      * ID of the user role.
      *
      * @var mixed
@@ -38,28 +48,35 @@ abstract class Role extends ValueObject
     protected $identifier;
 
     /**
-     * Creation date of the content type.
+     * The status of the role.
+     *
+     * @var int One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
+     */
+    protected $status;
+
+    /**
+     * Creation date of the role.
      *
      * @var \DateTime
      */
     protected $creationDate;
 
     /**
-     * Modification date of the content type.
+     * Modification date of the role.
      *
      * @var \DateTime
      */
     protected $modificationDate;
 
     /**
-     * Creator user id of the content type.
+     * Creator user id of the role.
      *
      * @var mixed
      */
     protected $creatorId;
 
     /**
-     * Modifier user id of the content type.
+     * Modifier user id of the role.
      *
      * @var mixed
      */

--- a/eZ/Publish/API/Repository/Values/User/RoleCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleCreateStruct.php
@@ -18,11 +18,25 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 abstract class RoleCreateStruct extends ValueObject
 {
     /**
+     * ID of a role.
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
      * Readable string identifier of a role.
      *
      * @var string
      */
     public $identifier;
+
+    /**
+     * The status of the role.
+     *
+     * @var int One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
+     */
+    public $status = Role::STATUS_DRAFT;
 
     /**
      * Returns policies associated with the role.

--- a/eZ/Publish/API/Repository/Values/User/RoleCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleCreateStruct.php
@@ -25,6 +25,20 @@ abstract class RoleCreateStruct extends ValueObject
     public $identifier;
 
     /**
+     * True before the role has been published.
+     *
+     * @var bool
+     */
+    public $is_new = true;
+
+    /**
+     * Version number: non-zero for draft roles.
+     *
+     * @var bool
+     */
+    public $version = 0;
+
+    /**
      * Returns policies associated with the role.
      *
      * @return \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct[]

--- a/eZ/Publish/API/Repository/Values/User/RoleCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleCreateStruct.php
@@ -25,20 +25,6 @@ abstract class RoleCreateStruct extends ValueObject
     public $identifier;
 
     /**
-     * True before the role has been published.
-     *
-     * @var bool
-     */
-    public $is_new = true;
-
-    /**
-     * Version number: non-zero for draft roles.
-     *
-     * @var bool
-     */
-    public $version = 0;
-
-    /**
      * Returns policies associated with the role.
      *
      * @return \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct[]

--- a/eZ/Publish/API/Repository/Values/User/RoleCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleCreateStruct.php
@@ -18,13 +18,6 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 abstract class RoleCreateStruct extends ValueObject
 {
     /**
-     * ID of a role.
-     *
-     * @var int
-     */
-    public $id;
-
-    /**
      * Readable string identifier of a role.
      *
      * @var string

--- a/eZ/Publish/API/Repository/Values/User/RoleCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleCreateStruct.php
@@ -25,13 +25,6 @@ abstract class RoleCreateStruct extends ValueObject
     public $identifier;
 
     /**
-     * The status of the role.
-     *
-     * @var int One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
-     */
-    public $status = Role::STATUS_DRAFT;
-
-    /**
      * Returns policies associated with the role.
      *
      * @return \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct[]

--- a/eZ/Publish/API/Repository/Values/User/RoleDraft.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleDraft.php
@@ -12,11 +12,6 @@ namespace eZ\Publish\API\Repository\Values\User;
 
 /**
  * This class represents a draft of a role.
- *
- * @property-read mixed $id the internal id of the role
- * @property-read string $identifier the identifier of the role
- *
- * @property-read array $policies an array of the policies {@link \eZ\Publish\API\Repository\Values\User\Policy} of the role.
  */
 abstract class RoleDraft extends Role
 {

--- a/eZ/Publish/API/Repository/Values/User/RoleDraft.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleDraft.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\User\Role class.
+ * File containing the eZ\Publish\API\Repository\Values\User\RoleDraft class.
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -11,7 +11,7 @@
 namespace eZ\Publish\API\Repository\Values\User;
 
 /**
- * This class represents a role.
+ * This class represents a draft of a role.
  *
  * @property-read mixed $id the internal id of the role
  * @property-read string $identifier the identifier of the role

--- a/eZ/Publish/API/Repository/Values/User/RoleDraft.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleDraft.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * File containing the eZ\Publish\API\Repository\Values\User\Role class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\API\Repository\Values\User;
+
+/**
+ * This class represents a role.
+ *
+ * @property-read mixed $id the internal id of the role
+ * @property-read string $identifier the identifier of the role
+ *
+ * @property-read array $policies an array of the policies {@link \eZ\Publish\API\Repository\Values\User\Policy} of the role.
+ */
+abstract class RoleDraft extends Role
+{
+}

--- a/eZ/Publish/API/Repository/Values/User/RoleUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleUpdateStruct.php
@@ -23,4 +23,11 @@ class RoleUpdateStruct extends ValueObject
      * @var string
      */
     public $identifier;
+
+    /**
+     * The status of the role.
+     *
+     * @var int One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
+     */
+    public $status;
 }

--- a/eZ/Publish/API/Repository/Values/User/RoleUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleUpdateStruct.php
@@ -23,11 +23,4 @@ class RoleUpdateStruct extends ValueObject
      * @var string
      */
     public $identifier;
-
-    /**
-     * The status of the role.
-     *
-     * @var int One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
-     */
-    public $status;
 }

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UserHandlerTest.php
@@ -697,7 +697,7 @@ class UserHandlerTest extends HandlerTest
 
         $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
         $this->persistenceHandlerMock
-            ->expects($this->once())
+            ->expects($this->at(0))
             ->method('userHandler')
             ->will($this->returnValue($innerHandlerMock));
 
@@ -709,17 +709,36 @@ class UserHandlerTest extends HandlerTest
                 $this->returnValue(true)
             );
 
-        $this->cacheMock
-            ->expects($this->at(0))
-            ->method('clear')
-            ->with('user', 'role', 33)
-            ->will($this->returnValue(true));
+        $this->persistenceHandlerMock
+            ->expects($this->at(1))
+            ->method('userHandler')
+            ->will($this->returnValue($innerHandlerMock));
+
+        $innerHandlerMock
+            ->expects($this->once())
+            ->method('loadRole')
+            ->with(33)
+            ->will(
+                $this->returnValue(new Role())
+            );
 
         $this->cacheMock
-            ->expects($this->at(1))
+            ->expects($this->once())
             ->method('clear')
             ->with('user', 'role', 'assignments')
             ->will($this->returnValue(true));
+
+        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $this->cacheMock
+            ->expects($this->once())
+            ->method('getItem')
+            ->with('user', 'role', 33)
+            ->will($this->returnValue($cacheItemMock));
+
+        $cacheItemMock
+            ->expects($this->once())
+            ->method('set')
+            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\User\\Role'));
 
         $handler = $this->persistenceCacheHandler->userHandler();
         $handler->publishRoleDraft(33);

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UserHandlerTest.php
@@ -481,7 +481,7 @@ class UserHandlerTest extends HandlerTest
         $innerHandlerMock
             ->expects($this->once())
             ->method('createRole')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\User\\Role'))
+            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\User\\RoleCreateStruct'))
             ->will(
                 $this->returnValue(
                     new Role(
@@ -492,26 +492,23 @@ class UserHandlerTest extends HandlerTest
 
         $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
         $this->cacheMock
-            ->expects($this->once())
-            ->method('getItem')
-            ->with('user', 'role', 33)
-            ->will($this->returnValue($cacheItemMock));
+            ->expects($this->never())
+            ->method('getItem');
 
         $cacheItemMock
-            ->expects($this->once())
-            ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\User\\Role'));
+            ->expects($this->never())
+            ->method('set');
 
         $cacheItemMock
             ->expects($this->never())
             ->method('get');
 
         $handler = $this->persistenceCacheHandler->userHandler();
-        $handler->createRole(new Role());
+        $handler->createRole(new User\RoleCreateStruct());
     }
 
     /**
-     * @covers eZ\Publish\Core\Persistence\Cache\UserHandler::createRole
+     * @covers eZ\Publish\Core\Persistence\Cache\UserHandler::createRoleDraft
      */
     public function testCreateRoleDraft()
     {
@@ -525,8 +522,8 @@ class UserHandlerTest extends HandlerTest
 
         $innerHandlerMock
             ->expects($this->once())
-            ->method('createRole')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\User\\Role'))
+            ->method('createRoleDraft')
+            ->with(33)
             ->will(
                 $this->returnValue(
                     new Role(
@@ -549,9 +546,8 @@ class UserHandlerTest extends HandlerTest
             ->method('get');
 
         $handler = $this->persistenceCacheHandler->userHandler();
-        $roleDraft = new Role();
-        $roleDraft->status = Role::STATUS_DRAFT;
-        $handler->createRole($roleDraft);
+        $role = new Role(['id' => 33]);
+        $handler->createRoleDraft($role->id);
     }
 
     /**
@@ -590,7 +586,7 @@ class UserHandlerTest extends HandlerTest
     }
 
     /**
-     * @covers eZ\Publish\Core\Persistence\Cache\UserHandler::updateRoleDraft
+     * @covers eZ\Publish\Core\Persistence\Cache\UserHandler::updateRole
      */
     public function testUpdateRoleDraft()
     {
@@ -604,8 +600,8 @@ class UserHandlerTest extends HandlerTest
 
         $innerHandler
             ->expects($this->once())
-            ->method('updateRoleDraft')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\User\\RoleUpdateStruct'));
+            ->method('updateRole')
+            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\User\\RoleUpdateStruct'), Role::STATUS_DRAFT);
 
         $roleUpdateStruct = new RoleUpdateStruct();
         $roleUpdateStruct->id = 42;
@@ -619,7 +615,7 @@ class UserHandlerTest extends HandlerTest
             ->method('getItem');
 
         $handler = $this->persistenceCacheHandler->userHandler();
-        $handler->updateRoleDraft($roleUpdateStruct);
+        $handler->updateRole($roleUpdateStruct, Role::STATUS_DRAFT);
     }
 
     /**
@@ -660,7 +656,7 @@ class UserHandlerTest extends HandlerTest
     }
 
     /**
-     * @covers eZ\Publish\Core\Persistence\Cache\UserHandler::deleteRoleDraft
+     * @covers eZ\Publish\Core\Persistence\Cache\UserHandler::deleteRole
      */
     public function testDeleteRoleDraft()
     {
@@ -674,8 +670,8 @@ class UserHandlerTest extends HandlerTest
 
         $innerHandlerMock
             ->expects($this->once())
-            ->method('deleteRoleDraft')
-            ->with(33)
+            ->method('deleteRole')
+            ->with(33, Role::STATUS_DRAFT)
             ->will(
                 $this->returnValue(true)
             );
@@ -685,7 +681,7 @@ class UserHandlerTest extends HandlerTest
             ->method('clear');
 
         $handler = $this->persistenceCacheHandler->userHandler();
-        $handler->deleteRoleDraft(33);
+        $handler->deleteRole(33, Role::STATUS_DRAFT);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Cache/UserHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UserHandler.php
@@ -103,9 +103,22 @@ class UserHandler extends AbstractHandler implements UserHandlerInterface
         $this->logger->logCall(__METHOD__, array('struct' => $struct));
         $role = $this->persistenceHandler->userHandler()->createRole($struct);
 
-        $this->cache->getItem('user', 'role', $role->id)->set($role);
+        // Don't cache draft roles
+        if ($role->status == Role::STATUS_DEFINED) {
+            $this->cache->getItem('user', 'role', $role->id)->set($role);
+        }
 
         return $role;
+    }
+
+    /**
+     * @see eZ\Publish\SPI\Persistence\User\Handler::loadRoleDraft
+     */
+    public function loadRoleDraft($roleId)
+    {
+        $this->logger->logCall(__METHOD__, array('role' => $roleId));
+
+        return $this->persistenceHandler->userHandler()->loadRoleDraft($roleId);
     }
 
     /**
@@ -122,6 +135,16 @@ class UserHandler extends AbstractHandler implements UserHandlerInterface
         }
 
         return $role;
+    }
+
+    /**
+     * @see eZ\Publish\SPI\Persistence\User\Handler::loadRoleDraftByIdentifier
+     */
+    public function loadRoleDraftByIdentifier($identifier)
+    {
+        $this->logger->logCall(__METHOD__, array('role' => $identifier));
+
+        return $this->persistenceHandler->userHandler()->loadRoleDraftByIdentifier($identifier);
     }
 
     /**
@@ -178,6 +201,16 @@ class UserHandler extends AbstractHandler implements UserHandlerInterface
     }
 
     /**
+     * @see eZ\Publish\SPI\Persistence\User\Handler::updateRoleDraft
+     */
+    public function updateRoleDraft(RoleUpdateStruct $struct)
+    {
+        $this->logger->logCall(__METHOD__, array('struct' => $struct));
+
+        $this->persistenceHandler->userHandler()->updateRoleDraft($struct);
+    }
+
+    /**
      * @see eZ\Publish\SPI\Persistence\User\Handler::updateRole
      */
     public function updateRole(RoleUpdateStruct $struct)
@@ -186,6 +219,16 @@ class UserHandler extends AbstractHandler implements UserHandlerInterface
         $this->persistenceHandler->userHandler()->updateRole($struct);
 
         $this->cache->clear('user', 'role', $struct->id);
+    }
+
+    /**
+     * @see eZ\Publish\SPI\Persistence\User\Handler::deleteRoleDraft
+     */
+    public function deleteRoleDraft($roleId)
+    {
+        $this->logger->logCall(__METHOD__, array('role' => $roleId));
+
+        return $this->persistenceHandler->userHandler()->deleteRoleDraft($roleId);
     }
 
     /**
@@ -200,6 +243,30 @@ class UserHandler extends AbstractHandler implements UserHandlerInterface
         $this->cache->clear('user', 'role', 'assignments');
 
         return $return;
+    }
+
+    /**
+     * @see eZ\Publish\SPI\Persistence\User\Handler::publishRoleDraft
+     */
+    public function publishRoleDraft($roleId)
+    {
+        $this->logger->logCall(__METHOD__, array('role' => $roleId));
+        $return = $this->persistenceHandler->userHandler()->publishRoleDraft($roleId);
+
+        $this->cache->clear('user', 'role', $roleId);
+        $this->cache->clear('user', 'role', 'assignments');
+
+        return $return;
+    }
+
+    /**
+     * @see eZ\Publish\SPI\Persistence\User\Handler::addPolicyByRoleDraft
+     */
+    public function addPolicyByRoleDraft($roleId, Policy $policy)
+    {
+        $this->logger->logCall(__METHOD__, array('role' => $roleId, 'struct' => $policy));
+
+        return $this->persistenceHandler->userHandler()->addPolicyByRoleDraft($roleId, $policy);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Cache/UserHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UserHandler.php
@@ -253,8 +253,10 @@ class UserHandler extends AbstractHandler implements UserHandlerInterface
         $this->logger->logCall(__METHOD__, array('role' => $roleId));
         $return = $this->persistenceHandler->userHandler()->publishRoleDraft($roleId);
 
-        $this->cache->clear('user', 'role', $roleId);
         $this->cache->clear('user', 'role', 'assignments');
+        $this->cache
+            ->getItem('user', 'role', $roleId)
+            ->set($this->persistenceHandler->userHandler()->loadRole($roleId));
 
         return $return;
     }

--- a/eZ/Publish/Core/Persistence/Doctrine/ConnectionHandler/SqliteConnectionHandler.php
+++ b/eZ/Publish/Core/Persistence/Doctrine/ConnectionHandler/SqliteConnectionHandler.php
@@ -91,6 +91,20 @@ class SqliteConnectionHandler extends ConnectionHandler
             return $this->lastInsertedIds['ezcontentclass_attribute.id'];
         }
 
+        if (($table === 'ezrole') && ($column === 'id')) {
+            // This is a @HACK -- since this table has a multi-column key with
+            // auto-increment, which is not easy to simulate in SQLite. This
+            // solves it for now.
+            $q = $this->createSelectQuery();
+            $q->select($q->expr->max('id'))->from('ezrole');
+            $statement = $q->prepare();
+            $statement->execute();
+
+            $this->lastInsertedIds['ezrole.id'] = (int)$statement->fetchColumn() + 1;
+
+            return $this->lastInsertedIds['ezrole.id'];
+        }
+
         return 'NULL';
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Exception/RoleNotFound.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Exception/RoleNotFound.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * File containing the RoleNotFound class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\Persistence\Legacy\Exception;
+
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+
+/**
+ * Exception thrown when a Role/RoleDraft to be loaded is not found.
+ */
+class RoleNotFound extends NotFoundException
+{
+    /**
+     * Creates a new exception for $roleId in $status.
+     *
+     * @param mixed $roleId
+     * @param mixed $status
+     */
+    public function __construct($roleId, $status)
+    {
+        parent::__construct(
+            'eZ\\Publish\\SPI\\Persistence\\User\\Role',
+            sprintf('ID: %s, Status: %s', $roleId, $status)
+        );
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
@@ -236,11 +236,11 @@ class UserHandlerTest extends TestCase
     {
         $handler = $this->getUserHandler();
 
-        $role = new Persistence\User\Role();
-        $role->identifier = 'Test';
-        $role->status = APIRole::STATUS_DEFINED;
+        $createStruct = new Persistence\User\RoleCreateStruct();
+        $createStruct->identifier = 'Test';
+        $createStruct->status = APIRole::STATUS_DEFINED;
 
-        $handler->createRole($role);
+        $handler->createRole($createStruct);
 
         $this->assertQueryResult(
             array(array(1, 'Test', APIRole::STATUS_DEFINED)),
@@ -253,11 +253,11 @@ class UserHandlerTest extends TestCase
     {
         $handler = $this->getUserHandler();
 
-        $role = new Persistence\User\Role();
-        $role->identifier = 'Test';
-        $role->status = APIRole::STATUS_DEFINED;
+        $createStruct = new Persistence\User\RoleCreateStruct();
+        $createStruct->identifier = 'Test';
+        $createStruct->status = APIRole::STATUS_DEFINED;
 
-        $role = $handler->createRole($role);
+        $role = $handler->createRole($createStruct);
 
         $this->assertSame('1', $role->id);
     }
@@ -266,11 +266,11 @@ class UserHandlerTest extends TestCase
     {
         $handler = $this->getUserHandler();
 
-        $role = new Persistence\User\Role();
-        $role->identifier = 'Test';
-        $role->status = APIRole::STATUS_DEFINED;
+        $createStruct = new Persistence\User\RoleCreateStruct();
+        $createStruct->identifier = 'Test';
+        $createStruct->status = APIRole::STATUS_DEFINED;
 
-        $role = $handler->createRole($role);
+        $role = $handler->createRole($createStruct);
 
         $this->assertEquals(
             $role,
@@ -282,11 +282,11 @@ class UserHandlerTest extends TestCase
     {
         $handler = $this->getUserHandler();
 
-        $role = new Persistence\User\Role();
-        $role->identifier = 'Test';
-        $role->status = APIRole::STATUS_DEFINED;
+        $createStruct = new Persistence\User\RoleCreateStruct();
+        $createStruct->identifier = 'Test';
+        $createStruct->status = APIRole::STATUS_DEFINED;
 
-        $role = $handler->createRole($role);
+        $role = $handler->createRole($createStruct);
 
         $policy = new Persistence\User\Policy();
         $policy->module = 'foo';
@@ -315,11 +315,11 @@ class UserHandlerTest extends TestCase
     {
         $handler = $this->getUserHandler();
 
-        $role = new Persistence\User\Role();
-        $role->identifier = 'Test';
-        $role->status = APIRole::STATUS_DEFINED;
+        $createStruct = new Persistence\User\RoleCreateStruct();
+        $createStruct->identifier = 'Test';
+        $createStruct->status = APIRole::STATUS_DEFINED;
 
-        $role = $handler->createRole($role);
+        $role = $handler->createRole($createStruct);
 
         $policy = new Persistence\User\Policy();
         $policy->module = 'foo';
@@ -351,11 +351,11 @@ class UserHandlerTest extends TestCase
     {
         $handler = $this->getUserHandler();
 
-        $role = new Persistence\User\Role();
-        $role->identifier = 'Test';
-        $role->status = APIRole::STATUS_DEFINED;
+        $createStruct = new Persistence\User\RoleCreateStruct();
+        $createStruct->identifier = 'Test';
+        $createStruct->status = APIRole::STATUS_DEFINED;
 
-        $role = $handler->createRole($role);
+        $role = $handler->createRole($createStruct);
 
         $policy = new Persistence\User\Policy();
         $policy->module = 'foo';
@@ -396,11 +396,11 @@ class UserHandlerTest extends TestCase
             $handler->loadRoles()
         );
 
-        $role = new Persistence\User\Role();
-        $role->identifier = 'Test';
-        $role->status = APIRole::STATUS_DEFINED;
+        $createStruct = new Persistence\User\RoleCreateStruct();
+        $createStruct->identifier = 'Test';
+        $createStruct->status = APIRole::STATUS_DEFINED;
 
-        $role = $handler->createRole($role);
+        $role = $handler->createRole($createStruct);
 
         $this->assertEquals(
             array($role),
@@ -412,11 +412,11 @@ class UserHandlerTest extends TestCase
     {
         $handler = $this->getUserHandler();
 
-        $role = new Persistence\User\Role();
-        $role->identifier = 'Test';
-        $role->status = APIRole::STATUS_DEFINED;
+        $createStruct = new Persistence\User\RoleCreateStruct();
+        $createStruct->identifier = 'Test';
+        $createStruct->status = APIRole::STATUS_DEFINED;
 
-        $role = $handler->createRole($role);
+        $role = $handler->createRole($createStruct);
 
         $update = new Persistence\User\RoleUpdateStruct();
         $update->id = $role->id;
@@ -462,11 +462,11 @@ class UserHandlerTest extends TestCase
     {
         $handler = $this->getUserHandler();
 
-        $role = new Persistence\User\Role();
-        $role->identifier = 'Test';
-        $role->status = APIRole::STATUS_DEFINED;
+        $createStruct = new Persistence\User\RoleCreateStruct();
+        $createStruct->identifier = 'Test';
+        $createStruct->status = APIRole::STATUS_DEFINED;
 
-        $handler->createRole($role);
+        $role = $handler->createRole($createStruct);
 
         $policy = new Persistence\User\Policy();
         $policy->module = 'foo';
@@ -485,11 +485,11 @@ class UserHandlerTest extends TestCase
     {
         $handler = $this->getUserHandler();
 
-        $role = new Persistence\User\Role();
-        $role->identifier = 'Test';
-        $role->status = APIRole::STATUS_DEFINED;
+        $createStruct = new Persistence\User\RoleCreateStruct();
+        $createStruct->identifier = 'Test';
+        $createStruct->status = APIRole::STATUS_DEFINED;
 
-        $handler->createRole($role);
+        $role = $handler->createRole($createStruct);
 
         $policy = new Persistence\User\Policy();
         $policy->module = 'foo';
@@ -504,11 +504,11 @@ class UserHandlerTest extends TestCase
     {
         $handler = $this->getUserHandler();
 
-        $role = new Persistence\User\Role();
-        $role->identifier = 'Test';
-        $role->status = APIRole::STATUS_DEFINED;
+        $createStruct = new Persistence\User\RoleCreateStruct();
+        $createStruct->identifier = 'Test';
+        $createStruct->status = APIRole::STATUS_DEFINED;
 
-        $handler->createRole($role);
+        $role = $handler->createRole($createStruct);
 
         $policy = new Persistence\User\Policy();
         $policy->module = 'foo';
@@ -534,11 +534,11 @@ class UserHandlerTest extends TestCase
     {
         $handler = $this->getUserHandler();
 
-        $role = new Persistence\User\Role();
-        $role->identifier = 'Test';
-        $role->status = APIRole::STATUS_DEFINED;
+        $createStruct = new Persistence\User\RoleCreateStruct();
+        $createStruct->identifier = 'Test';
+        $createStruct->status = APIRole::STATUS_DEFINED;
 
-        $handler->createRole($role);
+        $role = $handler->createRole($createStruct);
 
         $policy = new Persistence\User\Policy();
         $policy->module = 'foo';
@@ -580,12 +580,11 @@ class UserHandlerTest extends TestCase
             'Foo' => array('Blubb'),
         );
 
-        $role = new Persistence\User\Role();
-        $role->identifier = 'Test';
-        $role->status = APIRole::STATUS_DEFINED;
-        $role->policies = array($policy1, $policy2);
+        $createStruct = new Persistence\User\RoleCreateStruct();
+        $createStruct->identifier = 'Test';
+        $createStruct->policies = array($policy1, $policy2);
 
-        return $handler->createRole($role);
+        return $handler->createRole($createStruct);
     }
 
     public function testImplicitlyCreatePolicies()
@@ -606,14 +605,15 @@ class UserHandlerTest extends TestCase
     {
         $handler = $this->getUserHandler();
 
-        $role = $this->createRole();
-        $handler->deletePolicy($role->policies[0]->id);
+        $roleDraft = $this->createRole();
+        $handler->publishRoleDraft($roleDraft->id);
+        $handler->deletePolicy($roleDraft->policies[0]->id);
 
         $this->assertQueryResult(
             array(
                 array(2, 'foo', 'blubb', 1),
             ),
-            $this->handler->createSelectQuery()->select('id', 'module_name', 'function_name', 'role_id')->from('ezpolicy'),
+            $this->handler->createSelectQuery()->select('id', 'module_name', 'function_name', 'role_id')->from('ezpolicy')->where('original_id = 0'),
             'Expected a new policy.'
         );
     }
@@ -622,8 +622,8 @@ class UserHandlerTest extends TestCase
     {
         $handler = $this->getUserHandler();
 
-        $role = $this->createRole();
-        $handler->deletePolicy($role->policies[0]->id);
+        $roleDraft = $this->createRole();
+        $handler->deletePolicy($roleDraft->policies[0]->id);
 
         $this->assertQueryResult(
             array(array(3, 'Foo', 2)),
@@ -635,8 +635,8 @@ class UserHandlerTest extends TestCase
     {
         $handler = $this->getUserHandler();
 
-        $role = $this->createRole();
-        $handler->deletePolicy($role->policies[0]->id);
+        $roleDraft = $this->createRole();
+        $handler->deletePolicy($roleDraft->policies[0]->id);
 
         $this->assertQueryResult(
             array(array(4, 3, 'Blubb')),
@@ -648,9 +648,9 @@ class UserHandlerTest extends TestCase
     {
         $handler = $this->getUserHandler();
 
-        $role = $this->createRole();
+        $roleDraft = $this->createRole();
 
-        $policy = $role->policies[0];
+        $policy = $roleDraft->policies[0];
         $policy->limitations = array(
             'new' => array('something'),
         );
@@ -678,7 +678,9 @@ class UserHandlerTest extends TestCase
     {
         $handler = $this->getUserHandler();
 
-        $role = $this->createRole();
+        $roleDraft = $this->createRole();
+        $handler->publishRoleDraft($roleDraft->id);
+        $role = $handler->loadRole($roleDraft->id);
         $handler->create($user = $this->getValidUser());
 
         $handler->assignRole($user->id, $role->id, array());
@@ -696,7 +698,9 @@ class UserHandlerTest extends TestCase
     {
         $handler = $this->getUserHandler();
 
-        $role = $this->createRole();
+        $roleDraft = $this->createRole();
+        $handler->publishRoleDraft($roleDraft->id);
+        $role = $handler->loadRole($roleDraft->id);
         $handler->create($user = $this->getValidUser());
 
         $handler->assignRole(
@@ -720,7 +724,9 @@ class UserHandlerTest extends TestCase
     {
         $handler = $this->getUserHandler();
 
-        $role = $this->createRole();
+        $roleDraft = $this->createRole();
+        $handler->publishRoleDraft($roleDraft->id);
+        $role = $handler->loadRole($roleDraft->id);
         $handler->create($user = $this->getValidUser());
 
         $handler->assignRole(
@@ -747,7 +753,9 @@ class UserHandlerTest extends TestCase
     {
         $handler = $this->getUserHandler();
 
-        $role = $this->createRole();
+        $roleDraft = $this->createRole();
+        $handler->publishRoleDraft($roleDraft->id);
+        $role = $handler->loadRole($roleDraft->id);
         $handler->create($user = $this->getValidUser());
 
         $handler->assignRole(

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
@@ -10,6 +10,7 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\User;
 
+use eZ\Publish\API\Repository\Values\User\Role as APIRole;
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\Core\Persistence\Legacy\User;
 use eZ\Publish\Core\Persistence\Legacy\User\Role\LimitationConverter;
@@ -237,12 +238,13 @@ class UserHandlerTest extends TestCase
 
         $role = new Persistence\User\Role();
         $role->identifier = 'Test';
+        $role->status = APIRole::STATUS_DEFINED;
 
         $handler->createRole($role);
 
         $this->assertQueryResult(
-            array(array(1, 'Test')),
-            $this->handler->createSelectQuery()->select('id', 'name')->from('ezrole'),
+            array(array(1, 'Test', APIRole::STATUS_DEFINED)),
+            $this->handler->createSelectQuery()->select('id', 'name', 'version')->from('ezrole'),
             'Expected a new role.'
         );
     }
@@ -253,6 +255,7 @@ class UserHandlerTest extends TestCase
 
         $role = new Persistence\User\Role();
         $role->identifier = 'Test';
+        $role->status = APIRole::STATUS_DEFINED;
 
         $role = $handler->createRole($role);
 
@@ -265,6 +268,7 @@ class UserHandlerTest extends TestCase
 
         $role = new Persistence\User\Role();
         $role->identifier = 'Test';
+        $role->status = APIRole::STATUS_DEFINED;
 
         $role = $handler->createRole($role);
 
@@ -280,6 +284,7 @@ class UserHandlerTest extends TestCase
 
         $role = new Persistence\User\Role();
         $role->identifier = 'Test';
+        $role->status = APIRole::STATUS_DEFINED;
 
         $role = $handler->createRole($role);
 
@@ -312,6 +317,7 @@ class UserHandlerTest extends TestCase
 
         $role = new Persistence\User\Role();
         $role->identifier = 'Test';
+        $role->status = APIRole::STATUS_DEFINED;
 
         $role = $handler->createRole($role);
 
@@ -347,6 +353,7 @@ class UserHandlerTest extends TestCase
 
         $role = new Persistence\User\Role();
         $role->identifier = 'Test';
+        $role->status = APIRole::STATUS_DEFINED;
 
         $role = $handler->createRole($role);
 
@@ -391,6 +398,7 @@ class UserHandlerTest extends TestCase
 
         $role = new Persistence\User\Role();
         $role->identifier = 'Test';
+        $role->status = APIRole::STATUS_DEFINED;
 
         $role = $handler->createRole($role);
 
@@ -406,6 +414,7 @@ class UserHandlerTest extends TestCase
 
         $role = new Persistence\User\Role();
         $role->identifier = 'Test';
+        $role->status = APIRole::STATUS_DEFINED;
 
         $role = $handler->createRole($role);
 
@@ -455,6 +464,8 @@ class UserHandlerTest extends TestCase
 
         $role = new Persistence\User\Role();
         $role->identifier = 'Test';
+        $role->status = APIRole::STATUS_DEFINED;
+
         $handler->createRole($role);
 
         $policy = new Persistence\User\Policy();
@@ -476,6 +487,8 @@ class UserHandlerTest extends TestCase
 
         $role = new Persistence\User\Role();
         $role->identifier = 'Test';
+        $role->status = APIRole::STATUS_DEFINED;
+
         $handler->createRole($role);
 
         $policy = new Persistence\User\Policy();
@@ -493,6 +506,8 @@ class UserHandlerTest extends TestCase
 
         $role = new Persistence\User\Role();
         $role->identifier = 'Test';
+        $role->status = APIRole::STATUS_DEFINED;
+
         $handler->createRole($role);
 
         $policy = new Persistence\User\Policy();
@@ -521,6 +536,8 @@ class UserHandlerTest extends TestCase
 
         $role = new Persistence\User\Role();
         $role->identifier = 'Test';
+        $role->status = APIRole::STATUS_DEFINED;
+
         $handler->createRole($role);
 
         $policy = new Persistence\User\Policy();
@@ -565,6 +582,7 @@ class UserHandlerTest extends TestCase
 
         $role = new Persistence\User\Role();
         $role->identifier = 'Test';
+        $role->status = APIRole::STATUS_DEFINED;
         $role->policies = array($policy1, $policy2);
 
         return $handler->createRole($role);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
@@ -394,7 +394,7 @@ CREATE TABLE ezrole (
   name varchar(255) NOT NULL DEFAULT '',
   value char(1) DEFAULT NULL,
   version int(11) DEFAULT 0,
-  PRIMARY KEY (id)
+  PRIMARY KEY (id,version)
 ) ENGINE=InnoDB;
 
 DROP TABLE IF EXISTS ezurl;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
@@ -826,7 +826,7 @@ ALTER TABLE ONLY ezpolicy_limitation_value
     ADD CONSTRAINT ezpolicy_limitation_value_pkey PRIMARY KEY (id);
 
 ALTER TABLE ONLY ezrole
-    ADD CONSTRAINT ezrole_pkey PRIMARY KEY (id);
+    ADD CONSTRAINT ezrole_pkey PRIMARY KEY (id, version);
 
 ALTER TABLE ONLY ezsearch_object_word_link
     ADD CONSTRAINT ezsearch_object_word_link_pkey PRIMARY KEY (id);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
@@ -351,11 +351,12 @@ CREATE INDEX ezpolicy_limitation_value_val ON ezpolicy_limitation_value (value);
 CREATE INDEX ezpolicy_limitation_value_limitation_id ON ezpolicy_limitation_value (limitation_id);
 
 CREATE TABLE ezrole (
-  id integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+  id integer NOT NULL,
   is_new integer NOT NULL DEFAULT 0,
   name text(255) NOT NULL,
   value text(1),
-  version integer DEFAULT 0
+  version integer DEFAULT 0,
+  PRIMARY KEY (id,version)
 );
 
 CREATE TABLE ezurl (

--- a/eZ/Publish/Core/Persistence/Legacy/User/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Handler.php
@@ -363,6 +363,29 @@ class Handler implements BaseUserHandler
     {
         $roleDraft = $this->loadRoleDraft($roleId);
 
+        try {
+            $role = $this->loadRole($roleId);
+            $roleAssignments = $this->loadRoleAssignmentsByRoleId($role->id);
+            $this->deleteRole($role->id);
+
+            foreach ($roleAssignments as $roleAssignment) {
+                if (empty($roleAssignment->limitationIdentifier)) {
+                    $this->assignRole(
+                        $roleAssignment->contentId,
+                        $roleId
+                    );
+                } else {
+                    $this->assignRole(
+                        $roleAssignment->contentId,
+                        $roleId,
+                        [$roleAssignment->limitationIdentifier => $roleAssignment->values]
+                    );
+                }
+            }
+        } catch (NotFound $e) {
+            // If no published role is found, no updates are necessary to it
+        }
+
         $this->roleGateway->publishRoleDraft($roleDraft->id);
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/User/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Mapper.php
@@ -80,6 +80,7 @@ class Mapper
                     array(
                         'id' => $row['ezpolicy_id'],
                         'roleId' => $row['ezrole_id'],
+                        'status' => $row['ezpolicy_original_id'],
                         'module' => $row['ezpolicy_module_name'],
                         'function' => $row['ezpolicy_function_name'],
                         'limitations' => '*', // limitations must be '*' if not a non empty array of limitations
@@ -216,7 +217,6 @@ class Mapper
         $createStruct = new RoleCreateStruct();
 
         $createStruct->identifier = $role->identifier;
-        $createStruct->status = $role->status;
         $createStruct->policies = $role->policies;
 
         return $createStruct;
@@ -234,8 +234,8 @@ class Mapper
         $role = new Role();
 
         $role->identifier = $createStruct->identifier;
-        $role->status = $createStruct->status;
         $role->policies = $createStruct->policies;
+        $role->status = Role::STATUS_DRAFT;
 
         return $role;
     }

--- a/eZ/Publish/Core/Persistence/Legacy/User/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Mapper.php
@@ -117,6 +117,7 @@ class Mapper
             if (empty($role->id)) {
                 $role->id = (int)$row['ezrole_id'];
                 $role->identifier = $row['ezrole_name'];
+                $role->status = $row['ezrole_version'];
                 // skip name and description as they don't exist in legacy
             }
         }

--- a/eZ/Publish/Core/Persistence/Legacy/User/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Mapper.php
@@ -12,6 +12,7 @@ namespace eZ\Publish\Core\Persistence\Legacy\User;
 
 use eZ\Publish\SPI\Persistence\User;
 use eZ\Publish\SPI\Persistence\User\Role;
+use eZ\Publish\SPI\Persistence\User\RoleCreateStruct;
 use eZ\Publish\SPI\Persistence\User\Policy;
 use eZ\Publish\SPI\Persistence\User\RoleAssignment;
 
@@ -201,5 +202,41 @@ class Mapper
         );
 
         return $roleAssignments;
+    }
+
+    /**
+     * Creates a create struct from an existing $role.
+     *
+     * @param \eZ\Publish\SPI\Persistence\User\Role $role
+     *
+     * @return \eZ\Publish\SPI\Persistence\User\RoleCreateStruct
+     */
+    public function createCreateStructFromRole(Role $role)
+    {
+        $createStruct = new RoleCreateStruct();
+
+        $createStruct->identifier = $role->identifier;
+        $createStruct->status = $role->status;
+        $createStruct->policies = $role->policies;
+
+        return $createStruct;
+    }
+
+    /**
+     * Maps properties from $struct to $role.
+     *
+     * @param \eZ\Publish\SPI\Persistence\User\RoleCreateStruct $createStruct
+     *
+     * @return \eZ\Publish\SPI\Persistence\User\Role
+     */
+    public function createRoleFromCreateStruct(RoleCreateStruct $createStruct)
+    {
+        $role = new Role();
+
+        $role->identifier = $createStruct->identifier;
+        $role->status = $createStruct->status;
+        $role->policies = $createStruct->policies;
+
+        return $role;
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
@@ -32,35 +32,40 @@ abstract class Gateway
      * Loads a specified role by $roleId.
      *
      * @param mixed $roleId
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      *
      * @return array
      */
-    abstract public function loadRole($roleId);
+    abstract public function loadRole($roleId, $status = Role::STATUS_DEFINED);
 
     /**
      * Loads a specified role by $identifier.
      *
      * @param string $identifier
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      *
      * @return array
      */
-    abstract public function loadRoleByIdentifier($identifier);
+    abstract public function loadRoleByIdentifier($identifier, $status = Role::STATUS_DEFINED);
 
     /**
      * Loads all roles.
      *
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
+     *
      * @return array
      */
-    abstract public function loadRoles();
+    abstract public function loadRoles($status = Role::STATUS_DEFINED);
 
     /**
      * Loads all roles associated with the given content objects.
      *
      * @param array $contentIds
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      *
      * @return array
      */
-    abstract public function loadRolesForContentObjects($contentIds);
+    abstract public function loadRolesForContentObjects($contentIds, $status = Role::STATUS_DEFINED);
 
     /**
      * Loads role assignments for specified content ID.
@@ -91,28 +96,39 @@ abstract class Gateway
     abstract public function loadPoliciesByUserId($userId);
 
     /**
-     * Update role.
+     * Update role (draft).
      *
      * Will not throw anything if location id is invalid.
      *
      * @param RoleUpdateStruct $role
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      */
-    abstract public function updateRole(RoleUpdateStruct $role);
+    abstract public function updateRole(RoleUpdateStruct $role, $status = Role::STATUS_DEFINED);
 
     /**
-     * Delete the specified role including all of its assignments.
+     * Delete the specified role (draft).
+     * If it's not a draft, the role assignments will also be deleted.
+     *
+     * @param mixed $roleId
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
+     */
+    abstract public function deleteRole($roleId, $status = Role::STATUS_DEFINED);
+
+    /**
+     * Publish the specified role draft.
      *
      * @param mixed $roleId
      */
-    abstract public function deleteRole($roleId);
+    abstract public function publishRoleDraft($roleId);
 
     /**
      * Adds a policy to a role.
      *
      * @param mixed $roleId
      * @param Policy $policy
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      */
-    abstract public function addPolicy($roleId, Policy $policy);
+    abstract public function addPolicy($roleId, Policy $policy, $status = Role::STATUS_DEFINED);
 
     /**
      * Adds limitations to an existing policy.
@@ -126,8 +142,9 @@ abstract class Gateway
      * Removes a policy from a role.
      *
      * @param mixed $policyId
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      */
-    abstract public function removePolicy($policyId);
+    abstract public function removePolicy($policyId, $status = Role::STATUS_DEFINED);
 
     /**
      * Removes a policy from a role.

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
@@ -71,9 +71,11 @@ class DoctrineDatabase extends Gateway
             );
         $query->prepare()->execute();
 
-        $role->id = $this->handler->lastInsertId(
-            $this->handler->getSequenceName('ezrole', 'id')
-        );
+        if (!isset($role->id) || (int)$role->id < 1) {
+            $role->id = $this->handler->lastInsertId(
+                $this->handler->getSequenceName('ezrole', 'id')
+            );
+        }
     }
 
     /**
@@ -94,6 +96,7 @@ class DoctrineDatabase extends Gateway
             $this->handler->aliasedColumn($query, 'id', 'ezpolicy'),
             $this->handler->aliasedColumn($query, 'function_name', 'ezpolicy'),
             $this->handler->aliasedColumn($query, 'module_name', 'ezpolicy'),
+            $this->handler->aliasedColumn($query, 'original_id', 'ezpolicy'),
             $this->handler->aliasedColumn($query, 'identifier', 'ezpolicy_limitation'),
             $this->handler->aliasedColumn($query, 'value', 'ezpolicy_limitation_value')
         )->from(
@@ -159,6 +162,7 @@ class DoctrineDatabase extends Gateway
             $this->handler->aliasedColumn($query, 'id', 'ezpolicy'),
             $this->handler->aliasedColumn($query, 'function_name', 'ezpolicy'),
             $this->handler->aliasedColumn($query, 'module_name', 'ezpolicy'),
+            $this->handler->aliasedColumn($query, 'original_id', 'ezpolicy'),
             $this->handler->aliasedColumn($query, 'identifier', 'ezpolicy_limitation'),
             $this->handler->aliasedColumn($query, 'value', 'ezpolicy_limitation_value')
         )->from(
@@ -224,6 +228,7 @@ class DoctrineDatabase extends Gateway
             $this->handler->aliasedColumn($query, 'id', 'ezpolicy'),
             $this->handler->aliasedColumn($query, 'function_name', 'ezpolicy'),
             $this->handler->aliasedColumn($query, 'module_name', 'ezpolicy'),
+            $this->handler->aliasedColumn($query, 'original_id', 'ezpolicy'),
             $this->handler->aliasedColumn($query, 'identifier', 'ezpolicy_limitation'),
             $this->handler->aliasedColumn($query, 'value', 'ezpolicy_limitation_value')
         )->from(
@@ -290,6 +295,7 @@ class DoctrineDatabase extends Gateway
             $this->handler->aliasedColumn($query, 'id', 'ezpolicy'),
             $this->handler->aliasedColumn($query, 'function_name', 'ezpolicy'),
             $this->handler->aliasedColumn($query, 'module_name', 'ezpolicy'),
+            $this->handler->aliasedColumn($query, 'original_id', 'ezpolicy'),
             $this->handler->aliasedColumn($query, 'identifier', 'ezpolicy_limitation'),
             $this->handler->aliasedColumn($query, 'value', 'ezpolicy_limitation_value')
         )->from(

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
@@ -55,7 +55,7 @@ class DoctrineDatabase extends Gateway
                 $this->handler->getAutoIncrementValue('ezrole', 'id')
             )->set(
                 $this->handler->quoteColumn('is_new'),
-                $query->bindValue($role->is_new)
+                0
             )->set(
                 $this->handler->quoteColumn('name'),
                 $query->bindValue($role->identifier)
@@ -64,7 +64,7 @@ class DoctrineDatabase extends Gateway
                 0
             )->set(
                 $this->handler->quoteColumn('version'),
-                $query->bindValue($role->version)
+                0
             );
         $query->prepare()->execute();
 

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
@@ -47,12 +47,15 @@ class DoctrineDatabase extends Gateway
      */
     public function createRole(Role $role)
     {
+        // Role ID is set when creating a draft from an existing role
         $query = $this->handler->createInsertQuery();
         $query
             ->insertInto($this->handler->quoteTable('ezrole'))
             ->set(
                 $this->handler->quoteColumn('id'),
-                $this->handler->getAutoIncrementValue('ezrole', 'id')
+                (!isset($role->id) || (int)$role->id < 1) ?
+                $this->handler->getAutoIncrementValue('ezrole', 'id') :
+                $query->bindValue((int)$role->id)
             )->set(
                 $this->handler->quoteColumn('is_new'),
                 0
@@ -64,7 +67,7 @@ class DoctrineDatabase extends Gateway
                 0
             )->set(
                 $this->handler->quoteColumn('version'),
-                0
+                $query->bindValue($role->status)
             );
         $query->prepare()->execute();
 
@@ -77,15 +80,17 @@ class DoctrineDatabase extends Gateway
      * Loads a specified role by id.
      *
      * @param mixed $roleId
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      *
      * @return array
      */
-    public function loadRole($roleId)
+    public function loadRole($roleId, $status = Role::STATUS_DEFINED)
     {
         $query = $this->handler->createSelectQuery();
         $query->select(
             $this->handler->aliasedColumn($query, 'id', 'ezrole'),
             $this->handler->aliasedColumn($query, 'name', 'ezrole'),
+            $this->handler->aliasedColumn($query, 'version', 'ezrole'),
             $this->handler->aliasedColumn($query, 'id', 'ezpolicy'),
             $this->handler->aliasedColumn($query, 'function_name', 'ezpolicy'),
             $this->handler->aliasedColumn($query, 'module_name', 'ezpolicy'),
@@ -95,9 +100,15 @@ class DoctrineDatabase extends Gateway
             $this->handler->quoteTable('ezrole')
         )->leftJoin(
             $this->handler->quoteTable('ezpolicy'),
-            $query->expr->eq(
-                $this->handler->quoteColumn('role_id', 'ezpolicy'),
-                $this->handler->quoteColumn('id', 'ezrole')
+            $query->expr->lAnd(
+                $query->expr->eq(
+                    $this->handler->quoteColumn('role_id', 'ezpolicy'),
+                    $this->handler->quoteColumn('id', 'ezrole')
+                ),
+                $query->expr->eq(
+                    $this->handler->quoteColumn('original_id', 'ezpolicy'),
+                    $query->bindValue($status, null, \PDO::PARAM_INT)
+                )
             )
         )->leftJoin(
             $this->handler->quoteTable('ezpolicy_limitation'),
@@ -112,9 +123,15 @@ class DoctrineDatabase extends Gateway
                 $this->handler->quoteColumn('id', 'ezpolicy_limitation')
             )
         )->where(
-            $query->expr->eq(
-                $this->handler->quoteColumn('id', 'ezrole'),
-                $query->bindValue($roleId, null, \PDO::PARAM_INT)
+            $query->expr->lAnd(
+                $query->expr->eq(
+                    $this->handler->quoteColumn('id', 'ezrole'),
+                    $query->bindValue($roleId, null, \PDO::PARAM_INT)
+                ),
+                $query->expr->eq(
+                    $this->handler->quoteColumn('version', 'ezrole'),
+                    $query->bindValue($status, null, \PDO::PARAM_INT)
+                )
             )
         );
 
@@ -128,15 +145,17 @@ class DoctrineDatabase extends Gateway
      * Loads a specified role by $identifier.
      *
      * @param string $identifier
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      *
      * @return array
      */
-    public function loadRoleByIdentifier($identifier)
+    public function loadRoleByIdentifier($identifier, $status = Role::STATUS_DEFINED)
     {
         $query = $this->handler->createSelectQuery();
         $query->select(
             $this->handler->aliasedColumn($query, 'id', 'ezrole'),
             $this->handler->aliasedColumn($query, 'name', 'ezrole'),
+            $this->handler->aliasedColumn($query, 'version', 'ezrole'),
             $this->handler->aliasedColumn($query, 'id', 'ezpolicy'),
             $this->handler->aliasedColumn($query, 'function_name', 'ezpolicy'),
             $this->handler->aliasedColumn($query, 'module_name', 'ezpolicy'),
@@ -146,9 +165,86 @@ class DoctrineDatabase extends Gateway
             $this->handler->quoteTable('ezrole')
         )->leftJoin(
             $this->handler->quoteTable('ezpolicy'),
+            $query->expr->lAnd(
+                $query->expr->eq(
+                    $this->handler->quoteColumn('role_id', 'ezpolicy'),
+                    $this->handler->quoteColumn('id', 'ezrole')
+                ),
+                $query->expr->eq(
+                    $this->handler->quoteColumn('original_id', 'ezpolicy'),
+                    $query->bindValue($status, null, \PDO::PARAM_INT)
+                )
+            )
+        )->leftJoin(
+            $this->handler->quoteTable('ezpolicy_limitation'),
             $query->expr->eq(
-                $this->handler->quoteColumn('role_id', 'ezpolicy'),
+                $this->handler->quoteColumn('policy_id', 'ezpolicy_limitation'),
+                $this->handler->quoteColumn('id', 'ezpolicy')
+            )
+        )->leftJoin(
+            $this->handler->quoteTable('ezpolicy_limitation_value'),
+            $query->expr->eq(
+                $this->handler->quoteColumn('limitation_id', 'ezpolicy_limitation_value'),
+                $this->handler->quoteColumn('id', 'ezpolicy_limitation')
+            )
+        )->where(
+            $query->expr->lAnd(
+                $query->expr->eq(
+                    $this->handler->quoteColumn('name', 'ezrole'),
+                    $query->bindValue($identifier, null, \PDO::PARAM_STR)
+                ),
+                $query->expr->eq(
+                    $this->handler->quoteColumn('version', 'ezrole'),
+                    $query->bindValue($status, null, \PDO::PARAM_INT)
+                )
+            )
+        );
+
+        $statement = $query->prepare();
+        $statement->execute();
+
+        return $statement->fetchAll(\PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Loads all roles.
+     *
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
+     *
+     * @return array
+     */
+    public function loadRoles($status = Role::STATUS_DEFINED)
+    {
+        $query = $this->handler->createSelectQuery();
+        $query->select(
+            $this->handler->aliasedColumn($query, 'id', 'ezrole'),
+            $this->handler->aliasedColumn($query, 'name', 'ezrole'),
+            $this->handler->aliasedColumn($query, 'version', 'ezrole'),
+            $this->handler->aliasedColumn($query, 'contentobject_id', 'ezuser_role'),
+            $this->handler->aliasedColumn($query, 'id', 'ezpolicy'),
+            $this->handler->aliasedColumn($query, 'function_name', 'ezpolicy'),
+            $this->handler->aliasedColumn($query, 'module_name', 'ezpolicy'),
+            $this->handler->aliasedColumn($query, 'identifier', 'ezpolicy_limitation'),
+            $this->handler->aliasedColumn($query, 'value', 'ezpolicy_limitation_value')
+        )->from(
+            $this->handler->quoteTable('ezrole')
+        )->leftJoin(
+            $this->handler->quoteTable('ezuser_role'),
+            $query->expr->eq(
+                $this->handler->quoteColumn('role_id', 'ezuser_role'),
                 $this->handler->quoteColumn('id', 'ezrole')
+            )
+        )->leftJoin(
+            $this->handler->quoteTable('ezpolicy'),
+            $query->expr->lAnd(
+                $query->expr->eq(
+                    $this->handler->quoteColumn('role_id', 'ezpolicy'),
+                    $this->handler->quoteColumn('id', 'ezrole')
+                ),
+                $query->expr->eq(
+                    $this->handler->quoteColumn('original_id', 'ezpolicy'),
+                    $query->bindValue($status, null, \PDO::PARAM_INT)
+                )
             )
         )->leftJoin(
             $this->handler->quoteTable('ezpolicy_limitation'),
@@ -164,59 +260,8 @@ class DoctrineDatabase extends Gateway
             )
         )->where(
             $query->expr->eq(
-                $this->handler->quoteColumn('name', 'ezrole'),
-                $query->bindValue($identifier, null, \PDO::PARAM_STR)
-            )
-        );
-
-        $statement = $query->prepare();
-        $statement->execute();
-
-        return $statement->fetchAll(\PDO::FETCH_ASSOC);
-    }
-
-    /**
-     * Loads all roles.
-     *
-     * @return array
-     */
-    public function loadRoles()
-    {
-        $query = $this->handler->createSelectQuery();
-        $query->select(
-            $this->handler->aliasedColumn($query, 'id', 'ezrole'),
-            $this->handler->aliasedColumn($query, 'name', 'ezrole'),
-            $this->handler->aliasedColumn($query, 'contentobject_id', 'ezuser_role'),
-            $this->handler->aliasedColumn($query, 'id', 'ezpolicy'),
-            $this->handler->aliasedColumn($query, 'function_name', 'ezpolicy'),
-            $this->handler->aliasedColumn($query, 'module_name', 'ezpolicy'),
-            $this->handler->aliasedColumn($query, 'identifier', 'ezpolicy_limitation'),
-            $this->handler->aliasedColumn($query, 'value', 'ezpolicy_limitation_value')
-        )->from(
-            $this->handler->quoteTable('ezrole')
-        )->leftJoin(
-            $this->handler->quoteTable('ezuser_role'),
-            $query->expr->eq(
-                $this->handler->quoteColumn('role_id', 'ezuser_role'),
-                $this->handler->quoteColumn('id', 'ezrole')
-            )
-        )->leftJoin(
-            $this->handler->quoteTable('ezpolicy'),
-            $query->expr->eq(
-                $this->handler->quoteColumn('role_id', 'ezpolicy'),
-                $this->handler->quoteColumn('id', 'ezrole')
-            )
-        )->leftJoin(
-            $this->handler->quoteTable('ezpolicy_limitation'),
-            $query->expr->eq(
-                $this->handler->quoteColumn('policy_id', 'ezpolicy_limitation'),
-                $this->handler->quoteColumn('id', 'ezpolicy')
-            )
-        )->leftJoin(
-            $this->handler->quoteTable('ezpolicy_limitation_value'),
-            $query->expr->eq(
-                $this->handler->quoteColumn('limitation_id', 'ezpolicy_limitation_value'),
-                $this->handler->quoteColumn('id', 'ezpolicy_limitation')
+                $this->handler->quoteColumn('version', 'ezrole'),
+                $query->bindValue($status, null, \PDO::PARAM_INT)
             )
         );
 
@@ -230,16 +275,18 @@ class DoctrineDatabase extends Gateway
      * Loads all roles associated with the given content objects.
      *
      * @param array $contentIds
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      *
      * @return array
      */
-    public function loadRolesForContentObjects($contentIds)
+    public function loadRolesForContentObjects($contentIds, $status = Role::STATUS_DEFINED)
     {
         $query = $this->handler->createSelectQuery();
         $query->select(
             $this->handler->aliasedColumn($query, 'contentobject_id', 'ezuser_role'),
             $this->handler->aliasedColumn($query, 'id', 'ezrole'),
             $this->handler->aliasedColumn($query, 'name', 'ezrole'),
+            $this->handler->aliasedColumn($query, 'version', 'ezrole'),
             $this->handler->aliasedColumn($query, 'id', 'ezpolicy'),
             $this->handler->aliasedColumn($query, 'function_name', 'ezpolicy'),
             $this->handler->aliasedColumn($query, 'module_name', 'ezpolicy'),
@@ -252,9 +299,15 @@ class DoctrineDatabase extends Gateway
             )
         )->leftJoin(
             $this->handler->quoteTable('ezrole'),
-            $query->expr->eq(
-                $this->handler->quoteColumn('id', 'ezrole'),
-                $this->handler->quoteColumn('role_id', 'ezuser_role_search')
+            $query->expr->lAnd(
+                $query->expr->eq(
+                    $this->handler->quoteColumn('id', 'ezrole'),
+                    $this->handler->quoteColumn('role_id', 'ezuser_role_search')
+                ),
+                $query->expr->eq(
+                    $this->handler->quoteColumn('version', 'ezrole'),
+                    $query->bindValue($status, null, \PDO::PARAM_INT)
+                )
             )
         )->leftJoin(
             $this->handler->quoteTable('ezuser_role'),
@@ -264,9 +317,15 @@ class DoctrineDatabase extends Gateway
             )
         )->leftJoin(
             $this->handler->quoteTable('ezpolicy'),
-            $query->expr->eq(
-                $this->handler->quoteColumn('role_id', 'ezpolicy'),
-                $this->handler->quoteColumn('id', 'ezrole')
+            $query->expr->lAnd(
+                $query->expr->eq(
+                    $this->handler->quoteColumn('role_id', 'ezpolicy'),
+                    $this->handler->quoteColumn('id', 'ezrole')
+                ),
+                $query->expr->eq(
+                    $this->handler->quoteColumn('original_id', 'ezpolicy'),
+                    $query->bindValue($status, null, \PDO::PARAM_INT)
+                )
             )
         )->leftJoin(
             $this->handler->quoteTable('ezpolicy_limitation'),
@@ -453,13 +512,16 @@ class DoctrineDatabase extends Gateway
     }
 
     /**
-     * Update role.
+     * Update role (draft).
      *
      * Will not throw anything if location id is invalid.
      *
      * @param \eZ\Publish\SPI\Persistence\User\RoleUpdateStruct $role
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
+     *
+     * @return array
      */
-    public function updateRole(RoleUpdateStruct $role)
+    public function updateRole(RoleUpdateStruct $role, $status = Role::STATUS_DEFINED)
     {
         $query = $this->handler->createUpdateQuery();
         $query
@@ -468,9 +530,15 @@ class DoctrineDatabase extends Gateway
                 $this->handler->quoteColumn('name'),
                 $query->bindValue($role->identifier)
             )->where(
-                $query->expr->eq(
-                    $this->handler->quoteColumn('id'),
-                    $query->bindValue($role->id, null, \PDO::PARAM_INT)
+                $query->expr->lAnd(
+                    $query->expr->eq(
+                        $this->handler->quoteColumn('id'),
+                        $query->bindValue($role->id, null, \PDO::PARAM_INT)
+                    ),
+                    $query->expr->eq(
+                        $this->handler->quoteColumn('version'),
+                        $query->bindValue($status, null, \PDO::PARAM_INT)
+                    )
                 )
             );
         $statement = $query->prepare();
@@ -484,34 +552,90 @@ class DoctrineDatabase extends Gateway
     }
 
     /**
-     * Delete the specified role including all of its assignments.
+     * Delete the specified role (draft).
+     * If it's not a draft, the role assignments will also be deleted.
      *
      * @param mixed $roleId
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      */
-    public function deleteRole($roleId)
+    public function deleteRole($roleId, $status = Role::STATUS_DEFINED)
     {
-        $deleteAssignmentsQuery = $this->handler->createDeleteQuery();
-        $deleteAssignmentsQuery
-            ->deleteFrom($this->handler->quoteTable('ezuser_role'))
-            ->where(
-                $deleteAssignmentsQuery->expr->eq(
-                    $this->handler->quoteColumn('role_id'),
-                    $deleteAssignmentsQuery->bindValue($roleId, null, \PDO::PARAM_INT)
-                )
-            );
+        if ($status !== Role::STATUS_DRAFT) {
+            $deleteAssignmentsQuery = $this->handler->createDeleteQuery();
+            $deleteAssignmentsQuery
+                ->deleteFrom($this->handler->quoteTable('ezuser_role'))
+                ->where(
+                    $deleteAssignmentsQuery->expr->eq(
+                        $this->handler->quoteColumn('role_id'),
+                        $deleteAssignmentsQuery->bindValue($roleId, null, \PDO::PARAM_INT)
+                    )
+                );
+        }
 
         $deleteRoleQuery = $this->handler->createDeleteQuery();
         $deleteRoleQuery
             ->deleteFrom($this->handler->quoteTable('ezrole'))
             ->where(
-                $deleteRoleQuery->expr->eq(
-                    $this->handler->quoteColumn('id'),
-                    $deleteRoleQuery->bindValue($roleId, null, \PDO::PARAM_INT)
+                $deleteRoleQuery->expr->lAnd(
+                    $deleteRoleQuery->expr->eq(
+                        $this->handler->quoteColumn('id'),
+                        $deleteRoleQuery->bindValue($roleId, null, \PDO::PARAM_INT)
+                    ),
+                    $deleteRoleQuery->expr->eq(
+                        $this->handler->quoteColumn('version'),
+                        $deleteRoleQuery->bindValue($status, null, \PDO::PARAM_INT)
+                    )
                 )
             );
 
-        $deleteAssignmentsQuery->prepare()->execute();
+        if ($status !== Role::STATUS_DRAFT) {
+            $deleteAssignmentsQuery->prepare()->execute();
+        }
         $deleteRoleQuery->prepare()->execute();
+    }
+
+    /**
+     * Publish the specified role draft.
+     *
+     * @param mixed $roleId
+     */
+    public function publishRoleDraft($roleId)
+    {
+        $query = $this->handler->createUpdateQuery();
+        $query
+            ->update($this->handler->quoteTable('ezrole'))
+            ->set(
+                $this->handler->quoteColumn('version'),
+                $query->bindValue(Role::STATUS_DEFINED, null, \PDO::PARAM_INT)
+            )->where(
+                $query->expr->eq(
+                    $this->handler->quoteColumn('id'),
+                    $query->bindValue($roleId, null, \PDO::PARAM_INT)
+                )
+            );
+        $statement = $query->prepare();
+        $statement->execute();
+
+        $policyQuery = $this->handler->createUpdateQuery();
+        $policyQuery
+            ->update($this->handler->quoteTable('ezpolicy'))
+            ->set(
+                $this->handler->quoteColumn('original_id'),
+                $policyQuery->bindValue(Role::STATUS_DEFINED, null, \PDO::PARAM_INT)
+            )->where(
+                $policyQuery->expr->lAnd(
+                    $policyQuery->expr->eq(
+                        $this->handler->quoteColumn('role_id'),
+                        $policyQuery->bindValue($roleId, null, \PDO::PARAM_INT)
+                    ),
+                    $policyQuery->expr->eq(
+                        $this->handler->quoteColumn('original_id'),
+                        $policyQuery->bindValue(Role::STATUS_DRAFT, null, \PDO::PARAM_INT)
+                    )
+                )
+            );
+        $queryStatement = $policyQuery->prepare();
+        $queryStatement->execute();
     }
 
     /**
@@ -519,8 +643,9 @@ class DoctrineDatabase extends Gateway
      *
      * @param mixed $roleId
      * @param \eZ\Publish\SPI\Persistence\User\Policy $policy
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      */
-    public function addPolicy($roleId, Policy $policy)
+    public function addPolicy($roleId, Policy $policy, $status = Role::STATUS_DEFINED)
     {
         $query = $this->handler->createInsertQuery();
         $query
@@ -536,7 +661,7 @@ class DoctrineDatabase extends Gateway
                 $query->bindValue($policy->module)
             )->set(
                 $this->handler->quoteColumn('original_id'),
-                0
+                $query->bindValue($status, null, \PDO::PARAM_INT)
             )->set(
                 $this->handler->quoteColumn('role_id'),
                 $query->bindValue($roleId, null, \PDO::PARAM_INT)
@@ -610,8 +735,9 @@ class DoctrineDatabase extends Gateway
      * Removes a policy from a role.
      *
      * @param mixed $policyId
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      */
-    public function removePolicy($policyId)
+    public function removePolicy($policyId, $status = Role::STATUS_DEFINED)
     {
         $this->removePolicyLimitations($policyId);
 
@@ -619,9 +745,15 @@ class DoctrineDatabase extends Gateway
         $query
             ->deleteFrom($this->handler->quoteTable('ezpolicy'))
             ->where(
-                $query->expr->eq(
-                    $this->handler->quoteColumn('id'),
-                    $query->bindValue($policyId, null, \PDO::PARAM_INT)
+                $query->expr->lAnd(
+                    $query->expr->eq(
+                        $this->handler->quoteColumn('id'),
+                        $query->bindValue($policyId, null, \PDO::PARAM_INT)
+                    ),
+                    $query->expr->eq(
+                        $this->handler->quoteColumn('original_id'),
+                        $query->bindValue($status, null, \PDO::PARAM_INT)
+                    )
                 )
             );
         $query->prepare()->execute();

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
@@ -55,7 +55,7 @@ class DoctrineDatabase extends Gateway
                 $this->handler->getAutoIncrementValue('ezrole', 'id')
             )->set(
                 $this->handler->quoteColumn('is_new'),
-                0
+                $query->bindValue($role->is_new)
             )->set(
                 $this->handler->quoteColumn('name'),
                 $query->bindValue($role->identifier)
@@ -64,7 +64,7 @@ class DoctrineDatabase extends Gateway
                 0
             )->set(
                 $this->handler->quoteColumn('version'),
-                0
+                $query->bindValue($role->version)
             );
         $query->prepare()->execute();
 

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
@@ -62,13 +62,14 @@ class ExceptionConversion extends Gateway
      * Loads a specified role by $roleId.
      *
      * @param mixed $roleId
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      *
      * @return array
      */
-    public function loadRole($roleId)
+    public function loadRole($roleId, $status = Role::STATUS_DEFINED)
     {
         try {
-            return $this->innerGateway->loadRole($roleId);
+            return $this->innerGateway->loadRole($roleId, $status);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {
@@ -80,13 +81,14 @@ class ExceptionConversion extends Gateway
      * Loads a specified role by $identifier.
      *
      * @param string $identifier
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      *
      * @return array
      */
-    public function loadRoleByIdentifier($identifier)
+    public function loadRoleByIdentifier($identifier, $status = Role::STATUS_DEFINED)
     {
         try {
-            return $this->innerGateway->loadRoleByIdentifier($identifier);
+            return $this->innerGateway->loadRoleByIdentifier($identifier, $status);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {
@@ -97,9 +99,11 @@ class ExceptionConversion extends Gateway
     /**
      * Loads all roles.
      *
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
+     *
      * @return array
      */
-    public function loadRoles()
+    public function loadRoles($status = Role::STATUS_DEFINED)
     {
         try {
             return $this->innerGateway->loadRoles();
@@ -114,10 +118,11 @@ class ExceptionConversion extends Gateway
      * Loads all roles associated with the given content objects.
      *
      * @param array $contentIds
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      *
      * @return array
      */
-    public function loadRolesForContentObjects($contentIds)
+    public function loadRolesForContentObjects($contentIds, $status = Role::STATUS_DEFINED)
     {
         try {
             return $this->innerGateway->loadRolesForContentObjects($contentIds);
@@ -184,16 +189,17 @@ class ExceptionConversion extends Gateway
     }
 
     /**
-     * Update role.
+     * Update role (draft).
      *
      * @throws \eZ\Publish\Core\Base\Exceptions\NotFoundException
      *
      * @param RoleUpdateStruct $role
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      */
-    public function updateRole(RoleUpdateStruct $role)
+    public function updateRole(RoleUpdateStruct $role, $status = Role::STATUS_DEFINED)
     {
         try {
-            return $this->innerGateway->updateRole($role);
+            return $this->innerGateway->updateRole($role, $status);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {
@@ -202,14 +208,32 @@ class ExceptionConversion extends Gateway
     }
 
     /**
-     * Delete the specified role including all of its assignments.
+     * Delete the specified role (draft).
+     * If it's not a draft, the role assignments will also be deleted.
+     *
+     * @param mixed $roleId
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
+     */
+    public function deleteRole($roleId, $status = Role::STATUS_DEFINED)
+    {
+        try {
+            return $this->innerGateway->deleteRole($roleId, $status);
+        } catch (DBALException $e) {
+            throw new RuntimeException('Database error', 0, $e);
+        } catch (PDOException $e) {
+            throw new RuntimeException('Database error', 0, $e);
+        }
+    }
+
+    /**
+     * Publish the specified role draft.
      *
      * @param mixed $roleId
      */
-    public function deleteRole($roleId)
+    public function publishRoleDraft($roleId)
     {
         try {
-            return $this->innerGateway->deleteRole($roleId);
+            return $this->innerGateway->publishRoleDraft($roleId);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {
@@ -222,11 +246,12 @@ class ExceptionConversion extends Gateway
      *
      * @param mixed $roleId
      * @param Policy $policy
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      */
-    public function addPolicy($roleId, Policy $policy)
+    public function addPolicy($roleId, Policy $policy, $status = Role::STATUS_DEFINED)
     {
         try {
-            return $this->innerGateway->addPolicy($roleId, $policy);
+            return $this->innerGateway->addPolicy($roleId, $policy, $status);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {
@@ -255,11 +280,12 @@ class ExceptionConversion extends Gateway
      * Removes a policy from a role.
      *
      * @param mixed $policyId
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      */
-    public function removePolicy($policyId)
+    public function removePolicy($policyId, $status = Role::STATUS_DEFINED)
     {
         try {
-            return $this->innerGateway->removePolicy($policyId);
+            return $this->innerGateway->removePolicy($policyId, $status);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {

--- a/eZ/Publish/Core/REST/Client/RoleService.php
+++ b/eZ/Publish/Core/REST/Client/RoleService.php
@@ -8,7 +8,6 @@
  *
  * @version //autogentag//
  */
-
 namespace eZ\Publish\Core\REST\Client;
 
 use eZ\Publish\API\Repository\RoleService as APIRoleService;
@@ -17,6 +16,7 @@ use eZ\Publish\API\Repository\Values\User\Policy as APIPolicy;
 use eZ\Publish\API\Repository\Values\User\PolicyCreateStruct as APIPolicyCreateStruct;
 use eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct as APIPolicyUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\Role as APIRole;
+use eZ\Publish\API\Repository\Values\User\RoleDraft as APIRoleDraft;
 use eZ\Publish\API\Repository\Values\User\RoleCreateStruct as APIRoleCreateStruct;
 use eZ\Publish\API\Repository\Values\User\RoleUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\User;
@@ -99,7 +99,170 @@ class RoleService implements APIRoleService, Sessionable
     }
 
     /**
+     * Creates a new RoleDraft.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists or if limitation of the
+     *                                                                        same type is repeated in the policy create struct or if
+     *                                                                        limitation is not allowed on module/function
+     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a policy limitation in the $roleCreateStruct is not valid
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleCreateStruct $roleCreateStruct
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
+     */
+    public function createRoleDraft(APIRoleCreateStruct $roleCreateStruct)
+    {
+        //TODO
+    }
+
+    /**
+     * Creates a new RoleDraft for existing Role.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the Role already has a Role Draft that will need to be removed first
+     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a policy limitation in the $roleCreateStruct is not valid
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Role $role
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
+     */
+    public function createRoleDraftByRole(APIRole $role)
+    {
+        //TODO
+    }
+
+    /**
+     * Loads a role for the given id.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read this role
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a role with the given id was not found
+     *
+     * @param mixed $id
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
+     */
+    public function loadRoleDraft($id)
+    {
+        //TODO
+    }
+
+    /**
+     * Updates the properties of a role draft.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a role
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the identifier of the role already exists
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
+     * @param \eZ\Publish\API\Repository\Values\User\RoleUpdateStruct $roleUpdateStruct
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
+     */
+    public function updateRoleDraft(APIRoleDraft $roleDraft, RoleUpdateStruct $roleUpdateStruct)
+    {
+        //TODO
+    }
+
+    /**
+     * Adds a new policy to the role draft.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to add  a policy
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if limitation of the same type is repeated in policy create
+     *                                                                        struct or if limitation is not allowed on module/function
+     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a limitation in the $policyCreateStruct is not valid
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
+     * @param \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct $policyCreateStruct
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
+     */
+    public function addPolicyByRoleDraft(APIRoleDraft $roleDraft, APIPolicyCreateStruct $policyCreateStruct)
+    {
+        //TODO
+    }
+
+    /**
+     * Removes a policy from a role draft.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if policy does not belong to the given role draft
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
+     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to remove from the role
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft the updated role
+     */
+    public function removePolicyByRoleDraft(APIRoleDraft $roleDraft, APIPolicy $policy)
+    {
+        //TODO
+    }
+
+    /**
+     * Updates the limitations of a policy. The module and function cannot be changed and
+     * the limitations are replaced by the ones in $roleUpdateStruct.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a policy
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if limitation of the same type is repeated in policy update
+     *                                                                        struct or if limitation is not allowed on module/function
+     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a limitation in the $policyUpdateStruct is not valid
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
+     * @param \eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct $policyUpdateStruct
+     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\Policy
+     */
+    public function updatePolicyByRoleDraft(APIRoleDraft $roleDraft, APIPolicy $policy, APIPolicyUpdateStruct $policyUpdateStruct)
+    {
+        //TODO
+    }
+
+    /**
+     * Deletes the given role.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to delete this role
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
+     */
+    public function deleteRoleDraft(APIRoleDraft $roleDraft)
+    {
+        //TODO
+    }
+
+    /**
+     * Publishes a given Role draft.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to delete this role
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
+     */
+    public function publishRoleDraft(APIRoleDraft $roleDraft)
+    {
+        //TODO
+    }
+
+    /**
      * Creates a new Role.
+     *
+     * @deprecated since 6.0, use {@see createRoleDraft}
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists or if limitation of the
@@ -162,6 +325,8 @@ class RoleService implements APIRoleService, Sessionable
     /**
      * Updates the name of the role.
      *
+     * @deprecated since 6.0, use {@see updateRoleDraft}
+     *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a role
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists
      *
@@ -187,6 +352,8 @@ class RoleService implements APIRoleService, Sessionable
 
     /**
      * Adds a new policy to the role.
+     *
+     * @deprecated since 6.0, use {@see addPolicyByRoleDraft}
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to add  a policy
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if limitation of the same type is repeated in policy create
@@ -235,9 +402,9 @@ class RoleService implements APIRoleService, Sessionable
     }
 
     /**
-     * removes a policy from the role.
+     * Removes a policy from the role.
      *
-     * @deprecated since 5.3, use {@link deletePolicy()} instead.
+     * @deprecated since 5.3, use {@link removePolicyByRoleDraft()} instead.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if policy does not belong to the given role
@@ -278,6 +445,8 @@ class RoleService implements APIRoleService, Sessionable
     /**
      * Deletes a policy.
      *
+     * @deprecated since 6.0, use {@link removePolicyByRoleDraft()} instead.
+     *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
      *
      * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to delete
@@ -290,6 +459,8 @@ class RoleService implements APIRoleService, Sessionable
     /**
      * Updates the limitations of a policy. The module and function cannot be changed and
      * the limitations are replaced by the ones in $roleUpdateStruct.
+     *
+     * @deprecated since 6.0, use {@link updatePolicyByRoleDraft()} instead.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a policy
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if limitation of the same type is repeated in policy update

--- a/eZ/Publish/Core/REST/Client/RoleService.php
+++ b/eZ/Publish/Core/REST/Client/RoleService.php
@@ -104,9 +104,9 @@ class RoleService implements APIRoleService, Sessionable
      * @since 6.0
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists or if limitation of the
-     *                                                                        same type is repeated in the policy create struct or if
-     *                                                                        limitation is not allowed on module/function
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     *         if the name of the role already exists or if limitation of the same type
+     *         is repeated in the policy create struct or if limitation is not allowed on module/function
      * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a policy limitation in the $roleCreateStruct is not valid
      *
      * @param \eZ\Publish\API\Repository\Values\User\RoleCreateStruct $roleCreateStruct

--- a/eZ/Publish/Core/REST/Client/RoleService.php
+++ b/eZ/Publish/Core/REST/Client/RoleService.php
@@ -21,6 +21,7 @@ use eZ\Publish\API\Repository\Values\User\RoleCreateStruct as APIRoleCreateStruc
 use eZ\Publish\API\Repository\Values\User\RoleUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\User\UserGroup;
+use eZ\Publish\Core\Repository\Values\User\RoleDraft;
 use eZ\Publish\Core\Repository\Values\User\UserRoleAssignment;
 use eZ\Publish\Core\Repository\Values\User\UserGroupRoleAssignment;
 use eZ\Publish\Core\REST\Client\Values\User\PolicyCreateStruct;
@@ -99,26 +100,6 @@ class RoleService implements APIRoleService, Sessionable
     }
 
     /**
-     * Creates a new RoleDraft.
-     *
-     * @since 6.0
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     *         if the name of the role already exists or if limitation of the same type
-     *         is repeated in the policy create struct or if limitation is not allowed on module/function
-     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a policy limitation in the $roleCreateStruct is not valid
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\RoleCreateStruct $roleCreateStruct
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
-     */
-    public function createRoleDraft(APIRoleCreateStruct $roleCreateStruct)
-    {
-        //TODO
-    }
-
-    /**
      * Creates a new RoleDraft for existing Role.
      *
      * @since 6.0
@@ -131,7 +112,7 @@ class RoleService implements APIRoleService, Sessionable
      *
      * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
      */
-    public function createRoleDraftByRole(APIRole $role)
+    public function createRoleDraft(APIRole $role)
     {
         //TODO
     }
@@ -260,9 +241,7 @@ class RoleService implements APIRoleService, Sessionable
     }
 
     /**
-     * Creates a new Role.
-     *
-     * @deprecated since 6.0, use {@see createRoleDraft}
+     * Creates a new Role draft.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists or if limitation of the
@@ -272,7 +251,7 @@ class RoleService implements APIRoleService, Sessionable
      *
      * @param \eZ\Publish\API\Repository\Values\User\RoleCreateStruct $roleCreateStruct
      *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
      */
     public function createRole(APIRoleCreateStruct $roleCreateStruct)
     {
@@ -313,7 +292,7 @@ class RoleService implements APIRoleService, Sessionable
             $createdPolicies[] = $createdPolicy;
         }
 
-        return new Role(
+        return new RoleDraft(
             array(
                 'id' => $createdRole->id,
                 'identifier' => $createdRole->identifier,

--- a/eZ/Publish/Core/REST/Server/Controller/Role.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Role.php
@@ -11,6 +11,9 @@
 namespace eZ\Publish\Core\REST\Server\Controller;
 
 use eZ\Publish\API\Repository\Exceptions\LimitationValidationException;
+use eZ\Publish\Core\Base\Exceptions\ForbiddenException;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
 use eZ\Publish\Core\REST\Common\Message;
 use eZ\Publish\Core\REST\Common\Exceptions;
 use eZ\Publish\Core\REST\Server\Exceptions\BadRequestException;
@@ -74,18 +77,40 @@ class Role extends RestController
      */
     public function createRole(Request $request)
     {
-        return new Values\CreatedRole(
-            array(
-                'role' => $this->roleService->createRole(
-                    $this->inputDispatcher->parse(
-                        new Message(
-                            array('Content-Type' => $request->headers->get('Content-Type')),
-                            $request->getContent()
-                        )
+        $publish = ($request->query->has('publish') && $request->query->get('publish') === 'true');
+
+        try {
+            $roleDraft = $this->roleService->createRole(
+                $this->inputDispatcher->parse(
+                    new Message(
+                        [
+                            'Content-Type' => $request->headers->get('Content-Type'),
+                            // @todo Needs refactoring! Temporary solution so parser has access to get parameters
+                            '__publish' => $publish,
+                        ],
+                        $request->getContent()
                     )
-                ),
-            )
-        );
+                )
+            );
+        } catch (InvalidArgumentException $e) {
+            throw new ForbiddenException($e->getMessage());
+        } catch (UnauthorizedException $e) {
+            throw new ForbiddenException($e->getMessage());
+        } catch (LimitationValidationException $e) {
+            throw new BadRequestException($e->getMessage());
+        } catch (Exceptions\Parser $e) {
+            throw new BadRequestException($e->getMessage());
+        }
+
+        if ($publish) {
+            $this->roleService->publishRoleDraft($roleDraft);
+
+            $role = $this->roleService->loadRole($roleDraft->id);
+
+            return new Values\CreatedRole(['role' => new Values\RestRole($role)]);
+        }
+
+        return new Values\CreatedRole(['role' => new Values\RestRole($roleDraft)]);
     }
 
     /**
@@ -130,6 +155,18 @@ class Role extends RestController
     }
 
     /**
+     * Loads role draft.
+     *
+     * @param $roleId
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
+     */
+    public function loadRoleDraft($roleId)
+    {
+        return $this->roleService->loadRoleDraft($roleId);
+    }
+
+    /**
      * Updates a role.
      *
      * @param $roleId
@@ -147,6 +184,48 @@ class Role extends RestController
 
         return $this->roleService->updateRole(
             $this->roleService->loadRole($roleId),
+            $this->mapToUpdateStruct($createStruct)
+        );
+    }
+
+    /**
+     * Updates a role draft.
+     *
+     * @param $roleId
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
+     */
+    public function updateRoleDraft($roleId, Request $request)
+    {
+        $createStruct = $this->inputDispatcher->parse(
+            new Message(
+                array('Content-Type' => $request->headers->get('Content-Type')),
+                $request->getContent()
+            )
+        );
+
+        return $this->roleService->updateRoleDraft(
+            $this->roleService->loadRoleDraft($roleId),
+            $this->mapToUpdateStruct($createStruct)
+        );
+    }
+
+    /**
+     * Publishes a role draft.
+     *
+     * @param $roleId
+     */
+    public function publishRoleDraft($roleId, Request $request)
+    {
+        $createStruct = $this->inputDispatcher->parse(
+            new Message(
+                array('Content-Type' => $request->headers->get('Content-Type')),
+                $request->getContent()
+            )
+        );
+
+        $this->roleService->publishRoleDraft(
+            $this->roleService->loadRoleDraft($roleId),
             $this->mapToUpdateStruct($createStruct)
         );
     }

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/RoleInputTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/RoleInputTest.php
@@ -22,7 +22,7 @@ class RoleInputTest extends BaseTest
     {
         $inputArray = array(
             'identifier' => 'Identifier Bar',
-            /* @todo uncomment when support for multilingual names and descriptions is added
+            /* @todo uncomment when support for multilingual names and descriptions is added EZP-24776
             'mainLanguageCode' => 'eng-GB',
             'names' => array(
                 'value' => array(
@@ -58,7 +58,7 @@ class RoleInputTest extends BaseTest
             'RoleCreateStruct identifier property not created correctly.'
         );
 
-        /* @todo uncomment when support for multilingual names and descriptions is added
+        /* @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         $this->assertEquals(
             array( 'eng-GB' => 'Test role' ),
             $result->names,

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ContentTypeGroupTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ContentTypeGroupTest.php
@@ -36,7 +36,7 @@ class ContentTypeGroupTest extends ValueObjectVisitorBaseTest
                 'modificationDate' => new \DateTime('2012-12-31 19:35 Europe/Zagreb'),
                 'creatorId' => 14,
                 'modifierId' => 13,
-                /* @todo uncomment when support for multilingual names and descriptions is added
+                /* @todo uncomment when support for multilingual names and descriptions is added EZP-24776
                 'names' => array(
                     'eng-GB' => 'Group name EN',
                     'eng-US' => 'Group name EN US',

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RoleTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RoleTest.php
@@ -32,7 +32,7 @@ class RoleTest extends ValueObjectVisitorBaseTest
             array(
                 'id' => 42,
                 'identifier' => 'some-role',
-                /* @todo uncomment when support for multilingual names and descriptions is added
+                /* @todo uncomment when support for multilingual names and descriptions is added EZP-24776
                 'mainLanguageCode' => 'eng-GB',
                 'names' => array(
                     'eng-GB' => 'Role name EN',
@@ -136,7 +136,7 @@ class RoleTest extends ValueObjectVisitorBaseTest
      */
     public function testResultContainsMainLanguageCodeValueElement($result)
     {
-        $this->markTestSkipped('@todo uncomment when support for multilingual names and descriptions is added');
+        $this->markTestSkipped('@todo uncomment when support for multilingual names and descriptions is added EZP-24776');
         $this->assertXMLTag(
             array(
                 'tag' => 'mainLanguageCode',
@@ -157,7 +157,7 @@ class RoleTest extends ValueObjectVisitorBaseTest
      */
     public function testResultContainsNamesElement($result)
     {
-        $this->markTestSkipped('@todo uncomment when support for multilingual names and descriptions is added');
+        $this->markTestSkipped('@todo uncomment when support for multilingual names and descriptions is added EZP-24776');
         $this->assertXMLTag(
             array(
                 'tag' => 'names',
@@ -180,7 +180,7 @@ class RoleTest extends ValueObjectVisitorBaseTest
      */
     public function testResultContainsDescriptionsElement($result)
     {
-        $this->markTestSkipped('@todo uncomment when support for multilingual names and descriptions is added');
+        $this->markTestSkipped('@todo uncomment when support for multilingual names and descriptions is added EZP-24776');
         $this->assertXMLTag(
             array(
                 'tag' => 'descriptions',

--- a/eZ/Publish/Core/REST/Server/Values/CreatedRole.php
+++ b/eZ/Publish/Core/REST/Server/Values/CreatedRole.php
@@ -13,14 +13,14 @@ namespace eZ\Publish\Core\REST\Server\Values;
 use eZ\Publish\API\Repository\Values\ValueObject;
 
 /**
- * Struct representing a freshly created role.
+ * Struct representing a freshly created Role.
  */
 class CreatedRole extends ValueObject
 {
     /**
      * The created role.
      *
-     * @var \eZ\Publish\API\Repository\Values\User\Role
+     * @var \eZ\Publish\Core\REST\Server\Values\RestRole
      */
     public $role;
 }

--- a/eZ/Publish/Core/REST/Server/Values/RestRole.php
+++ b/eZ/Publish/Core/REST/Server/Values/RestRole.php
@@ -1,30 +1,39 @@
 <?php
 
 /**
- * File containing the eZ\Publish\Core\Repository\Values\User\RoleDraft class.
+ * File containing the RestRole class.
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  *
  * @version //autogentag//
  */
-namespace eZ\Publish\Core\Repository\Values\User;
+namespace eZ\Publish\Core\REST\Server\Values;
 
-use eZ\Publish\API\Repository\Values\User\RoleDraft as APIRoleDraft;
+use eZ\Publish\API\Repository\Values\User\Role;
+use eZ\Publish\Core\REST\Common\Value as RestValue;
 
 /**
- * This class represents a draft of a role.
+ * REST Role, as received by /roles/<ID>.
  */
-class RoleDraft extends APIRoleDraft
+class RestRole extends RestValue
 {
     /**
      * Holds internal role object.
      *
      * @var \eZ\Publish\API\Repository\Values\User\Role
-     *
-     * @todo document
      */
     protected $innerRole;
+
+    /**
+     * Construct.
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Role $role
+     */
+    public function __construct(Role $role)
+    {
+        $this->innerRole = $role;
+    }
 
     /**
      * Magic getter for routing get calls to innerRole.
@@ -59,15 +68,5 @@ class RoleDraft extends APIRoleDraft
     public function __isset($property)
     {
         return $this->innerRole->__isset($property);
-    }
-
-    /**
-     * Returns the list of policies of this role.
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Policy[]
-     */
-    public function getPolicies()
-    {
-        return $this->innerRole->getPolicies();
     }
 }

--- a/eZ/Publish/Core/Repository/Helper/RoleDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/RoleDomainMapper.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\Repository\Helper;
 use eZ\Publish\Core\Repository\Values\User\Policy;
 use eZ\Publish\Core\Repository\Values\User\Role;
 use eZ\Publish\API\Repository\Values\User\Role as APIRole;
+use eZ\Publish\Core\Repository\Values\User\RoleDraft;
 use eZ\Publish\API\Repository\Values\User\RoleCreateStruct as APIRoleCreateStruct;
 use eZ\Publish\Core\Repository\Values\User\UserRoleAssignment;
 use eZ\Publish\Core\Repository\Values\User\UserGroupRoleAssignment;
@@ -59,7 +60,25 @@ class RoleDomainMapper
             array(
                 'id' => $role->id,
                 'identifier' => $role->identifier,
+                'status' => $role->status,
                 'policies' => $rolePolicies,
+            )
+        );
+    }
+
+    /**
+     * Builds a ContentTypeDraft domain object from value object returned by persistence
+     * Decorates ContentType.
+     *
+     * @param \eZ\Publish\SPI\Persistence\User\Role $spiRole
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
+     */
+    public function buildDomainRoleDraftObject(SPIRole $spiRole)
+    {
+        return new RoleDraft(
+            array(
+                'innerRole' => $this->buildDomainRoleObject($spiRole),
             )
         );
     }
@@ -167,7 +186,9 @@ class RoleDomainMapper
 
         return new SPIRole(
             array(
+                'id' => $roleCreateStruct->id,
                 'identifier' => $roleCreateStruct->identifier,
+                'status' => $roleCreateStruct->status,
                 'policies' => $policiesToCreate,
             )
         );

--- a/eZ/Publish/Core/Repository/Helper/RoleDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/RoleDomainMapper.php
@@ -168,6 +168,8 @@ class RoleDomainMapper
         return new SPIRole(
             array(
                 'identifier' => $roleCreateStruct->identifier,
+                'is_new' => $roleCreateStruct->is_new,
+                'version' => $roleCreateStruct->version,
                 'policies' => $policiesToCreate,
             )
         );

--- a/eZ/Publish/Core/Repository/Helper/RoleDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/RoleDomainMapper.php
@@ -188,7 +188,6 @@ class RoleDomainMapper
         return new SPIRoleCreateStruct(
             array(
                 'identifier' => $roleCreateStruct->identifier,
-                'status' => $roleCreateStruct->status,
                 'policies' => $policiesToCreate,
             )
         );

--- a/eZ/Publish/Core/Repository/Helper/RoleDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/RoleDomainMapper.php
@@ -23,6 +23,7 @@ use eZ\Publish\API\Repository\Values\User\UserGroup;
 use eZ\Publish\SPI\Persistence\User\Policy as SPIPolicy;
 use eZ\Publish\SPI\Persistence\User\RoleAssignment as SPIRoleAssignment;
 use eZ\Publish\SPI\Persistence\User\Role as SPIRole;
+use eZ\Publish\SPI\Persistence\User\RoleCreateStruct as SPIRoleCreateStruct;
 
 /**
  * Internal service to map Role objects between API and SPI values.
@@ -67,8 +68,8 @@ class RoleDomainMapper
     }
 
     /**
-     * Builds a ContentTypeDraft domain object from value object returned by persistence
-     * Decorates ContentType.
+     * Builds a RoleDraft domain object from value object returned by persistence
+     * Decorates Role.
      *
      * @param \eZ\Publish\SPI\Persistence\User\Role $spiRole
      *
@@ -167,13 +168,13 @@ class RoleDomainMapper
     }
 
     /**
-     * Creates SPI Role value object from provided API role create struct.
+     * Creates SPI Role create struct from provided API role create struct.
      *
      * @param \eZ\Publish\API\Repository\Values\User\RoleCreateStruct $roleCreateStruct
      *
-     * @return \eZ\Publish\SPI\Persistence\User\Role
+     * @return \eZ\Publish\SPI\Persistence\User\RoleCreateStruct
      */
-    public function buildPersistenceRoleObject(APIRoleCreateStruct $roleCreateStruct)
+    public function buildPersistenceRoleCreateStruct(APIRoleCreateStruct $roleCreateStruct)
     {
         $policiesToCreate = array();
         foreach ($roleCreateStruct->getPolicies() as $policyCreateStruct) {
@@ -184,9 +185,8 @@ class RoleDomainMapper
             );
         }
 
-        return new SPIRole(
+        return new SPIRoleCreateStruct(
             array(
-                'id' => $roleCreateStruct->id,
                 'identifier' => $roleCreateStruct->identifier,
                 'status' => $roleCreateStruct->status,
                 'policies' => $policiesToCreate,

--- a/eZ/Publish/Core/Repository/Helper/RoleDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/RoleDomainMapper.php
@@ -168,8 +168,6 @@ class RoleDomainMapper
         return new SPIRole(
             array(
                 'identifier' => $roleCreateStruct->identifier,
-                'is_new' => $roleCreateStruct->is_new,
-                'version' => $roleCreateStruct->version,
                 'policies' => $policiesToCreate,
             )
         );

--- a/eZ/Publish/Core/Repository/RoleService.php
+++ b/eZ/Publish/Core/Repository/RoleService.php
@@ -128,7 +128,7 @@ class RoleService implements RoleServiceInterface
      *
      * @since 6.0
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a RoleDraft
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      *         if the name of the role already exists or if limitation of the same type
      *         is repeated in the policy create struct or if limitation is not allowed on module/function
@@ -165,7 +165,6 @@ class RoleService implements RoleServiceInterface
             throw new LimitationValidationException($limitationValidationErrors);
         }
 
-        $roleCreateStruct->status = APIRole::STATUS_DRAFT;
         $spiRoleCreateStruct = $this->roleDomainMapper->buildPersistenceRoleCreateStruct($roleCreateStruct);
 
         $this->repository->beginTransaction();
@@ -181,12 +180,12 @@ class RoleService implements RoleServiceInterface
     }
 
     /**
-     * Creates a new RoleDraft for existing Role.
+     * Creates a new RoleDraft for an existing Role.
      *
      * @since 6.0
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the Role already has a Role Draft that will need to be removed first
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a RoleDraft
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the Role already has a RoleDraft that will need to be removed first
      *
      * @param \eZ\Publish\API\Repository\Values\User\Role $role
      *
@@ -221,12 +220,12 @@ class RoleService implements RoleServiceInterface
     }
 
     /**
-     * Loads a role for the given id.
+     * Loads a RoleDraft for the given id.
      *
      * @since 6.0
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read this role
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a role with the given id was not found
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read this RoleDraft
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a RoleDraft with the given id was not found
      *
      * @param mixed $id
      *
@@ -244,12 +243,12 @@ class RoleService implements RoleServiceInterface
     }
 
     /**
-     * Updates the properties of a role draft.
+     * Updates the properties of a RoleDraft.
      *
      * @since 6.0
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the identifier of the role already exists
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a RoleDraft
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the identifier of the RoleDraft already exists
      *
      * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
      * @param \eZ\Publish\API\Repository\Values\User\RoleUpdateStruct $roleUpdateStruct
@@ -275,7 +274,7 @@ class RoleService implements RoleServiceInterface
                  * - The ID of the two are NOT the same (otherwise it's not an editing conflict)
                 */
                 $existingRole = $this->loadRoleByIdentifier($roleUpdateStruct->identifier);
-                if ($existingRole instanceof APIRole && $existingRole->id != $loadedRoleDraft->id) {
+                if ($existingRole->id != $loadedRoleDraft->id) {
                     throw new InvalidArgumentException(
                         '$roleUpdateStruct',
                         "Role '{$existingRole->id}' with the specified identifier '{$roleUpdateStruct->identifier}' " .
@@ -308,7 +307,7 @@ class RoleService implements RoleServiceInterface
     }
 
     /**
-     * Adds a new policy to the role draft.
+     * Adds a new policy to the RoleDraft.
      *
      * @since 6.0
      *
@@ -371,17 +370,17 @@ class RoleService implements RoleServiceInterface
     }
 
     /**
-     * Removes a policy from a role draft.
+     * Removes a policy from a RoleDraft.
      *
      * @since 6.0
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if policy does not belong to the given role draft
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if policy does not belong to the given RoleDraft
      *
      * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
-     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to remove from the role
+     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to remove from the RoleDraft
      *
-     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft the updated role
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft the updated RoleDraft
      */
     public function removePolicyByRoleDraft(APIRoleDraft $roleDraft, APIPolicy $policy)
     {
@@ -421,11 +420,11 @@ class RoleService implements RoleServiceInterface
     }
 
     /**
-     * Deletes the given role.
+     * Deletes the given RoleDraft.
      *
      * @since 6.0
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to delete this role
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to delete this RoleDraft
      *
      * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
      */
@@ -444,11 +443,11 @@ class RoleService implements RoleServiceInterface
     }
 
     /**
-     * Publishes a given Role draft.
+     * Publishes a given RoleDraft.
      *
      * @since 6.0
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to publish this role
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to publish this RoleDraft
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the role draft cannot be loaded
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the role draft has no policies
      *
@@ -480,7 +479,7 @@ class RoleService implements RoleServiceInterface
 
         $this->repository->beginTransaction();
         try {
-            $this->userHandler->publishRoleDraft($roleDraft->id);
+            $this->userHandler->publishRoleDraft($loadedRoleDraft->id);
             $this->repository->commit();
         } catch (Exception $e) {
             $this->repository->rollback();
@@ -680,8 +679,6 @@ class RoleService implements RoleServiceInterface
     /**
      * Updates the limitations of a policy. The module and function cannot be changed and
      * the limitations are replaced by the ones in $roleUpdateStruct.
-     *
-     * @deprecated since 6.0, use {@link updatePolicyByRoleDraft()} instead.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a policy
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if limitation of the same type is repeated in policy update

--- a/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentTypeBase.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentTypeBase.php
@@ -64,7 +64,7 @@ abstract class ContentTypeBase extends BaseServiceTest
                 'identifier' => 'new-group',
                 'creatorId' => null,
                 'creationDate' => null,
-                // @todo uncomment when support for multilingual names and descriptions is added
+                // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
                 //'mainLanguageCode' => null,
                 //'names' => null,
                 //'descriptions' => null
@@ -90,7 +90,7 @@ abstract class ContentTypeBase extends BaseServiceTest
         );
         $groupCreate->creatorId = $this->repository->getCurrentUser()->id;
         $groupCreate->creationDate = new \DateTime();
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         //$groupCreate->mainLanguageCode = 'eng-GB';
         //$groupCreate->names = array( 'eng-US' => 'A name.' );
         //$groupCreate->descriptions = array( 'eng-US' => 'A description.' );
@@ -153,7 +153,7 @@ abstract class ContentTypeBase extends BaseServiceTest
         );
         $groupCreate->creatorId = $this->repository->getCurrentUser()->id;
         $groupCreate->creationDate = new \DateTime();
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $groupCreate->mainLanguageCode = 'eng-GB';
         // $groupCreate->names = array( 'eng-US' => 'A name.' );
         // $groupCreate->descriptions = array( 'eng-US' => 'A description.' );
@@ -178,7 +178,7 @@ abstract class ContentTypeBase extends BaseServiceTest
         $groupCreate = $contentTypeService->newContentTypeGroupCreateStruct(
             'new-group'
         );
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         //$groupCreate->names = array( 'eng-GB'=> 'NewGroup' );
         //$groupCreate->descriptions = array();
         $contentTypeService->createContentTypeGroup($groupCreate);
@@ -186,7 +186,7 @@ abstract class ContentTypeBase extends BaseServiceTest
         $secondGroupCreate = $contentTypeService->newContentTypeGroupCreateStruct(
             'new-group'
         );
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         //$secondGroupCreate->names = array( 'eng-GB'=> 'NewGroup' );
         //$secondGroupCreate->descriptions = array();
 
@@ -212,7 +212,7 @@ abstract class ContentTypeBase extends BaseServiceTest
         );
         $groupCreate->creatorId = $this->repository->getCurrentUser()->id;
         $groupCreate->creationDate = new \DateTime();
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         //$groupCreate->mainLanguageCode = 'eng-GB';
         //$groupCreate->names = array( 'eng-US' => 'A name.' );
         //$groupCreate->descriptions = array( 'eng-US' => 'A description.' );
@@ -474,7 +474,7 @@ abstract class ContentTypeBase extends BaseServiceTest
         $groupUpdate->identifier = 'updated-group';
         $groupUpdate->modifierId = 42;
         $groupUpdate->modificationDate = new \DateTime();
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         //$groupUpdate->mainLanguageCode = 'en_US';
         //$groupUpdate->names = array(
         //    'en_US' => 'A name',
@@ -530,7 +530,7 @@ abstract class ContentTypeBase extends BaseServiceTest
             'modificationDate' => $updateStruct->modificationDate,
             'creatorId' => $originalGroup->creatorId,
             'modifierId' => $updateStruct->modifierId,
-            // @todo uncomment when support for multilingual names and descriptions is added
+            // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
             //'mainLanguageCode' => $updateStruct->mainLanguageCode,
             //'names' => $updateStruct->names,
             //'descriptions' => $updateStruct->descriptions,
@@ -557,7 +557,7 @@ abstract class ContentTypeBase extends BaseServiceTest
         );
         $groupCreate->creatorId = $this->repository->getCurrentUser()->id;
         $groupCreate->creationDate = new \DateTime();
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         //$groupCreate->mainLanguageCode = 'eng-US';
         //$groupCreate->names = array( 'eng-US' => 'Name' );
         //$groupCreate->descriptions = array( 'eng-US' => 'Description' );
@@ -582,7 +582,7 @@ abstract class ContentTypeBase extends BaseServiceTest
         $groupUpdate->identifier = 'updated-group';
         $groupUpdate->modifierId = 42;
         $groupUpdate->modificationDate = new \DateTime();
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         /*
         $groupUpdate->mainLanguageCode = 'en_US';
         $groupUpdate->names = array(
@@ -620,7 +620,7 @@ abstract class ContentTypeBase extends BaseServiceTest
             'updated-group'
         );
         $groupCreate->creatorId = $this->repository->getCurrentUser()->id;
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         //$groupCreate->names = array( 'eng-US' => 'Name' );
         //$groupCreate->descriptions = array( 'eng-US' => 'Description' );
         $groupToOverwrite = $contentTypeService->createContentTypeGroup($groupCreate);
@@ -719,7 +719,7 @@ abstract class ContentTypeBase extends BaseServiceTest
             );
             $groupCreate->creatorId = $this->repository->getCurrentUser()->id;
             $groupCreate->creationDate = new \DateTime();
-            // @todo uncomment when support for multilingual names and descriptions is added
+            // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
             //$groupCreate->mainLanguageCode = 'de_DE';
             //$groupCreate->names = array( 'en_US' => 'A name.' );
             //$groupCreate->descriptions = array( 'en_US' => 'A description.' );
@@ -2049,7 +2049,7 @@ abstract class ContentTypeBase extends BaseServiceTest
         );
         $groupCreate->creatorId = $this->repository->getCurrentUser()->id;
         $groupCreate->creationDate = new \DateTime();
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         //$groupCreate->mainLanguageCode = 'ger-DE';
         //$groupCreate->names = array( 'eng-US' => 'A name.' );
         //$groupCreate->descriptions = array( 'eng-US' => 'A description.' );

--- a/eZ/Publish/Core/Repository/Tests/Service/Integration/RoleBase.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Integration/RoleBase.php
@@ -37,7 +37,7 @@ abstract class RoleBase extends BaseServiceTest
             array(
                 'id' => null,
                 'identifier' => null,
-                // @todo uncomment when support for multilingual names and descriptions is added
+                // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
                 // 'mainLanguageCode' => null,
                 'policies' => array(),
             ),
@@ -157,7 +157,7 @@ abstract class RoleBase extends BaseServiceTest
     {
         $roleService = $this->repository->getRoleService();
         $roleCreateStruct = $roleService->newRoleCreateStruct('ultimate_permissions');
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreateStruct->mainLanguageCode = 'eng-GB';
         // $roleCreateStruct->names = array( 'eng-GB' => 'Ultimate permissions' );
         // $roleCreateStruct->descriptions = array( 'eng-GB' => 'This is a role with ultimate permissions' );
@@ -167,7 +167,7 @@ abstract class RoleBase extends BaseServiceTest
         self::assertInstanceOf('\\eZ\\Publish\\API\\Repository\\Values\\User\\Role', $createdRole);
         self::assertGreaterThan(0, $createdRole->id);
 
-        /* @todo uncomment when support for multilingual names and descriptions is added
+        /* @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         self::assertEquals(
             array(
                 'eng-GB' => $roleCreateStruct->names['eng-GB']
@@ -203,7 +203,7 @@ abstract class RoleBase extends BaseServiceTest
         $roleService = $this->repository->getRoleService();
         $roleCreateStruct = $roleService->newRoleCreateStruct('Anonymous');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreateStruct->mainLanguageCode = 'eng-GB';
         // $roleCreateStruct->names = array( 'eng-GB' => 'Anonymous' );
         // $roleCreateStruct->descriptions = array( 'eng-GB' => 'Anonymous role' );
@@ -242,7 +242,7 @@ abstract class RoleBase extends BaseServiceTest
 
         $roleCreateStruct = $roleService->newRoleCreateStruct('ultimate_permissions');
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleCreateStruct->mainLanguageCode = 'eng-GB';
         // $roleCreateStruct->names = array( 'eng-GB' => 'Ultimate permissions' );
         // $roleCreateStruct->descriptions = array( 'eng-GB' => 'This is a role with ultimate permissions' );
@@ -255,7 +255,7 @@ abstract class RoleBase extends BaseServiceTest
         self::assertInstanceOf('\\eZ\\Publish\\API\\Repository\\Values\\User\\Role', $createdRole);
         self::assertGreaterThan(0, $createdRole->id);
 
-        /* @todo uncomment when support for multilingual names and descriptions is added
+        /* @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         self::assertEquals(
             array(
                 'eng-GB' => $roleCreateStruct->names['eng-GB']
@@ -337,7 +337,7 @@ abstract class RoleBase extends BaseServiceTest
         $roleUpdateStruct = $roleService->newRoleUpdateStruct();
         $roleUpdateStruct->identifier = 'Anonymous 2';
 
-        // @todo uncomment when support for multilingual names and descriptions is added
+        // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $roleUpdateStruct->mainLanguageCode = 'eng-US';
         // $roleUpdateStruct->names['eng-US'] = 'Anonymous 2';
         // $roleUpdateStruct->descriptions['eng-US'] = 'Anonymous 2 role';
@@ -844,7 +844,7 @@ abstract class RoleBase extends BaseServiceTest
         $this->assertPropertiesCorrect(
             array(
                 'identifier' => 'Ultimate permissions',
-                // @todo uncomment when support for multilingual names and descriptions is added
+                // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
                 // 'mainLanguageCode' => null,
                 // 'names' => null,
                 // 'descriptions' => null
@@ -898,7 +898,7 @@ abstract class RoleBase extends BaseServiceTest
         $this->assertPropertiesCorrect(
             array(
                 'identifier' => null,
-                // @todo uncomment when support for multilingual names and descriptions is added
+                // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
                 // 'mainLanguageCode' => null,
                 // 'names' => null,
                 // 'descriptions' => null

--- a/eZ/Publish/Core/Repository/Values/User/RoleDraft.php
+++ b/eZ/Publish/Core/Repository/Values/User/RoleDraft.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * File containing the eZ\Publish\Core\Repository\Values\User\RoleDraft class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\Repository\Values\User;
+
+use eZ\Publish\API\Repository\Values\User\RoleDraft as APIRoleDraft;
+
+/**
+ * This class represents a draft of a role.
+ *
+ * @property-read mixed $id the internal id of the role
+ * @property-read string $identifier the identifier of the role
+ *
+ * @property-read array $policies an array of the policies {@link \eZ\Publish\API\Repository\Values\User\Policy} of the role.
+ */
+class RoleDraft extends APIRoleDraft
+{
+    /**
+     * Holds internal role object.
+     *
+     * @var \eZ\Publish\API\Repository\Values\User\Role
+     *
+     * @todo document
+     */
+    protected $innerRole;
+
+    /**
+     * Magic getter for routing get calls to innerRole.
+     *
+     * @param string $property The name of the property to retrieve
+     *
+     * @return mixed
+     */
+    public function __get($property)
+    {
+        return $this->innerRole->$property;
+    }
+
+    /**
+     * Magic set for routing set calls to innerRole.
+     *
+     * @param string $property
+     * @param mixed $propertyValue
+     */
+    public function __set($property, $propertyValue)
+    {
+        $this->innerRole->$property = $propertyValue;
+    }
+
+    /**
+     * Magic isset for routing isset calls to innerRole.
+     *
+     * @param string $property
+     *
+     * @return bool
+     */
+    public function __isset($property)
+    {
+        return $this->innerRole->__isset($property);
+    }
+
+    /**
+     * Returns the list of policies of this role.
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\Policy[]
+     */
+    public function getPolicies()
+    {
+        return $this->innerRole->getPolicies();
+    }
+}

--- a/eZ/Publish/Core/SignalSlot/RoleService.php
+++ b/eZ/Publish/Core/SignalSlot/RoleService.php
@@ -16,6 +16,7 @@ use eZ\Publish\API\Repository\Values\User\RoleUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\PolicyCreateStruct;
 use eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\Role;
+use eZ\Publish\API\Repository\Values\User\RoleDraft;
 use eZ\Publish\API\Repository\Values\User\Policy;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\User\UserGroup;
@@ -66,7 +67,242 @@ class RoleService implements RoleServiceInterface
     }
 
     /**
+     * Creates a new RoleDraft.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists or if limitation of the
+     *                                                                        same type is repeated in the policy create struct or if
+     *                                                                        limitation is not allowed on module/function
+     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a policy limitation in the $roleCreateStruct is not valid
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleCreateStruct $roleCreateStruct
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
+     */
+    public function createRoleDraft(RoleCreateStruct $roleCreateStruct)
+    {
+        $returnValue = $this->service->createRoleDraft($roleCreateStruct);
+        $this->signalDispatcher->emit(
+            //TODO: CreateRoleDraftSignal? Or skip it altogether?
+            new CreateRoleSignal(
+                array(
+                    'roleId' => $returnValue->id,
+                )
+            )
+        );
+
+        return $returnValue;
+    }
+
+    /**
+     * Creates a new RoleDraft for existing Role.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the Role already has a Role Draft that will need to be removed first
+     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a policy limitation in the $roleCreateStruct is not valid
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Role $role
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
+     */
+    public function createRoleDraftByRole(Role $role)
+    {
+        $returnValue = $this->service->createRoleDraftByRole($role);
+        $this->signalDispatcher->emit(
+            //TODO: CreateRoleDraftSignal? Or skip it altogether?
+            new CreateRoleSignal(
+                array(
+                    'roleId' => $returnValue->id,
+                )
+            )
+        );
+
+        return $returnValue;
+    }
+
+    /**
+     * Loads a role for the given id.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read this role
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a role with the given id was not found
+     *
+     * @param mixed $id
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
+     */
+    public function loadRoleDraft($id)
+    {
+        return $this->service->loadRoleDraft($id);
+    }
+
+    /**
+     * Updates the properties of a role draft.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a role
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the identifier of the role already exists
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
+     * @param \eZ\Publish\API\Repository\Values\User\RoleUpdateStruct $roleUpdateStruct
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
+     */
+    public function updateRoleDraft(RoleDraft $roleDraft, RoleUpdateStruct $roleUpdateStruct)
+    {
+        $returnValue = $this->service->updateRoleDraft($roleDraft, $roleUpdateStruct);
+        $this->signalDispatcher->emit(
+            //TODO: UpdateRoleDraftSignal? Or skip it altogether?
+            new UpdateRoleSignal(
+                array(
+                    'roleId' => $roleDraft->id,
+                )
+            )
+        );
+
+        return $returnValue;
+    }
+
+    /**
+     * Adds a new policy to the role draft.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to add  a policy
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if limitation of the same type is repeated in policy create
+     *                                                                        struct or if limitation is not allowed on module/function
+     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a limitation in the $policyCreateStruct is not valid
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
+     * @param \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct $policyCreateStruct
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
+     */
+    public function addPolicyByRoleDraft(RoleDraft $roleDraft, PolicyCreateStruct $policyCreateStruct)
+    {
+        $returnValue = $this->service->addPolicyByRoleDraft($roleDraft, $policyCreateStruct);
+        $this->signalDispatcher->emit(
+            //TODO: AddPolicyDraftSignal? Or skip it altogether?
+            new AddPolicySignal(
+                array(
+                    'roleId' => $roleDraft->id,
+                    'policyId' => $returnValue->id,
+                )
+            )
+        );
+
+        return $returnValue;
+    }
+
+    /**
+     * Removes a policy from a role draft.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if policy does not belong to the given role draft
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
+     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to remove from the role
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft the updated role
+     */
+    public function removePolicyByRoleDraft(RoleDraft $roleDraft, Policy $policy)
+    {
+        $returnValue = $this->service->removePolicyByRoleDraft($roleDraft, $policy);
+        $this->signalDispatcher->emit(
+            //TODO: RemovePolicyDraftSignal? Or skip it altogether?
+            new RemovePolicySignal(
+                array(
+                    'roleId' => $roleDraft->id,
+                    'policyId' => $policy->id,
+                )
+            )
+        );
+
+        return $returnValue;
+    }
+
+    /**
+     * Updates the limitations of a policy. The module and function cannot be changed and
+     * the limitations are replaced by the ones in $roleUpdateStruct.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a policy
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if limitation of the same type is repeated in policy update
+     *                                                                        struct or if limitation is not allowed on module/function
+     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a limitation in the $policyUpdateStruct is not valid
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
+     * @param \eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct $policyUpdateStruct
+     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\Policy
+     */
+    public function updatePolicyByRoleDraft(RoleDraft $roleDraft, Policy $policy, PolicyUpdateStruct $policyUpdateStruct)
+    {
+        //TODO This method doesn't seem to be needed, but keeping it until policy editing is done and we know for sure.
+    }
+
+    /**
+     * Deletes the given role draft.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to delete this role
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
+     */
+    public function deleteRoleDraft(RoleDraft $roleDraft)
+    {
+        $returnValue = $this->service->deleteRoleDraft($roleDraft);
+        $this->signalDispatcher->emit(
+            //TODO: DeleteRoleDraftSignal? Or skip it altogether?
+            new DeleteRoleSignal(
+                array(
+                    'roleId' => $roleDraft->id,
+                )
+            )
+        );
+
+        return $returnValue;
+    }
+
+    /**
+     * Publishes a given Role draft.
+     *
+     * @since 6.0
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to publish this role
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
+     */
+    public function publishRoleDraft(RoleDraft $roleDraft)
+    {
+        $returnValue = $this->service->publishRoleDraft($roleDraft);
+        $this->signalDispatcher->emit(
+            // TODO: PublishRoleSignal? Or keep this as is?
+            new UpdateRoleSignal(
+                array(
+                    'roleId' => $roleDraft->id,
+                )
+            )
+        );
+
+        return $returnValue;
+    }
+
+    /**
      * Creates a new Role.
+     *
+     * @deprecated since 6.0, use {@see createRoleDraft}
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists or if limitation of the
@@ -95,6 +331,8 @@ class RoleService implements RoleServiceInterface
     /**
      * Updates the name of the role.
      *
+     * @deprecated since 6.0, use {@see updateRoleDraft}
+     *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a role
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists
      *
@@ -119,6 +357,8 @@ class RoleService implements RoleServiceInterface
 
     /**
      * Adds a new policy to the role.
+     *
+     * @deprecated since 6.0, use {@see addPolicyByRoleDraft}
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to add  a policy
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if limitation of the same type is repeated in policy create
@@ -146,9 +386,9 @@ class RoleService implements RoleServiceInterface
     }
 
     /**
-     * removes a policy from the role.
+     * Removes a policy from the role.
      *
-     * @deprecated since 5.3, use {@link deletePolicy()} instead.
+     * @deprecated since 5.3, use {@link removePolicyByRoleDraft()} instead.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if policy does not belong to the given role
@@ -176,6 +416,8 @@ class RoleService implements RoleServiceInterface
     /**
      * Delete a policy.
      *
+     * @deprecated since 6.0, use {@link removePolicyByRoleDraft()} instead.
+     *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
      *
      * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to delete
@@ -198,6 +440,8 @@ class RoleService implements RoleServiceInterface
     /**
      * Updates the limitations of a policy. The module and function cannot be changed and
      * the limitations are replaced by the ones in $roleUpdateStruct.
+     *
+     * @deprecated since 6.0, use {@link updatePolicyByRoleDraft()} instead.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update a policy
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if limitation of the same type is repeated in policy update

--- a/eZ/Publish/Core/SignalSlot/RoleService.php
+++ b/eZ/Publish/Core/SignalSlot/RoleService.php
@@ -72,9 +72,9 @@ class RoleService implements RoleServiceInterface
      * @since 6.0
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists or if limitation of the
-     *                                                                        same type is repeated in the policy create struct or if
-     *                                                                        limitation is not allowed on module/function
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     *         if the name of the role already exists or if limitation of the same type
+     *         is repeated in the policy create struct or if limitation is not allowed on module/function
      * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a policy limitation in the $roleCreateStruct is not valid
      *
      * @param \eZ\Publish\API\Repository\Values\User\RoleCreateStruct $roleCreateStruct

--- a/eZ/Publish/Core/SignalSlot/RoleService.php
+++ b/eZ/Publish/Core/SignalSlot/RoleService.php
@@ -11,26 +11,32 @@
 namespace eZ\Publish\Core\SignalSlot;
 
 use eZ\Publish\API\Repository\RoleService as RoleServiceInterface;
-use eZ\Publish\API\Repository\Values\User\RoleCreateStruct;
-use eZ\Publish\API\Repository\Values\User\RoleUpdateStruct;
+use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation;
+use eZ\Publish\API\Repository\Values\User\Policy;
 use eZ\Publish\API\Repository\Values\User\PolicyCreateStruct;
 use eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\Role;
+use eZ\Publish\API\Repository\Values\User\RoleCreateStruct;
 use eZ\Publish\API\Repository\Values\User\RoleDraft;
-use eZ\Publish\API\Repository\Values\User\Policy;
+use eZ\Publish\API\Repository\Values\User\RoleUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\User\UserGroup;
-use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation;
-use eZ\Publish\Core\SignalSlot\Signal\RoleService\CreateRoleSignal;
-use eZ\Publish\Core\SignalSlot\Signal\RoleService\UpdateRoleSignal;
+use eZ\Publish\Core\SignalSlot\Signal\RoleService\AddPolicyByRoleDraftSignal;
 use eZ\Publish\Core\SignalSlot\Signal\RoleService\AddPolicySignal;
-use eZ\Publish\Core\SignalSlot\Signal\RoleService\RemovePolicySignal;
-use eZ\Publish\Core\SignalSlot\Signal\RoleService\UpdatePolicySignal;
-use eZ\Publish\Core\SignalSlot\Signal\RoleService\DeleteRoleSignal;
 use eZ\Publish\Core\SignalSlot\Signal\RoleService\AssignRoleToUserGroupSignal;
-use eZ\Publish\Core\SignalSlot\Signal\RoleService\UnassignRoleFromUserGroupSignal;
 use eZ\Publish\Core\SignalSlot\Signal\RoleService\AssignRoleToUserSignal;
+use eZ\Publish\Core\SignalSlot\Signal\RoleService\CreateRoleDraftSignal;
+use eZ\Publish\Core\SignalSlot\Signal\RoleService\CreateRoleSignal;
+use eZ\Publish\Core\SignalSlot\Signal\RoleService\DeleteRoleDraftSignal;
+use eZ\Publish\Core\SignalSlot\Signal\RoleService\DeleteRoleSignal;
+use eZ\Publish\Core\SignalSlot\Signal\RoleService\PublishRoleDraftSignal;
+use eZ\Publish\Core\SignalSlot\Signal\RoleService\RemovePolicyByRoleDraftSignal;
+use eZ\Publish\Core\SignalSlot\Signal\RoleService\RemovePolicySignal;
+use eZ\Publish\Core\SignalSlot\Signal\RoleService\UnassignRoleFromUserGroupSignal;
 use eZ\Publish\Core\SignalSlot\Signal\RoleService\UnassignRoleFromUserSignal;
+use eZ\Publish\Core\SignalSlot\Signal\RoleService\UpdatePolicySignal;
+use eZ\Publish\Core\SignalSlot\Signal\RoleService\UpdateRoleDraftSignal;
+use eZ\Publish\Core\SignalSlot\Signal\RoleService\UpdateRoleSignal;
 
 /**
  * RoleService class.
@@ -112,8 +118,7 @@ class RoleService implements RoleServiceInterface
     {
         $returnValue = $this->service->createRoleDraft($role);
         $this->signalDispatcher->emit(
-            //TODO: CreateRoleDraftSignal? Or skip it altogether?
-            new CreateRoleSignal(
+            new CreateRoleDraftSignal(
                 array(
                     'roleId' => $returnValue->id,
                 )
@@ -157,8 +162,7 @@ class RoleService implements RoleServiceInterface
     {
         $returnValue = $this->service->updateRoleDraft($roleDraft, $roleUpdateStruct);
         $this->signalDispatcher->emit(
-            //TODO: UpdateRoleDraftSignal? Or skip it altogether?
-            new UpdateRoleSignal(
+            new UpdateRoleDraftSignal(
                 array(
                     'roleId' => $roleDraft->id,
                 )
@@ -187,8 +191,7 @@ class RoleService implements RoleServiceInterface
     {
         $returnValue = $this->service->addPolicyByRoleDraft($roleDraft, $policyCreateStruct);
         $this->signalDispatcher->emit(
-            //TODO: AddPolicyDraftSignal? Or skip it altogether?
-            new AddPolicySignal(
+            new AddPolicyByRoleDraftSignal(
                 array(
                     'roleId' => $roleDraft->id,
                     'policyId' => $returnValue->id,
@@ -216,8 +219,7 @@ class RoleService implements RoleServiceInterface
     {
         $returnValue = $this->service->removePolicyByRoleDraft($roleDraft, $policy);
         $this->signalDispatcher->emit(
-            //TODO: RemovePolicyDraftSignal? Or skip it altogether?
-            new RemovePolicySignal(
+            new RemovePolicyByRoleDraftSignal(
                 array(
                     'roleId' => $roleDraft->id,
                     'policyId' => $policy->id,
@@ -263,8 +265,7 @@ class RoleService implements RoleServiceInterface
     {
         $returnValue = $this->service->deleteRoleDraft($roleDraft);
         $this->signalDispatcher->emit(
-            //TODO: DeleteRoleDraftSignal? Or skip it altogether?
-            new DeleteRoleSignal(
+            new DeleteRoleDraftSignal(
                 array(
                     'roleId' => $roleDraft->id,
                 )
@@ -287,8 +288,7 @@ class RoleService implements RoleServiceInterface
     {
         $returnValue = $this->service->publishRoleDraft($roleDraft);
         $this->signalDispatcher->emit(
-            // TODO: PublishRoleSignal? Or keep this as is?
-            new UpdateRoleSignal(
+            new PublishRoleDraftSignal(
                 array(
                     'roleId' => $roleDraft->id,
                 )

--- a/eZ/Publish/Core/SignalSlot/RoleService.php
+++ b/eZ/Publish/Core/SignalSlot/RoleService.php
@@ -81,11 +81,10 @@ class RoleService implements RoleServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
      */
-    public function createRoleDraft(RoleCreateStruct $roleCreateStruct)
+    public function createRole(RoleCreateStruct $roleCreateStruct)
     {
-        $returnValue = $this->service->createRoleDraft($roleCreateStruct);
+        $returnValue = $this->service->createRole($roleCreateStruct);
         $this->signalDispatcher->emit(
-            //TODO: CreateRoleDraftSignal? Or skip it altogether?
             new CreateRoleSignal(
                 array(
                     'roleId' => $returnValue->id,
@@ -109,9 +108,9 @@ class RoleService implements RoleServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\User\RoleDraft
      */
-    public function createRoleDraftByRole(Role $role)
+    public function createRoleDraft(Role $role)
     {
-        $returnValue = $this->service->createRoleDraftByRole($role);
+        $returnValue = $this->service->createRoleDraft($role);
         $this->signalDispatcher->emit(
             //TODO: CreateRoleDraftSignal? Or skip it altogether?
             new CreateRoleSignal(
@@ -292,35 +291,6 @@ class RoleService implements RoleServiceInterface
             new UpdateRoleSignal(
                 array(
                     'roleId' => $roleDraft->id,
-                )
-            )
-        );
-
-        return $returnValue;
-    }
-
-    /**
-     * Creates a new Role.
-     *
-     * @deprecated since 6.0, use {@see createRoleDraft}
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a role
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the name of the role already exists or if limitation of the
-     *                                                                        same type is repeated in the policy create struct or if
-     *                                                                        limitation is not allowed on module/function
-     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException if a policy limitation in the $roleCreateStruct is not valid
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\RoleCreateStruct $roleCreateStruct
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\Role
-     */
-    public function createRole(RoleCreateStruct $roleCreateStruct)
-    {
-        $returnValue = $this->service->createRole($roleCreateStruct);
-        $this->signalDispatcher->emit(
-            new CreateRoleSignal(
-                array(
-                    'roleId' => $returnValue->id,
                 )
             )
         );

--- a/eZ/Publish/Core/SignalSlot/Signal/RoleService/AddPolicyByRoleDraftSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/RoleService/AddPolicyByRoleDraftSignal.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * AddPolicyByRoleDraftSignal class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\SignalSlot\Signal\RoleService;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * AddPolicyByRoleDraftSignal class.
+ */
+class AddPolicyByRoleDraftSignal extends Signal
+{
+    /**
+     * RoleId.
+     *
+     * @var mixed
+     */
+    public $roleId;
+
+    /**
+     * PolicyId.
+     *
+     * @var mixed
+     */
+    public $policyId;
+}

--- a/eZ/Publish/Core/SignalSlot/Signal/RoleService/CreateRoleDraftSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/RoleService/CreateRoleDraftSignal.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * CreateRoleDraftSignal class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\SignalSlot\Signal\RoleService;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * CreateRoleDraftSignal class.
+ */
+class CreateRoleDraftSignal extends Signal
+{
+    /**
+     * RoleId.
+     *
+     * @var mixed
+     */
+    public $roleId;
+}

--- a/eZ/Publish/Core/SignalSlot/Signal/RoleService/DeleteRoleDraftSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/RoleService/DeleteRoleDraftSignal.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * DeleteRoleDraftSignal class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\SignalSlot\Signal\RoleService;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * DeleteRoleDraftSignal class.
+ */
+class DeleteRoleDraftSignal extends Signal
+{
+    /**
+     * RoleId.
+     *
+     * @var mixed
+     */
+    public $roleId;
+}

--- a/eZ/Publish/Core/SignalSlot/Signal/RoleService/PublishRoleDraftSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/RoleService/PublishRoleDraftSignal.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * PublishRoleDraftSignal class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\SignalSlot\Signal\RoleService;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * PublishRoleDraftSignal class.
+ */
+class PublishRoleDraftSignal extends Signal
+{
+    /**
+     * RoleId.
+     *
+     * @var mixed
+     */
+    public $roleId;
+}

--- a/eZ/Publish/Core/SignalSlot/Signal/RoleService/RemovePolicyByRoleDraftSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/RoleService/RemovePolicyByRoleDraftSignal.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * RemovePolicyByRoleDraftSignal class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\SignalSlot\Signal\RoleService;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * RemovePolicyByRoleDraftSignal class.
+ */
+class RemovePolicyByRoleDraftSignal extends Signal
+{
+    /**
+     * RoleId.
+     *
+     * @var mixed
+     */
+    public $roleId;
+
+    /**
+     * PolicyId.
+     *
+     * @var mixed
+     */
+    public $policyId;
+}

--- a/eZ/Publish/Core/SignalSlot/Signal/RoleService/UpdateRoleDraftSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/RoleService/UpdateRoleDraftSignal.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * UpdateRoleDraftSignal class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\SignalSlot\Signal\RoleService;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * UpdateRoleDraftSignal class.
+ */
+class UpdateRoleDraftSignal extends Signal
+{
+    /**
+     * RoleId.
+     *
+     * @var mixed
+     */
+    public $roleId;
+}

--- a/eZ/Publish/Core/SignalSlot/Tests/RoleServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/RoleServiceTest.php
@@ -15,6 +15,7 @@ use eZ\Publish\API\Repository\Values\User\RoleUpdateStruct;
 use eZ\Publish\Core\Repository\Values\User\PolicyCreateStruct;
 use eZ\Publish\Core\Repository\Values\User\PolicyUpdateStruct;
 use eZ\Publish\Core\Repository\Values\User\Role;
+use eZ\Publish\Core\Repository\Values\User\RoleDraft;
 use eZ\Publish\Core\Repository\Values\User\Policy;
 use eZ\Publish\API\Repository\Values\User\Limitation\SectionLimitation;
 use eZ\Publish\Core\Repository\Values\User\UserRoleAssignment;
@@ -50,6 +51,7 @@ class RoleServiceTest extends ServiceTest
                 'identifier' => $roleIdentifier,
             )
         );
+        $roleDraft = new RoleDraft(['innerRole' => $role]);
         $policy = new Policy(
             array(
                 'id' => $policyId,
@@ -88,11 +90,35 @@ class RoleServiceTest extends ServiceTest
                 array('roleId' => $roleId),
             ),
             array(
+                'createRoleDraft',
+                array($role),
+                $role,
+                1,
+                'eZ\Publish\Core\SignalSlot\Signal\RoleService\CreateRoleDraftSignal',
+                array('roleId' => $roleId),
+            ),
+            array(
                 'updateRole',
                 array($role, $roleUpdateStruct),
                 $role,
                 1,
                 'eZ\Publish\Core\SignalSlot\Signal\RoleService\UpdateRoleSignal',
+                array('roleId' => $roleId),
+            ),
+            array(
+                'updateRoleDraft',
+                array($roleDraft, $roleUpdateStruct),
+                $roleDraft,
+                1,
+                'eZ\Publish\Core\SignalSlot\Signal\RoleService\UpdateRoleDraftSignal',
+                array('roleId' => $roleId),
+            ),
+            array(
+                'publishRoleDraft',
+                array($roleDraft),
+                $roleDraft,
+                1,
+                'eZ\Publish\Core\SignalSlot\Signal\RoleService\PublishRoleDraftSignal',
                 array('roleId' => $roleId),
             ),
             array(
@@ -107,11 +133,33 @@ class RoleServiceTest extends ServiceTest
                 ),
             ),
             array(
+                'addPolicyByRoleDraft',
+                array($roleDraft, $policyCreateStruct),
+                $roleDraft,
+                1,
+                'eZ\Publish\Core\SignalSlot\Signal\RoleService\AddPolicyByRoleDraftSignal',
+                array(
+                    'roleId' => $roleId,
+                    'policyId' => $roleId,
+                ),
+            ),
+            array(
                 'removePolicy',
                 array($role, $policy),
                 $role,
                 1,
                 'eZ\Publish\Core\SignalSlot\Signal\RoleService\RemovePolicySignal',
+                array(
+                    'roleId' => $roleId,
+                    'policyId' => $policyId,
+                ),
+            ),
+            array(
+                'removePolicyByRoleDraft',
+                array($roleDraft, $policy),
+                $roleDraft,
+                1,
+                'eZ\Publish\Core\SignalSlot\Signal\RoleService\RemovePolicyByRoleDraftSignal',
                 array(
                     'roleId' => $roleId,
                     'policyId' => $policyId,
@@ -143,6 +191,12 @@ class RoleServiceTest extends ServiceTest
                 0,
             ),
             array(
+                'loadRoleDraft',
+                array($roleId),
+                $roleDraft,
+                0,
+            ),
+            array(
                 'loadRoleByIdentifier',
                 array($roleIdentifier),
                 $role,
@@ -160,6 +214,14 @@ class RoleServiceTest extends ServiceTest
                 null,
                 1,
                 'eZ\Publish\Core\SignalSlot\Signal\RoleService\DeleteRoleSignal',
+                array('roleId' => $roleId),
+            ),
+            array(
+                'deleteRoleDraft',
+                array($roleDraft),
+                null,
+                1,
+                'eZ\Publish\Core\SignalSlot\Signal\RoleService\DeleteRoleDraftSignal',
                 array('roleId' => $roleId),
             ),
             array(

--- a/eZ/Publish/SPI/Persistence/User/Handler.php
+++ b/eZ/Publish/SPI/Persistence/User/Handler.php
@@ -93,6 +93,17 @@ interface Handler
     public function createRole(Role $role);
 
     /**
+     * Loads a specified role draft by $roleId.
+     *
+     * @param mixed $roleId
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If role is not found
+     *
+     * @return \eZ\Publish\SPI\Persistence\User\Role
+     */
+    public function loadRoleDraft($roleId);
+
+    /**
      * Loads a specified role by $roleId.
      *
      * @param mixed $roleId
@@ -102,6 +113,17 @@ interface Handler
      * @return \eZ\Publish\SPI\Persistence\User\Role
      */
     public function loadRole($roleId);
+
+    /**
+     * Loads a specified role draft by $identifier.
+     *
+     * @param string $identifier
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If role is not found
+     *
+     * @return \eZ\Publish\SPI\Persistence\User\Role
+     */
+    public function loadRoleDraftByIdentifier($identifier);
 
     /**
      * Loads a specified role by $identifier.
@@ -146,6 +168,13 @@ interface Handler
     public function loadRoleAssignmentsByGroupId($groupId, $inherit = false);
 
     /**
+     * Update role draft.
+     *
+     * @param \eZ\Publish\SPI\Persistence\User\RoleUpdateStruct $role
+     */
+    public function updateRoleDraft(RoleUpdateStruct $role);
+
+    /**
      * Update role.
      *
      * @param \eZ\Publish\SPI\Persistence\User\RoleUpdateStruct $role
@@ -153,11 +182,39 @@ interface Handler
     public function updateRole(RoleUpdateStruct $role);
 
     /**
+     * Delete the specified role draft.
+     *
+     * @param mixed $roleId
+     */
+    public function deleteRoleDraft($roleId);
+
+    /**
      * Delete the specified role.
      *
      * @param mixed $roleId
      */
     public function deleteRole($roleId);
+
+    /**
+     * Publish the specified role draft.
+     *
+     * @param mixed $roleId
+     */
+    public function publishRoleDraft($roleId);
+
+    /**
+     * Adds a policy to a role draft.
+     *
+     * @param mixed $roleId
+     * @param \eZ\Publish\SPI\Persistence\User\Policy $policy
+     *
+     * @return \eZ\Publish\SPI\Persistence\User\Policy
+     *
+     * @todo Throw on invalid Role Id?
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If $policy->limitation is empty (null, empty string/array..)
+     */
+    public function addPolicyByRoleDraft($roleId, Policy $policy);
 
     /**
      * Adds a policy to a role.

--- a/eZ/Publish/SPI/Persistence/User/Handler.php
+++ b/eZ/Publish/SPI/Persistence/User/Handler.php
@@ -86,55 +86,48 @@ interface Handler
     /**
      * Create new role.
      *
-     * @param \eZ\Publish\SPI\Persistence\User\Role $role
+     * @param \eZ\Publish\SPI\Persistence\User\RoleCreateStruct $createStruct
      *
      * @return \eZ\Publish\SPI\Persistence\User\Role
      */
-    public function createRole(Role $role);
+    public function createRole(RoleCreateStruct $createStruct);
 
     /**
-     * Loads a specified role draft by $roleId.
+     * Creates a draft of existing defined role.
+     *
+     * Sets status to Role::STATUS_DRAFT on the new returned draft.
      *
      * @param mixed $roleId
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If role is not found
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If role with defined status is not found
      *
      * @return \eZ\Publish\SPI\Persistence\User\Role
      */
-    public function loadRoleDraft($roleId);
+    public function createRoleDraft($roleId);
 
     /**
-     * Loads a specified role by $roleId.
+     * Loads a specified role (draft) by $roleId.
      *
      * @param mixed $roleId
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If role is not found
      *
      * @return \eZ\Publish\SPI\Persistence\User\Role
      */
-    public function loadRole($roleId);
+    public function loadRole($roleId, $status = Role::STATUS_DEFINED);
 
     /**
-     * Loads a specified role draft by $identifier.
+     * Loads a specified role (draft) by $identifier.
      *
      * @param string $identifier
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If role is not found
      *
      * @return \eZ\Publish\SPI\Persistence\User\Role
      */
-    public function loadRoleDraftByIdentifier($identifier);
-
-    /**
-     * Loads a specified role by $identifier.
-     *
-     * @param string $identifier
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If role is not found
-     *
-     * @return \eZ\Publish\SPI\Persistence\User\Role
-     */
-    public function loadRoleByIdentifier($identifier);
+    public function loadRoleByIdentifier($identifier, $status = Role::STATUS_DEFINED);
 
     /**
      * Loads all roles.
@@ -168,32 +161,20 @@ interface Handler
     public function loadRoleAssignmentsByGroupId($groupId, $inherit = false);
 
     /**
-     * Update role draft.
+     * Update role (draft).
      *
      * @param \eZ\Publish\SPI\Persistence\User\RoleUpdateStruct $role
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      */
-    public function updateRoleDraft(RoleUpdateStruct $role);
+    public function updateRole(RoleUpdateStruct $role, $status = Role::STATUS_DEFINED);
 
     /**
-     * Update role.
-     *
-     * @param \eZ\Publish\SPI\Persistence\User\RoleUpdateStruct $role
-     */
-    public function updateRole(RoleUpdateStruct $role);
-
-    /**
-     * Delete the specified role draft.
+     * Delete the specified role (draft).
      *
      * @param mixed $roleId
+     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      */
-    public function deleteRoleDraft($roleId);
-
-    /**
-     * Delete the specified role.
-     *
-     * @param mixed $roleId
-     */
-    public function deleteRole($roleId);
+    public function deleteRole($roleId, $status = Role::STATUS_DEFINED);
 
     /**
      * Publish the specified role draft.

--- a/eZ/Publish/SPI/Persistence/User/Policy.php
+++ b/eZ/Publish/SPI/Persistence/User/Policy.php
@@ -31,6 +31,15 @@ class Policy extends ValueObject
     public $roleId;
 
     /**
+     * Status of the policy (legacy: "original_id").
+     *
+     * @since 6.0
+     *
+     * @var int One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
+     */
+    public $status;
+
+    /**
      * Name of module, associated with the Policy.
      *
      * Eg: content

--- a/eZ/Publish/SPI/Persistence/User/Role.php
+++ b/eZ/Publish/SPI/Persistence/User/Role.php
@@ -56,18 +56,4 @@ class Role extends ValueObject
      * @var \eZ\Publish\SPI\Persistence\User\Policy[]
      */
     public $policies = array();
-
-    /**
-     * True before the role has been published.
-     *
-     * @var bool
-     */
-    public $is_new = true;
-
-    /**
-     * Version number: non-zero for draft roles.
-     *
-     * @var bool
-     */
-    public $version = 0;
 }

--- a/eZ/Publish/SPI/Persistence/User/Role.php
+++ b/eZ/Publish/SPI/Persistence/User/Role.php
@@ -17,6 +17,16 @@ use eZ\Publish\SPI\Persistence\ValueObject;
 class Role extends ValueObject
 {
     /**
+     * @var int Status constant for defined (aka "published") role
+     */
+    const STATUS_DEFINED = 0;
+
+    /**
+     * @var int Status constant for draft (aka "temporary") role
+     */
+    const STATUS_DRAFT = 1;
+
+    /**
      * ID of the user rule.
      *
      * @var mixed
@@ -31,6 +41,15 @@ class Role extends ValueObject
      * @var string
      */
     public $identifier;
+
+    /**
+     * Status of the role (legacy: "version").
+     *
+     * @since 6.0
+     *
+     * @var int One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
+     */
+    public $status;
 
     /**
      * Name of the role.

--- a/eZ/Publish/SPI/Persistence/User/Role.php
+++ b/eZ/Publish/SPI/Persistence/User/Role.php
@@ -56,4 +56,18 @@ class Role extends ValueObject
      * @var \eZ\Publish\SPI\Persistence\User\Policy[]
      */
     public $policies = array();
+
+    /**
+     * True before the role has been published.
+     *
+     * @var bool
+     */
+    public $is_new = true;
+
+    /**
+     * Version number: non-zero for draft roles.
+     *
+     * @var bool
+     */
+    public $version = 0;
 }

--- a/eZ/Publish/SPI/Persistence/User/RoleCreateStruct.php
+++ b/eZ/Publish/SPI/Persistence/User/RoleCreateStruct.php
@@ -26,13 +26,6 @@ class RoleCreateStruct extends ValueObject
     public $identifier;
 
     /**
-     * The status of the role.
-     *
-     * @var int One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
-     */
-    public $status = Role::STATUS_DRAFT;
-
-    /**
      * Contains an array of role policies.
      *
      * @var mixed[]

--- a/eZ/Publish/SPI/Persistence/User/RoleCreateStruct.php
+++ b/eZ/Publish/SPI/Persistence/User/RoleCreateStruct.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * File containing the RoleCreateStruct class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\SPI\Persistence\User;
+
+use eZ\Publish\SPI\Persistence\ValueObject;
+
+/**
+ */
+class RoleCreateStruct extends ValueObject
+{
+    /**
+     * Identifier of the role.
+     *
+     * Legacy note: Maps to name in 4.x.
+     *
+     * @var string
+     */
+    public $identifier;
+
+    /**
+     * The status of the role.
+     *
+     * @var int One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
+     */
+    public $status = Role::STATUS_DRAFT;
+
+    /**
+     * Contains an array of role policies.
+     *
+     * @var mixed[]
+     */
+    public $policies = array();
+}


### PR DESCRIPTION
Role version support is required in order to edit roles safely.
~~Will add support for role `is_new` and `version`, and use them as in legacy.~~
Implement versioning in a similar way as for ContentType, with a RoleDraft class.

This requires a schema change: `ALTER TABLE ezrole DROP PRIMARY KEY, ADD PRIMARY KEY(id,version)`
I added `data/updates/6.0/mysql.sql` containing the change and a description.

https://jira.ez.no/browse/EZP-24701

TODO
- [x] Fix 2 errors in existing tests
- [x] Add tests for drafts functionality
- [x] update script for Postgres
- [x] Fix REST tests
- [x] BC doc