### PR TITLE
Bug when using URIElement value grater than 1

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIElement.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIElement.php
@@ -43,7 +43,7 @@ class URIElement implements VersatileMatcher, URILexer
      */
     public function __construct($elementNumber)
     {
-        $this->elementNumber = (int)$elementNumber;
+        $this->elementNumber = (int)$elementNumber['value'];
     }
 
     public function __sleep()


### PR DESCRIPTION
In the matcher we end up with an array so the (int) cast will always be 1. 
Not useful for when wanting to use URIElement > 1.
We should always take the value of the config.

See with @flovntp who worked on the topic as support.
(A voir avec Florent Huck qui est intervenu sur le sujet en tant que support pour eZPartner SQLI Paris.)
