### PR TITLE
Alternative QueryController approach

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/QueryTypePass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/QueryTypePass.php
@@ -5,6 +5,7 @@
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
 
 use Exception;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use ReflectionClass;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -16,23 +17,28 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class QueryTypePass implements CompilerPassInterface
 {
+    /** @var \Symfony\Component\DependencyInjection\Reference[] */
+    private $queryTypeRefs = [];
+
     public function process(ContainerBuilder $container)
     {
         if (!$container->hasDefinition('ezpublish.query_type.registry')) {
             return;
         }
 
-        $queryTypes = [];
+        $queryTypesRefs = [];
+
+        // array of QueryType classes. Used to prevent double handling between services & convention definitions.
+        $queryTypesClasses = [];
 
         // tagged query types
-        $taggedServiceIds = $container->findTaggedServiceIds('ezpublish.query_type');
-        foreach ($taggedServiceIds as $taggedServiceId => $tags) {
+        foreach ($container->findTaggedServiceIds('ezpublish.query_type') as $taggedServiceId => $tags) {
             $queryTypeDefinition = $container->getDefinition($taggedServiceId);
-            $queryTypeClass = $queryTypeDefinition->getClass();
+            $queryTypeClassName = $queryTypeDefinition->getClass();
 
             for ($i = 0, $count = count($tags); $i < $count; ++$i) {
-                // TODO: Check for duplicates
-                $queryTypes[] = new Reference($taggedServiceId);
+                $queryTypesRefs[] = new Reference($taggedServiceId);
+                $queryTypesClasses[$queryTypeClassName] = true;
             }
         }
 
@@ -48,30 +54,48 @@ class QueryTypePass implements CompilerPassInterface
                     continue;
                 }
 
-                $queryTypeServices = [];
+                $conventionQueryTypeDefs = [];
                 $bundleQueryTypeNamespace = substr($bundleClass, 0, strrpos($bundleClass, '\\') + 1) . 'QueryType';
                 foreach (glob($bundleQueryTypesDir . DIRECTORY_SEPARATOR . '*QueryType.php') as $queryTypeFilePath) {
                     $queryTypeFileName = basename($queryTypeFilePath, '.php');
                     $queryTypeClassName = $bundleQueryTypeNamespace . '\\' . $queryTypeFileName;
+                    if (isset($queryTypesClasses[$queryTypeClassName])) {
+                        continue;
+                    }
                     if (!class_exists($queryTypeClassName)) {
                         throw new Exception("Expected $queryTypeClassName to be defined in $queryTypeFilePath");
                     }
 
-                    $queryTypeReflectionClass = new ReflectionClass($queryTypeClassName);
-                    if (!$queryTypeReflectionClass->implementsInterface('eZ\Publish\Core\QueryType\QueryType')) {
-                        throw new Exception("$queryTypeClassName needs to implement eZ\\Publish\\Core\\QueryType\\QueryType");
-                    }
+                    $this->checkInterface($queryTypeClassName);
 
                     $serviceId = 'ezpublish.query_type.convention.' . strtolower($bundleName) . '_' . strtolower($queryTypeFileName);
-                    $queryTypeServices[$serviceId] = new Definition($queryTypeClassName);
-
-                    $queryTypes[] = new Reference($serviceId);
+                    $queryTypeDefinition = new Definition($queryTypeClassName);
+                    $conventionQueryTypeDefs[$serviceId] = $queryTypeDefinition;
+                    $queryTypesRefs[] = new Reference($serviceId);
                 }
-                $container->addDefinitions($queryTypeServices);
+                $container->addDefinitions($conventionQueryTypeDefs);
             }
         }
 
         $registryDef = $container->getDefinition('ezpublish.query_type.registry');
         $registryDef->addMethodCall('addQueryTypes', [$queryTypesRefs]);
+    }
+
+    /**
+     * Checks that $queryTypeClassName implements the QueryType interface.
+     *
+     * @param string $queryTypeClassName
+     *
+     * @throws InvalidArgumentException
+     */
+    private function checkInterface($queryTypeClassName)
+    {
+        $queryTypeReflectionClass = new ReflectionClass($queryTypeClassName);
+        if (!$queryTypeReflectionClass->implementsInterface('eZ\Publish\Core\QueryType\QueryType')) {
+            throw new InvalidArgumentException(
+                "QueryTypeClass $queryTypeClassName",
+                'needs to implement eZ\Publish\Core\QueryType\QueryType'
+            );
+        }
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/QueryTypePass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/QueryTypePass.php
@@ -32,7 +32,7 @@ class QueryTypePass implements CompilerPassInterface
 
             for ($i = 0, $count = count($tags); $i < $count; ++$i) {
                 // TODO: Check for duplicates
-                $queryTypes[$queryTypeClass::getName()] = new Reference($taggedServiceId);
+                $queryTypes[] = new Reference($taggedServiceId);
             }
         }
 
