### PR TITLE
EZP-25100: Removed @required doc tags on value objects properties

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/ContentCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentCreateStruct.php
@@ -20,7 +20,7 @@ abstract class ContentCreateStruct extends ContentStruct
     /**
      * The content type for which the new content is created.
      *
-     * @required
+     * Required.
      *
      * @var \eZ\Publish\API\Repository\Values\ContentType\ContentType
      */
@@ -62,7 +62,7 @@ abstract class ContentCreateStruct extends ContentStruct
      * be used for as initial language for the first created version.
      * It is also used as default language for added fields.
      *
-     * @required
+     * Required.
      *
      * @var string
      */

--- a/eZ/Publish/API/Repository/Values/Content/LocationCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/LocationCreateStruct.php
@@ -64,7 +64,7 @@ class LocationCreateStruct extends ValueObject
     /**
      * The id of the parent location under which the new location should be created.
      *
-     * @required
+     * Required.
      *
      * @var mixed
      */

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentTypeCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentTypeCreateStruct.php
@@ -23,7 +23,7 @@ abstract class ContentTypeCreateStruct extends ValueObject
     /**
      * String unique identifier of a type.
      *
-     * @required
+     * Required.
      *
      * @var string
      */
@@ -32,7 +32,7 @@ abstract class ContentTypeCreateStruct extends ValueObject
     /**
      * Main language Code.
      *
-     * @required
+     * Required.
      *
      * @var string
      */
@@ -95,7 +95,7 @@ abstract class ContentTypeCreateStruct extends ValueObject
     /**
      * An array of names with languageCode keys.
      *
-     * @required - at least one name in the main language is required
+     * Required. - at least one name in the main language is required
      *
      * @var array an array of string
      */

--- a/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionCreateStruct.php
@@ -20,7 +20,7 @@ class FieldDefinitionCreateStruct extends ValueObject
     /**
      * String identifier of the field type.
      *
-     * @required
+     * Required.
      *
      * @var string
      */
@@ -31,7 +31,7 @@ class FieldDefinitionCreateStruct extends ValueObject
      *
      * Needs to be unique within the context of the Content Type this is added to.
      *
-     * @required
+     * Required.
      *
      * @var string
      */

--- a/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateCreateStruct.php
@@ -20,7 +20,7 @@ class ObjectStateCreateStruct extends ValueObject
     /**
      * Readable unique string identifier of a group.
      *
-     * @required
+     * Required.
      *
      * @var string
      */
@@ -36,7 +36,7 @@ class ObjectStateCreateStruct extends ValueObject
     /**
      * The default language code.
      *
-     * @required
+     * Required.
      *
      * @var string
      */
@@ -45,7 +45,7 @@ class ObjectStateCreateStruct extends ValueObject
     /**
      * An array of names with languageCode keys.
      *
-     * @required - at least one name in the main language is required
+     * Required. - at least one name in the main language is required
      *
      * @var string[]
      */

--- a/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateGroupCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateGroupCreateStruct.php
@@ -20,7 +20,7 @@ class ObjectStateGroupCreateStruct extends ValueObject
     /**
      * Readable unique string identifier of a group.
      *
-     * @required
+     * Required.
      *
      * @var string
      */
@@ -29,7 +29,7 @@ class ObjectStateGroupCreateStruct extends ValueObject
     /**
      * The default language code.
      *
-     * @required
+     * Required.
      *
      * @var string
      */
@@ -38,7 +38,7 @@ class ObjectStateGroupCreateStruct extends ValueObject
     /**
      * An array of names with languageCode keys.
      *
-     * @required - at least one name in the main language is required
+     * Required. - at least one name in the main language is required
      *
      * @var string[]
      */

--- a/eZ/Publish/API/Repository/Values/User/UserCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/UserCreateStruct.php
@@ -20,7 +20,7 @@ abstract class UserCreateStruct extends ContentCreateStruct
     /**
      * User login.
      *
-     * @required
+     * Required.
      *
      * @var string
      */
@@ -29,7 +29,7 @@ abstract class UserCreateStruct extends ContentCreateStruct
     /**
      * User E-Mail address.
      *
-     * @required
+     * Required.
      *
      * @var string
      */
@@ -38,7 +38,7 @@ abstract class UserCreateStruct extends ContentCreateStruct
     /**
      * The plain password.
      *
-     * @required
+     * Required.
      *
      * @var string
      */

--- a/eZ/Publish/Core/FieldType/Image/Value.php
+++ b/eZ/Publish/Core/FieldType/Image/Value.php
@@ -28,8 +28,9 @@ class Value extends BaseValue
     /**
      * Image id.
      *
+     * Required.
+     *
      * @var mixed
-     * @required
      */
     public $id;
 
@@ -43,16 +44,18 @@ class Value extends BaseValue
     /**
      * Display file name of the image.
      *
+     * Required.
+     *
      * @var string
-     * @required
      */
     public $fileName;
 
     /**
      * Size of the image file.
      *
+     * Required.
+     *
      * @var int
-     * @required
      */
     public $fileSize;
 


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-25100

These tags are actually useless and are not taken into account by PHPDoc.
Problem is they conflict with Symfony (well actually Doctrine) annotation reader, used by Validation component.

They lead to exceptions like:

```
[Semantical Error] The annotation "@required" in property 
eZ\Publish\API\Repository\Values\Content\ContentCreateStruct::$contentType was never imported. 
Did you maybe forget to add a "use" statement for this annotation
```