### PR TITLE
Fix EZP-24939: Updating a role to the same name raises a notification error

### DIFF
--- a/eZ/Publish/Core/Repository/RoleService.php
+++ b/eZ/Publish/Core/Repository/RoleService.php
@@ -293,13 +293,14 @@ class RoleService implements RoleServiceInterface
             try {
                 /* Throw exception if:
                  * - A published role with the same identifier exists, AND
-                 * - The ID of the two are NOT the same (otherwise it's not an editing conflict)
+                 * - The ID of the published role does not match the original ID of the draft
                 */
-                $existingRole = $this->loadRoleByIdentifier($roleUpdateStruct->identifier);
-                if ($existingRole->id != $loadedRoleDraft->id) {
+                $existingSPIRole = $this->userHandler->loadRoleByIdentifier($roleUpdateStruct->identifier);
+                $SPIRoleDraft = $this->userHandler->loadRole($loadedRoleDraft->id, Role::STATUS_DRAFT);
+                if ($existingSPIRole->id != $SPIRoleDraft->originalId) {
                     throw new InvalidArgumentException(
                         '$roleUpdateStruct',
-                        "Role '{$existingRole->id}' with the specified identifier '{$roleUpdateStruct->identifier}' " .
+                        "Role '{$existingSPIRole->id}' with the specified identifier '{$roleUpdateStruct->identifier}' " .
                         'already exists'
                     );
                 }


### PR DESCRIPTION
Since we changed back to the old style of role versioning, a role draft does not have the same id as the published version. Instead we have to check the `originalId` of the draft. ~~This was not exposed in the API - added here order to fix the bug.~~ We check this using SPI roles, which know about the originalId.

- [x] ~~Tests~~ (this is already covered)

https://jira.ez.no/browse/EZP-24939