### PR TITLE
Allow transfering location to content view provider

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/View/Manager.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Manager.php
@@ -239,7 +239,11 @@ class Manager implements ViewManagerInterface
     {
         $contentInfo = $content->getVersionInfo()->getContentInfo();
         foreach ($this->getAllContentViewProviders() as $viewProvider) {
-            $view = $viewProvider->getView($contentInfo, $viewType);
+            $view = $viewProvider->getView(
+                $contentInfo,
+                isset($parameters['location']) ? $parameters['location'] : null,
+                $viewType
+            );
             if ($view instanceof ContentViewInterface) {
                 $parameters['content'] = $content;
 

--- a/eZ/Publish/Core/MVC/Symfony/View/Provider/Content.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Provider/Content.php
@@ -11,6 +11,8 @@
 namespace eZ\Publish\Core\MVC\Symfony\View\Provider;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location as APIContentLocation;
+use eZ\Publish\Core\MVC\Symfony\View\ViewManagerInterface;
 
 /**
  * Interface for content view providers.
@@ -23,9 +25,10 @@ interface Content
      * Returns a ContentView object corresponding to $contentInfo, or null if not applicable.
      *
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $location
      * @param string $viewType Variation of display for your content
      *
      * @return \eZ\Publish\Core\MVC\Symfony\View\ContentView|null
      */
-    public function getView(ContentInfo $contentInfo, $viewType);
+    public function getView(ContentInfo $contentInfo, APIContentLocation $location = null, $viewType = ViewManagerInterface::VIEW_TYPE_FULL);
 }

--- a/eZ/Publish/Core/MVC/Symfony/View/Provider/Content/Configured.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Provider/Content/Configured.php
@@ -13,6 +13,8 @@ namespace eZ\Publish\Core\MVC\Symfony\View\Provider\Content;
 use eZ\Publish\Core\MVC\Symfony\View\Provider\Configured as BaseConfigured;
 use eZ\Publish\Core\MVC\Symfony\View\Provider\Content as ContentViewProvider;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\Core\MVC\Symfony\View\ViewManagerInterface;
 
 class Configured extends BaseConfigured implements ContentViewProvider
 {
@@ -20,11 +22,12 @@ class Configured extends BaseConfigured implements ContentViewProvider
      * Returns a ContentView object corresponding to $contentInfo, or null if not applicable.
      *
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $location
      * @param string $viewType Variation of display for your content
      *
      * @return \eZ\Publish\Core\MVC\Symfony\View\ContentView|null
      */
-    public function getView(ContentInfo $contentInfo, $viewType)
+    public function getView(ContentInfo $contentInfo, Location $location = null, $viewType = ViewManagerInterface::VIEW_TYPE_FULL)
     {
         $viewConfig = $this->matcherFactory->match($contentInfo, $viewType);
         if (empty($viewConfig)) {

--- a/eZ/Publish/Core/MVC/Symfony/View/Provider/Location.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Provider/Location.php
@@ -11,6 +11,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\View\Provider;
 
 use eZ\Publish\API\Repository\Values\Content\Location as APIContentLocation;
+use eZ\Publish\Core\MVC\Symfony\View\ViewManagerInterface;
 
 /**
  * Interface for location view providers.
@@ -27,5 +28,5 @@ interface Location
      *
      * @return \eZ\Publish\Core\MVC\Symfony\View\ContentView|null
      */
-    public function getView(APIContentLocation $location, $viewType);
+    public function getView(APIContentLocation $location, $viewType = ViewManagerInterface::VIEW_TYPE_FULL);
 }

--- a/eZ/Publish/Core/MVC/Symfony/View/Provider/Location/Configured.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Provider/Location/Configured.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\MVC\Symfony\View\Provider\Location;
 use eZ\Publish\Core\MVC\Symfony\View\Provider\Configured as BaseConfigured;
 use eZ\Publish\Core\MVC\Symfony\View\Provider\Location as LocationViewProvider;
 use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\Core\MVC\Symfony\View\ViewManagerInterface;
 
 class Configured extends BaseConfigured implements LocationViewProvider
 {
@@ -26,7 +27,7 @@ class Configured extends BaseConfigured implements LocationViewProvider
      *
      * @return \eZ\Publish\Core\MVC\Symfony\View\ContentView|null
      */
-    public function getView(Location $location, $viewType)
+    public function getView(Location $location, $viewType = ViewManagerInterface::VIEW_TYPE_FULL)
     {
         $viewConfig = $this->matcherFactory->match($location, $viewType);
         if (empty($viewConfig)) {

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/Provider/Content/ConfiguredTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/Provider/Content/ConfiguredTest.php
@@ -41,6 +41,7 @@ class ConfiguredTest extends PHPUnit_Framework_TestCase
         $this->assertNull(
             $cvp->getView(
                 $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo'),
+                $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Location'),
                 'full'
             )
         );
@@ -66,6 +67,7 @@ class ConfiguredTest extends PHPUnit_Framework_TestCase
         $cvp = new ContentViewProvider($this->matcherFactoryMock);
         $view = $cvp->getView(
             $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo'),
+            $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Location'),
             'full'
         );
         $this->assertInstanceOf('eZ\\Publish\\Core\\MVC\\Symfony\\View\\ContentView', $view);

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/ViewManagerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/ViewManagerTest.php
@@ -113,6 +113,7 @@ class ViewManagerTest extends PHPUnit_Framework_TestCase
         $content = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Content');
         $versionInfo = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo');
         $contentInfo = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
+        $location = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Location');
         $content
             ->expects($this->once())
             ->method('getVersionInfo')
@@ -124,11 +125,11 @@ class ViewManagerTest extends PHPUnit_Framework_TestCase
 
         // Configuring view provider behaviour
         $templateIdentifier = 'foo:bar:baz';
-        $params = array('foo' => 'bar');
+        $params = array('foo' => 'bar', 'location' => $location);
         $viewProvider
             ->expects($this->once())
             ->method('getView')
-            ->with($contentInfo, 'customViewType')
+            ->with($contentInfo, $params['location'], 'customViewType')
             ->will(
                 $this->returnValue(
                     new ContentView($templateIdentifier, $params)
@@ -143,7 +144,7 @@ class ViewManagerTest extends PHPUnit_Framework_TestCase
             ->with($templateIdentifier, $params + array('content' => $content, 'viewbaseLayout' => $this->viewBaseLayout))
             ->will($this->returnValue($expectedTemplateResult));
 
-        self::assertSame($expectedTemplateResult, $this->viewManager->renderContent($content, 'customViewType'));
+        self::assertSame($expectedTemplateResult, $this->viewManager->renderContent($content, 'customViewType', $params));
     }
 
     public function testRenderContentWithClosure()


### PR DESCRIPTION
After #1425 and deprecating of location view controller, the fallback to legacy location view (`node_view_gui`) doesn't work. Instead, when viewing the location, `content_view_gui` is used which breaks all legacy full view overrides.

Location view controller does a fallback to content view controller and content view manager, which uses ONLY content view providers to render the template. Because of that, when opening a page through its URL alias, fallbacks happen as following:

location view -> content view -> legacy content view

when in fact, it should fallback as following:

location view -> content view -> legacy location view

This change allows the correct fallback to happen by changing the content view provider interface to transfer the location to it. New stack content view provider will ignore it (no change in implementation), while legacy content view provider should use it to forward the request to legacy location view provider (a separate PR will be needed on legacy bridge to remove the tag from legacy location view provider and inject it into legacy content view provider instead).

As discussed with @bdunogier on slack, changing the interface is not the most clean solution there is, so I'm opening this  PR to discuss the issue and not keep it private.

Change to the location view provider interface is only to make it consistent with content view provider interface and if accepted, it will need a PR to demo bundle.