### PR TITLE
Fix _ez_content_view route controller and allow fallback to legacy /content/view/full/42

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
@@ -7,8 +7,11 @@ _ezpublishLocation:
         layout: true
 
 _ez_content_view:
-    path: /content/view/{contentId}/{language}
-    defaults: { _controller: ezpublish.controller.content:viewContentAction }
+    path: /view/content/{contentId}/{language}/{viewType}/{layout}
+    defaults:
+        _controller: ez_content:viewContent
+        viewType: full
+        layout: true
 
 _ezpublishPreviewContent:
     path: /content/versionview/{contentId}/{versionNo}/{language}/site_access/{siteAccessName}

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
@@ -106,7 +106,7 @@ class PreviewController
 
         try {
             $response = $this->kernel->handle(
-                $this->getForwardRequest($location, $content, $siteAccess, $request),
+                $this->getForwardRequest($location, $content, $siteAccess, $request, $language),
                 HttpKernelInterface::SUB_REQUEST,
                 false
             );
@@ -139,10 +139,11 @@ EOF;
      * @param \eZ\Publish\API\Repository\Values\Content\Content $content
      * @param \eZ\Publish\Core\MVC\Symfony\SiteAccess $previewSiteAccess
      * @param Request $request
+     * @param string $language
      *
      * @return \Symfony\Component\HttpFoundation\Request
      */
-    protected function getForwardRequest(Location $location, Content $content, SiteAccess $previewSiteAccess, Request $request)
+    protected function getForwardRequest(Location $location, Content $content, SiteAccess $previewSiteAccess, Request $request, $language)
     {
         $forwardRequestParameters = array(
             '_controller' => 'ez_content:viewContent',
@@ -151,6 +152,7 @@ EOF;
             '_route_params' => array(
                 'contentId' => $content->id,
                 'locationId' => $location->id,
+                'language' => $language,
             ),
             'location' => $location,
             'viewType' => ViewManagerInterface::VIEW_TYPE_FULL,

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -105,6 +105,7 @@ class UrlAliasGenerator extends Generator
         }
 
         $queryString = '';
+        unset($parameters['language'], $parameters['contentId']);
         if (!empty($parameters)) {
             $queryString = '?' . http_build_query($parameters, '', '&');
         }


### PR DESCRIPTION
This PR fixes couple of issues with the new `_ez_content_view` route:

1) `ezpublish.controller.content` service does not exist, `ez_content` must be used instead. Additionally, when using the service notation here, `Action` should not be appended to action name. Thus, correct controller reference is `ez_content:viewContent`

2) `/content/view/{contentId}/{language}` route path clashes with legacy `/content/view/full/42` URLs. In order to avoid that, route path was renamed to `/view/content/{contentId}/{language}`.

3) The route was missing the `viewType` and `layout` parameters, which means that something like `/view/content/42/eng-GB` was failing with `Controller "eZ\Publish\Core\MVC\Symfony\Controller\Content\ViewController::viewContent()" requires that you provide a value for the "$viewType" argument (because there is no default value or because there is a non optional argument after this one).` error.

4) Now that route has two additional parameters, `contentId` and `language`, they have to be removed in URL alias generator, so they don't end up in query params.

5) The language parameter needs to be passed from preview controller to forwarded request.