### PR TITLE
Implement EZP-23247: missing field type Indexable definitions

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/AuthorIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/AuthorIntegrationTest.php
@@ -541,4 +541,11 @@ class AuthorIntegrationTest extends SearchMultivaluedBaseIntegrationTest
             ),
         );
     }
+
+    protected function getFullTextIndexedFieldData()
+    {
+        return array(
+            array('Ferdinand', 'Greta'),
+        );
+    }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/FloatIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/FloatIntegrationTest.php
@@ -344,4 +344,11 @@ class FloatIntegrationTest extends SearchBaseIntegrationTest
     {
         return 25.59;
     }
+
+    protected function getFullTextIndexedFieldData()
+    {
+        return array(
+            array('25.519', '25.59'),
+        );
+    }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/IntegerIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/IntegerIntegrationTest.php
@@ -343,4 +343,11 @@ class IntegerIntegrationTest extends SearchBaseIntegrationTest
     {
         return 26;
     }
+
+    protected function getFullTextIndexedFieldData()
+    {
+        return array(
+            array('25', '26'),
+        );
+    }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/RichTextIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/RichTextIntegrationTest.php
@@ -640,4 +640,11 @@ EOT;
         // ensure case-insensitivity
         return strtoupper('truth suffers from too much analysis');
     }
+
+    protected function getFullTextIndexedFieldData()
+    {
+        return array(
+            array('mediocrity', 'analysis'),
+        );
+    }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/RichTextIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/RichTextIntegrationTest.php
@@ -22,7 +22,7 @@ use eZ\Publish\API\Repository\Values\Content\Content;
  * @group integration
  * @group field-type
  */
