### PR TITLE
Fix EZP-24901: error in REST location id parsing

### DIFF
--- a/eZ/Publish/Core/REST/Server/Input/Parser/ContentUpdate.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ContentUpdate.php
@@ -60,8 +60,8 @@ class ContentUpdate extends BaseParser
 
         if (array_key_exists('MainLocation', $data)) {
             try {
-                $parsedData['mainLocationId'] = $this->requestParser->parseHref($data['MainLocation']['_href'], 'locationPath');
-                $parsedData['mainLocationId'] = '/' . $parsedData['mainLocationId'];
+                $mainLocationIdParts = explode('/', $this->requestParser->parseHref($data['MainLocation']['_href'], 'locationPath'));
+                $parsedData['mainLocationId'] = array_pop($mainLocationIdParts);
             } catch (Exceptions\InvalidArgumentException $e) {
                 throw new Exceptions\Parser('Invalid format for <MainLocation> reference in <ContentUpdate>.');
             }

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ContentUpdateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ContentUpdateTest.php
@@ -152,7 +152,7 @@ class ContentUpdateTest extends BaseTest
             array(
                 'mainLanguageCode' => 'eng-GB',
                 'sectionId' => 23,
-                'mainLocationId' => '/1/2/55',
+                'mainLocationId' => 55,
                 'ownerId' => 42,
                 'alwaysAvailable' => false,
                 'remoteId' => '7e7afb135e50490a281dafc0aafb6dac',


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-24901

The location id path string wasn't converted to a numerical id. Leftover from the initial implementation. The test has been updated, but I haven't tested it in real life.