### PR TITLE
Fix EZP-25178: Adding a "selection" field to a content type raises an error

### DIFF
--- a/eZ/Publish/Core/FieldType/Selection/Type.php
+++ b/eZ/Publish/Core/FieldType/Selection/Type.php
@@ -82,16 +82,6 @@ class Type extends FieldType
                             ),
                             "[$settingKey]"
                         );
-                    } elseif (empty($settingValue)) {
-                        $validationErrors[] = new ValidationError(
-                            "FieldType '%fieldType%' expects setting '%setting%' to contain at least one option",
-                            null,
-                            array(
-                                'fieldType' => $this->getFieldTypeIdentifier(),
-                                'setting' => $settingKey,
-                            ),
-                            "[$settingKey]"
-                        );
                     }
                     break;
                 default:

--- a/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
@@ -346,12 +346,6 @@ class SelectionTest extends FieldTypeTest
                     'options' => 23,
                 ),
             ),
-            array(
-                array(
-                    // options must not be empty
-                    'options' => [],
-                ),
-            ),
         );
     }
 


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-25178
> Regression from https://jira.ez.no/browse/EZP-25002
> Status: Ready for review

The validator requires at least one option to pass, which makes sense, but since the validator also runs when the field type is added, before the user has had a chance to add any options, it fails here. (If we're going to have this check we need to run it in a different way.)