### PR TITLE
Implemented QueryType View

### DIFF
--- a/doc/specifications/proposed/named_queries/developer_documentation.md
+++ b/doc/specifications/proposed/named_queries/developer_documentation.md
@@ -95,9 +95,9 @@ displayed using the object's properties or the `ez_content` controller actions.
 
 #### Available variables
 
-`location_list`                | array | Array of resulting Location. *Only set by the contentInfo action*
-`content_list`                 | array | Array of resulting Content. *Only set by the contentInfo action*
-`content_info_list`            | array | Array of resulting ContentInfo. *Only set by the contentInfo action*
+`location_list`                | array | Array of resulting Location. *Only set by the `location` action*
+`content_list`                 | array | Array of resulting Content. *Only set by the `content` action*
+`content_info_list`            | array | Array of resulting ContentInfo. *Only set by the `contentInfo` action*
 `list_count`                   | int   | Number of items in the resultset, within the limit if any
 `total_count`                  | int   | Total number of items in the search result
 `parameters`                   | array | The `parameters` hash that was passed to the Query

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/QueryTypePass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/QueryTypePass.php
@@ -5,6 +5,7 @@
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
 
 use Exception;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use ReflectionClass;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -16,23 +17,28 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class QueryTypePass implements CompilerPassInterface
 {
+    /** @var \Symfony\Component\DependencyInjection\Reference[] */
+    private $queryTypeRefs = [];
+
     public function process(ContainerBuilder $container)
     {
         if (!$container->hasDefinition('ezpublish.query_type.registry')) {
             return;
         }
 
-        $queryTypes = [];
+        $queryTypesRefs = [];
+
+        // array of QueryType classes. Used to prevent double handling between services & convention definitions.
+        $queryTypesClasses = [];
 
         // tagged query types
-        $taggedServiceIds = $container->findTaggedServiceIds('ezpublish.query_type');
-        foreach ($taggedServiceIds as $taggedServiceId => $tags) {
+        foreach ($container->findTaggedServiceIds('ezpublish.query_type') as $taggedServiceId => $tags) {
             $queryTypeDefinition = $container->getDefinition($taggedServiceId);
-            $queryTypeClass = $queryTypeDefinition->getClass();
+            $queryTypeClassName = $queryTypeDefinition->getClass();
 
             for ($i = 0, $count = count($tags); $i < $count; ++$i) {
-                // TODO: Check for duplicates
-                $queryTypes[] = new Reference($taggedServiceId);
+                $queryTypesRefs[] = new Reference($taggedServiceId);
+                $queryTypesClasses[$queryTypeClassName] = true;
             }
         }
 
@@ -48,30 +54,48 @@ class QueryTypePass implements CompilerPassInterface
                     continue;
                 }
 
-                $queryTypeServices = [];
+                $conventionQueryTypeDefs = [];
                 $bundleQueryTypeNamespace = substr($bundleClass, 0, strrpos($bundleClass, '\\') + 1) . 'QueryType';
                 foreach (glob($bundleQueryTypesDir . DIRECTORY_SEPARATOR . '*QueryType.php') as $queryTypeFilePath) {
                     $queryTypeFileName = basename($queryTypeFilePath, '.php');
                     $queryTypeClassName = $bundleQueryTypeNamespace . '\\' . $queryTypeFileName;
+                    if (isset($queryTypesClasses[$queryTypeClassName])) {
+                        continue;
+                    }
                     if (!class_exists($queryTypeClassName)) {
                         throw new Exception("Expected $queryTypeClassName to be defined in $queryTypeFilePath");
                     }
 
-                    $queryTypeReflectionClass = new ReflectionClass($queryTypeClassName);
-                    if (!$queryTypeReflectionClass->implementsInterface('eZ\Publish\Core\QueryType\QueryType')) {
-                        throw new Exception("$queryTypeClassName needs to implement eZ\\Publish\\Core\\QueryType\\QueryType");
-                    }
+                    $this->checkInterface($queryTypeClassName);
 
                     $serviceId = 'ezpublish.query_type.convention.' . strtolower($bundleName) . '_' . strtolower($queryTypeFileName);
-                    $queryTypeServices[$serviceId] = new Definition($queryTypeClassName);
-
-                    $queryTypes[] = new Reference($serviceId);
+                    $queryTypeDefinition = new Definition($queryTypeClassName);
+                    $conventionQueryTypeDefs[$serviceId] = $queryTypeDefinition;
+                    $queryTypesRefs[] = new Reference($serviceId);
                 }
-                $container->addDefinitions($queryTypeServices);
+                $container->addDefinitions($conventionQueryTypeDefs);
             }
         }
 
         $registryDef = $container->getDefinition('ezpublish.query_type.registry');
         $registryDef->addMethodCall('addQueryTypes', [$queryTypesRefs]);
+    }
+
+    /**
+     * Checks that $queryTypeClassName implements the QueryType interface.
+     *
+     * @param string $queryTypeClassName
+     *
+     * @throws InvalidArgumentException
+     */
+    private function checkInterface($queryTypeClassName)
+    {
+        $queryTypeReflectionClass = new ReflectionClass($queryTypeClassName);
+        if (!$queryTypeReflectionClass->implementsInterface('eZ\Publish\Core\QueryType\QueryType')) {
+            throw new InvalidArgumentException(
+                "QueryTypeClass $queryTypeClassName",
+                'needs to implement eZ\Publish\Core\QueryType\QueryType'
+            );
+        }
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/QueryTypePass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/QueryTypePass.php
@@ -32,7 +32,7 @@ class QueryTypePass implements CompilerPassInterface
 
             for ($i = 0, $count = count($tags); $i < $count; ++$i) {
                 // TODO: Check for duplicates
-                $queryTypes[$queryTypeClass::getName()] = new Reference($taggedServiceId);
+                $queryTypes[] = new Reference($taggedServiceId);
             }
         }
 
@@ -65,13 +65,13 @@ class QueryTypePass implements CompilerPassInterface
                     $serviceId = 'ezpublish.query_type.convention.' . strtolower($bundleName) . '_' . strtolower($queryTypeFileName);
                     $queryTypeServices[$serviceId] = new Definition($queryTypeClassName);
 
-                    $queryTypes[$queryTypeClassName::getName()] = new Reference($serviceId);
+                    $queryTypes[] = new Reference($serviceId);
                 }
                 $container->addDefinitions($queryTypeServices);
             }
         }
 
