### PR TITLE
Throw exception if loaded location does not belong to content

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -96,6 +96,10 @@ class ContentViewBuilder implements ViewBuilder
 
         $view->setContent($content);
         if (isset($location)) {
+            if ($location->contentId !== $content->id) {
+                throw new InvalidArgumentException('Location', 'Provided location does not belong to selected content');
+            }
+
             $view->setLocation($location);
         }
 


### PR DESCRIPTION
Title says it all :)

Eliminates the possiblity that you have  view with location that does not belong to content.