### PR TITLE
EZP-25068: XSLT warning on windows for rich text fields

### DIFF
--- a/eZ/Publish/Core/FieldType/RichText/Converter/Xslt.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter/Xslt.php
@@ -77,7 +77,10 @@ class Xslt extends XmlBase implements Converter
 
             $newEl = $xslDoc->createElement('xsl:import');
             $hrefAttr = $xslDoc->createAttribute('href');
-            $hrefAttr->value = $stylesheet;
+
+            // Prevents showing XSLTProcessor::importStylesheet() warning on Windows file system
+            $hrefAttr->value = str_replace('\\', '/', $stylesheet);
+
             $newEl->appendChild($hrefAttr);
             $xslDoc->documentElement->insertBefore($newEl, $insertBeforeEl);
         }


### PR DESCRIPTION
Link to Jira task: https://jira.ez.no/browse/EZP-25068

This fix was originally proposed by @gggeek in https://github.com/ezsystems/ezplatform-xmltext-fieldtype/pull/4

I can confirm that it fixes XSLT issue on Windows file system with RichText field type.