### PR TITLE
BDD: console siteaccess matching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,15 @@ matrix:
       env: TEST_CONFIG="phpunit.xml"
     - php: 5.6
       env: TEST_CONFIG="phpunit-integration-legacy.xml"
+    - php: 5.6
+      env: BEHAT_PROFILE="demo" TEST="clean"
+    - php: 5.6
+      env: BEHAT_PROFILE="core" TEST="console"
 # 7.0
     - php: 7.0
       env: REST_TEST_CONFIG="phpunit-functional-rest.xml"
     - php: 7.0
       env: TEST_CONFIG="phpunit.xml"
-    - php: 7.0
-      env: BEHAT_PROFILE="demo" TEST="clean"
     - php: 7.0
       env: BEHAT_PROFILE="rest" TEST="fullJson"
     - php: 7.0

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "matthiasnoback/symfony-dependency-injection-test": "0.*",
         "mockery/mockery": "~0.9.4",
         "symfony/assetic-bundle": "~2.3",
-        "zendframework/zend-code": "~2.4.3"
+        "zendframework/zend-code": "~2.4.3",
+        "ezsystems/behatbundle": "dev-master"
     },
     "replace": {
         "ezsystems/ezpublish": "*",

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,8 @@
     },
     "autoload": {
         "psr-4": {
-            "EzSystems\\PlatformInstallerBundle\\": "eZ/Bundle/PlatformInstallerBundle/src"
+            "EzSystems\\PlatformInstallerBundle\\": "eZ/Bundle/PlatformInstallerBundle/src",
+            "EzSystems\\PlatformBehatBundle\\": "eZ/Bundle/PlatformBehatBundle"
         },
         "psr-0": {
             "eZ": ""

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Console/console.feature
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Console/console.feature
@@ -1,8 +1,9 @@
 Feature: ezpublish/console
     Scenario: Commands use the default siteaccess if not specified
         When I run a console script without specifying a siteaccess
-        Then I expect it to be executed with the default siteaccess
+        Then it is executed with the default one
 
     Scenario: Commands use the siteaccess specified as with --siteaccess
-        When I run a console script with the siteaccess option "mobile"
-        Then I expect it to be executed with the siteaccess "mobile"
+        Given that there is a siteaccess that is not the default one
+         When I run a console script with it
+         Then I expect it to be executed with it

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Console/console.feature
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Console/console.feature
@@ -1,0 +1,8 @@
+Feature: ezpublish/console
+    Scenario: Commands use the default siteaccess if not specified
+        When I run a console script without specifying a siteaccess
+        Then I expect it to be executed with the default siteaccess
+
+    Scenario: Commands use the siteaccess specified as with --siteaccess
+        When I run a console script with the siteaccess option "mobile"
+        Then I expect it to be executed with the siteaccess "mobile"

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/ConsoleContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/ConsoleContext.php
@@ -1,0 +1,80 @@
+<?php
+namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
+use PHPUnit_Framework_Assert as Assertion;
+
+class ConsoleContext implements Context, SnippetAcceptingContext
+{
+    private $scriptOutput = null;
+
+    /**
+     * @When I run a console script without specifying a siteaccess
+     */
+    public function iRunAConsoleScriptWithoutSpecifyingASiteaccess()
+    {
+        $this->iRunTheCommand('ez:behat:siteaccess');
+    }
+
+    /**
+     * @When I run a console script with the siteaccess option :siteaccessOption
+     */
+    public function iRunAConsoleScriptWithTheSiteaccessOption($siteaccessOption)
+    {
+        $this->iRunTheCommand('ez:behat:siteaccess', $siteaccessOption);
+    }
+
+    /**
+     * @Then I expect it to be executed with the siteaccess :siteaccess
+     */
+    public function iExpectItToBeExecutedWithTheSiteaccess($siteaccess)
+    {
+        $actualSiteaccess = trim($this->scriptOutput);
+        Assertion::assertEquals(
+            $siteaccess,
+            $actualSiteaccess,
+            "The command was expected to be executed with the siteaccess \"$siteaccess\", but was executed with \"$actualSiteaccess\""
+        );
+    }
+
+    /**
+     * @Then I expect it to be executed with the default siteaccess
+     */
+    public function iExpectItToBeExecutedWithTheDefaultSiteaccess()
+    {
+        $this->iExpectItToBeExecutedWithTheSiteaccess('site');
+    }
+
+    private function iRunTheCommand($command, $siteaccess = null)
+    {
+        $phpFinder = new PhpExecutableFinder();
+        if (!$phpPath = $phpFinder->find(false)) {
+            throw new \RuntimeException('The php executable could not be found, add it to your PATH environment variable and try again');
+        }
+        $arguments = $phpFinder->findArguments();
+        if (false !== ($ini = php_ini_loaded_file())) {
+            $arguments[] = '--php-ini=' . $ini;
+        }
+        $php = escapeshellarg($phpPath);
+        $phpArgs = implode(' ', array_map('escapeshellarg', $arguments));
+        $console = escapeshellarg('ezpublish/console');
+        $cmd = escapeshellarg($command);
+
+        $console .= ' --env=' . escapeshellarg('behat');
+        if ($siteaccess !== null) {
+            $console .= ' --siteaccess=' . escapeshellarg($siteaccess);
+        }
+
+        $commandLine = $php . ($phpArgs ? ' ' . $phpArgs : '') . ' ' . $console . ' ' . $cmd;
+        $process = new Process($commandLine);
+        $process->run();
+        if (!$process->isSuccessful()) {
+            throw new \RuntimeException(sprintf('An error occurred when executing the "%s" command.', escapeshellarg($cmd)));
+        }
+
+        $this->scriptOutput = $process->getOutput();
+    }
+}

--- a/eZ/Bundle/PlatformBehatBundle/Command/TestSiteaccessCommand.php
+++ b/eZ/Bundle/PlatformBehatBundle/Command/TestSiteaccessCommand.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformBehatBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class TestSiteaccessCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('ez:behat:siteaccess')
+            ->setDescription('Outputs the name of the active siteaccess');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln($this->getContainer()->get('ezpublish.siteaccess')->name);
+    }
+}

--- a/eZ/Bundle/PlatformBehatBundle/EzPlatformBehatBundle.php
+++ b/eZ/Bundle/PlatformBehatBundle/EzPlatformBehatBundle.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformBehatBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * Bundle used by Behat tests, only loaded in the behat env.
+ */
+class EzPlatformBehatBundle extends Bundle
+{
+}

--- a/eZ/Bundle/PlatformInstallerBundle/src/Resources/config_templates/clean/ezpublish.yml
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Resources/config_templates/clean/ezpublish.yml
@@ -21,6 +21,7 @@ ezpublish:
         # Available siteaccesses
         list:
             - site
+            - mobile
         # Siteaccess groups. Use them to group common settings.
         groups:
             site_group: [site]


### PR DESCRIPTION
> Story: [EZP-24774](https://jira.ez.no/browse/EZP-24774)
> Related pull-requests: ezsystems/BehatBundle#32, ezsystems/ezplatform#38

Tests that the siteaccess is correctly matched with and without the `--siteaccess` parameter.

Adds a `mobile` siteaccess to the `clean` installer so that we have a valid scenario for testing.

## TODO 
- [x] Check which siteaccess is the default one for the `clean` install (it differs from demo).
- [ ] ~~Improve error reporting from behat~~
- [x] Rebase
- [ ] Remove commit f854fdb
- [ ] Update commit 9fade09