### PR TITLE
[Integration] Fix FieldRelation Criterion coverage tests

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -981,6 +981,8 @@ class SearchServiceTest extends BaseTest
         $createStruct->setField('image', 4);// User folder
         $draft = $contentService->createContent($createStruct);
         $contentService->publishVersion($draft->getVersionInfo());
+
+        $this->refreshSearch($repository);
     }
 
     /**


### PR DESCRIPTION
Fix coverage tests added in https://github.com/ezsystems/ezpublish-kernel/pull/1531

This is essentially calling SOLR's `commit()` after publishing content, otherwise search results will be wrong/empty.

Used to verify: ezsystems/ezplatform-solr-search-engine#31