### PR TITLE
BDD: config import + rest config

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/behat.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/behat.yml
@@ -1,0 +1,12 @@
+# This file is meant to be imported from ezplatform's behat.yml.dist.
+# All path are relative to the root ezplatform directory.
+core:
+    suites:
+        console:
+            paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishCoreBundle/Features/Console]
+            contexts: [ eZ\Bundle\EzPublishCoreBundle\Features\Context\ConsoleContext ]
+        web:
+            paths:
+                - vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishCoreBundle/Features
+            contexts:
+                - eZ\Bundle\EzPublishCoreBundle\Features\Context\ContentPreviewContext

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/RestContext.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/RestContext.php
@@ -77,17 +77,45 @@ class RestContext extends Context implements MinkAwareContext
      * @param string $json
      */
     public function __construct(
-        $url = self::DEFAULT_URL,
         $driver = self::DEFAULT_DRIVER,
         $type = self::DEFAULT_BODY_TYPE,
         $authType = self::DEFAULT_AUTH_TYPE
     ) {
         $this->driver = $driver;
-        $this->url = $url;
         $this->restBodyType = $type;
         $this->authType = $authType;
 
-        $this->setRestDriver($this->driver, $this->url);
+        $this->setRestDriver($this->driver);
+    }
+
+    private function setUrl($url)
+    {
+        $this->url = $url;
+        if (isset($this->restDriver)) {
+            $this->restDriver->setHost($this->url);
+        }
+    }
+
+    /**
+     * Sets Mink instance.
+     *
+     * @param Mink $mink Mink session manager
+     */
+    public function setMink(Mink $mink)
+    {
+        $this->mink = $mink;
+    }
+
+    /**
+     * Sets parameters provided for Mink.
+     * While at it, take the base_url, and use it to build the one for the REST driver.
+     *
+     * @param array $parameters
+     */
+    public function setMinkParameters(array $parameters)
+    {
+        $this->minkParameters = $parameters;
+        $this->setUrl($parameters['base_url'] . '/api/ezp/v2/');
     }
 
     /**
@@ -102,9 +130,8 @@ class RestContext extends Context implements MinkAwareContext
      * Create and set the REST driver to be used.
      *
      * @param string $restDriver REST driver class name
-     * @param string|null $restUrl Base URL for the REST calls
      */
-    private function setRestDriver($restDriver, $restUrl)
+    private function setRestDriver($restDriver)
     {
         $namespace = '\\' . __NAMESPACE__ .  '\\RestClient\\';
         $driver = $namespace . $restDriver;
@@ -120,7 +147,9 @@ class RestContext extends Context implements MinkAwareContext
 
         // create a new REST Driver
         $this->restDriver = new $driver();
-        $this->restDriver->setHost($restUrl);
+        if (isset($this->url)) {
+            $this->restDriver->setHost($this->url);
+        }
     }
 
     /**
@@ -263,26 +292,5 @@ class RestContext extends Context implements MinkAwareContext
             . "\nActual: "
             . print_r($this->restDriver->getBody(), true)
         );
-    }
-
-    /**
-     * Sets Mink instance.
-     *
-     * @param Mink $mink Mink session manager
-     */
-    public function setMink(Mink $mink)
-    {
-        $this->mink = $mink;
-    }
-
-    /**
-     * Sets parameters provided for Mink.
-     *
-     * @param array $parameters
-     */
-    public function setMinkParameters(array $parameters)
-    {
-        $this->minkParameters = $parameters;
-        $this->restDriver->setHost($parameters['base_url'] . '/api/ezp/v2');
     }
 }

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/RestContext.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/RestContext.php
@@ -10,6 +10,8 @@
  */
 namespace eZ\Bundle\EzPublishRestBundle\Features\Context;
 
+use Behat\Mink\Mink;
+use Behat\MinkExtension\Context\MinkAwareContext;
 use EzSystems\BehatBundle\Context\Api\Context;
 use EzSystems\BehatBundle\Helper\Gherkin as GherkinHelper;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
