### PR TITLE
Fix EZP-24959: binary field data isn't removed

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/FileSearchBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/FileSearchBaseIntegrationTest.php
@@ -193,4 +193,32 @@ abstract class FileSearchBaseIntegrationTest extends SearchBaseIntegrationTest
 
         return file_exists($path);
     }
+
+    /**
+     * Tests that a VersionUpdate can remove the stored file.
+     */
+    public function testUpdateWithRemove()
+    {
+        $type = $this->createContentType(
+            $this->getValidFieldSettings(),
+            $this->getValidValidatorConfiguration(),
+            array()
+        );
+
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+
+        $content = $contentService->publishVersion(
+            $this->createContent($this->getValidCreationFieldData(), $type
+            )->getVersionInfo());
+        $this->testIsNotEmptyValue($content->getFieldValue('data'));
+
+        $draft = $contentService->createContentDraft($content->contentInfo, $content->versionInfo);
+        $updateStruct = $contentService->newContentUpdateStruct();
+        $updateStruct->setField('data', null);
+        $contentService->updateContent($draft->getVersionInfo(), $updateStruct);
+
+        $updatedContent = $contentService->publishVersion($draft->getVersionInfo());
+        $this->testIsEmptyValue($updatedContent->getFieldValue('data'));
+    }
 }

--- a/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage.php
@@ -19,6 +19,8 @@ use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 
 /**
  * Storage for binary files.
+ *
+ * @method \eZ\Publish\Core\FieldType\BinaryBase\BinaryBaseStorage\Gateway getGateway(array $context)
  */
 class BinaryBaseStorage extends GatewayBasedStorage
 {
@@ -65,7 +67,8 @@ class BinaryBaseStorage extends GatewayBasedStorage
     public function storeFieldData(VersionInfo $versionInfo, Field $field, array $context)
     {
         if ($field->value->externalData === null) {
-            // Nothing to store
+            $this->deleteFieldData($versionInfo, [$field->id], $context);
+
             return false;
         }
 


### PR DESCRIPTION
> Fix for https://jira.ez.no/browse/EZP-24959
> Status: ready for review

Makes sure that a null fieldValue will delete stored data.

### TODO
- [x] Cover use-case in (`\eZ\Publish\API\Repository\Tests\FieldType\FileBaseIntegrationTest`)