### PR TITLE
[BDD] PlatformUI User/Content controller

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Features/Content/user_content.feature
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Content/user_content.feature
@@ -1,0 +1,34 @@
+Feature: users can be manipulated using the Content API
+
+    Background:
+        Given I have "administrator" permissions
+
+    Scenario: Creating and publishing a user with the Content API works
+         When I create a "POST" request to "/content/objects"
+          And I set header "content-type" with "ContentCreate" object
+          And I set the Content to a User RestContentCreateStruct
+          And I send the request
+         Then response status code is "201"
+          And it contains a Content of ContentType "user"
+          And the Content has the "published" status
+          And a User with the same id exists
+         When I send a publish request for this content
+         Then response status code is "204"
+
+    Scenario: Removing a User Content with the Content API works
+        Given there is a User Content
+         When I create a delete request for this content
+          And I send the request
+         Then response status code is "204"
+          And the User this Content referred to is deleted
+
+    Scenario: Editing a User Content with the Content API works
+        Given there is a User Content
+         When I create a draft of this content
+          And I create an edit request for this draft
+          And I set the email field to a new value
+          And I send the request
+         Then response status code is "200"
+          And it contains a Version of ContentType "user"
+          And the Content has the "published" status
+          And the User's email was updated to the new value

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/RestContext.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/RestContext.php
@@ -230,7 +230,7 @@ EOF;
         Assertion::assertEquals(
             $code,
             $this->restDriver->getStatusCode(),
-            "Expected status code '$code' found '{$this->restDriver->getStatusCode()}'"
+            "Expected status code '$code' found '{$this->restDriver->getStatusCode()}'$exceptionMessage"
         );
     }
 

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/RestContext.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/RestContext.php
@@ -12,6 +12,7 @@ namespace eZ\Bundle\EzPublishRestBundle\Features\Context;
 
 use Behat\Mink\Mink;
 use Behat\MinkExtension\Context\MinkAwareContext;
+use eZ\Publish\Core\REST\Client\Values\ErrorMessage;
 use EzSystems\BehatBundle\Context\Api\Context;
 use EzSystems\BehatBundle\Helper\Gherkin as GherkinHelper;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
