### PR TITLE
Full PHP 7.0 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,38 +12,36 @@ matrix:
   allow_failures:
     - php: hhvm
       env: TEST_CONFIG="phpunit.xml"
-    - php: 7.0
-      env: TEST_CONFIG="phpunit.xml"
   include:
 # 5.4
     - php: 5.4
       env: TEST_CONFIG="phpunit.xml"
     - php: 5.4
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/$DB_NAME"
-#    - php: 5.4
-#      env: SOLR_VERSION="4.10.4" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CORES_SETUP="dedicated" SOLR_CORES="core0 core1 core2 core3 core4 core5 core6 core7" SOLR_CONFS="vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/language-fieldtypes.xml"
-#    - php: 5.4
-#      env: SOLR_VERSION="4.10.4" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CORES_SETUP="shared" SOLR_CORES="core0 core1 core2 core3 core4" SOLR_CONFS="vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/language-fieldtypes.xml"
-    - php: 5.4
-      env: SOLR_VERSION="4.10.4" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CORES_SETUP="single" SOLR_CONFS="vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/language-fieldtypes.xml"
 # 5.5
     - php: 5.5
       env: TEST_CONFIG="phpunit.xml"
     - php: 5.5
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/$DB_NAME"
-    - php: 5.5
-      env: ELASTICSEARCH_VERSION="1.4.2" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
 # 5.6
     - php: 5.6
       env: TEST_CONFIG="phpunit.xml"
     - php: 5.6
       env: TEST_CONFIG="phpunit-integration-legacy.xml"
-    - php: 5.6
-      env: BEHAT_PROFILE="demo" TEST="clean"
 # 7.0
     - php: 7.0
       env: TEST_CONFIG="phpunit.xml"
-# hhvm - disabled, no need ot enable before travis has newer versions avaiable
+    - php: 7.0
+      env: BEHAT_PROFILE="demo" TEST="clean"
+    - php: 7.0
+      env: ELASTICSEARCH_VERSION="1.4.2" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml"
+#    - php: 7.0
+#      env: SOLR_VERSION="4.10.4" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CORES_SETUP="dedicated" SOLR_CORES="core0 core1 core2 core3 core4 core5 core6 core7" SOLR_CONFS="vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/language-fieldtypes.xml"
+#    - php: 7.0
+#      env: SOLR_VERSION="4.10.4" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CORES_SETUP="shared" SOLR_CORES="core0 core1 core2 core3 core4" SOLR_CONFS="vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/language-fieldtypes.xml"
+    - php: 7.0
+      env: SOLR_VERSION="4.10.4" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CORES_SETUP="single" SOLR_CONFS="vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/eZ/Publish/Core/Search/Solr/Resources/language-fieldtypes.xml"
+# hhvm - disabled, no need to enable before travis has newer versions avaiable
 #    - php: hhvm
 #      env: TEST_CONFIG="phpunit.xml"
 

--- a/composer.lock
+++ b/composer.lock
@@ -1548,12 +1548,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+                "reference": "1.0.0"
             },
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "reference": "1.0.0",
                 "shasum": ""
             },
             "type": "library",
@@ -1586,12 +1586,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Qafoo/REST-Micro-Framework.git",
-                "reference": "d382e9e20ff189c4351f12c70df083dac039e818"
+                "reference": "1.0.0"
             },
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/Qafoo/REST-Micro-Framework/zipball/d382e9e20ff189c4351f12c70df083dac039e818",
-                "reference": "d382e9e20ff189c4351f12c70df083dac039e818",
+                "reference": "1.0.0",
                 "shasum": ""
             },
             "type": "library",
@@ -1602,7 +1602,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "description": "Very simple VC framework which makes it easy to build HTTP applications / REST webservices",
-            "time": "2012-09-03 18:24:11"
+            "time": "2012-09-03 11:24:11"
         },
         {
             "name": "sensio/distribution-bundle",
@@ -1808,7 +1808,7 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony CMF community",
+                    "name": "Symfony CMF Community",
                     "homepage": "https://github.com/symfony-cmf/Routing/contributors"
                 }
             ],
@@ -2688,12 +2688,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/mikey179/vfsStream.git",
-                "reference": "fc0fe8f4d0b527254a2dc45f0c265567c881d07e"
+                "reference": "v1.1.0"
             },
             "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/mikey179/vfsStream/zipball/fc0fe8f4d0b527254a2dc45f0c265567c881d07e",
-                "reference": "fc0fe8f4d0b527254a2dc45f0c265567c881d07e",
+                "reference": "v1.1.0",
                 "shasum": ""
             },
             "require": {
@@ -2710,7 +2710,7 @@
                 "BSD"
             ],
             "homepage": "http://vfs.bovigo.org/",
-            "time": "2012-08-25 12:49:29"
+            "time": "2012-08-25 05:49:29"
         },
         {
             "name": "mockery/mockery",


### PR DESCRIPTION
Don't allow PHP 7.0 to fail anymore, *and* move several tests over to it to put more emphasis on 7.0 testing *(..and get some speed up of travis runs as a bonus)*.

Tests moved-to/enabled on 7.0:
- unit
- behat
- solr
- elastic search