### PR TITLE
Fix EZP-24854: http cache purge bans wrong/additional location ids

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/FOSPurgeClient.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/FOSPurgeClient.php
@@ -41,7 +41,7 @@ class FOSPurgeClient implements PurgeClientInterface
             $locationIds = array($locationIds);
         }
 
-        $this->cacheManager->invalidate(array('X-Location-Id' => '(' . implode('|', $locationIds) . ')'));
+        $this->cacheManager->invalidate(array('X-Location-Id' => '^(' . implode('|', $locationIds) . ')$'));
     }
 
     public function purgeAll()

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/FOSPurgeClientTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/FOSPurgeClientTest.php
@@ -55,7 +55,7 @@ class FOSPurgeClientTest extends PHPUnit_Framework_TestCase
         $this->cacheManager
             ->expects($this->once())
             ->method('invalidate')
-            ->with(array('X-Location-Id' => "($locationId)"));
+            ->with(array('X-Location-Id' => "^($locationId)$"));
 
         $this->purgeClient->purge($locationId);
     }
@@ -68,7 +68,7 @@ class FOSPurgeClientTest extends PHPUnit_Framework_TestCase
         $this->cacheManager
             ->expects($this->once())
             ->method('invalidate')
-            ->with(array('X-Location-Id' => '(' . implode('|', $locationIds) . ')'));
+            ->with(array('X-Location-Id' => '^(' . implode('|', $locationIds) . ')$'));
 
         $this->purgeClient->purge($locationIds);
     }


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-24854

##### Problem #####
When issue http cache (varnish) purge requests, a regex is used with multiple location Ids.
The problem is that the regex is matching all locations that __contain__ the value, for example, banning location 2 will also ban 12, 20, 21.


vcl ref: ` ban("obj.http.X-Location-Id ~ " + req.http.X-Location-Id);`
https://github.com/ezsystems/ezplatform/blob/master/doc/varnish/vcl/varnish4.vcl#L116

##### Solution #####
Fix by making sure that location __is__ one of the requested (starts/ends with provided value)

##### Tests #####
Manual