### PR TITLE
Fix EZP-24912: Publishing a role draft doesn't remove previous published role

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/User/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Handler.php
@@ -355,36 +355,34 @@ class Handler implements BaseUserHandler
     /**
      * Publish the specified role draft.
      *
-     * @param mixed $roleId
+     * @param mixed $roleDraftId
      */
-    public function publishRoleDraft($roleId)
+    public function publishRoleDraft($roleDraftId)
     {
-        $roleDraft = $this->loadRole($roleId, Role::STATUS_DRAFT);
+        $roleDraft = $this->loadRole($roleDraftId, Role::STATUS_DRAFT);
 
         try {
-            $role = $this->loadRole($roleId);
+            $originalRoleId = $roleDraft->originalId;
+            $role = $this->loadRole($originalRoleId);
             $roleAssignments = $this->loadRoleAssignmentsByRoleId($role->id);
             $this->deleteRole($role->id);
 
             foreach ($roleAssignments as $roleAssignment) {
                 if (empty($roleAssignment->limitationIdentifier)) {
-                    $this->assignRole(
-                        $roleAssignment->contentId,
-                        $roleId
-                    );
+                    $this->assignRole($roleAssignment->contentId, $originalRoleId);
                 } else {
                     $this->assignRole(
                         $roleAssignment->contentId,
-                        $roleId,
+                        $originalRoleId,
                         [$roleAssignment->limitationIdentifier => $roleAssignment->values]
                     );
                 }
             }
+            $this->roleGateway->publishRoleDraft($roleDraft->id, $role->id);
         } catch (NotFound $e) {
-            // If no published role is found, no updates are necessary to it
+            // If no published role is found, only publishing is needed, without specifying original role ID as there is none.
+            $this->roleGateway->publishRoleDraft($roleDraft->id);
         }
-
-        $this->roleGateway->publishRoleDraft($roleDraft->id);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
@@ -124,10 +124,12 @@ abstract class Gateway
 
     /**
      * Publish the specified role draft.
+     * If the draft was created from an existing role, published version will take the original role ID.
      *
-     * @param mixed $roleId
+     * @param mixed $roleDraftId
+     * @param mixed|null $originalRoleId ID of role the draft was created from. Will be null if the role draft was completely new.
      */
-    abstract public function publishRoleDraft($roleId);
+    abstract public function publishRoleDraft($roleDraftId, $originalRoleId = null);
 
     /**
      * Adds a policy to a role.

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
@@ -244,13 +244,15 @@ class ExceptionConversion extends Gateway
 
     /**
      * Publish the specified role draft.
+     * If the draft was created from an existing role, published version will take the original role ID.
      *
-     * @param mixed $roleId
+     * @param mixed $roleDraftId
+     * @param mixed|null $originalRoleId ID of role the draft was created from. Will be null if the role draft was completely new.
      */
-    public function publishRoleDraft($roleId)
+    public function publishRoleDraft($roleDraftId, $originalRoleId = null)
     {
         try {
-            return $this->innerGateway->publishRoleDraft($roleId);
+            return $this->innerGateway->publishRoleDraft($roleDraftId, $originalRoleId);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {

--- a/eZ/Publish/SPI/Persistence/User/Handler.php
+++ b/eZ/Publish/SPI/Persistence/User/Handler.php
@@ -189,9 +189,9 @@ interface Handler
     /**
      * Publish the specified role draft.
      *
-     * @param mixed $roleId
+     * @param mixed $roleDraftId
      */
-    public function publishRoleDraft($roleId);
+    public function publishRoleDraft($roleDraftId);
 
     /**
      * Adds a policy to a role draft.


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24912

Now the previous role is correctly removed in favor of the role draft, which becomes the *published* role.
The same `roleId` is also kept (like for ContentTypes).