### PR TITLE
Deprecated location view in ViewController

### DIFF
--- a/doc/bc/changes-6.0.md
+++ b/doc/bc/changes-6.0.md
@@ -185,6 +185,30 @@ Changes affecting version compatibility with former or future versions.
 * Some methods have been deprecated in `eZ/Publish/API/Repository/RoleService`: `updateRole`, `addPolicy`,
   `removePolicy`, `deletePolicy`, and `updatePolicy`. Use the corresponding `*Draft` and `*ByRoleDraft` methods instead.
 
+* The `viewLocation` and `embedLocation` controller actions are deprecated. `viewContent` and `embedContent` can be used
+  instead, with the location as an extra parameter.
+  The corresponding `location_view` configuration is also deprecated. It will transparently be converted to `content_view`,
+  but you should update your configuration:
+  ```
+  location_view:
+    full:
+      article:
+        match:
+          Identifier\ContentType: [article]
+  ```
+  becomes:
+  ```
+  content_view:
+    full:
+      article:
+        match:
+          Identifier\ContentType: [article]
+  ```
+
+  Rules that use a custom location view controller can't be transparently changed.
+  Those need to be changed to custom content view controllers, that use a contentId instead of a locationId as an
+  argument. The location is available in the `$parameters` array.
+
 ## Removed features
 
 * `getLegacyKernel()` shorthand method in `eZ\Bundle\EzPublishCoreBundle\Controller` has been removed.

--- a/eZ/Bundle/EzPublishCoreBundle/Converter/RepositoryParamConverter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Converter/RepositoryParamConverter.php
@@ -8,13 +8,9 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Converter;
 
-use eZ\Publish\API\Repository\Exceptions\NotFoundException;
-use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 abstract class RepositoryParamConverter implements ParamConverterInterface
 {
@@ -39,9 +35,6 @@ abstract class RepositoryParamConverter implements ParamConverterInterface
      * @param Request $request
      * @param ParamConverter $configuration
      *
-     * @throws NotFoundHttpException if value object was not found
-     * @throws AccessDeniedHttpException if user is not allowed to load the value object
-     *
      * @return bool
      */
     public function apply(Request $request, ParamConverter $configuration)
@@ -55,14 +48,8 @@ abstract class RepositoryParamConverter implements ParamConverterInterface
             return false;
         }
 
-        try {
-            $request->attributes->set($configuration->getName(), $this->loadValueObject($valueObjectId));
+        $request->attributes->set($configuration->getName(), $this->loadValueObject($valueObjectId));
 
-            return true;
-        } catch (NotFoundException $e) {
-            throw new NotFoundHttpException('Requested values not found', $e);
-        } catch (UnauthorizedException $e) {
-            throw new AccessDeniedHttpException('Access to values denied', $e);
-        }
+        return true;
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/BlockViewPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/BlockViewPass.php
@@ -15,8 +15,10 @@ namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
  * This includes adding BlockViewProvider implementations.
  *
  * @see \eZ\Publish\Core\MVC\Symfony\View\Manager
+ *
+ * @deprecated since 6.0
  */
