### PR TITLE
Refactored ContentType view matching

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
@@ -144,6 +144,12 @@ class ViewController extends Controller
      */
     public function viewLocation($locationId, $viewType, $layout = false, array $params = array())
     {
+        trigger_error(
+            "ViewController:viewLocation() is deprecated since kernel 6.0.0, and will be removed in the future.\n" .
+            "Use ViewController:viewAction() instead.",
+            E_USER_DEPRECATED
+        );
+
         $this->performAccessChecks();
         $response = $this->buildResponse();
 
@@ -198,6 +204,12 @@ class ViewController extends Controller
      */
     public function embedLocation($locationId, $viewType, $layout = false, array $params = array())
     {
+        trigger_error(
+            "ViewController:embedLocation() is deprecated since kernel 6.0.0, and will be removed in the future.\n" .
+            "Use ViewController:viewAction() instead.",
+            E_USER_DEPRECATED
+        );
+
         $this->performAccessChecks();
         $response = $this->buildResponse();
 
@@ -274,6 +286,12 @@ class ViewController extends Controller
      */
     public function viewContent($contentId, $viewType, $layout = false, array $params = array())
     {
+        trigger_error(
+            "ViewController:viewContent() is deprecated since kernel 6.0.0, and will be removed in the future.\n" .
+            "Use ViewController:viewAction() instead.",
+            E_USER_DEPRECATED
+        );
+
         if ($viewType === 'embed') {
             return $this->embedContent($contentId, $viewType, $layout, $params);
         }
@@ -323,6 +341,12 @@ class ViewController extends Controller
      */
     public function embedContent($contentId, $viewType, $layout = false, array $params = array())
     {
+        trigger_error(
+            "ViewController:embedContent() is deprecated since kernel 6.0.0, and will be removed in the future.\n" .
+            "Use ViewController:viewAction() instead.",
+            E_USER_DEPRECATED
+        );
+
         $this->performAccessChecks();
         $response = $this->buildResponse();
 

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Identifier/ContentType.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Identifier/ContentType.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Identifier;
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\MultipleValued;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\MVC\Symfony\View\ContentTypeView;
 use eZ\Publish\Core\MVC\Symfony\View\ContentValueView;
 use eZ\Publish\Core\MVC\Symfony\View\View;
 
@@ -52,14 +53,18 @@ class ContentType extends MultipleValued
 
     public function match(View $view)
     {
-        if (!$view instanceof ContentValueView) {
+        if ($view instanceof ContentTypeView) {
+            $contentTypeIdentifier = $this->repository
+                ->getContentTypeService()
+                ->loadContentType($view->getContentTypeId())->identifier;
+        } else if ($view instanceof ContentValueView) {
+            $contentTypeIdentifier = $this->repository
+                ->getContentTypeService()
+                ->loadContentType($view->getContent()->contentInfo->contentTypeId)->identifier;
+        } else {
             return false;
         }
 
-        $contentType = $this->repository
-            ->getContentTypeService()
-            ->loadContentType($view->getContent()->contentInfo->contentTypeId);
-
-        return isset($this->values[$contentType->identifier]);
+        return isset($this->values[$contentTypeIdentifier]);
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/View/ContentTypeView.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ContentTypeView.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\View;
+
+/**
+ * A View of a ContentType
+ * @package eZ\Publish\Core\MVC\Symfony\View
+ */
+interface ContentTypeView
+{
+    /**
+     * Returns the contained ContentType id.
+     *
+     * @return mixed
+     */
+    public function getContentTypeId();
+}

--- a/eZ/Publish/Core/MVC/Symfony/View/ContentValueView.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ContentValueView.php
@@ -7,7 +7,7 @@ namespace eZ\Publish\Core\MVC\Symfony\View;
 /**
  * A view that contains a Content.
  */
-interface ContentValueView
+interface ContentValueView extends ContentTypeView
 {
     /**
      * Returns the Content.

--- a/eZ/Publish/Core/MVC/Symfony/View/ContentView.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ContentView.php
@@ -108,4 +108,13 @@ class ContentView extends BaseView implements View, ContentValueView, LocationVa
     {
         return $this->isEmbed;
     }
+
+    /**
+     * Returns the contained ContentType id.
+     * @return mixed
+     */
+    public function getContentTypeId()
+    {
+        return $this->content->contentInfo->contentTypeId;
+    }
 }


### PR DESCRIPTION
> Required by https://github.com/ezsystems/repository-forms/pull/62

A `ContentTypeView` interface is added. The ContentType identifier matcher uses it to read the content type id from a view.

The `ContentEditView` in the related PR uses it to implement content type based view override.
