### PR TITLE
Removed deprecated Query::$criterion

### DIFF
--- a/doc/bc/changes-6.0.md
+++ b/doc/bc/changes-6.0.md
@@ -207,6 +207,9 @@ Changes affecting version compatibility with former or future versions.
     * `eZ\Publish\API\Repository\Values\Content\Query\SortClause\LocationPathString`
     * `eZ\Publish\API\Repository\Values\Content\Query\SortClause\LocationPriority`
 
+* Deprecated virtual property `$criterion` on class `eZ\Publish\API\Repository\Values\Content\Query`,
+  is removed.
+
 ## Changes from 2015.01 (6.0.0-alpha1)
 
 * Bundle `EzPublishElasticsearchBundle` has been renamed to `EzPublishElasticsearchSearchEngineBundle`

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP21906SearchOneContentMultipleLocationsTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP21906SearchOneContentMultipleLocationsTest.php
@@ -80,7 +80,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
             array(
                 new Query(
                     array(
-                        'criterion' => new Criterion\LogicalAnd(
+                        'query' => new Criterion\LogicalAnd(
                             array(
                                 new Criterion\Subtree('/1/2/'),
                                 new Criterion\ContentTypeIdentifier('feedback_form'),
@@ -94,7 +94,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
             array(
                 new Query(
                     array(
-                        'criterion' => new Criterion\LogicalAnd(
+                        'query' => new Criterion\LogicalAnd(
                             array(
                                 new Criterion\Subtree('/1/2/'),
                                 new Criterion\ContentTypeIdentifier('feedback_form'),
@@ -109,7 +109,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
             array(
                 new Query(
                     array(
-                        'criterion' => new Criterion\LogicalAnd(
+                        'query' => new Criterion\LogicalAnd(
                             array(
                                 new Criterion\Subtree('/1/2/'),
                                 new Criterion\ContentTypeIdentifier('feedback_form'),
@@ -123,7 +123,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
             array(
                 new Query(
                     array(
-                        'criterion' => new Criterion\LogicalAnd(
+                        'query' => new Criterion\LogicalAnd(
                             array(
                                 new Criterion\Subtree('/1/2/'),
                                 new Criterion\ContentTypeIdentifier('feedback_form'),
@@ -138,7 +138,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
             array(
                 new Query(
                     array(
-                        'criterion' => new Criterion\LogicalAnd(
+                        'query' => new Criterion\LogicalAnd(
                             array(
                                 new Criterion\Subtree('/1/2/'),
                                 new Criterion\ContentTypeIdentifier('feedback_form'),
@@ -152,7 +152,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
             array(
                 new Query(
                     array(
-                        'criterion' => new Criterion\LogicalAnd(
+                        'query' => new Criterion\LogicalAnd(
                             array(
                                 new Criterion\Subtree('/1/2/'),
                                 new Criterion\ContentTypeIdentifier('folder'),
@@ -167,7 +167,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
             array(
                 new Query(
                     array(
-                        'criterion' => new Criterion\LogicalAnd(
+                        'query' => new Criterion\LogicalAnd(
                             array(
                                 new Criterion\Subtree('/1/2/'),
                                 new Criterion\ContentTypeIdentifier('folder'),
@@ -182,7 +182,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
             array(
                 new Query(
                     array(
-                        'criterion' => new Criterion\LogicalAnd(
+                        'query' => new Criterion\LogicalAnd(
                             array(
                                 new Criterion\Subtree('/1/2/'),
                                 new Criterion\ContentTypeIdentifier('folder'),
@@ -196,7 +196,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
             array(
                 new Query(
                     array(
-                        'criterion' => new Criterion\LogicalAnd(
+                        'query' => new Criterion\LogicalAnd(
                             array(
                                 new Criterion\Subtree('/1/2/'),
                                 new Criterion\ContentTypeIdentifier('folder'),
@@ -210,7 +210,7 @@ class EZP21906SearchOneContentMultipleLocationsTest extends BaseTest
             array(
                 new Query(
                     array(
-                        'criterion' => new Criterion\LogicalAnd(
+                        'query' => new Criterion\LogicalAnd(
                             array(
                                 new Criterion\Subtree('/1/2/'),
                                 new Criterion\ContentTypeIdentifier('product'),

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP22958SearchSubtreePathstringFormatTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP22958SearchSubtreePathstringFormatTest.php
@@ -37,7 +37,7 @@ class EZP22958SearchSubtreePathstringFormatTest extends BaseTest
 
         $query = new Query(
             array(
-                'criterion' => new Criterion\Subtree($pathString),
+                'filter' => new Criterion\Subtree($pathString),
             )
         );
 

--- a/eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php
@@ -108,7 +108,7 @@ class SearchServiceLocationTest extends BaseTest
 
         $query = new LocationQuery(
             array(
-                'criterion' => new Criterion\Field(
+                'query' => new Criterion\Field(
                     'countries',
                     Criterion\Operator::CONTAINS,
                     $country
@@ -138,7 +138,7 @@ class SearchServiceLocationTest extends BaseTest
         $this->createMultipleCountriesContent();
         $query = new LocationQuery(
             array(
-                'criterion' => new Criterion\Field(
+                'query' => new Criterion\Field(
                     'countries',
                     Criterion\Operator::CONTAINS,
                     'Netherlands Antilles'
@@ -319,7 +319,7 @@ class SearchServiceLocationTest extends BaseTest
 
         $query = new LocationQuery(
             array(
-                'criterion' => new Criterion\ContentTypeId($contentType->id),
+                'query' => new Criterion\ContentTypeId($contentType->id),
                 'sortClauses' => array(
                     new SortClause\Field('test-type', 'integer', LocationQuery::SORT_DESC, 'eng-GB'),
                     new SortClause\Field('test-type', 'integer', LocationQuery::SORT_ASC, 'ger-DE'),
@@ -379,7 +379,7 @@ class SearchServiceLocationTest extends BaseTest
 
         $query = new LocationQuery(
             array(
-                'criterion' => new Criterion\ContentTypeId($contentType->id),
+                'query' => new Criterion\ContentTypeId($contentType->id),
                 'sortClauses' => array(
                     new SortClause\Field('test-type', 'integer', LocationQuery::SORT_ASC, 'eng-GB'),
                     new SortClause\Field('test-type', 'integer', LocationQuery::SORT_DESC, 'ger-DE'),
@@ -439,7 +439,7 @@ class SearchServiceLocationTest extends BaseTest
 
         $query = new LocationQuery(
             array(
-                'criterion' => new Criterion\ContentTypeId($contentType->id),
+                'query' => new Criterion\ContentTypeId($contentType->id),
                 'sortClauses' => array(
                     new SortClause\Field('test-type', 'integer', LocationQuery::SORT_DESC, 'ger-DE'),
                     new SortClause\Field('test-type', 'integer', LocationQuery::SORT_ASC, 'eng-GB'),
@@ -485,7 +485,7 @@ class SearchServiceLocationTest extends BaseTest
 
         $query = new LocationQuery(
             array(
-                'criterion' => new Criterion\ContentTypeId($contentType->id),
+                'query' => new Criterion\ContentTypeId($contentType->id),
                 'sortClauses' => array(
                     new SortClause\Field('test-type', 'integer', LocationQuery::SORT_ASC),
                 ),
@@ -510,7 +510,7 @@ class SearchServiceLocationTest extends BaseTest
 
         $query = new LocationQuery(
             array(
-                'criterion' => new Criterion\ContentTypeId($contentType->id),
+                'query' => new Criterion\ContentTypeId($contentType->id),
                 'sortClauses' => array(
                     // The main language can change, so no language code allowed on non-translatable field whatsoever
                     new SortClause\Field('test-type', 'integer2', LocationQuery::SORT_ASC, 'eng-GB'),
@@ -550,7 +550,7 @@ class SearchServiceLocationTest extends BaseTest
 
         $query = new LocationQuery(
             array(
-                'criterion' => new Criterion\ContentTypeId($contentType->id),
+                'query' => new Criterion\ContentTypeId($contentType->id),
                 'sortClauses' => array(
                     new SortClause\Field('test-type', 'integer', LocationQuery::SORT_DESC, 'eng-GB'),
                     new SortClause\Field('test-type', 'integer2', LocationQuery::SORT_ASC),
@@ -610,7 +610,7 @@ class SearchServiceLocationTest extends BaseTest
 
         $query = new LocationQuery(
             array(
-                'criterion' => new Criterion\ContentTypeId($contentType->id),
+                'query' => new Criterion\ContentTypeId($contentType->id),
                 'sortClauses' => array(
                     new SortClause\Field('test-type', 'integer', LocationQuery::SORT_ASC, 'eng-GB'),
                     new SortClause\Field('test-type', 'integer2', LocationQuery::SORT_DESC),
@@ -670,7 +670,7 @@ class SearchServiceLocationTest extends BaseTest
 
         $query = new LocationQuery(
             array(
-                'criterion' => new Criterion\ContentTypeId($contentType->id),
+                'query' => new Criterion\ContentTypeId($contentType->id),
                 'sortClauses' => array(
                     new SortClause\Field('test-type', 'integer2', LocationQuery::SORT_DESC),
                     new SortClause\Field('test-type', 'integer', LocationQuery::SORT_DESC, 'ger-DE'),
@@ -730,7 +730,7 @@ class SearchServiceLocationTest extends BaseTest
 
         $query = new LocationQuery(
             array(
-                'criterion' => new Criterion\ContentTypeId($contentType->id),
+                'query' => new Criterion\ContentTypeId($contentType->id),
                 'sortClauses' => array(
                     // "test-type" Content instance do not exist in "eng-US"
                     new SortClause\Field('test-type', 'integer', LocationQuery::SORT_ASC, 'eng-US'),
@@ -772,7 +772,7 @@ class SearchServiceLocationTest extends BaseTest
 
         $query = new LocationQuery(
             array(
-                'criterion' => new Criterion\ContentTypeId($contentType->id),
+                'query' => new Criterion\ContentTypeId($contentType->id),
                 'sortClauses' => array(
                     // "test-type" Content instance do not exist in "eng-US"
                     new SortClause\Field('test-type', 'integer', LocationQuery::SORT_DESC, 'eng-US'),

--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -590,14 +590,14 @@ class SearchServiceTest extends BaseTest
             ),
             array(
                 array(
-                    'criterion' => new Criterion\LanguageCode('eng-GB', false),
+                    'query' => new Criterion\LanguageCode('eng-GB', false),
                     'sortClauses' => array(new SortClause\ContentId()),
                 ),
                 $fixtureDir . 'LanguageCode.php',
             ),
             array(
                 array(
-                    'criterion' => new Criterion\LanguageCode(array('eng-US', 'eng-GB')),
+                    'query' => new Criterion\LanguageCode(array('eng-US', 'eng-GB')),
                     'offset' => 10,
                     'sortClauses' => array(new SortClause\ContentId()),
                 ),
@@ -605,7 +605,7 @@ class SearchServiceTest extends BaseTest
             ),
             array(
                 array(
-                    'criterion' => new Criterion\LanguageCode('eng-GB'),
+                    'query' => new Criterion\LanguageCode('eng-GB'),
                     'offset' => 10,
                     'sortClauses' => array(new SortClause\ContentId()),
                 ),
@@ -613,7 +613,7 @@ class SearchServiceTest extends BaseTest
             ),
             array(
                 array(
-                    'criterion' => new Criterion\Visibility(
+                    'query' => new Criterion\Visibility(
                         Criterion\Visibility::VISIBLE
                     ),
                     'sortClauses' => array(new SortClause\ContentId()),
@@ -631,28 +631,28 @@ class SearchServiceTest extends BaseTest
         return array(
             array(
                 array(
-                    'criterion' => new Criterion\Location\Depth(Criterion\Operator::EQ, 1),
+                    'query' => new Criterion\Location\Depth(Criterion\Operator::EQ, 1),
                     'sortClauses' => array(new SortClause\ContentId()),
                 ),
                 $fixtureDir . 'Depth.php',
             ),
             array(
                 array(
-                    'criterion' => new Criterion\Location\Depth(Criterion\Operator::IN, array(1, 3)),
+                    'query' => new Criterion\Location\Depth(Criterion\Operator::IN, array(1, 3)),
                     'sortClauses' => array(new SortClause\ContentId()),
                 ),
                 $fixtureDir . 'DepthIn.php',
             ),
             array(
                 array(
-                    'criterion' => new Criterion\Location\Depth(Criterion\Operator::GT, 2),
+                    'query' => new Criterion\Location\Depth(Criterion\Operator::GT, 2),
                     'sortClauses' => array(new SortClause\ContentId()),
                 ),
                 $fixtureDir . 'DepthGt.php',
             ),
             array(
                 array(
-                    'criterion' => new Criterion\Location\Depth(Criterion\Operator::GTE, 2),
+                    'query' => new Criterion\Location\Depth(Criterion\Operator::GTE, 2),
                     'sortClauses' => array(new SortClause\ContentId()),
                     'limit' => 50,
                 ),
@@ -660,14 +660,14 @@ class SearchServiceTest extends BaseTest
             ),
             array(
                 array(
-                    'criterion' => new Criterion\Location\Depth(Criterion\Operator::LT, 2),
+                    'query' => new Criterion\Location\Depth(Criterion\Operator::LT, 2),
                     'sortClauses' => array(new SortClause\ContentId()),
                 ),
                 $fixtureDir . 'Depth.php',
             ),
             array(
                 array(
-                    'criterion' => new Criterion\Location\Depth(Criterion\Operator::LTE, 2),
+                    'query' => new Criterion\Location\Depth(Criterion\Operator::LTE, 2),
                     'sortClauses' => array(new SortClause\ContentId()),
                     'limit' => 50,
                 ),
@@ -675,7 +675,7 @@ class SearchServiceTest extends BaseTest
             ),
             array(
                 array(
-                    'criterion' => new Criterion\Location\Depth(Criterion\Operator::BETWEEN, array(1, 2)),
+                    'query' => new Criterion\Location\Depth(Criterion\Operator::BETWEEN, array(1, 2)),
                     'sortClauses' => array(new SortClause\ContentId()),
                     'limit' => 50,
                 ),
@@ -733,7 +733,7 @@ class SearchServiceTest extends BaseTest
         $this->assertQueryFixture(
             new Query(
                 array(
-                    'criterion' => new Criterion\ContentId(
+                    'query' => new Criterion\ContentId(
                         array(1, 4, 10)
                     ),
                     'sortClauses' => array(new SortClause\ContentId()),
@@ -1043,7 +1043,7 @@ class SearchServiceTest extends BaseTest
 
         $query = new Query(
             array(
-                'criterion' => new Criterion\Field(
+                'query' => new Criterion\Field(
                     'countries',
                     Criterion\Operator::CONTAINS,
                     $country
@@ -1073,7 +1073,7 @@ class SearchServiceTest extends BaseTest
         $this->createMultipleCountriesContent();
         $query = new Query(
             array(
-                'criterion' => new Criterion\Field(
+                'query' => new Criterion\Field(
                     'countries',
                     Criterion\Operator::CONTAINS,
                     'Netherlands Antilles'
@@ -1565,7 +1565,7 @@ class SearchServiceTest extends BaseTest
 
         $query = new Query(
             array(
-                'criterion' => new Criterion\ContentTypeId($contentType->id),
+                'query' => new Criterion\ContentTypeId($contentType->id),
                 'sortClauses' => array(
                     new SortClause\Field('test-type', 'integer', Query::SORT_DESC, 'eng-GB'),
                     new SortClause\Field('test-type', 'integer', Query::SORT_ASC, 'ger-DE'),
@@ -1625,7 +1625,7 @@ class SearchServiceTest extends BaseTest
 
         $query = new Query(
             array(
-                'criterion' => new Criterion\ContentTypeId($contentType->id),
+                'query' => new Criterion\ContentTypeId($contentType->id),
                 'sortClauses' => array(
                     new SortClause\Field('test-type', 'integer', Query::SORT_ASC, 'eng-GB'),
                     new SortClause\Field('test-type', 'integer', Query::SORT_DESC, 'ger-DE'),
@@ -1687,7 +1687,7 @@ class SearchServiceTest extends BaseTest
 
         $query = new Query(
             array(
-                'criterion' => new Criterion\ContentTypeId($contentType->id),
+                'query' => new Criterion\ContentTypeId($contentType->id),
                 'sortClauses' => array(
                     new SortClause\Field('test-type', 'integer', Query::SORT_DESC, 'ger-DE'),
                     new SortClause\Field('test-type', 'integer', Query::SORT_ASC, 'eng-GB'),
@@ -1733,7 +1733,7 @@ class SearchServiceTest extends BaseTest
 
         $query = new Query(
             array(
-                'criterion' => new Criterion\ContentTypeId($contentType->id),
+                'query' => new Criterion\ContentTypeId($contentType->id),
                 'sortClauses' => array(
                     new SortClause\Field('test-type', 'integer', Query::SORT_ASC),
                 ),
@@ -1758,7 +1758,7 @@ class SearchServiceTest extends BaseTest
 
         $query = new Query(
             array(
-                'criterion' => new Criterion\ContentTypeId($contentType->id),
+                'query' => new Criterion\ContentTypeId($contentType->id),
                 'sortClauses' => array(
                     // The main language can change, so no language code allowed on non-translatable field whatsoever
                     new SortClause\Field('test-type', 'integer2', Query::SORT_ASC, 'eng-GB'),
@@ -1798,7 +1798,7 @@ class SearchServiceTest extends BaseTest
 
         $query = new Query(
             array(
-                'criterion' => new Criterion\ContentTypeId($contentType->id),
+                'query' => new Criterion\ContentTypeId($contentType->id),
                 'sortClauses' => array(
                     new SortClause\Field('test-type', 'integer', Query::SORT_DESC, 'eng-GB'),
                     new SortClause\Field('test-type', 'integer2', Query::SORT_ASC),
@@ -1858,7 +1858,7 @@ class SearchServiceTest extends BaseTest
 
         $query = new Query(
             array(
-                'criterion' => new Criterion\ContentTypeId($contentType->id),
+                'query' => new Criterion\ContentTypeId($contentType->id),
                 'sortClauses' => array(
                     new SortClause\Field('test-type', 'integer', Query::SORT_ASC, 'eng-GB'),
                     new SortClause\Field('test-type', 'integer2', Query::SORT_DESC),
@@ -1918,7 +1918,7 @@ class SearchServiceTest extends BaseTest
 
         $query = new Query(
             array(
-                'criterion' => new Criterion\ContentTypeId($contentType->id),
+                'query' => new Criterion\ContentTypeId($contentType->id),
                 'sortClauses' => array(
                     new SortClause\Field('test-type', 'integer2', Query::SORT_DESC),
                     new SortClause\Field('test-type', 'integer', Query::SORT_DESC, 'ger-DE'),
@@ -1978,7 +1978,7 @@ class SearchServiceTest extends BaseTest
 
         $query = new Query(
             array(
-                'criterion' => new Criterion\ContentTypeId($contentType->id),
+                'query' => new Criterion\ContentTypeId($contentType->id),
                 'sortClauses' => array(
                     // "test-type" Content instance do not exist in "eng-US"
                     new SortClause\Field('test-type', 'integer', Query::SORT_ASC, 'eng-US'),
@@ -2020,7 +2020,7 @@ class SearchServiceTest extends BaseTest
 
         $query = new Query(
             array(
-                'criterion' => new Criterion\ContentTypeId($contentType->id),
+                'query' => new Criterion\ContentTypeId($contentType->id),
                 'sortClauses' => array(
                     // "test-type" Content instance do not exist in "eng-US"
                     new SortClause\Field('test-type', 'integer', Query::SORT_DESC, 'eng-US'),

--- a/eZ/Publish/API/Repository/Values/Content/Query.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query.php
@@ -14,8 +14,6 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 
 /**
  * This class is used to perform a Content query.
- *
- * @property $criterion Deprecated alias for $query
  */
 class Query extends ValueObject
 {
@@ -100,53 +98,4 @@ class Query extends ValueObject
      * @var bool
      */
     public $performCount = true;
-
-    /**
-     * Wrapper for deprecated $criterion property.
-     *
-     * @param string $property
-     *
-     * @return mixed
-     */
-    public function __get($property)
-    {
-        if ($property === 'criterion') {
-            return $this->query;
-        }
-
-        return parent::__get($property);
-    }
-
-    /**
-     * Wrapper for deprecated $criterion property.
-     *
-     * @param string $property
-     * @param mixed $value
-     */
-    public function __set($property, $value)
-    {
-        if ($property === 'criterion') {
-            $this->query = $value;
-
-            return;
-        }
-
-        return parent::__set($property, $value);
-    }
-
-    /**
-     * Wrapper for deprecated $criterion property.
-     *
-     * @param string $property
-     *
-     * @return bool
-     */
-    public function __isset($property)
-    {
-        if ($property === 'criterion') {
-            return true;
-        }
-
-        return parent::__isset($property);
-    }
 }

--- a/eZ/Publish/Core/Pagination/Tests/ContentSearchHitAdapterTest.php
+++ b/eZ/Publish/Core/Pagination/Tests/ContentSearchHitAdapterTest.php
@@ -47,7 +47,7 @@ class ContentSearchHitAdapterTest extends PHPUnit_Framework_TestCase
     {
         $nbResults = 123;
         $query = new Query();
-        $query->criterion = $this->getMock('eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface');
+        $query->query = $this->getMock('eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface');
         $query->sortClauses = $this
             ->getMockBuilder('eZ\Publish\API\Repository\Values\Content\Query\SortClause')
             ->disableOriginalConstructor()
@@ -77,7 +77,7 @@ class ContentSearchHitAdapterTest extends PHPUnit_Framework_TestCase
         $nbResults = 123;
 
         $query = new Query();
-        $query->criterion = $this->getMock('eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface');
+        $query->query = $this->getMock('eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface');
         $query->sortClauses = $this
             ->getMockBuilder('eZ\Publish\API\Repository\Values\Content\Query\SortClause')
             ->disableOriginalConstructor()

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
@@ -920,7 +920,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\Field(
+                        'filter' => new Criterion\Field(
                             'name',
                             Criterion\Operator::CONTAINS,
                             'nonymous use'
@@ -939,7 +939,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\Field(
+                        'filter' => new Criterion\Field(
                             'publish_date',
                             Criterion\Operator::CONTAINS,
                             1174643880
@@ -958,7 +958,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\Field(
+                        'filter' => new Criterion\Field(
                             'publish_date',
                             Criterion\Operator::CONTAINS,
                             1174643
@@ -1200,7 +1200,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\LanguageCode('eng-GB', true),
+                        'filter' => new Criterion\LanguageCode('eng-GB', true),
                         'limit' => 20,
                         'sortClauses' => array(new SortClause\ContentId()),
                     )
@@ -1234,7 +1234,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\UserMetadata(
+                        'filter' => new Criterion\UserMetadata(
                             Criterion\UserMetadata::OWNER,
                             Criterion\Operator::EQ,
                             2
@@ -1252,7 +1252,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\UserMetadata(
+                        'filter' => new Criterion\UserMetadata(
                             Criterion\UserMetadata::OWNER,
                             Criterion\Operator::EQ,
                             14
@@ -1272,7 +1272,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\UserMetadata(
+                        'filter' => new Criterion\UserMetadata(
                             Criterion\UserMetadata::OWNER,
                             Criterion\Operator::EQ,
                             226
@@ -1290,7 +1290,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\UserMetadata(
+                        'filter' => new Criterion\UserMetadata(
                             Criterion\UserMetadata::OWNER,
                             Criterion\Operator::IN,
                             array(226)
@@ -1308,7 +1308,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\UserMetadata(
+                        'filter' => new Criterion\UserMetadata(
                             Criterion\UserMetadata::MODIFIER,
                             Criterion\Operator::EQ,
                             226
@@ -1326,7 +1326,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\UserMetadata(
+                        'filter' => new Criterion\UserMetadata(
                             Criterion\UserMetadata::MODIFIER,
                             Criterion\Operator::IN,
                             array(226)
@@ -1344,7 +1344,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\UserMetadata(
+                        'filter' => new Criterion\UserMetadata(
                             Criterion\UserMetadata::GROUP,
                             Criterion\Operator::EQ,
                             11
@@ -1362,7 +1362,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\UserMetadata(
+                        'filter' => new Criterion\UserMetadata(
                             Criterion\UserMetadata::GROUP,
                             Criterion\Operator::IN,
                             array(11)
@@ -1380,7 +1380,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\UserMetadata(
+                        'filter' => new Criterion\UserMetadata(
                             Criterion\UserMetadata::GROUP,
                             Criterion\Operator::EQ,
                             13
@@ -1398,7 +1398,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\UserMetadata(
+                        'filter' => new Criterion\UserMetadata(
                             Criterion\UserMetadata::GROUP,
                             Criterion\Operator::IN,
                             array(13)
@@ -1416,7 +1416,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\FieldRelation(
+                        'filter' => new Criterion\FieldRelation(
                             'billboard',
                             Criterion\Operator::CONTAINS,
                             array(60)
@@ -1434,7 +1434,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\FieldRelation(
+                        'filter' => new Criterion\FieldRelation(
                             'billboard',
                             Criterion\Operator::CONTAINS,
                             array(4)
@@ -1452,7 +1452,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\FieldRelation(
+                        'filter' => new Criterion\FieldRelation(
                             'billboard',
                             Criterion\Operator::CONTAINS,
                             array(60, 75)
@@ -1470,7 +1470,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\FieldRelation(
+                        'filter' => new Criterion\FieldRelation(
                             'billboard',
                             Criterion\Operator::CONTAINS,
                             array(60, 64)
@@ -1488,7 +1488,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\FieldRelation(
+                        'filter' => new Criterion\FieldRelation(
                             'billboard',
                             Criterion\Operator::IN,
                             array(60, 64)
@@ -1506,7 +1506,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->getContentSearchHandler()->findContent(
                 new Query(
                     array(
-                        'criterion' => new Criterion\FieldRelation(
+                        'filter' => new Criterion\FieldRelation(
                             'billboard',
                             Criterion\Operator::IN,
                             array(4, 10)


### PR DESCRIPTION
This removes deprecated (5.2) virtual property `$criterion` on the API Query class.
The property was mapped to concrete `$query` property.