### PR TITLE
Added 'location' to locationView request attributes

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewControllerListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewControllerListener.php
@@ -82,6 +82,7 @@ class ViewControllerListener implements EventSubscriberInterface
                     $request->attributes->get('locationId')
                 );
                 $request->attributes->set('contentId', $valueObject->contentId);
+                $request->attributes->set('location', $valueObject);
             } elseif ($request->attributes->get('location') instanceof Location) {
                 $valueObject = $request->attributes->get('location');
                 $request->attributes->set('locationId', $valueObject->id);


### PR DESCRIPTION
> See https://jira.ez.no/browse/EZP-24897

When a `locationId` is passed to the view controller, this adds the Location object to the request attributes. It makes it possible to typehint the Location object instead of the locationId scalar. This should make preview of first versions of a location work in much more cases.

Tested by changing `DemoController::showBlogPostAction` to expect `Location $location` instead of `$locationId`. Before the change, previewing the first draft of a blog post would generate a fatal error. After the change it works as expected.