### PR TITLE
Fix null siteAccess issue in siteaccess router

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
@@ -75,6 +75,13 @@ class SiteAccessMatchListener implements EventSubscriberInterface
             return;
         }
 
+        // The `getSiteAccessFromRequest()` method must be called, because it not only returns the matched siteaccess,
+        // but also initializes the siteAccess property in `$this->siteAccessRouter`.
+        // If the siteAccess property is not initialized, when calling `path(...)` inside an esi block, the following error occurs:
+        // >
+        // Notice: Trying to get property of non-object in vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/MVC/Symfony/SiteAccess/Router.php on line 223
+        $originalSiteaccess = $this->getSiteAccessFromRequest($request->attributes->get('_ez_original_request', $request));
+
         // We have a serialized siteaccess object from a fragment (sub-request), we need to get it back.
         if ($request->attributes->has('serialized_siteaccess')) {
             $request->attributes->set(
@@ -87,7 +94,7 @@ class SiteAccessMatchListener implements EventSubscriberInterface
             // "_ez_original_request" attribute is present in the case of user context hash generation (aka "user hash request").
             $request->attributes->set(
                 'siteaccess',
-                $this->getSiteAccessFromRequest($request->attributes->get('_ez_original_request', $request))
+                $originalSiteaccess
             );
         }
 


### PR DESCRIPTION
Calling `path(...)` inside an ESI block triggers the following error:

> Notice: Trying to get property of non-object in vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/MVC/Symfony/SiteAccess/Router.php on line 223

The root cause of this issue is as follows:

When the ESI block triggers a sub-request to `/_fragment?...`, the fragement listener
(priority 48) is called before the siteaccess listener (priority 45).
the fragement listener parses the serlized siteaccess and sets it as the
`siteaccess` attribute of the sub-request instance.

When the siteaccess listener is invoked, it finds the 'siteaccess'
attribute in the sub-request instance, thus it won't call the `match()`
method of its `siteAccessRouter` instance.

So the `siteAccess` property of its `siteAccessRouter` instance is null
in this case.

When the `path(...)` function is called, the `generate()` method of the
default router will be called, which will then call the `matchByName()`
method of its `siteAccessRouter` instance.

In the `matchByName()` method, it need access
`$this->siteAccess->matcher`, but because `$this->siteAccess` is null in
this case, it triggers the error above.

This issue can be reproduced as follows:

``` php
<?php
...
class DefaultController extends Controller
{
    public function indexAction()
    {
        return $this->render('DemoBundle:Default:index.html.twig');
    }
}

```

``` twig
{# index.html.twig #}
{{ path('ez_urlalias', {locationId: 2, siteaccess: ezdemo}) }}
```

``` twig
{# pagelayout.html.twig #}
{{ render_esi('DemoBundle:Default:index') }}
```
