### PR TITLE
Fixed broken covers statements

### DIFF
--- a/eZ/Publish/Core/IO/Tests/IOServiceTest.php
+++ b/eZ/Publish/Core/IO/Tests/IOServiceTest.php
@@ -316,7 +316,7 @@ class IOServiceTest extends PHPUnit_Framework_TestCase
 
     /**
      * @depends testCreateBinaryFile
-     * @covers IOService \eZ\Publish\Core\IO\IOService::exists()
+     * @covers \eZ\Publish\Core\IO\IOService::exists()
      */
     public function testExists(BinaryFile $binaryFile)
     {
@@ -334,7 +334,7 @@ class IOServiceTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers IOService \eZ\Publish\Core\IO\IOService::exists()
+     * @covers \eZ\Publish\Core\IO\IOService::exists()
      */
     public function testExistsNot()
     {
@@ -353,7 +353,7 @@ class IOServiceTest extends PHPUnit_Framework_TestCase
 
     /**
      * @depends testCreateBinaryFile
-     * @covers IOService \eZ\Publish\Core\IO\IOService::getMimeType()
+     * @covers \eZ\Publish\Core\IO\IOService::getMimeType()
      */
     public function testGetMimeType(BinaryFile $binaryFile)
     {

--- a/eZ/Publish/Core/Search/Tests/FieldNameResolverTest.php
+++ b/eZ/Publish/Core/Search/Tests/FieldNameResolverTest.php
@@ -15,7 +15,7 @@ use ArrayObject;
 /**
  * Test case for FieldNameResolver.
  *
- * @covers \eZ\Publish\Core\Search\FieldNameResolver
+ * @covers \eZ\Publish\Core\Search\Common\FieldNameResolver
  */
 class FieldNameResolverTest extends TestCase
 {


### PR DESCRIPTION
Fixed broken covers statements so that code coverage generation works again. Otherwise PHPUnit will just abort test execution at each broken statement.