### PR TITLE
[WIP] Fix EZP-24710: Paragraphs are stripped on the front-end if an XML block is published with the editor disabled

### DIFF
--- a/eZ/Publish/Core/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl
+++ b/eZ/Publish/Core/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Html5_core.xsl
@@ -35,10 +35,6 @@
         </xsl:element>
     </xsl:template>
 
-    <xsl:template match="paragraph[@ez-temporary]">
-        <xsl:apply-templates/>
-    </xsl:template>
-
     <xsl:template match="paragraph">
         <p>
             <xsl:copy-of select="@class"/>


### PR DESCRIPTION
**Work in progress**

Reverts change in EZP-23513 which blocks temp namespace from being rendered. This fails existing tests. It seems the change was essential in fixing the issue, so a different approach may be needed.

TODO
- [ ] Pass existing tests
- [ ] Add regression tests

Ref: https://jira.ez.no/browse/EZP-24710, https://jira.ez.no/browse/EZP-23513