### PR TITLE
EZP-24744 - Increase password security

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "liip/imagine-bundle": "~1.0",
         "oneup/flysystem-bundle": "~0.4",
         "friendsofsymfony/http-cache-bundle": "~1.2",
-        "sensio/framework-extra-bundle": "~3.0"
+        "sensio/framework-extra-bundle": "~3.0",
+        "ircmaxell/password-compat": "^1.0"
     },
     "require-dev": {
         "mikey179/vfsStream": "1.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1087,6 +1087,48 @@
             "time": "2014-11-20 16:49:30"
         },
         {
+            "name": "ircmaxell/password-compat",
+            "version": "v1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ircmaxell/password_compat.git",
+                "reference": "5c5cde8822a69545767f7c7f3058cb15ff84614c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ircmaxell/password_compat/zipball/5c5cde8822a69545767f7c7f3058cb15ff84614c",
+                "reference": "5c5cde8822a69545767f7c7f3058cb15ff84614c",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/password.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anthony Ferrara",
+                    "email": "ircmaxell@php.net",
+                    "homepage": "http://blog.ircmaxell.com"
+                }
+            ],
+            "description": "A compatibility library for the proposed simplified password hashing algorithm: https://wiki.php.net/rfc/password_hash",
+            "homepage": "https://github.com/ircmaxell/password_compat",
+            "keywords": [
+                "hashing",
+                "password"
+            ],
+            "time": "2014-11-20 16:49:30"
+        },
+        {
             "name": "jdorn/sql-formatter",
             "version": "v1.2.17",
             "source": {

--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -2240,7 +2240,7 @@ CREATE TABLE `ezuser` (
   `email` varchar(150) NOT NULL DEFAULT '',
   `login` varchar(150) NOT NULL DEFAULT '',
   `login_normalized` varchar(150) NOT NULL DEFAULT '',
-  `password_hash` varchar(50) DEFAULT NULL,
+  `password_hash` varchar(255) DEFAULT NULL,
   `password_hash_type` int(11) NOT NULL DEFAULT '1',
   PRIMARY KEY (`contentobject_id`),
   UNIQUE KEY `ezuser_login` (`login_normalized`)

--- a/doc/bc/changes-6.0.md
+++ b/doc/bc/changes-6.0.md
@@ -174,6 +174,11 @@ Changes affecting version compatibility with former or future versions.
   
 * Internal `limitationMap` repository service setting (for `RoleService`) has been renamed to `policyMap`.
 
+* Increase password security
+  EZP-24744 - Increase password security introduced a new encryption for the user password, BCRYPT.
+  This will allow the password to be stored with encryption instead of the present method md5 hash.
+  Caution - Using the PASSWORD_BCRYPT, will result in the password parameter being truncated to a maximum length of 72 characters
+
 ## Deprecations
 
 * `eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger::purge()` is deprecated and will be removed in v6.1.

--- a/eZ/Publish/API/Repository/Tests/FieldType/UserIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/UserIntegrationTest.php
@@ -131,8 +131,7 @@ class UserIntegrationTest extends BaseIntegrationTest
             'hasStoredLogin' => true,
             'login' => 'hans',
             'email' => 'hans@example.com',
-            'passwordHash' => '680869a9873105e365d39a6d14e68e46',
-            'passwordHashType' => 2,
+            'passwordHashType' => 6,
             'enabled' => true,
         );
 

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -834,17 +834,11 @@ class UserServiceTest extends BaseTest
             array(
                 'login' => 'user',
                 'email' => 'user@example.com',
-                'passwordHash' => $this->createHash(
-                    'user',
-                    'secret',
-                    $user->hashAlgorithm
-                ),
                 'mainLanguageCode' => 'eng-US',
             ),
             array(
                 'login' => $user->login,
                 'email' => $user->email,
-                'passwordHash' => $user->passwordHash,
                 'mainLanguageCode' => $user->contentInfo->mainLanguageCode,
             )
         );
@@ -1426,18 +1420,12 @@ class UserServiceTest extends BaseTest
             array(
                 'login' => 'user',
                 'email' => 'user@example.com',
-                'passwordHash' => $this->createHash(
-                    'user',
-                    'my-new-password',
-                    $user->hashAlgorithm
-                ),
                 'maxLogin' => 42,
                 'enabled' => false,
             ),
             array(
                 'login' => $user->login,
                 'email' => $user->email,
-                'passwordHash' => $user->passwordHash,
                 'maxLogin' => $user->maxLogin,
                 'enabled' => $user->enabled,
             )

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
@@ -483,7 +483,7 @@ CREATE TABLE ezuser (
   email varchar(150) NOT NULL DEFAULT '',
   login varchar(150) NOT NULL DEFAULT '',
   login_normalized varchar(150) NOT NULL DEFAULT '',
-  password_hash varchar(50) DEFAULT NULL,
+  password_hash varchar(255) DEFAULT NULL,
   password_hash_type int(11) NOT NULL DEFAULT 1,
   PRIMARY KEY (contentobject_id),
   UNIQUE KEY `ezuser_login` (`login_normalized`)

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
@@ -513,7 +513,7 @@ CREATE TABLE ezuser (
     email character varying(150) DEFAULT ''::character varying NOT NULL,
     login character varying(150) DEFAULT ''::character varying NOT NULL,
     login_normalized character varying(150) DEFAULT ''::character varying NOT NULL,
-    password_hash character varying(50),
+    password_hash character varying(255),
     password_hash_type integer DEFAULT 1 NOT NULL
 );
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
@@ -433,7 +433,7 @@ CREATE TABLE ezuser (
   email text(150) NOT NULL,
   login text(150) NOT NULL,
   login_normalized text(150) NOT NULL,
-  password_hash text(50),
+  password_hash text(255),
   password_hash_type integer NOT NULL DEFAULT 1,
   PRIMARY KEY (contentobject_id)
 );

--- a/eZ/Publish/Core/Repository/Values/User/User.php
+++ b/eZ/Publish/Core/Repository/Values/User/User.php
@@ -38,6 +38,11 @@ class User extends APIUser
     const PASSWORD_HASH_PLAINTEXT = 5;
 
     /**
+     * @var int Passwords in bcrypt
+     */
+    const PASSWORD_BCRYPT = 6;
+
+    /**
      * Internal content representation.
      *
      * @var \eZ\Publish\API\Repository\Values\Content\Content


### PR DESCRIPTION
## EZP-24744 - Increase password security

Currently eZ Publish is only using plain text or MD5 for password hash, this improvement implements the usage of BCRYPT to improve the security of the stored passwords