### PR TITLE
Fix BC issues with deprecated location view controller and fallback to content view controller

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewControllerListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewControllerListener.php
@@ -108,6 +108,12 @@ class ViewControllerListener implements EventSubscriberInterface
             return;
         }
 
+        $requestParams = $request->attributes->get('params', []);
+        if ($valueObject instanceof Location && !isset($requestParams['location'])) {
+            $requestParams += ['location' => $valueObject];
+            $request->attributes->set('params', $requestParams);
+        }
+
         $controllerReference = $this->controllerManager->getControllerReference(
             $valueObject,
             $request->attributes->get('viewType')

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewControllerListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewControllerListener.php
@@ -119,6 +119,15 @@ class ViewControllerListener implements EventSubscriberInterface
             $request->attributes->get('viewType')
         );
 
+        if ($valueObject instanceof Location && !$controllerReference instanceof ControllerReference) {
+            // If value object is a location and location view rules did not match a controller
+            // we should try matching with content view rules
+            $controllerReference = $this->controllerManager->getControllerReference(
+                $valueObject->contentInfo,
+                $request->attributes->get('viewType')
+            );
+        }
+
         if ($controllerReference instanceof ControllerReference) {
             $request->attributes->set('_controller', $controllerReference->controller);
             $event->setController($this->controllerResolver->getController($request));


### PR DESCRIPTION
Since deprecating location view controller in https://github.com/ezsystems/ezpublish-kernel/pull/1425, location is not transfered to `ez_content:viewContent`, so the main location is used instead. Is is then transfered to `location` variable in content view templates (https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php#L251-L253) which is wrong when location which is rendered (140 in example below) is not a main location:

```
{{ render(
    controller(
        'ez_content:viewLocation', {
            'locationId': 140,
            'viewType': 'line'
        }
    )
) }}
```

Second issue arises when converting `location_view` rule with custom controller to `content_view` rule with custom controller. Since $valueObject is a location, location matcher factory is used to match the controller from override rules, but since we removed the `location_view` rule, custom controller cannot be matched any more. Thus, we try to match with content info, if matching with location fails.

Tests are manual only for now.

TODO
----

- [ ] Fix tests
- [ ] Create issue
