### PR TITLE
Ensure we do not cause negative numbers

### DIFF
--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/Field.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/Field.php
@@ -153,7 +153,7 @@ class Field extends SortClauseHandler
         if ($fieldTarget->languageCode === null) {
             $languageExpression = $query->expr->gt(
                 $query->expr->bitAnd(
-                    $query->expr->bitAnd($this->dbHandler->quoteColumn('language_id', $table), ~1),
+                    $query->expr->bitAnd($this->dbHandler->quoteColumn('language_id', $table), (1 << 30) - 2),
                     $this->dbHandler->quoteColumn('initial_language_id', 'ezcontentobject')
                 ),
                 0
@@ -161,7 +161,7 @@ class Field extends SortClauseHandler
         } else {
             $languageExpression = $query->expr->gt(
                 $query->expr->bitAnd(
-                    $query->expr->bitAnd($this->dbHandler->quoteColumn('language_id', $table), ~1),
+                    $query->expr->bitAnd($this->dbHandler->quoteColumn('language_id', $table), (1 << 30) - 2),
                     $query->bindValue(
                         $this->languageHandler->loadByLanguageCode($fieldTarget->languageCode)->id,
                         null,


### PR DESCRIPTION
~1 will usually be equivalent to -2 on most platforms. Depending on the architecture (32bit vs 64bit) of the webserver and the DB server and integer representations in either I guess this can lead to wrong results. (1 << 30) - 2 also results in 111…1110 but should work on most platforms – but obviously only for up to 31 languages.
