### PR TITLE
[travis] Fixed Sf 2.8 in the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
     - php: 5.6
       env: TEST_CONFIG="phpunit.xml" SYMFONY_VERSION="~2.8.0@beta as 2.8.0"
     - php: 5.6
-      env: TEST_CONFIG="phpunit-integration-legacy.xml" SYMFONY_VERSION="~2.8.0@beta as 2.8.0"
+      env: TEST_CONFIG="phpunit-integration-legacy.xml" SYMFONY_VERSION="^2.8"
     - php: 5.6
       env: BEHAT_OPTS="--profile=core --tags='~@broken'"
 # 7.0


### PR DESCRIPTION
Should make Travis test 2.8.0 (the previous line led to an error, since inline aliasing requires an exact version number).