### PR TITLE
REST: Implemented SortClause in Query Parser

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php
@@ -154,4 +154,6 @@ abstract class Criterion
     {
         return new static($target, $operator, $value);
     }
+
+    abstract public function getSpecifications();
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOperator.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOperator.php
@@ -11,6 +11,7 @@
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 use InvalidArgumentException;
 
 /**
@@ -36,7 +37,7 @@ abstract class LogicalOperator extends Criterion
     public function __construct(array $criteria)
     {
         foreach ($criteria as $key => $criterion) {
-            if (!$criterion instanceof Criterion) {
+            if (!$criterion instanceof CriterionInterface) {
                 if ($criterion === null) {
                     $type = 'null';
                 } elseif (is_object($criterion)) {

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOperator.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOperator.php
@@ -18,7 +18,7 @@ use InvalidArgumentException;
  * Note that the class should ideally have been in a Logical namespace, but it would have then be named 'And',
  * and 'And' is a PHP reserved word.
  */
-abstract class LogicalOperator extends Criterion
+abstract class LogicalOperator extends Criterion implements CriterionInterface
 {
     /**
      * The set of criteria combined by the logical operator.
@@ -54,5 +54,10 @@ abstract class LogicalOperator extends Criterion
             }
             $this->criteria[] = $criterion;
         }
+    }
+
+    public function getSpecifications()
+    {
+        return [];
     }
 }

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ViewInput.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ViewInput.php
@@ -12,7 +12,6 @@ namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
-use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\Core\REST\Server\Values\RestViewInput;
 use eZ\Publish\Core\REST\Common\Input\BaseParser;
 

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ViewInputOneDotOne.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ViewInputOneDotOne.php
@@ -13,7 +13,6 @@ namespace eZ\Publish\Core\REST\Server\Input\Parser;
 use eZ\Publish\Core\REST\Server\Input\Parser\Criterion as CriterionParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
-use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\Core\REST\Server\Values\RestViewInput;
 
 /**

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ContentQueryTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ContentQueryTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * File containing a test class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\Core\REST\Server\Input\Parser\ContentQuery;
+
+class ContentQueryTest extends BaseTest
+{
+    /**
+     * Tests the LocationCreate parser.
+     */
+    public function testParse()
+    {
+        $inputArray = [
+            'Criteria' => [
+                'SomeCriterion' => '42',
+                'SomeOtherCriterion' => 'foo',
+            ],
+        ];
+
+        $this
+            ->getParsingDispatcherMock()
+            ->expects($this->exactly(2))
+            ->method('parse')
+            ->will(
+                $this->returnValue(
+                    $this->getMock('eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface')
+                )
+            );
+
+        $result = $this->getParser()->parse($inputArray, $this->getParsingDispatcherMock());
+
+        $this->assertInstanceOf(
+            'eZ\Publish\API\Repository\Values\Content\Query',
+            $result
+        );
+
+        return $result;
+    }
+
+    public function testParseSortClause()
+    {
+        $inputArray = [
+            'Criteria' => [],
+            'SortClauses' => [
+                ['SortField' => 'NAME', 'SortDirection' => 'ascending'],
+                ['SortField' => 'PATH', 'SortDirection' => 'descending'],
+                ['SortField' => 'MODIFIED'],
+                ['SortField' => 'CREATED'],
+                ['SortField' => 'SECTIONIDENTIFER'],
+                ['SortField' => 'PRIORITY'],
+            ],
+        ];
+
+        $result = $this->getParser()->parse($inputArray, $this->getParsingDispatcherMock());
+
+        $this->assertEquals(new Query\SortClause\ContentName(Query::SORT_ASC), $result->sortClauses[0]);
+        $this->assertEquals(new Query\SortClause\Location\Path(Query::SORT_DESC), $result->sortClauses[1]);
+        $this->assertEquals(new Query\SortClause\DateModified(Query::SORT_ASC), $result->sortClauses[2]);
+        $this->assertEquals(new Query\SortClause\DatePublished(Query::SORT_ASC), $result->sortClauses[3]);
+        $this->assertEquals(new Query\SortClause\SectionIdentifier(Query::SORT_ASC), $result->sortClauses[4]);
+        $this->assertEquals(new Query\SortClause\Location\Priority(Query::SORT_ASC), $result->sortClauses[5]);
+    }
+
+    /**
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\NotImplementedException
+     */
+    public function testParseFieldSortClause()
+    {
+        $inputArray = [
+            'Criteria' => [],
+            'SortClauses' => [
+                ['SortField' => 'FIELD'],
+            ],
+        ];
+
+        $this->getParser()->parse($inputArray, $this->getParsingDispatcherMock());
+    }
+
+    /**
+     * @return \eZ\Publish\Core\REST\Server\Input\Parser\ContentQuery
+     */
+    protected function internalGetParser()
+    {
+        return new ContentQuery();
+    }
+}


### PR DESCRIPTION
> Story: https://jira.ez.no/browse/EZP-24315
> Status: work in progress

This adds support for SortClause in queries from REST views.

It has only been manually tested on the `ContentName` clause.

Example curl call (REST auth in basic): 
```
curl -v -X POST http://admin:publish@localhost/api/ezp/v2/views --data @/tmp/ViewInput.xml -H 'Content-Type: application/vnd.ez.api.ViewInput+xml; version=1.1'
```

with `/tmp/ViewInput.xml`:
```
<?xml version="1.0" encoding="UTF-8"?>
<ViewInput>
  <identifier>ArticleTitleView</identifier>
  <ContentQuery>
    <Criteria>
      <AND>
        <ContentTypeIdentifierCriterion>article</ContentTypeIdentifierCriterion>
      </AND>
    </Criteria>
    <limit>10</limit>
    <offset>0</offset>
    <SortClauses>
      <SortClause>
        <SortField>NAME</SortField>
      </SortClause>
    </SortClauses>
  </ContentQuery>
</ViewInput>
```

## TODO
- [ ] Unit test the Query Input Parser, including SortClause parsing
- [ ] Specify direction support (not in the specs right now, currently uses `SortDirection` next to `SortField`