### PR TITLE
Fixes to controller refactoring

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ViewProvidersPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ViewProvidersPass.php
@@ -58,6 +58,20 @@ class ViewProvidersPass implements CompilerPassInterface
             );
         }
 
+        $flattenedViewProviders = [];
+        foreach ($viewProviders as $type => $typeViewProviders) {
+            foreach ($typeViewProviders as $typeViewProvider) {
+                $flattenedViewProviders[] = $typeViewProvider;
+            }
+        }
+
+        if ($container->hasDefinition('ezpublish.config_scope_listener')) {
+            $container->getDefinition('ezpublish.config_scope_listener')->addMethodCall(
+                'setViewProviders',
+                [$flattenedViewProviders]
+            );
+        }
+
         // 5.4.5 BC service after location view deprecation
         if ($container->hasDefinition('ezpublish.view.custom_location_controller_checker')) {
             $container->getDefinition('ezpublish.view.custom_location_controller_checker')->addMethodCall(

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ConfigScopeListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ConfigScopeListener.php
@@ -29,6 +29,11 @@ class ConfigScopeListener implements EventSubscriberInterface
      */
     private $viewManager;
 
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\View\ViewProvider|\eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware
+     */
+    private $viewProviders;
+
     public function __construct(
         VersatileScopeInterface $configResolver,
         ViewManagerInterface $viewManager
@@ -52,5 +57,21 @@ class ConfigScopeListener implements EventSubscriberInterface
         if ($this->viewManager instanceof SiteAccessAware) {
             $this->viewManager->setSiteAccess($siteAccess);
         }
+
+        foreach ($this->viewProviders as $viewProvider) {
+            if ($viewProvider instanceof SiteAccessAware) {
+                $viewProvider->setSiteAccess($siteAccess);
+            }
+        }
+    }
+
+    /**
+     * Sets the complete list of view providers.
+     *
+     * @param array $viewProviders
+     */
+    public function setViewProviders(array $viewProviders)
+    {
+        $this->viewProviders = $viewProviders;
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -191,7 +191,7 @@ services:
 
     ezpublish.view.template_renderer:
         class: eZ\Publish\Core\MVC\Symfony\View\Renderer\TemplateRenderer
-        arguments: [@templating]
+        arguments: [@templating, @event_dispatcher]
 
     ezpublish.view.renderer_listener:
         class: eZ\Bundle\EzPublishCoreBundle\EventListener\ViewRendererListener

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ConfigScopeListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ConfigScopeListenerTest.php
@@ -28,11 +28,20 @@ class ConfigScopeListenerTest extends PHPUnit_Framework_TestCase
      */
     private $viewManager;
 
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $viewProviders;
+
     protected function setUp()
     {
         parent::setUp();
         $this->configResolver = $this->getMock('eZ\Publish\Core\MVC\Symfony\Configuration\VersatileScopeInterface');
         $this->viewManager = $this->getMock('eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs\ViewManager');
+        $this->viewProviders = array(
+            $this->getMock('eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs\ViewProvider'),
+            $this->getMock('eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs\ViewProvider'),
+        );
     }
 
     public function testGetSubscribedEvents()
@@ -59,7 +68,15 @@ class ConfigScopeListenerTest extends PHPUnit_Framework_TestCase
             ->method('setSiteAccess')
             ->with($siteAccess);
 
+        foreach ($this->viewProviders as $viewProvider) {
+            $viewProvider
+                ->expects($this->once())
+                ->method('setSiteAccess')
+                ->with($siteAccess);
+        }
+
         $listener = new ConfigScopeListener($this->configResolver, $this->viewManager);
+        $listener->setViewProviders($this->viewProviders);
         $listener->onConfigScopeChange($event);
         $this->assertSame($siteAccess, $event->getSiteAccess());
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/Stubs/ViewProvider.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/Stubs/ViewProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * File containing the ViewProvider class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs;
+
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use eZ\Publish\Core\MVC\Symfony\View\ViewProvider as ViewProviderInterface;
+
+/**
+ * Stub class for SiteAccessAware ViewProvider.
+ */
+class ViewProvider implements ViewProviderInterface, SiteAccessAware
+{
+    public function setSiteAccess(SiteAccess $siteAccess = null)
+    {
+    }
+
+    /**
+     * @return View
+     */
+    public function getView(View $view)
+    {
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
@@ -111,7 +111,7 @@ class PreviewController
                 false
             );
         } catch (\Exception $e) {
-            if ($location->isDraft() && $this->controllerChecker->usesCustomController($location)) {
+            if ($location->isDraft() && $this->controllerChecker->usesCustomController($content, $location)) {
                 // @todo This should probably be an exception that embeds the original one
                 $message = <<<EOF
 <p>The view that rendered this location draft uses a custom controller, and resulted in a fatal error.</p>
@@ -166,7 +166,7 @@ EOF;
             'semanticPathinfo' => $request->attributes->get('semanticPathinfo'),
         );
 
-        if ($this->controllerChecker->usesCustomController($location)) {
+        if ($this->controllerChecker->usesCustomController($content, $location)) {
             $forwardRequestParameters = [
                 '_controller' => 'ez_content:viewLocation',
                 '_route' => self::INTERNAL_LOCATION_VIEW_ROUTE,

--- a/eZ/Publish/Core/MVC/Symfony/Event/APIContentExceptionEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/APIContentExceptionEvent.php
@@ -11,7 +11,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Event;
 
 use Symfony\Component\EventDispatcher\Event;
-use eZ\Publish\Core\MVC\Symfony\View\ContentViewInterface;
+use eZ\Publish\Core\MVC\Symfony\View\View;
 use Exception;
 
 /**
@@ -26,7 +26,7 @@ class APIContentExceptionEvent extends Event
     private $apiException;
 
     /**
-     * @var \eZ\Publish\Core\MVC\Symfony\View\ContentView
+     * @var \eZ\Publish\Core\MVC\Symfony\View\View
      */
     private $contentView;
 
@@ -53,15 +53,15 @@ class APIContentExceptionEvent extends Event
      * Injects the ContentView object to display content from.
      * It is a good idea to call {@link stopPropagation()} after that so that other listeners won't override it.
      *
-     * @param \eZ\Publish\Core\MVC\Symfony\View\ContentViewInterface $contentView
+     * @param \eZ\Publish\Core\MVC\Symfony\View\View $contentView
      */
-    public function setContentView(ContentViewInterface $contentView)
+    public function setContentView(View $contentView)
     {
         $this->contentView = $contentView;
     }
 
     /**
-     * @return \eZ\Publish\Core\MVC\Symfony\View\ContentView
+     * @return \eZ\Publish\Core\MVC\Symfony\View\View
      */
     public function getContentView()
     {

--- a/eZ/Publish/Core/MVC/Symfony/View/CustomLocationControllerChecker.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/CustomLocationControllerChecker.php
@@ -4,6 +4,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\View;
 
+use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Location;
 
 /**
@@ -11,7 +12,7 @@ use eZ\Publish\API\Repository\Values\Content\Location;
  */
 class CustomLocationControllerChecker
 {
-    /** @var \eZ\Publish\Core\MVC\Symfony\View\Provider\Location[] */
+    /** @var \eZ\Publish\Core\MVC\Symfony\View\ViewProvider[] */
     private $viewProviders;
 
     /**
@@ -19,17 +20,22 @@ class CustomLocationControllerChecker
      *
      * @since 5.4.5
      *
+     * @param $content Content
      * @param $location Location
+     * @param $viewMode string
      *
      * @return bool
      */
-    public function usesCustomController(Location $location, $viewMode = 'full')
+    public function usesCustomController(Content $content, Location $location, $viewMode = 'full')
     {
+        $contentView = new ContentView(null, [], $viewMode);
+        $contentView->setContent($content);
+        $contentView->setLocation($location);
+
         foreach ($this->viewProviders as $viewProvider) {
-            $view = $viewProvider->getView($location, $viewMode);
-            if ($view instanceof ContentViewInterface) {
-                $configHash = $view->getConfigHash();
-                if (isset($configHash['controller'])) {
+            $view = $viewProvider->getView($contentView);
+            if ($view instanceof View) {
+                if ($view->getControllerReference() !== null) {
                     return true;
                 }
             }
@@ -39,7 +45,7 @@ class CustomLocationControllerChecker
     }
 
     /**
-     * @param $viewProviders \eZ\Publish\Core\MVC\Symfony\View\Provider\Location[]
+     * @param $viewProviders \eZ\Publish\Core\MVC\Symfony\View\ViewProvider[]
      */
     public function addViewProviders(array $viewProviders)
     {

--- a/eZ/Publish/Core/MVC/Symfony/View/Renderer/TemplateRenderer.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Renderer/TemplateRenderer.php
@@ -7,6 +7,9 @@ namespace eZ\Publish\Core\MVC\Symfony\View\Renderer;
 
 use eZ\Publish\Core\MVC\Symfony\View\Renderer;
 use eZ\Publish\Core\MVC\Symfony\View\View;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use eZ\Publish\Core\MVC\Symfony\MVCEvents;
+use eZ\Publish\Core\MVC\Symfony\Event\PreContentViewEvent;
 use Symfony\Component\Templating\EngineInterface as TemplateEngine;
 use Closure;
 
@@ -17,9 +20,15 @@ class TemplateRenderer implements Renderer
      */
     protected $templateEngine;
 
-    public function __construct(TemplateEngine $templateEngine)
+    /**
+     * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+     */
+    protected $eventDispatcher;
+
+    public function __construct(TemplateEngine $templateEngine, EventDispatcherInterface $eventDispatcher)
     {
         $this->templateEngine = $templateEngine;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**
@@ -29,6 +38,11 @@ class TemplateRenderer implements Renderer
      */
     public function render(View $view)
     {
+        $this->eventDispatcher->dispatch(
+            MVCEvents::PRE_CONTENT_VIEW,
+            new PreContentViewEvent($view)
+        );
+
         $templateIdentifier = $view->getTemplateIdentifier();
         if ($templateIdentifier instanceof Closure) {
             return $templateIdentifier($view->getParameters());

--- a/eZ/Publish/Core/MVC/Symfony/View/Renderer/TemplateRenderer.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Renderer/TemplateRenderer.php
@@ -8,6 +8,7 @@ namespace eZ\Publish\Core\MVC\Symfony\View\Renderer;
 use eZ\Publish\Core\MVC\Symfony\View\Renderer;
 use eZ\Publish\Core\MVC\Symfony\View\View;
 use Symfony\Component\Templating\EngineInterface as TemplateEngine;
+use Closure;
 
 class TemplateRenderer implements Renderer
 {
@@ -22,12 +23,17 @@ class TemplateRenderer implements Renderer
     }
 
     /**
-     * @param \eZ\Publish\Core\MVC\Symfony\View\ContentViewInterface $view
+     * @param \eZ\Publish\Core\MVC\Symfony\View\View $view
      *
      * @return string
      */
     public function render(View $view)
     {
+        $templateIdentifier = $view->getTemplateIdentifier();
+        if ($templateIdentifier instanceof Closure) {
+            return $templateIdentifier($view->getParameters());
+        }
+
         return $this->templateEngine->render(
             $view->getTemplateIdentifier(),
             $view->getParameters()


### PR DESCRIPTION
1) Template renderer needs special handling if template identifier is a closure

2) Dispatch `MVCEvents::PRE_CONTENT_VIEW` event prior to rendering the template, just as view manager did

3) Fix interface name in `APIContentExceptionEvent`