### PR TITLE
[WIP][Integration] EZP-24744: Add test for user load case sensitivity

### DIFF
--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -2238,7 +2238,7 @@ DROP TABLE IF EXISTS `ezuser`;
 CREATE TABLE `ezuser` (
   `contentobject_id` int(11) NOT NULL DEFAULT '0',
   `email` varchar(150) NOT NULL DEFAULT '',
-  `login` varchar(150) NOT NULL DEFAULT '',
+  `login` varchar(150) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
   `password_hash` varchar(50) DEFAULT NULL,
   `password_hash_type` int(11) NOT NULL DEFAULT '1',
   PRIMARY KEY (`contentobject_id`),

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -1245,6 +1245,28 @@ class UserServiceTest extends BaseTest
     }
 
     /**
+     * Test for the loadUserByLogin() method.
+     *
+     * @see \eZ\Publish\API\Repository\UserService::loadUserByLogin()
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @depends eZ\Publish\API\Repository\Tests\UserServiceTest::testLoadUserByLogin
+     */
+    public function testLoadUserByLoginThrowsNotFoundExceptionForLoginWithWrongCase()
+    {
+        $repository = $this->getRepository();
+
+        $userService = $repository->getUserService();
+
+        /* BEGIN: Use Case */
+        $this->createUserVersion1();
+
+        // This call will fail with a "NotFoundException", because the given
+        // login does not exist.
+        $userService->loadUserByLogin('USER');
+        /* END: Use Case */
+    }
+
+    /**
      * Test for the loadUsersByEmail() method.
      *
      * @see \eZ\Publish\API\Repository\UserService::loadUsersByEmail()

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
@@ -477,15 +477,16 @@ CREATE TABLE ezurlwildcard (
   PRIMARY KEY (id)
 ) ENGINE=InnoDB;
 
-DROP TABLE IF EXISTS ezuser;
-CREATE TABLE ezuser (
-  contentobject_id int(11) NOT NULL DEFAULT 0,
-  email varchar(150) NOT NULL DEFAULT '',
-  login varchar(150) NOT NULL DEFAULT '',
-  password_hash varchar(50) DEFAULT NULL,
-  password_hash_type int(11) NOT NULL DEFAULT 1,
-  PRIMARY KEY (contentobject_id)
-) ENGINE=InnoDB;
+DROP TABLE IF EXISTS `ezuser`;
+CREATE TABLE `ezuser` (
+  `contentobject_id` int(11) NOT NULL DEFAULT '0',
+  `email` varchar(150) NOT NULL DEFAULT '',
+  `login` varchar(150) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL DEFAULT '',
+  `password_hash` varchar(50) DEFAULT NULL,
+  `password_hash_type` int(11) NOT NULL DEFAULT '1',
+  PRIMARY KEY (`contentobject_id`),
+  KEY `ezuser_login` (`login`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 DROP TABLE IF EXISTS ezuser_role;
 CREATE TABLE ezuser_role (


### PR DESCRIPTION
To test loadUser in regards to case sensitivity as that is an issue in #1388.

This PR sets collation to `utf8_bin`, this makes Mysql behave closer to other databases *(being case sensitive on where clauses)*, and while it is documented to have a impact on order by, all tests seems to be fine with this.

Discussion ping @joaoinacio @yannickroger @pedroresende @bdunogier  *Note: I'm somewhat sure this is not the way to go as this treats all strings as binary, meaning Order by probably won't take any language rules into account like utf8_unicode_ci does*