@@ -22,7 +24,7 @@ use PHPUnit_Framework_Assert as Assertion;
  *   Settings and client initializations is done here
  *   Also it contains all REST generic actions.
  */
-class RestContext extends Context
+class RestContext extends Context implements MinkAwareContext
 {
     use SubContext\EzRest;
     use SubContext\Authentication;
@@ -56,6 +58,16 @@ class RestContext extends Context
      * @var string
      */
     private $driver;
+
+    /**
+     * @var \Behat\Mink\Mink
+     */
+    private $mink;
+
+    /**
+     * @var array
+     */
+    private $minkParameters;
 
     /**
      * Initialize class.
@@ -251,5 +263,26 @@ class RestContext extends Context
             . "\nActual: "
             . print_r($this->restDriver->getBody(), true)
         );
+    }
+
+    /**
+     * Sets Mink instance.
+     *
+     * @param Mink $mink Mink session manager
+     */
+    public function setMink(Mink $mink)
+    {
+        $this->mink = $mink;
+    }
+
+    /**
+     * Sets parameters provided for Mink.
+     *
+     * @param array $parameters
+     */
+    public function setMinkParameters(array $parameters)
+    {
+        $this->minkParameters = $parameters;
+        $this->restDriver->setHost($parameters['base_url'] . '/api/ezp/v2');
     }
 }

--- a/eZ/Bundle/EzPublishRestBundle/behat.yml
+++ b/eZ/Bundle/EzPublishRestBundle/behat.yml
@@ -4,20 +4,17 @@ rest:
             paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Features ]
             contexts:
                 - eZ\Bundle\EzPublishRestBundle\Features\Context\RestContext:
-                    url: http://localhost/api/ezp/v2/
                     driver: BuzzDriver
                     type: json
         fullXml:
             paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Features ]
             contexts:
                 - eZ\Bundle\EzPublishRestBundle\Features\Context\RestContext:
-                    url: http://localhost/api/ezp/v2/
                     driver: BuzzDriver
                     type: xml
         guzzle:
             paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Features ]
             contexts:
                 - eZ\Bundle\EzPublishRestBundle\Features\Context\RestContext:
-                    url: http://localhost/api/ezp/v2/
                     driver: GuzzleDriver
                     type: json

--- a/eZ/Bundle/EzPublishRestBundle/behat.yml
+++ b/eZ/Bundle/EzPublishRestBundle/behat.yml
@@ -1,0 +1,23 @@
+rest:
+    suites:
+        fullJson:
+            paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Features ]
+            contexts:
+                - eZ\Bundle\EzPublishRestBundle\Features\Context\RestContext:
+                    url: http://localhost/api/ezp/v2/
+                    driver: BuzzDriver
+                    type: json
+        fullXml:
+            paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Features ]
+            contexts:
+                - eZ\Bundle\EzPublishRestBundle\Features\Context\RestContext:
+                    url: http://localhost/api/ezp/v2/
+                    driver: BuzzDriver
+                    type: xml
+        guzzle:
+            paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Features ]
+            contexts:
+                - eZ\Bundle\EzPublishRestBundle\Features\Context\RestContext:
+                    url: http://localhost/api/ezp/v2/
+                    driver: GuzzleDriver
+                    type: json


### PR DESCRIPTION
> See ezsystems/ezplatform#55

In addition to moving the rest & core behat suites from ezplatform to ezpublish-kernel, this PR also changes the RestContext so that it gets the configured URL from Mink instead of re-declaring it in each suite.

This should make it possible to a) simplify the rest context arguments (format + driver should be sufficient) b) customize the base uri (including for REST) using the [`BEHAT_CONFIG` environment variable](http://docs.behat.org/en/v3.0/guides/6.profiles.html#environment-variable-behat-params).

Example:
```bash
export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"base_url" : "https://ez.loc/"}}}'
./bin/behat --profile=rest --suite=fullJson
```

### TODO
- [x] Remove the `base_url` setting from the `RestContext` arguments in class + `behat.yml.dist`