### PR TITLE
Fix EZP-24848: Content Type removal does not take into account Contents in the trash

### DIFF
--- a/eZ/Publish/API/Repository/ContentTypeService.php
+++ b/eZ/Publish/API/Repository/ContentTypeService.php
@@ -347,4 +347,15 @@ interface ContentTypeService
      * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionUpdateStruct
      */
     public function newFieldDefinitionUpdateStruct();
+
+    /**
+     * Returns true if the given content type $contentType has content instances.
+     *
+     * @since 6.0.1
+     *
+     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
+     *
+     * @return bool
+     */
+    public function isContentTypeUsed(ContentType $contentType);
 }

--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
@@ -3597,4 +3597,27 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
             'Folder content type not in media group after commit.'
         );
     }
+
+    /**
+     * Test for the isContentTypeUsed() method.
+     *
+     * @see \eZ\Publish\API\Repository\ContentTypeService::isContentTypeUsed()
+     */
+    public function testIsContentTypeUsed()
+    {
+        $repository = $this->getRepository();
+
+        /* BEGIN: Use Case */
+        $contentTypeService = $repository->getContentTypeService();
+
+        $folderType = $contentTypeService->loadContentTypeByIdentifier('folder');
+        $eventType = $contentTypeService->loadContentTypeByIdentifier('event');
+
+        $isFolderUsed = $contentTypeService->isContentTypeUsed($folderType);
+        $isEventUsed = $contentTypeService->isContentTypeUsed($eventType);
+        /* END: Use Case */
+
+        $this->assertTrue($isFolderUsed);
+        $this->assertFalse($isEventUsed);
+    }
 }

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentTypeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentTypeHandlerTest.php
@@ -1289,4 +1289,30 @@ class ContentTypeHandlerTest extends HandlerTest
         $handler = $this->persistenceCacheHandler->contentTypeHandler();
         $handler->publish(44);
     }
+
+    /**
+     * @covers eZ\Publish\Core\Persistence\Cache\ContentTypeHandler::getContentCount
+     */
+    public function testGetContentCount()
+    {
+        $this->loggerMock->expects($this->once())->method('logCall');
+        $this->cacheMock
+            ->expects($this->never())
+            ->method($this->anything());
+
+        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $this->persistenceHandlerMock
+            ->expects($this->once())
+            ->method('contentTypeHandler')
+            ->will($this->returnValue($innerHandler));
+
+        $innerHandler
+            ->expects($this->once())
+            ->method('getContentCount')
+            ->with(1)
+            ->will($this->returnValue(18));
+
+        $handler = $this->persistenceCacheHandler->contentTypeHandler();
+        $handler->getContentCount(1);
+    }
 }

--- a/eZ/Publish/Core/REST/Client/ContentTypeService.php
+++ b/eZ/Publish/Core/REST/Client/ContentTypeService.php
@@ -869,4 +869,18 @@ class ContentTypeService implements APIContentTypeService, Sessionable
     {
         return new FieldDefinitionUpdateStruct();
     }
+
+    /**
+     * Returns true if the given content type $contentType has content instances.
+     *
+     * @since 6.0.1
+     *
+     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
+     *
+     * @return bool
+     */
+    public function isContentTypeUsed(ContentType $contentType)
+    {
+        throw new \Exception('@todo: Implement.');
+    }
 }

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -1928,4 +1928,18 @@ class ContentTypeService implements ContentTypeServiceInterface
     {
         return new FieldDefinitionUpdateStruct();
     }
+
+    /**
+     * Returns true if the given content type $contentType has content instances.
+     *
+     * @since 6.0.1
+     *
+     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
+     *
+     * @return bool
+     */
+    public function isContentTypeUsed(APIContentType $contentType)
+    {
+        return $this->contentTypeHandler->getContentCount($contentType->id) > 0;
+    }
 }

--- a/eZ/Publish/Core/SignalSlot/ContentTypeService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentTypeService.php
@@ -606,4 +606,18 @@ class ContentTypeService implements ContentTypeServiceInterface
     {
         return $this->service->newFieldDefinitionUpdateStruct();
     }
+
+    /**
+     * Returns true if the given content type $contentType has content instances.
+     *
+     * @since 6.0.1
+     *
+     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
+     *
+     * @return bool
+     */
+    public function isContentTypeUsed(ContentType $contentType)
+    {
+        return $this->service->isContentTypeUsed($contentType);
+    }
 }

--- a/eZ/Publish/Core/SignalSlot/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ContentTypeServiceTest.php
@@ -310,6 +310,12 @@ class ContentTypeServiceTest extends ServiceTest
                 array($fieldDefinitionUpdateStruct),
                 0,
             ),
+            array(
+                'isContentTypeUsed',
+                array($contentType),
+                true,
+                0,
+            ),
         );
     }
 }


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-24848
> Also requires https://github.com/ezsystems/PlatformUIBundle/pull/479
> Status: Ready for review

Adds a count method to check for existing content, used with CT delete buttons.

- [x] Tests