### PR TITLE
Fixed ezpublish.core.io.metadata_handler.flysystem service to be instantiated from correct class

### DIFF
--- a/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
+++ b/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
@@ -40,7 +40,7 @@ services:
     # Base service for flysystem metadata handler
     ezpublish.core.io.metadata_handler.flysystem:
         abstract: true
-        class: %ezpublish.core.io.binarydata_handler.flysystem.class%
+        class: %ezpublish.core.io.metadata_handler.flysystem.class%
         arguments:
             - ~
 


### PR DESCRIPTION
Seems to be a error in eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml which makes it impossible to change ez_io.metadata_handler because it will be instantiated as a binarydata handler