### PR TITLE
EZP-24294: Search not working correctly after decoupling from Persistence

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\API\Repository\Tests;
+
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+/**
+ * Test case for indexing operations with a search engine.
+ *
+ * @group integration
+ * @group search
+ * @group indexing
+ */
+class SearchEngineIndexingTest extends BaseTest
+{
+    public function testCreateLocation()
+    {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+        $contentService = $repository->getContentService();
+        $searchService = $repository->getSearchService();
+
+        $rootLocationId = 2;
+        $membersContentId = 11;
+        $membersContentInfo = $contentService->loadContentInfo($membersContentId);
+
+        $locationCreateStruct = $locationService->newLocationCreateStruct($rootLocationId);
+        $membersLocation = $locationService->createLocation($membersContentInfo, $locationCreateStruct);
+
+        $this->refreshSearch($repository);
+
+        // Found
+        $criterion = new Criterion\LocationId($membersLocation->id);
+        $query = new LocationQuery(array('filter' => $criterion));
+        $result = $searchService->findLocations($query);
+        $this->assertEquals(1, $result->totalCount);
+        $this->assertEquals(
+            $membersLocation->id,
+            $result->searchHits[0]->valueObject->id
+        );
+    }
+
+    public function testMoveSubtree()
+    {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+        $contentService = $repository->getContentService();
+        $searchService = $repository->getSearchService();
+
+        $rootLocationId = 2;
+        $membersContentId = 11;
+        $adminsContentId = 12;
+        $editorsContentId = 13;
+        $membersContentInfo = $contentService->loadContentInfo($membersContentId);
+        $adminsContentInfo = $contentService->loadContentInfo($adminsContentId);
+        $editorsContentInfo = $contentService->loadContentInfo($editorsContentId);
+
+        $locationCreateStruct = $locationService->newLocationCreateStruct($rootLocationId);
+        $membersLocation = $locationService->createLocation($membersContentInfo, $locationCreateStruct);
+        $editorsLocation = $locationService->createLocation($editorsContentInfo, $locationCreateStruct);
+        $adminsLocation = $locationService->createLocation(
+            $adminsContentInfo,
+            $locationService->newLocationCreateStruct($membersLocation->id)
+        );
+
+        $this->refreshSearch($repository);
+
+        // Not found under Editors
+        $criterion = new Criterion\ParentLocationId($editorsLocation->id);
+        $query = new LocationQuery(array('filter' => $criterion));
+        $result = $searchService->findLocations($query);
+        $this->assertEquals(0, $result->totalCount);
+
+        // Found under Members
+        $criterion = new Criterion\ParentLocationId($membersLocation->id);
+        $query = new LocationQuery(array('filter' => $criterion));
+        $result = $searchService->findLocations($query);
+        $this->assertEquals(1, $result->totalCount);
+        $this->assertEquals(
+            $adminsLocation->id,
+            $result->searchHits[0]->valueObject->id
+        );
+
+        $locationService->moveSubtree($adminsLocation, $editorsLocation);
+        $this->refreshSearch($repository);
+
+        // Found under Editors
+        $criterion = new Criterion\ParentLocationId($editorsLocation->id);
+        $query = new LocationQuery(array('filter' => $criterion));
+        $result = $searchService->findLocations($query);
+        $this->assertEquals(1, $result->totalCount);
+        $this->assertEquals(
+            $adminsLocation->id,
+            $result->searchHits[0]->valueObject->id
+        );
+
+        // Not found under Members
+        $criterion = new Criterion\ParentLocationId($membersLocation->id);
+        $query = new LocationQuery(array('filter' => $criterion));
+        $result = $searchService->findLocations($query);
+        $this->assertEquals(0, $result->totalCount);
+    }
+}

--- a/phpunit-integration-legacy-elasticsearch.xml
+++ b/phpunit-integration-legacy-elasticsearch.xml
@@ -50,6 +50,7 @@
           <file>eZ/Publish/API/Repository/Tests/SearchServiceFieldFiltersTest.php</file>
           <file>eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php</file>
           <file>eZ/Publish/API/Repository/Tests/SearchServiceAuthorizationTest.php</file>
+          <file>eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php</file>
           <file>eZ/Publish/API/Repository/Tests/LimitationTest.php</file>
           <file>eZ/Publish/API/Repository/Tests/FieldTypeServiceTest.php</file>
           <directory>eZ/Publish/API/Repository/Tests/Values/User/Limitation</directory>

--- a/phpunit-integration-legacy-solr.xml
+++ b/phpunit-integration-legacy-solr.xml
@@ -51,6 +51,7 @@
             <file>eZ/Publish/API/Repository/Tests/SearchServiceTranslationLanguageFallbackTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SearchServiceAuthorizationTest.php</file>
+            <file>eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LimitationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/FieldTypeServiceTest.php</file>
             <directory>eZ/Publish/API/Repository/Tests/Values/User/Limitation</directory>

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -42,6 +42,7 @@
             <file>eZ/Publish/API/Repository/Tests/SearchServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SearchServiceAuthorizationTest.php</file>
+            <file>eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LimitationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/FieldTypeServiceTest.php</file>
             <directory>eZ/Publish/API/Repository/Tests/Values/User/Limitation</directory>


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24294

The reported issue was apparently resolved since reported, this adds new test case testing data indexing on a search engine. For now only creating a Location and moving a subtree is tested, as was reported in the issue. More will be added later.