### PR TITLE
Fix EZP-25204: FosHttpCache sets 'Vary:Cookie' for forward requests.

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/RequestEventListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/RequestEventListener.php
@@ -82,6 +82,9 @@ class RequestEventListener implements EventSubscriberInterface
                     $request->getContent()
                 );
                 $forwardRequest->attributes->add($request->attributes->all());
+                if ($request->headers->has('X-User-Hash')) {
+                    $forwardRequest->headers->set('X-User-Hash', $request->headers->get('X-User-Hash'));
+                }
                 // Not forcing HttpKernelInterface::SUB_REQUEST on purpose since we're very early here
                 // and we need to bootstrap essential stuff like sessions.
                 $event->setResponse($event->getKernel()->handle($forwardRequest));

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fos_http_cache.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fos_http_cache.yml
@@ -7,3 +7,5 @@ user_context:
     enabled: true
     hash_cache_ttl: 600
     user_hash_header: X-User-Hash
+    user_identifier_headers:
+        - Authorization


### PR DESCRIPTION
…ward requests.

JIRA: https://jira.ez.no/browse/EZP-25204

### Problem:
When performing internal request forwards (such as using a non-default `index_page` as described in the JIRA issue), FOSHttpCache will add headers to the `Vary:` response header.

This happens because it will not find the `user_hash_header` , so will add what is defined in `user_identifier_headers` : `Cookie` and `Authentication` by default.
Ref: https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/blob/master/EventListener/UserContextSubscriber.php#L134

#### Solution:
The suggested approach is to: 
1. add the user-hash header to the forwarded request if it is already set, and
2. (optional) remove 'Cookie' from the `user_identifier_headers` config, as ezp kernel implements and uses its own user-hash generator, and the cookie vary should be added when necessary.

ping @lolautruche ?
