### PR TITLE
Implemented generic ExceptionListener

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ExceptionListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ExceptionListener.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * This file is part of the eZ Publish kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\EventListener;
+
+use eZ\Publish\API\Repository\Exceptions\ForbiddenException;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class ExceptionListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::EXCEPTION => ['onKernelException', -90],
+        ];
+    }
+
+    public function onKernelException(GetResponseForExceptionEvent $event)
+    {
+        $exception = $event->getException();
+        if ($exception instanceof NotFoundException) {
+            $event->setException(new NotFoundHttpException($exception->getMessage(), $exception));
+        } elseif ($exception instanceof UnauthorizedException || $exception instanceof ForbiddenException) {
+            $event->setException(new AccessDeniedHttpException($exception->getMessage(), $exception));
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -28,6 +28,7 @@ parameters:
     ezpublish.controller_manager.class: eZ\Publish\Core\MVC\Symfony\Controller\Manager
     ezpublish.controller_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\ViewControllerListener
     ezpublish.page_controller_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\PageControllerListener
+    ezpublish.exception_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\ExceptionListener
 
 services:
     # Siteaccess is injected in the container at runtime
@@ -169,3 +170,7 @@ services:
         tags:
             - { name: request.param_converter, priority: %ezpublish.param_converter.location.priority%, converter: ez_location_converter }
 
+    ezpublish.exception_listener:
+        class: %ezpublish.exception_listener.class%
+        tags:
+            - { name: kernel.event_subscriber }


### PR DESCRIPTION
Purpose is to automatically convert exceptions coming from the Repository to appropriate HTTP exception, expected by Symfony.

Converts:
* `eZ\Publish\API\Repository\Exceptions\NotFoundException` => `Symfony\Component\HttpKernel\Exception\NotFoundHttpException`
* `eZ\Publish\API\Repository\Exceptions\UnauthorizedException` => `Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException`
* `\eZ\Publish\API\Repository\Exceptions\ForbiddenException` => `Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException`

Please note that this only occurs using HTTP, not console.
As for REST, a similar listener is already in place, with a higher priority.