### PR TITLE
Fix EZP-24867: undefined offset when trying to build object from SPI

### DIFF
--- a/eZ/Publish/Core/Repository/Helper/DomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/DomainMapper.php
@@ -136,6 +136,11 @@ class DomainMapper
 
         $fields = array();
         foreach ($spiFields as $spiField) {
+            // We ignore fields in content not part of the content type
+            if (!isset($fieldIdentifierMap[$spiField->fieldDefinitionId])) {
+                continue;
+            }
+
             $fields[] = new Field(
                 array(
                     'id' => $spiField->id,


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24867

It appears when SPI has more fields than current content type definition