### PR TITLE
Fix travis composer require for alternate sf version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/$DB_NAME"
 # 5.6
     - php: 5.6
-      env: TEST_CONFIG="phpunit.xml" SYMFONY_VERSION="~2.8.0@beta as 2.8.0"
+      env: TEST_CONFIG="phpunit.xml" SYMFONY_VERSION="^2.8"
     - php: 5.6
       env: TEST_CONFIG="phpunit-integration-legacy.xml" SYMFONY_VERSION="^2.8"
     - php: 5.6

--- a/bin/.travis/prepare_unittest.sh
+++ b/bin/.travis/prepare_unittest.sh
@@ -16,11 +16,11 @@ if [ "$DB" = "postgresql" ] ; then psql -c "CREATE DATABASE $DB_NAME;" -U postgr
 # Setup github key to avoid api rate limit
 ./bin/.travis/install_composer_github_key.sh
 
-# Switch to another Symfony version if asked for
-if [ "$SYMFONY_VERSION" != "" ] ; then composer require --no-update symfony/symfony="$SYMFONY_VERSION" ; fi;
-
 # Install packages using composer
 composer install -v --no-progress --no-interaction
+
+# Switch to another Symfony version if asked for
+if [ "$SYMFONY_VERSION" != "" ] ; then composer require symfony/symfony="$SYMFONY_VERSION" ; fi;
 
 # Setup Solr / Elastic search if asked for
 if [ "$TEST_CONFIG" = "phpunit-integration-legacy-elasticsearch.xml" ] ; then ./bin/.travis/init_elasticsearch.sh ; fi


### PR DESCRIPTION
Travis was using the  sf version from the composer.lock instead of the newly required version.  This requires and updates to the correct version regardless of the lock file.