### PR TITLE
REST: verify existence of users by login or email

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -4260,30 +4260,30 @@ User Management
 Overview
 --------
 
-============================================= ===================== ===================== ===================== =======================
-Resource                                      POST                  GET                   PUT                   DELETE
---------------------------------------------- --------------------- --------------------- --------------------- -----------------------
-/user/groups                                  .                     load all topl. groups .                     .
-/user/groups/root                             .                     redirect to root      .                     .
-/user/groups/<path>                           .                     load user group       update user group     delete user group
-/user/groups/<path>/users                     .                     load users of group   .                     .
-/user/groups/<path>/subgroups                 create user group     load sub groups       .                     remove all sub groups
-/user/groups/<path>/roles                     assign role to group  load roles of group   .                     .
-/user/groups/<path>/roles/<ID>                .                     .                     .                     unassign role from group
-/user/users                                   create user           list users            .                     .
-/user/users/<ID>                              update user           load user             .                     delete user
-/user/users/<ID>/groups                       .                     load groups of user   add to group          .
-/user/users/<ID>/drafts                       .                     list all drafts owned .                     .
-                                                                    by the user
-/user/users/<ID>/roles                        assign role to user   load roles of group   .                     .
-/user/users/<ID>/roles/<ID>                   .                     load roleassignment   .                     unassign role from user
-/user/roles                                   create new role       load all roles        .                     .
-/user/roles/<ID>                              .                     load role             update role           delete role
-/user/roles/<ID>/policies                     create policy         load policies         .                     delete all policies from role
-/user/roles/<ID>/policies/<ID>                .                     load policy           update policy         delete policy
-/user/sessions                                create session        .                     .                     .
-/user/sessions/<sessionID>                    .                     .                     .                     delete session
-============================================= ===================== ===================== ===================== =======================
+============================================= ===================== ===================== ===================== ============================= =============
+Resource                                      POST                  GET                   PUT                   DELETE                        HEAD
+--------------------------------------------- --------------------- --------------------- --------------------- ----------------------------- -------------
+/user/groups                                  .                     load all topl. groups .                     .                             .
+/user/groups/root                             .                     redirect to root      .                     .                             .
+/user/groups/<path>                           .                     load user group       update user group     delete user group             .
+/user/groups/<path>/users                     .                     load users of group   .                     .                             .
+/user/groups/<path>/subgroups                 create user group     load sub groups       .                     remove all sub groups         .
+/user/groups/<path>/roles                     assign role to group  load roles of group   .                     .                             .
+/user/groups/<path>/roles/<ID>                .                     .                     .                     unassign role from group      .
+/user/users                                   create user           list users            .                     .                             Verify users
+/user/users/<ID>                              update user           load user             .                     delete user                   .
+/user/users/<ID>/groups                       .                     load groups of user   add to group          .                             .
+/user/users/<ID>/drafts                       .                     list all drafts owned .                     .                             .
+                                                                    by the user                                                               .
+/user/users/<ID>/roles                        assign role to user   load roles of group   .                     .                             .
+/user/users/<ID>/roles/<ID>                   .                     load roleassignment   .                     unassign role from user       .
+/user/roles                                   create new role       load all roles        .                     .                             .
+/user/roles/<ID>                              .                     load role             update role           delete role                   .
+/user/roles/<ID>/policies                     create policy         load policies         .                     delete all policies from role .
+/user/roles/<ID>/policies/<ID>                .                     load policy           update policy         delete policy                 .
+/user/sessions                                create session        .                     .                     .                             .
+/user/sessions/<sessionID>                    .                     .                     .                     delete session                .
+============================================= ===================== ===================== ===================== ============================= =============
 
 
 Managing Users and Groups
@@ -4871,6 +4871,8 @@ List Users
 :Parameters:
     :roleId: lists users assigned to the given role (ex: ``GET /user/users?roleId=/user/roles/1``)
     :remoteId: retrieves the user for the given remoteId (ex: ``GET /user/users?remoteId=55dd9713db75145f374bbd0b4f60ad29``)
+    :login: retrieves the user for the given login (ex: ``GET /user/users?login=editor``)
+    :email: lists users with the given email (ex: ``GET /user/users?email=editor@example.com``)
 :Headers:
     :Accept:
          :application/vnd.ez.api.UserList+xml:  if set the user list returned in xml format (see User_)
@@ -4888,7 +4890,28 @@ List Users
           User_
 
 :Error Codes:
