### PR TITLE
Fix EZP-25171: UTF8 Encoded ViewParameters are not matched

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/SiteAccessListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/SiteAccessListener.php
@@ -80,7 +80,7 @@ class SiteAccessListener extends ContainerAware implements EventSubscriberInterf
         }
 
         // Analyse the pathinfo if needed since it might contain the siteaccess (i.e. like in URI mode)
-        $pathinfo = $request->getPathInfo();
+        $pathinfo = rawurldecode($request->getPathInfo());
         if ($siteAccess->matcher instanceof URILexer) {
             $semanticPathinfo = $siteAccess->matcher->analyseURI($pathinfo);
         } else {

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SiteAccessListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SiteAccessListenerTest.php
@@ -80,6 +80,7 @@ class SiteAccessListenerTest extends PHPUnit_Framework_TestCase
             array('/foo/bar/(some)/thing/orphan/(other)', '/foo/bar', '/(some)/thing/orphan/(other)', array('some' => 'thing/orphan', 'other' => '')),
             array('/my_siteaccess/foo/bar/(some)/thing', '/foo/bar', '/(some)/thing', array('some' => 'thing')),
             array('/foo/bar/(some)/thing/(toto_titi)/tata_tutu', '/foo/bar', '/(some)/thing/(toto_titi)/tata_tutu', array('some' => 'thing', 'toto_titi' => 'tata_tutu')),
+            array('/foo/%E8%B5%A4/%28some%29/thing', '/foo/赤', '/(some)/thing', array('some' => 'thing')),
         );
     }
 
@@ -92,6 +93,7 @@ class SiteAccessListenerTest extends PHPUnit_Framework_TestCase
         $expectedVPString,
         array $expectedVPArray
     ) {
+        $uri = rawurldecode($uri);
         $semanticPathinfoPos = strpos($uri, $expectedSemanticPathinfo);
         if ($semanticPathinfoPos !== 0) {
             $semanticPathinfo = substr($uri, $semanticPathinfoPos);

--- a/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
@@ -123,7 +123,7 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
     public function matchRequest(Request $request)
     {
         try {
-            $requestedPath = rawurldecode($request->attributes->get('semanticPathinfo', $request->getPathInfo()));
+            $requestedPath = $request->attributes->get('semanticPathinfo', $request->getPathInfo());
             $urlAlias = $this->getUrlAlias($requestedPath);
             if ($this->rootLocationId === null) {
                 $pathPrefix = '/';


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25171

When I copy a URL with ViewParameters in Firefox. The Url will be UTF8 encoded. So the brackets are %28 and %29
E.g.: http://www.example.tld/site/(param)/value -> http://www.example.tld/site/%28param%29/value

The new stack can now not match the route and give it to the legacy. There it can be matched.

When I look in the code I see, that the rawurldecode function has been used only for the semanticPathinfo:
https://github.com/ezsystems/ezpublish-kernel/blob/2267c6e903c38b027b3b97e2901ccf0923bcbbad/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php#L126

In legacy it works because of:
https://github.com/ezsystems/ezpublish-legacy/blob/e6c912113a8cee636070d2ac1fcbd308f713b97e/lib/ezutils/classes/ezuri.php#L224