### PR TITLE
EZP-23242: UserService uses Content search instead of Location search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,11 @@ matrix:
     - php: 5.4
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/$DB_NAME"
 #    - php: 5.4
-#      env: SOLR_VERSION="4.10.4" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CORES_SETUP="dedicated" SOLR_CORES="core0 core1 core2 core3 core4 core5 core6 core7" SOLR_CONFS="vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/schema.xml"
+#      env: SOLR_VERSION="4.10.4" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CORES_SETUP="dedicated" SOLR_CORES="core0 core1 core2 core3 core4 core5 core6 core7" SOLR_CONFS="vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/language-fieldtypes.xml"
 #    - php: 5.4
-#      env: SOLR_VERSION="4.10.4" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CORES_SETUP="shared" SOLR_CORES="core0 core1 core2 core3 core4" SOLR_CONFS="vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/schema.xml"
+#      env: SOLR_VERSION="4.10.4" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CORES_SETUP="shared" SOLR_CORES="core0 core1 core2 core3 core4" SOLR_CONFS="vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/language-fieldtypes.xml"
     - php: 5.4
-      env: SOLR_VERSION="4.10.4" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CORES_SETUP="single" SOLR_CONFS="vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/schema.xml"
+      env: SOLR_VERSION="4.10.4" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CORES_SETUP="single" SOLR_CONFS="vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/language-fieldtypes.xml"
 # 5.5
     - php: 5.5
       env: TEST_CONFIG="phpunit.xml"


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-23242

Blocks https://jira.ez.no/browse/EZP-24718

This replaces Content search with Location search in UserService.
Existing tests apply.

Additionally Travis parameters for Solr integration tests are updated.