@@ -213,6 +214,19 @@ class RestContext extends Context implements MinkAwareContext
      */
     public function assertStatusCode($code)
     {
+        $exceptionMessage = '';
+        if ($code != $this->restDriver->getStatusCode() && $code >= 200 && $code < 400) {
+            $errorMessage = $this->getResponseObject();
+            if ($errorMessage instanceof ErrorMessage) {
+                $exceptionMessage = <<< EOF
+
+Exception ({$errorMessage->code}): {$errorMessage->description}
+
+{$errorMessage->trace}
+EOF;
+            }
+        }
+
         Assertion::assertEquals(
             $code,
             $this->restDriver->getStatusCode(),

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/EzRest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/EzRest.php
@@ -302,7 +302,7 @@ trait EzRest
      *
      * @return \eZ\Publish\API\Repository\Values\ValueObject
      */
-    protected function convertResponseBodyToObject($responseBody, $contentTypeHeader)
+    public function convertResponseBodyToObject($responseBody, $contentTypeHeader)
     {
         try {
             $this->responseObject = $this->getKernel()->getContainer()->get('ezpublish_rest.input.dispatcher')->parse(

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/UserContentContext.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/UserContentContext.php
@@ -1,0 +1,255 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishRestBundle\Features\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use Behat\Behat\Hook\Scope\BeforeScenarioScope;
+use Behat\MinkExtension\Context\MinkAwareContext;
+use Behat\MinkExtension\Context\RawMinkContext;
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\FieldType\User\Value as UserValue;
+use eZ\Publish\Core\FieldType\TextLine\Value as TextLineValue;
+use eZ\Publish\Core\REST\Client\Values\Content\Content;
+use eZ\Publish\Core\REST\Client\Values\Content\VersionUpdate;
+use eZ\Publish\Core\REST\Server\Values\RestContentCreateStruct;
+use eZ\Publish\Core\REST\Server\Values\Version;
+use PHPUnit_Framework_Assert as Assertion;
+
+class UserContentContext extends RawMinkContext implements Context, SnippetAcceptingContext, MinkAwareContext
+{
+    /** @var \eZ\Bundle\EzPublishRestBundle\Features\Context\RestContext */
+    private $restContext;
+
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    private $contentTypeService;
+
+    /** @var \eZ\Publish\Core\REST\Client\Values\Content\Content */
+    private $currentContent;
+
+    /** @var \eZ\Publish\API\Repository\UserService */
+    private $userService;
+
+    /** @var Version */
+    private $currentDraft;
+
+    /**
+     * The new value the user account's email is set to.
+     * @var string
+     */
+    private $newEmailValue;
+
+    public function __construct(ContentService $contentService, ContentTypeService $contentTypeService, UserService $userService)
+    {
+        $this->contentService = $contentService;
+        $this->contentTypeService = $contentTypeService;
+        $this->userService = $userService;
+    }
+
+    /** @BeforeScenario */
+    public function gatherContexts(BeforeScenarioScope $scope)
+    {
+        $environment = $scope->getEnvironment();
+        $this->restContext = $environment->getContext('eZ\Bundle\EzPublishRestBundle\Features\Context\RestContext');
+    }
+
+    /**
+     * @Given /^I set the Content to a User RestContentCreateStruct$/
+     */
+    public function iSetTheContentToUserContentCreateStruct()
+    {
+        $contentCreateStruct = $this->contentService->newContentCreateStruct(
+            $this->contentTypeService->loadContentTypeByIdentifier('user'),
+            'eng-GB'
+        );
+
+        $userFieldValue = new UserValue([
+            'login' => 'user_content_' . time(),
+            'email' => 'user_content_' . time() . '@example.com',
+            'passwordHash' => 'not_a_hash',
+        ]);
+
+        $contentCreateStruct->setField('first_name', new TextLineValue('User Content'));
+        $contentCreateStruct->setField('last_name', new TextLineValue('@' . microtime(true)));
+        $contentCreateStruct->setField('user_account', $userFieldValue);
+
+        $restStruct = new RestContentCreateStruct(
+            $contentCreateStruct,
+            new LocationCreateStruct(['parentLocationId' => 12])
+        );
+        $this->restContext->requestObject = $restStruct;
+    }
+
+    /**
+     * @Given /^it contains a Content of ContentType "([^"]*)"$/
+     */
+    public function itContainsAContentOfContentType($contentTypeIdentifier)
+    {
+        $object = $this->restContext->getResponseObject();
+        Assertion::assertInstanceOf('eZ\Publish\Core\REST\Client\Values\Content\Content', $object);
+        Assertion::assertEquals(
+            $contentTypeIdentifier,
+            $this->contentTypeService->loadContentType($object->contentInfo->contentTypeId)->identifier
+        );
+
+        $this->currentContent = $object;
+    }
+
+    /**
+     * @Given /^it contains a Version of ContentType "([^"]*)"$/
+     */
+    public function itContainsAVersionOfContentType($contentTypeIdentifier)
+    {
+        $object = $this->restContext->getResponseObject();
+        Assertion::assertInstanceOf('eZ\Publish\Core\REST\Server\Values\Version', $object);
+        Assertion::assertEquals(
+            $contentTypeIdentifier,
+            $this->contentTypeService->loadContentType($object->content->contentInfo->contentTypeId)->identifier
+        );
+
+        $this->currentContent = $this->contentService->loadContentByVersionInfo(
+            $object->content->versionInfo
+        );
+    }
+
+    /**
+     * @Given /^a User with the same id exists$/
+     */
+    public function aUserWithTheSameIdExists()
+    {
+        Assertion::assertInstanceOf(
+            'eZ\Publish\API\Repository\Values\User\User',
+            $this->userService->loadUser($this->currentContent->id)
+        );
+    }
+
+    /**
+     * @When /^I send a publish request for this content$/
+     */
+    public function iSendAPublishRequestForThisContent()
+    {
+        Assertion::assertInstanceOf('\eZ\Publish\API\Repository\Values\Content\Content', $this->currentContent);
+
+        $href = sprintf('/content/objects/%d/versions/1', $this->currentContent->id);
+        $this->restContext->createAndSendRequest('publish', $href);
+    }
+
+    /**
+     * @Given /^there is a User Content$/
+     */
+    public function thereIsAUserContent()
+    {
+        $login = 'user_content_' . microtime(true);
+        $email = $login . '@example.com';
+
+        $struct = $this->userService->newUserCreateStruct($login, $email, 'publish', 'eng-GB');
+        $struct->setField('first_name', 'John');
+        $struct->setField('last_name', 'Doe');
+
+        $parentGroup = $this->userService->loadUserGroup(11);
+        $user = $this->userService->createUser($struct, [$parentGroup]);
+
+        $this->currentContent = $this->contentService->loadContentByContentInfo($user->contentInfo);
+    }
+
+    /**
+     * @When /^I create a delete request for this content$/
+     */
+    public function iCreateDeleteRequestForThisContent()
+    {
+        $this->restContext->createRequest('delete', '/content/objects/' . $this->currentContent->id);
+    }
+
+    /**
+     * @Then /^the User this Content referred to is deleted$/
+     */
+    public function theUserThisContentReferredToIsDeleted()
+    {
+        // delete the user over HTTP as the user service will have inmemory cache
+        $this->restContext->createAndSendRequest('get', '/user/users/' . $this->currentContent->id);
+        Assertion::assertInstanceOf(
+            'eZ\Publish\Core\REST\Common\Exceptions\NotFoundException',
+            $object = $this->restContext->getResponseObject(),
+            'The user the content referred to exists'
+        );
+    }
+
+    /**
+     * @Given /^the Content has the "([^"]*)" status$/
+     */
+    public function theContentHasTheStatus($statusString)
+    {
+        $statusCodeMap = [
+            'published' => VersionInfo::STATUS_PUBLISHED,
+            'draft' => VersionInfo::STATUS_DRAFT,
+            'archived' => VersionInfo::STATUS_DRAFT,
+        ];
+
+        if (!isset($statusCodeMap[$statusString])) {
+            throw new InvalidArgumentException('status string', "Unknown status string $statusString");
+        }
+
+        Assertion::assertEquals(
+            $statusCodeMap[$statusString],
+            $this->currentContent->versionInfo->status
+        );
+    }
+
+    /**
+     * @When /^I create a draft of this content$/
+     */
+    public function iCreateADraftOfThisContent()
+    {
+        $this->restContext->createAndSendRequest('copy', '/content/objects/' . $this->currentContent->id . '/currentversion');
+        $this->currentDraft = $this->restContext->getResponseObject();
+    }
+
+    /**
+     * @When /^I create an edit request for this draft$/
+     */
+    public function iCreateAnEditRequestForThisDraft()
+    {
+        $url = sprintf(
+            '/content/objects/%d/versions/%d',
+            $this->currentDraft->content->id,
+            $this->currentDraft->content->versionInfo->versionNo
+        );
+        $this->restContext->createRequest('patch', $url);
+
+        $this->restContext->requestObject = new VersionUpdate([
+            'contentUpdateStruct' => $this->contentService->newContentUpdateStruct(),
+            'contentType' => $this->currentDraft->contentType,
+        ]);
+        $this->restContext->setHeaderWithObject('content-type', 'VersionUpdate');
+    }
+
+    /**
+     * @Given /^I set the email field to a new value$/
+     */
+    public function iSetTheEmailFieldToNewValue()
+    {
+        $this->newEmailValue = 'user_content_' . microtime(true) . '@example.com';
+        $contentUpdateStruct = $this->restContext->requestObject->contentUpdateStruct;
+        $contentUpdateStruct->setField('user_account', new UserValue(['email' => $this->newEmailValue]));
+    }
+
+    /**
+     * @Given /^the User's email was updated to the new value$/
+     */
+    public function theUserSEmailWasUpdatedToTheNewValue()
+    {
+        $field = $this->currentContent->getField('user_account');
+        Assertion::assertInstanceOf('eZ\Publish\Core\FieldType\User\Value', $field->value);
+        Assertion::assertEquals($this->newEmailValue, $field->value->email);
+    }
+}

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
@@ -94,6 +94,7 @@ parameters:
     ezpublish_rest.input.parser.Section.class: eZ\Publish\Core\REST\Client\Input\Parser\Section
     ezpublish_rest.input.parser.SectionList.class: eZ\Publish\Core\REST\Client\Input\Parser\SectionList
     ezpublish_rest.input.parser.VersionInfo.class: eZ\Publish\Core\REST\Client\Input\Parser\VersionInfo
+    ezpublish_rest.input.parser.Version.class: eZ\Publish\Core\REST\Client\Input\Parser\Version
     ezpublish_rest.input.parser.Session.class: eZ\Publish\Core\REST\Client\Input\Parser\Session
     ezpublish_rest.input.parser.UserList.class: eZ\Publish\Core\REST\Client\Input\Parser\UserList
     ezpublish_rest.input.parser.UserRefList.class: eZ\Publish\Core\REST\Client\Input\Parser\UserRefList
@@ -797,6 +798,16 @@ services:
             - @ezpublish.api.service.content
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.VersionInfo }
+
+    ezpublish_rest.input.parser.Version:
+        parent: ezpublish_rest.input.parser
+        class: %ezpublish_rest.input.parser.Version.class%
+        arguments:
+            - @ezpublish_rest.parser_tools
+            - @ezpublish.api.service.content
+            - @ezpublish.api.service.content_type
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.Version }
 
     ezpublish_rest.input.parser.Session:
         parent: ezpublish_rest.input.parser

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -39,6 +39,8 @@ parameters:
     ezpublish_rest.output.value_object_visitor.VersionInfo.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\VersionInfo
     ezpublish_rest.output.value_object_visitor.ImageVariation.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\ImageVariation
     ezpublish_rest.output.value_object_visitor.Version.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\Version
+    ezpublish_rest.output.value_object_visitor.VersionUpdate.class: eZ\Publish\Core\REST\Client\Output\ValueObjectVisitor\VersionUpdate
+    ezpublish_rest.output.value_object_visitor.RestContentCreateStruct.class: eZ\Publish\Core\REST\Client\Output\ValueObjectVisitor\RestContentCreateStruct
 
     # User group
     ezpublish_rest.output.value_object_visitor.RestUserGroup.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\RestUserGroup
@@ -339,6 +341,20 @@ services:
         arguments: [ @ezpublish_rest.field_type_serializer  ]
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Values\Version }
+
+    ezpublish_rest.output.value_object_visitor.VersionUpdate:
+        parent: ezpublish_rest.output.value_object_visitor.base
+        class: %ezpublish_rest.output.value_object_visitor.VersionUpdate.class%
+        arguments: [ @ezpublish_rest.field_type_serializer  ]
+        tags:
+            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Client\Values\Content\VersionUpdate }
+
+    ezpublish_rest.output.value_object_visitor.RestContentCreateStruct:
+        parent: ezpublish_rest.output.value_object_visitor.base
+        class: %ezpublish_rest.output.value_object_visitor.RestContentCreateStruct.class%
+        arguments: [ @ezpublish_rest.field_type_serializer  ]
+        tags:
+            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Values\RestContentCreateStruct }
 
     # UserGroup
     ezpublish_rest.output.value_object_visitor.RestUserGroup:
