### PR TITLE
Fix EZP-25002: Unable to add more options to ezselection field type

### DIFF
--- a/eZ/Publish/Core/FieldType/Selection/Type.php
+++ b/eZ/Publish/Core/FieldType/Selection/Type.php
@@ -59,7 +59,7 @@ class Type extends FieldType
                 case 'isMultiple':
                     if (!is_bool($settingValue)) {
                         $validationErrors[] = new ValidationError(
-                            "FieldType '%fieldType%' expects setting %setting% to be a of type %type%",
+                            "FieldType '%fieldType%' expects setting '%setting%' to be of type '%type%'",
                             null,
                             array(
                                 'fieldType' => $this->getFieldTypeIdentifier(),
@@ -73,12 +73,22 @@ class Type extends FieldType
                 case 'options':
                     if (!is_array($settingValue)) {
                         $validationErrors[] = new ValidationError(
-                            "FieldType '%fieldType%' expects setting %setting% to be a of type %type%",
+                            "FieldType '%fieldType%' expects setting '%setting%' to be of type '%type%'",
                             null,
                             array(
                                 'fieldType' => $this->getFieldTypeIdentifier(),
                                 'setting' => $settingKey,
                                 'type' => 'hash',
+                            ),
+                            "[$settingKey]"
+                        );
+                    } elseif (empty($settingValue)) {
+                        $validationErrors[] = new ValidationError(
+                            "FieldType '%fieldType%' expects setting '%setting%' to contain at least one option",
+                            null,
+                            array(
+                                'fieldType' => $this->getFieldTypeIdentifier(),
+                                'setting' => $settingKey,
                             ),
                             "[$settingKey]"
                         );

--- a/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
@@ -346,6 +346,12 @@ class SelectionTest extends FieldTypeTest
                     'options' => 23,
                 ),
             ),
+            array(
+                array(
+                    // options must not be empty
+                    'options' => [],
+                ),
+            ),
         );
     }
 


### PR DESCRIPTION
> Part of https://jira.ez.no/browse/EZP-25002
> Other PRs for this: https://github.com/ezsystems/repository-forms/pull/56 and https://github.com/ezsystems/PlatformUIBundle/pull/417
> Status: Ready for review

Require at least one selection option in order to validate the field type settings.