### PR TITLE
Missing BC notes

### DIFF
--- a/doc/bc/changes-5.4.md
+++ b/doc/bc/changes-5.4.md
@@ -202,6 +202,9 @@ Changes affecting version compatibility with former or future versions.
   Note: Possibility to search across all languages remains, however Field SortClause will
   for instance not work properly in this case, and we plan to start to give warnings about this.
 
+* 5.4.5: `eZ\Publish\API\Repository\Values\ValueObject\SearchHit` has a new property `$matchedTranslation`,
+  which will hold language code of the Content translation that matched the search query.
+
 ## Deprecations
 
 * `imagemagick` siteaccess settings are now deprecated. It is mandatory to remove them.

--- a/doc/bc/changes-6.0.md
+++ b/doc/bc/changes-6.0.md
@@ -155,6 +155,9 @@ Changes affecting version compatibility with former or future versions.
   `minFloatValue` and `maxFloatValue`. Use `null` instead of `false` if you want to deactivate these validators.
   Default validator value has been changed accordingly.
 
+* `eZ\Publish\API\Repository\Values\ValueObject\SearchHit` has a new property `$matchedTranslation`,
+  which will hold language code of the Content translation that matched the search query.
+
 ## Deprecations
 
 * `eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger::purge()` is deprecated and will be removed in v6.1.

--- a/doc/bc/changes-6.0.md
+++ b/doc/bc/changes-6.0.md
@@ -198,6 +198,15 @@ Changes affecting version compatibility with former or future versions.
   The legacy-bridge requirement introduced in this version isn't included by default. The legacy application, as well
   as the related bundle, libraries and configuration, are no longer shipped by default.
 
+* Following criteria and sort clauses deprecated in 5.3 are removed:
+
+    * `eZ\Publish\API\Repository\Values\Content\Query\Criterion\Depth`
+    * `eZ\Publish\API\Repository\Values\Content\Query\Criterion\LocationPriority`
+    * `eZ\Publish\API\Repository\Values\Content\Query\SortClause\LocationDepth`
+    * `eZ\Publish\API\Repository\Values\Content\Query\SortClause\LocationPath`
+    * `eZ\Publish\API\Repository\Values\Content\Query\SortClause\LocationPathString`
+    * `eZ\Publish\API\Repository\Values\Content\Query\SortClause\LocationPriority`
+
 ## Changes from 2015.01 (6.0.0-alpha1)
 
 * Bundle `EzPublishElasticsearchBundle` has been renamed to `EzPublishElasticsearchSearchEngineBundle`

--- a/eZ/Publish/API/Repository/Values/Content/Search/SearchHit.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/SearchHit.php
@@ -41,6 +41,8 @@ class SearchHit extends ValueObject
     /**
      * Language code of the Content translation that matched the query.
      *
+     * @since 5.4.5
+     *
      * @var string
      */
     public $matchedTranslation;


### PR DESCRIPTION
This adds BC notes for:

* Introduction of `SearchHit::$matchedTranslation`
* removal of deprecated criteria and sort clauses