### PR TITLE
Fixes to view refactoring

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/CacheViewResponseListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/CacheViewResponseListener.php
@@ -61,8 +61,10 @@ class CacheViewResponseListener implements EventSubscriberInterface
         $response = $event->getResponse();
         $request = $event->getRequest();
 
-        if ($view instanceof LocationValueView && ($location = $view->getLocation()) instanceof Location) {
-            $response->headers->set('X-Location-Id', $location->id, false);
+        if (!$response->isNotModified($event->getRequest())) {
+            if ($view instanceof LocationValueView && ($location = $view->getLocation()) instanceof Location) {
+                $response->headers->set('X-Location-Id', $location->id, false);
+            }
         }
 
         $response->setPublic();

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewRendererListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewRendererListener.php
@@ -37,7 +37,9 @@ class ViewRendererListener implements EventSubscriberInterface
             $response = new Response();
         }
 
-        $response->setContent($this->viewRenderer->render($view));
+        if (!$response->isNotModified($event->getRequest())) {
+            $response->setContent($this->viewRenderer->render($view));
+        }
 
         $event->setResponse($response);
     }

--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -7,6 +8,7 @@ namespace eZ\Publish\Core\MVC\Symfony\View\Builder;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
 use eZ\Publish\Core\MVC\Symfony\View\ContentView;
@@ -14,6 +16,7 @@ use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as Authorizatio
 use eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
@@ -70,8 +73,9 @@ class ContentViewBuilder implements ViewBuilder
             } elseif (isset($location)) {
                 $contentId = $location->contentId;
             } else {
-                throw new InvalidArgumentException('Content', 'No content could not be loaded from parameters');
+                throw new InvalidArgumentException('Content', 'No content could be loaded from parameters');
             }
+
             $content = $this->loadContent(
                 $view->getViewType(),
                 $contentId,
@@ -105,11 +109,12 @@ class ContentViewBuilder implements ViewBuilder
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content
+     *
      * @throws \eZ\Publish\Core\Base\Exceptions\UnauthorizedException
      */
     private function loadContent($viewType, $contentId, Location $location = null)
     {
-        if ($viewType === 'embed') {
+        if ($viewType === 'embed' || $viewType === 'embed-inline') {
             $content = $this->repository->sudo(
                 function (Repository $repository) use ($contentId) {
                     return $repository->getContentService()->loadContent($contentId);
@@ -121,6 +126,16 @@ class ContentViewBuilder implements ViewBuilder
                     'content', 'read|view_embed',
                     ['contentId' => $contentId, 'locationId' => $location !== null ? $location->id : 'n/a']
                 );
+            }
+
+            // Check that Content is published, since sudo allows loading unpublished content.
+            if (
+                $content->getVersionInfo()->status !== VersionInfo::STATUS_PUBLISHED
+                && !$this->authorizationChecker->isGranted(
+                    new AuthorizationAttribute('content', 'versionread', array('valueObject' => $content))
+                )
+            ) {
+                throw new UnauthorizedException('content', 'versionread', ['contentId' => $contentId]);
             }
         } else {
             $content = $this->repository->getContentService()->loadContent($contentId);
@@ -153,7 +168,7 @@ class ContentViewBuilder implements ViewBuilder
     {
         $limitations = ['valueObject' => $content->contentInfo];
         if (isset($location)) {
-            $limitations['location'] = $location;
+            $limitations['targets'] = $location;
         }
 
         $readAttribute = new AuthorizationAttribute('content', 'read', $limitations);


### PR DESCRIPTION
This PR fixes two small issues:

1) Replicates all ViewController functionality in ContentViewBuilder and fixes typos

2) Again, same as in ViewController, if the response is not modified, ViewRendererListener should not render the content and X-Location-Id should not be set.