### PR TITLE
EZP-24732: run normalization even if no XML declaration

### DIFF
--- a/eZ/Publish/Core/FieldType/RichText/Normalizer/DocumentTypeDefinition.php
+++ b/eZ/Publish/Core/FieldType/RichText/Normalizer/DocumentTypeDefinition.php
@@ -98,7 +98,7 @@ class DocumentTypeDefinition extends Normalizer
     {
         if ($this->expression === null) {
             $this->expression =
-                '/(<\?xml.*\?>)([ \t\n\r]*)(<' .
+                '/(<\?xml.*\?>)?([ \t\n\r]*)(<' .
                 preg_quote($this->documentElement, '/') .
                 '.*xmlns="' .
                 preg_quote($this->namespace, '/') .

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Normalizer/DocumentTypeDefinitionTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Normalizer/DocumentTypeDefinitionTest.php
@@ -101,6 +101,29 @@ xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
      * @param string $documentElement
      * @param string $namespace
      * @param string $dtdPath
+     * @param string $input Ignored
+     */
+    public function testAcceptNoXmlDeclaration($documentElement, $namespace, $dtdPath, $input)
+    {
+        $normalizer = $this->getNormalizer($documentElement, $namespace, $dtdPath);
+
+        $this->assertTrue($normalizer->accept(<<<XML
+<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
+  <p>You will need chili pepper, black pepper, bat wings (dried and grounded) and tomato juice.</p>
+  <p>Then you combine the ingredients and shake.</p>
+  <p>Serve chilled.</p>
+  <p>The price is 165¥.</p>
+</section>
+XML
+));
+    }
+
+    /**
+     * @dataProvider providerForTestNormalize
+     *
+     * @param string $documentElement
+     * @param string $namespace
+     * @param string $dtdPath
      * @param string $input
      * @param string $expectedOutput
      * @param string $expectedSaved
@@ -129,14 +152,6 @@ xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
                 'http://ez.no/namespaces/ezpublish5/xhtml5/edit',
                 __DIR__ . '/_fixtures/pound.dtd',
                 '`eZ` flavored **markdown**',
-            ),
-            array(
-                'section',
-                'http://ez.no/namespaces/ezpublish5/xhtml5/edit',
-                __DIR__ . '/_fixtures/pound.dtd',
-                '<section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
-  <p>Where is my prolog at...</p>
-</section>',
             ),
             array(
                 'section',


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-24732

The normalization done on input XML in #1489 wasn't applied if the XML didn't include an XML declaration tag. PlatformUI doesn't include it.

According to @dpobel, it is optional in XML 1.0 (and according to what I've read online.

### Tests
- Updated unit test
- Manual test with [damien's script](https://github.com/dpobel/TestCommandsBundle/blob/master/Command/CreateRichTextEntitiesCommand.php)
- Manual CURL test on create content
- Manual PlatformUI test