### PR TITLE
Implement EZP-24804: Ancestor criterion

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
@@ -38,6 +38,7 @@ parameters:
 
     ezpublish_rest.input.parser.internal.ContentQuery.class: eZ\Publish\Core\REST\Server\Input\Parser\ContentQuery
     ezpublish_rest.input.parser.internal.LocationQuery.class: eZ\Publish\Core\REST\Server\Input\Parser\LocationQuery
+    ezpublish_rest.input.parser.internal.criterion.Ancestor.class: eZ\Publish\Core\REST\Server\Input\Parser\Criterion\Ancestor
     ezpublish_rest.input.parser.internal.criterion.ContentId.class: eZ\Publish\Core\REST\Server\Input\Parser\Criterion\ContentId
     ezpublish_rest.input.parser.internal.criterion.ContentRemoteId.class: eZ\Publish\Core\REST\Server\Input\Parser\Criterion\ContentRemoteId
     ezpublish_rest.input.parser.internal.criterion.ContentTypeGroupId.class: eZ\Publish\Core\REST\Server\Input\Parser\Criterion\ContentTypeGroupId
@@ -398,6 +399,12 @@ services:
         class: %ezpublish_rest.input.parser.internal.LocationQuery.class%
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.LocationQuery }
+
+    ezpublish_rest.input.parser.internal.criterion.Ancestor:
+        parent: ezpublish_rest.input.parser
+        class: %ezpublish_rest.input.parser.internal.criterion.Ancestor.class%
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.Ancestor }
 
     ezpublish_rest.input.parser.internal.criterion.ContentId:
         parent: ezpublish_rest.input.parser

--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -546,6 +546,21 @@ class SearchServiceTest extends BaseTest
                 ),
                 $fixtureDir . 'UserMetadata.php',
             ),
+            array(
+                array(
+                    'filter' => new Criterion\Ancestor(
+                        array(
+                            '/1/5/44/',
+                            '/1/5/44/45/',
+                        )
+                    ),
+                    'sortClauses' => array(
+                        new SortClause\ContentId(),
+                    ),
+                    'limit' => 50,
+                ),
+                $fixtureDir . 'AncestorContent.php',
+            ),
         );
     }
 
@@ -680,6 +695,16 @@ class SearchServiceTest extends BaseTest
                     'limit' => 50,
                 ),
                 $fixtureDir . 'DepthLte.php',
