### PR TITLE
EZP-25041 implement getField method on User and UserGroup

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/Content.php
+++ b/eZ/Publish/API/Repository/Values/Content/Content.php
@@ -60,4 +60,16 @@ abstract class Content extends ValueObject
      * @return \eZ\Publish\API\Repository\Values\Content\Field[] An array of {@link Field} with field identifier as keys
      */
     abstract public function getFieldsByLanguage($languageCode = null);
+
+    /**
+     * This method returns the field for a given field definition identifier and language.
+     *
+     * If not set the initialLanguage of the content version is used.
+     *
+     * @param string $fieldDefIdentifier
+     * @param string|null $languageCode
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Field|null A {@link Field} or null if nothing is found
+     */
+    abstract public function getField($fieldDefIdentifier, $languageCode = null);
 }

--- a/eZ/Publish/Core/REST/Client/Values/User/User.php
+++ b/eZ/Publish/Core/REST/Client/Values/User/User.php
@@ -77,6 +77,21 @@ class User extends APIUser
         return $this->content->getFieldsByLanguage($languageCode);
     }
 
+    /**
+     * This method returns the field for a given field definition identifier and language.
+     *
+     * If not set the initialLanguage of the content version is used.
+     *
+     * @param string $fieldDefIdentifier
+     * @param string|null $languageCode
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Field|null A {@link Field} or null if nothing is found
+     */
+    public function getField($fieldDefIdentifier, $languageCode = null)
+    {
+        return $this->content->getField($fieldDefIdentifier, $languageCode);
+    }
+
     public function __get($property)
     {
         switch ($property) {

--- a/eZ/Publish/Core/REST/Client/Values/User/UserGroup.php
+++ b/eZ/Publish/Core/REST/Client/Values/User/UserGroup.php
@@ -77,6 +77,21 @@ class UserGroup extends APIUserGroup
         return $this->content->getFieldsByLanguage($languageCode);
     }
 
+    /**
+     * This method returns the field for a given field definition identifier and language.
+     *
+     * If not set the initialLanguage of the content version is used.
+     *
+     * @param string $fieldDefIdentifier
+     * @param string|null $languageCode
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Field|null A {@link Field} or null if nothing is found
+     */
+    public function getField($fieldDefIdentifier, $languageCode = null)
+    {
+        return $this->content->getField($fieldDefIdentifier, $languageCode);
+    }
+
     public function __get($property)
     {
         switch ($property) {

--- a/eZ/Publish/Core/Repository/Values/Content/Content.php
+++ b/eZ/Publish/Core/Repository/Values/Content/Content.php
@@ -126,7 +126,7 @@ class Content extends APIContent
      * If not set the initialLanguage of the content version is used.
      *
      * @param string $fieldDefIdentifier
-     * @param null $languageCode
+     * @param string|null $languageCode
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Field|null A {@link Field} or null if nothing is found
      */

--- a/eZ/Publish/Core/Repository/Values/User/User.php
+++ b/eZ/Publish/Core/Repository/Values/User/User.php
@@ -96,6 +96,21 @@ class User extends APIUser
     }
 
     /**
+     * This method returns the field for a given field definition identifier and language.
+     *
+     * If not set the initialLanguage of the content version is used.
+     *
+     * @param string $fieldDefIdentifier
+     * @param string|null $languageCode
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Field|null A {@link Field} or null if nothing is found
+     */
+    public function getField($fieldDefIdentifier, $languageCode = null)
+    {
+        return $this->content->getField($fieldDefIdentifier, $languageCode);
+    }
+
+    /**
      * Function where list of properties are returned.
      *
      * Override to add dynamic properties

--- a/eZ/Publish/Core/Repository/Values/User/UserGroup.php
+++ b/eZ/Publish/Core/Repository/Values/User/UserGroup.php
@@ -76,6 +76,21 @@ class UserGroup extends APIUserGroup
     }
 
     /**
+     * This method returns the field for a given field definition identifier and language.
+     *
+     * If not set the initialLanguage of the content version is used.
+     *
+     * @param string $fieldDefIdentifier
+     * @param string|null $languageCode
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Field|null A {@link Field} or null if nothing is found
+     */
+    public function getField($fieldDefIdentifier, $languageCode = null)
+    {
+        return $this->content->getField($fieldDefIdentifier, $languageCode);
+    }
+
+    /**
      * Function where list of properties are returned.
      *
      * Override to add dynamic properties


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-25041

User and UserGroup do not implement getField method, which in turn means they can not be used with translation and field helper, nor can the ez_field_value and ez_render_field be used directly on User/UserGroup (only on their 'content' property, accessed via magic method).
As they can be used however with ez_render_name, for example, and considering they do extend abstract 'content' class, it would make sense for them to behave in the same way the Content itself does.

This PR moves getField method to abstract class Content and implements it in User and UserGroup.