@@ -652,6 +668,7 @@ services:
         class: %ezpublish_rest.output.value_object_visitor.LocationCreateStruct.class%
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\Content\LocationCreateStruct }
+        arguments: [@ezpublish.api.service.location]
 
     ezpublish_rest.output.value_object_visitor.LocationUpdateStruct:
         parent: ezpublish_rest.output.value_object_visitor.base

--- a/eZ/Bundle/EzPublishRestBundle/behat.yml
+++ b/eZ/Bundle/EzPublishRestBundle/behat.yml
@@ -6,6 +6,10 @@ rest:
                 - eZ\Bundle\EzPublishRestBundle\Features\Context\RestContext:
                     driver: BuzzDriver
                     type: json
+                - eZ\Bundle\EzPublishRestBundle\Features\Context\UserContentContext:
+                    contentService: @ezpublish.api.service.content
+                    contentTypeService: @ezpublish.api.service.content_type
+                    userService: @ezpublish.api.service.user
         fullXml:
             paths: [ vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Features ]
             contexts:

--- a/eZ/Publish/Core/REST/Client/Input/Parser/ErrorMessage.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/ErrorMessage.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Client\Input\Parser;
 
 use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
+use eZ\Publish\Core\REST\Client\Values\ErrorMessage as ErrorMessageValue;
 
 /**
  * Parser for ErrorMessage.
@@ -37,19 +38,22 @@ class ErrorMessage extends BaseParser
      * @param array $data
      * @param \eZ\Publish\Core\REST\Common\Input\ParsingDispatcher $parsingDispatcher
      *
-     * @throws \Exception
+     * @return \Exception|ErrorMessage
      */
     public function parse(array $data, ParsingDispatcher $parsingDispatcher)
     {
         if (isset($this->errorCodeMapping[$data['errorCode']])) {
             $exceptionClass = $this->errorCodeMapping[$data['errorCode']];
-        } else {
-            $exceptionClass = '\\Exception';
+            return new $exceptionClass($data['errorDescription'], $data['errorCode']);
         }
 
-        throw new $exceptionClass(
-            $data['errorDescription'],
-            $data['errorCode']
-        );
+        return new ErrorMessageValue([
+            'code' => $data['errorCode'],
+            'message' => isset($data['errorMessage']) ? $data['errorMessage'] : null,
+            'description' => isset($data['errorDescription']) ? $data['errorDescription'] : null,
+            'trace' => isset($data['trace']) ? $data['trace'] : null,
+            'file' => isset($data['file']) ? $data['file'] : null,
+            'line' => isset($data['line']) ? $data['line'] : null,
+        ]);
     }
 }

