### PR TITLE
Made REST FieldTypeProcessor registry lazy

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
@@ -252,6 +252,7 @@ services:
 
     ezpublish_rest.field_type_processor_registry:
         class: %ezpublish_rest.field_type_processor_registry.class%
+        lazy: true
 
     ezpublish_rest.field_type_processor.ezimage:
         class: %ezpublish_rest.field_type_processor.ezimage.class%


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-24910

It is used by many REST services, and some FieldTypeProcessors may depend on core repository services. Injecting those in a request listener, like the UserContentGateway from PlatformUIBundle, will initialize some settings (vardir) too early.

It materializes as invalid BinaryFileId exceptions unless the vardir is defined in the `default` scope.