### PR TITLE
Fix EZP-24755: (FOS) Http cache not purged if execution terminates

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/FOSPurgeClient.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/FOSPurgeClient.php
@@ -31,6 +31,11 @@ class FOSPurgeClient implements PurgeClientInterface
         $this->cacheManager = $cacheManager;
     }
 
+    public function __destruct()
+    {
+        $this->cacheManager->flush();
+    }
+
     public function purge($locationIds)
     {
         if (empty($locationIds)) {


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24755

FOSHttpCacheBundle has a listener on kernel terminate event which issues a flush() call, however legacy ajax requests through ezjscore (and other places such as scripts, etc) terminate execution before this event.

This ensures that a call to flush() is always performed.