### PR TITLE
[EZP-25294] Fix embed template, location condition

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed.html.twig
@@ -1,6 +1,6 @@
 {% set content_name=ez_content_name(content) %}
 
-{% if location is defined %}
+{% if location is not null %}
     <h3><a href="{{ path(location) }}">{{ content_name }}</a></h3>
 {% else %}
     <h3>{{ content_name }}</h3>


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-25294

## Description
Hello :)

On the default embed template, the condition throws an exception on images, the location var returns "null".

I update the "undefined" condition to "is not null", but maybe it's better to have both ? 