### PR TITLE
Fix EZP-25032: Repository authentication provider cannot be used with custom user classes

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RepositoryAuthenticationProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RepositoryAuthenticationProvider.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Security\Authentication;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Repository;
-use eZ\Publish\Core\MVC\Symfony\Security\User as EzUser;
+use eZ\Publish\Core\MVC\Symfony\Security\UserInterface as EzUserInterface;
 use Symfony\Component\Security\Core\Authentication\Provider\DaoAuthenticationProvider;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
@@ -32,15 +32,15 @@ class RepositoryAuthenticationProvider extends DaoAuthenticationProvider
 
     protected function checkAuthentication(UserInterface $user, UsernamePasswordToken $token)
     {
-        if (!$user instanceof EzUser) {
+        if (!$user instanceof EzUserInterface) {
             return parent::checkAuthentication($user, $token);
         }
 
         // $currentUser can either be an instance of UserInterface or just the username (e.g. during form login).
-        /** @var EzUser|string $currentUser */
+        /** @var EzUserInterface|string $currentUser */
         $currentUser = $token->getUser();
         if ($currentUser instanceof UserInterface) {
-            if ($currentUser->getPassword() !== $user->getPassword()) {
+            if ($currentUser->getAPIUser()->passwordHash !== $user->getAPIUser()->passwordHash) {
                 throw new BadCredentialsException('The credentials were changed from another session.');
             }
 


### PR DESCRIPTION
> JIRA issue: https://jira.ez.no/browse/EZP-25032

I have a custom provider which uses a custom user class with DOES NOT extend `eZ\Publish\Core\MVC\Symfony\Security\User` class, but it DOES implement `eZ\Publish\Core\MVC\Symfony\Security\UserInterface`.

Since I want to use eZ repository to check for user authentication, this combination is not possible since eZ Publish `RepositoryAuthenticationProvider` explicitly checks if user is an instance of `eZ\Publish\Core\MVC\Symfony\Security\User` class instead of checking for `eZ\Publish\Core\MVC\Symfony\Security\UserInterface`.

This PR changes the provider to use the interface rather than the concrete implementation of User class.