### PR TITLE
EZP-24720: increase default search limit value from 10 to 25

### DIFF
--- a/doc/bc/changes-6.0.md
+++ b/doc/bc/changes-6.0.md
@@ -119,23 +119,23 @@ Changes affecting version compatibility with former or future versions.
 
 * `eZ\Publish\API\Repository\Values\Content\Query` and `eZ\Publish\API\Repository\Values\Content\LocationQuery`
   property `$limit` is now defined as `integer` (instead of `integer|null`), which means its value must always be
-  set. By default, it's value will be `10`. No way is provided to return all search hits, pagination should be used
+  set. By default, it's value will be `25`. No way is provided to return all search hits, pagination should be used
   if full result set is desired.
 
 * `eZ\Publish\API\Repository\LocationService::loadLocationChildren()` signature has changed, default value of
-  parameter `$limit` is now `10`. No way is provided to return all children, pagination should be used if full
+  parameter `$limit` is now `25`. No way is provided to return all children, pagination should be used if full
   result set is desired.
 
 * `eZ\Publish\API\Repository\UserService::loadUsersOfUserGroup()` signature has changed, default value of
-  parameter `$limit` is now `10`. No way is provided to return all users, pagination should be used if full
+  parameter `$limit` is now `25`. No way is provided to return all users, pagination should be used if full
   result set is desired.
 
 * `eZ\Publish\API\Repository\UserService::loadSubUserGroups()` signature has changed, parameters `$offset = 0`
-  and `$limit = 10` are added. No way is provided to return all user groups, pagination should be used if full
+  and `$limit = 25` are added. No way is provided to return all user groups, pagination should be used if full
   result set is desired.
 
 * `eZ\Publish\API\Repository\UserService::loadUserGroupsOfUser()` signature has changed, parameters `$offset = 0`
-  and `$limit = 10` are added. No way is provided to return all user groups, pagination should be used if full
+  and `$limit = 25` are added. No way is provided to return all user groups, pagination should be used if full
   result set is desired.
 
 * SiteAccess service (`ezpublish.siteaccess`) is not synchronized any more.

--- a/eZ/Publish/API/Repository/LocationService.php
+++ b/eZ/Publish/API/Repository/LocationService.php
@@ -86,7 +86,7 @@ interface LocationService
      *
      * @return \eZ\Publish\API\Repository\Values\Content\LocationList
      */
-    public function loadLocationChildren(Location $location, $offset = 0, $limit = 10);
+    public function loadLocationChildren(Location $location, $offset = 0, $limit = 25);
 
     /**
      * Returns the number of children which are readable by the current user of a location object.

--- a/eZ/Publish/API/Repository/UserService.php
+++ b/eZ/Publish/API/Repository/UserService.php
@@ -66,7 +66,7 @@ interface UserService
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the user group
      */
-    public function loadSubUserGroups(UserGroup $userGroup, $offset = 0, $limit = 10);
+    public function loadSubUserGroups(UserGroup $userGroup, $offset = 0, $limit = 25);
 
     /**
      * Removes a user group.
@@ -250,7 +250,7 @@ interface UserService
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
      */
-    public function loadUserGroupsOfUser(User $user, $offset = 0, $limit = 10);
+    public function loadUserGroupsOfUser(User $user, $offset = 0, $limit = 25);
 
     /**
      * Loads the users of a user group.
@@ -263,7 +263,7 @@ interface UserService
      *
      * @return \eZ\Publish\API\Repository\Values\User\User[]
      */
-    public function loadUsersOfUserGroup(UserGroup $userGroup, $offset = 0, $limit = 10);
+    public function loadUsersOfUserGroup(UserGroup $userGroup, $offset = 0, $limit = 25);
 
     /**
      * Instantiate a user create class.

--- a/eZ/Publish/API/Repository/Values/Content/Query.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query.php
@@ -85,7 +85,7 @@ class Query extends ValueObject
      *
      * @var int
      */
-    public $limit = 10;
+    public $limit = 25;
 
     /**
      * If true spellcheck suggestions are returned.

--- a/eZ/Publish/Core/Pagination/Tests/ContentSearchHitAdapterTest.php
+++ b/eZ/Publish/Core/Pagination/Tests/ContentSearchHitAdapterTest.php
@@ -73,7 +73,7 @@ class ContentSearchHitAdapterTest extends PHPUnit_Framework_TestCase
     public function testGetSlice()
     {
         $offset = 20;
-        $limit = 10;
+        $limit = 25;
         $nbResults = 123;
 
         $query = new Query();

--- a/eZ/Publish/Core/Pagination/Tests/LocationSearchHitAdapterTest.php
+++ b/eZ/Publish/Core/Pagination/Tests/LocationSearchHitAdapterTest.php
@@ -73,7 +73,7 @@ class LocationSearchHitAdapterTest extends PHPUnit_Framework_TestCase
     public function testGetSlice()
     {
         $offset = 20;
-        $limit = 10;
+        $limit = 25;
         $nbResults = 123;
 
         $query = new LocationQuery();

--- a/eZ/Publish/Core/REST/Client/LocationService.php
+++ b/eZ/Publish/Core/REST/Client/LocationService.php
@@ -240,7 +240,7 @@ class LocationService implements APILocationService, Sessionable
      *
      * @return \eZ\Publish\API\Repository\Values\Content\LocationList
      */
