### PR TITLE
REST: Marked UserList.User as a forced list item

### DIFF
--- a/eZ/Publish/Core/REST/Common/Input/Handler/Xml.php
+++ b/eZ/Publish/Core/REST/Common/Input/Handler/Xml.php
@@ -54,6 +54,9 @@ class Xml extends Handler
         'FieldDefinitions' => array(
             'FieldDefinition',
         ),
+        'UserList' => array(
+            'User',
+        ),
         'names' => array(
             'value',
         ),


### PR DESCRIPTION
The REST XML Input Parser can't distinguish if a one item list is a unique item or a list. The test was failing while the feature was working since this affects the parser, only used in tests.