### PR TITLE
EZP-24779 Fix undefined index when url link does no longer exist in DB

### DIFF
--- a/eZ/Publish/Core/FieldType/XmlText/XmlTextStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/XmlText/XmlTextStorage/Gateway/LegacyStorage.php
@@ -92,7 +92,7 @@ class LegacyStorage extends Gateway
                 }
             }
 
-            if (count($links)) {
+            if (!empty($links)) {
                 $linkIdUrlMap = $this->getIdUrlMap(array_keys($links));
 
                 foreach ($linkIdUrlMap as $urlId => $url) {

--- a/eZ/Publish/Core/FieldType/XmlText/XmlTextStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/XmlText/XmlTextStorage/Gateway/LegacyStorage.php
@@ -77,23 +77,27 @@ class LegacyStorage extends Gateway
             return;
         }
 
-        /* @var $linkTagsById \DOMElement[] */
-        $linkIds = array();
         $linkTags = $doc->getElementsByTagName('link');
+
         if ($linkTags->length > 0) {
+            $links = array();
+
             foreach ($linkTags as $link) {
                 $urlId = $link->getAttribute('url_id');
                 if (!empty($urlId)) {
-                    $linkIds[$urlId] = true;
+                    if (!isset($links[$urlId])) {
+                        $links[$urlId] = array();
+                    }
+                    $links[$urlId][] = $link;
                 }
             }
 
-            if (!empty($linkIds)) {
-                $linkIdUrlMap = $this->getIdUrlMap(array_keys($linkIds));
-                foreach ($linkTags as $link) {
-                    $urlId = $link->getAttribute('url_id');
-                    if (!empty($urlId)) {
-                        $link->setAttribute('url', $linkIdUrlMap[$urlId]);
+            if (count($links)) {
+                $linkIdUrlMap = $this->getIdUrlMap(array_keys($links));
+
+                foreach ($linkIdUrlMap as $urlId => $url) {
+                    foreach ($links[$urlId] as $link) {
+                        $link->setAttribute('url', $url);
                         $link->removeAttribute('url_id');
                     }
                 }


### PR DESCRIPTION
JIRA ticket related: https://jira.ez.no/browse/EZP-24779

**Issue:**
The problem appears if (for some unknown reason, ie. failed import from 3rd party system) there's no url link in database for content.

**Output:**
```xml
<?xml version="1.0" encoding="UTF-8"?>
<ErrorMessage media-type="application/vnd.ez.api.ErrorMessage+xml">
 <errorCode>500</errorCode>
 <errorMessage>Internal Server Error</errorMessage>
 <errorDescription>Notice: Undefined offset: 14179</errorDescription>
 <trace>#0 /var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/XmlText/XmlTextStorage/Gateway/LegacyStorage.php(95): Symfony\Component\Debug\ErrorHandler-&gt;handleError(8, 'Undefined offse...', '/var/www/amnh/v...', 95, Array)
#1 /var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/XmlText/XmlTextStorage.php(42): eZ\Publish\Core\FieldType\XmlText\XmlTextStorage\Gateway\LegacyStorage-&gt;getFieldData(Object(eZ\Publish\SPI\Persistence\Content\Field))
#2 /var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Persistence/Legacy/Content/StorageHandler.php(95): eZ\Publish\Core\FieldType\XmlText\XmlTextStorage-&gt;getFieldData(Object(eZ\Publish\SPI\Persistence\Content\VersionInfo), Object(eZ\Publish\SPI\Persistence\Content\Field), Array)
#3 /var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Persistence/Legacy/Content/FieldHandler.php(340): eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler-&gt;getFieldData(Object(eZ\Publish\SPI\Persistence\Content\VersionInfo), Object(eZ\Publish\SPI\Persistence\Content\Field))
#4 /var/www/amnh/ezpublish/cache/dev/ezpublishDevDebugProjectContainer.php(35055): eZ\Publish\Core\Persistence\Legacy\Content\FieldHandler-&gt;loadExternalFieldData(Object(eZ\Publish\SPI\Persistence\Content))
#5 /var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php(330): eZPublishCorePersistenceLegacyContentFieldHandler_000000001ac7e0e4000000006d588310-&gt;loadExternalFieldData(Object(eZ\Publish\SPI\Persistence\Content))
#6 /var/www/amnh/ezpublish/cache/dev/ezpublishDevDebugProjectContainer.php(35323): eZ\Publish\Core\Persistence\Legacy\Content\Handler-&gt;load(3033, 1, NULL)
#7 /var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Persistence/Cache/ContentHandler.php(70): eZPublishCorePersistenceLegacyContentHandler_000000001ac7e0d0000000006d588310-&gt;load(3033, 1, NULL)
#8 /var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Repository/ContentService.php(409): eZ\Publish\Core\Persistence\Cache\ContentHandler-&gt;load(3033, 1, NULL)
#9 /var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Repository/ContentService.php(343): eZ\Publish\Core\Repository\ContentService-&gt;internalLoadContent(3033, NULL, NULL, false, true)
#10 /var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Repository/SearchService.php(145): eZ\Publish\Core\Repository\ContentService-&gt;loadContent(3033, NULL, NULL, true)
#11 /var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/SignalSlot/SearchService.php(68): eZ\Publish\Core\Repository\SearchService-&gt;findContent(Object(eZ\Publish\API\Repository\Values\Content\Query), Array, true)
#12 /var/www/amnh/ezpublish/cache/dev/ezpublishDevDebugProjectContainer.php(33415): eZ\Publish\Core\SignalSlot\SearchService-&gt;findContent(Object(eZ\Publish\API\Repository\Values\Content\Query), Array, true)
#13 /var/www/amnh/src/EzSystems/RecommendationBundle/Rest/Controller/ContentController.php(100): eZPublishCoreRepositorySearchService_000000001ac7e3d7000000006d588310-&gt;findContent(Object(eZ\Publish\API\Repository\Values\Content\Query))
#14 [internal function]: EzSystems\RecommendationBundle\Rest\Controller\ContentController-&gt;getContent('3033')
#15 /var/www/amnh/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(145): call_user_func_array(Array, Array)
#16 /var/www/amnh/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpKernel.php(66): Symfony\Component\HttpKernel\HttpKernel-&gt;handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#17 /var/www/amnh/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php(64): Symfony\Component\HttpKernel\HttpKernel-&gt;handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#18 /var/www/amnh/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Kernel.php(186): Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel-&gt;handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#19 /var/www/amnh/web/index.php(77): Symfony\Component\HttpKernel\Kernel-&gt;handle(Object(Symfony\Component\HttpFoundation\Request))
#20 {main}</trace>
 <file>/var/www/amnh/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/XmlText/XmlTextStorage/Gateway/LegacyStorage.php</file>
 <line>95</line>
```

**Solution:**
I've reverted logic a little bit so we modify only links for which we have urls instead of relying on data consistency.