### PR TITLE
Fix EZP-21864: Do not store empty XML Value

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/XmlTextConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/XmlTextConverter.php
@@ -41,7 +41,9 @@ class XmlTextConverter implements Converter
      */
     public function toStorageValue(FieldValue $value, StorageFieldValue $storageFieldValue)
     {
-        $storageFieldValue->dataText = $value->data;
+        if (!empty($value->data)) {
+            $storageFieldValue->dataText = $value->data;
+        }
     }
 
     /**
@@ -67,7 +69,10 @@ class XmlTextConverter implements Converter
         $storageDefinition->dataText2 = $fieldDefinition->fieldTypeConstraints->fieldSettings['tagPreset'];
 
         if (!empty($fieldDefinition->defaultValue->data)) {
-            $storageDefinition->dataText1 = $fieldDefinition->defaultValue->data;
+            $xmlValue = trim($fieldDefinition->defaultValue->data);
+            if ($xmlValue !== Value::EMPTY_VALUE) {
+                $storageDefinition->dataText1 = $fieldDefinition->defaultValue->data;
+            }
         }
     }
 


### PR DESCRIPTION
Hi guys, I've progressed on that issue.

https://jira.ez.no/browse/EZP-21864

The LegacyKernel do not store the Empty Value when it's just the EmptyValue
```php
// ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/XmlText/Value.php
const EMPTY_VALUE = <<<EOT
<?xml version="1.0" encoding="utf-8"?>
<section/>
EOT; 
```
This empty value triggers an error later in the new stack (https://github.com/ezsystems/ezpublish-kernel/pull/715)

Don't really know if you can accept that, but if the LegacyStorage didn't store the EmptyValue I don't see why we should store it now.
And additionally, if you add an attribute through the administration interface the sql row differs from the one generated via the API ( which is not good I suppose)

++


