### PR TITLE
Add the ability to set shared max age in custom controllers

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/CacheViewResponseListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/CacheViewResponseListener.php
@@ -66,7 +66,7 @@ class CacheViewResponseListener implements EventSubscriberInterface
         }
 
         $response->setPublic();
-        if ($this->enableTtlCache) {
+        if ($this->enableTtlCache && !$response->headers->hasCacheControlDirective('s-maxage')) {
             $response->setSharedMaxAge($this->defaultTtl);
         }
     }


### PR DESCRIPTION
Previously, if you wanted to modify shared max age in your custom controller, you would do it directly in `Response` object that `ez_content:view(Location|Content)` returned.

Now, since setting shared max age is done in `CacheViewResponseListener` which subscribes to `KernelEvents::RESPONSE` event, it is not possible to set the custom shared max age in your controllers as it will be overwritten.

This makes sure shared max age is set only if not set previously in the response.

Similar thing is already done with `X-Location-Id` header which is set only if it was not set before (third `false` param in https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Bundle/EzPublishCoreBundle/EventListener/CacheViewResponseListener.php#L65).