@@ -65,13 +65,13 @@ class QueryTypePass implements CompilerPassInterface
                     $serviceId = 'ezpublish.query_type.convention.' . strtolower($bundleName) . '_' . strtolower($queryTypeFileName);
                     $queryTypeServices[$serviceId] = new Definition($queryTypeClassName);
 
-                    $queryTypes[$queryTypeClassName::getName()] = new Reference($serviceId);
+                    $queryTypes[] = new Reference($serviceId);
                 }
                 $container->addDefinitions($queryTypeServices);
             }
         }
 
-        $aggregatorDefinition = $container->getDefinition('ezpublish.query_type.registry');
-        $aggregatorDefinition->addMethodCall('addQueryTypes', [$queryTypes]);
+        $registryDef = $container->getDefinition('ezpublish.query_type.registry');
+        $registryDef->addMethodCall('addQueryTypes', [$queryTypesRefs]);
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Content/query_controller.feature
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Content/query_controller.feature
@@ -1,0 +1,15 @@
+Feature: The ez_query controller can be used in content views to get query results into a view template
+
+    Scenario: A content view that uses the query controller...
+        Given there is a blog content_view configuration
+          And it sets the controller to 'ez_query:contentAction'
+          And it sets the parameter "query" to a valid QueryType name
+         When a content matching the blog configuration is rendered
+         Then the view template has an 'items' variable
+          And the 'items' variable is an array with the results from the queryType
+
+    Scenario: The template variable search results are assigned to can be customized
+
+    Scenario: Parameters can be passed to the QueryType
+
+    Scenario: Parameters from the view object can be passed to the QueryType

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/NavigationContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/NavigationContext.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\MinkExtension\Context\MinkAwareContext;
+use Behat\MinkExtension\Context\RawMinkContext;
+use eZ\Publish\API\Repository\URLAliasService;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use PHPUnit_Framework_Assert as Assertion;
+use Symfony\Component\Routing\RouterInterface;
+
+class NavigationContext extends RawMinkContext implements Context, SnippetAcceptingContext, MinkAwareContext
+{
+    /**
+     * @var \Symfony\Component\Routing\RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var \eZ\Publish\API\Repository\URLAliasService
+     */
+    private $urlAliasService;
+
+    /**
+     * @var \Symfony\Component\Routing\Route
+     */
+    private $currentRoute;
+
+    public function __construct(RouterInterface $router, UrlAliasService $urlAliasService)
+    {
+        $this->router = $router;
+        $this->urlAliasService = $urlAliasService;
+    }
+
+    /**
+     * @Given /^there is a route "([^"]*)"$/
+     */
+    public function thereIsARoute($routeIdentifier)
+    {
+        /** @var \Symfony\Component\Routing\RouterInterface $router */
+        $routeCollection = $this->router->getRouteCollection();
+        Assertion::assertNotNull(
+            $route = $routeCollection->get($routeIdentifier),
+            "Failed asserting that there is a route named $routeIdentifier"
+        );
+
+        $this->currentRoute = $route;
+    }
+
+    /**
+     * @Given /^that route has the default "([^"]*)" set to "([^"]*)"$/
+     */
+    public function routeHasTheDefaultSetTo($defaultName, $defaultValue)
+    {
+        Assertion::assertNotNull($this->currentRoute, 'No currentRoute was set');
+
+        Assertion::assertTrue(
+            $this->currentRoute->hasDefault($defaultName),
+            "Failed asserting that the route has the default attribute '$defaultName'"
+        );
+
+        if (is_string($defaultValue)) {
+            Assertion::assertEquals(
+                $defaultValue,
+                $this->currentRoute->getDefault($defaultName),
+                "Failed asserting that the route has the default attribute '$defaultName' set to '$defaultValue'"
+            );
+        } elseif (is_array($defaultValue)) {
+            Assertion::assertArraySubset(
+                $defaultValue,
+                $this->currentRoute->getDefault($defaultName),
+                "Failed asserting that the route has the default attribute '$defaultName' with the given array items"
+            );
+        }
+    }
+
+    /**
+     * @Given /^that route has the default "([^"]*)" set to an array with the key "([^"]*)" set to "([^"]*)"$/
+     */
+    public function routeHasTheDefaultSetToArray($defaultName, $arrayKey, $arrayValue)
+    {
+        $this->routeHasTheDefaultSetTo($defaultName, [$arrayKey => $arrayValue]);
+    }
+
+    /**
+     * @When /^I go to that route$/
+     */
+    public function iGoToThatRoute()
+    {
+        Assertion::assertTrue(isset($this->currentRoute), 'No current Route was set');
+        $this->visitPath($this->currentRoute->getPath());
+    }
+
+    public function iVisitLocation(Location $location)
+    {
+        $urlAlias = $this->urlAliasService->reverseLookup($location);
+        $this->visitPath($urlAlias->path);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/ViewConfigurationContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/ViewConfigurationContext.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use PHPUnit_Framework_Assert as Assertion;
+
+class ViewConfigurationContext implements Context, SnippetAcceptingContext
+{
+    const BLOG_LOCATION_ID = 90;
+
+    /**
+     * @var \eZ\Publish\Core\MVC\ConfigResolverInterface
+     */
+    private $configResolver;
+
+    /**
+     * @var \eZ\Publish\API\Repository\LocationService
+     */
+    private $locationService;
+
+    /**
+     * @var NavigationContext
+     */
+    private $navigationContext;
+
+    /**
+     * @var array
+     */
+    private $currentViewConfiguration;
+
+    public function __construct(ConfigResolverInterface $configResolver, LocationService $locationService)
+    {
+        $this->configResolver = $configResolver;
+        $this->locationService = $locationService;
+    }
+
+    /** @BeforeScenario */
+    public function gatherContexts(BeforeScenarioScope $scope)
+    {
+        $environment = $scope->getEnvironment();
+        $this->navigationContext = $environment->getContext('eZ\Bundle\EzPublishCoreBundle\Features\Context\NavigationContext');
+    }
+
+    /**
+     * Looks up and asserts a view configuration existence.
+     *
+     * @param string $name The name of the view configuration block (blog, landing_page, ...)
+     * @param string $type The type of view configuration (content_view, block_view...)
+     * @param string $viewType full, line, ...
+     *
+     * @Given /^there is a ([a-z0-9_-]*) ([a-z0-9_]+) configuration$/
+     * @Given /^there is a ([a-z0-9_-]*) ([a-z0-9_]+) configuration for the ([a-z0-9_]+) viewType$/
+     *
+     * @return array The matching view configuration
+     */
+    public function thereIsAViewConfiguration($name, $type, $viewType = 'full')
+    {
+        Assertion::assertTrue($this->configResolver->hasParameter($type));
+        $configuration = $this->configResolver->getParameter($type);
+
+        Assertion::assertArrayHasKey(
+            $viewType,
+            $configuration,
+            "Failed asserting that there are $type configurations for the '$viewType' viewType"
+        );
+
+        Assertion::assertArrayHasKey(
+            $name,
+            $configuration[$viewType],
+            "Failed asserting that there is a '$viewType' query_type_view configuration named '$name'"
+        );
+
+        $this->currentViewConfiguration = $configuration[$viewType][$name];
+
+        return $this->currentViewConfiguration;
+    }
+
+    /**
+     * @Given /^there is a "([^"]*)" ([a-z0-9_]+) configuration for the "([^"]*)" viewType$/
+     */
+    public function thereIsAViewConfigurationForTheViewTypeWithTheTemplate($viewConfigName, $what, $viewType)
+    {
+        /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver */
+        $queryTypeViewConfiguration = $this->configResolver->getParameter($what);
+
+        Assertion::assertArrayHasKey(
+            $viewType,
+            $queryTypeViewConfiguration,
+            "Failed asserting that there are $what configurations for the viewType $viewType"
+        );
+
+        Assertion::assertArrayHasKey(
+            $viewConfigName,
+            $queryTypeViewConfiguration[$viewType],
+            "Failed asserting that there is a '$viewType' query_type_view configuration named '$viewConfigName'"
+        );
+
+        $this->currentViewConfiguration = $queryTypeViewConfiguration[$viewType][$viewConfigName];
+    }
+
+    /**
+     * @Given /^that configuration has "([^"]*)" set to "([^"]*)"$/
+     */
+    public function configurationHasThePropertySetToTheValue($propertyName, $propertyValue)
+    {
+        Assertion::assertNotNull($this->currentViewConfiguration, 'No currentViewConfiguration was set');
+
+        Assertion::assertArrayHasKey(
+            $propertyName,
+            $this->currentViewConfiguration,
+            "Failed asserting that the query_type_view configuration sets the $propertyName property"
+        );
+
+        Assertion::assertEquals(
+            $propertyValue,
+            $this->currentViewConfiguration[$propertyName],
+            "Failed asserting that the query_type_view configuration sets the $propertyName property to $propertyValue"
+        );
+    }
+
+    /**
+     * @Given /^that configuration has "([^"]*)" set to the boolean "([^"]*)"$/
+     */
+    public function configurationHasThePropertySetToTheBooleanValue($propertyName, $propertyValue)
+    {
+        if ($propertyValue === 'true') {
+            $propertyValue = true;
+        } elseif ($propertyValue === 'false') {
+            $propertyValue = false;
+        } else {
+            throw new InvalidArgumentException('propertyValue', "Unknown boolean value '$propertyValue''");
+        }
+
+        $this->configurationHasThePropertySetToTheValue($propertyName, $propertyValue);
+    }
+
+    /**
+     * @Given /^that configuration matches on "([^"]*)" "([^"]*)"$/
+     */
+    public function configurationHasMatch($matcherName, $matcherValue)
+    {
+        Assertion::assertNotNull($this->currentViewConfiguration, 'No currentViewConfiguration was set');
+
+        $matchConfig = $this->currentViewConfiguration['match'];
+
+        Assertion::assertArrayHasKey(
+            $matcherName,
+            $matchConfig,
+            "Failed asserting that the view has a matcher '$matcherName'"
+        );
+
+        if (is_string($matcherValue)) {
+            Assertion::assertEquals(
+                $matcherValue,
+                $matchConfig[$matcherName],
+                "Failed asserting that the view matches on '$matcherName: $matcherValue'"
+            );
+        } elseif (is_array($matcherValue)) {
+            Assertion::assertArraySubset(
+                $matcherValue,
+                $matchConfig[$matcherName],
+                "Failed asserting that the view matches on '$matcherName' with the given array"
+            );
+        }
+    }
+
+    /**
+     * @Given /^it sets the controller to \'([^\']*)\'$/
+     */
+    public function itSetsTheControllerTo($controller)
+    {
+        Assertion::assertNotNull($this->currentViewConfiguration, 'No current view configuration was set');
+        Assertion::assertArrayHasKey('controller', $this->currentViewConfiguration);
+        Assertion::assertEquals($controller, $this->currentViewConfiguration['controller']);
+    }
+
+    /**
+     * @Given /^it sets the parameter "([^"]*)" to a valid QueryType name$/
+     */
+    public function itSetsParameterToAValidQueryTypeName($parameter)
+    {
+        $this->itSetsParameterTo($parameter, 'EzPlatformBehatBundle:LatestContent');
+    }
+
+    /**
+     * @Given /^it sets the parameter "([^"]*)" to "([^"]*)"$/
+     */
+    public function itSetsParameterTo($parameterName, $parameterValue)
+    {
+        Assertion::assertNotNull($this->currentViewConfiguration, 'No current view configuration was set');
+        Assertion::assertArrayHasKey('params', $this->currentViewConfiguration);
+        Assertion::assertArrayHasKey($parameterName, $this->currentViewConfiguration['params']);
+        Assertion::assertEquals($parameterValue, $this->currentViewConfiguration['params'][$parameterName]);
+    }
+
+    /**
+     * @When /^a content matching the blog configuration is rendered$/
+     */
+    public function aContentMatchingTheBlogConfigurationIsRendered()
+    {
+        $this->navigationContext->iVisitLocation(
+            $this->locationService->loadLocation(self::BLOG_LOCATION_ID)
+        );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/ViewTemplateContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/ViewTemplateContext.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Mink\Element\NodeElement;
+use Behat\MinkExtension\Context\RawMinkContext;
+use PHPUnit_Framework_Assert as Assertion;
+
+/**
+ * Used to describe expectations in the context of view templates.
+ */
+class ViewTemplateContext extends RawMinkContext implements Context, SnippetAcceptingContext
+{
+    /**
+     * @Then /^the view template has an? \'([^\']*)\' variable$/
+     */
+    public function theViewTemplateHasAVariable($variableName)
+    {
+        $this->assertSession()->elementExists('xpath', '//' . $this->buildVariableXpath($variableName));
+    }
+
+    /**
+     * @Given /^the \'([^\']*)\' variable is an array with the results from the queryType$/
+     */
+    public function theVariableIsAnArrayWithTheResultsFrom($variableName, $queryTypeName)
+    {
+        $xpath = '//' . $this->buildVariableXpath($variableName);
+        $elements = $this->getSession()->getPage()->findAll('xpath', $xpath);
+        /** @var NodeElement $element */
+        $element = $elements[0];
+        Assertion::assertEquals(
+            $element->find('xpath', '/following-sibling::abbr')->getText(),
+            'array:1'
+        );
+    }
+
+    private function buildVariableXpath($variableName)
+    {
+        return "span[@class='sf-dump-key' and text() = '$variableName']";
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -30,6 +30,8 @@ parameters:
     ezpublish.exception_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\ExceptionListener
 
     ezpublish.fields_groups.list.class: eZ\Publish\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList
+    
+    ezpublish.query_type.registry.class: eZ\Publish\Core\QueryType\QueryTypeNameRegistry
 
 services:
     # Siteaccess is injected in the container at runtime
@@ -173,7 +175,7 @@ services:
             - { name: kernel.event_subscriber }
 
     ezpublish.query_type.registry:
-        class: eZ\Publish\Core\QueryType\ArrayQueryTypeRegistry
+        class: %ezpublish.query_type.registry.class%
 
     ezpublish.fields_groups.list:
         class: %ezpublish.fields_groups.list.class%

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -12,6 +12,7 @@ parameters:
     ezpublish.controller.content.preview.class: eZ\Publish\Core\MVC\Symfony\Controller\Content\PreviewController
     ezpublish.controller.content.download.class: eZ\Publish\Core\MVC\Symfony\Controller\Content\DownloadController
     ezpublish.controller.content.download_redirection.class: eZ\Publish\Core\MVC\Symfony\Controller\Content\DownloadRedirectionController
+    ezpublish.controller.content.query.class: eZ\Publish\Core\MVC\Symfony\Controller\Content\QueryController
     ezpublish.controller.page.view.class: eZ\Bundle\EzPublishCoreBundle\Controller\PageController
 
     # Param converters
@@ -184,3 +185,11 @@ services:
         class: eZ\Publish\Core\Helper\FieldsGroups\RepositoryConfigFieldsGroupsListFactory
         arguments:
             - @ezpublish.api.repository_configuration_provider
+    ezpublish.controller.content.query:
+        class: %ezpublish.controller.content.query.class%
+        arguments:
+            - @ezpublish.query_type.registry
+            - @ezpublish.api.service.search
+
+    ez_query:
+        alias: ezpublish.controller.content.query

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/QueryTypePassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/QueryTypePassTest.php
@@ -31,11 +31,11 @@ class QueryTypePassTest extends AbstractCompilerPassTestCase
 
     public function testRegisterTaggedQueryType()
     {
-        $def = new Definition();
-        $def->addTag('ezpublish.query_type');
-        $def->setClass('eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub\QueryTypeBundle\QueryType\TestQueryType');
         $serviceId = 'test.query_type';
-        $this->setDefinition($serviceId, $def);
+        $this->defineQueryTypeService(
+            $serviceId,
+            'eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub\QueryTypeBundle\QueryType\TestQueryType'
+        );
 
         $this->compile();
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
@@ -47,13 +47,52 @@ class QueryTypePassTest extends AbstractCompilerPassTestCase
 
     public function testConventionQueryType()
     {
-        $this->setParameter('kernel.bundles', ['QueryTypeBundle' => 'eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub\QueryTypeBundle\QueryTypeBundle']);
+        $this->defineQueryTypeBundle();
 
         $this->compile();
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'ezpublish.query_type.registry',
             'addQueryTypes',
             [[new Reference('ezpublish.query_type.convention.querytypebundle_testquerytype')]]
+        );
+    }
+
+    /**
+     * Tests that a QueryType that is declared as a service and named by convention is registered correctly.
+     */
+    public function testServicePlusConvention()
+    {
+        $this->defineQueryTypeService(
+            'test.query_type',
+            'eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub\QueryTypeBundle\QueryType\TestQueryType'
+        );
+        $this->defineQueryTypeBundle();
+
+        $this->compile();
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'ezpublish.query_type.registry',
+            'addQueryTypes',
+            [[new Reference('test.query_type')]]
+        );
+        $this->assertContainerBuilderNotHasService('ezpublish.query_type.convention.querytypebundle_testquerytype');
+    }
+
+    private function defineQueryTypeService($serviceId, $class)
+    {
+        $def = new Definition();
+        $def->addTag('ezpublish.query_type');
+        $def->setClass($class);
+        $this->setDefinition($serviceId, $def);
+    }
+
+    /**
+     * Adds to the kernel the path to a stub bundle that contains a QueryType class named by convention.
+     */
+    private function defineQueryTypeBundle()
+    {
+        $this->setParameter(
+            'kernel.bundles',
+            ['QueryTypeBundle' => 'eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub\QueryTypeBundle\QueryTypeBundle']
         );
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/QueryTypePassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/QueryTypePassTest.php
@@ -41,7 +41,7 @@ class QueryTypePassTest extends AbstractCompilerPassTestCase
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'ezpublish.query_type.registry',
             'addQueryTypes',
-            [['Test:Test' => new Reference($serviceId)]]
+            [[new Reference($serviceId)]]
         );
     }
 
@@ -53,7 +53,7 @@ class QueryTypePassTest extends AbstractCompilerPassTestCase
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'ezpublish.query_type.registry',
             'addQueryTypes',
-            [['Test:Test' => new Reference('ezpublish.query_type.convention.querytypebundle_testquerytype')]]
+            [[new Reference('ezpublish.query_type.convention.querytypebundle_testquerytype')]]
         );
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/behat_suites.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/behat_suites.yml
@@ -12,7 +12,14 @@ core:
                 - vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishCoreBundle/Features/Content
                 - vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishCoreBundle/Features/Exception
             contexts:
+                - eZ\Bundle\EzPublishCoreBundle\Features\Context\NavigationContext:
+                    router: @router
+                    urlAliasService: @ezpublish.api.service.url_alias
                 - eZ\Bundle\EzPublishCoreBundle\Features\Context\ContentPreviewContext
                 - eZ\Bundle\EzPublishCoreBundle\Features\Context\ContentContext:
                     repository: @ezpublish.api.repository
                 - eZ\Bundle\EzPublishCoreBundle\Features\Context\ExceptionContext
+                - eZ\Bundle\EzPublishCoreBundle\Features\Context\ViewTemplateContext
+                - eZ\Bundle\EzPublishCoreBundle\Features\Context\ViewConfigurationContext:
+                    configResolver: @ezpublish.config.resolver
+                    locationService: @ezpublish.api.service.location

--- a/eZ/Bundle/PlatformBehatBundle/DependencyInjection/EzPlatformBehatExtension.php
+++ b/eZ/Bundle/PlatformBehatBundle/DependencyInjection/EzPlatformBehatExtension.php
@@ -5,11 +5,14 @@
 namespace EzSystems\PlatformBehatBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 
-class EzPlatformBehatExtension extends Extension
+class EzPlatformBehatExtension extends Extension implements PrependExtensionInterface
 {
     public function load(array $config, ContainerBuilder $container)
     {
@@ -19,5 +22,13 @@ class EzPlatformBehatExtension extends Extension
         );
 
         $loader->load('services.yml');
+    }
+
+    public function prepend(ContainerBuilder $container)
+    {
+        $configFile = __DIR__ . '/../Resources/config/ez_view.yml';
+        $config = Yaml::parse(file_get_contents($configFile));
+        $container->prependExtensionConfig('ezpublish', $config);
+        $container->addResource(new FileResource($configFile));
     }
 }

--- a/eZ/Bundle/PlatformBehatBundle/QueryType/LatestContentQueryType.php
+++ b/eZ/Bundle/PlatformBehatBundle/QueryType/LatestContentQueryType.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformBehatBundle\QueryType;
+
+use eZ\Publish\Core\QueryType\QueryType;
+use eZ\Publish\API\Repository\Values\Content\Query;
+
+class LatestContentQueryType implements QueryType
+{
+    public function getQuery(array $parameters = [])
+    {
+        $criteria[] = new Query\Criterion\Visibility(Query\Criterion\Visibility::VISIBLE);
+        if (isset($parameters['type'])) {
+            $criteria[] = new Query\Criterion\ContentTypeIdentifier($parameters['type']);
+        }
+
+        return new Query([
+            'filter' => new Query\Criterion\LogicalAnd($criteria),
+            'sortClauses' => [new Query\SortClause\DatePublished()],
+            'limit' => isset($parameters['limit']) ? $parameters['limit'] : 10,
+        ]);
+    }
+
+    public static function getName()
+    {
+        return 'EzPlatformBehatBundle:LatestContent';
+    }
+
+    /**
+     * Returns an array listing the parameters supported by the QueryType.
+     * @return array
+     */
+    public function getSupportedParameters()
+    {
+        return ['type'];
+    }
+}

--- a/eZ/Bundle/PlatformBehatBundle/Resources/config/ez_view.yml
+++ b/eZ/Bundle/PlatformBehatBundle/Resources/config/ez_view.yml
@@ -1,0 +1,11 @@
+system:
+    default:
+        content_view:
+            full:
+                blog:
+                    template: 'EzPlatformBehatBundle:full:dump.html.twig'
+                    match:
+                        Identifier\ContentType: 'blog'
+                    controller: ez_query:contentAction
+                    params:
+                        query: 'EzPlatformBehatBundle:LatestContent'

--- a/eZ/Bundle/PlatformBehatBundle/Resources/views/full/dump.html.twig
+++ b/eZ/Bundle/PlatformBehatBundle/Resources/views/full/dump.html.twig
@@ -1,0 +1,5 @@
+<html>
+<body>
+{{ dump() }}
+</body>
+</html>

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/QueryController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/QueryController.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Controller\Content;
+
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\MVC\Symfony\View\ContentView;
+use eZ\Publish\Core\QueryType\QueryTypeRegistry;
+
+class QueryController
+{
+    /** @var \eZ\Publish\API\Repository\SearchService */
+    private $searchService;
+
+    /** @var \eZ\Publish\Core\QueryType\QueryTypeRegistry */
+    private $queryTypeRegistry;
+
+    public function __construct(QueryTypeRegistry $queryTypeRegistry, SearchService $searchService)
+    {
+        $this->queryTypeRegistry = $queryTypeRegistry;
+        $this->searchService = $searchService;
+    }
+
+    public function contentAction(ContentView $view)
+    {
+        $searchResults = $this->searchService->findContent(
+            $this->getQuery($view),
+            [] // @todo we most likely want to use the Viewed content language(s)
+        );
+        $variableName = $view->hasParameter('variable') ? $view->getParameter('variable') : 'content_list';
+        $view->addParameters([$variableName => $searchResults]);
+
+        return $view;
+    }
+
+    public function locationAction(ContentView $view)
+    {
+        return $view;
+    }
+
+    public function contentInfoAction(ContentView $view)
+    {
+        return $view;
+    }
+
+    /**
+     * Returns the query configured in the view parameters
+     *
+     * @param \eZ\Publish\Core\MVC\Symfony\View\ContentView $view
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Query
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException If the query parameter isn't set
+     */
+    private function getQuery(ContentView $view)
+    {
+        if (!$view->hasParameter('query')) {
+            throw new InvalidArgumentException('query', 'Missing required query parameter');
+        }
+        $queryType = $this->queryTypeRegistry->getQueryType($view->getParameter('queryType'));
+
+        $queryParameters = $view->hasParameter('queryParameters') ? $view->getParameter('query_parameters') : [];
+        $supportedQueryParameters = array_flip($queryType->getSupportedParameters());
+        foreach (array_keys($queryParameters) as $queryParameterName) {
+            if (!isset( $supportedQueryParameters[$queryParameterName] )) {
+                throw new InvalidArgumentException('query parameters',
+                    "unsupported query parameter $queryParameterName");
+            }
+        }
+
+        return $queryType->getQuery($queryParameters);
+}
+}

--- a/eZ/Publish/Core/MVC/Symfony/View/Configurator/ViewProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Configurator/ViewProvider.php
@@ -42,6 +42,8 @@ class ViewProvider implements Configurator
                     $view->setControllerReference($controllerReference);
                 }
 
+                $view->addParameters($providerView->getParameters());
+
                 return;
             }
         }

