### PR TITLE
Fix EZP-24982: Generating links when previewing content in siteaccess with URI matching does not work

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
@@ -25,7 +25,7 @@ services:
 
     ezpublish.content_preview_helper:
         class: %ezpublish.content_preview_helper.class%
-        arguments: [@event_dispatcher]
+        arguments: [@event_dispatcher, @ezpublish.siteaccess_router]
         calls:
             - [setSiteAccess, [@ezpublish.siteaccess]]
 

--- a/eZ/Publish/Core/Helper/ContentPreviewHelper.php
+++ b/eZ/Publish/Core/Helper/ContentPreviewHelper.php
@@ -16,6 +16,7 @@ use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ContentPreviewHelper implements SiteAccessAware
@@ -24,6 +25,11 @@ class ContentPreviewHelper implements SiteAccessAware
      * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
      */
     protected $eventDispatcher;
+
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface
+     */
+    protected $siteAccessRouter;
 
     /**
      * @var \eZ\Publish\Core\MVC\Symfony\SiteAccess
@@ -45,9 +51,10 @@ class ContentPreviewHelper implements SiteAccessAware
      */
     private $previewedLocation;
 
-    public function __construct(EventDispatcherInterface $eventDispatcher)
+    public function __construct(EventDispatcherInterface $eventDispatcher, SiteAccessRouterInterface $siteAccessRouter)
     {
         $this->eventDispatcher = $eventDispatcher;
+        $this->siteAccessRouter = $siteAccessRouter;
     }
 
     public function setSiteAccess(SiteAccess $siteAccess = null)
@@ -74,7 +81,7 @@ class ContentPreviewHelper implements SiteAccessAware
      */
     public function changeConfigScope($siteAccessName)
     {
-        $event = new ScopeChangeEvent(new SiteAccess($siteAccessName, 'preview'));
+        $event = new ScopeChangeEvent($this->siteAccessRouter->matchByName($siteAccessName));
         $this->eventDispatcher->dispatch(MVCEvents::CONFIG_SCOPE_CHANGE, $event);
 
         return $event->getSiteAccess();

--- a/eZ/Publish/Core/Helper/Tests/ContentPreviewHelperTest.php
+++ b/eZ/Publish/Core/Helper/Tests/ContentPreviewHelperTest.php
@@ -24,6 +24,11 @@ class ContentPreviewHelperTest extends PHPUnit_Framework_TestCase
     private $eventDispatcher;
 
     /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $siteAccessRouter;
+
+    /**
      * @var \eZ\Publish\Core\Helper\ContentPreviewHelper
      */
     private $previewHelper;
@@ -32,13 +37,21 @@ class ContentPreviewHelperTest extends PHPUnit_Framework_TestCase
     {
         parent::setUp();
         $this->eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $this->previewHelper = new ContentPreviewHelper($this->eventDispatcher);
+        $this->siteAccessRouter = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface');
+        $this->previewHelper = new ContentPreviewHelper($this->eventDispatcher, $this->siteAccessRouter);
     }
 
     public function testChangeConfigScope()
     {
         $newSiteAccessName = 'test';
-        $newSiteAccess = new SiteAccess($newSiteAccessName, 'preview');
+        $newSiteAccess = new SiteAccess($newSiteAccessName);
+
+        $this->siteAccessRouter
+            ->expects($this->once())
+            ->method('matchByName')
+            ->with($this->equalTo($newSiteAccessName))
+            ->willReturn($newSiteAccess);
+
         $event = new ScopeChangeEvent($newSiteAccess);
         $this->eventDispatcher
             ->expects($this->once())


### PR DESCRIPTION
> JIRA issue: https://jira.ez.no/browse/EZP-24982

When previewing content in a siteaccess which is matched with URI type matching (e.g. http://example.com/cro), generated links loose their URI part.

The siteaccess is correctly set to preview subrequest, but not the info that it's an URI type matched siteaccess, which means that URLs can't be generated correctly.