--- a/eZ/Publish/Core/REST/Client/Input/Parser/Version.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/Version.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * File containing the VersionInfo parser class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\REST\Client\Input\Parser;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
+use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
+use eZ\Publish\Core\REST\Common\Input\ParserTools;
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\Core\REST\Server\Values\Version as VersionValue;
+
+/**
+ * Parser for VersionInfo.
+ */
+class Version extends BaseParser
+{
+    /**
+     * @var \eZ\Publish\Core\REST\Common\Input\ParserTools
+     */
+    protected $parserTools;
+
+    /**
+     * Content Service.
+     *
+     * @var \eZ\Publish\Core\REST\Client\ContentService
+     */
+    protected $contentService;
+
+    /**
+     * @var \eZ\Publish\API\Repository\ContentTypeService
+     */
+    private $contentTypeService;
+
+    /**
+     * @param \eZ\Publish\Core\REST\Common\Input\ParserTools $parserTools
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
+     */
+    public function __construct(ParserTools $parserTools, ContentService $contentService, ContentTypeService $contentTypeService)
+    {
+        $this->parserTools = $parserTools;
+        $this->contentService = $contentService;
+        $this->contentTypeService = $contentTypeService;
+    }
+
+    /**
+     * Parse input structure.
+     *
+     * @param array $data
+     * @param \eZ\Publish\Core\REST\Common\Input\ParsingDispatcher $parsingDispatcher
+     *
+     * @return \eZ\Publish\Core\REST\Server\Values\Version
+     */
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher)
+    {
+        $contentId = $this->requestParser->parseHref($data['VersionInfo']['Content']['_href'], 'contentId');
+
+        $content = $this->contentService->loadContent($contentId, null, $data['VersionInfo']['versionNo']);
+        $contentType = $this->contentTypeService->loadContentType($content->contentInfo->contentTypeId);
+        $relations = $this->contentService->loadRelations($content->versionInfo);
+
+        return new VersionValue($content, $contentType, $relations);
+    }
+}

