### PR TITLE
EZP-24582: implement Indexable for Author field type

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/AuthorIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/AuthorIntegrationTest.php
@@ -21,7 +21,7 @@ use eZ\Publish\API\Repository\Values\Content\Field;
  * @group integration
  * @group field-type
  */
-class AuthorIntegrationTest extends BaseIntegrationTest
+class AuthorIntegrationTest extends SearchMultivaluedBaseIntegrationTest
 {
     /**
      * Get name of tested field type.
@@ -399,6 +399,145 @@ class AuthorIntegrationTest extends BaseIntegrationTest
                         ),
                     )
                 ),
+            ),
+        );
+    }
+
+    protected function checkSearchEngineSupport()
+    {
+        if (ltrim(get_class($this->getSetupFactory()), '\\') === 'eZ\\Publish\\API\\Repository\\Tests\\SetupFactory\\Legacy') {
+            $this->markTestSkipped(
+                "'ezauthor' field type is not searchable with Legacy Search Engine"
+            );
+        }
+    }
+
+    protected function getValidSearchValueOne()
+    {
+        return array(
+            new Author(
+                array(
+                    'id' => 2,
+                    'name' => 'Ferdinand',
+                    'email' => 'ferdinand@example.com',
+                )
+            ),
+        );
+    }
+
+    protected function getValidSearchValueTwo()
+    {
+        return array(
+            new Author(
+                array(
+                    'id' => 3,
+                    'name' => 'Greta',
+                    'email' => 'greta@example.com',
+                )
+            ),
+        );
+    }
+
+    protected function getSearchTargetValueOne()
+    {
+        return 'Ferdinand';
+    }
+
+    protected function getSearchTargetValueTwo()
+    {
+        return 'Greta';
+    }
+
+    protected function getAdditionallyIndexedFieldData()
+    {
+        return array(
+            array(
+                'id',
+                2,
+                3,
+            ),
+            array(
+                'email',
+                'ferdinand@example.com',
+                'greta@example.com',
+            ),
+            array(
+                'sort_value',
+                'Ferdinand',
+                'Greta',
+            ),
+        );
+    }
+
+    protected function getValidMultivaluedSearchValuesOne()
+    {
+        return array(
+            new Author(
+                array(
+                    'id' => 1,
+                    'name' => 'Antoinette',
+                    'email' => 'antoinette@example.com',
+                )
+            ),
+            new Author(
+                array(
+                    'id' => 2,
+                    'name' => 'Ferdinand',
+                    'email' => 'ferdinand@example.com',
+                )
+            ),
+        );
+    }
+
+    protected function getValidMultivaluedSearchValuesTwo()
+    {
+        return array(
+            new Author(
+                array(
+                    'id' => 3,
+                    'name' => 'Greta',
+                    'email' => 'greta@example.com',
+                )
+            ),
+            new Author(
+                array(
+                    'id' => 4,
+                    'name' => 'Leopold',
+                    'email' => 'leopold@example.com',
+                )
+            ),
+            new Author(
+                array(
+                    'id' => 5,
+                    'name' => 'Maximilian',
+                    'email' => 'maximilian@example.com',
+                )
+            ),
+        );
+    }
+
+    protected function getMultivaluedSearchTargetValuesOne()
+    {
+        return array('Antoinette', 'Ferdinand');
+    }
+
+    protected function getMultivaluedSearchTargetValuesTwo()
+    {
+        return array('Greta', 'Leopold', 'Maximilian');
+    }
+
+    protected function getAdditionallyIndexedMultivaluedFieldData()
+    {
+        return array(
+            array(
+                'id',
+                array(1, 2),
+                array(3, 4, 5),
+            ),
+            array(
+                'email',
+                array('antoinette@example.com', 'ferdinand@example.com'),
+                array('greta@example.com', 'leopold@example.com', 'maximilian@example.com'),
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Author/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Author/SearchField.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\FieldType\Author;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
+use eZ\Publish\SPI\FieldType\Indexable;
+use eZ\Publish\SPI\Search;
+
+/**
+ * Indexable definition for Author field type.
+ */
+class SearchField implements Indexable
+{
+    /**
+     * Get index data for field for search backend.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    public function getIndexData(Field $field, FieldDefinition $fieldDefinition)
+    {
+        $name = array();
+        $id = array();
+        $email = array();
+
+        foreach ($field->value->data as $author) {
+            $name[] = $author['name'];
+            $id[] = $author['id'];
+            $email[] = $author['email'];
+        }
+
+        return array(
+            new Search\Field(
+                'name',
+                $name,
+                new Search\FieldType\MultipleStringField()
+            ),
+            new Search\Field(
+                'id',
+                $id,
+                new Search\FieldType\MultipleIntegerField()
+            ),
+            new Search\Field(
+                'email',
+                $email,
+                new Search\FieldType\MultipleStringField()
+            ),
+            new Search\Field(
+                'count',
+                count($field->value->data),
+                new Search\FieldType\IntegerField()
+            ),
+            new Search\Field(
+                'sort_value',
+                implode('-', $name),
+                new Search\FieldType\StringField()
+            ),
+        );
+    }
+
+    /**
+     * Get index field types for search backend.
+     *
+     * @return \eZ\Publish\SPI\Search\FieldType[]
+     */
+    public function getIndexDefinition()
+    {
+        return array(
+            'name' => new Search\FieldType\MultipleStringField(),
+            'id' => new Search\FieldType\MultipleIntegerField(),
+            'email' => new Search\FieldType\MultipleStringField(),
+            'count' => new Search\FieldType\IntegerField(),
+            'sort_value' => new Search\FieldType\StringField(),
+        );
+    }
+
+    /**
+     * Get name of the default field to be used for matching.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for matching. Default field is typically used by Field criterion.
+     *
+     * @return string
+     */
+    public function getDefaultMatchField()
+    {
+        return 'name';
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return 'sort_value';
+    }
+}

--- a/eZ/Publish/Core/settings/indexable_fieldtypes.yml
+++ b/eZ/Publish/Core/settings/indexable_fieldtypes.yml
@@ -1,4 +1,5 @@
 parameters:
+    ezpublish.fieldType.indexable.ezauthor.class: eZ\Publish\Core\FieldType\Author\SearchField
     ezpublish.fieldType.indexable.ezstring.class: eZ\Publish\Core\FieldType\TextLine\SearchField
     ezpublish.fieldType.indexable.eztext.class: eZ\Publish\Core\FieldType\TextBlock\SearchField
     ezpublish.fieldType.indexable.ezisbn.class: eZ\Publish\Core\FieldType\ISBN\SearchField
@@ -21,6 +22,11 @@ parameters:
     ezpublish.fieldType.indexable.unindexed.class: eZ\Publish\Core\FieldType\Unindexed
 
 services:
+    ezpublish.fieldType.indexable.ezauthor:
+        class: %ezpublish.fieldType.indexable.ezauthor.class%
+        tags:
+            - {name: ezpublish.fieldType.indexable, alias: ezauthor}
+
     ezpublish.fieldType.indexable.ezstring:
         class: %ezpublish.fieldType.indexable.ezstring.class%
         tags:
@@ -137,7 +143,6 @@ services:
             - {name: ezpublish.fieldType.indexable, alias: ezpackage}
             - {name: ezpublish.fieldType.indexable, alias: ezurl}
             - {name: ezpublish.fieldType.indexable, alias: ezmultioption}
-            - {name: ezpublish.fieldType.indexable, alias: ezauthor}
             - {name: ezpublish.fieldType.indexable, alias: ezsrrating}
             - {name: ezpublish.fieldType.indexable, alias: ezsubtreesubscription}
             - {name: ezpublish.fieldType.indexable, alias: ezoption}


### PR DESCRIPTION
#### This PR https://jira.ez.no/browse/EZP-24582

This implements `Indexable` definition for `Author` field type.

Indexed data:

1. `name`, a list of author names
2. `id`, a list of author IDs
3. `email`, a list of author emails
3. `count`, number of authors
4. `sort_value`, list of author names concatenated with `-` and used for sorting