### PR TITLE
Fix EZP-24951: embed element's text content is converted from XHTML5 edit format

### DIFF
--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -457,7 +457,7 @@
       <xsl:attribute name="itemscope">itemscope</xsl:attribute>
     </xsl:if>
     <xsl:if test="@xlink:href">
-      <xsl:attribute name="href">
+      <xsl:attribute name="data-href">
         <xsl:value-of select="@xlink:href"/>
       </xsl:attribute>
     </xsl:if>

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -445,14 +445,14 @@
   <xsl:template match="ezxhtml5:div[@data-ezelement='ezembed']">
     <xsl:element name="ezembed" namespace="http://docbook.org/ns/docbook">
       <xsl:call-template name="addCommonEmbedAttributes"/>
-      <xsl:apply-templates/>
+      <xsl:apply-templates select="node()[not(self::text())]"/>
     </xsl:element>
   </xsl:template>
 
   <xsl:template match="ezxhtml5:span[@data-ezelement='ezembedinline']">
     <xsl:element name="ezembedinline" namespace="http://docbook.org/ns/docbook">
       <xsl:call-template name="addCommonEmbedAttributes"/>
-      <xsl:apply-templates/>
+      <xsl:apply-templates select="node()[not(self::text())]"/>
     </xsl:element>
   </xsl:template>
 
@@ -464,7 +464,7 @@
     </xsl:if>
     <xsl:if test="@href">
       <xsl:attribute name="xlink:href">
-        <xsl:value-of select="@href"/>
+        <xsl:value-of select="@data-href"/>
       </xsl:attribute>
     </xsl:if>
     <xsl:if test="@data-ezview">

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -462,7 +462,7 @@
         <xsl:value-of select="@id"/>
       </xsl:attribute>
     </xsl:if>
-    <xsl:if test="@href">
+    <xsl:if test="@data-href">
       <xsl:attribute name="xlink:href">
         <xsl:value-of select="@data-href"/>
       </xsl:attribute>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/BaseTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/BaseTest.php
@@ -57,7 +57,7 @@ abstract class BaseTest extends PHPUnit_Framework_TestCase
         $lossySubdirectory = "_fixtures/{$fixtureSubdirectories['input']}/lossy";
         $inputDirNormalized = str_replace('/', '.', $fixtureSubdirectories['input']);
         $outputDirNormalized = str_replace('/', '.', $fixtureSubdirectories['output']);