+            ),
+            array(
+                array(
+                    'filter' => new Criterion\Ancestor('/1/5/44/45/'),
+                    'sortClauses' => array(
+                        new SortClause\Location\Depth(),
+                    ),
+                    'limit' => 50,
+                ),
+                $fixtureDir . 'AncestorLocation.php',
             ),
         );
     }

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/AncestorContent.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/AncestorContent.php
@@ -1,0 +1,52 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(array(
+   'facets' => 
+  array (
+  ),
+   'searchHits' => 
+  array (
+    0 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => NULL,
+       'highlight' => NULL,
+    )),
+    1 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 10,
+        'title' => 'Anonymous User',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => NULL,
+       'highlight' => NULL,
+    )),
+    2 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 42,
+        'title' => 'Anonymous Users',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => NULL,
+       'highlight' => NULL,
+    )),
+  ),
+   'spellSuggestion' => NULL,
+   'time' => 1,
+   'timedOut' => NULL,
+   'maxScore' => NULL,
+   'totalCount' => 3,
+));
+

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/AncestorLocation.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/AncestorLocation.php
@@ -1,0 +1,52 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(array(
+   'facets' => 
+  array (
+  ),
+   'searchHits' => 
+  array (
+    0 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => NULL,
+       'highlight' => NULL,
+    )),
+    1 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 42,
+        'title' => 'Anonymous Users',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => NULL,
+       'highlight' => NULL,
+    )),
+    2 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 10,
+        'title' => 'Anonymous User',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => NULL,
+       'highlight' => NULL,
+    )),
+  ),
+   'spellSuggestion' => NULL,
+   'time' => 1,
+   'timedOut' => NULL,
+   'maxScore' => NULL,
+   'totalCount' => 3,
+));
+

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/AncestorContent.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/AncestorContent.php
@@ -1,0 +1,52 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(array(
+   'facets' => 
+  array (
+  ),
+   'searchHits' => 
+  array (
+    0 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 10,
+        'title' => 'Anonymous User',
+      ),
+       'score' => 1.0,
+       'index' => NULL,
+       'matchedTranslation' => NULL,
+       'highlight' => NULL,
+    )),
+    1 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
+      ),
+       'score' => 1.0,
+       'index' => NULL,
+       'matchedTranslation' => NULL,
+       'highlight' => NULL,
+    )),
+    2 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 42,
+        'title' => 'Anonymous Users',
+      ),
+       'score' => 1.0,
+       'index' => NULL,
+       'matchedTranslation' => NULL,
+       'highlight' => NULL,
+    )),
+  ),
+   'spellSuggestion' => NULL,
+   'time' => 1,
+   'timedOut' => NULL,
+   'maxScore' => 1.0,
+   'totalCount' => 3,
+));
+

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Solr/AncestorLocation.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Solr/AncestorLocation.php
@@ -1,0 +1,52 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(array(
+   'facets' => 
+  array (
+  ),
+   'searchHits' => 
+  array (
+    0 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 4,
+        'title' => 'Users',
+      ),
+       'score' => 1.0,
+       'index' => NULL,
+       'matchedTranslation' => NULL,
+       'highlight' => NULL,
+    )),
+    1 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 42,
+        'title' => 'Anonymous Users',
+      ),
+       'score' => 1.0,
+       'index' => NULL,
+       'matchedTranslation' => NULL,
+       'highlight' => NULL,
+    )),
+    2 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 10,
+        'title' => 'Anonymous User',
+      ),
+       'score' => 1.0,
+       'index' => NULL,
+       'matchedTranslation' => NULL,
+       'highlight' => NULL,
+    )),
+  ),
+   'spellSuggestion' => NULL,
+   'time' => 1,
+   'timedOut' => NULL,
+   'maxScore' => 1.0,
+   'totalCount' => 3,
+));
+

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Ancestor.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Ancestor.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
+use InvalidArgumentException;
+
+/**
+ * A criterion that matches content that is ancestor to the given Location path string.
+ *
+ * Content will be matched if it is part of at least one of the given subtree path strings.
+ */
+class Ancestor extends Criterion implements CriterionInterface
+{
+    /**
+     * Creates a new Ancestor criterion.
+     *
+     * @param string $value Location path string
+     *
+     * @throws \InvalidArgumentException if a non integer or string id is given
+     * @throws \InvalidArgumentException if the value type doesn't match the operator
+     */
+    public function __construct($value)
+    {
+        foreach ((array)$value as $pathString) {
+            if (preg_match('/^(\/\w+)+\/$/', $pathString) !== 1) {
+                throw new InvalidArgumentException(
+                    "value '$pathString' must follow the pathString format, eg /1/2/"
+                );
+            }
+        }
+
+        parent::__construct(null, null, $value);
+    }
+
+    public function getSpecifications()
+    {
+        return array(
+            new Specifications(
+                Operator::EQ,
+                Specifications::FORMAT_SINGLE,
+                Specifications::TYPE_STRING
+            ),
+            new Specifications(
+                Operator::IN,
+                Specifications::FORMAT_ARRAY,
+                Specifications::TYPE_STRING
+            ),
+        );
+    }
+
+    public static function createFromQueryBuilder($target, $operator, $value)
+    {
+        return new self($value);
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/Ancestor.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/Ancestor.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
+
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
+use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
+use eZ\Publish\Core\REST\Common\Exceptions;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Ancestor as AncestorCriterion;
+
+/**
+ * Parser for Ancestor Criterion.
+ */
+class Ancestor extends BaseParser
+{
+    /**
+     * Parses input structure to a Criterion object.
+     *
+     * @param array $data
+     * @param \eZ\Publish\Core\REST\Common\Input\ParsingDispatcher $parsingDispatcher
+     *
+     * @throws \eZ\Publish\Core\REST\Common\Exceptions\Parser
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion\Ancestor
+     */
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher)
+    {
+        if (!array_key_exists('AncestorCriterion', $data)) {
+            throw new Exceptions\Parser('Invalid <AncestorCriterion> format');
+        }
+
+        return new AncestorCriterion(explode(',', $data['AncestorCriterion']));
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Ancestor.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Ancestor.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler;
+
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
+
+/**
+ * Visits the Ancestor criterion.
+ */
+class Ancestor extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     *
+     * @return bool
+     */
+    public function accept(Criterion $criterion)
+    {
+        return $criterion instanceof Criterion\Ancestor;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts.
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
+     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     *
+     * @return \eZ\Publish\Core\Persistence\Database\Expression
+     */
+    public function handle(CriteriaConverter $converter, SelectQuery $query, Criterion $criterion)
+    {
+        $idSet = array();
+        foreach ($criterion->value as $value) {
+            foreach (explode('/', trim($value, '/')) as $id) {
+                $idSet[$id] = true;
+            }
+        }
+
+        $subSelect = $query->subSelect();
+        $subSelect
+            ->select($this->dbHandler->quoteColumn('contentobject_id'))
+            ->from($this->dbHandler->quoteTable('ezcontentobject_tree'))
+            ->where(
+                $query->expr->in(
+                    $this->dbHandler->quoteColumn('node_id'),
+                    array_keys($idSet)
+                )
+            );
+
+        return $query->expr->in(
+            $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
+            $subSelect
+        );
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Ancestor.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Ancestor.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler;
+
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
+use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
+
+/**
+ * Visits the Ancestor criterion.
+ */
+class Ancestor extends CriterionHandler
+{
+    /**
+     * Check if this criterion handler accepts to handle the given criterion.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     *
+     * @return bool
+     */
+    public function accept(Criterion $criterion)
+    {
+        return $criterion instanceof Criterion\Ancestor;
+    }
+
+    /**
+     * Generate query expression for a Criterion this handler accepts.
+     *
+     * accept() must be called before calling this method.
+     *
+     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
+     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     *
+     * @return \eZ\Publish\Core\Persistence\Database\Expression
+     */
+    public function handle(CriteriaConverter $converter, SelectQuery $query, Criterion $criterion)
+    {
+        $idSet = array();
+        foreach ($criterion->value as $value) {
+            foreach (explode('/', trim($value, '/')) as $id) {
+                $idSet[$id] = true;
+            }
+        }
+
+        return $query->expr->in(
+            $this->dbHandler->quoteColumn('node_id', 'ezcontentobject_tree'),
+            array_keys($idSet)
+        );
+    }
+}

--- a/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_content.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_content.yml
@@ -1,4 +1,5 @@
 parameters:
+    ezpublish.search.legacy.gateway.criterion_handler.content.ancestor.class: eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler\Ancestor
     ezpublish.search.legacy.gateway.criterion_handler.content.location_id.class: eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler\LocationId
     ezpublish.search.legacy.gateway.criterion_handler.content.location_remote_id.class: eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler\LocationRemoteId
     ezpublish.search.legacy.gateway.criterion_handler.content.parent_location_id.class: eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler\ParentLocationId
@@ -12,6 +13,12 @@ services:
     # are registered to this one using compilation pass
     ezpublish.search.legacy.gateway.criteria_converter.content:
         class: %ezpublish.search.legacy.gateway.criteria_converter.class%
+
+    ezpublish.search.legacy.gateway.criterion_handler.content.ancestor:
+        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        class: %ezpublish.search.legacy.gateway.criterion_handler.content.ancestor.class%
+        tags:
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
 
     ezpublish.search.legacy.gateway.criterion_handler.content.location_id:
         parent: ezpublish.search.legacy.gateway.criterion_handler.base

--- a/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_location.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_location.yml
@@ -1,4 +1,5 @@
 parameters:
+    ezpublish.search.legacy.gateway.criterion_handler.location.ancestor.class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Ancestor
     ezpublish.search.legacy.gateway.criterion_handler.location.depth.class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Location\Depth
     ezpublish.search.legacy.gateway.criterion_handler.location.location_id.class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\LocationId
     ezpublish.search.legacy.gateway.criterion_handler.location.is_main_location.class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Location\IsMainLocation
@@ -14,6 +15,12 @@ services:
     # are registered to this one using compilation pass
     ezpublish.search.legacy.gateway.criteria_converter.location:
         class: %ezpublish.search.legacy.gateway.criteria_converter.class%
+
+    ezpublish.search.legacy.gateway.criterion_handler.location.ancestor:
+        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        class: %ezpublish.search.legacy.gateway.criterion_handler.location.ancestor.class%
+        tags:
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.location.depth:
         parent: ezpublish.search.legacy.gateway.criterion_handler.base


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24804
Review together with https://github.com/ezsystems/ezplatform-solr-search-engine/pull/19

This implements `Ancestor` criterion, accepting Location path string(s) as value.

#### TODOs
- [x] implement criterion handlers for Legacy engine
- [x] implement REST input parser