-class RichTextIntegrationTest extends RelationBaseIntegrationTest
+class RichTextIntegrationTest extends RelationSearchBaseIntegrationTest
 {
     /**
      * @var \DOMDocument
@@ -598,5 +598,46 @@ EOT;
             str_replace('[ObjectId]', $objectId, $expected),
             $test->getField('description')->value->xml->saveXML()
         );
+    }
+
+    protected function checkSearchEngineSupport()
+    {
+        if (ltrim(get_class($this->getSetupFactory()), '\\') === 'eZ\\Publish\\API\\Repository\\Tests\\SetupFactory\\Legacy') {
+            $this->markTestSkipped(
+                "'ezrichtext' field type is not searchable with Legacy Search Engine"
+            );
+        }
+    }
+
+    protected function getValidSearchValueOne()
+    {
+        return <<<EOT
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <para>caution is the path to mediocrity</para>
+</section>
+EOT;
+    }
+
+    protected function getSearchTargetValueOne()
+    {
+        // ensure case-insensitivity
+        return strtoupper('caution is the path to mediocrity');
+    }
+
+    protected function getValidSearchValueTwo()
+    {
+        return <<<EOT
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <para>truth suffers from too much analysis</para>
+</section>
+EOT;
+    }
+
+    protected function getSearchTargetValueTwo()
+    {
+        // ensure case-insensitivity
+        return strtoupper('truth suffers from too much analysis');
     }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/SelectionIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SelectionIntegrationTest.php
@@ -390,4 +390,11 @@ class SelectionIntegrationTest extends SearchMultivaluedBaseIntegrationTest
             ),
         );
     }
+
+    protected function getFullTextIndexedFieldData()
+    {
+        return array(
+            array('Bielefeld', 'Sindelfingen'),
+        );
+    }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/TextBlockIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/TextBlockIntegrationTest.php
@@ -341,4 +341,11 @@ class TextBlockIntegrationTest extends SearchBaseIntegrationTest
         // ensure case-insensitivity
         return strtoupper($this->getValidSearchValueTwo());
     }
+
+    protected function getFullTextIndexedFieldData()
+    {
+        return array(
+            array('path', 'analysis'),
+        );
+    }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/TextLineIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/TextLineIntegrationTest.php
@@ -339,7 +339,7 @@ class TextLineIntegrationTest extends SearchBaseIntegrationTest
 
     protected function getValidSearchValueOne()
     {
-        return 'a';
+        return 'aaa';
     }
 
     protected function getSearchTargetValueOne()
@@ -350,12 +350,19 @@ class TextLineIntegrationTest extends SearchBaseIntegrationTest
 
     protected function getValidSearchValueTwo()
     {
-        return 'b';
+        return 'bbb';
     }
 
     protected function getSearchTargetValueTwo()
     {
         // ensure case-insensitivity
         return strtoupper($this->getValidSearchValueTwo());
+    }
+
+    protected function getFullTextIndexedFieldData()
+    {
+        return array(
+            array('aaa', 'bbb'),
+        );
     }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/UrlIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/UrlIntegrationTest.php
@@ -364,4 +364,11 @@ class UrlIntegrationTest extends SearchBaseIntegrationTest
             ),
         );
     }
+
+    protected function getFullTextIndexedFieldData()
+    {
+        return array(
+            array('ample', 'example'),
+        );
+    }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/XmlTextIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/XmlTextIntegrationTest.php
@@ -640,4 +640,11 @@ EOT;
         // ensure case-insensitivity
         return strtoupper('truth suffers from too much analysis');
     }
+
+    protected function getFullTextIndexedFieldData()
+    {
+        return array(
+            array('mediocrity', 'analysis'),
+        );
+    }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/XmlTextIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/XmlTextIntegrationTest.php
@@ -23,7 +23,7 @@ use eZ\Publish\API\Repository\Values\Content\Content;
  * @group integration
  * @group field-type
  */
-class XmlTextIntegrationTest extends RelationBaseIntegrationTest
+class XmlTextIntegrationTest extends RelationSearchBaseIntegrationTest
 {
     /**
      * @var \DOMDocument
@@ -598,5 +598,46 @@ EOT
             $test->getField('intro')->value->xml->saveXML(),
             str_replace('[ObjectId]', $object_id, $expected)
         );
+    }
+
+    protected function checkSearchEngineSupport()
+    {
+        if (ltrim(get_class($this->getSetupFactory()), '\\') === 'eZ\\Publish\\API\\Repository\\Tests\\SetupFactory\\Legacy') {
+            $this->markTestSkipped(
+                "'ezxmltext' field type is not searchable with Legacy Search Engine"
+            );
+        }
+    }
+
+    protected function getValidSearchValueOne()
+    {
+        return <<<EOT
+<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
+    <paragraph>caution is the path to mediocrity</paragraph>
+</section>
+EOT;
+    }
+
+    protected function getSearchTargetValueOne()
+    {
+        // ensure case-insensitivity
+        return strtoupper('caution is the path to mediocrity');
+    }
+
+    protected function getValidSearchValueTwo()
+    {
+        return <<<EOT
+<?xml version="1.0" encoding="utf-8"?>
+<section xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/">
+    <paragraph>truth suffers from too much analysis</paragraph>
+</section>
+EOT;
+    }
+
+    protected function getSearchTargetValueTwo()
+    {
+        // ensure case-insensitivity
+        return strtoupper('truth suffers from too much analysis');
     }
 }

--- a/eZ/Publish/Core/FieldType/Author/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Author/SearchField.php
@@ -64,6 +64,11 @@ class SearchField implements Indexable
                 implode('-', $name),
                 new Search\FieldType\StringField()
             ),
+            new Search\Field(
+                'fulltext',
+                $name,
+                new Search\FieldType\FullTextField()
+            ),
         );
     }
 

--- a/eZ/Publish/Core/FieldType/Country/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Country/SearchField.php
@@ -36,6 +36,11 @@ class SearchField implements Indexable
                 $field->value->data,
                 new Search\FieldType\MultipleStringField()
             ),
+            new Search\Field(
+                'fulltext',
+                $field->value->data,
+                new Search\FieldType\FullTextField()
+            ),
         );
     }
 

--- a/eZ/Publish/Core/FieldType/Float/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Float/SearchField.php
@@ -36,6 +36,11 @@ class SearchField implements Indexable
                 $field->value->data,
                 new Search\FieldType\FloatField()
             ),
+            new Search\Field(
+                'fulltext',
+                $field->value->data,
+                new Search\FieldType\FullTextField()
+            ),
         );
     }
 

--- a/eZ/Publish/Core/FieldType/Integer/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Integer/SearchField.php
@@ -36,6 +36,11 @@ class SearchField implements Indexable
                 $field->value->data,
                 new Search\FieldType\IntegerField()
             ),
+            new Search\Field(
+                'fulltext',
+                $field->value->data,
+                new Search\FieldType\FullTextField()
+            ),
         );
     }
 

--- a/eZ/Publish/Core/FieldType/MapLocation/SearchField.php
+++ b/eZ/Publish/Core/FieldType/MapLocation/SearchField.php
@@ -44,6 +44,11 @@ class SearchField implements Indexable
                 ),
                 new Search\FieldType\GeoLocationField()
             ),
+            new Search\Field(
+                'fulltext',
+                $field->value->externalData['address'],
+                new Search\FieldType\FullTextField()
+            ),
         );
     }
 

--- a/eZ/Publish/Core/FieldType/Price/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Price/SearchField.php
@@ -38,6 +38,11 @@ class SearchField implements Indexable
                 $field->value->sortKey['sort_key_int'] / 1000,
                 new Search\FieldType\PriceField()
             ),
+            new Search\Field(
+                'fulltext',
+                $field->value->sortKey['sort_key_int'] / 1000,
+                new Search\FieldType\FullTextField()
+            ),
         );
     }
 

--- a/eZ/Publish/Core/FieldType/Relation/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Relation/SearchField.php
@@ -33,7 +33,7 @@ class SearchField implements Indexable
         return array(
             new Search\Field(
                 'value',
-                $field->value->data,
+                reset($field->value->data),
                 new Search\FieldType\StringField()
             ),
         );

--- a/eZ/Publish/Core/FieldType/RichText/SearchField.php
+++ b/eZ/Publish/Core/FieldType/RichText/SearchField.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\FieldType\RichText;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
+use eZ\Publish\SPI\FieldType\Indexable;
+use eZ\Publish\SPI\Search;
+use DOMDocument;
+use DOMNode;
+
+/**
+ * Indexable definition for RichText field type.
+ */
+class SearchField implements Indexable
+{
+    /**
+     * Get index data for field for search backend.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    public function getIndexData(Field $field, FieldDefinition $fieldDefinition)
+    {
+        $document = new DOMDocument();
+        $document->loadXML($field->value->data);
+
+        return array(
+            new Search\Field(
+                'value',
+                $this->extractShortText($document),
+                new Search\FieldType\StringField()
+            ),
+            new Search\Field(
+                'fulltext',
+                $this->extractText($document->documentElement),
+                new Search\FieldType\FullTextField()
+            ),
+        );
+    }
+
+    /**
+     * Extracts text content of the given $node.
+     *
+     * @param \DOMNode $node
+     *
+     * @return string
+     */
+    private function extractText(DOMNode $node)
+    {
+        $text = '';
+
+        if ($node->childNodes) {
+            foreach ($node->childNodes as $child) {
+                $text .= $this->extractText($child);
+            }
+        } else {
+            $text .= $node->nodeValue . ' ';
+        }
+
+        return $text;
+    }
+
+    /**
+     * Extracts short text content of the given $document.
+     *
+     * @param \DOMDocument $document
+     *
+     * @return string
+     */
+    private function extractShortText(DOMDocument $document)
+    {
+        $result = null;
+        if ($section = $document->documentElement->firstChild) {
+            $textDom = $section->firstChild;
+
+            if ($textDom && $textDom->hasChildNodes()) {
+                $result = $textDom->firstChild->textContent;
+            } elseif ($textDom) {
+                $result = $textDom->textContent;
+            }
+        }
+
+        if ($result === null) {
+            $result = $document->documentElement->textContent;
+        }
+
+        return trim($result);
+    }
+
+    /**
+     * Get index field types for search backend.
+     *
+     * @return \eZ\Publish\SPI\Search\FieldType[]
+     */
+    public function getIndexDefinition()
+    {
+        return array(
+            'value' => new Search\FieldType\StringField(),
+        );
+    }
+
+    /**
+     * Get name of the default field to be used for matching.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for matching. Default field is typically used by Field criterion.
+     *
+     * @return string
+     */
+    public function getDefaultMatchField()
+    {
+        return 'value';
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
+    }
+}

--- a/eZ/Publish/Core/FieldType/Selection/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Selection/SearchField.php
@@ -64,6 +64,11 @@ class SearchField implements Indexable
                 implode('-', $indexes),
                 new Search\FieldType\StringField()
             ),
+            new Search\Field(
+                'fulltext',
+                $values,
+                new Search\FieldType\FullTextField()
+            ),
         );
     }
 