-        foreach (glob(__DIR__ . "/{$lossySubdirectory}/*.{$fixtureSubdirectories['input']}.xml") as $inputFile) {
+        foreach (glob(__DIR__ . "/{$lossySubdirectory}/*.{$inputDirNormalized}.xml") as $inputFile) {
             $basename = basename(basename($inputFile, '.xml'), ".{$inputDirNormalized}");
             $outputFile = __DIR__ . "/{$lossySubdirectory}/{$basename}.{$outputDirNormalized}.xml";
 

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/022-embed.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/022-embed.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
-  <div data-ezelement="ezembed" href="ezcontent://106" id="embed-id-1" data-ezview="embed" class="embed-class" data-ezalign="left">
+  <div data-ezelement="ezembed" data-href="ezcontent://106" id="embed-id-1" data-ezview="embed" class="embed-class" data-ezalign="left">
     <span data-ezelement="ezconfig">
       <span data-ezelement="ezvalue" data-ezvalue-key="size">medium</span>
       <span data-ezelement="ezvalue" data-ezvalue-key="offset">10</span>
       <span data-ezelement="ezvalue" data-ezvalue-key="limit">5</span>
     </span>
   </div>
-  <div data-ezelement="ezembed" href="ezlocation://601" id="embed-id-2" data-ezview="line" class="embedClass2" data-ezalign="right"/>
+  <div data-ezelement="ezembed" data-href="ezlocation://601" id="embed-id-2" data-ezview="line" class="embedClass2" data-ezalign="right"/>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/023-embedInline.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/023-embedInline.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
-  <p>Some <span data-ezelement="ezembedinline" id="id3" href="ezcontent://601" data-ezview="embed-inline-custom" class="embedClass" data-ezalign="left"/> for the otherwise unremarkable paragraph.</p>
-  <p>This paragraph is just showing off its <span data-ezelement="ezembedinline" id="id5" href="ezcontent://501" data-ezview="embed-inline" class="embedClass2" data-ezalign="right">
+  <p>Some <span data-ezelement="ezembedinline" id="id3" data-href="ezcontent://601" data-ezview="embed-inline-custom" class="embedClass" data-ezalign="left"/> for the otherwise unremarkable paragraph.</p>
+  <p>This paragraph is just showing off its <span data-ezelement="ezembedinline" id="id5" data-href="ezcontent://501" data-ezview="embed-inline" class="embedClass2" data-ezalign="right">
     <span data-ezelement="ezconfig">
       <span data-ezelement="ezvalue" data-ezvalue-key="size">medium</span>
     </span>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/027-linkedEmbed.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/027-linkedEmbed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
-  <div itemscope="itemscope" data-ezelement="ezembed" href="ezcontent://106" id="embed-id-1" data-ezview="embed" class="embed-class" data-ezalign="left">
+  <div itemscope="itemscope" data-ezelement="ezembed" data-href="ezcontent://106" id="embed-id-1" data-ezview="embed" class="embed-class" data-ezalign="left">
     <link itemprop="url" data-ezelement="ezlink" href="ezurl://95#fragment1" target="_blank" id="link-id-1" title="Link title" class="link-class"/>
     <span data-ezelement="ezconfig">
       <span data-ezelement="ezvalue" data-ezvalue-key="size">medium</span>
@@ -8,7 +8,7 @@
       <span data-ezelement="ezvalue" data-ezvalue-key="limit">5</span>
     </span>
   </div>
-  <div itemscope="itemscope" data-ezelement="ezembed" href="ezlocation://601" id="embed-id-2" data-ezview="line" class="embedClass2" data-ezalign="right">
+  <div itemscope="itemscope" data-ezelement="ezembed" data-href="ezlocation://601" id="embed-id-2" data-ezview="line" class="embedClass2" data-ezalign="right">
     <link itemprop="url" data-ezelement="ezlink" href="ezlocation://202" class="linkClass2"/>
   </div>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/028-linkedEmbedInline.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/028-linkedEmbedInline.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
-  <p>Some <span itemscope="itemscope" data-ezelement="ezembedinline" id="id3" href="ezcontent://601" data-ezview="embed-inline-custom" class="embedClass" data-ezalign="left">
+  <p>Some <span itemscope="itemscope" data-ezelement="ezembedinline" id="id3" data-href="ezcontent://601" data-ezview="embed-inline-custom" class="embedClass" data-ezalign="left">
     <link itemprop="url" data-ezelement="ezlink" href="ezcontent://106" id="id4" target="_blank" title="Link title" class="linkClass"/>
   </span> for the otherwise unremarkable paragraph.</p>
-  <p>This paragraph is just showing off its <span itemscope="itemscope" data-ezelement="ezembedinline" id="id5" href="ezcontent://501" data-ezview="embed-inline" class="embedClass2" data-ezalign="right">
+  <p>This paragraph is just showing off its <span itemscope="itemscope" data-ezelement="ezembedinline" id="id5" data-href="ezcontent://501" data-ezview="embed-inline" class="embedClass2" data-ezalign="right">
     <link itemprop="url" data-ezelement="ezlink" href="ezcontent://105" id="id6" title="Link title 2" class="linkClass2"/>
     <span data-ezelement="ezconfig">
       <span data-ezelement="ezvalue" data-ezvalue-key="size">medium</span>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/001-embedContent.docbook.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/001-embedContent.docbook.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+    <ezembed xlink:href="ezcontent://106" view="embed" xml:id="embed-id-1" ezxhtml:class="embed-class" ezxhtml:align="left">
+        <ezconfig>
+            <ezvalue key="size">medium</ezvalue>
+            <ezvalue key="offset">10</ezvalue>
+            <ezvalue key="limit">5</ezvalue>
+        </ezconfig>
+    </ezembed>
+    <ezembed xlink:href="ezlocation://601" view="line" xml:id="embed-id-2" ezxhtml:class="embedClass2" ezxhtml:align="right"/>
+</section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/001-embedContent.xhtml5.edit.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/001-embedContent.xhtml5.edit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
+  <div data-ezelement="ezembed" data-href="ezcontent://106" id="embed-id-1" data-ezview="embed" class="embed-class" data-ezalign="left">
+    cabbage
+    <span data-ezelement="ezconfig">
+      <span data-ezelement="ezvalue" data-ezvalue-key="size">medium</span>
+      <span data-ezelement="ezvalue" data-ezvalue-key="offset">10</span>
+      <span data-ezelement="ezvalue" data-ezvalue-key="limit">5</span>
+    </span>
+  </div>
+  <div data-ezelement="ezembed" data-href="ezlocation://601" id="embed-id-2" data-ezview="line" class="embedClass2" data-ezalign="right">cheese</div>
+</section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/002-embedInlineContent.docbook.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/002-embedInlineContent.docbook.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+    <para>Some <ezembedinline xlink:href="ezcontent://601" view="embed-inline-custom" xml:id="id3" ezxhtml:class="embedClass" ezxhtml:align="left"/> for the otherwise unremarkable paragraph.</para>
+    <para>This paragraph is just showing off its <ezembedinline xlink:href="ezcontent://501" view="embed-inline" xml:id="id5" ezxhtml:class="embedClass2" ezxhtml:align="right">
+        <ezconfig>
+            <ezvalue key="size">medium</ezvalue>
+        </ezconfig>
+    </ezembedinline> content.</para>
+</section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/002-embedInlineContent.xhtml5.edit.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/lossy/002-embedInlineContent.xhtml5.edit.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
+  <p>Some <span data-ezelement="ezembedinline" id="id3" data-href="ezcontent://601" data-ezview="embed-inline-custom" class="embedClass" data-ezalign="left">dacquoise</span> for the otherwise unremarkable paragraph.</p>
+  <p>This paragraph is just showing off its <span data-ezelement="ezembedinline" id="id5" data-href="ezcontent://501" data-ezview="embed-inline" class="embedClass2" data-ezalign="right">
+    sachertorte
+    <span data-ezelement="ezconfig">
+      <span data-ezelement="ezvalue" data-ezvalue-key="size">medium</span>
+    </span>
+  </span> content.</p>
+</section>


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24951

Conversion stylesheet for converting from XHTML5 edit format to the internal format was converting embed element's text content, which is in the case of edit format a div or span element. This was causing the validation of the converted result to fail when the source element contained text content.

The problem is fixed by applying conversion only on non-text children of the embed elements.

Additionally fixed: using `data-href` instead of just `href` on embed elements in XHTML5 edit format.