### PR TITLE
EZP-24467: Location visibility on move when new parent is hidden/invisible

### DIFF
--- a/data/update/mysql/unstable/dbupdate-6.0.0rc1-to-6.0.1rc1.sql
+++ b/data/update/mysql/unstable/dbupdate-6.0.0rc1-to-6.0.1rc1.sql
@@ -1,0 +1,20 @@
+--
+-- If you have used Platform API (PHP/REST) in 5.x/6.0.0 or UI in 6.0.0 for moving trees around
+-- then the following will solve issues caused by visibility not taken into account (see EZP-24467)
+--
+
+UPDATE ezcontentobject_tree
+SET is_invisible=1
+WHERE path_string LIKE concat(
+    (SELECT path_string FROM ezcontentobject_tree WHERE is_hidden=1),
+    '%'
+);
+
+-- You may also execute the following SQL if you have locations marked as invisible when they should not be
+
+UPDATE ezcontentobject_tree
+SET is_invisible=0
+WHERE path_string NOT LIKE concat(
+    (SELECT path_string FROM ezcontentobject_tree WHERE is_hidden=1),
+    '%'
+);

--- a/data/update/postgres/unstable/dbupdate-6.0.0rc1-to-6.0.1rc1.sql
+++ b/data/update/postgres/unstable/dbupdate-6.0.0rc1-to-6.0.1rc1.sql
@@ -1,0 +1,20 @@
+--
+-- If you have used Platform API (PHP/REST) in 5.x/6.0.0 or UI in 6.0.0 for moving trees around
+-- then the following will solve issues caused by visibility not taken into account (see EZP-24467)
+--
+
+UPDATE ezcontentobject_tree
+SET is_invisible=1
+WHERE path_string LIKE concat(
+    (SELECT path_string FROM ezcontentobject_tree WHERE is_hidden=1),
+    '%'
+);
+
+-- You may also execute the following SQL if you have locations marked as invisible when they should not be
+
+UPDATE ezcontentobject_tree
+SET is_invisible=0
+WHERE path_string NOT LIKE concat(
+    (SELECT path_string FROM ezcontentobject_tree WHERE is_hidden=1),
+    '%'
+);

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -1658,6 +1658,61 @@ class LocationServiceTest extends BaseTest
 
         $this->assertPropertiesCorrect(
             array(
+                'hidden' => false,
+                'invisible' => false,
+                'depth' => $newParentLocation->depth + 1,
+                'parentLocationId' => $newParentLocation->id,
+                'pathString' => "{$newParentLocation->pathString}" . $this->parseId('location', $movedLocation->id) . '/',
+            ),
+            $movedLocation
+        );
+    }
+
+    /**
+     * Test for the moveSubtree() method.
+     *
+     * @see \eZ\Publish\API\Repository\LocationService::moveSubtree()
+     * @depends eZ\Publish\API\Repository\Tests\LocationServiceTest::testMoveSubtree
+     */
+    public function testMoveSubtreeHidden()
+    {
+        $repository = $this->getRepository();
+
+        $mediaLocationId = $this->generateId('location', 43);
+        $demoDesignLocationId = $this->generateId('location', 56);
+        /* BEGIN: Use Case */
+        // $mediaLocationId is the ID of the "Media" page location in
+        // an eZ Publish demo installation
+
+        // $demoDesignLocationId is the ID of the "Demo Design" page location in an eZ
+        // Publish demo installation
+
+        // Load the location service
+        $locationService = $repository->getLocationService();
+
+        // Load location to move
+        $locationToMove = $locationService->loadLocation($mediaLocationId);
+
+        // Load new parent location
+        $newParentLocation = $locationService->loadLocation($demoDesignLocationId);
+
+        // Hide the target location before we move
+        $newParentLocation = $locationService->hideLocation($newParentLocation);
+
+        // Move location from "Home" to "Demo Design"
+        $locationService->moveSubtree(
+            $locationToMove,
+            $newParentLocation
+        );
+
+        // Load moved location
+        $movedLocation = $locationService->loadLocation($mediaLocationId);
+        /* END: Use Case */
+
+        $this->assertPropertiesCorrect(
+            array(
+                'hidden' => false,
+                'invisible' => true,
                 'depth' => $newParentLocation->depth + 1,
                 'parentLocationId' => $newParentLocation->id,
                 'pathString' => "{$newParentLocation->pathString}" . $this->parseId('location', $movedLocation->id) . '/',
@@ -1683,6 +1738,71 @@ class LocationServiceTest extends BaseTest
         // Load Subtree properties before move
         $expected = $this->loadSubtreeProperties($locationToMove);
         foreach ($expected as $id => $properties) {
+            $expected[$id]['depth'] = $properties['depth'] + 2;
+            $expected[$id]['pathString'] = str_replace(
+                $locationToMove->pathString,
+                "{$newParentLocation->pathString}" . $this->parseId('location', $locationToMove->id) . '/',
+                $properties['pathString']
+            );
+        }
+
+        $mediaLocationId = $this->generateId('location', 43);
+        $demoDesignLocationId = $this->generateId('location', 56);
+        /* BEGIN: Use Case */
+        // $mediaLocationId is the ID of the "Media" page location in
+        // an eZ Publish demo installation
+
+        // $demoDesignLocationId is the ID of the "Demo Design" page location in an eZ
+        // Publish demo installation
+
+        // Load the location service
+        $locationService = $repository->getLocationService();
+
+        // Load location to move
+        $locationToMove = $locationService->loadLocation($mediaLocationId);
+
+        // Load new parent location
+        $newParentLocation = $locationService->loadLocation($demoDesignLocationId);
+
+        // Move location from "Home" to "Demo Design"
+        $locationService->moveSubtree(
+            $locationToMove,
+            $newParentLocation
+        );
+
+        // Load moved location
+        $movedLocation = $locationService->loadLocation($mediaLocationId);
+        /* END: Use Case */
+
+        $this->refreshSearch($repository);
+
+        // Load Subtree properties after move
+        $actual = $this->loadSubtreeProperties($movedLocation);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Test for the moveSubtree() method.
+     *
+     * @see \eZ\Publish\API\Repository\LocationService::moveSubtree()
+     * @depends eZ\Publish\API\Repository\Tests\LocationServiceTest::testMoveSubtreeUpdatesSubtreeProperties
+     */
+    public function testMoveSubtreeUpdatesSubtreePropertiesHidden()
+    {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        $locationToMove = $locationService->loadLocation($this->generateId('location', 43));
+        $newParentLocation = $locationService->loadLocation($this->generateId('location', 56));
+
+        // Hide the target location before we move
+        $newParentLocation = $locationService->hideLocation($newParentLocation);
+
+        // Load Subtree properties before move
+        $expected = $this->loadSubtreeProperties($locationToMove);
+        foreach ($expected as $id => $properties) {
+            $expected[$id]['invisible'] = true;
             $expected[$id]['depth'] = $properties['depth'] + 2;
             $expected[$id]['pathString'] = str_replace(
                 $locationToMove->pathString,

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
@@ -155,10 +155,14 @@ class DoctrineDatabaseTest extends TestCase
             array(
                 'path_string' => '/1/2/69/',
                 'path_identification_string' => 'products',
+                'is_hidden' => 0,
+                'is_invisible' => 0,
             ),
             array(
                 'path_string' => '/1/2/77/',
                 'path_identification_string' => 'solutions',
+                'is_hidden' => 0,
+                'is_invisible' => 0,
             )
         );
 
@@ -166,16 +170,135 @@ class DoctrineDatabaseTest extends TestCase
         $query = $this->handler->createSelectQuery();
         $this->assertQueryResult(
             array(
-                array(65, '/1/2/', '', 1, 1),
-                array(67, '/1/2/77/69/', 'solutions/products', 77, 3),
-                array(69, '/1/2/77/69/70/71/', 'solutions/products/software/os_type_i', 70, 5),
-                array(73, '/1/2/77/69/72/75/', 'solutions/products/boxes/cd_dvd_box_iii', 72, 5),
-                array(75, '/1/2/77/', 'solutions', 2, 2),
+                array(65, '/1/2/', '', 1, 1, 0, 0),
+                array(67, '/1/2/77/69/', 'solutions/products', 77, 3, 0, 0),
+                array(69, '/1/2/77/69/70/71/', 'solutions/products/software/os_type_i', 70, 5, 0, 0),
+                array(73, '/1/2/77/69/72/75/', 'solutions/products/boxes/cd_dvd_box_iii', 72, 5, 0, 0),
+                array(75, '/1/2/77/', 'solutions', 2, 2, 0, 0),
             ),
             $query
-                ->select('contentobject_id', 'path_string', 'path_identification_string', 'parent_node_id', 'depth')
+                ->select('contentobject_id', 'path_string', 'path_identification_string', 'parent_node_id', 'depth', 'is_hidden', 'is_invisible')
                 ->from('ezcontentobject_tree')
                 ->where($query->expr->in('node_id', array(69, 71, 75, 77, 2)))
+                ->orderBy('contentobject_id')
+        );
+    }
+
+    public function testMoveHiddenDestinationUpdate()
+    {
+        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/full_example_tree.php');
+        $handler = $this->getLocationGateway();
+        $handler->hideSubtree('/1/2/77/');
+        $handler->moveSubtreeNodes(
+            array(
+                'path_string' => '/1/2/69/',
+                'path_identification_string' => 'products',
+                'is_hidden' => 0,
+                'is_invisible' => 0,
+            ),
+            array(
+                'path_string' => '/1/2/77/',
+                'path_identification_string' => 'solutions',
+                'is_hidden' => 1,
+                'is_invisible' => 1,
+
+            )
+        );
+
+        /** @var $query \eZ\Publish\Core\Persistence\Database\SelectQuery */
+        $query = $this->handler->createSelectQuery();
+        $this->assertQueryResult(
+            array(
+                array(65, '/1/2/', '', 1, 1, 0, 0),
+                array(67, '/1/2/77/69/', 'solutions/products', 77, 3, 0, 1),
+                array(69, '/1/2/77/69/70/71/', 'solutions/products/software/os_type_i', 70, 5, 0, 1),
+                array(73, '/1/2/77/69/72/75/', 'solutions/products/boxes/cd_dvd_box_iii', 72, 5, 0, 1),
+                array(75, '/1/2/77/', 'solutions', 2, 2, 1, 1),
+            ),
+            $query
+                ->select('contentobject_id', 'path_string', 'path_identification_string', 'parent_node_id', 'depth', 'is_hidden', 'is_invisible')
+                ->from('ezcontentobject_tree')
+                ->where($query->expr->in('node_id', array(69, 71, 75, 77, 2)))
+                ->orderBy('contentobject_id')
+        );
+    }
+
+    public function testMoveHiddenSourceUpdate()
+    {
+        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/full_example_tree.php');
+        $handler = $this->getLocationGateway();
+        $handler->hideSubtree('/1/2/69/');
+        $handler->moveSubtreeNodes(
+            array(
+                'path_string' => '/1/2/69/',
+                'path_identification_string' => 'products',
+                'is_hidden' => 1,
+                'is_invisible' => 1,
+            ),
+            array(
+                'path_string' => '/1/2/77/',
+                'path_identification_string' => 'solutions',
+                'is_hidden' => 0,
+                'is_invisible' => 0,
+
+            )
+        );
+
+        /** @var $query \eZ\Publish\Core\Persistence\Database\SelectQuery */
+        $query = $this->handler->createSelectQuery();
+        $this->assertQueryResult(
+            array(
+                array(65, '/1/2/', '', 1, 1, 0, 0),
+                array(67, '/1/2/77/69/', 'solutions/products', 77, 3, 1, 1),
+                array(69, '/1/2/77/69/70/71/', 'solutions/products/software/os_type_i', 70, 5, 0, 1),
+                array(73, '/1/2/77/69/72/75/', 'solutions/products/boxes/cd_dvd_box_iii', 72, 5, 0, 1),
+                array(75, '/1/2/77/', 'solutions', 2, 2, 0, 0),
+            ),
+            $query
+                ->select('contentobject_id', 'path_string', 'path_identification_string', 'parent_node_id', 'depth', 'is_hidden', 'is_invisible')
+                ->from('ezcontentobject_tree')
+                ->where($query->expr->in('node_id', array(69, 71, 75, 77, 2)))
+                ->orderBy('contentobject_id')
+        );
+    }
+
+    public function testMoveHiddenSourceChildUpdate()
+    {
+        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/full_example_tree.php');
+        $handler = $this->getLocationGateway();
+        $handler->hideSubtree('/1/2/69/70/');
+
+        $handler->moveSubtreeNodes(
+            array(
+                'path_string' => '/1/2/69/',
+                'path_identification_string' => 'products',
+                'is_hidden' => 0,
+                'is_invisible' => 0,
+            ),
+            array(
+                'path_string' => '/1/2/77/',
+                'path_identification_string' => 'solutions',
+                'is_hidden' => 0,
+                'is_invisible' => 0,
+
+            )
+        );
+
+        /** @var $query \eZ\Publish\Core\Persistence\Database\SelectQuery */
+        $query = $this->handler->createSelectQuery();
+        $this->assertQueryResult(
+            array(
+                array(65, '/1/2/', '', 1, 1, 0, 0),
+                array(67, '/1/2/77/69/', 'solutions/products', 77, 3, 0, 0),
+                array(68, '/1/2/77/69/70/', 'solutions/products/software', 69, 4, 1, 1),
+                array(69, '/1/2/77/69/70/71/', 'solutions/products/software/os_type_i', 70, 5, 0, 1),
+                array(73, '/1/2/77/69/72/75/', 'solutions/products/boxes/cd_dvd_box_iii', 72, 5, 0, 0),
+                array(75, '/1/2/77/', 'solutions', 2, 2, 0, 0),
+            ),
+            $query
+                ->select('contentobject_id', 'path_string', 'path_identification_string', 'parent_node_id', 'depth', 'is_hidden', 'is_invisible')
+                ->from('ezcontentobject_tree')
+                ->where($query->expr->in('node_id', array(69, 70, 71, 75, 77, 2)))
                 ->orderBy('contentobject_id')
         );
     }


### PR DESCRIPTION
Legacy SE did not handle hidden state at all, adding that.

- [x] update sql to fix existing installs
- [x] change to take existing hidden nodes in the moved tree into account