### PR TITLE
[PHP 7] Fixed reference issue in ConfigurationProcessor

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/ConfigurationProcessor.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/ConfigurationProcessor.php
@@ -105,7 +105,7 @@ class ConfigurationProcessor
         $scopeNodeName = $this->contextualizer->getSiteAccessNodeName();
         foreach ($config[$scopeNodeName] as $currentScope => &$scopeSettings) {
             if ($mapperCallable) {
-                call_user_func_array($mapper, array($scopeSettings, $currentScope, $this->contextualizer));
+                call_user_func_array($mapper, array(&$scopeSettings, $currentScope, $this->contextualizer));
             } else {
                 $mapper->mapConfig($scopeSettings, $currentScope, $this->contextualizer);
             }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/SiteAccessAware/ConfigurationProcessorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/SiteAccessAware/ConfigurationProcessorTest.php
@@ -101,7 +101,7 @@ class ConfigurationProcessorTest extends PHPUnit_Framework_TestCase
             ),
         );
 
-        $mapperClosure = function (array $scopeSettings, $currentScope, ContextualizerInterface $contextualizer) use ($config, $availableSAs, $saNodeName, $expectedContextualizer) {
+        $mapperClosure = function (array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer) use ($config, $availableSAs, $saNodeName, $expectedContextualizer) {
             self::assertTrue(isset($availableSAs[$currentScope]));
             self::assertTrue(isset($config[$saNodeName][$currentScope]));
             self::assertSame($config[$saNodeName][$currentScope], $scopeSettings);


### PR DESCRIPTION
References behave differently in PHP 7 and calls to
`call_user_func_array()` now must have explicit references when passing
arguments (not variables assigned by reference).

See [reported PHP bug](https://bugs.php.net/bug.php?id=70379).
Tests should have broken but they did not because of a issue in
`testMapConfigClosure()`.

*Important*: There is *no change on the behavior*. We only avoid a warning from being triggered.