--- a/eZ/Publish/Core/FieldType/TextBlock/SearchField.php
+++ b/eZ/Publish/Core/FieldType/TextBlock/SearchField.php
@@ -36,6 +36,11 @@ class SearchField implements Indexable
                 $field->value->data,
                 new Search\FieldType\StringField()
             ),
+            new Search\Field(
+                'fulltext',
+                $field->value->data,
+                new Search\FieldType\FullTextField()
+            ),
         );
     }
 

--- a/eZ/Publish/Core/FieldType/TextLine/SearchField.php
+++ b/eZ/Publish/Core/FieldType/TextLine/SearchField.php
@@ -36,6 +36,11 @@ class SearchField implements Indexable
                 $field->value->data,
                 new Search\FieldType\StringField()
             ),
+            new Search\Field(
+                'fulltext',
+                $field->value->data,
+                new Search\FieldType\FullTextField()
+            ),
         );
     }
 

--- a/eZ/Publish/Core/FieldType/Url/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Url/SearchField.php
@@ -43,8 +43,13 @@ class SearchField implements Indexable
             ),
             new Search\Field(
                 'value_text',
-                isset($field->value->data['text']) ? $field->value->data['text'] : '',
+                $text = (isset($field->value->data['text']) ? $field->value->data['text'] : ''),
                 new Search\FieldType\StringField()
+            ),
+            new Search\Field(
+                'fulltext',
+                $text,
+                new Search\FieldType\FullTextField()
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/XmlText/SearchField.php
+++ b/eZ/Publish/Core/FieldType/XmlText/SearchField.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\FieldType\XmlText;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
+use eZ\Publish\SPI\FieldType\Indexable;
+use eZ\Publish\SPI\Search;
+use DOMDocument;
+use DOMNode;
+
+/**
+ * Indexable definition for XmlText field type.
+ */
+class SearchField implements Indexable
+{
+    /**
+     * Get index data for field for search backend.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDefinition
+     *
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    public function getIndexData(Field $field, FieldDefinition $fieldDefinition)
+    {
+        $document = new DOMDocument();
+        $document->loadXML($field->value->data);
+
+        return array(
+            new Search\Field(
+                'value',
+                $this->extractShortText($document),
+                new Search\FieldType\StringField()
+            ),
+            new Search\Field(
+                'fulltext',
+                $this->extractText($document->documentElement),
+                new Search\FieldType\FullTextField()
+            ),
+        );
+    }
+
+    /**
+     * Extracts text content of the given $node.
+     *
+     * @param \DOMNode $node
+     *
+     * @return string
+     */
+    private function extractText(DOMNode $node)
+    {
+        $text = '';
+
+        if ($node->childNodes) {
+            foreach ($node->childNodes as $child) {
+                $text .= $this->extractText($child);
+            }
+        } else {
+            $text .= $node->nodeValue . ' ';
+        }
+
+        return $text;
+    }
+
+    /**
+     * Extracts short text content of the given $document.
+     *
+     * @param \DOMDocument $document
+     *
+     * @return string
+     */
+    private function extractShortText(DOMDocument $document)
+    {
+        $result = null;
+        if ($section = $document->documentElement->firstChild) {
+            $textDom = $section->firstChild;
+
+            if ($textDom && $textDom->hasChildNodes()) {
+                $result = $textDom->firstChild->textContent;
+            } elseif ($textDom) {
+                $result = $textDom->textContent;
+            }
+        }
+
+        if ($result === null) {
+            $result = $document->documentElement->textContent;
+        }
+
+        return trim($result);
+    }
+
+    /**
+     * Get index field types for search backend.
+     *
+     * @return \eZ\Publish\SPI\Search\FieldType[]
+     */
+    public function getIndexDefinition()
+    {
+        return array(
+            'value' => new Search\FieldType\StringField(),
+        );
+    }
+
+    /**
+     * Get name of the default field to be used for matching.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for matching. Default field is typically used by Field criterion.
+     *
+     * @return string
+     */
+    public function getDefaultMatchField()
+    {
+        return 'value';
+    }
+
+    /**
+     * Get name of the default field to be used for sorting.
+     *
+     * As field types can index multiple fields (see MapLocation field type's
+     * implementation of this interface), this method is used to define default
+     * field for sorting. Default field is typically used by Field sort clause.
+     *
+     * @return string
+     */
+    public function getDefaultSortField()
+    {
+        return $this->getDefaultMatchField();
+    }
+}

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/FieldValueMapper/MultipleStringMapper.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/FieldValueMapper/MultipleStringMapper.php
@@ -10,7 +10,7 @@
  */
 namespace eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper;
 
-use eZ\Publish\SPI\Search\FieldType\MultipleStringField;
+use eZ\Publish\SPI\Search\FieldType;
 use eZ\Publish\SPI\Search\Field;
 
 /**
@@ -27,7 +27,9 @@ class MultipleStringMapper extends StringMapper
      */
     public function canMap(Field $field)
     {
-        return $field->type instanceof MultipleStringField;
+        return
+            $field->type instanceof FieldType\MultipleStringField ||
+            $field->type instanceof FieldType\FullTextField;
     }
 
     /**

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/FieldValueMapper/StringMapper.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/FieldValueMapper/StringMapper.php
@@ -13,7 +13,6 @@ namespace eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper;
 use eZ\Publish\Core\Search\Elasticsearch\Content\FieldValueMapper;
 use eZ\Publish\SPI\Search\FieldType;
 use eZ\Publish\SPI\Search\Field;
-use DOMDocument;
 
 /**
  * Maps raw document field values to something Elasticsearch can index.
@@ -56,6 +55,6 @@ class StringMapper extends FieldValueMapper
     protected function convert($value)
     {
         // Remove non-printable characters
-        return preg_replace('([\x00-\x09\x0B\x0C\x1E\x1F]+)', '', $value instanceof DOMDocument ? $value->saveXML() : $value);
+        return preg_replace('([\x00-\x09\x0B\x0C\x1E\x1F]+)', '', (string)$value);
     }
 }

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Mapper/StandardMapper.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Mapper/StandardMapper.php
@@ -328,10 +328,7 @@ class StandardMapper implements MapperInterface
                             $indexField->type
                         );
 
-                        if (
-                            $indexField->type instanceof FieldType\StringField ||
-                            $indexField->type instanceof FieldType\MultipleStringField
-                        ) {
+                        if ($indexField->type instanceof FieldType\FullTextField) {
                             $fields[] = new Field(
                                 $name . '_meta_all_' . str_replace('-', '_', $languageCode),
                                 $indexField->value,

--- a/eZ/Publish/Core/settings/indexable_fieldtypes.yml
+++ b/eZ/Publish/Core/settings/indexable_fieldtypes.yml
@@ -1,6 +1,8 @@
 parameters:
     ezpublish.fieldType.indexable.ezauthor.class: eZ\Publish\Core\FieldType\Author\SearchField
     ezpublish.fieldType.indexable.ezstring.class: eZ\Publish\Core\FieldType\TextLine\SearchField
+    ezpublish.fieldType.indexable.ezxmltext.class: eZ\Publish\Core\FieldType\XmlText\SearchField
+    ezpublish.fieldType.indexable.ezrichtext.class: eZ\Publish\Core\FieldType\RichText\SearchField
     ezpublish.fieldType.indexable.eztext.class: eZ\Publish\Core\FieldType\TextBlock\SearchField
     ezpublish.fieldType.indexable.ezisbn.class: eZ\Publish\Core\FieldType\ISBN\SearchField
     ezpublish.fieldType.indexable.ezboolean.class: eZ\Publish\Core\FieldType\Checkbox\SearchField
@@ -103,15 +105,13 @@ services:
         tags:
             - {name: ezpublish.fieldType.indexable, alias: ezdatetime}
 
-    # TODO: define proper type
     ezpublish.fieldType.indexable.ezxmltext:
-        class: %ezpublish.fieldType.indexable.ezstring.class%
+        class: %ezpublish.fieldType.indexable.ezxmltext.class%
         tags:
             - {name: ezpublish.fieldType.indexable, alias: ezxmltext}
 
-    # TODO: define proper type
     ezpublish.fieldType.indexable.ezrichtext:
-        class: %ezpublish.fieldType.indexable.ezstring.class%
+        class: %ezpublish.fieldType.indexable.ezrichtext.class%
         tags:
             - {name: ezpublish.fieldType.indexable, alias: ezrichtext}
 

--- a/eZ/Publish/Core/settings/search_engines/common.yml
+++ b/eZ/Publish/Core/settings/search_engines/common.yml
@@ -21,6 +21,7 @@ parameters:
         ez_currency: 'c'
         ez_geolocation: 'gl'
         ez_document: 'doc'
+        ez_fulltext: 'fulltext'
 
 services:
     # Note: services tagged with 'ezpublish.fieldType.indexable'

--- a/eZ/Publish/SPI/Search/FieldType/FullTextField.php
+++ b/eZ/Publish/SPI/Search/FieldType/FullTextField.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\SPI\Search\FieldType;
+
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Full text document field.
+ */
+class FullTextField extends FieldType
+{
+    /**
+     * The type name of the facet. Has to be handled by the solr schema.
+     *
+     * @var string
+     */
+    protected $type = 'ez_fulltext';
+}


### PR DESCRIPTION
> #### This PR resolves https://jira.ez.no/browse/EZP-23247
> #### Review with https://github.com/ezsystems/ezplatform-solr-search-engine/pull/21

This implements `Indexable`s for `XmlText` and `RichText` field types.
Previously these were handled by `TextLine` implementation of `Indexable`.

Implementing this properly required separately indexing field type value as string field and as full text field.
String field indexes shortened variant of the field value, while full text field indexes complete text content of the field value. This is achieved by using new SPI search field type `FullText`. Fields of this type, in both Solr and Elasticsearch, are not stored, but instead copied to the real full text field.
This gives better control of what goes into full text index than was the case previously. Explicit copying of all text fields (string, text and HTML) to the full text field is removed.

Existing field types are updated to use new `FullText` search backend field type.

#### Additionaly fixed

* removed handling of `DOMDocument` from string field value mapper (cleanup after merge of https://github.com/ezsystems/ezpublish-kernel/pull/262)
* Relation field type's `Indexable` definition was passing an array of strings

#### TODOs

- [x] Add new cases to field type search tests