### PR TITLE
Fix EZP-24294: Search Not working correctly after decoupling from Persistence

### DIFF
--- a/eZ/Publish/Core/settings/search_engines/common.yml
+++ b/eZ/Publish/Core/settings/search_engines/common.yml
@@ -1,3 +1,6 @@
+imports:
+    - {resource: search_engines/slots.yml}
+
 parameters:
     ezpublish.search.common.field_registry.class: eZ\Publish\Core\Search\Common\FieldRegistry
     ezpublish.search.common.field_name_resolver.class: eZ\Publish\Core\Search\Common\FieldNameResolver


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24294

The problem was search Slots were not configured when using the Repository in Symfony context.
Fixed by adding `slots.yml` to `common.yml`, as common for all search engines.