### PR TITLE
[experiment] content render helper

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -22,6 +22,7 @@ parameters:
     ezpublish.templating.extension.routing.class: eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\RoutingExtension
     ezpublish.templating.field_block_renderer.twig.class: eZ\Publish\Core\MVC\Symfony\Templating\Twig\FieldBlockRenderer
     ezpublish.twig.extension.field_rendering.class: eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\FieldRenderingExtension
+    ezpublish.twig.extension.content_rendering.class: eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\ContentRenderingExtension
     ezpublish.twig.extension.image.class: eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\ImageExtension
     ezpublish.twig.extension.rich_text.class: eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\RichTextExtension
 
@@ -185,6 +186,15 @@ services:
             - @ezpublish.api.service.content_type
             - @ezpublish.fieldType.parameterProviderRegistry
             - @ezpublish.translation_helper
+        tags:
+            - { name: twig.extension }
+
+    ezpublish.twig.extension.content_rendering:
+        class: %ezpublish.twig.extension.content_rendering.class%
+        arguments:
+            - @ezpublish.view_controller_listener
+            - @kernel
+            - @controller_resolver
         tags:
             - { name: twig.extension }
 

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentRenderingExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentRenderingExtension.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension;
+
+use eZ\Bundle\EzPublishCoreBundle\EventListener\ViewControllerListener;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\MVC\Symfony\View\Renderer;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Kernel;
+use Twig_Environment;
+use Twig_Extension;
+use Twig_SimpleFunction;
+
+/**
+ * Twig extension for content fields/fieldDefinitions rendering (view and edit).
+ */
+class ContentRenderingExtension extends Twig_Extension
+{
+    /** @var \eZ\Bundle\EzPublishCoreBundle\EventListener\ViewControllerListener */
+    private $controllerListener;
+
+    /** @var \Symfony\Component\HttpKernel\Kernel */
+    private $kernel;
+
+    /** @var \Symfony\Component\HttpKernel\Controller\ControllerResolverInterface */
+    private $controllerResolver;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\View\Renderer */
+    private $viewRenderer;
+
+    /** @var \Twig_Environment */
+    private $twig;
+
+    /**
+     * ContentRenderingExtension constructor.
+     *
+     * @param \eZ\Bundle\EzPublishCoreBundle\EventListener\ViewControllerListener $controllerListener
+     * @param \Symfony\Component\HttpKernel\Kernel $kernel
+     * @param \Symfony\Component\HttpKernel\Controller\ControllerResolverInterface $controllerResolver
+     */
+    public function __construct(
+        ViewControllerListener $controllerListener,
+        Kernel $kernel,
+        ControllerResolverInterface $controllerResolver
+    ) {
+        $this->controllerListener = $controllerListener;
+        $this->kernel = $kernel;
+        $this->controllerResolver = $controllerResolver;
+    }
+
+    public function getName()
+    {
+        return 'ezpublish.content_rendering';
+    }
+
+    public function initRuntime(Twig_Environment $environment)
+    {
+        $this->twig = $environment;
+    }
+
+    public function getFunctions()
+    {
+        return [
+            new Twig_SimpleFunction(
+                'ez_render_content',
+                [$this, 'renderContent'],
+                ['is_safe' => ['html']]
+            ),
+        ];
+    }
+
+    /**
+     * Renders the HTML for a given content.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     * @param array $params An array of parameters to pass to the field view
+     *
+     * @return string The HTML markup
+     *
+     * @throws InvalidArgumentException
+     */
+    public function renderContent(Content $content, array $params = [])
+    {
+        $request = new Request();
+        $request->attributes->add([
+            '_controller' => 'ez_content:viewAction',
+            'contentId' => $content->id,
+            'content' => $content,
+            'viewType' => 'embed'
+        ]);
+
+        $controller = $this->controllerResolver->getController($request);
+
+        if (isset($params['inline']) && $params['inline'] === true) {
+            $this->controllerListener->getController(
+                $event = new FilterControllerEvent(
+                    $this->kernel,
+                    $controller,
+                    $request,
+                    HttpKernelInterface::SUB_REQUEST
+                )
+            );
+
+
+            $arguments = $this->controllerResolver->getArguments($request, $event->getController());
+            $response = call_user_func_array($event->getController(), $arguments);
+            if ($response instanceof View) {
+                return $this->twig->render($response->getTemplateIdentifier(), $response->getParameters());
+            } elseif ($response instanceof Response) {
+                return $response->getContent();
+            }
+        } else {
+            $response = $this->kernel->handle($request);
+
+            return $response->getContent();
+        }
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentRenderingExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentRenderingExtension.php
@@ -13,12 +13,9 @@ namespace eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension;
 use eZ\Bundle\EzPublishCoreBundle\EventListener\ViewControllerListener;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
-use eZ\Publish\Core\MVC\Symfony\View\Renderer;
 use eZ\Publish\Core\MVC\Symfony\View\View;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -102,7 +99,7 @@ class ContentRenderingExtension extends Twig_Extension
             '_controller' => 'ez_content:viewAction',
             'contentId' => $content->id,
             'content' => $content,
-            'viewType' => 'embed'
+            'viewType' => 'embed',
         ]);
 
         $controller = $this->controllerResolver->getController($request);
@@ -116,7 +113,6 @@ class ContentRenderingExtension extends Twig_Extension
                     HttpKernelInterface::SUB_REQUEST
                 )
             );
-
 
             $arguments = $this->controllerResolver->getArguments($request, $event->getController());
             $response = call_user_func_array($event->getController(), $arguments);


### PR DESCRIPTION
This PR implements a `ez_render_content` twig helper that wraps the rendering of a content:

```
{{ render( controller( ez_content:viewAction ) ) }}
```

By default, it does a sub-request, like the call it replaces. But with the `inline` parameter set to true, rendering is done without a sub-request, by re-using the pieces of the View API. This is similar to what has been made by Kaliop with their [object wrapper](https://github.com/kaliop/ezobjectwrapper) (to some extent) or by [CJW network](https://github.com/cjw-network/CjwPublishToolsBundle#cjw_render_location---a-fast-render-controller-ez_contentviewlocation-replacement).

Example:

```
{{ ez_render_content( embed_content, {'inline': true} ) }}
```

In both inline and not inline, rendering uses the override configuration for `content_view`. Custom templates as well as custom controllers are used to render the content. 
## Performances

> Overall, inline rendering takes about 30% of the time it takes for a full rendering.

In my case, inline rendering took approximately 100ms, while full rendering took between 300 and 500ms. For 10 renderings of the same content, inline takes 830ms, while full takes 2610ms.
## Integration

This uses the recent changes to the View API. Inline rendering uses the `ViewControllerListener` to get the View built, and renders the View object using twig.

It bypasses all of the other listeners, as well as the kernel.
## TODO
- [ ] Confirm the approach
- [ ] Pass other parameters to the sub-request
- [ ] Refactor into, possibly, `ViewRenderer` objects (we might have a naming conflict there)
