### PR TITLE
EZP-25039: Updating a BinaryFile field with a different mimetype will fail

### DIFF
--- a/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage.php
@@ -72,30 +72,18 @@ class BinaryBaseStorage extends GatewayBasedStorage
             return false;
         }
 
-        // no mimeType means we are dealing with an input, local file
-        if (!isset($field->value->externalData['mimeType'])) {
-            $field->value->externalData['mimeType'] =
-                $this->mimeTypeDetector->getFromPath($field->value->externalData['inputUri']);
-        }
-
-        $storedValue = $field->value->externalData;
-
-        // The file referenced in externalData MAY be an existing IOService file which we can use
-        if ($storedValue['id'] === null) {
-            $createStruct = $this->IOService->newBinaryCreateStructFromLocalFile(
-                $storedValue['inputUri']
-            );
-            $storagePath = $this->pathGenerator->getStoragePathForField($field, $versionInfo);
-            $createStruct->id = $storagePath;
+        if (isset($field->value->externalData['inputUri'])) {
+            $field->value->externalData['mimeType'] = $this->mimeTypeDetector->getFromPath($field->value->externalData['inputUri']);
+            $createStruct = $this->IOService->newBinaryCreateStructFromLocalFile($field->value->externalData['inputUri']);
+            $createStruct->id = $this->pathGenerator->getStoragePathForField($field, $versionInfo);
             $binaryFile = $this->IOService->createBinaryFile($createStruct);
-            $storedValue['id'] = $binaryFile->id;
-            $storedValue['mimeType'] = $createStruct->mimeType;
-            $storedValue['uri'] = isset($this->downloadUrlGenerator) ?
+
+            $field->value->externalData['id'] = $binaryFile->id;
+            $field->value->externalData['mimeType'] = $createStruct->mimeType;
+            $field->value->externalData['uri'] = isset($this->downloadUrlGenerator) ?
                 $this->downloadUrlGenerator->getStoragePathForField($field, $versionInfo) :
                 $binaryFile->uri;
         }
-
-        $field->value->externalData = $storedValue;
 
         $this->removeOldFile($field->id, $versionInfo->versionNo, $context);
 

--- a/eZ/Publish/SPI/Tests/FieldType/BinaryFileIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BinaryFileIntegrationTest.php
@@ -196,11 +196,13 @@ class BinaryFileIntegrationTest extends FileBaseIntegrationTest
             array(
                 'data' => null,
                 'externalData' => array(
-                    'id' => null,
+                    // used to ensure that inputUri has precedence over 'id'
+                    'id' => 'some/value',
                     'inputUri' => ($path = __DIR__ . '/_fixtures/image.png'),
                     'fileName' => 'Blueish-Blue-Binary.jpg',
                     'fileSize' => filesize($path),
-                    'mimeType' => 'image/png',
+                    // on purpuse wrong, as it should be ignored by storage
+                    'mimeType' => 'foo/bar',
                     'downloadCount' => 23,
                     'uri' => __DIR__ . '/_fixtures/image.jpg',
                 ),


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-25039
> Status: ready for review

The PR makes sure that both `id` and `mimeType`, if provided in the update data, are ignored. The mimeType is generated from the filepath instead.

This also rewrites a bit the store method to be clearer.

### TODO
- [x] Add issue # to 911a93b