### PR TITLE
The ezpublish.image_alias.variation_path_generator should be use here

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -77,7 +77,7 @@ services:
             - @router.request_context
             - @liip_imagine.filter.configuration
             - @ezpublish.image_alias.variation_purger
-            - @ezpublish.image_alias.variation_path_generator.alias_directory
+            - @ezpublish.image_alias.variation_path_generator
         tags:
             - { name: liip_imagine.cache.resolver, resolver: ezpublish }
 


### PR DESCRIPTION
Hey guys,

I think that is a typo, but what a typo! It triggers the new name schema. That works... but it was impossible again to purge the variations..and it messes up the cluster...

You owe me a beer for that one ;-)

++