### PR TITLE
EZP-24834: Add possibility to set current user on Repository w/o loading

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
@@ -11,6 +11,7 @@
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\Repository\Values\User\UserReference;
 use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
 use eZ\Publish\SPI\Search\Handler as SearchHandler;
 use eZ\Publish\SPI\Limitation\Type as SPILimitationType;
@@ -77,14 +78,9 @@ class RepositoryFactory extends ContainerAware
                     'limitationTypes' => $this->roleLimitations,
                 ),
                 'languages' => $this->configResolver->getParameter('languages'),
-            )
+            ),
+            new UserReference($this->configResolver->getParameter('anonymous_user_id'))
         );
-
-        /* @var \eZ\Publish\API\Repository\Repository $repository */
-        $anonymousUser = $repository->getUserService()->loadUser(
-            $this->configResolver->getParameter('anonymous_user_id')
-        );
-        $repository->setCurrentUser($anonymousUser);
 
         return $repository;
     }

--- a/eZ/Publish/API/Repository/Repository.php
+++ b/eZ/Publish/API/Repository/Repository.php
@@ -11,7 +11,7 @@
 namespace eZ\Publish\API\Repository;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\User;
+use eZ\Publish\API\Repository\Values\User\UserReference;
 
 /**
  * Repository interface.
@@ -21,25 +21,35 @@ interface Repository
     /**
      * Get current user.
      *
+     * Loads the full user object if not already loaded, if you only need to know user id use {@see getCurrentUserReference()}
+     *
      * @return \eZ\Publish\API\Repository\Values\User\User
      */
     public function getCurrentUser();
 
     /**
+     * Get current user reference.
+     *
+     * @since 5.4.5
+     * @return \eZ\Publish\API\Repository\Values\User\UserReference
+     */
+    public function getCurrentUserReference();
+
+    /**
      * Sets the current user to the given $user.
      *
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $user
      */
-    public function setCurrentUser(User $user);
+    public function setCurrentUser(UserReference $user);
 
     /**
      * @param string $module The module, aka controller identifier to check permissions on
      * @param string $function The function, aka the controller action to check permissions on
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $user
      *
      * @return bool|array if limitations are on this function an array of limitations is returned
      */
-    public function hasAccess($module, $function, User $user = null);
+    public function hasAccess($module, $function, UserReference $user = null);
 
     /**
      * Indicates if the current user is allowed to perform an action given by the function on the given

--- a/eZ/Publish/API/Repository/Tests/SetupFactory/Legacy.php
+++ b/eZ/Publish/API/Repository/Tests/SetupFactory/Legacy.php
@@ -16,6 +16,7 @@ use eZ\Publish\API\Repository\Tests\IdManager;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\MemoryCachingHandler as CachingContentTypeHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Language\CachingHandler as CachingLanguageHandler;
 use Exception;
+use eZ\Publish\Core\Repository\Values\User\UserReference;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
@@ -128,9 +129,8 @@ class Legacy extends SetupFactory
         $this->clearInternalCaches();
         $repository = $this->getServiceContainer()->get($this->repositoryReference);
 
-        $repository->setCurrentUser(
-            $repository->getUserService()->loadUser(14)
-        );
+        // Set admin user as current user by default
+        $repository->setCurrentUser(new UserReference(14));
 
         return $repository;
     }

--- a/eZ/Publish/API/Repository/Values/User/User.php
+++ b/eZ/Publish/API/Repository/Values/User/User.php
@@ -22,7 +22,7 @@ use eZ\Publish\API\Repository\Values\Content\Content;
  * @property-read boolean $enabled User can not login if false
  * @property-read int $maxLogin Max number of time user is allowed to login
  */
-abstract class User extends Content
+abstract class User extends Content implements UserReference
 {
     /**
      * User login.
@@ -70,4 +70,14 @@ abstract class User extends Content
      * @var int
      */
     protected $maxLogin;
+
+    /**
+     * The User id of the User.
+     *
+     * @return mixed
+     */
+    public function getUserId()
+    {
+        return $this->id;
+    }
 }

--- a/eZ/Publish/API/Repository/Values/User/UserReference.php
+++ b/eZ/Publish/API/Repository/Values/User/UserReference.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * File containing the eZ\Publish\API\Repository\Values\User\UserReference interface.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Publish\API\Repository\Values\User;
+
+/**
+ *  This interface represents a user reference for use in sessions and Repository.
+ */
+interface UserReference
+{
+    /**
+     * The User id of the User this reference represent.
+     *
+     * @return mixed
+     */
+    public function getUserId();
+}

--- a/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
@@ -10,6 +10,7 @@
  */
 namespace eZ\Publish\Core\Base\Container\ApiLoader;
 
+use eZ\Publish\Core\Repository\Values\User\UserReference;
 use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
 use eZ\Publish\SPI\Search\Handler as SearchHandler;
 use eZ\Publish\SPI\Limitation\Type as SPILimitationType;
@@ -66,14 +67,9 @@ class RepositoryFactory extends ContainerAware
                     'limitationTypes' => $this->roleLimitations,
                 ),
                 'languages' => $this->container->getParameter('languages'),
-            )
+            ),
+            new UserReference($this->container->getParameter('anonymous_user_id'))
         );
-
-        /* @var \eZ\Publish\API\Repository\Repository $repository */
-        $anonymousUser = $repository->getUserService()->loadUser(
-            $this->container->getParameter('anonymous_user_id')
-        );
-        $repository->setCurrentUser($anonymousUser);
 
         return $repository;
     }

--- a/eZ/Publish/Core/Limitation/BlockingLimitationType.php
+++ b/eZ/Publish/Core/Limitation/BlockingLimitationType.php
@@ -10,7 +10,7 @@ namespace eZ\Publish\Core\Limitation;
 
 use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\User\Limitation as APILimitationValue;
 use eZ\Publish\API\Repository\Values\User\Limitation\BlockingLimitation as APIBlockingLimitation;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -112,13 +112,13 @@ class BlockingLimitationType implements SPILimitationTypeInterface
      *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object
      * @param \eZ\Publish\API\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool
      */
