### PR TITLE
Mark test property as protected to allow legacy bridge tests to run

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Controller/Tests/Controller/Content/PreviewControllerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Tests/Controller/Content/PreviewControllerTest.php
@@ -48,7 +48,7 @@ class PreviewControllerTest extends PHPUnit_Framework_TestCase
     /** @var PreviewLocationProvider|\PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\Core\MVC\Symfony\View\CustomLocationControllerChecker */
     protected $locationProvider;
 
-    private $controllerChecker;
+    protected $controllerChecker;
 
     protected function setUp()
     {


### PR DESCRIPTION
Quick fix to allow legacy bridge tests that error out to run.

They depend on this test class but can't access the property.

See: https://github.com/ezsystems/LegacyBridge/pull/43