### PR TITLE
Implement EZP-24999: As a bundle developer I want to use standard ezpublish semantic configuration

### DIFF
--- a/doc/specifications/config/semantic_configuration_integration.md
+++ b/doc/specifications/config/semantic_configuration_integration.md
@@ -1,0 +1,47 @@
+# Integrating custom semantic configuration
+
+> Added in 6.0 / 2015.09.02
+
+When developing an external bundle, one might want to define semantic configuration that integrates
+with existing eZ Platform's semantic configuration. That means such configuration would need to be
+available under provided `ezpublish` DIC extension from CoreBundle. Hence such configuration would
+also be SiteAccess aware.
+
+To facilitate the above, two methods are provided in CoreBundle's DIC extension.
+
+```php
+/**
+ * Adds a new config parser to the internal collection.
+ *
+ * @param \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface $configParser
+ */
+public function addConfigParser(ParserInterface $configParser);
+
+/**
+ * Adds new default settings to the internal collection.
+ *
+ * @param string $fileLocation
+ * @param array $files
+ */
+public function addDefaultSettings($fileLocation, array $files)
+```
+
+These methods are intended to be called from bundle's `build()` method:
+
+```php
+namespace Acme\FooBundle\AcmeFooBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class AcmeFooBundle extends Bundle
+{
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $eZExtension = $container->getExtension('ezpublish');
+        $eZExtension->addConfigParser(new MyConfigParser());
+        $eZExtension->addDefaultSettings('/path/to/my/', array('default_settings.yml'));
+    }
+}
+```

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
@@ -71,7 +71,10 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
     {
         // Injecting needed config parsers.
         $refExtension = new ReflectionObject($this->extension);
-        $refParser = $refExtension->getProperty('configParser');
+        $refMethod = $refExtension->getMethod('getMainConfigParser');
+        $refMethod->setAccessible(true);
+        $refMethod->invoke($this->extension);
+        $refParser = $refExtension->getProperty('mainConfigParser');
         $refParser->setAccessible(true);
         /** @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigParser $parser */
         $parser = $refParser->getValue($this->extension);
@@ -559,7 +562,10 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
 
         // Injecting needed config parsers.
         $refExtension = new ReflectionObject($this->extension);
-        $refParser = $refExtension->getProperty('configParser');
+        $refMethod = $refExtension->getMethod('getMainConfigParser');
+        $refMethod->setAccessible(true);
+        $refMethod->invoke($this->extension);
+        $refParser = $refExtension->getProperty('mainConfigParser');
         $refParser->setAccessible(true);
         /** @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigParser $parser */
         $parser = $refParser->getValue($this->extension);


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-24999

The goal is to be able to define semantic configuration and default settings from external bundle, that will be available under standard `ezpublish` configuration root and subject to resolving (ConfigResolver).

This is achieved through two new methods in Core bundle extension, intended to be called from bundle's `build()` method:

* `addConfigParser()`
* `addDefaultSettings()`

Default settings could probably work if imported into standard `ezpublish.yml`, however this approach does not require manual configuration.