### PR TITLE
EZP-25151: total count in REST search results

### DIFF
--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestExecutedView.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestExecutedView.php
@@ -95,6 +95,20 @@ class RestExecutedView extends ValueObjectVisitor
         );
         $generator->endAttribute('href');
 
+        // BEGIN Result metadata
+        $generator->startValueElement('count', $data->searchResults->totalCount);
+        $generator->endValueElement('count');
+
+        $generator->startValueElement('time', $data->searchResults->time);
+        $generator->endValueElement('time');
+
+        $generator->startValueElement('timedOut', $generator->serializeBool($data->searchResults->timedOut));
+        $generator->endValueElement('timedOut');
+
+        $generator->startValueElement('maxScore', $data->searchResults->maxScore);
+        $generator->endValueElement('maxScore');
+        // END Result metadata
+
         // BEGIN searchHits
         $generator->startHashElement('searchHits');
         $generator->startList('searchHit');


### PR DESCRIPTION
> Implements https://jira.ez.no/browse/EZP-25151

Adds `count`, with the total results count, to the Result node.
Also adds `time`, `timedOut` and `maxScore`, as per [specs](https://github.com/ezsystems/ezpublish-kernel/blob/master/doc/specifications/rest/REST-API-V2.rst#L7464-L7467).