### PR TITLE
Fix EZP-25093: REST API does not accept real boolean value as input

### DIFF
--- a/eZ/Publish/Core/REST/Common/Input/ParserTools.php
+++ b/eZ/Publish/Core/REST/Common/Input/ParserTools.php
@@ -79,22 +79,26 @@ class ParserTools
     }
 
     /**
-     * Parses a boolean from $stringValue.
+     * Parses a boolean from $value.
      *
-     * @param string $stringValue
+     * @param string|bool $value
      *
      * @return bool
+     * @throws \RuntimeException if the value can not be transformed to a boolean
      */
-    public function parseBooleanValue($stringValue)
+    public function parseBooleanValue($value)
     {
-        switch (strtolower($stringValue)) {
+        if (is_bool($value)) {
+            return $value;
+        }
+        switch (strtolower($value)) {
             case 'true':
                 return true;
             case 'false':
                 return false;
         }
 
-        throw new RuntimeException("Unknown boolean value '{$stringValue}'.");
+        throw new RuntimeException("Unknown boolean value '{$value}'.");
     }
 
     /**

--- a/eZ/Publish/Core/REST/Common/Tests/Input/ParserToolsTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Input/ParserToolsTest.php
@@ -100,6 +100,24 @@ class ParserToolsTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testNormalParseBooleanValue()
+    {
+        $tools = $this->getParserTools();
+
+        $this->assertTrue($tools->parseBooleanValue('true'));
+        $this->assertTrue($tools->parseBooleanValue(true));
+        $this->assertFalse($tools->parseBooleanValue('false'));
+        $this->assertFalse($tools->parseBooleanValue(false));
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testUnexpectedValueParseBooleanValue()
+    {
+        $this->getParserTools()->parseBooleanValue('whatever but not a boolean');
+    }
+
     protected function getParserTools()
     {
         return new ParserTools();


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25093

# Description

when using the REST API with a JSON input, you are forced to use boolean as string (ie `"false"` or `"true"`) which is a bit stupid given you can put real boolean values in JSON.
This patch improves the REST parser tools to be a bit smarter on that.

(This was discovered in https://github.com/ezsystems/PlatformUIBundle/pull/431 / https://github.com/ezsystems/ez-js-rest-client/pull/68 / [EZP-25091](https://jira.ez.no/browse/EZP-25091))

# Tests

manual tests for EZP-25091 (and added unit tests, just waiting for Travis to run them).