### PR TITLE
Add injector to inject embed objectParameters variable into template

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -208,6 +208,11 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    ezpublish.view.view_parameters.injector.embed_object_parameters:
+        class: eZ\Publish\Core\MVC\Symfony\View\ParametersInjector\EmbedObjectParameters
+        tags:
+            - { name: kernel.event_subscriber }
+
     ezpublish.view.view_parameters.injector.no_layout:
         class: eZ\Publish\Core\MVC\Symfony\View\ParametersInjector\NoLayout
         tags:

--- a/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/EmbedObjectParameters.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/EmbedObjectParameters.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;
+
+use eZ\Publish\Core\MVC\Symfony\View\Event\ViewParametersFilterEvent;
+use eZ\Publish\Core\MVC\Symfony\View\Events;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Injects the 'objectParameters' array as a standalone variable.
+ */
+class EmbedObjectParameters implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [Events::VIEW_PARAMETERS_INJECTION => 'injectEmbedObjectParameters'];
+    }
+
+    public function injectEmbedObjectParameters(ViewParametersFilterEvent $event)
+    {
+        $viewType = $event->getView()->getViewType();
+        if ($viewType == 'embed' || $viewType == 'embed-inline') {
+            $builderParameters = $event->getBuilderParameters();
+            if (isset($builderParameters['params']['objectParameters']) && is_array($builderParameters['params']['objectParameters'])) {
+                $event->getParameterBag()->set('objectParameters', $builderParameters['params']['objectParameters']);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Event handler that injects `$params['objectParameters']` as a standalone variable into view.