### PR TITLE
Fix EZP-25079: When saving a new policy draft module/function choice is lost

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/User/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Mapper.php
@@ -74,13 +74,19 @@ class Mapper
         $policies = array();
         foreach ($data as $row) {
             $policyId = $row['ezpolicy_id'];
-            if (!isset($policies[$policyId]) &&
-                 ($policyId !== null)) {
+            if (!isset($policies[$policyId]) && ($policyId !== null)) {
+                $originalId = null;
+                if ($row['ezpolicy_original_id']) {
+                    $originalId = (int)$row['ezpolicy_original_id'];
+                } elseif ($row['ezrole_version']) {
+                    $originalId = (int)$policyId;
+                }
+
                 $policies[$policyId] = new Policy(
                     array(
-                        'id' => (int)$row['ezpolicy_id'],
+                        'id' => (int)$policyId,
                         'roleId' => (int)$row['ezrole_id'],
-                        'originalId' => $row['ezpolicy_original_id'] ? (int)$row['ezpolicy_original_id'] : null,
+                        'originalId' => $originalId,
                         'module' => $row['ezpolicy_module_name'],
                         'function' => $row['ezpolicy_function_name'],
                         'limitations' => '*', // limitations must be '*' if not a non empty array of limitations


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-25079

Related PRs: https://github.com/ezsystems/repository-forms/pull/57 / https://github.com/ezsystems/PlatformUIBundle/pull/426

Legacy storage engine: This ensures that all policies inside a RoleDraft (`ezrole_version !== 0`) is a PolicyDraft (i.e. has `originalId !== null`), including when a new policy is added to the role draft.

Before, when adding a policy to a role draft, the new policy was not considered as a draft since it didn't have any reference from an existing policy (`ezpolicy_original_id`). Result was that we ended with a RoleDraft object having mixed PolicyDraft and Policy objects.
Now `originalId` is filled with the newly created policy's ID.