### PR TITLE
Add common base for Section create/update structs

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/SectionCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/SectionCreateStruct.php
@@ -10,28 +10,10 @@
  */
 namespace eZ\Publish\API\Repository\Values\Content;
 
-use eZ\Publish\API\Repository\Values\ValueObject;
-
 /**
  * This class represents a section.
+ * $identifier and $name are required.
  */
-class SectionCreateStruct extends ValueObject
+class SectionCreateStruct extends SectionStruct
 {
-    /**
-     * Unique string identifier of the section.
-     *
-     * @required
-     *
-     * @var string
-     */
-    public $identifier;
-
-    /**
-     * Name of the section.
-     *
-     * @required
-     *
-     * @var string
-     */
-    public $name;
 }

--- a/eZ/Publish/API/Repository/Values/Content/SectionStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/SectionStruct.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Publish\API\Repository\Values\Content;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+abstract class SectionStruct extends ValueObject
+{
+    /**
+     * If set the Unique identifier of the section is changes.
+     *
+     * Needs to be a unique Section->identifier string value.
+     *
+     * @var string
+     */
+    public $identifier;
+
+    /**
+     * If set the name of the section is changed.
+     *
+     * @var string
+     */
+    public $name;
+}

--- a/eZ/Publish/API/Repository/Values/Content/SectionUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/SectionUpdateStruct.php
@@ -10,26 +10,9 @@
  */
 namespace eZ\Publish\API\Repository\Values\Content;
 
-use eZ\Publish\API\Repository\Values\ValueObject;
-
 /**
  * This class is used to provide data for updating a section. At least one property has to set.
  */
-class SectionUpdateStruct extends ValueObject
+class SectionUpdateStruct extends SectionStruct
 {
-    /**
-     * If set the Unique identifier of the section is changes.
-     *
-     * Needs to be a unique Section->identifier string value.
-     *
-     * @var string
-     */
-    public $identifier;
-
-    /**
-     * If set the name of the section is changed.
-     *
-     * @var string
-     */
-    public $name;
 }


### PR DESCRIPTION
This helps a lot form management (`data_class` option) / validation config (FQCN based).

See implementation for sections at https://github.com/ezsystems/repository-forms/pull/37

This PR also introduces 2 new interfaces: `CreateStruct` and `UpdateStruct`, mostly for type hint/check.

This change is completely BC and is applicable to most (maybe all) structs defined in the Repository.