### PR TITLE
Implement EZP-25329: getTranslatedField twig helper function

### DIFF
--- a/doc/specifications/template/ez_functions.md
+++ b/doc/specifications/template/ez_functions.md
@@ -68,6 +68,13 @@ Note: PHP Object names referred to in these examples exist in the \eZ\Publish\AP
   Example: `ez_trans_prop( versionInfo, 'name' )` will provide the same result as using `ez_content_name( content )`, in
       both cases `VersionInfo->getName( $lang )` is internally used in prioritized language order, with main language fallback.
       
+* ez_field
+
+  _Since 6.0_
+
+  `Field|null = ez_field( Content $content, string $fieldDefIdentifier[, string $forcedLanguage] )`
+
+  Just like ez_field_value except it returns the whole translated Field.
 
 
 ## Rendering helpers

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/content_functions/ez_field.test
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/content_functions/ez_field.test
@@ -1,0 +1,49 @@
+--TEST--
+"ez_field" function
+--TEMPLATE--
+{{ ez_field( content, "testfield" ).value }}
+{{ ez_field( content, "testfield", "eng-GB" ).value }}
+
+--DATA--
+return array(
+    'content' => $this->getContent(
+        'article',
+        array(
+            'ezrichtext' => array(
+                'id' => 5,
+                'fieldDefIdentifier' => 'testfield',
+                'value' => 'foo2',
+                'languageCode' => 'fre-FR'
+            )
+        )
+    )
+)
+--EXPECT--
+foo2
+foo2
+
+--DATA--
+return array(
+    'content' => $this->getContent(
+        'article',
+        array(
+            'ezrichtext' => array(
+                array(
+                    'id' => 5,
+                    'fieldDefIdentifier' => 'testfield',
+                    'value' => 'bar3',
+                    'languageCode' => 'eng-GB'
+                ),
+                array(
+                    'id' => 5,
+                    'fieldDefIdentifier' => 'testfield',
+                    'value' => 'foo2',
+                    'languageCode' => 'fre-FR'
+                ),
+            )
+        )
+    )
+)
+--EXPECT--
+foo2
+bar3

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
@@ -78,6 +78,10 @@ class ContentExtension extends Twig_Extension
                 array($this, 'getTranslatedFieldValue')
             ),
             new Twig_SimpleFunction(
+                'ez_field',
+                array($this, 'getTranslatedField')
+            ),
+            new Twig_SimpleFunction(
                 'ez_is_field_empty',
                 array($this, 'isFieldEmpty')
             ),
@@ -123,6 +127,21 @@ class ContentExtension extends Twig_Extension
         }
 
         throw new InvalidArgumentType('$content', 'eZ\Publish\API\Repository\Values\Content\Content or eZ\Publish\API\Repository\Values\Content\ContentInfo', $content);
+    }
+
+    /**
+     * Returns the translated field, very similar to getTranslatedFieldValue but this returns the whole field.
+     * To be used with ez_image_alias for example, which requires the whole field.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     * @param string $fieldDefIdentifier Identifier for the field we want to get.
+     * @param string $forcedLanguage Locale we want the field in (e.g. "cro-HR"). Null by default (takes current locale).
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Field
+     */
+    public function getTranslatedField(Content $content, $fieldDefIdentifier, $forcedLanguage = null)
+    {
+        return $this->translationHelper->getTranslatedField($content, $fieldDefIdentifier, $forcedLanguage);
     }
 
     /**


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-25329

As the ticket mentions, this adds a simple twig helper function that returns the whole Field so that it can be used for example for ez_image_alias().

I tried seeing whether I should write some tests for this, but I'm not sure. Same goes for the documentation, should I extend that as well?

Example of how this could be used in combination with ez_image_alias:

```
{% set thumb_image_variation = ez_image_alias( ez_translated_field( content, "image" ), content.versionInfo, "gallerythumbnail" ) %}
```