-class BlockViewPass extends ViewPass
+class BlockViewPass extends ViewManagerPass
 {
     const VIEW_PROVIDER_IDENTIFIER = 'ezpublish.block_view_provider';
     const ADD_VIEW_PROVIDER_METHOD = 'addBlockViewProvider';

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ContentViewPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ContentViewPass.php
@@ -16,8 +16,10 @@ namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
  *
  * @see \eZ\Publish\Core\MVC\Symfony\View\Manager
  * @see \eZ\Publish\Core\MVC\Symfony\View\ContentViewProvider
+ *
+ * @deprecated since 6.0
  */
-class ContentViewPass extends ViewPass
+class ContentViewPass extends ViewManagerPass
 {
     const VIEW_PROVIDER_IDENTIFIER = 'ezpublish.content_view_provider';
     const ADD_VIEW_PROVIDER_METHOD = 'addContentViewProvider';

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/LocationViewPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/LocationViewPass.php
@@ -16,8 +16,10 @@ namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
  *
  * @see \eZ\Publish\Core\MVC\Symfony\View\Manager
  * @see \eZ\Publish\Core\MVC\Symfony\View\ContentViewProvider
+ *
+ * @deprecated since 6.0
  */
-class LocationViewPass extends ViewPass
+class LocationViewPass extends ViewManagerPass
 {
     const VIEW_PROVIDER_IDENTIFIER = 'ezpublish.location_view_provider';
     const ADD_VIEW_PROVIDER_METHOD = 'addLocationViewProvider';

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ViewManagerPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ViewManagerPass.php
@@ -20,8 +20,10 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @see \eZ\Publish\Core\MVC\Symfony\View\Manager
  * @see \eZ\Publish\Core\MVC\Symfony\View\ContentViewProvider
+ *
+ * @deprecated since 6.0
  */
-abstract class ViewPass implements CompilerPassInterface
+abstract class ViewManagerPass implements CompilerPassInterface
 {
     /**
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ViewProvidersPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ViewProvidersPass.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * File containing the ViewPass class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
+
+use LogicException;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Registers services tagged as ezpublish.view_provider into the view_provider registry.
+ */
+class ViewProvidersPass implements CompilerPassInterface
+{
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $rawViewProviders = [];
+        foreach ($container->findTaggedServiceIds('ezpublish.view_provider') as $serviceId => $tags) {
+            foreach ($tags as $attributes) {
+                // Priority range is between -255 (the lowest) and 255 (the highest)
+                $priority = isset($attributes['priority']) ? max(min((int)$attributes['priority'], 255), -255) : 0;
+
+                if (!isset($attributes['type'])) {
+                    throw new LogicException("Missing mandatory attribute 'type' for ezpublish.view_provider tag");
+                }
+                $type = $attributes['type'];
+
+                $rawViewProviders[$type][$priority][] = new Reference($serviceId);
+            }
+        }
+
+        $viewProviders = [];
+        foreach ($rawViewProviders as $type => $viewProvidersPerPriority) {
+            krsort($viewProvidersPerPriority);
+            foreach ($viewProvidersPerPriority as $priorityViewProviders) {
+                if (!isset($viewProviders[$type])) {
+                    $viewProviders[$type] = [];
+                }
+                $viewProviders[$type] = array_merge($viewProviders[$type], $priorityViewProviders);
+            }
+        }
+
+        if ($container->hasDefinition('ezpublish.view.type_provider_registry')) {
+            $container->getDefinition('ezpublish.view.type_provider_registry')->addMethodCall(
+                'addViewProviders',
+                [$viewProviders]
+            );
+        }
+
+        // 5.4.5 BC service after location view deprecation
+        if ($container->hasDefinition('ezpublish.view.custom_location_controller_checker')) {
+            $container->getDefinition('ezpublish.view.custom_location_controller_checker')->addMethodCall(
+                'addViewProviders',
+                [$viewProviders['eZ\Publish\API\Repository\Values\Content\Location']]
+            );
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/LocationView.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/LocationView.php
@@ -10,8 +10,46 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;
 
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+
 class LocationView extends View
 {
     const NODE_KEY = 'location_view';
     const INFO = 'Template selection settings when displaying a location';
+
+    public function preMap(array $config, ContextualizerInterface $contextualizer)
+    {
+        $scopes = array_merge(
+            [ConfigResolver::SCOPE_DEFAULT, ConfigResolver::SCOPE_GLOBAL],
+            $config['siteaccess']['list'],
+            array_keys($config['siteaccess']['groups'])
+        );
+
+        foreach ($scopes as $scope) {
+            if (!isset($config[$contextualizer->getSiteAccessNodeName()][$scope][static::NODE_KEY])) {
+                continue;
+            }
+
+            $locationViewConfig =& $config[$contextualizer->getSiteAccessNodeName()][$scope][static::NODE_KEY];
+            $contentViewConfig =& $config[$contextualizer->getSiteAccessNodeName()][$scope][ContentView::NODE_KEY];
+
+            // view rules without a custom controller are moved from $locationViewConfig to $contentViewConfig
+            foreach ($locationViewConfig as $viewIdentifier => $viewRules) {
+                foreach ($viewRules as $viewRuleIdentifier => $viewRule) {
+                    if (!isset($viewRule['controller'])) {
+                        $contentViewConfig[$viewIdentifier][$viewRuleIdentifier] =
+                            $locationViewConfig[$viewIdentifier][$viewRuleIdentifier];
+                        unset($locationViewConfig[$viewIdentifier][$viewRuleIdentifier]);
+                    }
+                }
+                if (count($locationViewConfig[$viewIdentifier]) === 0) {
+                    unset($locationViewConfig[$viewIdentifier]);
+                }
+            }
+        }
+
+        parent::preMap($config, $contextualizer);
+        $contextualizer->mapConfigArray(ContentView::NODE_KEY, $config, ContextualizerInterface::MERGE_FROM_SECOND_LEVEL);
+    }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/LocationView.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/LocationView.php
@@ -16,7 +16,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAw
 class LocationView extends View
 {
     const NODE_KEY = 'location_view';
-    const INFO = 'Template selection settings when displaying a location';
+    const INFO = 'Template selection settings when displaying a location. Deprecated from 5.4.5/2015.09, use content_view instead.';
 
     public function preMap(array $config, ContextualizerInterface $contextualizer)
     {
@@ -31,8 +31,8 @@ class LocationView extends View
                 continue;
             }
 
-            $locationViewConfig =& $config[$contextualizer->getSiteAccessNodeName()][$scope][static::NODE_KEY];
-            $contentViewConfig =& $config[$contextualizer->getSiteAccessNodeName()][$scope][ContentView::NODE_KEY];
+            $locationViewConfig = &$config[$contextualizer->getSiteAccessNodeName()][$scope][static::NODE_KEY];
+            $contentViewConfig = &$config[$contextualizer->getSiteAccessNodeName()][$scope][ContentView::NODE_KEY];
 
             // view rules without a custom controller are moved from $locationViewConfig to $contentViewConfig
             foreach ($locationViewConfig as $viewIdentifier => $viewRules) {

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewControllerListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewControllerListener.php
@@ -81,9 +81,11 @@ class ViewControllerListener implements EventSubscriberInterface
                 $valueObject = $this->repository->getLocationService()->loadLocation(
                     $request->attributes->get('locationId')
                 );
+                $request->attributes->set('contentId', $valueObject->contentId);
             } elseif ($request->attributes->get('location') instanceof Location) {
                 $valueObject = $request->attributes->get('location');
                 $request->attributes->set('locationId', $valueObject->id);
+                $request->attributes->set('contentId', $valueObject->contentId);
             } elseif ($request->attributes->has('contentId')) {
                 $valueObject = $this->repository->sudo(
                     function (Repository $repository) use ($request) {
@@ -111,11 +113,21 @@ class ViewControllerListener implements EventSubscriberInterface
             $request->attributes->get('viewType')
         );
 
-        if (!$controllerReference instanceof ControllerReference) {
+        if ($controllerReference instanceof ControllerReference) {
+            $request->attributes->set('_controller', $controllerReference->controller);
+            $event->setController($this->controllerResolver->getController($request));
+
             return;
         }
 
-        $request->attributes->set('_controller', $controllerReference->controller);
-        $event->setController($this->controllerResolver->getController($request));
+        // if there is no custom controller, viewContent can be used instead of viewLocation.
+        if ($request->attributes->get('_controller') === 'ez_content:viewLocation') {
+            $request->attributes->set('_controller', 'ez_content:viewContent');
+            $event->setController($this->controllerResolver->getController($request));
+        }
+        if ($request->attributes->get('_controller') === 'ez_content:embedLocation') {
+            $request->attributes->set('_controller', 'ez_content:embedContent');
+            $event->setController($this->controllerResolver->getController($request));
+        }
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
@@ -31,6 +31,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\LocationViewPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\BlockViewPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\SecurityPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\SignalSlotPass;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\ViewProvidersPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\XmlTextConverterPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\RichTextHtml5ConverterPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\StorageConnectionPass;
@@ -88,6 +89,7 @@ class EzPublishCoreBundle extends Bundle
             PassConfig::TYPE_BEFORE_REMOVING
         );
         $container->addCompilerPass(new BinaryContentDownloadPass());
+        $container->addCompilerPass(new ViewProvidersPass());
 
         // Storage passes
         $container->addCompilerPass(new ExternalStorageRegistryPass());

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Content/content_preview.feature
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Content/content_preview.feature
@@ -1,0 +1,17 @@
+Feature: Preview of content drafts
+
+    As a content editor
+    While I'm editing content
+    I need to preview the result before publishing
+
+    Scenario: Previewing the first version of a content works
+        Given I have "administrator" permissions
+          And I create an article draft
+         When I preview this draft
+         Then the output is valid
+
+    Scenario: Previewing the first version of a content with a custom location controller works
+        Given I have "administrator" permissions
+          And I create a draft for a content type that uses a custom location controller
+         When I preview this draft
+         Then the output is valid

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/ContentPreviewContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/ContentPreviewContext.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use EzSystems\BehatBundle\Context\Browser\Context as BrowserContext;
+use PHPUnit_Framework_Assert as Assertion;
+
+class ContentPreviewContext extends BrowserContext implements Context, SnippetAcceptingContext
+{
+    private $currentDraft;
+
+    /**
+     * @Given /^I create an article draft$/
+     */
+    public function iCreateAnArticleDraft()
+    {
+        $draft = $this->createArticleDraft('Preview draft ' . date('c'));
+        $this->currentDraft = $draft;
+    }
+
+    /**
+     * That would be a blog post.
+     *
+     * @Given /^I create a draft for a content type that uses a custom location controller$/
+     */
+    public function iCreateDraftContentTypeWithCustomLocationController()
+    {
+        $fields = array(
+            'title' => 'Preview draft ' . date('c'),
+            'body' => '<?xml version="1.0" encoding="utf-8"?><section xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/" xmlns:image="http://ez.no/namespaces/ezpublish3/image/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/"><paragraph>This is a paragraph.</paragraph></section>',
+        );
+        $draft = $this->getBasicContentManager()->createContentDraft(2, 'blog_post', $fields);
+        $this->currentDraft = $draft;
+    }
+
+    /**
+     * @When /^I preview this draft$/
+     */
+    public function iPreviewThisDraft()
+    {
+        if (!$this->currentDraft instanceof Content) {
+            throw new \Exception("'this draft' is not set. Bad context ?");
+        }
+        $this->visit($this->mapToVersionViewUri($this->currentDraft->versionInfo));
+    }
+
+    /**
+     * @return string
+     */
+    private function mapToVersionViewUri(VersionInfo $version)
+    {
+        return sprintf(
+            '/content/versionview/%s/%s/%s',
+            $version->contentInfo->id,
+            $version->versionNo,
+            $version->initialLanguageCode
+        );
+    }
+
+    /**
+     * @Then /^the output is valid$/
+     */
+    public function theOutputIsValid()
+    {
+        $this->checkForExceptions();
+    }
+
+    protected function checkForExceptions()
+    {
+        $exceptionElements = $this->getXpath()->findXpath("//div[@class='text-exception']/h1");
+        $exceptionStackTraceItems = $this->getXpath()->findXpath("//ol[@id='traces-0']/li");
+        if (count($exceptionElements) > 0) {
+            $exceptionElement = $exceptionElements[0];
+            $exceptionLines = [$exceptionElement->getText(), ''];
+
+            foreach ($exceptionStackTraceItems as $stackTraceItem) {
+                $html = $stackTraceItem->getHtml();
+                $html = substr($html, 0, strpos($html, '<a href', 1));
+                $html = htmlspecialchars_decode(strip_tags($html));
+                $html = preg_replace('/\s+/', ' ', $html);
+                $html = str_replace('  (', '(', $html);
+                $html = str_replace(' ->', '->', $html);
+                $exceptionLines[] = trim($html);
+            }
+            $message = 'An exception occured during rendering:' . implode("\n", $exceptionLines);
+            Assertion::assertTrue(false, $message);
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
@@ -6,6 +6,10 @@ _ezpublishLocation:
         viewType: full
         layout: true
 
+_ez_content_view:
+    path: /content/view/{contentId}/{language}
+    defaults: { _controller: ezpublish.controller.content:viewContentAction }
+
 _ezpublishPreviewContent:
     path: /content/versionview/{contentId}/{versionNo}/{language}/site_access/{siteAccessName}
     defaults: { _controller: ezpublish.controller.content.preview:previewContentAction }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -87,6 +87,7 @@ services:
             - @ezpublish.content_preview_helper
             - @security.authorization_checker
             - @ezpublish.content_preview.location_provider
+            - @ezpublish.view.custom_location_controller_checker
 
     ezpublish.controller.content.preview:
         alias: ezpublish.controller.content.preview.core

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -12,6 +12,7 @@ parameters:
     ezpublish.block_view_provider.configured.class: eZ\Bundle\EzPublishCoreBundle\View\Provider\BlockConfigured
     ezpublish.content_view.viewbase_layout: "EzPublishCoreBundle::viewbase_layout.html.twig"
     ezpublish.content_view.content_block_name: "content"
+    ezpublish.view.custom_location_controller_checker.class: eZ\Publish\Core\MVC\Symfony\View\CustomLocationControllerChecker
 
     ezpublish.templating.global_helper.core.class: eZ\Publish\Core\MVC\Symfony\Templating\GlobalHelper
     ezpublish.twig.extension.core.class: eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\CoreExtension
@@ -57,6 +58,7 @@ services:
         arguments: [@ezpublish.content_view.matcher_factory]
         tags:
             - {name: ezpublish.content_view_provider, priority: 10}
+            - {name: ezpublish.view_provider, type: 'eZ\Publish\API\Repository\Values\Content', priority: 10}
 
     ezpublish.content_view.matcher_factory:
         class: %ezpublish.content_view.matcher_factory.class%
@@ -69,6 +71,7 @@ services:
         arguments: [@ezpublish.location_view.matcher_factory]
         tags:
             - {name: ezpublish.location_view_provider, priority: 10}
+            - {name: ezpublish.view_provider, type: 'eZ\Publish\API\Repository\Values\Content\Location', priority: 10}
 
     ezpublish.location_view.matcher_factory:
         class: %ezpublish.location_view.matcher_factory.class%
@@ -81,6 +84,7 @@ services:
         arguments: [@ezpublish.block_view.matcher_factory]
         tags:
             - {name: ezpublish.block_view_provider, priority: 10}
+            - {name: ezpublish.view_provider, type: 'eZ\Publish\Core\FieldType\Page\Parts\Block', priority: 10}
 
     ezpublish.block_view.matcher_factory:
         class: %ezpublish.block_view.matcher_factory.class%
@@ -158,3 +162,6 @@ services:
         tags:
             - { name: twig.extension }
 
+
+    ezpublish.view.custom_location_controller_checker:
+        class: %ezpublish.view.custom_location_controller_checker.class%

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Converter/ContentParamConverterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Converter/ContentParamConverterTest.php
@@ -12,8 +12,6 @@ namespace eZ\Bundle\EzPublishCoreBundle\Tests\Converter;
 
 use eZ\Bundle\EzPublishCoreBundle\Converter\ContentParamConverter;
 use Symfony\Component\HttpFoundation\Request;
-use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
-use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 
 class ContentParamConverterTest extends AbstractParamConverterTest
 {
@@ -64,38 +62,6 @@ class ContentParamConverterTest extends AbstractParamConverterTest
         $this->converter->apply($request, $config);
 
         $this->assertInstanceOf(self::CONTENT_CLASS, $request->attributes->get('content'));
-    }
-
-    public function testApplyContentNotFound404Exception()
-    {
-        $id = 42;
-        $request = new Request([], [], [self::PROPERTY_NAME => $id]);
-        $config = $this->createConfiguration(self::CONTENT_CLASS, 'content');
-
-        $this->contentServiceMock
-            ->expects($this->once())
-            ->method('loadContent')
-            ->with($id)
-            ->will($this->throwException(new NotFoundException('', '')));
-
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'Requested values not found');
-        $this->converter->apply($request, $config);
-    }
-
-    public function testApplyContentUnauthorized403Exception()
-    {
-        $id = 42;
-        $request = new Request([], [], [self::PROPERTY_NAME => $id]);
-        $config = $this->createConfiguration(self::CONTENT_CLASS, 'content');
-
-        $this->contentServiceMock
-            ->expects($this->once())
-            ->method('loadContent')
-            ->with($id)
-            ->will($this->throwException(new UnauthorizedException('', '')));
-
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException', 'Access to values denied');
-        $this->converter->apply($request, $config);
     }
 
     public function testApplyContentOptionalWithEmptyAttribute()

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Converter/LocationParamConverterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Converter/LocationParamConverterTest.php
@@ -12,8 +12,6 @@ namespace eZ\Bundle\EzPublishCoreBundle\Tests\Converter;
 
 use eZ\Bundle\EzPublishCoreBundle\Converter\LocationParamConverter;
 use Symfony\Component\HttpFoundation\Request;
-use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
-use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 
 class LocationParamConverterTest extends AbstractParamConverterTest
 {
@@ -64,38 +62,6 @@ class LocationParamConverterTest extends AbstractParamConverterTest
         $this->converter->apply($request, $config);
 
         $this->assertInstanceOf(self::LOCATION_CLASS, $request->attributes->get('location'));
-    }
-
-    public function testApplyLocationNotFound404Exception()
-    {
-        $id = 42;
-        $request = new Request([], [], [self::PROPERTY_NAME => $id]);
-        $config = $this->createConfiguration(self::LOCATION_CLASS, 'location');
-
-        $this->locationServiceMock
-            ->expects($this->once())
-            ->method('loadLocation')
-            ->with($id)
-            ->will($this->throwException(new NotFoundException('', '')));
-
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\NotFoundHttpException', 'Requested values not found');
-        $this->converter->apply($request, $config);
-    }
-
-    public function testApplyLocationUnauthorized403Exception()
-    {
-        $id = 42;
-        $request = new Request([], [], [self::PROPERTY_NAME => $id]);
-        $config = $this->createConfiguration(self::LOCATION_CLASS, 'location');
-
-        $this->locationServiceMock
-            ->expects($this->once())
-            ->method('loadLocation')
-            ->with($id)
-            ->will($this->throwException(new UnauthorizedException('', '')));
-
-        $this->setExpectedException('Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException', 'Access to values denied');
-        $this->converter->apply($request, $config);
     }
 
     public function testApplyLocationOptionalWithEmptyAttribute()

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/ViewTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/ViewTest.php
@@ -36,6 +36,11 @@ class ViewTest extends AbstractParserTestCase
     {
         $this->load();
         $expectedLocationView = $this->config['system']['ezdemo_frontend_group']['location_view'];
+
+        // Items that don't use a custom controller got converted to content view (location view depreciation)
+        unset($expectedLocationView['full']['frontpage']);
+        unset($expectedLocationView['line']['article']);
+
         foreach ($expectedLocationView as &$rulesets) {
             foreach ($rulesets as &$config) {
                 if (!isset($config['params'])) {

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
@@ -11,7 +11,9 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;
 
 use eZ\Bundle\EzPublishCoreBundle\EventListener\ViewControllerListener;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
+use eZ\Publish\Core\Repository\Values\Content\Location;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use PHPUnit_Framework_TestCase;
@@ -169,10 +171,11 @@ class ViewControllerListenerTest extends PHPUnit_Framework_TestCase
             ->will($this->returnValue(null));
 
         $this->event
-            ->expects($this->never())
+            ->expects($this->once())
             ->method('setController');
 
         $this->assertNull($this->controllerListener->getController($this->event));
+        $this->assertEquals('ez_content:viewContent', $this->request->attributes->get('_controller'));
     }
 
     public function testGetControllerLocationId()
@@ -223,10 +226,8 @@ class ViewControllerListenerTest extends PHPUnit_Framework_TestCase
     public function testGetControllerLocation()
     {
         $id = 123;
-        $location = $this
-            ->getMockBuilder('eZ\Publish\API\Repository\Values\Content\Location')
-            ->setConstructorArgs(array(array('id' => $id)))
-            ->getMockForAbstractClass();
+        $contentId = 456;
+        $location = new Location(['id' => $id, 'contentInfo' => new ContentInfo(['id' => $contentId])]);
         $viewType = 'full';
         $this->request->attributes->add(
             array(

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Routing/UrlAliasRouterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Routing/UrlAliasRouterTest.php
@@ -13,6 +13,8 @@ namespace eZ\Bundle\EzPublishCoreBundle\Tests\Routing;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\URLAliasService;
 use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\Repository\Values\Content\Location;
 use Symfony\Component\Routing\RequestContext;
 use eZ\Bundle\EzPublishCoreBundle\Routing\UrlAliasRouter;
 use eZ\Publish\API\Repository\Values\Content\URLAlias;
@@ -121,10 +123,16 @@ class UrlAliasRouterTest extends BaseUrlAliasRouterTest
             ->with($prefix . $path)
             ->will($this->returnValue($urlAlias));
 
+        $this->urlALiasGenerator
+            ->expects($this->once())
+            ->method('loadLocation')
+            ->will($this->returnValue(new Location(array('contentInfo' => new ContentInfo(array('id' => 456))))));
+
         $expected = array(
             '_route' => UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
-            '_controller' => UrlAliasRouter::LOCATION_VIEW_CONTROLLER,
+            '_controller' => UrlAliasRouter::CONTENT_VIEW_CONTROLLER,
             'locationId' => $locationId,
+            'contentId' => 456,
             'viewType' => ViewManager::VIEW_TYPE_FULL,
             'layout' => true,
         );
@@ -155,6 +163,10 @@ class UrlAliasRouterTest extends BaseUrlAliasRouterTest
             ->method('getPathPrefixByRootLocationId')
             ->with($rootLocationId)
             ->will($this->returnValue($prefix));
+        $this->urlALiasGenerator
+            ->expects($this->once())
+            ->method('loadLocation')
+            ->will($this->returnValue(new Location(array('contentInfo' => new ContentInfo(array('id' => 456))))));
 
         $locationId = 789;
         $path = '/foo/bar';
@@ -175,8 +187,9 @@ class UrlAliasRouterTest extends BaseUrlAliasRouterTest
 
         $expected = array(
             '_route' => UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
-            '_controller' => UrlAliasRouter::LOCATION_VIEW_CONTROLLER,
+            '_controller' => UrlAliasRouter::CONTENT_VIEW_CONTROLLER,
             'locationId' => $locationId,
+            'contentId' => 456,
             'viewType' => ViewManager::VIEW_TYPE_FULL,
             'layout' => true,
         );
@@ -226,11 +239,16 @@ class UrlAliasRouterTest extends BaseUrlAliasRouterTest
             ->method('lookup')
             ->with($requestedPath)
             ->will($this->returnValue($urlAlias));
+        $this->urlALiasGenerator
+            ->expects($this->once())
+            ->method('loadLocation')
+            ->will($this->returnValue(new Location(array('contentInfo' => new ContentInfo(array('id' => 456))))));
 
         $expected = array(
             '_route' => UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
-            '_controller' => UrlAliasRouter::LOCATION_VIEW_CONTROLLER,
+            '_controller' => UrlAliasRouter::CONTENT_VIEW_CONTROLLER,
             'locationId' => $locationId,
+            'contentId' => 456,
             'viewType' => ViewManager::VIEW_TYPE_FULL,
             'layout' => true,
         );
@@ -374,11 +392,16 @@ class UrlAliasRouterTest extends BaseUrlAliasRouterTest
             ->method('lookup')
             ->with($pathInfo)
             ->will($this->returnValue($urlAlias));
+        $this->urlALiasGenerator
+            ->expects($this->once())
+            ->method('loadLocation')
+            ->will($this->returnValue(new Location(array('contentInfo' => new ContentInfo(array('id' => 456))))));
 
         $expected = array(
             '_route' => UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
-            '_controller' => UrlAliasRouter::LOCATION_VIEW_CONTROLLER,
+            '_controller' => UrlAliasRouter::CONTENT_VIEW_CONTROLLER,
             'locationId' => $destinationId,
+            'contentId' => 456,
             'viewType' => ViewManager::VIEW_TYPE_FULL,
             'layout' => true,
         );

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
@@ -10,6 +10,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Controller\Content;
 
+use Exception;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
@@ -18,6 +19,7 @@ use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\Helper\ContentPreviewHelper;
 use eZ\Publish\Core\Helper\PreviewLocationProvider;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\View\CustomLocationControllerChecker;
 use eZ\Publish\Core\MVC\Symfony\View\ViewManagerInterface;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
 use eZ\Publish\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator;
@@ -28,6 +30,8 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class PreviewController
 {
+    const INTERNAL_LOCATION_VIEW_ROUTE = '_ezpublishLocation';
+
     /**
      * @var \eZ\Publish\API\Repository\ContentService
      */
@@ -49,22 +53,24 @@ class PreviewController
     private $authorizationChecker;
 
     /**
-     * @var \eZ\Publish\Core\Helper\PreviewLocationProvider
+     * @var \eZ\Publish\Core\MVC\Symfony\View\CustomLocationControllerChecker
      */
-    private $locationProvider;
+    private $controllerChecker;
 
     public function __construct(
         ContentService $contentService,
         HttpKernelInterface $kernel,
         ContentPreviewHelper $previewHelper,
         AuthorizationCheckerInterface $authorizationChecker,
-        PreviewLocationProvider $locationProvider
+        PreviewLocationProvider $locationProvider,
+        CustomLocationControllerChecker $controllerChecker
     ) {
         $this->contentService = $contentService;
         $this->kernel = $kernel;
         $this->previewHelper = $previewHelper;
         $this->authorizationChecker = $authorizationChecker;
         $this->locationProvider = $locationProvider;
+        $this->controllerChecker = $controllerChecker;
     }
 
     /**
@@ -98,10 +104,25 @@ class PreviewController
             $siteAccess = $this->previewHelper->changeConfigScope($siteAccessName);
         }
 
-        $response = $this->kernel->handle(
-            $this->getForwardRequest($location, $content, $siteAccess, $request),
-            HttpKernelInterface::SUB_REQUEST
-        );
+        try {
+            $response = $this->kernel->handle(
+                $this->getForwardRequest($location, $content, $siteAccess, $request),
+                HttpKernelInterface::SUB_REQUEST,
+                false
+            );
+        } catch (\Exception $e) {
+            if ($location->isDraft() && $this->controllerChecker->usesCustomController($location)) {
+                // @todo This should probably be an exception that embeds the original one
+                $message = <<<EOF
+<p>The view that rendered this location draft uses a custom controller, and resulted in a fatal error.</p>
+<p>Location View is deprecated, as it causes issues with preview, such as an empty location id when previewing the first version of a content.</p>
+EOF;
+
+                throw new Exception($message, 0, $e);
+            } else {
+                throw $e;
+            }
+        }
         $response->headers->remove('cache-control');
         $response->headers->remove('expires');
 
@@ -123,27 +144,37 @@ class PreviewController
      */
     protected function getForwardRequest(Location $location, Content $content, SiteAccess $previewSiteAccess, Request $request)
     {
+        $forwardRequestParameters = array(
+            '_controller' => 'ez_content:viewContent',
+            // specify a route for RouteReference generator
+            '_route' => UrlAliasGenerator::INTERNAL_CONTENT_VIEW_ROUTE,
+            '_route_params' => array(
+                'contentId' => $content->id,
+                'locationId' => $location->id,
+            ),
+            'location' => $location,
+            'viewType' => ViewManagerInterface::VIEW_TYPE_FULL,
+            'layout' => true,
+            'params' => array(
+                'content' => $content,
+                'location' => $location,
+                'isPreview' => true,
+            ),
+            'siteaccess' => $previewSiteAccess,
+            'semanticPathinfo' => $request->attributes->get('semanticPathinfo'),
+        );
+
+        if ($this->controllerChecker->usesCustomController($location)) {
+            $forwardRequestParameters = [
+                '_controller' => 'ez_content:viewLocation',
+                '_route' => self::INTERNAL_LOCATION_VIEW_ROUTE,
+            ] + $forwardRequestParameters;
+        }
+
         return $request->duplicate(
             null,
             null,
-            array(
-                '_controller' => 'ez_content:viewLocation',
-                // specify a route for RouteReference generator
-                '_route' => UrlAliasGenerator::INTERNAL_CONTENT_VIEW_ROUTE,
-                '_route_params' => array(
-                    'locationId' => $location->id,
-                ),
-                'location' => $location,
-                'viewType' => ViewManagerInterface::VIEW_TYPE_FULL,
-                'layout' => true,
-                'params' => array(
-                    'content' => $content,
-                    'location' => $location,
-                    'isPreview' => true,
-                ),
-                'siteaccess' => $previewSiteAccess,
-                'semanticPathinfo' => $request->attributes->get('semanticPathinfo'),
-            )
+            $forwardRequestParameters
         );
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
@@ -129,7 +129,7 @@ class PreviewController
             array(
                 '_controller' => 'ez_content:viewLocation',
                 // specify a route for RouteReference generator
-                '_route' => UrlAliasGenerator::INTERNAL_LOCATION_ROUTE,
+                '_route' => UrlAliasGenerator::INTERNAL_CONTENT_VIEW_ROUTE,
                 '_route_params' => array(
                     'locationId' => $location->id,
                 ),

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
@@ -99,6 +99,8 @@ class ViewController extends Controller
      * @throws \Exception
      *
      * @return \Symfony\Component\HttpFoundation\Response
+     *
+     * @deprecated Since 6.0.0. Viewing locations is now done with ViewContent.
      */
     public function viewLocation($locationId, $viewType, $layout = false, array $params = array())
     {
@@ -151,6 +153,8 @@ class ViewController extends Controller
      * @throws \Exception
      *
      * @return \Symfony\Component\HttpFoundation\Response
+     *
+     * @deprecated Since 6.0.0. Viewing locations is now done with ViewContent.
      */
     public function embedLocation($locationId, $viewType, $layout = false, array $params = array())
     {
@@ -244,6 +248,9 @@ class ViewController extends Controller
                 return $response;
             }
 
+            if (!isset($params['location']) && !isset($params['locationId'])) {
+                $params['location'] = $this->getRepository()->getLocationService()->loadLocation($content->contentInfo->mainLocationId);
+            }
             $response->headers->set('X-Location-Id', $content->contentInfo->mainLocationId);
             $response->setContent(
                 $this->renderContent($content, $viewType, $layout, $params)

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Tests/Controller/Content/PreviewControllerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Tests/Controller/Content/PreviewControllerTest.php
@@ -45,8 +45,10 @@ class PreviewControllerTest extends PHPUnit_Framework_TestCase
      */
     protected $authorizationChecker;
 
-    /** @var PreviewLocationProvider|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var PreviewLocationProvider|\PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\Core\MVC\Symfony\View\CustomLocationControllerChecker */
     protected $locationProvider;
+
+    private $controllerChecker;
 
     protected function setUp()
     {
@@ -63,6 +65,7 @@ class PreviewControllerTest extends PHPUnit_Framework_TestCase
             ->getMockBuilder('eZ\Publish\Core\Helper\PreviewLocationProvider')
             ->disableOriginalConstructor()
             ->getMock();
+        $this->controllerChecker = $this->getMock('eZ\Publish\Core\MVC\Symfony\View\CustomLocationControllerChecker');
     }
 
     /**
@@ -75,7 +78,8 @@ class PreviewControllerTest extends PHPUnit_Framework_TestCase
             $this->httpKernel,
             $this->previewHelper,
             $this->authorizationChecker,
-            $this->locationProvider
+            $this->locationProvider,
+            $this->controllerChecker
         );
 
         return $controller;

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -23,6 +23,7 @@ use Symfony\Component\Routing\RouterInterface;
 class UrlAliasGenerator extends Generator
 {
     const INTERNAL_LOCATION_ROUTE = '_ezpublishLocation';
+    const INTERNAL_CONTENT_VIEW_ROUTE = '_ez_content_view';
 
     /**
      * @var \eZ\Publish\Core\Repository\Repository
@@ -124,8 +125,8 @@ class UrlAliasGenerator extends Generator
             }
         } else {
             $path = $this->defaultRouter->generate(
-                self::INTERNAL_LOCATION_ROUTE,
-                array('locationId' => $location->id)
+                self::INTERNAL_CONTENT_VIEW_ROUTE,
+                array('contentId' => $location->contentId, 'locationId' => $location->id)
             );
         }
 

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
@@ -10,6 +10,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Routing\Tests;
 
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\URLAlias;
 use eZ\Publish\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
@@ -297,7 +298,7 @@ class UrlAliasGeneratorTest extends PHPUnit_Framework_TestCase
 
     public function testDoGenerateNoUrlAlias()
     {
-        $location = new Location(array('id' => 123));
+        $location = new Location(array('id' => 123, 'contentInfo' => new ContentInfo(array('id' => 456))));
         $uri = "/content/location/$location->id";
         $this->urlAliasService
             ->expects($this->once())
@@ -308,8 +309,8 @@ class UrlAliasGeneratorTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('generate')
             ->with(
-                UrlAliasGenerator::INTERNAL_LOCATION_ROUTE,
-                array('locationId' => $location->id)
+                UrlAliasGenerator::INTERNAL_CONTENT_VIEW_ROUTE,
+                array('contentId' => $location->contentId, 'locationId' => $location->id)
             )
             ->will($this->returnValue($uri));
 

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasRouterTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasRouterTest.php
@@ -187,11 +187,16 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
             ->method('lookup')
             ->with($pathInfo)
             ->will($this->returnValue($urlAlias));
+        $this->urlALiasGenerator
+            ->expects($this->once())
+            ->method('loadLocation')
+            ->will($this->returnValue(new Location(array('contentInfo' => new ContentInfo(array('id' => 456))))));
 
         $expected = array(
             '_route' => UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
-            '_controller' => UrlAliasRouter::LOCATION_VIEW_CONTROLLER,
+            '_controller' => UrlAliasRouter::CONTENT_VIEW_CONTROLLER,
             'locationId' => $destinationId,
+            'contentId' => 456,
             'viewType' => ViewManager::VIEW_TYPE_FULL,
             'layout' => true,
         );
@@ -223,11 +228,16 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
             ->method('lookup')
             ->with($pathInfo)
             ->will($this->returnValue($urlAlias));
+        $this->urlALiasGenerator
+            ->expects($this->once())
+            ->method('loadLocation')
+            ->will($this->returnValue(new Location(array('contentInfo' => new ContentInfo(array('id' => 456))))));
 
         $expected = array(
             '_route' => UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
-            '_controller' => UrlAliasRouter::LOCATION_VIEW_CONTROLLER,
+            '_controller' => UrlAliasRouter::CONTENT_VIEW_CONTROLLER,
             'locationId' => $destinationId,
+            'contentId' => 456,
             'viewType' => ViewManager::VIEW_TYPE_FULL,
             'layout' => true,
         );
@@ -261,10 +271,15 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
             ->method('lookup')
             ->with($pathInfo)
             ->will($this->returnValue($urlAlias));
+        $this->urlALiasGenerator
+            ->expects($this->once())
+            ->method('loadLocation')
+            ->will($this->returnValue(new Location(array('contentInfo' => new ContentInfo(array('id' => 456))))));
 
         $expected = array(
             '_route' => UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
-            '_controller' => UrlAliasRouter::LOCATION_VIEW_CONTROLLER,
+            '_controller' => UrlAliasRouter::CONTENT_VIEW_CONTROLLER,
+            'contentId' => 456,
             'locationId' => $destinationId,
             'viewType' => ViewManager::VIEW_TYPE_FULL,
             'layout' => true,
@@ -298,11 +313,16 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
             ->method('lookup')
             ->with($pathInfo)
             ->will($this->returnValue($urlAlias));
+        $this->urlALiasGenerator
+            ->expects($this->once())
+            ->method('loadLocation')
+            ->will($this->returnValue(new Location(array('contentInfo' => new ContentInfo(array('id' => 456))))));
 
         $expected = array(
             '_route' => UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
-            '_controller' => UrlAliasRouter::LOCATION_VIEW_CONTROLLER,
+            '_controller' => UrlAliasRouter::CONTENT_VIEW_CONTROLLER,
             'locationId' => $destinationId,
+            'contentId' => 456,
             'viewType' => ViewManager::VIEW_TYPE_FULL,
             'layout' => true,
         );
@@ -317,7 +337,7 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
         $pathInfo = '/foo/bar';
         $newPathInfo = '/foo/bar-new';
         $destinationId = 123;
-        $destinationLocation = new Location(array('id' => $destinationId));
+        $destinationLocation = new Location(array('id' => $destinationId, 'contentInfo' => new ContentInfo(array('id' => 456))));
         $urlAlias = new URLAlias(
             array(
                 'path' => $pathInfo,
@@ -334,21 +354,19 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
             ->will($this->returnValue($urlAlias));
         $this->urlALiasGenerator
             ->expects($this->once())
-            ->method('loadLocation')
-            ->with($destinationId)
-            ->will(
-                $this->returnValue($destinationLocation)
-            );
-        $this->urlALiasGenerator
-            ->expects($this->once())
             ->method('generate')
             ->with($destinationLocation)
             ->will($this->returnValue($newPathInfo));
+        $this->urlALiasGenerator
+            ->expects($this->once())
+            ->method('loadLocation')
+            ->will($this->returnValue($destinationLocation));
 
         $expected = array(
             '_route' => UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
-            '_controller' => UrlAliasRouter::LOCATION_VIEW_CONTROLLER,
+            '_controller' => UrlAliasRouter::CONTENT_VIEW_CONTROLLER,
             'locationId' => $destinationId,
+            'contentId' => 456,
             'viewType' => ViewManager::VIEW_TYPE_FULL,
             'layout' => true,
         );
@@ -378,11 +396,16 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
             ->method('lookup')
             ->with($pathInfo)
             ->will($this->returnValue($urlAlias));
+        $this->urlALiasGenerator
+            ->expects($this->once())
+            ->method('loadLocation')
+            ->will($this->returnValue(new Location(array('contentInfo' => new ContentInfo(array('id' => 456))))));
 
         $expected = array(
             '_route' => UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
-            '_controller' => UrlAliasRouter::LOCATION_VIEW_CONTROLLER,
+            '_controller' => UrlAliasRouter::CONTENT_VIEW_CONTROLLER,
             'locationId' => $destinationId,
+            'contentId' => 456,
             'viewType' => ViewManager::VIEW_TYPE_FULL,
             'layout' => true,
         );
@@ -395,7 +418,7 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
         $pathInfo = '/foo/bar';
         $newPathInfo = '/foo/bar-new';
         $destinationId = 123;
-        $destinationLocation = new Location(array('id' => $destinationId));
+        $destinationLocation = new Location(array('id' => $destinationId, 'contentInfo' => new ContentInfo(array('id' => 456))));
         $urlAlias = new URLAlias(
             array(
                 'path' => $pathInfo,
@@ -424,11 +447,16 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
             ->method('generate')
             ->with($destinationLocation)
             ->will($this->returnValue($newPathInfo));
+        $this->urlALiasGenerator
+            ->expects($this->once())
+            ->method('loadLocation')
+            ->will($this->returnValue($destinationLocation));
 
         $expected = array(
             '_route' => UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
-            '_controller' => UrlAliasRouter::LOCATION_VIEW_CONTROLLER,
+            '_controller' => UrlAliasRouter::CONTENT_VIEW_CONTROLLER,
             'locationId' => $destinationId,
+            'contentId' => 456,
             'viewType' => ViewManager::VIEW_TYPE_FULL,
             'layout' => true,
         );

--- a/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
@@ -36,6 +36,7 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
     const URL_ALIAS_ROUTE_NAME = 'ez_urlalias';
 
     const LOCATION_VIEW_CONTROLLER = 'ez_content:viewLocation';
+    const CONTENT_VIEW_CONTROLLER = 'ez_content:viewContent';
 
     /**
      * @var \Symfony\Component\Routing\RequestContext
@@ -128,8 +129,10 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
             );
             switch ($urlAlias->type) {
                 case URLAlias::LOCATION:
+                    $location = $this->generator->loadLocation($urlAlias->destination);
                     $params += array(
-                        '_controller' => static::LOCATION_VIEW_CONTROLLER,
+                        '_controller' => static::CONTENT_VIEW_CONTROLLER,
+                        'contentId' => $location->contentId,
                         'locationId' => $urlAlias->destination,
                         'viewType' => ViewManager::VIEW_TYPE_FULL,
                         'layout' => true,
@@ -142,12 +145,7 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
                     // 2. alias is custom with forward flag true
                     // 3. requested URL is not case-sensitive equal with the one loaded
                     if ($urlAlias->isHistory === true || ($urlAlias->isCustom === true && $urlAlias->forward === true)) {
-                        $request->attributes->set(
-                            'semanticPathinfo',
-                            $this->generate(
-                                $this->generator->loadLocation($urlAlias->destination)
-                            )
-                        );
+                        $request->attributes->set('semanticPathinfo', $this->generate($location));
                         $request->attributes->set('needsRedirect', true);
                         // Specify not to prepend siteaccess while redirecting when applicable since it would be already present (see UrlAliasGenerator::doGenerate())
                         $request->attributes->set('prependSiteaccessOnRedirect', false);

--- a/eZ/Publish/Core/MVC/Symfony/View/CustomLocationControllerChecker.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/CustomLocationControllerChecker.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\View;
+
+use eZ\Publish\API\Repository\Values\Content\Location;
+
+/**
+ * Used to check if a Location is rendered using a custom controller.
+ */
+class CustomLocationControllerChecker
+{
+    /** @var \eZ\Publish\Core\MVC\Symfony\View\Provider\Location[] */
+    private $viewProviders;
+
+    /**
+     * Tests if $location has match a view that uses a custom controller.
+     *
+     * @since 5.4.5
+     *
+     * @param $location Location
+     *
+     * @return bool
+     */
+    public function usesCustomController(Location $location, $viewMode = 'full')
+    {
+        foreach ($this->viewProviders as $viewProvider) {
+            $view = $viewProvider->getView($location, $viewMode);
+            if ($view instanceof ContentViewInterface) {
+                $configHash = $view->getConfigHash();
+                if (isset($configHash['controller'])) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param $viewProviders \eZ\Publish\Core\MVC\Symfony\View\Provider\Location[]
+     */
+    public function addViewProviders(array $viewProviders)
+    {
+        $this->viewProviders = $viewProviders;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/View/Provider/Configured.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Provider/Configured.php
@@ -12,7 +12,6 @@ namespace eZ\Publish\Core\MVC\Symfony\View\Provider;
 
 use eZ\Publish\Core\MVC\Symfony\Matcher\MatcherFactoryInterface;
 use eZ\Publish\Core\MVC\Symfony\View\ContentView;
-use InvalidArgumentException;
 
 /**
  * Base for View Providers.
@@ -37,18 +36,15 @@ abstract class Configured
      *
      * @param array $viewConfig
      *
-     * @throws \InvalidArgumentException
-     *
      * @return ContentView
      */
     protected function buildContentView(array $viewConfig)
     {
-        if (!isset($viewConfig['template'])) {
-            throw new InvalidArgumentException('$viewConfig must contain the template identifier in order to correctly generate the ContentView object');
-        }
-
-        $view = new ContentView($viewConfig['template']);
+        $view = new ContentView();
         $view->setConfigHash($viewConfig);
+        if (isset($viewConfig['template'])) {
+            $view->setTemplateIdentifier($viewConfig['template']);
+        }
 
         return $view;
     }

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/Provider/Block/ConfiguredTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/Provider/Block/ConfiguredTest.php
@@ -61,29 +61,6 @@ class ConfiguredTest extends PHPUnit_Framework_TestCase
      * @covers \eZ\Publish\Core\MVC\Symfony\View\Provider\Configured::__construct
      * @covers \eZ\Publish\Core\MVC\Symfony\View\Provider\Configured::buildContentView
      * @covers \eZ\Publish\Core\MVC\Symfony\View\Provider\Block\Configured::getView
-     *
-     * @expectedException InvalidArgumentException
-     */
-    public function testGetViewContentNoTemplate()
-    {
-        $this->matcherFactoryMock
-            ->expects($this->once())
-            ->method('match')
-            ->will($this->returnValue(array('match' => array())));
-
-        $cvp = new BlockViewProvider($this->matcherFactoryMock);
-        $this->assertNull(
-            $cvp->getView(
-                $this->getBlockMock(),
-                'full'
-            )
-        );
-    }
-
-    /**
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\Provider\Configured::__construct
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\Provider\Configured::buildContentView
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\Provider\Block\Configured::getView
      */
     public function testGetViewContent()
     {

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/Provider/Content/ConfiguredTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/Provider/Content/ConfiguredTest.php
@@ -50,29 +50,6 @@ class ConfiguredTest extends PHPUnit_Framework_TestCase
      * @covers \eZ\Publish\Core\MVC\Symfony\View\Provider\Configured::__construct
      * @covers \eZ\Publish\Core\MVC\Symfony\View\Provider\Configured::buildContentView
      * @covers \eZ\Publish\Core\MVC\Symfony\View\Provider\Content\Configured::getView
-     *
-     * @expectedException InvalidArgumentException
-     */
-    public function testGetViewContentNoTemplate()
-    {
-        $this->matcherFactoryMock
-            ->expects($this->once())
-            ->method('match')
-            ->will($this->returnValue(array('match' => array())));
-
-        $cvp = new ContentViewProvider($this->matcherFactoryMock);
-        $this->assertNull(
-            $cvp->getView(
-                $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo'),
-                'full'
-            )
-        );
-    }
-
-    /**
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\Provider\Configured::__construct
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\Provider\Configured::buildContentView
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\Provider\Content\Configured::getView
      */
     public function testGetViewContent()
     {

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/Provider/Location/ConfiguredTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/Provider/Location/ConfiguredTest.php
@@ -50,29 +50,6 @@ class ConfiguredTest extends PHPUnit_Framework_TestCase
      * @covers \eZ\Publish\Core\MVC\Symfony\View\Provider\Configured::__construct
      * @covers \eZ\Publish\Core\MVC\Symfony\View\Provider\Configured::buildContentView
      * @covers \eZ\Publish\Core\MVC\Symfony\View\Provider\Location\Configured::getView
-     *
-     * @expectedException InvalidArgumentException
-     */
-    public function testGetViewLocationNoTemplate()
-    {
-        $this->matcherFactoryMock
-            ->expects($this->once())
-            ->method('match')
-            ->will($this->returnValue(array('match' => array())));
-
-        $lvp = new LocationViewProvider($this->matcherFactoryMock);
-        $this->assertNull(
-            $lvp->getView(
-                $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Location'),
-                'full'
-            )
-        );
-    }
-
-    /**
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\Provider\Configured::__construct
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\Provider\Configured::buildContentView
-     * @covers \eZ\Publish\Core\MVC\Symfony\View\Provider\Location\Configured::getView
      */
     public function testGetViewLocation()
     {


### PR DESCRIPTION
> Status: ready for review
> Implements [EZP-24869](https://jira.ez.no/browse/EZP-24869)
> Related changes: ezsystems/BehatBundle#34, ezsystems/DemoBundle/pull/182, ezsystems/ezplatform#48.

This deprecates Location View in general, in favour of Content View. The Location becomes an optional information provided to Content View.

### Backward compatibility
No code changes should be necessary.

When applicable, existing `location_view` rules are silently converted to `content_view`. When a custom controller is used, they are left untouched.

The UrlAlias router will route to `viewContent` by default, and `render()` calls from PHP or Twig will be changed by the ViewControllerListener to `viewLocation` when applicable.

### TODO
- [x] Make tests pass
- [x] Merge related PR ezsystems/BehatBundle#34
- [x] Merge related PR ezsystems/DemoBundle/pull/182
- [ ] Merge (test) related PR ezsystems/ezplatform#48
- [ ] Before merge: remove temporary commits 
- [ ] After merge: doc updates...