--- a/eZ/Publish/Core/MVC/Symfony/View/Provider/Configured.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Provider/Configured.php
@@ -60,6 +60,9 @@ class Configured implements ViewProvider
         if (isset($viewConfig['controller'])) {
             $view->setControllerReference(new ControllerReference($viewConfig['controller']));
         }
+        if (isset($viewConfig['params']) && is_array($viewConfig['params'])) {
+            $view->addParameters($viewConfig['params']);
+        }
 
         return $view;
     }

--- a/eZ/Publish/Core/QueryType/LocationChildrenQueryType.php
+++ b/eZ/Publish/Core/QueryType/LocationChildrenQueryType.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace BD\SandboxBundle\QueryType;
+
+use BD\SandboxBundle\QueryType\Sorter\LocationOptionsSorter;
+use eZ\Publish\Core\QueryType\OptionsResolverBasedQueryType;
+use eZ\Publish\Core\QueryType\QueryType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+class LocationChildrenQueryType extends OptionsResolverBasedQueryType implements QueryType
+{
+    private $languages;
+
+    private $excludedContentTypes;
+
+    /**
+     * @var Sorter\LocationOptionsSorter
+     */
+    private $sorter;
+
+    public function __construct(LocationOptionsSorter $sorter, array $languages, array $excludedContentTypes)
+    {
+        $this->languages = $languages;
+        $this->excludedContentTypes = $excludedContentTypes;
+        $this->sorter = $sorter;
+    }
+
+    protected function configureOptions(OptionsResolver $optionsResolver)
+    {
+        $optionsResolver->setRequired('location');
+        $optionsResolver->setDefault('types', []);
+        $optionsResolver->setAllowedValues('location', function ($value) { return $value instanceof Location; });
+        $optionsResolver->setAllowedTypes('types', 'array');
+    }
+
+    protected function doGetQuery(array $parameters)
+    {
+        $query = new \eZ\Publish\API\Repository\Values\Content\LocationQuery();
+
+        $criteria = [
+            new Criterion\Visibility(Criterion\Visibility::VISIBLE),
+            new Criterion\ParentLocationId($parameters['location']->id),
+            new Criterion\LanguageCode($this->languages),
+        ];
+
+        if (isset($parameters['types'])) {
+            $criteria[] = new Criterion\ContentTypeIdentifier($parameters['types']);
+        }
+
+        if (!empty($this->excludedContentTypes)) {
+            $criteria[] = new Criterion\LogicalNot(
+                new Criterion\ContentTypeIdentifier($this->excludedContentTypes)
+            );
+        }
+
+        $query->filter = $criteria;
+
+        $this->sorter->sortFromLocation($query, $parameters['location']);
+
+        return $query;
+    }
+
+    /**
+     * Returns the QueryType name.
+     * @return string
+     */
+    public static function getName()
+    {
+        return 'LocationChildren';
+    }
+}

