### PR TITLE
Fix EZP-24862: Expose available repository policies

### DIFF
--- a/doc/specifications/security/policies_extensibility.md
+++ b/doc/specifications/security/policies_extensibility.md
@@ -1,0 +1,81 @@
+# Expose custom policies to the repository
+
+> Added in 6.0 / 2015.09
+
+## Description
+
+eZ content repository uses the concept of roles and policies in order to authorize a user to do something (e.g. read content).
+
+* A role is composed of policies and can be assigned to a user or a user group.
+* A policy is composed of a combination of **module** and **function** (e.g. `content/read`, `content` being the module
+  and `read` being the function).
+* Depending on **module** and **function** combination, a policy can also be composed of limitations.
+
+It is possible for any bundle to expose available policies via a `PolicyProvider` which can be added to EzPublishCoreBundle's DIC extension.
+
+## PolicyProvider
+
+A `PolicyProvider` is an object providing a hash containing declared modules, functions and limitations.
+
+* Each policy provider provides a collection of permission *modules*.
+* Each module can provide *functions* (e.g. "content/read": "content" is the module, "read" is the function)
+* Each function can provide a collection of limitations.
+
+Limitations need to be implemented as *limitation types* and declared as services identified with `ezpublish.limitationType` tag.
+
+### Example
+
+```php
+namespace Acme\FooBundle\AcmeFooBundle\Security;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigBuilderInterface;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider\PolicyProviderInterface;
+
+class MyPolicyProvider implements PolicyProviderInterface
+{
+    public function addPolicies(ConfigBuilderInterface $configBuilder)
+    {
+        $configBuilder->addConfig([
+             "custom_module" => [
+                 "custom_function_1" => null,
+                 "custom_function_2" => ["CustomLimitation"],
+             ],
+         ]);
+    }
+}
+```
+
+### YamlPolicyProvider
+An abstract class based on YAML is provided: `eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider\YamlPolicyProvider`.
+It defines an abstract `getFiles()` method. Implement it to return absolute paths to your YAML files.
+
+### Extending existing policies
+A PolicyProvider may provide new functions to a module, and additional limitations to an existing function.
+**It is however strongly encouraged to add functions to your own policy modules.**
+
+Note that it is not possible to remove an existing module, function or limitation.
+
+## Integrating the PolicyProvider into CoreBundle
+A bundle just has to to retrieve CoreBundle's DIC extension and call `addPolicyProvider()`. 
+This must be done in bundle's `build()` method.
+
+```php
+namespace Acme\FooBundle\AcmeFooBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class AcmeFooBundle extends Bundle
+{
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $eZExtension = $container->getExtension('ezpublish');
+        $eZExtension->addPolicyProvider(new MyPolicyProvider());
+    }
+}
+```
+
+## Core policies
+Policies used internally in repository services are defined in `EzPublishCoreBundle/Resources/config/policies.yml`.
+

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigBuilderInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigBuilderInterface.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration;
+
+use Symfony\Component\Config\Resource\ResourceInterface;
+
+/**
+ * Interface for config builders.
+ * Config builders can be used to add/extend configuration.
+ */
+interface ConfigBuilderInterface
+{
+    /**
+     * Adds config to the builder.
+     *
+     * @param array $config
+     */
+    public function addConfig(array $config);
+
+    /**
+     * Adds given resource, which would typically be added to container resources.
+     *
+     * @param ResourceInterface $resource
+     */
+    public function addResource(ResourceInterface $resource);
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ContainerConfigBuilder.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ContainerConfigBuilder.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+abstract class ContainerConfigBuilder implements ConfigBuilderInterface
+{
+    /**
+     * @var ContainerBuilder
+     */
+    protected $containerBuilder;
+
+    public function __construct(ContainerBuilder $containerBuilder)
+    {
+        $this->containerBuilder = $containerBuilder;
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/PolicyProvider/PoliciesConfigBuilder.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/PolicyProvider/PoliciesConfigBuilder.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ContainerConfigBuilder;
+use Symfony\Component\Config\Resource\ResourceInterface;
+
+class PoliciesConfigBuilder extends ContainerConfigBuilder
+{
+    public function addConfig(array $config)
+    {
+        $policyMap = [];
+        if ($this->containerBuilder->hasParameter('ezpublish.api.role.policy_map')) {
+            $policyMap = $this->containerBuilder->getParameter('ezpublish.api.role.policy_map');
+        }
+
+        $this->containerBuilder->setParameter(
+            'ezpublish.api.role.policy_map',
+            array_merge_recursive($policyMap, $config)
+        );
+    }
+
+    public function addResource(ResourceInterface $resource)
+    {
+        $this->containerBuilder->addResource($resource);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/PolicyProvider/PolicyProviderInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/PolicyProvider/PolicyProviderInterface.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigBuilderInterface;
+
+/**
+ * Interface for DIC extensions which provide policies to be exposed for permissions in the Repository.
+ *
+ * Each policy provider provides a collection of permission "modules".
+ * Each module can provide "functions".
+ * E.g. "content/read": "content" is the module, "read" is the function.
+ *
+ * Each function can provide a collection of limitations.
+ * These need to be implemented as "limitation types" and declared as services with "ezpublish.limitationType" service tag.
+ * Limitation types also provide value objects based on \eZ\Publish\API\Repository\Values\User\Limitation abstract class.
+ *
+ * @since 6.0
+ */
+interface PolicyProviderInterface
+{
+    /**
+     * Adds policies configuration hash to $configBuilder.
+     *
+     * Policies configuration hash contains declared modules, functions and limitations.
+     * First level key is the module name, value is a hash of available functions, with function name as key.
+     * Function value is an array of available limitations, identified by the alias declared in LimitationType service tag.
+     * If no limitation is provided, value can be null.
+     *
+     * Example:
+     *
+     * ```php
+     * [
+     *     "content" => [
+     *         "read" => ["Class", "ParentClass", "Node", "Language"],
+     *         "edit" => ["Class", "ParentClass", "Language"]
+     *     ],
+     *     "custom_module" => [
+     *         "custom_function_1" => null,
+     *         "custom_function_2" => ["CustomLimitation"]
+     *     ],
+     * ]
+     * ```
+     *
+     * Equivalent in YAML:
+     *
+     * ```yaml
+     * content:
+     *     read: [Class, ParentClass, Node, Language]
+     *     edit: [Class, ParentClass, Language]
+     *     # ...
+     *
+     * custom_module:
+     *     custom_function_1: ~
+     *     custom_function_2: [CustomLimitation]
+     * ```
+     *
+     * @return array
+     */
+    public function addPolicies(ConfigBuilderInterface $configBuilder);
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/PolicyProvider/RepositoryPolicyProvider.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/PolicyProvider/RepositoryPolicyProvider.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider;
+
+class RepositoryPolicyProvider extends YamlPolicyProvider
+{
+    public function getFiles()
+    {
+        return [__DIR__ . '/../../../Resources/config/policies.yml'];
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/PolicyProvider/YamlPolicyProvider.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/PolicyProvider/YamlPolicyProvider.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigBuilderInterface;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * YAML based policy provider.
+ */
+abstract class YamlPolicyProvider implements PolicyProviderInterface
+{
+    public function addPolicies(ConfigBuilderInterface $configBuilder)
+    {
+        $policiesConfig = [];
+        foreach ($this->getFiles() as $file) {
+            $configBuilder->addResource(new FileResource($file));
+            $policiesConfig = array_merge_recursive($policiesConfig, Yaml::parse(file_get_contents($file)));
+        }
+
+        $configBuilder->addConfig($policiesConfig);
+    }
+
+    /**
+     * Returns an array of files where the policy configuration lies.
+     * Each file path MUST be absolute.
+     *
+     * Example:
+     *
+     * ```php
+     * return [__DIR__ . '/../Resources/config/policies.yml'];
+     * ```
+     *
+     * @return array
+     */
+    abstract protected function getFiles();
+}

--- a/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
@@ -35,6 +35,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\RichTextHtml5Conv
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\StorageConnectionPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ComplexSettings\ComplexSettingParser;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\DynamicSettingParser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider\RepositoryPolicyProvider;
 use eZ\Publish\Core\Base\Container\Compiler\FieldTypeCollectionPass;
 use eZ\Publish\Core\Base\Container\Compiler\RegisterLimitationTypePass;
 use eZ\Publish\Core\Base\Container\Compiler\Storage\ExternalStorageRegistryPass;
@@ -119,6 +120,8 @@ class EzPublishCoreBundle extends Bundle
                     new ConfigParser\IO(new ComplexSettingParser()),
                 )
             );
+
+            $this->extension->addPolicyProvider(new RepositoryPolicyProvider());
         }
 
         return $this->extension;

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/policies.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/policies.yml
@@ -1,0 +1,53 @@
+content:
+    read: [Class, Section, Owner, Group, Node, Subtree, State]
+    diff: [Class, Section, Owner, Node, Subtree]
+    view_embed: [Class, Section, Owner, Node, Subtree]
+    create: [Class, Section, ParentOwner, ParentGroup, ParentClass, ParentDepth, Node, Subtree, Language]
+    edit: [Class, Section, Owner, Group, Node, Subtree, Language, State]
+    manage_locations: [Class, Section, Owner, Subtree]
+    hide: [Class, Section, Owner, Group, Node, Subtree, Language]
+    reverserelatedlist: ~
+    translate: [Class, Section, Owner, Node, Subtree, Language]
+    remove: [Class, Section, Owner, Node, Subtree, State]
+    versionread: [Class, Section, Owner, Node, Subtree]
+    versionremove: [Class, Section, Owner, Node, Subtree]
+    translations: ~
+    urltranslator: ~
+    pendinglist: ~
+    restore: ~
+    cleantrash: ~
+
+class:
+    update: ~
+    create: ~
+    delete: ~
+
+state:
+    assign: [Class, Section, Owner, Group, Node, Subtree, NewState]
+    administrate: ~
+
+role:
+    assign: ~
+    update: ~
+    create: ~
+    delete: ~
+    read: ~
+
+section:
+    assign: [Class, Section, Owner, NewSection]
+    edit: ~
+    view: ~
+
+setup:
+    administrate: ~
+    install: ~
+    setup: ~
+    system_info: ~
+
+user:
+    login: [SiteAccess]
+    password: ~
+    preferences: ~
+    register: ~
+    selfedit: ~
+    activation: ~

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Fixtures/policies1.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Fixtures/policies1.yml
@@ -1,0 +1,7 @@
+custom_module:
+    custom_function_1: ~
+    custom_function_2:  ['CustomLimitation']
+
+helloworld:
+    foo: ['bar']
+    baz: ~

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Fixtures/policies2.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Fixtures/policies2.yml
@@ -1,0 +1,6 @@
+custom_module2:
+    custom_function_3: ~
+    custom_function_4: ['CustomLimitation2', 'CustomLimitation3']
+
+helloworld:
+    some: ['thingy', 'thing', 'but', 'wait']

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Security/PolicyProvider/PoliciesConfigBuilderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Security/PolicyProvider/PoliciesConfigBuilderTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Security\PolicyProvider;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider\PoliciesConfigBuilder;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Config\Resource\DirectoryResource;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class PoliciesConfigBuilderTest extends PHPUnit_Framework_TestCase
+{
+    public function testAddConfig()
+    {
+        $containerBuilder = new ContainerBuilder();
+        $configBuilder = new PoliciesConfigBuilder($containerBuilder);
+        $config1 = ['foo' => ['bar' => null]];
+        $config2 = ['some' => ['thing' => ['limitation']]];
+        $expected = [
+            'foo' => ['bar' => null],
+            'some' => ['thing' => ['limitation']],
+        ];
+        $configBuilder->addConfig($config1);
+        $configBuilder->addConfig($config2);
+
+        self::assertSame($expected, $containerBuilder->getParameter('ezpublish.api.role.policy_map'));
+    }
+
+    public function testAddResource()
+    {
+        $containerBuilder = new ContainerBuilder();
+        $configBuilder = new PoliciesConfigBuilder($containerBuilder);
+        $resource1 = new FileResource(__FILE__);
+        $resource2 = new DirectoryResource(__DIR__);
+        $configBuilder->addResource($resource1);
+        $configBuilder->addResource($resource2);
+
+        self::assertSame([$resource1, $resource2], $containerBuilder->getResources());
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Security/PolicyProvider/YamlPolicyProviderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Security/PolicyProvider/YamlPolicyProviderTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Security\PolicyProvider;
+
+use eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub\StubYamlPolicyProvider;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Config\Resource\FileResource;
+
+class YamlPolicyProviderTest extends PHPUnit_Framework_TestCase
+{
+    public function testSingleYaml()
+    {
+        $files = [__DIR__ . '/../../Fixtures/policies1.yml'];
+        $provider = new StubYamlPolicyProvider($files);
+        $expectedConfig = [
+            'custom_module' => [
+                'custom_function_1' => null,
+                'custom_function_2' => ['CustomLimitation'],
+            ],
+            'helloworld' => [
+                'foo' => ['bar'],
+                'baz' => null,
+            ],
+        ];
+
+        $configBuilder = $this->getMock('\eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigBuilderInterface');
+        foreach ($files as $file) {
+            $configBuilder
+                ->expects($this->once())
+                ->method('addResource')
+                ->with($this->equalTo(new FileResource($file)));
+        }
+        $configBuilder
+            ->expects($this->once())
+            ->method('addConfig')
+            ->with($expectedConfig);
+
+        $provider->addPolicies($configBuilder);
+    }
+
+    public function testMultipleYaml()
+    {
+        $file1 = __DIR__ . '/../../Fixtures/policies1.yml';
+        $file2 = __DIR__ . '/../../Fixtures/policies2.yml';
+        $files = [$file1, $file2];
+        $provider = new StubYamlPolicyProvider($files);
+        $expectedConfig = [
+            'custom_module' => [
+                'custom_function_1' => null,
+                'custom_function_2' => ['CustomLimitation'],
+            ],
+            'helloworld' => [
+                'foo' => ['bar'],
+                'baz' => null,
+                'some' => ['thingy', 'thing', 'but', 'wait'],
+            ],
+            'custom_module2' => [
+                'custom_function_3' => null,
+                'custom_function_4' => ['CustomLimitation2', 'CustomLimitation3'],
+            ],
+        ];
+
+        $configBuilder = $this->getMock('\eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigBuilderInterface');
+        $configBuilder
+            ->expects($this->exactly(count($files)))
+            ->method('addResource')
+            ->willReturnMap([
+                [$this->equalTo(new FileResource($file1)), null],
+                [$this->equalTo(new FileResource($file2)), null],
+            ]);
+        $configBuilder
+            ->expects($this->once())
+            ->method('addConfig')
+            ->with($expectedConfig);
+
+        $provider->addPolicies($configBuilder);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/StubPolicyProvider.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/StubPolicyProvider.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigBuilderInterface;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider\PolicyProviderInterface;
+
+/**
+ * For tests only!!!
+ * Dummy policy provider that does return policies it's given in constructor.
+ */
+class StubPolicyProvider implements PolicyProviderInterface
+{
+    /**
+     * @var array
+     */
+    private $policies;
+
+    public function __construct(array $policies)
+    {
+        $this->policies = $policies;
+    }
+
+    public function addPolicies(ConfigBuilderInterface $configBuilder)
+    {
+        $configBuilder->addConfig($this->policies);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/StubYamlPolicyProvider.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/StubYamlPolicyProvider.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider\YamlPolicyProvider;
+
+class StubYamlPolicyProvider extends YamlPolicyProvider
+{
+    /**
+     * @var array
+     */
+    private $files;
+
+    public function __construct(array $files)
+    {
+        $this->files = $files;
+    }
+
+    protected function getFiles()
+    {
+        return $this->files;
+    }
+}

--- a/eZ/Publish/Core/settings/roles.yml
+++ b/eZ/Publish/Core/settings/roles.yml
@@ -17,6 +17,8 @@ parameters:
     ezpublish.api.role.limitation_type.user_group.class: eZ\Publish\Core\Limitation\UserGroupLimitationType
     ezpublish.api.role.limitation_type.status.class: eZ\Publish\Core\Limitation\StatusLimitationType
 
+    ezpublish.api.role.policy_map: {}
+
 services:
     ## Implemented Limitations
     ezpublish.api.role.limitation_type.content_type:


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24862

This patch makes it possible for any bundle to expose available policies checkable against repository with a user. It introduces the concept of `PolicyProvider` which can be added to EzPublishCoreBundle's DIC extension.

## PolicyProvider
A `PolicyProvider` is an object providing a hash containing declared modules, functions and limitations.
* Each policy provider provides a collection of permission *modules*.
* Each module can provide *functions* (e.g. "content/read": "content" is the module, "read" is the function)
* Each function can provide a collection of limitations.

Limitations need to be implemented as *limitation types* and declared as services (already in place).

### Example

```php
namespace Acme\FooBundle\AcmeFooBundle\Security;

use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigBuilderInterface;
use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider\PolicyProviderInterface;

class MyPolicyProvider implements PolicyProviderInterface
{
    public function addPolicies(ConfigBuilderInterface $configBuilder)
    {
        $configBuilder->addConfig([
             "custom_module" => [
                 "custom_function_1" => null,
                  "custom_function_2" => ["CustomLimitation"]
             ],
         ]);
    }
}
```

### YamlPolicyProvider
An abstract class based on YAML is provided: `eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider\YamlPolicyProvider`.
It defines an abstract `getFiles()` method. Implement it to return absolute paths to your YAML files.

## Integrating the PolicyProvider into CoreBundle
A bundle just has to to retrieve CoreBundle's DIC extension and call `addPolicyProvider()`. This must be done in bundle's `build()` method.

```php
namespace Acme\FooBundle\AcmeFooBundle;

use Symfony\Component\HttpKernel\Bundle\Bundle;

class AcmeFooBundle extends Bundle
{
    public function build(ContainerBuilder $container)
    {
        parent::build($container);

        $eZExtension = $container->getExtension('ezpublish');
        $eZExtension->addPolicyProvider(new MyPolicyProvider());
    }
}
```

## Core policies
Policies used internally in repository services have been added and configured like they were in legacy.