-    public function loadLocationChildren(Location $location, $offset = 0, $limit = 10)
+    public function loadLocationChildren(Location $location, $offset = 0, $limit = 25)
     {
         $values = $this->requestParser->parse('location', $location->id);
         $response = $this->client->request(

--- a/eZ/Publish/Core/REST/Client/UserService.php
+++ b/eZ/Publish/Core/REST/Client/UserService.php
@@ -128,7 +128,7 @@ class UserService implements APIUserService, Sessionable
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the user group
      */
-    public function loadSubUserGroups(UserGroup $userGroup, $offset = 0, $limit = 10)
+    public function loadSubUserGroups(UserGroup $userGroup, $offset = 0, $limit = 25)
     {
         throw new \Exception('@todo: Implement.');
     }
@@ -343,7 +343,7 @@ class UserService implements APIUserService, Sessionable
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
      */
-    public function loadUserGroupsOfUser(User $user, $offset = 0, $limit = 10)
+    public function loadUserGroupsOfUser(User $user, $offset = 0, $limit = 25)
     {
         throw new \Exception('@todo: Implement.');
     }
@@ -359,7 +359,7 @@ class UserService implements APIUserService, Sessionable
      *
      * @return \eZ\Publish\API\Repository\Values\User\User[]
      */
-    public function loadUsersOfUserGroup(UserGroup $userGroup, $offset = 0, $limit = 10)
+    public function loadUsersOfUserGroup(UserGroup $userGroup, $offset = 0, $limit = 25)
     {
         throw new \Exception('@todo: Implement.');
     }

--- a/eZ/Publish/Core/REST/Server/Controller/Location.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Location.php
@@ -351,7 +351,7 @@ class Location extends RestController
         $children = $this->locationService->loadLocationChildren(
             $this->locationService->loadLocation($locationId),
             $offset >= 0 ? $offset : 0,
-            $limit >= 0 ? $limit : 10
+            $limit >= 0 ? $limit : 25
         )->locations;
         foreach ($children as $location) {
             $restLocations[] = new Values\RestLocation(

--- a/eZ/Publish/Core/REST/Server/Controller/User.php
+++ b/eZ/Publish/Core/REST/Server/Controller/User.php
@@ -678,7 +678,7 @@ class User extends RestController
     public function loadSubUserGroups($groupPath, Request $request)
     {
         $offset = $request->query->has('offset') ? (int)$request->query->get('offset') : 0;
-        $limit = $request->query->has('limit') ? (int)$request->query->get('limit') : 10;
+        $limit = $request->query->has('limit') ? (int)$request->query->get('limit') : 25;
 
         $userGroupLocation = $this->locationService->loadLocation(
             $this->extractLocationIdFromPath($groupPath)
@@ -691,7 +691,7 @@ class User extends RestController
         $subGroups = $this->userService->loadSubUserGroups(
             $userGroup,
             $offset >= 0 ? $offset : 0,
-            $limit >= 0 ? $limit : 10
+            $limit >= 0 ? $limit : 25
         );
 
         $restUserGroups = array();
@@ -734,13 +734,13 @@ class User extends RestController
     public function loadUserGroupsOfUser($userId, Request $request)
     {
         $offset = $request->query->has('offset') ? (int)$request->query->get('offset') : 0;
-        $limit = $request->query->has('limit') ? (int)$request->query->get('limit') : 10;
+        $limit = $request->query->has('limit') ? (int)$request->query->get('limit') : 25;
 
         $user = $this->userService->loadUser($userId);
         $userGroups = $this->userService->loadUserGroupsOfUser(
             $user,
             $offset >= 0 ? $offset : 0,
-            $limit >= 0 ? $limit : 10
+            $limit >= 0 ? $limit : 25
         );
 
         $restUserGroups = array();
@@ -782,12 +782,12 @@ class User extends RestController
         );
 
         $offset = $request->query->has('offset') ? (int)$request->query->get('offset') : 0;
-        $limit = $request->query->has('limit') ? (int)$request->query->get('limit') : 10;
+        $limit = $request->query->has('limit') ? (int)$request->query->get('limit') : 25;
 
         $users = $this->userService->loadUsersOfUserGroup(
             $userGroup,
             $offset >= 0 ? $offset : 0,
-            $limit >= 0 ? $limit : 10
+            $limit >= 0 ? $limit : 25
         );
 
         $restUsers = array();

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -276,7 +276,7 @@ class LocationService implements LocationServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\Content\LocationList
      */
-    public function loadLocationChildren(APILocation $location, $offset = 0, $limit = 10)
+    public function loadLocationChildren(APILocation $location, $offset = 0, $limit = 25)
     {
         if (!$this->domainMapper->isValidLocationSortField($location->sortField)) {
             throw new InvalidArgumentValue('sortField', $location->sortField, 'Location');

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
@@ -268,7 +268,7 @@ class SearchTest extends BaseServiceMockTest
             );
 
         $serviceQuery = new Query();
-        $handlerQuery = new Query(array('filter' => new Criterion\MatchAll(), 'limit' => 10));
+        $handlerQuery = new Query(array('filter' => new Criterion\MatchAll(), 'limit' => 25));
         $languageFilter = array();
         $spiContentInfo = new SPIContentInfo();
         $contentMock = $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\Content\\Content');
@@ -588,7 +588,7 @@ class SearchTest extends BaseServiceMockTest
                 new Query(
                     array(
                         'filter' => new Criterion\MatchAll(),
-                        'limit' => 10,
+                        'limit' => 25,
                     )
                 ),
                 array()
@@ -837,7 +837,7 @@ class SearchTest extends BaseServiceMockTest
         $repositoryMock->expects($this->never())->method('hasAccess');
 
         $serviceQuery = new LocationQuery();
-        $handlerQuery = new LocationQuery(array('filter' => new Criterion\MatchAll(), 'limit' => 10));
+        $handlerQuery = new LocationQuery(array('filter' => new Criterion\MatchAll(), 'limit' => 25));
         $spiLocation = new SPILocation();
         $locationMock = $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\Content\\Location');
 
@@ -1012,7 +1012,7 @@ class SearchTest extends BaseServiceMockTest
                 new LocationQuery(
                     array(
                         'filter' => new Criterion\MatchAll(),
-                        'limit' => 10,
+                        'limit' => 25,
                     )
                 )
             )

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -164,7 +164,7 @@ class UserService implements UserServiceInterface
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the user group
      */
-    public function loadSubUserGroups(APIUserGroup $userGroup, $offset = 0, $limit = 10)
+    public function loadSubUserGroups(APIUserGroup $userGroup, $offset = 0, $limit = 25)
     {
         $locationService = $this->repository->getLocationService();
 
@@ -215,7 +215,7 @@ class UserService implements UserServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
      */
-    protected function searchSubGroups($locationId, $sortField = null, $sortOrder = Location::SORT_ORDER_ASC, $offset = 0, $limit = 10)
+    protected function searchSubGroups($locationId, $sortField = null, $sortOrder = Location::SORT_ORDER_ASC, $offset = 0, $limit = 25)
     {
         $searchQuery = new LocationQuery();
 
@@ -875,7 +875,7 @@ class UserService implements UserServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
      */
-    public function loadUserGroupsOfUser(APIUser $user, $offset = 0, $limit = 10)
+    public function loadUserGroupsOfUser(APIUser $user, $offset = 0, $limit = 25)
     {
         $locationService = $this->repository->getLocationService();
 
@@ -932,7 +932,7 @@ class UserService implements UserServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\User\User[]
      */
-    public function loadUsersOfUserGroup(APIUserGroup $userGroup, $offset = 0, $limit = 10)
+    public function loadUsersOfUserGroup(APIUserGroup $userGroup, $offset = 0, $limit = 25)
     {
         $loadedUserGroup = $this->loadUserGroup($userGroup->id);
 

--- a/eZ/Publish/Core/SignalSlot/LocationService.php
+++ b/eZ/Publish/Core/SignalSlot/LocationService.php
@@ -145,7 +145,7 @@ class LocationService implements LocationServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\Content\LocationList
      */
-    public function loadLocationChildren(Location $location, $offset = 0, $limit = 10)
+    public function loadLocationChildren(Location $location, $offset = 0, $limit = 25)
     {
         return $this->service->loadLocationChildren($location, $offset, $limit);
     }

--- a/eZ/Publish/Core/SignalSlot/UserService.php
+++ b/eZ/Publish/Core/SignalSlot/UserService.php
@@ -118,7 +118,7 @@ class UserService implements UserServiceInterface
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the user group
      */
-    public function loadSubUserGroups(UserGroup $userGroup, $offset = 0, $limit = 10)
+    public function loadSubUserGroups(UserGroup $userGroup, $offset = 0, $limit = 25)
     {
         return $this->service->loadSubUserGroups($userGroup, $offset, $limit);
     }
@@ -410,7 +410,7 @@ class UserService implements UserServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
      */
-    public function loadUserGroupsOfUser(User $user, $offset = 0, $limit = 10)
+    public function loadUserGroupsOfUser(User $user, $offset = 0, $limit = 25)
     {
         return $this->service->loadUserGroupsOfUser($user, $offset, $limit);
     }
@@ -426,7 +426,7 @@ class UserService implements UserServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\User\User[]
      */
-    public function loadUsersOfUserGroup(UserGroup $userGroup, $offset = 0, $limit = 10)
+    public function loadUsersOfUserGroup(UserGroup $userGroup, $offset = 0, $limit = 25)
     {
         return $this->service->loadUsersOfUserGroup($userGroup, $offset, $limit);
     }


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24720

This increases default search limit value from 10 to 25.
That is done to limit impact of backporting removal of unlimited search hits option in https://jira.ez.no/browse/EZP-23405 to 5.4.