### PR TITLE
Fix automatic conversion of location view rules to content view rules

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
@@ -107,8 +107,12 @@ class EzPublishCoreBundle extends Bundle
         if (!isset($this->extension)) {
             $this->extension = new EzPublishCoreExtension(
                 array(
-                    new ConfigParser\LocationView(),
+                    // LocationView config parser needs to be specified AFTER ContentView config
+                    // parser since it is used to convert location view override rules to content
+                    // view override rules. If it were specified before, ContentView provider would
+                    // just undo the conversion LocationView did.
                     new ConfigParser\ContentView(),
+                    new ConfigParser\LocationView(),
                     new ConfigParser\BlockView(),
                     new ConfigParser\Common(),
                     new ConfigParser\Content(),


### PR DESCRIPTION
After #1425, when no custom controller is specified in location view rules, they should automatically be converted to content view override rules. This is implemented in https://github.com/ezsystems/ezpublish-kernel/commit/e18b76458981c55fe1bc1618eb023f1f3de3a596.

However, since ContentView config parser is registered *after* LocationView config parser (which handles the conversion), and `$config` variable is passed around by value instead of by reference, ContentView parser just undos everything LocationView parser did in relation to automatic conversion.

Since LocationView provider also removes the rules it converted, the system is left without rules used to render the location/content view.

This makes sure LocationView parser is registered after ContentView parser, so conversion will be retained.

Another approach to solving this issue would be to transfer $config to all `preMap` and `postMap` methods by reference, but that could potentially have undesired consequences where custom bundles could modify the rules.