### PR TITLE
Upgrade http-cache-bundle to ~1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "doctrine/doctrine-bundle": "~1.3",
         "liip/imagine-bundle": "~1.0",
         "oneup/flysystem-bundle": "~0.4",
-        "friendsofsymfony/http-cache-bundle": "~1.2",
+        "friendsofsymfony/http-cache-bundle": "~1.3",
         "sensio/framework-extra-bundle": "~3.0"
     },
     "require-dev": {


### PR DESCRIPTION
I get hit with this: https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/issues/238

@dbu closed this on Sep 30