### PR TITLE
EZP-24922: Image file can't be updated over REST

### DIFF
--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -74,11 +74,7 @@ class ImageStorage extends GatewayBasedStorage
                 $field->value->externalData['fileName']
             );
 
-            if (isset($field->value->externalData['id'])) {
-                $binaryFile = $this->IOService->loadBinaryFile($field->value->externalData['id']);
-            } elseif ($this->IOService->exists($targetPath)) {
-                $binaryFile = $this->IOService->loadBinaryFile($targetPath);
-            } elseif (isset($field->value->externalData['inputUri'])) {
+            if (isset($field->value->externalData['inputUri'])) {
                 $localFilePath = $field->value->externalData['inputUri'];
                 unset($field->value->externalData['inputUri']);
 
@@ -89,6 +85,10 @@ class ImageStorage extends GatewayBasedStorage
                 $imageSize = getimagesize($localFilePath);
                 $field->value->externalData['width'] = $imageSize[0];
                 $field->value->externalData['height'] = $imageSize[1];
+            } elseif (isset($field->value->externalData['id'])) {
+                $binaryFile = $this->IOService->loadBinaryFile($field->value->externalData['id']);
+            } elseif ($this->IOService->exists($targetPath)) {
+                $binaryFile = $this->IOService->loadBinaryFile($targetPath);
             } else {
                 throw new InvalidArgumentException(
                     'inputUri',

--- a/eZ/Publish/Core/REST/Common/FieldTypeProcessor/BinaryInputProcessor.php
+++ b/eZ/Publish/Core/REST/Common/FieldTypeProcessor/BinaryInputProcessor.php
@@ -41,7 +41,7 @@ abstract class BinaryInputProcessor extends FieldTypeProcessor
             );
 
             unset($incomingValueHash['data']);
-            $incomingValueHash['path'] = $tempFile;
+            $incomingValueHash['inputUri'] = $tempFile;
         }
 
         return $incomingValueHash;

--- a/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/BinaryInputProcessorTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/BinaryInputProcessorTest.php
@@ -79,17 +79,12 @@ abstract class BinaryInputProcessorTest extends PHPUnit_Framework_TestCase
 
         $outputHash = $processor->preProcessValueHash($inputHash);
 
-        $this->assertFalse(isset($outputHash['data']), 'No data in output hash');
-        $this->assertTrue(isset($outputHash['path']), 'No path in output hash');
+        $this->assertFalse(isset($outputHash['data']), 'Data found in input hash');
+        $this->assertTrue(isset($outputHash['inputUri']), 'No path found in output hash');
 
-        $this->assertTrue(
-            file_exists($outputHash['path'])
-        );
+        $this->assertTrue(file_exists($outputHash['inputUri']), "The output path {$outputHash['inputUri']} does not exist");
 
-        $this->assertEquals(
-            $fileContent,
-            file_get_contents($outputHash['path'])
-        );
+        $this->assertEquals($fileContent, file_get_contents($outputHash['inputUri']));
     }
 
     /**

--- a/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
@@ -216,6 +216,8 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
             array(
                 'data' => null,
                 'externalData' => array(
+                    // should be ignored
+                    'id' => 'some/value',
                     'inputUri' => ($path = __DIR__ . '/_fixtures/image.png'),
                     'fileName' => 'Blueish-Blue.jpg',
                     'alternativeText' => 'This blue is so blueish.',


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-24922
> Status: ready for review

There are two issues here:

### Passing the `id` property to REST
PlatformUI re-uses the current Image Field Value when updating a field, the id is always passed. Since the id was checked before the inputUri, the inputUri was always ignored. Doing so shouldn't prevent the file from being updated, since it is a calculated value. 

The PR makes sure that `inputUri` has precedence over `id` if both are given. This behaviour is covered by the integration test update.

### Usage of deprecated `path` by the Image FieldTypeProcessor
The processor was creating the file from `data`, and passing this file as `path`, a property that is now deprecated. It has been changed to use `inputUri`, and the test was updated.

The SPI test doesn't cover this, as it belongs to the REST layer.

The behaviour has been tested on PlatformUI, by updating an image to a new one.