-    :401: If the user has no permission to read users
+    :404: If there are no visibile users matching the filter
+
+Verify users
+````````````
+:Resource: /user/users
+:Method: HEAD
+:Description: Verifies if there are users matching the given filter.
+:Parameters:
+    :roleId: lists users assigned to the given role (ex: ``GET /user/users?roleId=/user/roles/1``)
+    :remoteId: retrieves the user for the given remoteId (ex: ``GET /user/users?remoteId=55dd9713db75145f374bbd0b4f60ad29``)
+    :login: retrieves the user for the given login (ex: ``GET /user/users?login=editor``)
+    :email: lists users with the given email (ex: ``GET /user/users?email=editor@example.com``)
+:Headers:
+:Response:
+
+.. code:: http
+
+          HTTP/1.1 200 OK
+          Content-Length: 0
+
+:Error Codes:
+    :404: If there are no users visible to the current user matching the given filter
 
 Load User
 `````````

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/RestContext.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/RestContext.php
@@ -29,6 +29,7 @@ class RestContext extends Context
     use SubContext\ContentTypeGroup;
     use SubContext\Exception;
     use SubContext\Views;
+    use SubContext\User;
 
     const AUTHTYPE_BASICHTTP = 'http_basic';
     const AUTHTYPE_SESSION = 'session';

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/User.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/User.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishRestBundle\Features\Context\SubContext;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\Core\Base\Exceptions\BadStateException;
+use PHPUnit_Framework_Assert as Assertion;
+
+/**
+ * @method \eZ\Publish\API\Repository\Repository getRepository()
+ */
+trait User
+{
+    /**
+     * @Given /^there is a user with the login "([^"]*)"$/
+     */
+    public function thereIsAUserWithTheLogin($login)
+    {
+        Assertion::assertInstanceOf(
+            'eZ\Publish\API\Repository\Values\User\User',
+            $this->getRepository()->getUserService()->loadUserByLogin($login)
+        );
+    }
+
+    /**
+     * @Given /^there isn't a user with the login "([^"]*)"$/
+     */
+    public function thereIsNotAUserWithTheLogin($login)
+    {
+        try {
+            $this->getRepository()->getUserService()->loadUserByLogin($login);
+        } catch (NotFoundException $e) {
+            return;
+        }
+        throw new BadStateException('login', "A user with the login $login exists");
+    }
+
+    /**
+     * Verifies that there is at least one user with a given email address.
+     *
+     * @Given /^there is a at least one user with the email "([^"]*)"$/
+     * @Given /^there is a user with the email "([^"]*)"$/
+     */
+    public function thereIsAUserWithTheEmail($email)
+    {
+        $users = $this->getRepository()->getUserService()->loadUsersByEmail($email);
+
+        Assertion::assertGreaterThan(0, count($users), "No user was found with the email '$email'");
+        Assertion::assertInstanceOf('eZ\Publish\API\Repository\Values\User\User', $users[0]);
+    }
+
+    /**
+     * Verifies that there is at least one user with a given email address.
+     *
+     * @Given /^there isn't a user with the email "([^"]*)"$/
+     * @Given /^there are no users with the email "([^"]*)"$/
+     */
+    public function thereAreNoUsersWithTheEmail($email)
+    {
+        $users = $this->getRepository()->getUserService()->loadUsersByEmail($email);
+        Assertion::assertEquals(0, count($users), "Users with the email '$email' exist");
+    }
+
+    /**
+     * @Given /^response contains only the user with the login "([^"]*)"$/
+     */
+    public function responseContainsOnlyTheUserWithTheLogin($login)
+    {
+        $userList = $this->getResponseObject();
+
+        Assertion::assertEquals(
+            1,
+            count($userList),
+            'UserList was expected to contain one user only'
+        );
+
+        Assertion::assertInstanceOf(
+            'eZ\Publish\API\Repository\Values\User\User',
+            $userList[0],
+            'UserList[0] is not a user'
+        );
+
+        Assertion::assertEquals(
+            $login,
+            $userList[0]->login,
+            "UserList was expected to contain the user with login '$login'"
+        );
+    }
+
+    /**
+     * @Given /^response contains only the user with the email "([^"]*)"$/
+     */
+    public function responseContainsOnlyUsersWithTheEmail($email)
+    {
+        $userList = $this->getResponseObject();
+
+        Assertion::assertGreaterThan(
+            0,
+            count($userList),
+            'UserList was expected to contain one user only'
+        );
+
+        foreach ($userList as $user) {
+            Assertion::assertInstanceOf(
+                'eZ\Publish\API\Repository\Values\User\User',
+                $user,
+                'Non User found in the response'
+            );
+
+            Assertion::assertEquals(
+                $email,
+                $user->email,
+                "UserList was expected to contain only users with email '$email'"
+            );
+        }
+    }
+
+    /**
+     * @Given /^that I can't view users$/
+     */
+    public function thatICannotViewUsers()
+    {
+        $this->usePermissionsOfRole('anonymous');
+    }
+}

--- a/eZ/Bundle/EzPublishRestBundle/Features/User/load_users.feature
+++ b/eZ/Bundle/EzPublishRestBundle/Features/User/load_users.feature
@@ -6,20 +6,28 @@ Feature: List users from the repository
     Scenario: The list of users can be filtered by login using a "login" query parameter
        Given I have "administrator" permissions
          And there is a user with the login "admin"
+         And there isn't a user with the login "foo"
         When I create a "GET" request to "/user/users?login=admin"
          And I set header "Accept" with "UserList" object
          And I send the request
         Then response status code is 200
          And response contains only the user with the login "admin"
+        When I create a "GET" request to "/user/users?login=foo"
+         And I send the request
+        Then response status code is 404
 
     Scenario: The list of users can be filtered by email using an "email" query parameter
        Given I have "administrator" permissions
          And there is a user with the email "nospam@ez.no"
+         And there isn't a user with the email "foo@bar.com"
         When I create a "GET" request to "/user/users?email=nospam@ez.no"
          And I set header "Accept" with "UserList" object
          And I send the request
         Then response status code is 200
          And response contains only the user with the email "nospam@ez.no"
+        When I create a "GET" request to "/user/users?email=foo@bar.com"
+         And I send the request
+        Then response status code is 404
 
     Scenario: Check if an email address is used by an existing user
        Given I have "administrator" permissions

--- a/eZ/Bundle/EzPublishRestBundle/Features/User/load_users.feature
+++ b/eZ/Bundle/EzPublishRestBundle/Features/User/load_users.feature
@@ -1,0 +1,55 @@
+@user
+Feature: List users from the repository
+    As a REST API consumer
+    I need to list users from the Repository
+
+    Scenario: The list of users can be filtered by login using a "login" query parameter
+       Given I have "administrator" permissions
+         And there is a user with the login "admin"
+        When I create a "GET" request to "/user/users?login=admin"
+         And I set header "Accept" with "UserList" object
+         And I send the request
+        Then response status code is 200
+         And response contains only the user with the login "admin"
+
+    Scenario: The list of users can be filtered by email using an "email" query parameter
+       Given I have "administrator" permissions
+         And there is a user with the email "nospam@ez.no"
+        When I create a "GET" request to "/user/users?email=nospam@ez.no"
+         And I set header "Accept" with "UserList" object
+         And I send the request
+        Then response status code is 200
+         And response contains only the user with the email "nospam@ez.no"
+
+    Scenario: Check if an email address is used by an existing user
+       Given I have "administrator" permissions
+         And there is a user with the email "nospam@ez.no"
+         And there isn't a user with the email "foo@bar.com"
+        When I create a "HEAD" request to "/user/users?email=nospam@ez.no"
+         And I send the request
+        Then response status code is 200
+        When I create a "HEAD" request to "/user/users?email=foo@bar.com"
+         And I send the request
+        Then response status code is 404
+
+    Scenario: Check if a login is used by an existing user
+       Given I have "administrator" permissions
+         And there is a user with the login "admin"
+         And there isn't a user with the login "foo"
+        When I create a "HEAD" request to "/user/users?login=admin"
+         And I send the request
+        Then response status code is 200
+        When I create a "HEAD" request to "/user/users?login=foo"
+         And I send the request
+        Then response status code is 404
+
+    Scenario: All users can't verify email or login usage
+       Given that I can't view users
+         And there is a user with the login "admin"
+         And there is a user with the email "nospam@ez.no"
+        When I create a "HEAD" request to "/user/users?login=admin"
+         And I send the request
+        Then response status code is 404
+        When I create a "HEAD" request to "/user/users?email=nospam@ez.no"
+         And I send the request
+        Then response status code is 404

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
@@ -95,6 +95,8 @@ parameters:
     ezpublish_rest.input.parser.SectionList.class: eZ\Publish\Core\REST\Client\Input\Parser\SectionList
     ezpublish_rest.input.parser.VersionInfo.class: eZ\Publish\Core\REST\Client\Input\Parser\VersionInfo
     ezpublish_rest.input.parser.Session.class: eZ\Publish\Core\REST\Client\Input\Parser\Session
+    ezpublish_rest.input.parser.UserList.class: eZ\Publish\Core\REST\Client\Input\Parser\UserList
+    ezpublish_rest.input.parser.UserRefList.class: eZ\Publish\Core\REST\Client\Input\Parser\UserRefList
 
 services:
     ezpublish_rest.input.parser:
@@ -804,3 +806,21 @@ services:
             - @ezpublish.api.service.user
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.Session }
+
+    ezpublish_rest.input.parser.UserRefList:
+        parent: ezpublish_rest.input.parser
+        class: %ezpublish_rest.input.parser.UserRefList.class%
+        arguments:
+            - @ezpublish_rest.parser_tools
+            - @ezpublish.api.service.user
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.UserRefList }
+
+    ezpublish_rest.input.parser.UserList:
+        parent: ezpublish_rest.input.parser
+        class: %ezpublish_rest.input.parser.UserList.class%
+        arguments:
+            - @ezpublish_rest.parser_tools
+            - @ezpublish.api.service.user
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.UserList }

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
@@ -849,6 +849,12 @@ ezpublish_rest_deletePolicy:
 # Users
 
 
+ezpublish_rest_verifyUsers:
+    path: /user/users
+    defaults:
+        _controller: ezpublish_rest.controller.user:verifyUsers
+    methods: [HEAD]
+
 ezpublish_rest_loadUsers:
     path: /user/users
     defaults:

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -133,6 +133,7 @@ parameters:
     ezpublish_rest.output.value_object_visitor.PermanentRedirect.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\PermanentRedirect
     ezpublish_rest.output.value_object_visitor.TemporaryRedirect.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\TemporaryRedirect
     ezpublish_rest.output.value_object_visitor.Options.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\Options
+    ezpublish_rest.output.value_object_visitor.OK.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\OK
 
     # Cache
     ezpublish_rest.output.value_object_visitor.cached_value.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\CachedValue
@@ -801,6 +802,12 @@ services:
         arguments: [ true  ]
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Values\Options }
+
+    ezpublish_rest.output.value_object_visitor.OK:
+        parent: ezpublish_rest.output.value_object_visitor.base
+        class: %ezpublish_rest.output.value_object_visitor.OK.class%
+        tags:
+            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Values\OK }
 
     ezpublish_rest.output.value_object_visitor.cached_value:
         class: %ezpublish_rest.output.value_object_visitor.cached_value.class%

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/UserTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/UserTest.php
@@ -221,7 +221,7 @@ XML;
             $this->createHttpRequest('GET', '/api/ezp/v2/user/users')
         );
 
-        self::assertHttpResponseCodeEquals($response, 200);
+        self::assertHttpResponseCodeEquals($response, 404);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Client/Input/Parser/UserList.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/UserList.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * File containing the RoleList parser class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\REST\Client\Input\Parser;
+
+use eZ\Publish\Core\Repository\Values\User\User;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
+use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
+use eZ\Publish\Core\REST\Common\Exceptions;
+
+/**
+ * Parser for UserList.
+ */
+class UserList extends BaseParser
+{
+    /**
+     * Parse input structure.
+     *
+     * @param array $data
+     * @param \eZ\Publish\Core\REST\Common\Input\ParsingDispatcher $parsingDispatcher
+     *
+     * @todo Error handling
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\Role[]
+     */
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher)
+    {
+        if (!array_key_exists('User', $data) || !is_array($data['User'])) {
+            throw new Exceptions\Parser("Missing 'User' element in UserRefList.");
+        }
+
+        $userList = array();
+        foreach ($data['User'] as $userData) {
+            $userList[] = new User(
+                array(
+                    'login' => $userData['login'],
+                    'email' => $userData['email'],
+                    'enabled' => (bool)$userData['enabled']
+                )
+            );
+        }
+        return $userList;
+    }
+}

--- a/eZ/Publish/Core/REST/Client/Input/Parser/UserRefList.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/UserRefList.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * File containing the RoleList parser class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\REST\Client\Input\Parser;
+
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
+use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
+use eZ\Publish\Core\REST\Common\Exceptions;
+
+/**
+ * Parser for UserRefList.
+ */
+class UserRefList extends BaseParser
+{
+    /**
+     * Parse input structure.
+     *
+     * @param array $data
+     * @param \eZ\Publish\Core\REST\Common\Input\ParsingDispatcher $parsingDispatcher
+     *
+     * @todo Error handling
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\Role[]
+     */
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher)
+    {
+        if (!array_key_exists('User', $data) || !is_array($data['User'])) {
+            throw new Exceptions\Parser("Missing 'User' element in UserRefList.");
+        }
+
+        // workaround for list with 1 items parsed as non arrays
+        if (!isset($data['User'][0])) {
+            $data['User'] = array($data['User']);
+        }
+
+        $userRefList = array();
+        foreach ($data['User'] as $userRefData) {
+            $hrefData = $this->requestParser->parse($userRefData['_href']);
+            if (!isset($hrefData['userId'])) {
+                throw new Exceptions\Parser("Invalid application/vnd.ez.api.User href");
+            }
+            $userRefList[] = $hrefData['userId'];
+        }
+        return $userRefList;
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/OK.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/OK.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+
+class OK extends ValueObjectVisitor
+{
+    public function visit(Visitor $visitor, Generator $generator, $data)
+    {
+        $visitor->setStatus(200);
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Root.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Root.php
@@ -106,6 +106,30 @@ class Root extends ValueObjectVisitor
         $generator->endAttribute('href');
         $generator->endObjectElement('users');
 
+        // Users by role id
+        $generator->startObjectElement('usersByRoleId', 'UserRefList');
+        $generator->startAttribute('href', $this->templateRouter->generate('ezpublish_rest_loadUsers', ['roleId' => '{roleId}']));
+        $generator->endAttribute('href');
+        $generator->endObjectElement('usersByRoleId');
+
+        // Users by remote id
+        $generator->startObjectElement('usersByRemoteId', 'UserRefList');
+        $generator->startAttribute('href', $this->templateRouter->generate('ezpublish_rest_loadUsers', ['remoteId' => '{remoteId}']));
+        $generator->endAttribute('href');
+        $generator->endObjectElement('usersByRemoteId');
+
+        // Users by email
+        $generator->startObjectElement('usersByEmail', 'UserRefList');
+        $generator->startAttribute('href', $this->templateRouter->generate('ezpublish_rest_loadUsers', ['email' => '{email}']));
+        $generator->endAttribute('href');
+        $generator->endObjectElement('usersByEmail');
+
+        // Users by login
+        $generator->startObjectElement('usersByLogin', 'UserRefList');
+        $generator->startAttribute('href', $this->templateRouter->generate('ezpublish_rest_loadUsers', ['login' => '{login}']));
+        $generator->endAttribute('href');
+        $generator->endObjectElement('usersByLogin');
+
         // Roles
         $generator->startObjectElement('roles', 'RoleList');
         $generator->startAttribute('href', $this->router->generate('ezpublish_rest_listRoles'));

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RootTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RootTest.php
@@ -53,6 +53,11 @@ class RootTest extends ValueObjectVisitorBaseTest
             '/content/typegroups?{&identifier}'
         );
         $this->addRouteExpectation('ezpublish_rest_loadUsers', array(), '/user/users');
+        $this->addTemplatedRouteExpectation('ezpublish_rest_loadUsers', array('roleId' => '{roleId}'), '/user/users{?roleId}');
+        $this->addTemplatedRouteExpectation('ezpublish_rest_loadUsers', array('remoteId' => '{remoteId}'), '/user/users{?remoteId}');
+        $this->addTemplatedRouteExpectation('ezpublish_rest_loadUsers', array('email' => '{email}'), '/user/users{?email}');
+        $this->addTemplatedRouteExpectation('ezpublish_rest_loadUsers', array('login' => '{login}'), '/user/users{?login}');
+
         $this->addRouteExpectation('ezpublish_rest_listRoles', array(), '/user/roles');
         $this->addRouteExpectation(
             'ezpublish_rest_loadLocation',

--- a/eZ/Publish/Core/REST/Server/Values/OK.php
+++ b/eZ/Publish/Core/REST/Server/Values/OK.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Values;
+
+/**
+ * Value object for a 200 OK response.
+ */
+class OK
+{
+}


### PR DESCRIPTION
> Implements [EZP-24820](https://jira.ez.no/browse/EZP-24820)
> Status: ready for review

Adds support for `login` and `email` query parameters on `GET /user/users`. Will return the user(s) matching the criteria. While login might only return one user, email might return several if non unique emails are allowed.

Also adds support for `HEAD` requests on the same resource. In that case, it will either respond with a `200` (yes, there is content matching the filter) or `404` (couldn't find anything). It doesn't differenciate between no permissions and no content.

Testing is done via behat, with a scenario for each filtering method. This required adding (primitive) Input Parsers for `UserList` and `UserRefList`.

## TODO
- [x] Update [specification](https://github.com/ezsystems/ezpublish-kernel/blob/master/doc/specifications/rest/REST-API-V2.rst#list-users)
- [x] Fix travis failure
- [x] ~~Create issue for the bugfix commit ("Fixed loading of user/group by roleId")~~