-        $aggregatorDefinition = $container->getDefinition('ezpublish.query_type.registry');
-        $aggregatorDefinition->addMethodCall('addQueryTypes', [$queryTypes]);
+        $registryDef = $container->getDefinition('ezpublish.query_type.registry');
+        $registryDef->addMethodCall('addQueryTypes', [$queryTypesRefs]);
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/QueryTypeView.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/QueryTypeView.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * File containing the LocationView class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;
+
+class QueryTypeView extends View
+{
+    const NODE_KEY = 'query_type_view';
+    const INFO = 'Template selection settings when viewing a query type result';
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/QueryTypeView.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/QueryTypeView.php
@@ -10,8 +10,65 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;
 
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
 class QueryTypeView extends View
 {
     const NODE_KEY = 'query_type_view';
-    const INFO = 'Template selection settings when viewing a query type result';
+    const INFO = 'Query types view configuration';
+
+    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    {
+        $nodeBuilder
+            ->arrayNode(static::NODE_KEY)
+                ->info(static::INFO)
+                ->useAttributeAsKey('key')
+                ->normalizeKeys(false)
+                ->prototype('array')
+                    ->useAttributeAsKey('key')
+                    ->normalizeKeys(false)
+                    ->info("View selection rulesets, grouped by view type. Key is the view type (e.g. 'full', 'line', ...)")
+                    ->prototype('array')
+                        ->children()
+                            ->scalarNode('template')->info('Your template path, as MyBundle:subdir:my_template.html.twig')->end()
+                            ->booleanNode('enable_pager')
+                                ->info('If enabled, the result list is a PagerFanta pager object. If disabled, it is an array.')
+                                ->defaultTrue()
+                            ->end()
+                            ->scalarNode('controller')
+                            ->info(
+                                <<<EOT
+Use custom controller instead of the default one to display a content matching your rules.
+You can use the controller reference notation supported by Symfony.
+EOT
+                            )
+                            ->example('MyBundle:MyControllerClass:view')
+                        ->end()
+                        ->arrayNode('match')
+                            ->info('Condition matchers configuration')
+                            ->isRequired()
+                            ->useAttributeAsKey('key')
+                            ->prototype('variable')->end()
+                        ->end()
+                        ->arrayNode('params')
+                            ->info(
+                                <<<EOT
+Arbitrary params that will be passed in the ContentView object, manageable by ViewProviders.
+Those params will NOT be passed to the resulting view template by default.
+EOT
+                            )
+                            ->example(
+                                array(
+                                    'foo' => '%some.parameter.reference%',
+                                    'osTypes' => array('osx', 'linux', 'windows'),
+                                )
+                            )
+                            ->useAttributeAsKey('key')
+                            ->prototype('variable')->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ->end();
+    }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
@@ -114,6 +114,7 @@ class EzPublishCoreBundle extends Bundle
                     new ConfigParser\ContentView(),
                     new ConfigParser\LocationView(),
                     new ConfigParser\BlockView(),
+                    new ConfigParser\QueryTypeView(),
                     new ConfigParser\Common(),
                     new ConfigParser\Content(),
                     new ConfigParser\FieldType\RichText(),

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/NavigationContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/NavigationContext.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\MinkExtension\Context\MinkAwareContext;
+use Behat\MinkExtension\Context\RawMinkContext;
+use PHPUnit_Framework_Assert as Assertion;
+use Symfony\Component\Routing\RouterInterface;
+
+class NavigationContext extends RawMinkContext implements Context, SnippetAcceptingContext, MinkAwareContext
+{
+    /**
+     * @var \Symfony\Component\Routing\RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var \Symfony\Component\Routing\Route
+     */
+    private $currentRoute;
+
+    public function __construct(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * @Given /^there is a route "([^"]*)"$/
+     */
+    public function thereIsARoute($routeIdentifier)
+    {
+        /** @var \Symfony\Component\Routing\RouterInterface $router */
+        $routeCollection = $this->router->getRouteCollection();
+        Assertion::assertNotNull(
+            $route = $routeCollection->get($routeIdentifier),
+            "Failed asserting that there is a route named $routeIdentifier"
+        );
+
+        $this->currentRoute = $route;
+    }
+
+    /**
+     * @Given /^that route has the default "([^"]*)" set to "([^"]*)"$/
+     */
+    public function routeHasTheDefaultSetTo($defaultName, $defaultValue)
+    {
+        Assertion::assertNotNull($this->currentRoute, 'No currentRoute was set');
+
+        Assertion::assertTrue(
+            $this->currentRoute->hasDefault($defaultName),
+            "Failed asserting that the route has the default attribute '$defaultName'"
+        );
+
+        if (is_string($defaultValue)) {
+            Assertion::assertEquals(
+                $defaultValue,
+                $this->currentRoute->getDefault($defaultName),
+                "Failed asserting that the route has the default attribute '$defaultName' set to '$defaultValue'"
+            );
+        } elseif (is_array($defaultValue)) {
+            Assertion::assertArraySubset(
+                $defaultValue,
+                $this->currentRoute->getDefault($defaultName),
+                "Failed asserting that the route has the default attribute '$defaultName' with the given array items"
+            );
+        }
+    }
+
+    /**
+     * @Given /^that route has the default "([^"]*)" set to an array with the key "([^"]*)" set to "([^"]*)"$/
+     */
+    public function routeHasTheDefaultSetToArray($defaultName, $arrayKey, $arrayValue)
+    {
+        $this->routeHasTheDefaultSetTo($defaultName, [$arrayKey => $arrayValue]);
+    }
+
+    /**
+     * @When /^I go to that route$/
+     */
+    public function iGoToThatRoute()
+    {
+        Assertion::assertTrue(isset($this->currentRoute), 'No current Route was set');
+        $this->visitPath($this->currentRoute->getPath());
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/QueryTypeContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/QueryTypeContext.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\MinkExtension\Context\MinkAwareContext;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\Core\QueryType\QueryTypeRegistry;
+use EzSystems\BehatBundle\Context\Browser\MinkTrait;
+use PHPUnit_Framework_Assert as Assertion;
+
+class QueryTypeContext implements Context, SnippetAcceptingContext, MinkAwareContext
+{
+    use MinkTrait;
+
+    /**
+     * @var \eZ\Publish\Core\QueryType\QueryType
+     */
+    private $currentQueryType;
+
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
+     */
+    private $searchResult;
+
+    /**
+     * @var \eZ\Publish\Core\QueryType\QueryTypeRegistry
+     */
+    private $queryTypeRegistry;
+
+    /**
+     * @var \eZ\Publish\API\Repository\SearchService
+     */
+    private $searchService;
+
+    public function __construct(QueryTypeRegistry $queryTypeRegistry, SearchService $searchService)
+    {
+        $this->queryTypeRegistry = $queryTypeRegistry;
+        $this->searchService = $searchService;
+    }
+
+    /**
+     * Sets the current QueryType given a QueryType name.
+     *
+     * @param string $queryTypeName
+     */
+    public function setCurrentQueryTypeByName($queryTypeName)
+    {
+        $this->currentQueryType = $this->queryTypeRegistry->getQueryType($queryTypeName);
+    }
+
+    /**
+     * @Given /^that a QueryType with that name exists$/
+     */
+    public function thatAQueryTypeWithThatNameExists()
+    {
+        // it was already checked when the QueryType was loaded, but you never know
+        Assertion::assertInstanceOf('eZ\Publish\Core\QueryType\QueryType', $this->currentQueryType);
+    }
+
+    public function runContentQuery()
+    {
+        return $this->searchService->findContent($this->currentQueryType->getQuery());
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/QueryTypeViewContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/QueryTypeViewContext.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\MinkExtension\Context\MinkAwareContext;
+use EzSystems\BehatBundle\Context\Browser\MinkTrait;
+use PHPUnit_Framework_Assert as Assertion;
+
+class QueryTypeViewContext implements Context, SnippetAcceptingContext, MinkAwareContext
+{
+    use MinkTrait;
+
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\Features\Context\ViewConfigurationContext
+     */
+    private $viewConfigurationContext;
+
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\Features\Context\NavigationContext
+     */
+    private $navigationContext;
+
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\Features\Context\QueryTypeContext
+     */
+    private $queryTypeContext;
+
+    /** @BeforeScenario */
+    public function gatherContexts(BeforeScenarioScope $scope)
+    {
+        $environment = $scope->getEnvironment();
+        $this->viewConfigurationContext = $environment->getContext('eZ\Bundle\EzPublishCoreBundle\Features\Context\ViewConfigurationContext');
+        $this->navigationContext = $environment->getContext('eZ\Bundle\EzPublishCoreBundle\Features\Context\NavigationContext');
+        $this->queryTypeContext = $environment->getContext('eZ\Bundle\EzPublishCoreBundle\Features\Context\QueryTypeContext');
+    }
+
+    /**
+     * @Given /^that a query_type view has enable_pager set to false$/
+     */
+    public function aQueryTypeViewHasEnablePagerSetToFalse()
+    {
+        $viewConfiguration = $this->viewConfigurationContext
+            ->thereIsAViewConfiguration('query_type_view', 'full', 'pager_disabled');
+
+        Assertion::assertArrayHasKey('enable_pager', $viewConfiguration);
+        Assertion::assertFalse($viewConfiguration['enable_pager']);
+
+        $this->navigationContext->thereIsARoute('ez_platform_behat_views_query_type_pager_disabled');
+    }
+
+    /**
+     * @Given /^that a query_type view does not specify enable_pager$/
+     */
+    public function aQueryTypeViewDoesNotSpecifyEnablePager()
+    {
+        $viewConfiguration = $this->viewConfigurationContext
+            ->thereIsAViewConfiguration('query_type_view', 'full', 'pager_enabled');
+
+        Assertion::assertArrayHasKey('enable_pager', $viewConfiguration);
+        // If enable_pager is not specified, it is set to true by default
+        Assertion::assertTrue($viewConfiguration['enable_pager']);
+
+        $this->navigationContext->thereIsARoute('ez_platform_behat_views_query_type_pager_enabled');
+    }
+
+    /**
+     * @When /^that view is rendered$/
+     */
+    public function thatViewIsRendered()
+    {
+        $this->navigationContext->iGoToThatRoute();
+    }
+
+    /**
+     * @Then /^the query results are assigned to the template as an array$/
+     */
+    public function theQueryResultsAreAssignedToTheTemplateAsAnArray()
+    {
+        $this->assertSession()->elementExists('css', 'div#assertion-result-type-array.true');
+    }
+
+    /**
+     * @Then /^the query results are assigned to the template as a PagerFanta Pager object$/
+     */
+    public function theQueryResultsAreAssignedToTheTemplateAsAPagerFantaPagerObject()
+    {
+        $this->assertSession()->elementExists('css', 'div#assertion-result-type-pager.true');
+    }
+
+    /**
+     * @Given /^that a query_type view matches on a QueryType name$/
+     */
+    public function aQueryTypeViewMatchesOnQueryTypeName()
+    {
+        $viewConfiguration = $this->viewConfigurationContext
+            ->thereIsAViewConfiguration('query_type_view', 'full', 'match_name');
+
+        Assertion::assertArrayHasKey('match', $viewConfiguration);
+        Assertion::assertArrayHasKey('QueryType\Name', $viewConfiguration['match']);
+
+        $this->queryTypeContext->setCurrentQueryTypeByName($viewConfiguration['match']['QueryType\Name']);
+        $this->navigationContext->thereIsARoute('ez_platform_behat_views_query_type_match_name');
+    }
+
+    /**
+     * @When /^ez_query:content is rendered with that QueryType name$/
+     */
+    public function ezQueryContentIsRenderedWithThatQueryTypeName()
+    {
+        $this->navigationContext->thereIsARoute('ez_platform_behat_views_query_type_match_name');
+        $this->navigationContext->iGoToThatRoute();
+    }
+
+    /**
+     * @Then /^the search results from that QueryType are assigned to the template as content_list$/
+     */
+    public function theSearchResultsFromThatQueryTypeAreAssignedToTheTemplateAsContentList()
+    {
+        $searchResult = $this->queryTypeContext->runContentQuery();
+
+        // the pager limit
+        $limit = 10;
+        $i = 1;
+        foreach ($searchResult->searchHits as $item) {
+            if (++$i == $limit) {
+                break;
+            }
+            $this->assertSession()->elementExists('css', "li#content-id-{$item->valueObject->id}");
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/ViewConfigurationContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/ViewConfigurationContext.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Behat\Tester\Exception\PendingException;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use PHPUnit_Framework_Assert as Assertion;
+
+class ViewConfigurationContext implements Context, SnippetAcceptingContext
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\ConfigResolverInterface
+     */
+    private $configResolver;
+
+    /**
+     * @var array
+     */
+    private $currentViewConfiguration;
+
+    public function __construct(ConfigResolverInterface $configResolver)
+    {
+        $this->configResolver = $configResolver;
+    }
+
+    /**
+     * @Given /^there is a "([^"]*)" ([a-z0-9_]+) configuration for the "([^"]*)" viewType$/
+     */
+    public function thereIsAQueryTypeViewConfigurationForTheViewTypeWithTheTemplate($viewConfigName, $what, $viewType)
+    {
+        /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver */
+        $queryTypeViewConfiguration = $this->configResolver->getParameter($what);
+
+        Assertion::assertArrayHasKey(
+            $viewType,
+            $queryTypeViewConfiguration,
+            "Failed asserting that there are $what configurations for the viewType $viewType"
+        );
+
+        Assertion::assertArrayHasKey(
+            $viewConfigName,
+            $queryTypeViewConfiguration[$viewType],
+            "Failed asserting that there is a '$viewType' query_type_view configuration named '$viewConfigName'"
+        );
+
+        $this->currentViewConfiguration = $queryTypeViewConfiguration[$viewType][$viewConfigName];
+    }
+
+    /**
+     * @Given /^that configuration has "([^"]*)" set to "([^"]*)"$/
+     */
+    public function configurationHasThePropertySetToTheValue($propertyName, $propertyValue)
+    {
+        Assertion::assertNotNull($this->currentViewConfiguration, 'No currentViewConfiguration was set');
+
+        Assertion::assertArrayHasKey(
+            $propertyName,
+            $this->currentViewConfiguration,
+            "Failed asserting that the query_type_view configuration sets the $propertyName property"
+        );
+
+        Assertion::assertEquals(
+            $propertyValue,
+            $this->currentViewConfiguration[$propertyName],
+            "Failed asserting that the query_type_view configuration sets the $propertyName property to $propertyValue"
+        );
+    }
+
+    /**
+     * @Given /^that configuration has "([^"]*)" set to the boolean "([^"]*)"$/
+     */
+    public function configurationHasThePropertySetToTheBooleanValue($propertyName, $propertyValue)
+    {
+        if ($propertyValue === 'true') {
+            $propertyValue = true;
+        } elseif ($propertyValue === 'false') {
+            $propertyValue = false;
+        } else {
+            throw new InvalidArgumentException('propertyValue', "Unknown boolean value '$propertyValue''");
+        }
+
+        $this->configurationHasThePropertySetToTheValue($propertyName, $propertyValue);
+    }
+
+    /**
+     * @Given /^that configuration matches on "([^"]*)" "([^"]*)"$/
+     */
+    public function configurationHasMatch($matcherName, $matcherValue)
+    {
+        Assertion::assertNotNull($this->currentViewConfiguration, 'No currentViewConfiguration was set');
+
+        $matchConfig = $this->currentViewConfiguration['match'];
+
+        Assertion::assertArrayHasKey(
+            $matcherName,
+            $matchConfig,
+            "Failed asserting that the view has a matcher '$matcherName'"
+        );
+
+        if (is_string($matcherValue)) {
+            Assertion::assertEquals(
+                $matcherValue,
+                $matchConfig[$matcherName],
+                "Failed asserting that the view matches on '$matcherName: $matcherValue'"
+            );
+        } elseif (is_array($matcherValue)) {
+            Assertion::assertArraySubset(
+                $matcherValue,
+                $matchConfig[$matcherName],
+                "Failed asserting that the view matches on '$matcherName' with the given array"
+            );
+        }
+    }
+
+    /**
+     * @Given /^that configuration matches the QueryType name "([^"]*)"$/
+     */
+    public function configurationHasMatchOnQueryTypeName($queryTypeName)
+    {
+        $this->configurationHasMatch('QueryType\Name', $queryTypeName);
+    }
+
+    /**
+     * @Given /^that configuration matches the QueryType parameter "([^"]*)" with the value "([^"]*)"$/
+     */
+    public function configurationHasMatchOnQueryTypeParameter($queryTypeParameterName, $queryTypeParameterValue)
+    {
+        $this->configurationHasMatch('QueryType\Parameters', [$queryTypeParameterName => $queryTypeParameterValue]);
+    }
+
+    /**
+     * @todo This needs to go either in the QueryTypeContext or a new QueryTypeViewConfigurationContext (that would
+     * inherit from ViewConfigurationContext, and interact with the QueryType one).
+     *
+     * @Given /^that a query_type view that matches on a QueryType and has enable_pager set to false$/
+     */
+    public function thatAQuery_typeViewThatMatchesOnAQueryTypeAndHasEnable_pagerSetToFalse()
+    {
+        throw new PendingException();
+    }
+
+    /**
+     * Finds and returns the $type (query_type_view, content_view) ViewConfiguration with $identifier.
+     *
+     * @param string $type query_type_view, content_view...
+     * @param string $viewType full, line...
+     * @param string $identifier the config block key
+     *
+     * @return array The view configuration
+     */
+    public function thereIsAViewConfiguration($type, $viewType, $identifier)
+    {
+        Assertion::assertTrue($this->configResolver->hasParameter($type));
+
+        $typeConfig = $this->configResolver->getParameter($type);
+        Assertion::assertArrayHasKey($viewType, $typeConfig);
+        Assertion::assertArrayHasKey($identifier, $typeConfig[$viewType]);
+
+        return $typeConfig[$viewType][$identifier];
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Features/View/named_queries.feature
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/View/named_queries.feature
@@ -1,0 +1,17 @@
+Feature: QueryType objects can be used with Views
+
+    Scenario: ez_query controller actions can be overridden
+       Given that a query_type view matches on a QueryType name
+         And that a QueryType with that name exists
+        When ez_query:content is rendered with that QueryType name
+        Then the search results from that QueryType are assigned to the template as content_list
+
+    Scenario: When enable_pager is set to false in a QueryType View, then search results are passed to the template as an array
+       Given that a query_type view has enable_pager set to false
+        When that view is rendered
+        Then the query results are assigned to the template as an array
+
+    Scenario: When enable_pager is not specified in a QueryType View, then search results are passed to the template as a pager object
+        Given that a query_type view does not specify enable_pager
+        When that view is rendered
+        Then the query results are assigned to the template as a PagerFanta Pager object

--- a/eZ/Bundle/EzPublishCoreBundle/Matcher/QueryTypeMatcherFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Matcher/QueryTypeMatcherFactory.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * File containing the ContentMatcherFactory class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Matcher;
+
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\Matcher\QueryTypeMatcherFactory as BaseFactory;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class QueryTypeMatcherFactory extends BaseFactory implements SiteAccessAware, ContainerAwareInterface
+{
+    /**
+     * @var \Symfony\Component\DependencyInjection\ContainerInterface
+     */
+    private $container;
+
+    /**
+     * @var \eZ\Publish\Core\MVC\ConfigResolverInterface;
+     */
+    private $configResolver;
+
+    public function __construct(ConfigResolverInterface $configResolver, Repository $repository)
+    {
+        $this->configResolver = $configResolver;
+        parent::__construct(
+            $repository,
+            $this->configResolver->getParameter('query_type_view')
+        );
+    }
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @param string $matcherIdentifier
+     *
+     * @return \eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\MatcherInterface
+     */
+    protected function getMatcher($matcherIdentifier)
+    {
+        if ($this->container->has($matcherIdentifier)) {
+            return $this->container->get($matcherIdentifier);
+        }
+
+        return parent::getMatcher($matcherIdentifier);
+    }
+
+    /**
+     * Changes internal configuration to use the one for passed SiteAccess.
+     *
+     * @param SiteAccess $siteAccess
+     */
+    public function setSiteAccess(SiteAccess $siteAccess = null)
+    {
+        if ($siteAccess === null) {
+            return;
+        }
+
+        $this->matchConfig = $this->configResolver->getParameter('query_type_view', 'ezsettings', $siteAccess->name);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -10,6 +10,7 @@ parameters:
     ezsettings.default.location_view: {}
     ezsettings.default.content_view: {}
     ezsettings.default.block_view: {}
+    ezsettings.default.query_type_view: {}
 
     # Common settings
     ezpublish.repositories: {}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -28,6 +28,8 @@ parameters:
     ezpublish.view_controller_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\ViewControllerListener
     ezpublish.exception_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\ExceptionListener
 
+    ezpublish.query_type.registry.class: eZ\Publish\Core\QueryType\QueryTypeNameRegistry
+
 services:
     # Siteaccess is injected in the container at runtime
     ezpublish.siteaccess:
@@ -177,4 +179,4 @@ services:
             - { name: kernel.event_subscriber }
 
     ezpublish.query_type.registry:
-        class: eZ\Publish\Core\QueryType\ArrayQueryTypeRegistry
+        class: %ezpublish.query_type.registry.class%

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -114,6 +114,13 @@ services:
         parent: ezpublish.controller.base
         scope: request
 
+    ezpublish.controller.query:
+        class: eZ\Publish\Core\MVC\Symfony\Controller\Content\QueryController
+
+    # Short alias for subrequests
+    ez_query:
+        alias: ezpublish.controller.query
+
     # This alias allows easier management for subrequests
     # {{ render( controller( "ez_content:viewLocation", {"locationId": 123, "viewType": "line"} ) ) }
     ez_content:

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -9,6 +9,7 @@ parameters:
     ezpublish.content_view.matcher_factory.class: eZ\Bundle\EzPublishCoreBundle\Matcher\ContentMatcherFactory
     ezpublish.location_view.matcher_factory.class: eZ\Bundle\EzPublishCoreBundle\Matcher\LocationMatcherFactory
     ezpublish.block_view.matcher_factory.class: eZ\Bundle\EzPublishCoreBundle\Matcher\BlockMatcherFactory
+    ezpublish.query_type.matcher_factory.class: eZ\Bundle\EzPublishCoreBundle\Matcher\QueryTypeMatcherFactory
 
     ezpublish.content_view.viewbase_layout: "EzPublishCoreBundle::viewbase_layout.html.twig"
     ezpublish.content_view.content_block_name: "content"

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -269,6 +269,11 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    ezpublish.view.view_parameters.injector.query_type_results:
+        class: eZ\Publish\Core\MVC\Symfony\View\ParametersInjector\QueryTypeResults
+        tags:
+            - { name: kernel.event_subscriber }
+
     ezpublish.view.cache_response_listener:
         class: %ezpublish.view.cache_response_listener.class%
         arguments:

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -190,7 +190,7 @@ services:
     ezpublish.view_builder.registry:
         class: %ezpublish.view_builder.registry.class%
         calls:
-            - [addToRegistry, [[@ezpublish.view_builder.content, @ezpublish.view_builder.block]]]
+            - [addToRegistry, [[@ezpublish.view_builder.content, @ezpublish.view_builder.block, @ezpublish.view_builder.query_type]]]
 
     ezpublish.view_builder.content:
         class: %ezpublish.view_builder.content.class%
@@ -203,6 +203,26 @@ services:
     ezpublish.view_builder.block:
         class: %ezpublish.view_builder.block.class%
         arguments: [@ezpublish.fieldType.ezpage.pageService]
+
+    ezpublish.view_builder.query_type:
+        class: eZ\Publish\Core\MVC\Symfony\View\Builder\QueryTypeViewBuilder
+        arguments:
+            - @ezpublish.query_type.registry
+            - @ezpublish.api.service.search
+            - @ezpublish.view.configurator
+            - @ezpublish.view.view_parameters.injector.dispatcher
+
+    ezpublish.query_type_view_provider.configured:
+        class: %ezpublish.view_provider.configured.class%
+        arguments: [@ezpublish.query_type.matcher_factory]
+        tags:
+            - {name: ezpublish.view_provider, type: 'eZ\Publish\Core\MVC\Symfony\View\QueryTypeView', priority: 10}
+
+    ezpublish.query_type.matcher_factory:
+        class: %ezpublish.query_type.matcher_factory.class%
+        arguments: [@ezpublish.config.resolver, @ezpublish.api.repository]
+        calls:
+            - [setContainer, [@service_container]]
 
     ezpublish.view.builder_parameter_collector.request_attributes:
         class: %ezpublish.view.builder_parameter_collector.request_attributes.class%

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/QueryTypePassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/QueryTypePassTest.php
@@ -86,7 +86,7 @@ class QueryTypePassTest extends AbstractCompilerPassTestCase
     }
 
     /**
-     * Adds to the kernel the path to a stub bundle that contains a QueryType class named by convention
+     * Adds to the kernel the path to a stub bundle that contains a QueryType class named by convention.
      */
     private function defineQueryTypeBundle()
     {

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/QueryTypePassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/QueryTypePassTest.php
@@ -41,7 +41,7 @@ class QueryTypePassTest extends AbstractCompilerPassTestCase
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'ezpublish.query_type.registry',
             'addQueryTypes',
-            [['Test:Test' => new Reference($serviceId)]]
+            [[new Reference($serviceId)]]
         );
     }
 
@@ -53,7 +53,7 @@ class QueryTypePassTest extends AbstractCompilerPassTestCase
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'ezpublish.query_type.registry',
             'addQueryTypes',
-            [['Test:Test' => new Reference('ezpublish.query_type.convention.querytypebundle_testquerytype')]]
+            [[new Reference('ezpublish.query_type.convention.querytypebundle_testquerytype')]]
         );
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/behat.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/behat.yml
@@ -11,6 +11,15 @@ core:
             paths:
                 - vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishCoreBundle/Features/Content
                 - vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishCoreBundle/Features/Exception
+                - vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishCoreBundle/Features/View
             contexts:
                 - eZ\Bundle\EzPublishCoreBundle\Features\Context\ContentPreviewContext
                 - eZ\Bundle\EzPublishCoreBundle\Features\Context\ExceptionContext
+                - eZ\Bundle\EzPublishCoreBundle\Features\Context\QueryTypeContext:
+                    queryTypeRegistry: @ezpublish.query_type.registry
+                    searchService: @ezpublish.api.service.search
+                - eZ\Bundle\EzPublishCoreBundle\Features\Context\ViewConfigurationContext:
+                    configResolver: @ezpublish.config.resolver
+                - eZ\Bundle\EzPublishCoreBundle\Features\Context\NavigationContext:
+                    router: @router
+                - eZ\Bundle\EzPublishCoreBundle\Features\Context\QueryTypeViewContext

--- a/eZ/Bundle/PlatformBehatBundle/DependencyInjection/EzPlatformBehatExtension.php
+++ b/eZ/Bundle/PlatformBehatBundle/DependencyInjection/EzPlatformBehatExtension.php
@@ -5,11 +5,14 @@
 namespace EzSystems\PlatformBehatBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 
-class EzPlatformBehatExtension extends Extension
+class EzPlatformBehatExtension extends Extension implements PrependExtensionInterface
 {
     public function load(array $config, ContainerBuilder $container)
     {
@@ -19,5 +22,13 @@ class EzPlatformBehatExtension extends Extension
         );
 
         $loader->load('services.yml');
+    }
+
+    public function prepend(ContainerBuilder $container)
+    {
+        $configFile = __DIR__ . '/../Resources/config/ez_view.yml';
+        $config = Yaml::parse(file_get_contents($configFile));
+        $container->prependExtensionConfig('ezpublish', $config);
+        $container->addResource(new FileResource($configFile));
     }
 }

--- a/eZ/Bundle/PlatformBehatBundle/QueryType/EmptyQuery.php
+++ b/eZ/Bundle/PlatformBehatBundle/QueryType/EmptyQuery.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformBehatBundle\QueryType;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+
+abstract class EmptyQuery
+{
+    public function getQuery(array $parameters = [])
+    {
+        return new Query();
+    }
+
+    public function getSupportedParameters()
+    {
+        return [];
+    }
+}

--- a/eZ/Bundle/PlatformBehatBundle/QueryType/LatestContentQueryType.php
+++ b/eZ/Bundle/PlatformBehatBundle/QueryType/LatestContentQueryType.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformBehatBundle\QueryType;
+
+use eZ\Publish\Core\QueryType\QueryType;
+use eZ\Publish\API\Repository\Values\Content\Query;
+
+class LatestContentQueryType implements QueryType
+{
+    public function getQuery(array $parameters = [])
+    {
+        $criteria[] = new Query\Criterion\Visibility(Query\Criterion\Visibility::VISIBLE);
+        if (isset($parameters['type'])) {
+            $criteria[] = new Query\Criterion\ContentTypeIdentifier($parameters['type']);
+        }
+
+        return new Query([
+            'filter' => new Query\Criterion\LogicalAnd($criteria),
+            'sortClauses' => [new Query\SortClause\DatePublished()],
+            'limit' => isset($parameters['limit']) ? $parameters['limit'] : 10,
+        ]);
+    }
+
+    public static function getName()
+    {
+        return 'EzPlatformBehatBundle:LatestContent';
+    }
+
+    /**
+     * Returns an array listing the parameters supported by the QueryType.
+     * @return array
+     */
+    public function getSupportedParameters()
+    {
+        return ['type'];
+    }
+}

--- a/eZ/Bundle/PlatformBehatBundle/QueryType/MatchNameQueryType.php
+++ b/eZ/Bundle/PlatformBehatBundle/QueryType/MatchNameQueryType.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformBehatBundle\QueryType;
+
+use eZ\Publish\Core\QueryType\QueryType;
+
+/**
+ * Used by the named_queries scenario.
+ */
+class MatchNameQueryType extends EmptyQuery implements QueryType
+{
+    public static function getName()
+    {
+        return 'EzPlatformBehatBundle:MatchName';
+    }
+}

--- a/eZ/Bundle/PlatformBehatBundle/QueryType/PagerDisabledQueryType.php
+++ b/eZ/Bundle/PlatformBehatBundle/QueryType/PagerDisabledQueryType.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformBehatBundle\QueryType;
+
+use eZ\Publish\Core\QueryType\QueryType;
+
+/**
+ * Used by the named_queries scenario.
+ */
+class PagerDisabledQueryType extends EmptyQuery implements QueryType
+{
+    public static function getName()
+    {
+        return 'EzPlatformBehatBundle:PagerDisabled';
+    }
+}

--- a/eZ/Bundle/PlatformBehatBundle/QueryType/PagerEnabledQueryType.php
+++ b/eZ/Bundle/PlatformBehatBundle/QueryType/PagerEnabledQueryType.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformBehatBundle\QueryType;
+
+use eZ\Publish\Core\QueryType\QueryType;
+
+/**
+ * Used by the named_queries scenario.
+ */
+class PagerEnabledQueryType extends EmptyQuery implements QueryType
+{
+    public static function getName()
+    {
+        return 'EzPlatformBehatBundle:PagerEnabled';
+    }
+}

--- a/eZ/Bundle/PlatformBehatBundle/Resources/config/ez_view.yml
+++ b/eZ/Bundle/PlatformBehatBundle/Resources/config/ez_view.yml
@@ -1,0 +1,26 @@
+system:
+    default:
+        query_type_view:
+            full:
+                latest_articles:
+                    template: 'EzPlatformBehatBundle:full:query_latest_article.html.twig'
+                    enable_pager: true
+                    match:
+                        QueryType\Name: 'EzPlatformBehatBundle:LatestContent'
+                        QueryType\Parameters:
+                            type: 'article'
+                pager_disabled:
+                    template: 'EzPlatformBehatBundle:full:list-variable-is-an-array.html.twig'
+                    match:
+                        QueryType\Name: 'EzPlatformBehatBundle:PagerDisabled'
+                    enable_pager: false
+
+                pager_enabled:
+                    template: 'EzPlatformBehatBundle:full:list-variable-is-a-pager.html.twig'
+                    match:
+                        QueryType\Name: 'EzPlatformBehatBundle:PagerEnabled'
+
+                match_name:
+                    template: 'EzPlatformBehatBundle:full:view-query-type-list-results.html.twig'
+                    match:
+                        QueryType\Name: 'EzPlatformBehatBundle:MatchName'

--- a/eZ/Bundle/PlatformBehatBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/PlatformBehatBundle/Resources/config/routing.yml
@@ -2,3 +2,32 @@ ez_platform_behat_repository_unauthorized_exception:
     path: '/platform-behat/exceptions/repository-unauthorized'
     defaults:
         _controller: 'platform_behat.controller.exception:throwRepositoryUnauthorizedAction'
+
+ez_platform_behat_latest_articles:
+    path: '/platform-behat/latest-articles'
+    defaults:
+        _controller: 'ez_query:content'
+        queryTypeName: 'EzPlatformBehatBundle:LatestContent'
+        parameters: {type: 'article'}
+        viewType: 'full'
+
+ez_platform_behat_views_query_type_pager_disabled:
+    path: '/platform-behat/views/query-type/pager-disabled'
+    defaults:
+        _controller: 'ez_query:content'
+        queryTypeName: 'EzPlatformBehatBundle:PagerDisabled'
+        viewType: 'full'
+
+ez_platform_behat_views_query_type_pager_enabled:
+    path: '/platform-behat/views/query-type/pager-enabled'
+    defaults:
+        _controller: 'ez_query:content'
+        queryTypeName: 'EzPlatformBehatBundle:PagerEnabled'
+        viewType: 'full'
+
+ez_platform_behat_views_query_type_match_name:
+    path: '/platform-behat/views/query-type/match-name'
+    defaults:
+        _controller: 'ez_query:content'
+        queryTypeName: 'EzPlatformBehatBundle:MatchName'
+        viewType: 'full'

--- a/eZ/Bundle/PlatformBehatBundle/Resources/config/services.yml
+++ b/eZ/Bundle/PlatformBehatBundle/Resources/config/services.yml
@@ -1,3 +1,9 @@
 services:
     platform_behat.controller.exception:
         class: eZ\Bundle\PlatformBehatBundle\Controller\ExceptionController
+
+    platform_behat.type_twig_extension:
+        class: eZ\Bundle\PlatformBehatBundle\Twig\TypeTwigExtension
+        public: false
+        tags:
+            - { name: twig.extension }

--- a/eZ/Bundle/PlatformBehatBundle/Resources/views/full/list-variable-is-a-pager.html.twig
+++ b/eZ/Bundle/PlatformBehatBundle/Resources/views/full/list-variable-is-a-pager.html.twig
@@ -1,0 +1,1 @@
+<div id="assertion-result-type-pager" class="{% if content_list is aPager %}true{% else %}false{% endif %}"/>

--- a/eZ/Bundle/PlatformBehatBundle/Resources/views/full/list-variable-is-an-array.html.twig
+++ b/eZ/Bundle/PlatformBehatBundle/Resources/views/full/list-variable-is-an-array.html.twig
@@ -1,0 +1,1 @@
+<div id="assertion-result-type-array" class="{% if content_list is anArray %}true{% else %}false{% endif %}"/>

--- a/eZ/Bundle/PlatformBehatBundle/Resources/views/full/query_latest_article.html.twig
+++ b/eZ/Bundle/PlatformBehatBundle/Resources/views/full/query_latest_article.html.twig
@@ -1,0 +1,13 @@
+<div>
+    <ul class="latest-articles">
+        {% for article in content_list %}
+            <li class="article">{{ ez_content_name(article) }}</li>
+        {% endfor %}
+    </ul>
+</div>
+
+{% if content_list.haveToPaginate() %}
+    <div class="pagination-centered">
+        {{ pagerfanta( content_list, 'twitter_bootstrap_translated', {'routeName': 'bd_sandbox_latest_articles'} ) }}
+    </div>
+{% endif %}

--- a/eZ/Bundle/PlatformBehatBundle/Resources/views/full/view-query-type-list-results.html.twig
+++ b/eZ/Bundle/PlatformBehatBundle/Resources/views/full/view-query-type-list-results.html.twig
@@ -1,0 +1,5 @@
+<ul id="query-results">
+    {% for item in content_list %}
+        <li id="content-id-{{ item.id }}" />
+    {% endfor %}
+</ul>

--- a/eZ/Bundle/PlatformBehatBundle/Twig/TypeTwigExtension.php
+++ b/eZ/Bundle/PlatformBehatBundle/Twig/TypeTwigExtension.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\PlatformBehatBundle\Twig;
+
+use Pagerfanta\Pagerfanta;
+
+class TypeTwigExtension extends \Twig_Extension
+{
+    public function isBoolean($var)
+    {
+        return is_bool($var);
+    }
+    public function isAnArray($var)
+    {
+        return is_array($var);
+    }
+
+    public function isAPager($var)
+    {
+        return $var instanceof Pagerfanta;
+    }
+
+    public function getTests()
+    {
+        return array(
+            'anArray' => new \Twig_Function_Method($this, 'isAnArray'),
+            'aPager' => new \Twig_Function_Method($this, 'isAPager'),
+        );
+    }
+
+    public function getName()
+    {
+        return 'EzSystemsPlatformBehatTypeOfTwigExtension';
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/QueryController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/QueryController.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Controller\Content;
+
+use eZ\Publish\Core\MVC\Symfony\View\QueryTypeView;
+
+class QueryController
+{
+    public function content(QueryTypeView $view)
+    {
+        return $view;
+    }
+
+    public function location(QueryTypeView $view)
+    {
+        return $view;
+    }
+
+    public function contentInfo(QueryTypeView $view)
+    {
+        return $view;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/QueryType/MultipleValued.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/QueryType/MultipleValued.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * File containing the MultipleValued matcher class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Matcher\QueryType;
+
+use eZ\Publish\Core\MVC\RepositoryAware;
+use eZ\Publish\Core\MVC\Symfony\Matcher\MatcherInterface;
+
+/**
+ * Abstract class for basic matchers, accepting multiple values to match against.
+ */
+abstract class MultipleValued extends RepositoryAware implements MatcherInterface
+{
+    /**
+     * @var array Values to test against with isset(). Key is the actual value.
+     */
+    protected $values;
+
+    /**
+     * Registers the matching configuration for the matcher.
+     * $matchingConfig can have single (string|int...) or multiple values (array).
+     *
+     * @param mixed $matchingConfig
+     *
+     * @throws \InvalidArgumentException Should be thrown if $matchingConfig is not valid.
+     */
+    public function setMatchingConfig($matchingConfig)
+    {
+        $matchingConfig = !is_array($matchingConfig) ? array($matchingConfig) : $matchingConfig;
+        $this->values = array_fill_keys($matchingConfig, true);
+    }
+
+    /**
+     * Returns matcher's values.
+     *
+     * @return array
+     */
+    public function getValues()
+    {
+        return array_keys($this->values);
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Repository
+     */
+    public function getRepository()
+    {
+        return $this->repository;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/QueryType/Name.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/QueryType/Name.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Matcher\QueryType;
+
+use eZ\Publish\Core\MVC\Symfony\Matcher\MatcherInterface;
+use eZ\Publish\Core\MVC\Symfony\View\QueryTypeView;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+
+class Name extends MultipleValued implements MatcherInterface
+{
+    public function match(View $view)
+    {
+        if (!$view instanceof QueryTypeView) {
+            return false;
+        }
+
+        return isset($this->values[$view->getQueryTypeName()]);
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/QueryType/Parameters.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/QueryType/Parameters.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Matcher\QueryType;
+
+use eZ\Publish\Core\MVC\Symfony\Matcher\MatcherInterface;
+use eZ\Publish\Core\MVC\Symfony\View\QueryTypeView;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+
+class Parameters implements MatcherInterface
+{
+    private $parameters;
+
+    public function match(View $view)
+    {
+        if (!$view instanceof QueryTypeView) {
+            return false;
+        }
+
+        $queryParameters = $view->getQueryParameters();
+        foreach ($this->parameters as $parameterName => $parameterValue) {
+            if (!isset($queryParameters[$parameterName]) || $parameterValue != $queryParameters[$parameterName]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function setMatchingConfig($matchingConfig)
+    {
+        $this->parameters = $matchingConfig;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/QueryTypeMatcherFactory.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/QueryTypeMatcherFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * File containing the BlockMatcherFactory class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Matcher;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\MVC\Symfony\Matcher\MatcherInterface as BaseMatcherInterface;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use InvalidArgumentException;
+
+class QueryTypeMatcherFactory extends AbstractMatcherFactory
+{
+    const MATCHER_RELATIVE_NAMESPACE = 'eZ\\Publish\\Core\\MVC\\Symfony\\Matcher';
+
+    protected function getMatcher($matcherIdentifier)
+    {
+        $matcher = parent::getMatcher($matcherIdentifier);
+        if (!$matcher instanceof MatcherInterface) {
+            throw new InvalidArgumentException(
+                'Matcher for QueryTypes must implement eZ\\Publish\\Core\\MVC\\Symfony\\Matcher\\QueryType\\MatcherInterface.'
+            );
+        }
+
+        return $matcher;
+    }
+
+    /**
+     * Checks if $valueObject matches $matcher rules.
+     *
+     * @param \eZ\Publish\Core\MVC\Symfony\Matcher\Block\MatcherInterface|\eZ\Publish\Core\MVC\Symfony\Matcher\MatcherInterface $matcher
+     * @param ValueObject $valueObject
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return bool
+     */
+    protected function doMatch(BaseMatcherInterface $matcher, View $view)
+    {
+        return $matcher->match($view);
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/QueryTypeSearchAdapter.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/QueryTypeSearchAdapter.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\View\Builder;
+
+use Closure;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use Pagerfanta\Adapter\AdapterInterface;
+
+/**
+ * A QueryType PagerFanta adapter that uses a callback to the search service.
+ */
+class QueryTypeSearchAdapter implements AdapterInterface
+{
+    /**
+     * The closure that runs the search.
+     * @var Closure
+     */
+    private $searchClosure;
+
+    /**
+     * The search query.
+     * @var \eZ\Publish\Core\Persistence\Database\Query
+     */
+    private $query;
+
+    public function __construct(Query $query, Closure $searchClosure)
+    {
+        $this->searchClosure = $searchClosure;
+        $this->query = $query;
+    }
+
+    public function getNbResults()
+    {
+        if (isset($this->nbResults)) {
+            return $this->nbResults;
+        }
+
+        $countQuery = clone $this->query;
+        $countQuery->limit = 0;
+
+        return $this->nbResults = $this->runQuery($countQuery)->totalCount;
+    }
+
+    public function getSlice($offset, $length)
+    {
+        $query = clone $this->query;
+        $query->offset = $offset;
+        $query->limit = $length;
+        $query->performCount = false;
+
+        $searchResult = $this->runQuery($query);
+
+        // Set count for further use if returned by search engine despite !performCount (Solr, ES)
+        if (!isset($this->nbResults) && isset($searchResult->totalCount)) {
+            $this->nbResults = $searchResult->totalCount;
+        }
+
+        $results = [];
+        foreach ($searchResult->searchHits as $searchHit) {
+            $results[] = $searchHit->valueObject;
+        }
+
+        return $results;
+    }
+
+    /**
+     * @return SearchResult
+     */
+    private function runQuery($query)
+    {
+        $callback = $this->searchClosure;
+
+        return $callback($query);
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/QueryTypeViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/QueryTypeViewBuilder.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\View\Builder;
+
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\MVC\Symfony\View\Configurator;
+use eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;
+use eZ\Publish\Core\MVC\Symfony\View\QueryTypeView;
+use eZ\Publish\Core\QueryType\QueryTypeRegistry;
+
+class QueryTypeViewBuilder implements ViewBuilder
+{
+    /**
+     * @var \eZ\Publish\Core\QueryType\QueryTypeRegistry
+     */
+    private $queryTypeRegistry;
+
+    /**
+     * @var \eZ\Publish\API\Repository\SearchService
+     */
+    private $searchService;
+
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\View\ParametersInjector
+     */
+    private $viewParametersInjector;
+
+    public function __construct(
+        QueryTypeRegistry $queryTypeRegistry,
+        SearchService $searchService,
+        Configurator $viewConfigurator,
+        ParametersInjector $viewParametersInjector
+    ) {
+        $this->queryTypeRegistry = $queryTypeRegistry;
+        $this->searchService = $searchService;
+        $this->viewConfigurator = $viewConfigurator;
+        $this->viewParametersInjector = $viewParametersInjector;
+    }
+
+    public function matches($argument)
+    {
+        return strpos($argument, 'ez_query:') !== false;
+    }
+
+    /**
+     * Builds the View based on $parameters.
+     *
+     * @param array $parameters
+     *
+     * @return QueryTypeView
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException
+     */
+    public function buildView(array $parameters)
+    {
+        $view = new QueryTypeView(null, [], $parameters['viewType']);
+
+        if (!isset($parameters['queryTypeName'])) {
+            throw new InvalidArgumentException('queryTypeName', 'QueryTypeName not specified');
+        }
+        $view->setQueryTypeName($parameters['queryTypeName']);
+
+        $view->setQueryParameters(isset($parameters['parameters']) ? $parameters['parameters'] : []);
+        $view->setQuery(
+            $this->queryTypeRegistry->getQueryType($parameters['queryTypeName'])->getQuery(
+                $view->getQueryParameters()
+            )
+        );
+
+        $this->viewConfigurator->configure($view);
+
+        $view->setSearchedType(
+            $this->extractSearchedType($parameters['_controller'])
+        );
+
+        $this->viewParametersInjector->injectViewParameters($view, $parameters);
+
+        return $view;
+    }
+
+    /**
+     * Runs the query using the relevant SearchService method, based on the controller string.
+     *
+     * @param Query|LocationQuery $query
+     * @param string $controllerString ez_query:(content|location|contentInfo)
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\SearchResult
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException If the query controller action couldn't be resolved.
+     */
+    private function runQuery($query, $searchedType)
+    {
+        $searchedTypeMethodMap = [
+            'location' => 'findLocations',
+            'content' => 'findContent',
+            'contentInfo' => 'findContentInfo',
+        ];
+        $searchMethod = $searchedTypeMethodMap[$searchedType];
+
+        return $this->searchService->$searchMethod($query);
+    }
+
+    private function extractSearchedType($controllerString)
+    {
+        $actionSearchedTypeMap = [
+            'location' => QueryTypeView::SEARCH_TYPE_LOCATION,
+            'content' => QueryTypeView::SEARCH_TYPE_CONTENT,
+            'contentInfo' => QueryTypeView::SEARCH_TYPE_CONTENT_INFO,
+        ];
+        list(, $action) = explode(':', $controllerString);
+
+        if (!isset($actionSearchedTypeMap[$action])) {
+            throw new InvalidArgumentException('Query controller action', 'Unknown query controller action');
+        }
+
+        return $actionSearchedTypeMap[$action];
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/QueryTypeResults.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/QueryTypeResults.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;
+
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\MVC\Symfony\View\Event\FilterViewParametersEvent;
+use eZ\Publish\Core\MVC\Symfony\View\QueryTypeView;
+use eZ\Publish\Core\MVC\Symfony\View\ViewEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class QueryTypeResults implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [ViewEvents::FILTER_VIEW_PARAMETERS => 'injectQueryTypeResults'];
+    }
+
+    public function injectQueryTypeResults(FilterViewParametersEvent $event)
+    {
+        $view = $event->getView();
+        if (!$view instanceof QueryTypeView) {
+            return;
+        }
+
+        $searchResult = $view->getSearchResult();
+        $parameters = [
+            'total_count' => $searchResult->totalCount,
+            'parameters' => $view->getQueryParameters(),
+            'list_count' => count($searchResult->searchHits),
+        ] + $this->extractSearchResults($view);
+
+        $event->getParameterBag()->add($parameters);
+    }
+
+    /**
+     * Extracts the search results into a $key + value objects array, with $key depending on the search type.
+     *
+     * @param \eZ\Publish\Core\MVC\Symfony\View\QueryTypeView $view
+     *
+     * @return array resultsKey => resultsArray
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException If the searched type is unknown
+     */
+    private function extractSearchResults(QueryTypeView $view)
+    {
+        $searchedTypeListKeyMap = [
+            QueryTypeView::SEARCH_TYPE_CONTENT_INFO => 'content_info_list',
+            QueryTypeView::SEARCH_TYPE_CONTENT => 'content_list',
+            QueryTypeView::SEARCH_TYPE_LOCATION => 'location_list',
+        ];
+
+        if (!isset($searchedTypeListKeyMap[$view->getSearchedType()])) {
+            throw new InvalidArgumentException('searchedType', 'Unknown search type ' . $view->getSearchedType());
+        }
+        $itemsKey = $searchedTypeListKeyMap[$view->getSearchedType()];
+
+        $items = [];
+        foreach ($view->getSearchResult()->searchHits as $searchHit) {
+            $items[] = $searchHit->valueObject;
+        }
+
+        return [$itemsKey => $items];
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/View/QueryTypeView.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/QueryTypeView.php
@@ -5,6 +5,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\View;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 
 class QueryTypeView extends BaseView implements View
 {
@@ -63,7 +64,7 @@ class QueryTypeView extends BaseView implements View
     }
 
     /**
-     * @param mixed $searchResults
+     * @param \eZ\Publish\API\Repository\Values\Content\Search\SearchResult|\Pagerfanta\Pagerfanta $searchResults
      */
     public function setSearchResult($searchResults)
     {

--- a/eZ/Publish/Core/MVC/Symfony/View/QueryTypeView.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/QueryTypeView.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\View;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+
+class QueryTypeView extends BaseView implements View
+{
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\Query
+     */
+    private $query;
+
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\SearchResult[]
+     */
+    private $searchResult;
+
+    /**
+     * @var string
+     */
+    private $queryTypeName;
+
+    /**
+     * @var array
+     */
+    private $queryParameters = [];
+
+    /**
+     * The value object type that was searched for (content, location or contentInfo).
+     * @var string
+     */
+    private $searchedType;
+
+    const SEARCH_TYPE_CONTENT = 'content';
+    const SEARCH_TYPE_LOCATION = 'location';
+    const SEARCH_TYPE_CONTENT_INFO = 'contentInfo';
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Query
+     */
+    public function getQuery()
+    {
+        return $this->query;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Query $query
+     */
+    public function setQuery($query)
+    {
+        $this->query = $query;
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
+     */
+    public function getSearchResult()
+    {
+        return $this->searchResult;
+    }
+
+    /**
+     * @param mixed $searchResults
+     */
+    public function setSearchResult($searchResults)
+    {
+        $this->searchResult = $searchResults;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getQueryTypeName()
+    {
+        return $this->queryTypeName;
+    }
+
+    /**
+     * @param mixed $queryTypeName
+     */
+    public function setQueryTypeName($queryTypeName)
+    {
+        $this->queryTypeName = $queryTypeName;
+    }
+
+    /**
+     * @return array
+     */
+    public function getQueryParameters()
+    {
+        return $this->queryParameters;
+    }
+
+    /**
+     * @param mixed $queryParameters
+     */
+    public function setQueryParameters(array $queryParameters)
+    {
+        $this->queryParameters = $queryParameters;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSearchedType()
+    {
+        return $this->searchedType;
+    }
+
+    /**
+     * @param string $searchedType
+     */
+    public function setSearchedType($searchedType)
+    {
+        $this->searchedType = $searchedType;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/Builder/QueryTypeViewBuilderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/Builder/QueryTypeViewBuilderTest.php
@@ -24,12 +24,21 @@ class QueryTypeViewBuilderTest extends \PHPUnit_Framework_TestCase
     /** @var \eZ\Publish\Core\MVC\Symfony\View\Builder\QueryTypeViewBuilder */
     private $builder;
 
+    /** @var \eZ\Publish\Core\MVC\Symfony\View\Configurator|\PHPUnit_Framework_MockObject_MockObject */
+    private $viewConfiguratorMock;
+
     public function setUp()
     {
         $this->registryMock = $this->getMock('eZ\Publish\Core\QueryType\QueryTypeRegistry');
         $this->searchServiceMock = $this->getMock('eZ\Publish\API\Repository\SearchService');
         $this->injectorMock = $this->getMock('eZ\Publish\Core\MVC\Symfony\View\ParametersInjector');
-        $this->builder = new QueryTypeViewBuilder($this->registryMock, $this->searchServiceMock, $this->injectorMock);
+        $this->viewConfiguratorMock = $this->getMock('eZ\Publish\Core\MVC\Symfony\View\Configurator');
+        $this->builder = new QueryTypeViewBuilder(
+            $this->registryMock,
+            $this->searchServiceMock,
+            $this->viewConfiguratorMock,
+            $this->injectorMock
+        );
     }
 
     public function testMatches()
@@ -47,7 +56,6 @@ class QueryTypeViewBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $parameters = ['_controller' => $controller, 'queryTypeName' => 'latest_articles', 'viewType' => 'full'];
 
-        $searchResult = new SearchResult();
         $queryTypeMock = $this->getMock('eZ\Publish\Core\QueryType\QueryType');
         $queryTypeMock
             ->expects($this->once())
@@ -60,16 +68,10 @@ class QueryTypeViewBuilderTest extends \PHPUnit_Framework_TestCase
             ->with('latest_articles')
             ->will($this->returnValue($queryTypeMock));
 
-        $this->searchServiceMock
-            ->expects($this->once())
-            ->method($searchMethod)
-            ->with($query)
-            ->will($this->returnValue($searchResult));
-
         $view = $this->builder->buildView($parameters);
 
         self::assertEquals('latest_articles', $view->getQueryTypeName());
-        self::assertEquals($searchResult, $view->getSearchResult());
+        self::assertInstanceOf('Pagerfanta\Pagerfanta', $view->getSearchResult());
         self::assertEquals($expectedSearchedType, $view->getSearchedType());
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/Builder/QueryTypeViewBuilderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/Builder/QueryTypeViewBuilderTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\View\Tests\Builder;
+
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use eZ\Publish\Core\MVC\Symfony\View\Builder\QueryTypeViewBuilder;
+use eZ\Publish\Core\MVC\Symfony\View\QueryTypeView;
+
+class QueryTypeViewBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \eZ\Publish\Core\MVC\Symfony\View\ParametersInjector|\PHPUnit_Framework_MockObject_MockObject */
+    private $injectorMock;
+
+    /** @var \eZ\Publish\Core\QueryType\QueryTypeRegistry|\PHPUnit_Framework_MockObject_MockObject */
+    private $registryMock;
+
+    /** @var \eZ\Publish\API\Repository\SearchService|\PHPUnit_Framework_MockObject_MockObject */
+    private $searchServiceMock;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\View\Builder\QueryTypeViewBuilder */
+    private $builder;
+
+    public function setUp()
+    {
+        $this->registryMock = $this->getMock('eZ\Publish\Core\QueryType\QueryTypeRegistry');
+        $this->searchServiceMock = $this->getMock('eZ\Publish\API\Repository\SearchService');
+        $this->injectorMock = $this->getMock('eZ\Publish\Core\MVC\Symfony\View\ParametersInjector');
+        $this->builder = new QueryTypeViewBuilder($this->registryMock, $this->searchServiceMock, $this->injectorMock);
+    }
+
+    public function testMatches()
+    {
+        self::assertTrue($this->builder->matches('ez_query:content'));
+        self::assertTrue($this->builder->matches('ez_query:location'));
+        self::assertTrue($this->builder->matches('ez_query:contentInfo'));
+        self::assertFalse($this->builder->matches('any:foo'));
+    }
+
+    /**
+     * @dataProvider builderParametersProvider
+     */
+    public function testBuild($controller, $query, $expectedSearchedType, $searchMethod)
+    {
+        $parameters = ['_controller' => $controller, 'queryTypeName' => 'latest_articles', 'viewType' => 'full'];
+
+        $searchResult = new SearchResult();
+        $queryTypeMock = $this->getMock('eZ\Publish\Core\QueryType\QueryType');
+        $queryTypeMock
+            ->expects($this->once())
+            ->method('getQuery')
+            ->will($this->returnValue($query));
+
+        $this->registryMock
+            ->expects($this->once())
+            ->method('getQueryType')
+            ->with('latest_articles')
+            ->will($this->returnValue($queryTypeMock));
+
+        $this->searchServiceMock
+            ->expects($this->once())
+            ->method($searchMethod)
+            ->with($query)
+            ->will($this->returnValue($searchResult));
+
+        $view = $this->builder->buildView($parameters);
+
+        self::assertEquals('latest_articles', $view->getQueryTypeName());
+        self::assertEquals($searchResult, $view->getSearchResult());
+        self::assertEquals($expectedSearchedType, $view->getSearchedType());
+    }
+
+    public function builderParametersProvider()
+    {
+        return [
+            ['ez_query:content', new Query(), QueryTypeView::SEARCH_TYPE_CONTENT, 'findContent'],
+            ['ez_query:contentInfo', new Query(), QueryTypeView::SEARCH_TYPE_CONTENT_INFO, 'findContentInfo'],
+            ['ez_query:location', new LocationQuery(), QueryTypeView::SEARCH_TYPE_LOCATION, 'findLocations'],
+        ];
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/Builder/QueryTypeViewBuilderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/Builder/QueryTypeViewBuilderTest.php
@@ -6,7 +6,6 @@ namespace eZ\Publish\Core\MVC\Symfony\View\Tests\Builder;
 
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query;
-use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\Core\MVC\Symfony\View\Builder\QueryTypeViewBuilder;
 use eZ\Publish\Core\MVC\Symfony\View\QueryTypeView;
 

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/ParametersInjector/QueryTypeResultsTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/ParametersInjector/QueryTypeResultsTest.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\View\Tests\ParametersInjector;
+
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use eZ\Publish\Core\MVC\Symfony\View\Event\FilterViewParametersEvent;
+use eZ\Publish\Core\MVC\Symfony\View\ParametersInjector\QueryTypeResults;
+use eZ\Publish\Core\MVC\Symfony\View\QueryTypeView;
+
+class QueryTypeResultsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\View\ParametersInjector\QueryTypeResults
+     */
+    private $injector;
+
+    public function setUp()
+    {
+        $this->injector = new QueryTypeResults();
+    }
+
+    public function testInjectCommonParameters()
+    {
+        $view = new QueryTypeView();
+        $view->setSearchResult(
+            new SearchResult([
+                'totalCount' => 42,
+                'searchHits' => [new SearchHit(), new SearchHit()],
+            ])
+        );
+        $view->setSearchedType(QueryTypeView::SEARCH_TYPE_CONTENT_INFO);
+        $view->setQueryParameters(['foo' => 'bar']);
+        $event = new FilterViewParametersEvent($view, []);
+
+        $this->injector->injectQueryTypeResults($event);
+
+        $parameterBag = $event->getParameterBag();
+        self::assertEquals(42, $parameterBag->get('total_count'));
+        self::assertEquals(['foo' => 'bar'], $parameterBag->get('parameters'));
+        self::assertEquals(2, $parameterBag->get('list_count'));
+    }
+
+    public function testInjectLocationList()
+    {
+        $view = new QueryTypeView();
+        $view->setSearchResult(
+            new SearchResult([
+                'searchHits' => [new SearchHit(), new SearchHit()],
+            ])
+        );
+        $view->setSearchedType(QueryTypeView::SEARCH_TYPE_LOCATION);
+        $view->setQueryParameters(['foo' => 'bar']);
+        $event = new FilterViewParametersEvent($view, []);
+
+        $this->injector->injectQueryTypeResults($event);
+
+        $parameterBag = $event->getParameterBag();
+        self::assertTrue($parameterBag->has('location_list'));
+    }
+
+    public function testInjectContentInfoList()
+    {
+        $view = new QueryTypeView();
+        $view->setSearchResult(
+            new SearchResult([
+                'searchHits' => [new SearchHit(), new SearchHit()],
+            ])
+        );
+        $view->setSearchedType(QueryTypeView::SEARCH_TYPE_CONTENT_INFO);
+        $view->setQueryParameters(['foo' => 'bar']);
+        $event = new FilterViewParametersEvent($view, []);
+
+        $this->injector->injectQueryTypeResults($event);
+
+        $parameterBag = $event->getParameterBag();
+        self::assertTrue($parameterBag->has('content_info_list'));
+    }
+
+    public function testInjectContentList()
+    {
+        $view = new QueryTypeView();
+        $view->setSearchResult(
+            new SearchResult([
+                'searchHits' => [new SearchHit(), new SearchHit()],
+            ])
+        );
+        $view->setSearchedType(QueryTypeView::SEARCH_TYPE_CONTENT);
+        $view->setQueryParameters(['foo' => 'bar']);
+        $event = new FilterViewParametersEvent($view, []);
+
+        $this->injector->injectQueryTypeResults($event);
+
+        $parameterBag = $event->getParameterBag();
+        self::assertTrue($parameterBag->has('content_list'));
+    }
+}

--- a/eZ/Publish/Core/QueryType/ArrayQueryTypeRegistry.php
+++ b/eZ/Publish/Core/QueryType/ArrayQueryTypeRegistry.php
@@ -10,7 +10,7 @@ use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 /**
  * A QueryType registry based on an array.
  */
-class ArrayQueryTypeRegistry
+class ArrayQueryTypeRegistry implements QueryTypeRegistry
 {
     /** @var QueryType[] */
     private $registry = [];

--- a/eZ/Publish/Core/QueryType/QueryTypeNameRegistry.php
+++ b/eZ/Publish/Core/QueryType/QueryTypeNameRegistry.php
@@ -8,27 +8,29 @@ namespace eZ\Publish\Core\QueryType;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 /**
- * A QueryType registry based on an array.
+ * A QueryType registry that uses the QueryTypes names.
  */
-class ArrayQueryTypeRegistry implements QueryTypeRegistry
+class QueryTypeNameRegistry implements QueryTypeRegistry
 {
     /** @var QueryType[] */
     private $registry = [];
 
-    public function addQueryType($name, QueryType $queryType)
+    public function addQueryType(QueryType $queryType)
     {
-        $this->registry[$name] = $queryType;
+        $this->registry[$queryType::getName()] = $queryType;
     }
 
     public function addQueryTypes(array $queryTypes)
     {
-        $this->registry += $queryTypes;
+        foreach ($queryTypes as $queryType) {
+            $this->addQueryType($queryType);
+        }
     }
 
     public function getQueryType($name)
     {
         if (!isset($this->registry[$name])) {
-            throw new InvalidArgumentException('QueryType name', 'No QueryType found with that name');
+            throw new InvalidArgumentException($name, 'No QueryType found with that name');
         }
 
         return $this->registry[$name];

--- a/eZ/Publish/Core/QueryType/QueryTypeRegistry.php
+++ b/eZ/Publish/Core/QueryType/QueryTypeRegistry.php
@@ -11,22 +11,22 @@ namespace eZ\Publish\Core\QueryType;
 interface QueryTypeRegistry
 {
     /**
-     * Registers $queryType as $name.
+     * Registers $queryType.
      *
      * @param string $name
      * @param \eZ\Publish\Core\QueryType\QueryType $queryType
      */
-    public function addQueryType($name, QueryType $queryType);
+    public function addQueryType(QueryType $queryType);
 
     /**
      * Registers QueryTypes from the $queryTypes array.
      *
-     * @param \eZ\Publish\Core\QueryType\QueryType[] $queryTypes An array of QueryTypes, with their name as the index
+     * @param \eZ\Publish\Core\QueryType\QueryType[] $queryTypes An array of QueryTypes.
      */
     public function addQueryTypes(array $queryTypes);
 
     /**
-     * Get the QueryType $name.
+     * Get the QueryType named $name.
      *
      * @param string $name
      *


### PR DESCRIPTION
> Implements [EZP-24624](https://jira.ez.no/browse/EZP-24624)
> Status: working, reviews accepted
> Note: many of the changed files are for BDD (21 files with 728 additions and 2 deletions). The real code is much smaller :-)

This implements the Query controller according to the [named queries specifications](https://github.com/ezsystems/ezpublish-kernel/blob/master/doc/specifications/proposed/named_queries/developer_documentation.md).

A new Platform controller is added to the Core: `ez_query` (alias for `ezpublish.controller.query`). It exposes three actions: `location`, `content` and `contentInfo`. The views (template, controller, ...) can be configured using the `query_type_view` key.

It also **supports PagerFanta** by default (could be a separate story, it's in a distinct commit). The list variable assigned to the view template is a pager instead of being an array of value objects. The behaviour can be disabled by setting `enable_pager: false` in the view configuration.
### Coverage

The feature is covered by a couple [behat scenarii](https://github.com/ezsystems/ezpublish-kernel/blob/ezp24624-query_controller/eZ/Bundle/EzPublishCoreBundle/Features/View/named_queries.feature):
- _ez_query controller actions can be overridden_
- _When enable_pager is set to false in a QueryType View, then search results are passed to the template as an array_
- _When enable_pager is not specified in a QueryType View, then search results are passed to the template as a pager object_

Given that none of the view feature was covered before, there are probably things that would better covered in a global View context. I'm open to suggestions.
### TODO
- [x] Consider replacing the `xxx_list` variables with `PagerFanta` instances transparently
