### PR TITLE
Fixed tests: Use dedicated method for checking search engine support

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/BinaryFileIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/BinaryFileIntegrationTest.php
@@ -426,15 +426,13 @@ class BinaryFileIntegrationTest extends FileSearchBaseIntegrationTest
      * BinaryFile field type is not searchable with Field criterion
      * and sort clause in Legacy search engine.
      */
-    public function testCreateTestContent()
+    protected function checkSearchEngineSupport()
     {
         if (ltrim(get_class($this->getSetupFactory()), '\\') === 'eZ\\Publish\\API\\Repository\\Tests\\SetupFactory\\Legacy') {
             $this->markTestSkipped(
-                'BinaryFile field type is not searchable with Field criterion and sort clause in Legacy search engine'
+                "'ezbinaryfile' field type is not searchable with Legacy Search Engine"
             );
         }
-
-        return parent::testCreateTestContent();
     }
 
     protected function getValidSearchValueTwo()


### PR DESCRIPTION
This makes tests less fragile as it removes the need to override test method that other tests depend on in order to skip the tests for specific search engine.

See https://github.com/ezsystems/ezpublish-kernel/pull/1483