-    public function evaluate(APILimitationValue $value, APIUser $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
     {
         if (!$value instanceof APIBlockingLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: BlockingLimitation');
@@ -131,11 +131,11 @@ class BlockingLimitationType implements SPILimitationTypeInterface
      * Returns Criterion for use in find() query.
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUser $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
     {
         return new Criterion\MatchNone();
     }

--- a/eZ/Publish/Core/Limitation/ContentTypeLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ContentTypeLimitationType.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\Core\Limitation;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
@@ -105,13 +105,13 @@ class ContentTypeLimitationType extends AbstractPersistenceLimitationType implem
      *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object
      * @param \eZ\Publish\API\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool
      */
-    public function evaluate(APILimitationValue $value, APIUser $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
     {
         if (!$value instanceof APIContentTypeLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIContentTypeLimitation');
@@ -146,11 +146,11 @@ class ContentTypeLimitationType extends AbstractPersistenceLimitationType implem
      * Returns Criterion for use in find() query.
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUser $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
     {
         if (empty($value->limitationValues)) {
             // no limitation values

--- a/eZ/Publish/Core/Limitation/LanguageLimitationType.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitationType.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\Core\Limitation;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
@@ -105,13 +105,13 @@ class LanguageLimitationType extends AbstractPersistenceLimitationType implement
      *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object
      * @param \eZ\Publish\API\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool
      */
-    public function evaluate(APILimitationValue $value, APIUser $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
     {
         if (!$value instanceof APILanguageLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APILanguageLimitation');
@@ -153,11 +153,11 @@ class LanguageLimitationType extends AbstractPersistenceLimitationType implement
      * Returns Criterion for use in find() query.
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUser $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
     {
         if (empty($value->limitationValues)) {
             // no limitation values

--- a/eZ/Publish/Core/Limitation/LocationLimitationType.php
+++ b/eZ/Publish/Core/Limitation/LocationLimitationType.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\Core\Limitation;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
@@ -108,13 +108,13 @@ class LocationLimitationType extends AbstractPersistenceLimitationType implement
      *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object
      * @param \eZ\Publish\API\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool
      */
-    public function evaluate(APILimitationValue $value, APIUser $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
     {
         if (!$value instanceof APILocationLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APILocationLimitation');
@@ -197,11 +197,11 @@ class LocationLimitationType extends AbstractPersistenceLimitationType implement
      * Returns Criterion for use in find() query.
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUser $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
     {
         if (empty($value->limitationValues)) {
             // no limitation values

--- a/eZ/Publish/Core/Limitation/NewObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/NewObjectStateLimitationType.php
@@ -13,7 +13,7 @@ namespace eZ\Publish\Core\Limitation;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
 use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectState;
@@ -107,13 +107,13 @@ class NewObjectStateLimitationType extends AbstractPersistenceLimitationType imp
      *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object
      * @param \eZ\Publish\API\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool
      */
-    public function evaluate(APILimitationValue $value, APIUser $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
     {
         if (!$value instanceof APINewObjectStateLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: NewObjectStateLimitation');
@@ -148,13 +148,13 @@ class NewObjectStateLimitationType extends AbstractPersistenceLimitationType imp
      * Returns Criterion for use in find() query.
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException Not applicable, needs context of new state.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUser $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
     {
         throw new NotImplementedException(__METHOD__);
     }

--- a/eZ/Publish/Core/Limitation/NewSectionLimitationType.php
+++ b/eZ/Publish/Core/Limitation/NewSectionLimitationType.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\Core\Limitation;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
@@ -105,13 +105,13 @@ class NewSectionLimitationType extends AbstractPersistenceLimitationType impleme
      *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object
      * @param \eZ\Publish\API\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool
      */
-    public function evaluate(APILimitationValue $value, APIUser $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
     {
         if (!$value instanceof APINewSectionLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APINewSectionLimitation');
@@ -146,13 +146,13 @@ class NewSectionLimitationType extends AbstractPersistenceLimitationType impleme
      * Returns Criterion for use in find() query.
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException Not applicable, needs context of new section.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUser $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
     {
         throw new \eZ\Publish\API\Repository\Exceptions\NotImplementedException(__METHOD__);
     }

--- a/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\Core\Limitation;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
@@ -106,13 +106,13 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
      *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object
      * @param \eZ\Publish\API\Repository\Values\ValueObject[]| $targets An array of location, parent or "assignment" value objects
      *
      * @return bool
      */
-    public function evaluate(APILimitationValue $value, APIUser $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
     {
         if (!$value instanceof APIObjectStateLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIObjectStateLimitation');
@@ -178,11 +178,11 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
      * Returns Criterion for use in find() query.
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUser $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
     {
         if (empty($value->limitationValues)) {
             // no limitation values

--- a/eZ/Publish/Core/Limitation/OwnerLimitationType.php
+++ b/eZ/Publish/Core/Limitation/OwnerLimitationType.php
@@ -11,7 +11,7 @@
 namespace eZ\Publish\Core\Limitation;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
@@ -106,7 +106,7 @@ class OwnerLimitationType extends AbstractPersistenceLimitationType implements S
      *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object
      * @param \eZ\Publish\API\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
@@ -114,7 +114,7 @@ class OwnerLimitationType extends AbstractPersistenceLimitationType implements S
      *
      * @todo Add support for $limitationValues[0] == 2 when session values can be injected somehow, or deprecate
      */
-    public function evaluate(APILimitationValue $value, APIUser $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
     {
         if (!$value instanceof APIOwnerLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIOwnerLimitation');
@@ -141,20 +141,20 @@ class OwnerLimitationType extends AbstractPersistenceLimitationType implements S
         /*
          * @var $object ContentInfo
          */
-        return $object->ownerId === $currentUser->id;
+        return $object->ownerId === $currentUser->getUserId();
     }
 
     /**
      * Returns Criterion for use in find() query.
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
      *
      * @todo Add support for $limitationValues[0] == 2 when session values can be injected somehow, or deprecate
      */
-    public function getCriterion(APILimitationValue $value, APIUser $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
     {
         if (empty($value->limitationValues)) {
             // no limitation values
@@ -171,7 +171,7 @@ class OwnerLimitationType extends AbstractPersistenceLimitationType implements S
         return new Criterion\UserMetadata(
             Criterion\UserMetadata::OWNER,
             Criterion\Operator::EQ,
-            $currentUser->id
+            $currentUser->getUserId()
         );
     }
 

--- a/eZ/Publish/Core/Limitation/ParentContentTypeLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ParentContentTypeLimitationType.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\Core\Limitation;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
@@ -107,13 +107,13 @@ class ParentContentTypeLimitationType extends AbstractPersistenceLimitationType 
      *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object
      * @param \eZ\Publish\API\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool
      */
-    public function evaluate(APILimitationValue $value, APIUser $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
     {
         if (!$value instanceof APIParentContentTypeLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIParentContentTypeLimitation');
@@ -215,11 +215,11 @@ class ParentContentTypeLimitationType extends AbstractPersistenceLimitationType 
      * Returns Criterion for use in find() query.
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUser $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
     {
         throw new \eZ\Publish\API\Repository\Exceptions\NotImplementedException(__METHOD__);
     }

--- a/eZ/Publish/Core/Limitation/ParentDepthLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ParentDepthLimitationType.php
@@ -11,7 +11,7 @@
 namespace eZ\Publish\Core\Limitation;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
@@ -90,13 +90,13 @@ class ParentDepthLimitationType extends AbstractPersistenceLimitationType implem
      *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object
      * @param \eZ\Publish\API\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool
      */
-    public function evaluate(APILimitationValue $value, APIUser $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
     {
         if (!$value instanceof APIParentDepthLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIParentDepthLimitation');
@@ -131,11 +131,11 @@ class ParentDepthLimitationType extends AbstractPersistenceLimitationType implem
      * Returns Criterion for use in find() query.
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUser $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
     {
         throw new \eZ\Publish\API\Repository\Exceptions\NotImplementedException(__METHOD__);
     }

--- a/eZ/Publish/Core/Limitation/ParentOwnerLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ParentOwnerLimitationType.php
@@ -11,7 +11,7 @@
 namespace eZ\Publish\Core\Limitation;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\Core\Base\Exceptions\BadStateException;
@@ -104,7 +104,7 @@ class ParentOwnerLimitationType extends AbstractPersistenceLimitationType implem
      *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object
      * @param \eZ\Publish\API\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
@@ -112,7 +112,7 @@ class ParentOwnerLimitationType extends AbstractPersistenceLimitationType implem
      *
      * @todo Add support for $limitationValues[0] == 2 when session values can be injected somehow
      */
-    public function evaluate(APILimitationValue $value, APIUser $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
     {
         if (!$value instanceof APIParentOwnerLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIParentOwnerLimitation');
@@ -147,7 +147,7 @@ class ParentOwnerLimitationType extends AbstractPersistenceLimitationType implem
                 );
             }
 
-            if ($ownerId !== $currentUser->id) {
+            if ($ownerId !== $currentUser->getUserId()) {
                 return false;
             }
         }
@@ -159,11 +159,11 @@ class ParentOwnerLimitationType extends AbstractPersistenceLimitationType implem
      * Returns Criterion for use in find() query.
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUser $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
     {
         throw new \eZ\Publish\API\Repository\Exceptions\NotImplementedException(__METHOD__);
     }

--- a/eZ/Publish/Core/Limitation/ParentUserGroupLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ParentUserGroupLimitationType.php
@@ -11,7 +11,7 @@
 namespace eZ\Publish\Core\Limitation;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\Core\Base\Exceptions\BadStateException;
@@ -107,13 +107,13 @@ class ParentUserGroupLimitationType extends AbstractPersistenceLimitationType im
      *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object
      * @param \eZ\Publish\API\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool
      */
-    public function evaluate(APILimitationValue $value, APIUser $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
     {
         if (!$value instanceof APIParentUserGroupLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIParentUserGroupLimitation');
@@ -132,7 +132,7 @@ class ParentUserGroupLimitationType extends AbstractPersistenceLimitationType im
         }
 
         $locationHandler = $this->persistence->locationHandler();
-        $currentUserLocations = $locationHandler->loadLocationsByContent($currentUser->id);
+        $currentUserLocations = $locationHandler->loadLocationsByContent($currentUser->getUserId());
         if (empty($currentUserLocations)) {
             return false;
         }
@@ -156,7 +156,7 @@ class ParentUserGroupLimitationType extends AbstractPersistenceLimitationType im
                 );
             }
 
-            if ($parentOwnerId === $currentUser->id) {
+            if ($parentOwnerId === $currentUser->getUserId()) {
                 continue;
             }
 
@@ -187,11 +187,11 @@ class ParentUserGroupLimitationType extends AbstractPersistenceLimitationType im
      * Returns Criterion for use in find() query.
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUser $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
     {
         throw new \eZ\Publish\API\Repository\Exceptions\NotImplementedException(__METHOD__);
     }

--- a/eZ/Publish/Core/Limitation/SectionLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SectionLimitationType.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\Core\Limitation;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
@@ -106,13 +106,13 @@ class SectionLimitationType extends AbstractPersistenceLimitationType implements
      *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object
      * @param \eZ\Publish\API\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool
      */
-    public function evaluate(APILimitationValue $value, APIUser $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
     {
         if (!$value instanceof APISectionLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APISectionLimitation');
@@ -151,11 +151,11 @@ class SectionLimitationType extends AbstractPersistenceLimitationType implements
      * Returns Criterion for use in find() query.
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUser $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
     {
         if (empty($value->limitationValues)) {
             // no limitation values

--- a/eZ/Publish/Core/Limitation/SiteAccessLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SiteAccessLimitationType.php
@@ -11,7 +11,7 @@
 namespace eZ\Publish\Core\Limitation;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\API\Repository\Values\User\Limitation\SiteAccessLimitation as APISiteAccessLimitation;
@@ -88,13 +88,13 @@ class SiteAccessLimitationType implements SPILimitationTypeInterface
      *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object
      * @param \eZ\Publish\API\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool
      */
-    public function evaluate(APILimitationValue $value, APIUser $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
     {
         if (!$value instanceof APISiteAccessLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APISiteAccessLimitation');
@@ -121,11 +121,11 @@ class SiteAccessLimitationType implements SPILimitationTypeInterface
      * Returns Criterion for use in find() query.
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUser $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
     {
         throw new \eZ\Publish\API\Repository\Exceptions\NotImplementedException(__METHOD__);
     }

--- a/eZ/Publish/Core/Limitation/StatusLimitationType.php
+++ b/eZ/Publish/Core/Limitation/StatusLimitationType.php
@@ -11,7 +11,7 @@
 namespace eZ\Publish\Core\Limitation;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
@@ -107,13 +107,13 @@ class StatusLimitationType implements SPILimitationTypeInterface
      *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object
      * @param \eZ\Publish\API\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool
      */
-    public function evaluate(APILimitationValue $value, APIUser $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
     {
         if (!$value instanceof APIStatusLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIStatusLimitation');
@@ -145,11 +145,11 @@ class StatusLimitationType implements SPILimitationTypeInterface
      *         being used as a Criterion.
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUser $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
     {
         throw new NotImplementedException('Status Limitation Criterion');
     }

--- a/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\Core\Limitation;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
@@ -114,13 +114,13 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
      *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object
      * @param \eZ\Publish\API\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool
      */
-    public function evaluate(APILimitationValue $value, APIUser $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
     {
         if (!$value instanceof APISubtreeLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APISubtreeLimitation');
@@ -215,11 +215,11 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
      * Returns Criterion for use in find() query.
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUser $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
     {
         if (empty($value->limitationValues)) {
             // no limitation values

--- a/eZ/Publish/Core/Limitation/UserGroupLimitationType.php
+++ b/eZ/Publish/Core/Limitation/UserGroupLimitationType.php
@@ -11,7 +11,7 @@
 namespace eZ\Publish\Core\Limitation;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
@@ -109,13 +109,13 @@ class UserGroupLimitationType extends AbstractPersistenceLimitationType implemen
      *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1 ]
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object
      * @param \eZ\Publish\API\Repository\Values\ValueObject[]|null $targets The context of the $object, like Location of Content, if null none where provided by caller
      *
      * @return bool
      */
-    public function evaluate(APILimitationValue $value, APIUser $currentUser, ValueObject $object, array $targets = null)
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, ValueObject $object, array $targets = null)
     {
         if (!$value instanceof APIUserGroupLimitation) {
             throw new InvalidArgumentException('$value', 'Must be of type: APIUserGroupLimitation');
@@ -142,7 +142,7 @@ class UserGroupLimitationType extends AbstractPersistenceLimitationType implemen
         /**
          * @var ContentInfo|ContentCreateStruct
          */
-        if ($object->ownerId === $currentUser->id) {
+        if ($object->ownerId === $currentUser->getUserId()) {
             return true;
         }
 
@@ -155,7 +155,7 @@ class UserGroupLimitationType extends AbstractPersistenceLimitationType implemen
             return false;
         }
 
-        $currentUserLocations = $locationHandler->loadLocationsByContent($currentUser->id);
+        $currentUserLocations = $locationHandler->loadLocationsByContent($currentUser->getUserId());
         if (empty($currentUserLocations)) {
             return false;
         }
@@ -176,11 +176,11 @@ class UserGroupLimitationType extends AbstractPersistenceLimitationType implemen
      * Returns Criterion for use in find() query.
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUser $currentUser)
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
     {
         if (empty($value->limitationValues)) {
             // no limitation values
@@ -195,7 +195,7 @@ class UserGroupLimitationType extends AbstractPersistenceLimitationType implemen
         }
 
         $groupIds = array();
-        $currentUserLocations = $this->persistence->locationHandler()->loadLocationsByContent($currentUser->id);
+        $currentUserLocations = $this->persistence->locationHandler()->loadLocationsByContent($currentUser->getUserId());
         if (!empty($currentUserLocations)) {
             foreach ($currentUserLocations as $currentUserLocation) {
                 $groupIds[] = $currentUserLocation->parentId;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Authentication/AnonymousAuthenticationProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Authentication/AnonymousAuthenticationProvider.php
@@ -12,6 +12,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Security\Authentication;
 
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\Repository\Values\User\UserReference;
 use Symfony\Component\Security\Core\Authentication\Provider\AnonymousAuthenticationProvider as BaseAnonymousProvider;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
@@ -40,11 +41,7 @@ class AnonymousAuthenticationProvider extends BaseAnonymousProvider
     public function authenticate(TokenInterface $token)
     {
         $token = parent::authenticate($token);
-        $this->repository->setCurrentUser(
-            $this->repository->getUserService()->loadUser(
-                $this->configResolver->getParameter('anonymous_user_id')
-            )
-        );
+        $this->repository->setCurrentUser(new UserReference($this->configResolver->getParameter('anonymous_user_id')));
 
         return $token;
     }

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/AnonymousAuthenticationProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/AnonymousAuthenticationProviderTest.php
@@ -11,6 +11,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\Authentication;
 
 use eZ\Publish\Core\MVC\Symfony\Security\Authentication\AnonymousAuthenticationProvider;
+use eZ\Publish\Core\Repository\Values\User\UserReference;
 use PHPUnit_Framework_TestCase;
 
 class AnonymousAuthenticationProviderTest extends PHPUnit_Framework_TestCase
@@ -40,21 +41,11 @@ class AnonymousAuthenticationProviderTest extends PHPUnit_Framework_TestCase
             ->method('getParameter')
             ->with('anonymous_user_id')
             ->will($this->returnValue($anonymousUserId));
-        $userService = $this->getMock('eZ\Publish\API\Repository\UserService');
-        $anonymousUser = $this->getMock('eZ\Publish\API\Repository\Values\User\User');
-        $userService
-            ->expects($this->once())
-            ->method('loadUser')
-            ->with($anonymousUserId)
-            ->will($this->returnValue($anonymousUser));
-        $this->repository
-            ->expects($this->once())
-            ->method('getUserService')
-            ->will($this->returnValue($userService));
+
         $this->repository
             ->expects($this->once())
             ->method('setCurrentUser')
-            ->with($anonymousUser);
+            ->with(new UserReference($anonymousUserId));
 
         $key = 'some_key';
         $authProvider = new AnonymousAuthenticationProvider($key);

--- a/eZ/Publish/Core/REST/Client/IntegrationTestRepository.php
+++ b/eZ/Publish/Core/REST/Client/IntegrationTestRepository.php
@@ -11,7 +11,7 @@
 
 namespace eZ\Publish\Core\REST\Client;
 
-use eZ\Publish\API\Repository\Values\User\User;
+use eZ\Publish\API\Repository\Values\User\UserReference;
 use eZ\Publish\Core\REST\Common\RequestParser;
 use eZ\Publish\Core\REST\Common\Input\Dispatcher;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
@@ -92,11 +92,13 @@ class IntegrationTestRepository extends Repository implements Sessionable
     /**
      * Sets the current user to the given $user.
      *
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $user
+     *
+     * @return void
      */
-    public function setCurrentUser(User $user)
+    public function setCurrentUser(UserReference $user)
     {
         $this->currentUser = $user;
-        $this->authenticator->setUserId($user->id);
+        $this->authenticator->setUserId($user->getUserId());
     }
 }

--- a/eZ/Publish/Core/REST/Client/Repository.php
+++ b/eZ/Publish/Core/REST/Client/Repository.php
@@ -13,7 +13,7 @@ namespace eZ\Publish\Core\REST\Client;
 
 use eZ\Publish\API\Repository\Repository as APIRepository;
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\User;
+use eZ\Publish\API\Repository\Values\User\UserReference;
 use eZ\Publish\Core\REST\Common;
 
 /**
@@ -141,11 +141,23 @@ class Repository implements APIRepository
     }
 
     /**
+     * Get current user.
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\UserReference
+     */
+    public function getCurrentUserReference()
+    {
+        return null;
+    }
+
+    /**
      * Sets the current user to the given $user.
      *
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $user
+     *
+     * @return void
      */
-    public function setCurrentUser(User $user)
+    public function setCurrentUser(UserReference $user)
     {
         throw new Exceptions\MethodNotAllowedException(
             'It is not allowed to set a current user in this implementation. Please use a corresponding authenticating HttpClient instead.'
@@ -155,11 +167,11 @@ class Repository implements APIRepository
     /**
      * @param string $module
      * @param string $function
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $user
      *
      * @return bool|\eZ\Publish\API\Repository\Values\User\Limitation[] if limitations are on this function an array of limitations is returned
      */
-    public function hasAccess($module, $function, User $user = null)
+    public function hasAccess($module, $function, UserReference $user = null)
     {
         // @todo: Implement
     }

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -141,7 +141,7 @@ class ContentTypeService implements ContentTypeServiceInterface
         }
 
         if ($contentTypeGroupCreateStruct->creatorId === null) {
-            $userId = $this->repository->getCurrentUser()->id;
+            $userId = $this->repository->getCurrentUserReference()->getUserId();
         } else {
             $userId = $contentTypeGroupCreateStruct->creatorId;
         }
@@ -272,7 +272,7 @@ class ContentTypeService implements ContentTypeServiceInterface
                     $contentTypeGroupUpdateStruct->identifier,
                 'modified' => $modifiedTimestamp,
                 'modifierId' => $contentTypeGroupUpdateStruct->modifierId === null ?
-                    $this->repository->getCurrentUser()->id :
+                    $this->repository->getCurrentUserReference()->getUserId() :
                     $contentTypeGroupUpdateStruct->modifierId,
             )
         );
@@ -806,7 +806,7 @@ class ContentTypeService implements ContentTypeServiceInterface
         );
 
         if ($contentTypeCreateStruct->creatorId === null) {
-            $contentTypeCreateStruct->creatorId = $this->repository->getCurrentUser()->id;
+            $contentTypeCreateStruct->creatorId = $this->repository->getCurrentUserReference()->getUserId();
         }
 
         if ($contentTypeCreateStruct->creationDate === null) {
@@ -1216,7 +1216,7 @@ class ContentTypeService implements ContentTypeServiceInterface
             SPIContentType::STATUS_DRAFT
         );
 
-        if ($spiContentType->modifierId != $this->repository->getCurrentUser()->id) {
+        if ($spiContentType->modifierId != $this->repository->getCurrentUserReference()->getUserId()) {
             throw new NotFoundException('ContentType owned by someone else', $contentTypeId);
         }
 
@@ -1280,7 +1280,7 @@ class ContentTypeService implements ContentTypeServiceInterface
             $this->repository->beginTransaction();
             try {
                 $spiContentType = $this->contentTypeHandler->createDraft(
-                    $this->repository->getCurrentUser()->id,
+                    $this->repository->getCurrentUserReference()->getUserId(),
                     $contentType->id
                 );
                 $this->repository->commit();
@@ -1399,7 +1399,7 @@ class ContentTypeService implements ContentTypeServiceInterface
             time();
         $updateStruct->modifierId = $contentTypeUpdateStruct->modifierId !== null ?
             $contentTypeUpdateStruct->modifierId :
-            $this->repository->getCurrentUser()->id;
+            $this->repository->getCurrentUserReference()->getUserId();
 
         $updateStruct->urlAliasSchema = $contentTypeUpdateStruct->urlAliasSchema !== null ?
             $contentTypeUpdateStruct->urlAliasSchema :
@@ -1477,13 +1477,13 @@ class ContentTypeService implements ContentTypeServiceInterface
         }
 
         if (empty($creator)) {
-            $creator = $this->repository->getCurrentUser();
+            $creator = $this->repository->getCurrentUserReference();
         }
 
         $this->repository->beginTransaction();
         try {
             $spiContentType = $this->contentTypeHandler->copy(
-                $creator->id,
+                $creator->getUserId(),
                 $contentType->id,
                 SPIContentType::STATUS_DEFINED
             );

--- a/eZ/Publish/Core/Repository/PermissionsCriterionHandler.php
+++ b/eZ/Publish/Core/Repository/PermissionsCriterionHandler.php
@@ -92,7 +92,7 @@ class PermissionsCriterionHandler
          * If RoleAssignment has limitation then policy OR conditions are wrapped in a AND condition with the
          * role limitation, otherwise it will be merged into RoleAssignment's OR condition.
          */
-        $currentUser = $this->repository->getCurrentUser();
+        $currentUserRef = $this->repository->getCurrentUserReference();
         $roleAssignmentOrCriteria = array();
         $roleService = $this->repository->getRoleService();
         foreach ($permissionSets as $permissionSet) {
@@ -110,7 +110,7 @@ class PermissionsCriterionHandler
                 $limitationsAndCriteria = array();
                 foreach ($limitations as $limitation) {
                     $type = $roleService->getLimitationType($limitation->getIdentifier());
-                    $limitationsAndCriteria[] = $type->getCriterion($limitation, $currentUser);
+                    $limitationsAndCriteria[] = $type->getCriterion($limitation, $currentUserRef);
                 }
 
                 $policyOrCriteria[] = isset($limitationsAndCriteria[1]) ?
@@ -129,12 +129,12 @@ class PermissionsCriterionHandler
                 if (!empty($policyOrCriteria)) {
                     $roleAssignmentOrCriteria[] = new LogicalAnd(
                         array(
-                            $type->getCriterion($permissionSet['limitation'], $currentUser),
+                            $type->getCriterion($permissionSet['limitation'], $currentUserRef),
                             isset($policyOrCriteria[1]) ? new LogicalOr($policyOrCriteria) : $policyOrCriteria[0],
                         )
                     );
                 } else {
-                    $roleAssignmentOrCriteria[] = $type->getCriterion($permissionSet['limitation'], $currentUser);
+                    $roleAssignmentOrCriteria[] = $type->getCriterion($permissionSet['limitation'], $currentUserRef);
                 }
             } elseif (!empty($policyOrCriteria)) {
                 // Otherwise merge $policyOrCriteria into $roleAssignmentOrCriteria

--- a/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentBase.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentBase.php
@@ -67,7 +67,7 @@ abstract class ContentBase extends BaseServiceTest
 
         if ($draft) {
             //$values["id"] = 675;
-            $values['creatorId'] = $this->repository->getCurrentUser()->id;
+            $values['creatorId'] = $this->repository->getCurrentUserReference()->getUserId();
             $values['versionNo'] = 2;
             $values['status'] = VersionInfo::STATUS_DRAFT;
             unset($values['modificationDate']);
@@ -705,7 +705,7 @@ abstract class ContentBase extends BaseServiceTest
         $contentCreate->setField('test_required_empty', 'value for field definition with empty default value');
         $contentCreate->setField('test_translatable', 'and thumbs opposable', 'eng-US');
         $contentCreate->sectionId = 1;
-        $contentCreate->ownerId = $this->repository->getCurrentUser()->id;
+        $contentCreate->ownerId = $this->repository->getCurrentUserReference()->getUserId();
         $contentCreate->remoteId = 'abcdef0123456789abcdef0123456789';
         $contentCreate->alwaysAvailable = true;
 
@@ -978,7 +978,7 @@ abstract class ContentBase extends BaseServiceTest
         $contentCreate->setField('test_required_empty', 'value for field definition with empty default value');
         $contentCreate->setField('test_translatable', 'and thumbs opposable', 'eng-US');
         $contentCreate->sectionId = 1;
-        $contentCreate->ownerId = $this->repository->getCurrentUser()->id;
+        $contentCreate->ownerId = $this->repository->getCurrentUserReference()->getUserId();
         $contentCreate->remoteId = 'abcdef0123456789abcdef0123456789';
         $contentCreate->alwaysAvailable = true;
 
@@ -1012,7 +1012,7 @@ abstract class ContentBase extends BaseServiceTest
         $contentCreate->setField('test_required_empty', 'value for field definition with empty default value');
         $contentCreate->setField('test_translatable', 'and thumbs opposable', 'eng-US');
         $contentCreate->sectionId = 1;
-        $contentCreate->ownerId = $this->repository->getCurrentUser()->id;
+        $contentCreate->ownerId = $this->repository->getCurrentUserReference()->getUserId();
         $contentCreate->remoteId = 'abcdef0123456789abcdef0123456789';
         $contentCreate->alwaysAvailable = true;
 
@@ -2560,7 +2560,7 @@ abstract class ContentBase extends BaseServiceTest
         $typeCreateStruct->names = array('eng-GB' => 'Test type name');
         $typeCreateStruct->descriptions = array('eng-GB' => 'Test type description');
         $typeCreateStruct->remoteId = 'test-type-remoteid';
-        $typeCreateStruct->creatorId = $this->repository->getCurrentUser()->id;
+        $typeCreateStruct->creatorId = $this->repository->getCurrentUserReference()->getUserId();
         $typeCreateStruct->creationDate = $this->getDateTime(0);
         $typeCreateStruct->mainLanguageCode = 'eng-GB';
         $typeCreateStruct->nameSchema = '<test_required_empty>';

--- a/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentTypeBase.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentTypeBase.php
@@ -88,7 +88,7 @@ abstract class ContentTypeBase extends BaseServiceTest
         $groupCreate = $contentTypeService->newContentTypeGroupCreateStruct(
             'new-group'
         );
-        $groupCreate->creatorId = $this->repository->getCurrentUser()->id;
+        $groupCreate->creatorId = $this->repository->getCurrentUserReference()->getUserId();
         $groupCreate->creationDate = new \DateTime();
         // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         //$groupCreate->mainLanguageCode = 'eng-GB';
@@ -151,7 +151,7 @@ abstract class ContentTypeBase extends BaseServiceTest
         $groupCreate = $contentTypeService->newContentTypeGroupCreateStruct(
             'new-group'
         );
-        $groupCreate->creatorId = $this->repository->getCurrentUser()->id;
+        $groupCreate->creatorId = $this->repository->getCurrentUserReference()->getUserId();
         $groupCreate->creationDate = new \DateTime();
         // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         // $groupCreate->mainLanguageCode = 'eng-GB';
@@ -210,7 +210,7 @@ abstract class ContentTypeBase extends BaseServiceTest
         $groupCreate = $contentTypeService->newContentTypeGroupCreateStruct(
             'new-group'
         );
-        $groupCreate->creatorId = $this->repository->getCurrentUser()->id;
+        $groupCreate->creatorId = $this->repository->getCurrentUserReference()->getUserId();
         $groupCreate->creationDate = new \DateTime();
         // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         //$groupCreate->mainLanguageCode = 'eng-GB';
@@ -555,7 +555,7 @@ abstract class ContentTypeBase extends BaseServiceTest
         $groupCreate = $contentTypeService->newContentTypeGroupCreateStruct(
             'new-group'
         );
-        $groupCreate->creatorId = $this->repository->getCurrentUser()->id;
+        $groupCreate->creatorId = $this->repository->getCurrentUserReference()->getUserId();
         $groupCreate->creationDate = new \DateTime();
         // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         //$groupCreate->mainLanguageCode = 'eng-US';
@@ -619,7 +619,7 @@ abstract class ContentTypeBase extends BaseServiceTest
         $groupCreate = $contentTypeService->newContentTypeGroupCreateStruct(
             'updated-group'
         );
-        $groupCreate->creatorId = $this->repository->getCurrentUser()->id;
+        $groupCreate->creatorId = $this->repository->getCurrentUserReference()->getUserId();
         // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         //$groupCreate->names = array( 'eng-US' => 'Name' );
         //$groupCreate->descriptions = array( 'eng-US' => 'Description' );
@@ -717,7 +717,7 @@ abstract class ContentTypeBase extends BaseServiceTest
             $groupCreate = $contentTypeService->newContentTypeGroupCreateStruct(
                 'first-group'
             );
-            $groupCreate->creatorId = $this->repository->getCurrentUser()->id;
+            $groupCreate->creatorId = $this->repository->getCurrentUserReference()->getUserId();
             $groupCreate->creationDate = new \DateTime();
             // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
             //$groupCreate->mainLanguageCode = 'de_DE';
@@ -938,7 +938,7 @@ abstract class ContentTypeBase extends BaseServiceTest
     {
         $contentTypeService = $this->repository->getContentTypeService();
         if (!isset($creatorId)) {
-            $creatorId = $this->repository->getCurrentUser()->id;
+            $creatorId = $this->repository->getCurrentUserReference()->getUserId();
         }
 
         $typeCreateStruct = $contentTypeService->newContentTypeCreateStruct(
@@ -1071,7 +1071,7 @@ abstract class ContentTypeBase extends BaseServiceTest
             'eng-GB' => 'British type description',
         );
         $typeCreateStruct->remoteId = 'new-remoteid';
-        $typeCreateStruct->creatorId = $this->repository->getCurrentUser()->id;
+        $typeCreateStruct->creatorId = $this->repository->getCurrentUserReference()->getUserId();
         $typeCreateStruct->creationDate = new \DateTime();
         $typeCreateStruct->mainLanguageCode = 'eng-GB';
         $typeCreateStruct->nameSchema = '<name>';
@@ -1355,7 +1355,7 @@ abstract class ContentTypeBase extends BaseServiceTest
             'new-type'
         );
         $typeCreateStruct->remoteId = 'other-remoteid';
-        $typeCreateStruct->creatorId = $this->repository->getCurrentUser()->id;
+        $typeCreateStruct->creatorId = $this->repository->getCurrentUserReference()->getUserId();
         $typeCreateStruct->creationDate = new \DateTime();
         $typeCreateStruct->mainLanguageCode = 'eng-US';
         $typeCreateStruct->names = array('eng-US' => 'A name.');
@@ -1394,7 +1394,7 @@ abstract class ContentTypeBase extends BaseServiceTest
             'other-type'
         );
         $typeCreateStruct->remoteId = 'new-remoteid';
-        $typeCreateStruct->creatorId = $this->repository->getCurrentUser()->id;
+        $typeCreateStruct->creatorId = $this->repository->getCurrentUserReference()->getUserId();
         $typeCreateStruct->creationDate = new \DateTime();
         $typeCreateStruct->mainLanguageCode = 'eng-US';
         $typeCreateStruct->names = array('eng-US' => 'A name.');
@@ -1432,7 +1432,7 @@ abstract class ContentTypeBase extends BaseServiceTest
             'other-type'
         );
         $typeCreateStruct->remoteId = 'new-unique-remoteid';
-        $typeCreateStruct->creatorId = $this->repository->getCurrentUser()->id;
+        $typeCreateStruct->creatorId = $this->repository->getCurrentUserReference()->getUserId();
         $typeCreateStruct->creationDate = new \DateTime();
         $typeCreateStruct->mainLanguageCode = 'eng-US';
         $typeCreateStruct->names = array('eng-US' => 'A name.');
@@ -1478,7 +1478,7 @@ abstract class ContentTypeBase extends BaseServiceTest
             'eng-GB' => 'British type description',
         );
         $typeCreateStruct->remoteId = 'new-remoteid';
-        $typeCreateStruct->creatorId = $this->repository->getCurrentUser()->id;
+        $typeCreateStruct->creatorId = $this->repository->getCurrentUserReference()->getUserId();
         $typeCreateStruct->creationDate = new \DateTime();
         $typeCreateStruct->mainLanguageCode = 'eng-GB';
         $typeCreateStruct->nameSchema = '<name>';
@@ -2047,7 +2047,7 @@ abstract class ContentTypeBase extends BaseServiceTest
         $groupCreate = $contentTypeService->newContentTypeGroupCreateStruct(
             'test-group-1'
         );
-        $groupCreate->creatorId = $this->repository->getCurrentUser()->id;
+        $groupCreate->creatorId = $this->repository->getCurrentUserReference()->getUserId();
         $groupCreate->creationDate = new \DateTime();
         // @todo uncomment when support for multilingual names and descriptions is added EZP-24776
         //$groupCreate->mainLanguageCode = 'ger-DE';
@@ -2067,7 +2067,7 @@ abstract class ContentTypeBase extends BaseServiceTest
             'eng-GB' => 'British type description',
         );
         $typeCreateStruct->remoteId = 'test-remoteid-1';
-        $typeCreateStruct->creatorId = $this->repository->getCurrentUser()->id;
+        $typeCreateStruct->creatorId = $this->repository->getCurrentUserReference()->getUserId();
         $typeCreateStruct->creationDate = new \DateTime();
         $typeCreateStruct->mainLanguageCode = 'eng-GB';
         $typeCreateStruct->nameSchema = '<name>';
@@ -2284,7 +2284,7 @@ abstract class ContentTypeBase extends BaseServiceTest
         $typeUpdate->isContainer = true;
         $typeUpdate->mainLanguageCode = 'eng-US';
         $typeUpdate->defaultAlwaysAvailable = false;
-        $typeUpdate->modifierId = $this->repository->getCurrentUser()->id;
+        $typeUpdate->modifierId = $this->repository->getCurrentUserReference()->getUserId();
         $typeUpdate->modificationDate = new \DateTime();
         $typeUpdate->defaultSortField = Location::SORT_FIELD_PUBLISHED;
         $typeUpdate->defaultSortOrder = Location::SORT_ORDER_ASC;
@@ -2545,7 +2545,7 @@ abstract class ContentTypeBase extends BaseServiceTest
             'originalType' => $commentType,
             'copiedType' => $copiedCommentType,
             'time' => $time,
-            'userId' => $this->repository->getCurrentUser()->id,
+            'userId' => $this->repository->getCurrentUserReference()->getUserId(),
         );
     }
 

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -38,6 +38,7 @@ use eZ\Publish\SPI\Persistence\Content\VersionInfo as SPIVersionInfo;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo as SPIContentInfo;
 use eZ\Publish\SPI\Persistence\Content\MetadataUpdateStruct as SPIMetadataUpdateStruct;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\Repository\Values\User\UserReference;
 use Exception;
 
 /**
@@ -917,8 +918,8 @@ class ContentTest extends BaseServiceMockTest
         );
 
         $repositoryMock->expects($this->once())
-            ->method('getCurrentUser')
-            ->will($this->returnValue($this->getStubbedUser(169)));
+            ->method('getCurrentUserReference')
+            ->will($this->returnValue(new UserReference(169)));
 
         $contentTypeServiceMock->expects($this->once())
             ->method('loadContentType')
@@ -978,8 +979,8 @@ class ContentTest extends BaseServiceMockTest
         );
 
         $repositoryMock->expects($this->once())
-            ->method('getCurrentUser')
-            ->will($this->returnValue($this->getStubbedUser(169)));
+            ->method('getCurrentUserReference')
+            ->will($this->returnValue(new UserReference(169)));
 
         $contentTypeServiceMock->expects($this->once())
             ->method('loadContentType')
@@ -3134,8 +3135,8 @@ class ContentTest extends BaseServiceMockTest
             ->will($this->returnValue($contentTypeServiceMock));
 
         $repositoryMock->expects($this->once())
-            ->method('getCurrentUser')
-            ->will($this->returnValue($this->getStubbedUser(169)));
+            ->method('getCurrentUserReference')
+            ->will($this->returnValue(new UserReference(169)));
 
         $fieldTypeMock->expects($this->any())
             ->method('acceptValue')

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionsCriterionHandlerTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionsCriterionHandlerTest.php
@@ -342,7 +342,7 @@ class PermissionsCriterionHandlerTest extends BaseServiceMockTest
 
         $repositoryMock
             ->expects($this->once())
-            ->method('getCurrentUser')
+            ->method('getCurrentUserReference')
             ->will($this->returnValue($userMock));
 
         return $repositoryMock;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/RepositoryTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/RepositoryTest.php
@@ -11,6 +11,7 @@
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 
 use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\Core\Repository\Values\User\UserReference;
 use eZ\Publish\Core\Base\Exceptions\NotFound\LimitationNotFoundException;
 use eZ\Publish\Core\Repository\Tests\Service\Mock\Base as BaseServiceMockTest;
 use eZ\Publish\SPI\Persistence\User\RoleAssignment;
@@ -293,7 +294,7 @@ class RepositoryTest extends BaseServiceMockTest
         );
         $repositoryMock = $this->getMock(
             'eZ\\Publish\\Core\\Repository\\Repository',
-            array('getRoleDomainMapper', 'getCurrentUser'),
+            array('getRoleDomainMapper', 'getCurrentUserReference'),
             array(
                 $this->getPersistenceMock(),
                 $this->getSPIMockHandler('Search\\Handler'),
@@ -306,8 +307,8 @@ class RepositoryTest extends BaseServiceMockTest
             ->will($this->returnValue($roleDomainMapper));
         $repositoryMock
             ->expects($this->once())
-            ->method('getCurrentUser')
-            ->will($this->returnValue($this->getStubbedUser(14)));
+            ->method('getCurrentUserReference')
+            ->will($this->returnValue(new UserReference(14)));
 
         $userHandlerMock
             ->expects($this->once())
@@ -430,7 +431,7 @@ class RepositoryTest extends BaseServiceMockTest
         );
         $repositoryMock = $this->getMock(
             'eZ\\Publish\\Core\\Repository\\Repository',
-            array('getRoleDomainMapper', 'getCurrentUser'),
+            array('getRoleDomainMapper', 'getCurrentUserReference'),
             array(
                 $this->getPersistenceMock(),
                 $this->getSPIMockHandler('Search\\Handler'),
@@ -443,8 +444,8 @@ class RepositoryTest extends BaseServiceMockTest
             ->will($this->returnValue($roleDomainMapper));
         $repositoryMock
             ->expects($this->once())
-            ->method('getCurrentUser')
-            ->will($this->returnValue($this->getStubbedUser(14)));
+            ->method('getCurrentUserReference')
+            ->will($this->returnValue(new UserReference(14)));
 
         $userHandlerMock
             ->expects($this->once())
@@ -542,7 +543,7 @@ class RepositoryTest extends BaseServiceMockTest
         $limitationTypeMock = $this->getMock('eZ\\Publish\\SPI\\Limitation\\Type');
         $repositoryMock = $this->getMock(
             'eZ\\Publish\\Core\\Repository\\Repository',
-            array('getRoleDomainMapper', 'getCurrentUser', 'getLimitationService'),
+            array('getRoleDomainMapper', 'getCurrentUserReference', 'getLimitationService'),
             array(
                 $this->getPersistenceMock(),
                 $this->getSPIMockHandler('Search\\Handler'),
@@ -570,8 +571,8 @@ class RepositoryTest extends BaseServiceMockTest
             ->will($this->returnValue($limitationService));
         $repositoryMock
             ->expects($this->once())
-            ->method('getCurrentUser')
-            ->will($this->returnValue($this->getStubbedUser(14)));
+            ->method('getCurrentUserReference')
+            ->will($this->returnValue(new UserReference(14)));
 
         $userHandlerMock
             ->expects($this->once())
@@ -673,7 +674,7 @@ class RepositoryTest extends BaseServiceMockTest
     {
         $repositoryMock = $this->getMock(
             'eZ\\Publish\\Core\\Repository\\Repository',
-            array('hasAccess', 'getCurrentUser'),
+            array('hasAccess', 'getCurrentUserReference'),
             array(
                 $this->getPersistenceMock(),
                 $this->getSPIMockHandler('Search\\Handler'),
@@ -707,7 +708,7 @@ class RepositoryTest extends BaseServiceMockTest
     {
         $repositoryMock = $this->getMock(
             'eZ\\Publish\\Core\\Repository\\Repository',
-            array('hasAccess', 'getCurrentUser'),
+            array('hasAccess', 'getCurrentUserReference'),
             array(
                 $this->getPersistenceMock(),
                 $this->getSPIMockHandler('Search\\Handler'),
@@ -737,11 +738,10 @@ class RepositoryTest extends BaseServiceMockTest
             ->with($this->equalTo('test-module'), $this->equalTo('test-function'))
             ->will($this->returnValue($permissionSets));
 
-        $userMock = $this->getStubbedUser(14);
         $repositoryMock
             ->expects($this->once())
-            ->method('getCurrentUser')
-            ->will($this->returnValue($userMock));
+            ->method('getCurrentUserReference')
+            ->will($this->returnValue(new UserReference(14)));
 
         /** @var $valueObject \eZ\Publish\API\Repository\Values\ValueObject */
         $valueObject = $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\ValueObject');
@@ -884,7 +884,7 @@ class RepositoryTest extends BaseServiceMockTest
         $valueObject = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\ValueObject');
         $repositoryMock = $this->getMock(
             'eZ\\Publish\\Core\\Repository\\Repository',
-            array('getCurrentUser', 'hasAccess', 'getLimitationService'),
+            array('getCurrentUserReference', 'hasAccess', 'getLimitationService'),
             array(),
             '',
             false
@@ -921,11 +921,11 @@ class RepositoryTest extends BaseServiceMockTest
             ->with($this->equalTo('test-module'), $this->equalTo('test-function'))
             ->will($this->returnValue($permissionSets));
 
-        $userMock = $this->getStubbedUser(14);
+        $userRef = new UserReference(14);
         $repositoryMock
             ->expects($this->once())
-            ->method('getCurrentUser')
-            ->will($this->returnValue($userMock));
+            ->method('getCurrentUserReference')
+            ->will($this->returnValue(new UserReference(14)));
 
         $invocation = 0;
         for ($i = 0; $i < count($permissionSets); ++$i) {
@@ -933,7 +933,7 @@ class RepositoryTest extends BaseServiceMockTest
             $limitation
                 ->expects($this->once())
                 ->method('evaluate')
-                ->with($permissionSets[$i]['limitation'], $userMock, $valueObject, array($valueObject))
+                ->with($permissionSets[$i]['limitation'], $userRef, $valueObject, array($valueObject))
                 ->will($this->returnValue($roleLimitationEvaluations[$i]));
             $limitationService
                 ->expects($this->at($invocation++))
@@ -955,7 +955,7 @@ class RepositoryTest extends BaseServiceMockTest
                     $limitation
                         ->expects($this->once())
                         ->method('evaluate')
-                        ->with($limitations[$k], $userMock, $valueObject, array($valueObject))
+                        ->with($limitations[$k], $userRef, $valueObject, array($valueObject))
                         ->will($this->returnValue($policyLimitationEvaluations[$i][$j][$k]));
                     $limitationService
                         ->expects($this->at($invocation++))

--- a/eZ/Publish/Core/Repository/Values/User/UserReference.php
+++ b/eZ/Publish/Core/Repository/Values/User/UserReference.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * File containing the eZ\Publish\Core\Repository\Values\User\User class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\Repository\Values\User;
+
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
+
+/**
+ * This class represents a user reference for use in sessions and Repository.
+ */
+class UserReference implements APIUserReference
+{
+    /**
+     * @var mixed
+     */
+    private $userId;
+
+    /**
+     * @param mixed $userId
+     */
+    public function __construct($userId)
+    {
+        $this->userId = $userId;
+    }
+
+    /**
+     * The User id of the User this reference represent.
+     *
+     * @return mixed
+     */
+    public function getUserId()
+    {
+        return $this->userId;
+    }
+}

--- a/eZ/Publish/Core/SignalSlot/Repository.php
+++ b/eZ/Publish/Core/SignalSlot/Repository.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\Core\SignalSlot;
 
 use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\API\Repository\Values\User\User;
+use eZ\Publish\API\Repository\Values\User\UserReference;
 use eZ\Publish\SPI\Persistence\TransactionHandler;
 
 /**
@@ -158,11 +158,21 @@ class Repository implements RepositoryInterface
     }
 
     /**
+     * Get current user ref.
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\UserReference
+     */
+    public function getCurrentUserReference()
+    {
+        return $this->repository->getCurrentUserReference();
+    }
+
+    /**
      * Sets the current user to the given $user.
      *
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $user
      */
-    public function setCurrentUser(User $user)
+    public function setCurrentUser(UserReference $user)
     {
         return $this->repository->setCurrentUser($user);
     }
@@ -201,11 +211,11 @@ class Repository implements RepositoryInterface
      *
      * @param string $module
      * @param string $function
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $user
      *
      * @return bool|array Bool if user has full or no access, array if limitations if not
      */
-    public function hasAccess($module, $function, User $user = null)
+    public function hasAccess($module, $function, UserReference $user = null)
     {
         return $this->repository->hasAccess($module, $function, $user);
     }

--- a/eZ/Publish/SPI/Limitation/Type.php
+++ b/eZ/Publish/SPI/Limitation/Type.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\SPI\Limitation;
 
 use eZ\Publish\API\Repository\Values\ValueObject as APIValueObject;
 use eZ\Publish\API\Repository\Values\User\Limitation as APILimitationValue;
-use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 
 /**
  * This interface represent the Limitation Type.
@@ -91,14 +91,14 @@ interface Type
      *         Example if OwnerLimitationValue->limitationValues[0] is not one of: [ 1,  2 ]
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      * @param \eZ\Publish\API\Repository\Values\ValueObject $object
      * @param \eZ\Publish\API\Repository\Values\ValueObject[]|null $targets An array of location, parent or "assignment"
      *                                                                 objects, if null: none where provided by caller
      *
      * @return bool|null Returns one of ACCESS_* constants
      */
-    public function evaluate(APILimitationValue $value, APIUser $currentUser, APIValueObject $object, array $targets = null);
+    public function evaluate(APILimitationValue $value, APIUserReference $currentUser, APIValueObject $object, array $targets = null);
 
     /**
      * Returns Criterion for use in find() query.
@@ -107,11 +107,11 @@ interface Type
      *         being used as a Criterion.
      *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
-     * @param \eZ\Publish\API\Repository\Values\User\User $currentUser
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
      */
-    public function getCriterion(APILimitationValue $value, APIUser $currentUser);
+    public function getCriterion(APILimitationValue $value, APIUserReference $currentUser);
 
     /**
      * Returns info on valid $limitationValues.


### PR DESCRIPTION
[EZP-24834](https://jira.ez.no/browse/EZP-24834): Add possibility to set current user on Repository w/o loading


To reduce amount of logic and loading going on that does not really add any security, a simple UserReference interface is added that only holds id, the only thing we need for authentication and authorization needs.

Existing User object is implementing this to keep API BC.

- [x] Tests
- [x] ~~BC doc~~ *(no bc change anymore, I was originally planning to deprecate getCurrentUser)*
- [x] Issue


Possible followups:
- [JV/?] Find a way to avoid having to serialize full user object in Sessions *(for 6.0, while this PR can be back ported safely to 5.4 afaik to get users to start to adopt their user API code)*
- [API] Consider to improve security by re introduce permission checking on UserService->load* *(but not login())* now that we no longer need to load to set current user.