--- a/eZ/Publish/Core/QueryType/QueryTypeNameRegistry.php
+++ b/eZ/Publish/Core/QueryType/QueryTypeNameRegistry.php
@@ -8,27 +8,29 @@ namespace eZ\Publish\Core\QueryType;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 /**
- * A QueryType registry based on an array.
+ * A QueryType registry that uses the QueryTypes names.
  */
-class ArrayQueryTypeRegistry
+class QueryTypeNameRegistry implements QueryTypeRegistry
 {
     /** @var QueryType[] */
     private $registry = [];
 
-    public function addQueryType($name, QueryType $queryType)
+    public function addQueryType(QueryType $queryType)
     {
-        $this->registry[$name] = $queryType;
+        $this->registry[$queryType::getName()] = $queryType;
     }
 
     public function addQueryTypes(array $queryTypes)
     {
-        $this->registry += $queryTypes;
+        foreach ($queryTypes as $queryType) {
+            $this->addQueryType($queryType);
+        }
     }
 
     public function getQueryType($name)
     {
         if (!isset($this->registry[$name])) {
-            throw new InvalidArgumentException('QueryType name', 'No QueryType found with that name');
+            throw new InvalidArgumentException($name, 'No QueryType found with that name');
         }
 
         return $this->registry[$name];

--- a/eZ/Publish/Core/QueryType/QueryTypeRegistry.php
+++ b/eZ/Publish/Core/QueryType/QueryTypeRegistry.php
@@ -11,22 +11,22 @@ namespace eZ\Publish\Core\QueryType;
 interface QueryTypeRegistry
 {
     /**
-     * Registers $queryType as $name.
+     * Registers $queryType.
      *
      * @param string $name
      * @param \eZ\Publish\Core\QueryType\QueryType $queryType
      */
-    public function addQueryType($name, QueryType $queryType);
+    public function addQueryType(QueryType $queryType);
 
     /**
      * Registers QueryTypes from the $queryTypes array.
      *
-     * @param \eZ\Publish\Core\QueryType\QueryType[] $queryTypes An array of QueryTypes, with their name as the index
+     * @param \eZ\Publish\Core\QueryType\QueryType[] $queryTypes An array of QueryTypes.
      */
     public function addQueryTypes(array $queryTypes);
 
     /**
-     * Get the QueryType $name.
+     * Get the QueryType named $name.
      *
      * @param string $name
      *


### PR DESCRIPTION
> Story: http://jira.ez.no/browse/EZP-24624
> DemoBundle implementation : https://github.com/ezsystems/DemoBundle/pull/189

This is an alternative approach to what was done in #1460.

The goal is still to facilitate viewing of a list of content / locations. #1460 was based on a new "view" (as in content view or block view), where a QueryType got executed, and the results assigned to a template. But upon implementation, it appeared to be tedious, on simple use cases like a list of children.

In this approach, a built-in `QueryController` is added. It can be used in any `content_view` config to add the results of a `QueryType` to the view:

```yaml
system:
    default:
        content_view:
            full:
                blog:
                    match:
                        Identifier\ContentType: [blog]
                    controller: 'ez_query:contentAction'
                    template: 'eZDemoBundle:full:blog.html.twig'
                    params:
                        query: 'DemoBundle:BlogPosts'
                        queryParameters:
                            blogPathString: @=location.pathString
                        variable: blog_posts_list
                        enablePager: true
```

The view is configured to use `ez_query:contentAction`. The controller action runs the QueryType specified as `query`, and sets the results to the variable specified as `variable`.

The elements from `queryParameters` are passed to the QueryType's `getQuery()` method.
The expression language can be used in any queryParameter by prefixing the value with `@=`. The expression is given the `view`, the `location` and the `content`. This makes it easy to pass any property from those value objects to generate the query.

The `enable_pager` parameter (not implemented yet) will pass the search results as a PagerFanta pager object. If set to false, an array will be passed instead.

### TODO
- [ ] BDD
- [ ] Pager support
- [ ] Extract to another package/bundle
- [ ] Convert to a listener based approach, with the query parameters interpreted from the content_view level