--- a/eZ/Publish/Core/REST/Client/Input/Parser/VersionInfo.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/VersionInfo.php
@@ -56,7 +56,7 @@ class VersionInfo extends BaseParser
      */
     public function parse(array $data, ParsingDispatcher $parsingDispatcher)
     {
-        $contentInfoId = $this->parserTools->parseObjectElement($data['Content'], $parsingDispatcher);
+        $contentInfoId = $this->requestParser->parseHref($data['Content']['_href'], 'contentId');
 
         return new Values\Content\VersionInfo(
             $this->contentService,

--- a/eZ/Publish/Core/REST/Client/Output/ValueObjectVisitor/ContentTypeCreateStruct.php
+++ b/eZ/Publish/Core/REST/Client/Output/ValueObjectVisitor/ContentTypeCreateStruct.php
@@ -22,47 +22,48 @@ class ContentTypeCreateStruct extends ValueObjectVisitor
 {
     /**
      * Visit struct returned by controllers.
+
      *
-     * @param \eZ\Publish\Core\REST\Common\Output\Visitor $visitor
+*@param \eZ\Publish\Core\REST\Common\Output\Visitor $visitor
      * @param \eZ\Publish\Core\REST\Common\Output\Generator $generator
-     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentTypeCreateStruct $contentTypeCreateStruct
+     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentTypeCreateStruct $contentCreateStruct
      */
-    public function visit(Visitor $visitor, Generator $generator, $contentTypeCreateStruct)
+    public function visit(Visitor $visitor, Generator $generator, $contentCreateStruct)
     {
         $generator->startObjectElement('ContentTypeCreate');
         $visitor->setHeader('Content-Type', $generator->getMediaType('ContentTypeCreate'));
 
-        $generator->startValueElement('identifier', $contentTypeCreateStruct->identifier);
+        $generator->startValueElement('identifier', $contentCreateStruct->identifier);
         $generator->endValueElement('identifier');
 
-        $generator->startValueElement('remoteId', $contentTypeCreateStruct->remoteId);
+        $generator->startValueElement('remoteId', $contentCreateStruct->remoteId);
         $generator->endValueElement('remoteId');
 
-        $generator->startValueElement('urlAliasSchema', $contentTypeCreateStruct->urlAliasSchema);
+        $generator->startValueElement('urlAliasSchema', $contentCreateStruct->urlAliasSchema);
         $generator->endValueElement('urlAliasSchema');
 
-        $generator->startValueElement('nameSchema', $contentTypeCreateStruct->nameSchema);
+        $generator->startValueElement('nameSchema', $contentCreateStruct->nameSchema);
         $generator->endValueElement('nameSchema');
 
-        $generator->startValueElement('isContainer', ($contentTypeCreateStruct->isContainer ? 'true' : 'false'));
+        $generator->startValueElement('isContainer', ( $contentCreateStruct->isContainer ? 'true' : 'false'));
         $generator->endValueElement('isContainer');
 
-        $generator->startValueElement('mainLanguageCode', $contentTypeCreateStruct->mainLanguageCode);
+        $generator->startValueElement('mainLanguageCode', $contentCreateStruct->mainLanguageCode);
         $generator->endValueElement('mainLanguageCode');
 
-        $generator->startValueElement('defaultAlwaysAvailable', ($contentTypeCreateStruct->defaultAlwaysAvailable ? 'true' : 'false'));
+        $generator->startValueElement('defaultAlwaysAvailable', ( $contentCreateStruct->defaultAlwaysAvailable ? 'true' : 'false'));
         $generator->endValueElement('defaultAlwaysAvailable');
 
-        $generator->startValueElement('defaultSortField', $this->serializeSortField($contentTypeCreateStruct->defaultSortField));
+        $generator->startValueElement('defaultSortField', $this->serializeSortField($contentCreateStruct->defaultSortField));
         $generator->endValueElement('defaultSortField');
 
-        $generator->startValueElement('defaultSortOrder', $this->serializeSortOrder($contentTypeCreateStruct->defaultSortOrder));
+        $generator->startValueElement('defaultSortOrder', $this->serializeSortOrder($contentCreateStruct->defaultSortOrder));
         $generator->endValueElement('defaultSortOrder');
 
-        if (!empty($contentTypeCreateStruct->names)) {
+        if (!empty( $contentCreateStruct->names)) {
             $generator->startHashElement('names');
             $generator->startList('value');
-            foreach ($contentTypeCreateStruct->names as $languageCode => $name) {
+            foreach ($contentCreateStruct->names as $languageCode => $name) {
                 $generator->startValueElement('value', $name, array('languageCode' => $languageCode));
                 $generator->endValueElement('value');
             }
@@ -70,10 +71,10 @@ class ContentTypeCreateStruct extends ValueObjectVisitor
             $generator->endHashElement('names');
         }
 
-        if (!empty($contentTypeCreateStruct->descriptions)) {
+        if (!empty( $contentCreateStruct->descriptions)) {
             $generator->startHashElement('descriptions');
             $generator->startList('value');
-            foreach ($contentTypeCreateStruct->descriptions as $languageCode => $description) {
+            foreach ($contentCreateStruct->descriptions as $languageCode => $description) {
                 $generator->startValueElement('value', $description, array('languageCode' => $languageCode));
                 $generator->endValueElement('value');
             }
@@ -81,22 +82,22 @@ class ContentTypeCreateStruct extends ValueObjectVisitor
             $generator->endHashElement('descriptions');
         }
 
-        if ($contentTypeCreateStruct->creationDate !== null) {
-            $generator->startValueElement('modificationDate', $contentTypeCreateStruct->creationDate->format('c'));
+        if ($contentCreateStruct->creationDate !== null) {
+            $generator->startValueElement('modificationDate', $contentCreateStruct->creationDate->format('c'));
             $generator->endValueElement('modificationDate');
         }
 
-        if ($contentTypeCreateStruct->creatorId !== null) {
+        if ($contentCreateStruct->creatorId !== null) {
             $generator->startObjectElement('User');
-            $generator->startAttribute('href', $contentTypeCreateStruct->creatorId);
+            $generator->startAttribute('href', $contentCreateStruct->creatorId);
             $generator->endAttribute('href');
             $generator->endObjectElement('User');
         }
 
-        if (!empty($contentTypeCreateStruct->fieldDefinitions)) {
+        if (!empty( $contentCreateStruct->fieldDefinitions)) {
             $generator->startHashElement('FieldDefinitions');
             $generator->startList('FieldDefinition');
-            foreach ($contentTypeCreateStruct->fieldDefinitions as $fieldDefinitionCreateStruct) {
+            foreach ($contentCreateStruct->fieldDefinitions as $fieldDefinitionCreateStruct) {
                 $visitor->visitValueObject($fieldDefinitionCreateStruct);
             }
             $generator->endList('FieldDefinition');

--- a/eZ/Publish/Core/REST/Client/Output/ValueObjectVisitor/RestContentCreateStruct.php
+++ b/eZ/Publish/Core/REST/Client/Output/ValueObjectVisitor/RestContentCreateStruct.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * File containing the ContentCreateStruct visitor class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\REST\Client\Output\ValueObjectVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\Core\REST\Common\Output\FieldTypeSerializer;
+use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+
+/**
+ * ContentCreateStruct value object visitor.
+ */
+class RestContentCreateStruct extends ValueObjectVisitor
+{
+    public function __construct(FieldTypeSerializer $fieldTypeSerializer)
+    {
+        $this->fieldTypeSerializer = $fieldTypeSerializer;
+    }
+
+    /**
+     * @param \eZ\Publish\Core\REST\Common\Output\Visitor $visitor
+     * @param \eZ\Publish\Core\REST\Common\Output\Generator $generator
+     * @param \eZ\Publish\Core\REST\Server\Values\RestContentCreateStruct $restContentCreateStruct
+     */
+    public function visit(Visitor $visitor, Generator $generator, $restContentCreateStruct)
+    {
+        $contentCreateStruct = $restContentCreateStruct->contentCreateStruct;
+
+        $generator->startObjectElement('ContentCreate');
+        $visitor->setHeader('Content-Type', $generator->getMediaType('TypeCreate'));
+
+        $generator->startValueElement('mainLanguageCode', $contentCreateStruct->mainLanguageCode);
+        $generator->endValueElement('mainLanguageCode');
+
+        $generator->startValueElement('alwaysAvailable', $contentCreateStruct->alwaysAvailable ? 'true' : 'false');
+        $generator->endValueElement('alwaysAvailable');
+
+        $generator->startValueElement('remoteId', (int)$contentCreateStruct->remoteId);
+        $generator->endValueElement('remoteId');
+
+        if ($contentCreateStruct->modificationDate !== null) {
+            $generator->startValueElement('modificationDate', $contentCreateStruct->modificationDate->format('c'));
+            $generator->endValueElement('modificationDate');
+        }
+
+        if ($contentCreateStruct->ownerId !== null) {
+            $generator->startObjectElement('User');
+            $generator->startAttribute('href', $contentCreateStruct->ownerId);
+            $generator->endAttribute('href');
+            $generator->endObjectElement('User');
+        }
+
+        $generator->startObjectElement('ContentType');
+        $generator->startAttribute(
+            'href',
+            $this->router->generate(
+                'ezpublish_rest_loadContentType',
+                array('contentTypeId' => $contentCreateStruct->contentType->id)
+            )
+        );
+        $generator->endAttribute('href');
+        $generator->endObjectElement('ContentType');
+
+        if (!empty($contentCreateStruct->fields)) {
+            $generator->startHashElement('fields');
+            $generator->startList('field');
+
+            foreach ($contentCreateStruct->fields as $field) {
+                $this->visitField($generator, $contentCreateStruct->contentType, $field);
+            }
+            $generator->endList('field');
+            $generator->endHashElement('fields');
+        }
+
+        $visitor->visitValueObject($restContentCreateStruct->locationCreateStruct);
+
+        $generator->endObjectElement('ContentCreate');
+    }
+
+    /**
+     * Visits a single content field and generates its content.
+     *
+     * @param \eZ\Publish\Core\REST\Common\Output\Generator $generator
+     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
+     * @param \eZ\Publish\API\Repository\Values\Content\Field $field
+     */
+    public function visitField(Generator $generator, ContentType $contentType, Field $field)
+    {
+        $generator->startHashElement('field');
+
+        $generator->startValueElement('fieldDefinitionIdentifier', $field->fieldDefIdentifier);
+        $generator->endValueElement('fieldDefinitionIdentifier');
+
+        $generator->startValueElement('languageCode', $field->languageCode);
+        $generator->endValueElement('languageCode');
+
+        $this->fieldTypeSerializer->serializeFieldValue(
+            $generator,
+            $contentType,
+            $field
+        );
+
+        $generator->endHashElement('field');
+    }
+}

--- a/eZ/Publish/Core/REST/Client/Output/ValueObjectVisitor/VersionUpdate.php
+++ b/eZ/Publish/Core/REST/Client/Output/ValueObjectVisitor/VersionUpdate.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * This file is part of the ezpublish-kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+
+namespace eZ\Publish\Core\REST\Client\Output\ValueObjectVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\Core\REST\Common\Output\FieldTypeSerializer;
+use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+
+/**
+ * Visits a ContentUpdateStruct into a VersionUpdate request.
+ */
+class VersionUpdate extends ValueObjectVisitor
+{
+    /**
+     * @param \eZ\Publish\Core\REST\Common\Output\FieldTypeSerializer $fieldTypeSerializer
+     */
+    public function __construct(FieldTypeSerializer $fieldTypeSerializer)
+    {
+        $this->fieldTypeSerializer = $fieldTypeSerializer;
+    }
+
+    /**
+     * @param \eZ\Publish\Core\REST\Common\Output\Visitor $visitor
+     * @param \eZ\Publish\Core\REST\Common\Output\Generator $generator
+     * @param \eZ\Publish\Core\REST\Client\Values\Content\VersionUpdate $versionUpdate
+     */
+    public function visit(Visitor $visitor, Generator $generator, $versionUpdate)
+    {
+        $updateStruct = $versionUpdate->contentUpdateStruct;
+
+        $generator->startObjectElement('VersionUpdate');
+        $visitor->setHeader('Content-Type', $generator->getMediaType('VersionUpdate'));
+        $generator->startValueElement('initialLanguageCode', $updateStruct->initialLanguageCode);
+        $generator->endValueElement('initialLanguageCode');
+
+        if (is_array($updateStruct->fields) && count($updateStruct->fields) > 0) {
+            $generator->startHashElement('fields');
+            $generator->startList('field');
+            foreach ($updateStruct->fields as $field) {
+                $this->visitField($generator, $versionUpdate->contentType, $field);
+            }
+            $generator->endList('field');
+            $generator->endHashElement('fields');
+        }
+
+        $generator->endObjectElement('VersionUpdate');
+    }
+
+    private function visitField(Generator $generator, ContentType $contentType, Field $field)
+    {
+        $generator->startHashElement('field');
+
+        $generator->startValueElement('id', $field->id);
+        $generator->endValueElement('id');
+
+        $generator->startValueElement('fieldDefinitionIdentifier', $field->fieldDefIdentifier);
+        $generator->endValueElement('fieldDefinitionIdentifier');
+
+        $generator->startValueElement('languageCode', $field->languageCode);
+        $generator->endValueElement('languageCode');
+
+        $this->fieldTypeSerializer->serializeFieldValue(
+            $generator,
+            $contentType,
+            $field
+        );
+
+        $generator->endHashElement('field');
+    }
+}

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/BadStateExceptionTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/BadStateExceptionTest.php
@@ -17,9 +17,6 @@ class BadStateExceptionTest extends BaseTest
 {
     /**
      * Tests the parsing of BadStateException.
-     *
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\BadStateException
-     * @expectedExceptionMessage Section with ID "23" not found.
      */
     public function testParse()
     {
@@ -30,7 +27,9 @@ class BadStateExceptionTest extends BaseTest
             'errorCode' => '409',
         );
 
-        $parser->parse($inputArray, $this->getParsingDispatcherMock());
+        $exception = $parser->parse($inputArray, $this->getParsingDispatcherMock());
+        self::assertInstanceOf('eZ\Publish\API\Repository\Exceptions\BadStateException', $exception);
+        self::assertEquals('Section with ID "23" not found.', $exception->getMessage());
     }
 
     /**

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/InvalidArgumentExceptionTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/InvalidArgumentExceptionTest.php
@@ -17,9 +17,6 @@ class InvalidArgumentExceptionTest extends BaseTest
 {
     /**
      * Tests parsing of InvalidArgumentException error message.
-     *
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     * @expectedExceptionMessage Section with ID "23" not found.
      */
     public function testParse()
     {
@@ -30,7 +27,9 @@ class InvalidArgumentExceptionTest extends BaseTest
             'errorCode' => '406',
         );
 
-        $parser->parse($inputArray, $this->getParsingDispatcherMock());
+        $exception = $parser->parse($inputArray, $this->getParsingDispatcherMock());
+        self::assertInstanceOf('eZ\Publish\API\Repository\Exceptions\InvalidArgumentException', $exception);
+        self::assertEquals('Section with ID "23" not found.', $exception->getMessage());
     }
 
     /**

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/NotFoundExceptionTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/NotFoundExceptionTest.php
@@ -17,9 +17,6 @@ class NotFoundExceptionTest extends BaseTest
 {
     /**
      * Tests parsing of NotFoundException.
-     *
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     * @expectedExceptionMessage Section with ID "23" not found.
      */
     public function testParse()
     {
@@ -30,7 +27,9 @@ class NotFoundExceptionTest extends BaseTest
             'errorCode' => '404',
         );
 
-        $parser->parse($inputArray, $this->getParsingDispatcherMock());
+        $exception = $parser->parse($inputArray, $this->getParsingDispatcherMock());
+        self::assertInstanceOf('eZ\Publish\API\Repository\Exceptions\NotFoundException', $exception);
+        self::assertEquals('Section with ID "23" not found.', $exception->getMessage());
     }
 
     /**

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/VersionInfoTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/VersionInfoTest.php
@@ -14,6 +14,7 @@ namespace eZ\Publish\Core\REST\Client\Tests\Input\Parser;
 use eZ\Publish\Core\REST\Client\Input;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\API\Repository\Values;
+use eZ\Publish\Core\REST\Common\RequestParser;
 
 class VersionInfoTest extends BaseTest
 {
@@ -56,6 +57,12 @@ class VersionInfoTest extends BaseTest
                 '_href' => '/content/objects/10',
             ),
         );
+
+        $this->getRequestParserMock()
+            ->expects($this->once())
+            ->method('parseHref')
+            ->with('/content/objects/10', 'contentId')
+            ->will($this->returnValue(10));
 
         $result = $relationParser->parse($inputArray, $this->getParsingDispatcherMock());
 
@@ -171,7 +178,7 @@ class VersionInfoTest extends BaseTest
     public function testParsedContentInfoId($parsedVersionInfo)
     {
         $this->assertEquals(
-            '/content/objects/10',
+            10,
             $parsedVersionInfo->contentInfoId
         );
     }
@@ -183,10 +190,13 @@ class VersionInfoTest extends BaseTest
      */
     protected function getParser()
     {
-        return new Input\Parser\VersionInfo(
+        $parser = new Input\Parser\VersionInfo(
             new ParserTools(),
             $this->getContentServiceMock()
         );
+        $parser->setRequestParser($this->getRequestParserMock());
+
+        return $parser;
     }
 
     /**
@@ -205,5 +215,19 @@ class VersionInfoTest extends BaseTest
         }
 
         return $this->contentServiceMock;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\Core\REST\Common\RequestParser
+     */
+    protected function getRequestParserMock()
+    {
+        static $parser = null;
+
+        if (!isset($parser)) {
+            $parser =$this->getMock('eZ\Publish\Core\REST\Common\RequestParser');
+        }
+
+        return $parser;
     }
 }

--- a/eZ/Publish/Core/REST/Client/Values/Content/Content.php
+++ b/eZ/Publish/Core/REST/Client/Values/Content/Content.php
@@ -12,7 +12,7 @@
 namespace eZ\Publish\Core\REST\Client\Values\Content;
 
 use eZ\Publish\API\Repository\ContentService;
-use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
+use eZ\Publish\Core\Repository\Values\Content\Content as APIContent;
 
 /**
  * Implementation of the {@link \eZ\Publish\API\Repository\Values\Content\Content}

--- a/eZ/Publish/Core/REST/Client/Values/Content/VersionUpdate.php
+++ b/eZ/Publish/Core/REST/Client/Values/Content/VersionUpdate.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Client\Values\Content;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * A REST VersionUpdate.
+ *
+ * Aggregate of a ContentUpdateStruct and the updated ContentType.
+ *
+ * @property-read \eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct $contentUpdateStruct
+ * @property-read \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
+ * @property-read string $url
+ */
+class VersionUpdate extends ValueObject
+{
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct
+     */
+    protected $contentUpdateStruct;
+
+    /**
+     * @var \eZ\Publish\API\Repository\Values\ContentType\ContentType
+     */
+    protected $contentType;
+}

--- a/eZ/Publish/Core/REST/Client/Values/ErrorMessage.php
+++ b/eZ/Publish/Core/REST/Client/Values/ErrorMessage.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Client\Values;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+class ErrorMessage extends ValueObject
+{
+    protected $code;
+
+    protected $message;
+
+    protected $description;
+
+    protected $trace;
+
+    protected $file;
+
+    protected $line;
+}

--- a/eZ/Publish/Core/REST/Server/Values/RestContentCreateStruct.php
+++ b/eZ/Publish/Core/REST/Server/Values/RestContentCreateStruct.php
@@ -12,12 +12,12 @@ namespace eZ\Publish\Core\REST\Server\Values;
 
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
-use eZ\Publish\Core\REST\Common\Value as RestValue;
+use eZ\Publish\API\Repository\Values\ValueObject;
 
 /**
  * RestContentCreateStruct view model.
  */
-class RestContentCreateStruct extends RestValue
+class RestContentCreateStruct extends ValueObject
 {
     /**
      * @var \eZ\Publish\API\Repository\Values\Content\ContentCreateStruct


### PR DESCRIPTION
> Testing branch for https://github.com/ezsystems/PlatformUIBundle/pull/401
> See BDD @ https://travis-ci.org/ezsystems/ezpublish-kernel/jobs/87190070#L944
> Ready for review

Adds coverage for creation of users with the REST Content API (instead of the User API).

Would belong to PlatformUIBundle, but since PlatformUI is installed in the kernel, and we have the REST test infrastructure, it is acceptable I think to have it in here.

Some of the REST Client (only used by rest afaik) parsers/visitors were returning REST ids (`/path/to/resource/id`) while the ones in the Server namespace use "normal" ids. I'm not 100% sure about the change, but to the best of my knowledge, it does work fine.

The error improvement changes two things:
- the parser doesn't _throw_ exceptions anymore, it returns them. I don't think there was any value in throwing it, and it was messing up the REST client
- when an unknown error is parsed, instead of being an `Exception`, it is an `ErrorMessage` ValueObject. The main value is that we can set the trace, file, line... in the ErrorMessage. Given that it is mostly used on 500, it makes debugging easier.

### TODO
- [x] Cover create user
- [x] Cover edit user
- [x] Cover publish user
- [x] Cover delete