### PR TITLE
Fix EZP-24909: SiteAccessMatchListener does not dispatch a scope change

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/DynamicSettingsListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/DynamicSettingsListener.php
@@ -69,7 +69,7 @@ class DynamicSettingsListener implements EventSubscriberInterface
             return;
         }
 
-        $this->resetDynamicSettings();
+        $this->container->get('event_dispatcher')->dispatch(MVCEvents::CONFIG_SCOPE_CHANGE, new ScopeChangeEvent($event->getSiteAccess()));
     }
 
     public function onConfigScopeChange(ScopeChangeEvent $event)

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router as SiteAccessRouter;
+use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
 use eZ\Publish\Core\MVC\Symfony\Event\PostSiteAccessMatchEvent;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
@@ -95,6 +96,7 @@ class SiteAccessMatchListener implements EventSubscriberInterface
         if ($siteaccess instanceof SiteAccess) {
             $siteAccessEvent = new PostSiteAccessMatchEvent($siteaccess, $request, $event->getRequestType());
             $this->eventDispatcher->dispatch(MVCEvents::SITEACCESS, $siteAccessEvent);
+            $this->eventDispatcher->dispatch(MVCEvents::CONFIG_SCOPE_CHANGE, new ScopeChangeEvent($siteaccess));
         }
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
@@ -95,8 +95,8 @@ class SiteAccessMatchListener implements EventSubscriberInterface
         $siteaccess = $request->attributes->get('siteaccess');
         if ($siteaccess instanceof SiteAccess) {
             $siteAccessEvent = new PostSiteAccessMatchEvent($siteaccess, $request, $event->getRequestType());
-            $this->eventDispatcher->dispatch(MVCEvents::SITEACCESS, $siteAccessEvent);
             $this->eventDispatcher->dispatch(MVCEvents::CONFIG_SCOPE_CHANGE, new ScopeChangeEvent($siteaccess));
+            $this->eventDispatcher->dispatch(MVCEvents::SITEACCESS, $siteAccessEvent);
         }
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
@@ -16,7 +16,6 @@ use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router as SiteAccessRouter;
-use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
 use eZ\Publish\Core\MVC\Symfony\Event\PostSiteAccessMatchEvent;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
@@ -95,7 +94,6 @@ class SiteAccessMatchListener implements EventSubscriberInterface
         $siteaccess = $request->attributes->get('siteaccess');
         if ($siteaccess instanceof SiteAccess) {
             $siteAccessEvent = new PostSiteAccessMatchEvent($siteaccess, $request, $event->getRequestType());
-            $this->eventDispatcher->dispatch(MVCEvents::CONFIG_SCOPE_CHANGE, new ScopeChangeEvent($siteaccess));
             $this->eventDispatcher->dispatch(MVCEvents::SITEACCESS, $siteAccessEvent);
         }
     }


### PR DESCRIPTION
Dynamic parameters are not updated when a site access match is performed. On a match it should be updated so services like the UrlAliasRouter have the updated site access.