### PR TITLE
Fix EZP-24913: Cannot remove a policy from a RoleDraft

### DIFF
--- a/eZ/Publish/API/Repository/RoleService.php
+++ b/eZ/Publish/API/Repository/RoleService.php
@@ -10,6 +10,7 @@
  */
 namespace  eZ\Publish\API\Repository;
 
+use eZ\Publish\API\Repository\Values\User\PolicyDraft;
 use eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\Policy;
 use eZ\Publish\API\Repository\Values\User\RoleUpdateStruct;
@@ -125,11 +126,10 @@ interface RoleService
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if policy does not belong to the given RoleDraft
      *
      * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
-     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to remove from the RoleDraft
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft the updated RoleDraft
+     * @param PolicyDraft $policyDraft the policy to remove from the RoleDraft
+     * @return RoleDraft if the authenticated user is not allowed to remove a policy
      */
-    public function removePolicyByRoleDraft(RoleDraft $roleDraft, Policy $policy);
+    public function removePolicyByRoleDraft(RoleDraft $roleDraft, PolicyDraft $policyDraft);
 
     /**
      * Updates the limitations of a policy. The module and function cannot be changed and

--- a/eZ/Publish/Core/Persistence/Legacy/User/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Handler.php
@@ -346,7 +346,7 @@ class Handler implements BaseUserHandler
         $role = $this->loadRole($roleId, $status);
 
         foreach ($role->policies as $policy) {
-            $this->roleGateway->removePolicy($policy->id, $status);
+            $this->roleGateway->removePolicy($policy->id);
         }
 
         $this->roleGateway->deleteRole($role->id, $status);

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
@@ -151,9 +151,8 @@ abstract class Gateway
      * Removes a policy from a role.
      *
      * @param mixed $policyId
-     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      */
-    abstract public function removePolicy($policyId, $status = Role::STATUS_DEFINED);
+    abstract public function removePolicy($policyId);
 
     /**
      * Removes a policy from a role.

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
@@ -828,34 +828,18 @@ class DoctrineDatabase extends Gateway
      * Removes a policy from a role.
      *
      * @param mixed $policyId
-     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      */
-    public function removePolicy($policyId, $status = Role::STATUS_DEFINED)
+    public function removePolicy($policyId)
     {
         $this->removePolicyLimitations($policyId);
 
         $query = $this->handler->createDeleteQuery();
-        if ($status === Role::STATUS_DEFINED) {
-            $policyCondition = $query->expr->eq(
-                $this->handler->quoteColumn('original_id', 'ezpolicy'),
-                $query->bindValue(0, null, \PDO::PARAM_INT)
-            );
-        } else {
-            $policyCondition = $query->expr->neq(
-                $this->handler->quoteColumn('original_id', 'ezpolicy'),
-                $query->bindValue(0, null, \PDO::PARAM_INT)
-            );
-        }
-
         $query
             ->deleteFrom($this->handler->quoteTable('ezpolicy'))
             ->where(
-                $query->expr->lAnd(
-                    $query->expr->eq(
-                        $this->handler->quoteColumn('id'),
-                        $query->bindValue($policyId, null, \PDO::PARAM_INT)
-                    ),
-                    $policyCondition
+                $query->expr->eq(
+                    $this->handler->quoteColumn('id'),
+                    $query->bindValue($policyId, null, \PDO::PARAM_INT)
                 )
             );
         $query->prepare()->execute();

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
@@ -298,12 +298,11 @@ class ExceptionConversion extends Gateway
      * Removes a policy from a role.
      *
      * @param mixed $policyId
-     * @param int $status One of Role::STATUS_DEFINED|Role::STATUS_DRAFT
      */
-    public function removePolicy($policyId, $status = Role::STATUS_DEFINED)
+    public function removePolicy($policyId)
     {
         try {
-            return $this->innerGateway->removePolicy($policyId, $status);
+            return $this->innerGateway->removePolicy($policyId);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {

--- a/eZ/Publish/Core/REST/Client/RoleService.php
+++ b/eZ/Publish/Core/REST/Client/RoleService.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\RoleService as APIRoleService;
 use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation;
 use eZ\Publish\API\Repository\Values\User\Policy as APIPolicy;
 use eZ\Publish\API\Repository\Values\User\PolicyCreateStruct as APIPolicyCreateStruct;
+use eZ\Publish\API\Repository\Values\User\PolicyDraft;
 use eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct as APIPolicyUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\Role as APIRole;
 use eZ\Publish\API\Repository\Values\User\RoleDraft as APIRoleDraft;
@@ -192,15 +193,12 @@ class RoleService implements APIRoleService, Sessionable
      *
      * @since 6.0
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if policy does not belong to the given role draft
      *
      * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
-     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to remove from the role
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft the updated role
+     * @param PolicyDraft $policyDraft the policy to remove from the role
+     * @return APIRoleDraft if the authenticated user is not allowed to remove a policy
      */
-    public function removePolicyByRoleDraft(APIRoleDraft $roleDraft, APIPolicy $policy)
+    public function removePolicyByRoleDraft(APIRoleDraft $roleDraft, PolicyDraft $policyDraft)
     {
         //TODO
     }

--- a/eZ/Publish/Core/Repository/RoleService.php
+++ b/eZ/Publish/Core/Repository/RoleService.php
@@ -17,6 +17,7 @@ use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation;
 use eZ\Publish\API\Repository\Values\User\Policy as APIPolicy;
 use eZ\Publish\API\Repository\Values\User\PolicyCreateStruct as APIPolicyCreateStruct;
+use eZ\Publish\API\Repository\Values\User\PolicyDraft;
 use eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct as APIPolicyUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\Role as APIRole;
 use eZ\Publish\API\Repository\Values\User\RoleCreateStruct as APIRoleCreateStruct;
@@ -398,21 +399,21 @@ class RoleService implements RoleServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if policy does not belong to the given RoleDraft
      *
      * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
-     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to remove from the RoleDraft
+     * @param PolicyDraft $policyDraft the policy to remove from the RoleDraft
      *
-     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft the updated RoleDraft
+     * @return APIRoleDraft if the authenticated user is not allowed to remove a policy
      */
-    public function removePolicyByRoleDraft(APIRoleDraft $roleDraft, APIPolicy $policy)
+    public function removePolicyByRoleDraft(APIRoleDraft $roleDraft, PolicyDraft $policyDraft)
     {
         if ($this->repository->hasAccess('role', 'update') !== true) {
             throw new UnauthorizedException('role', 'update');
         }
 
-        if ($policy->roleId != $roleDraft->id) {
+        if ($policyDraft->roleId != $roleDraft->id) {
             throw new InvalidArgumentException('$policy', 'Policy does not belong to the given role');
         }
 
-        $this->internalDeletePolicy($policy);
+        $this->internalDeletePolicy($policyDraft);
 
         return $this->loadRoleDraft($roleDraft->id);
     }

--- a/eZ/Publish/Core/SignalSlot/RoleService.php
+++ b/eZ/Publish/Core/SignalSlot/RoleService.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\RoleService as RoleServiceInterface;
 use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation;
 use eZ\Publish\API\Repository\Values\User\Policy;
 use eZ\Publish\API\Repository\Values\User\PolicyCreateStruct;
+use eZ\Publish\API\Repository\Values\User\PolicyDraft;
 use eZ\Publish\API\Repository\Values\User\PolicyUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\Role;
 use eZ\Publish\API\Repository\Values\User\RoleCreateStruct;
@@ -223,21 +224,20 @@ class RoleService implements RoleServiceInterface
      * @since 6.0
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to remove a policy
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if policy does not belong to the given role draft
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if policy does not belong to the given RoleDraft
      *
      * @param \eZ\Publish\API\Repository\Values\User\RoleDraft $roleDraft
-     * @param \eZ\Publish\API\Repository\Values\User\Policy $policy the policy to remove from the role
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\RoleDraft the updated role
+     * @param PolicyDraft $policyDraft the policy to remove from the role
+     * @return RoleDraft if the authenticated user is not allowed to remove a policy
      */
-    public function removePolicyByRoleDraft(RoleDraft $roleDraft, Policy $policy)
+    public function removePolicyByRoleDraft(RoleDraft $roleDraft, PolicyDraft $policyDraft)
     {
-        $returnValue = $this->service->removePolicyByRoleDraft($roleDraft, $policy);
+        $returnValue = $this->service->removePolicyByRoleDraft($roleDraft, $policyDraft);
         $this->signalDispatcher->emit(
             new RemovePolicyByRoleDraftSignal(
                 array(
                     'roleId' => $roleDraft->id,
-                    'policyId' => $policy->id,
+                    'policyId' => $policyDraft->id,
                 )
             )
         );

--- a/eZ/Publish/Core/SignalSlot/Tests/RoleServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/RoleServiceTest.php
@@ -10,6 +10,7 @@
  */
 namespace eZ\Publish\Core\SignalSlot\Tests;
 
+use eZ\Publish\Core\Repository\Values\User\PolicyDraft;
 use eZ\Publish\Core\Repository\Values\User\RoleCreateStruct;
 use eZ\Publish\API\Repository\Values\User\RoleUpdateStruct;
 use eZ\Publish\Core\Repository\Values\User\PolicyCreateStruct;
@@ -58,6 +59,7 @@ class RoleServiceTest extends ServiceTest
                 'roleId' => $roleId,
             )
         );
+        $policyDraft = new PolicyDraft(['innerPolicy' => $policy]);
         $roleCreateStruct = new RoleCreateStruct();
         $roleUpdateStruct = new RoleUpdateStruct();
         $policyCreateStruct = new PolicyCreateStruct();
@@ -156,7 +158,7 @@ class RoleServiceTest extends ServiceTest
             ),
             array(
                 'removePolicyByRoleDraft',
-                array($roleDraft, $policy),
+                array($roleDraft, $policyDraft),
                 $roleDraft,
                 1,
                 'eZ\Publish\Core\SignalSlot\Signal\RoleService\RemovePolicyByRoleDraftSignal',


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-24913

API has been updated to accept `PolicyDraft` object and gateway was also updated to stop discriminate policy draft vs regular policy removal.