### PR TITLE
Fix EZP-25335: Use ContainerAwareTrait instead for sf 2.8+ support

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/CacheFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/CacheFactory.php
@@ -11,6 +11,7 @@
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
@@ -18,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerAwareTrait;
  *
  * Service "ezpublish.cache_pool", selects a Stash cache service based on siteaccess[-group] setting "cache_pool_name"
  */
-class CacheFactory
+class CacheFactory implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/CacheFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/CacheFactory.php
@@ -11,7 +11,6 @@
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
@@ -19,7 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerAwareTrait;
  *
  * Service "ezpublish.cache_pool", selects a Stash cache service based on siteaccess[-group] setting "cache_pool_name"
  */
-class CacheFactory implements ContainerAwareInterface
+class CacheFactory
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/CacheFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/CacheFactory.php
@@ -11,15 +11,18 @@
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * Class CacheFactory.
  *
  * Service "ezpublish.cache_pool", selects a Stash cache service based on siteaccess[-group] setting "cache_pool_name"
  */
-class CacheFactory extends ContainerAware
+class CacheFactory implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * @param ConfigResolverInterface $configResolver
      *

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
@@ -17,10 +17,11 @@ use eZ\Publish\SPI\Search\Handler as SearchHandler;
 use eZ\Publish\SPI\Limitation\Type as SPILimitationType;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\Core\Base\Container\ApiLoader\FieldTypeCollectionFactory;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
-class RepositoryFactory
+class RepositoryFactory implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
@@ -17,11 +17,10 @@ use eZ\Publish\SPI\Search\Handler as SearchHandler;
 use eZ\Publish\SPI\Limitation\Type as SPILimitationType;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\Core\Base\Container\ApiLoader\FieldTypeCollectionFactory;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
-class RepositoryFactory implements ContainerAwareInterface
+class RepositoryFactory
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
@@ -17,11 +17,14 @@ use eZ\Publish\SPI\Search\Handler as SearchHandler;
 use eZ\Publish\SPI\Limitation\Type as SPILimitationType;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\Core\Base\Container\ApiLoader\FieldTypeCollectionFactory;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
-class RepositoryFactory extends ContainerAware
+class RepositoryFactory implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * @var \eZ\Publish\Core\MVC\ConfigResolverInterface
      */

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/StorageConnectionFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/StorageConnectionFactory.php
@@ -10,10 +10,11 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;
 
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use InvalidArgumentException;
 
-class StorageConnectionFactory
+class StorageConnectionFactory implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/StorageConnectionFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/StorageConnectionFactory.php
@@ -10,11 +10,14 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;
 
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use InvalidArgumentException;
 
-class StorageConnectionFactory extends ContainerAware
+class StorageConnectionFactory implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * @var \eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider
      */

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/StorageConnectionFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/StorageConnectionFactory.php
@@ -10,11 +10,10 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use InvalidArgumentException;
 
-class StorageConnectionFactory implements ContainerAwareInterface
+class StorageConnectionFactory
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
@@ -14,7 +14,6 @@ use eZ\Publish\Core\MVC\Symfony\Configuration\VersatileScopeInterface;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Exception\ParameterNotFoundException;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
@@ -34,7 +33,7 @@ use Symfony\Component\DependencyInjection\ContainerAwareTrait;
  * 2. SiteAccess name
  * 3. "default"
  */
-class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, ContainerAwareInterface
+class ConfigResolver implements VersatileScopeInterface, SiteAccessAware
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
@@ -14,7 +14,8 @@ use eZ\Publish\Core\MVC\Symfony\Configuration\VersatileScopeInterface;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Exception\ParameterNotFoundException;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * This class will help you get settings for a specific scope.
@@ -33,8 +34,10 @@ use Symfony\Component\DependencyInjection\ContainerAware;
  * 2. SiteAccess name
  * 3. "default"
  */
-class ConfigResolver extends ContainerAware implements VersatileScopeInterface, SiteAccessAware
+class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     const SCOPE_GLOBAL = 'global',
           SCOPE_DEFAULT = 'default';
 

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\MVC\Symfony\Configuration\VersatileScopeInterface;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Exception\ParameterNotFoundException;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
@@ -33,7 +34,7 @@ use Symfony\Component\DependencyInjection\ContainerAwareTrait;
  * 2. SiteAccess name
  * 3. "default"
  */
-class ConfigResolver implements VersatileScopeInterface, SiteAccessAware
+class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, ContainerAwareInterface
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/SiteAccessListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/SiteAccessListener.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\Event\PostSiteAccessMatchEvent;
 use eZ\Publish\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\URILexer;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
@@ -22,7 +23,7 @@ use Symfony\Component\Security\Http\HttpUtils;
 /**
  * SiteAccess match listener.
  */
-class SiteAccessListener implements EventSubscriberInterface
+class SiteAccessListener implements EventSubscriberInterface, ContainerAwareInterface
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/SiteAccessListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/SiteAccessListener.php
@@ -14,7 +14,6 @@ use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\Event\PostSiteAccessMatchEvent;
 use eZ\Publish\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\URILexer;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
@@ -23,7 +22,7 @@ use Symfony\Component\Security\Http\HttpUtils;
 /**
  * SiteAccess match listener.
  */
-class SiteAccessListener implements EventSubscriberInterface, ContainerAwareInterface
+class SiteAccessListener implements EventSubscriberInterface
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/SiteAccessListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/SiteAccessListener.php
@@ -14,7 +14,8 @@ use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\Event\PostSiteAccessMatchEvent;
 use eZ\Publish\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\URILexer;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Http\HttpUtils;
@@ -22,8 +23,10 @@ use Symfony\Component\Security\Http\HttpUtils;
 /**
  * SiteAccess match listener.
  */
-class SiteAccessListener extends ContainerAware implements EventSubscriberInterface
+class SiteAccessListener implements EventSubscriberInterface, ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * @var \Symfony\Component\Routing\RouterInterface
      */

--- a/eZ/Bundle/EzPublishCoreBundle/Matcher/BlockMatcherFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Matcher/BlockMatcherFactory.php
@@ -16,17 +16,14 @@ use eZ\Publish\Core\MVC\Symfony\Matcher\BlockMatcherFactory as BaseFactory;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @deprecated Deprecated since 6.0, will be removed in 6.1. Use the ServiceAwareMatcherFactory instead.
  */
 class BlockMatcherFactory extends BaseFactory implements SiteAccessAware, ContainerAwareInterface
 {
-    /**
-     * @var \Symfony\Component\DependencyInjection\ContainerInterface
-     */
-    private $container;
+    use ContainerAwareTrait;
 
     /**
      * @var \eZ\Publish\Core\MVC\ConfigResolverInterface;
@@ -46,11 +43,6 @@ class BlockMatcherFactory extends BaseFactory implements SiteAccessAware, Contai
             $repository,
             $this->configResolver->getParameter('block_view')
         );
-    }
-
-    public function setContainer(ContainerInterface $container = null)
-    {
-        $this->container = $container;
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/Matcher/BlockMatcherFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Matcher/BlockMatcherFactory.php
@@ -15,12 +15,13 @@ use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\Matcher\BlockMatcherFactory as BaseFactory;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @deprecated Deprecated since 6.0, will be removed in 6.1. Use the ServiceAwareMatcherFactory instead.
  */
-class BlockMatcherFactory extends BaseFactory implements SiteAccessAware
+class BlockMatcherFactory extends BaseFactory implements SiteAccessAware, ContainerAwareInterface
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishCoreBundle/Matcher/BlockMatcherFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Matcher/BlockMatcherFactory.php
@@ -15,13 +15,12 @@ use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\Matcher\BlockMatcherFactory as BaseFactory;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @deprecated Deprecated since 6.0, will be removed in 6.1. Use the ServiceAwareMatcherFactory instead.
  */
-class BlockMatcherFactory extends BaseFactory implements SiteAccessAware, ContainerAwareInterface
+class BlockMatcherFactory extends BaseFactory implements SiteAccessAware
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishCoreBundle/Matcher/ContentMatcherFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Matcher/ContentMatcherFactory.php
@@ -15,13 +15,12 @@ use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentMatcherFactory as BaseFactory;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @deprecated Deprecated since 6.0, will be removed in 6.1. Use the ServiceAwareMatcherFactory instead.
  */
-class ContentMatcherFactory extends BaseFactory implements SiteAccessAware, ContainerAwareInterface
+class ContentMatcherFactory extends BaseFactory implements SiteAccessAware
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishCoreBundle/Matcher/ContentMatcherFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Matcher/ContentMatcherFactory.php
@@ -15,12 +15,13 @@ use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentMatcherFactory as BaseFactory;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @deprecated Deprecated since 6.0, will be removed in 6.1. Use the ServiceAwareMatcherFactory instead.
  */
-class ContentMatcherFactory extends BaseFactory implements SiteAccessAware
+class ContentMatcherFactory extends BaseFactory implements SiteAccessAware, ContainerAwareInterface
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishCoreBundle/Matcher/ContentMatcherFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Matcher/ContentMatcherFactory.php
@@ -16,17 +16,14 @@ use eZ\Publish\Core\MVC\Symfony\Matcher\ContentMatcherFactory as BaseFactory;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @deprecated Deprecated since 6.0, will be removed in 6.1. Use the ServiceAwareMatcherFactory instead.
  */
 class ContentMatcherFactory extends BaseFactory implements SiteAccessAware, ContainerAwareInterface
 {
-    /**
-     * @var \Symfony\Component\DependencyInjection\ContainerInterface
-     */
-    private $container;
+    use ContainerAwareTrait;
 
     /**
      * @var \eZ\Publish\Core\MVC\ConfigResolverInterface;
@@ -46,11 +43,6 @@ class ContentMatcherFactory extends BaseFactory implements SiteAccessAware, Cont
             $repository,
             $this->configResolver->getParameter('content_view')
         );
-    }
-
-    public function setContainer(ContainerInterface $container = null)
-    {
-        $this->container = $container;
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/Matcher/LocationMatcherFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Matcher/LocationMatcherFactory.php
@@ -15,12 +15,13 @@ use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\Matcher\LocationMatcherFactory as BaseMatcherFactory;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @deprecated Deprecated since 6.0, will be removed in 6.1. Location view in general is deprecated. Use content view instead.
  */
-class LocationMatcherFactory extends BaseMatcherFactory implements SiteAccessAware
+class LocationMatcherFactory extends BaseMatcherFactory implements SiteAccessAware, ContainerAwareInterface
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishCoreBundle/Matcher/LocationMatcherFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Matcher/LocationMatcherFactory.php
@@ -16,17 +16,14 @@ use eZ\Publish\Core\MVC\Symfony\Matcher\LocationMatcherFactory as BaseMatcherFac
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @deprecated Deprecated since 6.0, will be removed in 6.1. Location view in general is deprecated. Use content view instead.
  */
 class LocationMatcherFactory extends BaseMatcherFactory implements SiteAccessAware, ContainerAwareInterface
 {
-    /**
-     * @var \Symfony\Component\DependencyInjection\ContainerInterface
-     */
-    private $container;
+    use ContainerAwareTrait;
 
     /**
      * @var \eZ\Publish\Core\MVC\ConfigResolverInterface;
@@ -46,11 +43,6 @@ class LocationMatcherFactory extends BaseMatcherFactory implements SiteAccessAwa
             $repository,
             $this->configResolver->getParameter('location_view')
         );
-    }
-
-    public function setContainer(ContainerInterface $container = null)
-    {
-        $this->container = $container;
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/Matcher/LocationMatcherFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Matcher/LocationMatcherFactory.php
@@ -15,13 +15,12 @@ use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\Matcher\LocationMatcherFactory as BaseMatcherFactory;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * @deprecated Deprecated since 6.0, will be removed in 6.1. Location view in general is deprecated. Use content view instead.
  */
-class LocationMatcherFactory extends BaseMatcherFactory implements SiteAccessAware, ContainerAwareInterface
+class LocationMatcherFactory extends BaseMatcherFactory implements SiteAccessAware
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishCoreBundle/Matcher/ServiceAwareMatcherFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Matcher/ServiceAwareMatcherFactory.php
@@ -6,7 +6,7 @@ namespace eZ\Bundle\EzPublishCoreBundle\Matcher;
 
 use eZ\Publish\Core\MVC\Symfony\Matcher\ClassNameMatcherFactory;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * A view matcher factory that also accepts services as matchers.
@@ -16,15 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class ServiceAwareMatcherFactory extends ClassNameMatcherFactory implements ContainerAwareInterface
 {
-    /**
-     * @var \Symfony\Component\DependencyInjection\ContainerInterface
-     */
-    private $container;
-
-    public function setContainer(ContainerInterface $container = null)
-    {
-        $this->container = $container;
-    }
+    use ContainerAwareTrait;
 
     /**
      * @param string $matcherIdentifier

--- a/eZ/Bundle/EzPublishCoreBundle/Matcher/ServiceAwareMatcherFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Matcher/ServiceAwareMatcherFactory.php
@@ -5,6 +5,7 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Matcher;
 
 use eZ\Publish\Core\MVC\Symfony\Matcher\ClassNameMatcherFactory;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
@@ -13,7 +14,7 @@ use Symfony\Component\DependencyInjection\ContainerAwareTrait;
  * If a service id is passed as the MatcherIdentifier, this service will be used for the matching.
  * Otherwise, it will fallback to the class name based matcher factory.
  */
-class ServiceAwareMatcherFactory extends ClassNameMatcherFactory
+class ServiceAwareMatcherFactory extends ClassNameMatcherFactory implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishCoreBundle/Matcher/ServiceAwareMatcherFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Matcher/ServiceAwareMatcherFactory.php
@@ -5,7 +5,6 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Matcher;
 
 use eZ\Publish\Core\MVC\Symfony\Matcher\ClassNameMatcherFactory;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
@@ -14,7 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerAwareTrait;
  * If a service id is passed as the MatcherIdentifier, this service will be used for the matching.
  * Otherwise, it will fallback to the class name based matcher factory.
  */
-class ServiceAwareMatcherFactory extends ClassNameMatcherFactory implements ContainerAwareInterface
+class ServiceAwareMatcherFactory extends ClassNameMatcherFactory
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishElasticsearchSearchEngineBundle/ApiLoader/ElasticsearchEngineFactory.php
+++ b/eZ/Bundle/EzPublishElasticsearchSearchEngineBundle/ApiLoader/ElasticsearchEngineFactory.php
@@ -11,10 +11,9 @@
 namespace eZ\Bundle\EzPublishElasticsearchSearchEngineBundle\ApiLoader;
 
 use eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class ElasticsearchEngineFactory implements ContainerAwareInterface
+class ElasticsearchEngineFactory
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishElasticsearchSearchEngineBundle/ApiLoader/ElasticsearchEngineFactory.php
+++ b/eZ/Bundle/EzPublishElasticsearchSearchEngineBundle/ApiLoader/ElasticsearchEngineFactory.php
@@ -11,10 +11,13 @@
 namespace eZ\Bundle\EzPublishElasticsearchSearchEngineBundle\ApiLoader;
 
 use eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class ElasticsearchEngineFactory extends ContainerAware
+class ElasticsearchEngineFactory implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * @var RepositoryConfigurationProvider
      */

--- a/eZ/Bundle/EzPublishElasticsearchSearchEngineBundle/ApiLoader/ElasticsearchEngineFactory.php
+++ b/eZ/Bundle/EzPublishElasticsearchSearchEngineBundle/ApiLoader/ElasticsearchEngineFactory.php
@@ -11,9 +11,10 @@
 namespace eZ\Bundle\EzPublishElasticsearchSearchEngineBundle\ApiLoader;
 
 use eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class ElasticsearchEngineFactory
+class ElasticsearchEngineFactory implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishIOBundle/ApiLoader/HandlerFactory.php
+++ b/eZ/Bundle/EzPublishIOBundle/ApiLoader/HandlerFactory.php
@@ -9,13 +9,12 @@
 namespace eZ\Bundle\EzPublishIOBundle\ApiLoader;
 
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * Factory of IO handlers, given an alias.
  */
-class HandlerFactory implements ContainerAwareInterface
+class HandlerFactory
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishIOBundle/ApiLoader/HandlerFactory.php
+++ b/eZ/Bundle/EzPublishIOBundle/ApiLoader/HandlerFactory.php
@@ -9,13 +9,16 @@
 namespace eZ\Bundle\EzPublishIOBundle\ApiLoader;
 
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * Factory of IO handlers, given an alias.
  */
-class HandlerFactory extends ContainerAware
+class HandlerFactory implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * Map of handler id to handler service id.
      *

--- a/eZ/Bundle/EzPublishIOBundle/ApiLoader/HandlerFactory.php
+++ b/eZ/Bundle/EzPublishIOBundle/ApiLoader/HandlerFactory.php
@@ -9,12 +9,13 @@
 namespace eZ\Bundle\EzPublishIOBundle\ApiLoader;
 
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
 /**
  * Factory of IO handlers, given an alias.
  */
-class HandlerFactory
+class HandlerFactory implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishIOBundle/DependencyInjection/ConfigurationFactory.php
+++ b/eZ/Bundle/EzPublishIOBundle/DependencyInjection/ConfigurationFactory.php
@@ -52,7 +52,7 @@ interface ConfigurationFactory
      * Arguments or calls can be added to the $serviceDefinition, extra services or parameters can be added to the
      * container.
      *
-     * Note: if the factory extends ContainerAware, the ContainerBuilder will be made available as $this->container.
+     * Note: if the factory implements ContainerAwareInterface, the ContainerBuilder will be made available as $this->container.
      *
      * @param ServiceDefinition $serviceDefinition
      * @param array $config

--- a/eZ/Bundle/EzPublishIOBundle/DependencyInjection/ConfigurationFactory/Flysystem.php
+++ b/eZ/Bundle/EzPublishIOBundle/DependencyInjection/ConfigurationFactory/Flysystem.php
@@ -11,7 +11,8 @@ namespace eZ\Bundle\EzPublishIOBundle\DependencyInjection\ConfigurationFactory;
 use eZ\Bundle\EzPublishIOBundle\DependencyInjection\ConfigurationFactory;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition as ServiceDefinition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
@@ -22,8 +23,10 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * Binarydata & metadata are identical, except for the parent service.
  */
-abstract class Flysystem extends ContainerAware implements ConfigurationFactory
+abstract class Flysystem implements ConfigurationFactory, ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     public function addConfiguration(ArrayNodeDefinition $node)
     {
         $node

--- a/eZ/Bundle/EzPublishLegacySearchEngineBundle/ApiLoader/ConnectionFactory.php
+++ b/eZ/Bundle/EzPublishLegacySearchEngineBundle/ApiLoader/ConnectionFactory.php
@@ -11,11 +11,14 @@
 namespace eZ\Bundle\EzPublishLegacySearchEngineBundle\ApiLoader;
 
 use eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use InvalidArgumentException;
 
-class ConnectionFactory extends ContainerAware
+class ConnectionFactory implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * @var \eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider
      */

--- a/eZ/Bundle/EzPublishLegacySearchEngineBundle/ApiLoader/ConnectionFactory.php
+++ b/eZ/Bundle/EzPublishLegacySearchEngineBundle/ApiLoader/ConnectionFactory.php
@@ -11,11 +11,10 @@
 namespace eZ\Bundle\EzPublishLegacySearchEngineBundle\ApiLoader;
 
 use eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use InvalidArgumentException;
 
-class ConnectionFactory implements ContainerAwareInterface
+class ConnectionFactory
 {
     use ContainerAwareTrait;
 

--- a/eZ/Bundle/EzPublishLegacySearchEngineBundle/ApiLoader/ConnectionFactory.php
+++ b/eZ/Bundle/EzPublishLegacySearchEngineBundle/ApiLoader/ConnectionFactory.php
@@ -11,10 +11,11 @@
 namespace eZ\Bundle\EzPublishLegacySearchEngineBundle\ApiLoader;
 
 use eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use InvalidArgumentException;
 
-class ConnectionFactory
+class ConnectionFactory implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
 

--- a/eZ/Publish/Core/Base/Container/ApiLoader/FieldTypeCollectionFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/FieldTypeCollectionFactory.php
@@ -10,9 +10,10 @@
  */
 namespace eZ\Publish\Core\Base\Container\ApiLoader;
 
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class FieldTypeCollectionFactory
+class FieldTypeCollectionFactory implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
 

--- a/eZ/Publish/Core/Base/Container/ApiLoader/FieldTypeCollectionFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/FieldTypeCollectionFactory.php
@@ -10,10 +10,13 @@
  */
 namespace eZ\Publish\Core\Base\Container\ApiLoader;
 
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class FieldTypeCollectionFactory extends ContainerAware
+class FieldTypeCollectionFactory implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * Collection of fieldTypes, lazy loaded via a closure.
      *

--- a/eZ/Publish/Core/Base/Container/ApiLoader/FieldTypeCollectionFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/FieldTypeCollectionFactory.php
@@ -10,10 +10,9 @@
  */
 namespace eZ\Publish\Core\Base\Container\ApiLoader;
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class FieldTypeCollectionFactory implements ContainerAwareInterface
+class FieldTypeCollectionFactory
 {
     use ContainerAwareTrait;
 

--- a/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
@@ -15,10 +15,11 @@ use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
 use eZ\Publish\SPI\Search\Handler as SearchHandler;
 use eZ\Publish\SPI\Limitation\Type as SPILimitationType;
 use eZ\Publish\API\Repository\Repository;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
-class RepositoryFactory
+class RepositoryFactory implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
 

--- a/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
@@ -15,11 +15,14 @@ use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
 use eZ\Publish\SPI\Search\Handler as SearchHandler;
 use eZ\Publish\SPI\Limitation\Type as SPILimitationType;
 use eZ\Publish\API\Repository\Repository;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
-class RepositoryFactory extends ContainerAware
+class RepositoryFactory implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * @var string
      */

--- a/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
@@ -15,11 +15,10 @@ use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
 use eZ\Publish\SPI\Search\Handler as SearchHandler;
 use eZ\Publish\SPI\Limitation\Type as SPILimitationType;
 use eZ\Publish\API\Repository\Repository;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
-class RepositoryFactory implements ContainerAwareInterface
+class RepositoryFactory
 {
     use ContainerAwareTrait;
 

--- a/eZ/Publish/Core/Base/Container/ApiLoader/Storage/ExternalStorageRegistryFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/Storage/ExternalStorageRegistryFactory.php
@@ -10,10 +10,13 @@
  */
 namespace eZ\Publish\Core\Base\Container\ApiLoader\Storage;
 
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class ExternalStorageRegistryFactory extends ContainerAware
+class ExternalStorageRegistryFactory implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * Collection of external storage handlers for field types that need them.
      *

--- a/eZ/Publish/Core/Base/Container/ApiLoader/Storage/ExternalStorageRegistryFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/Storage/ExternalStorageRegistryFactory.php
@@ -10,9 +10,10 @@
  */
 namespace eZ\Publish\Core\Base\Container\ApiLoader\Storage;
 
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class ExternalStorageRegistryFactory
+class ExternalStorageRegistryFactory implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
 

--- a/eZ/Publish/Core/Base/Container/ApiLoader/Storage/ExternalStorageRegistryFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/Storage/ExternalStorageRegistryFactory.php
@@ -10,10 +10,9 @@
  */
 namespace eZ\Publish\Core\Base\Container\ApiLoader\Storage;
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class ExternalStorageRegistryFactory implements ContainerAwareInterface
+class ExternalStorageRegistryFactory
 {
     use ContainerAwareTrait;
 

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Controller.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Controller.php
@@ -10,11 +10,12 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Controller;
 
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpFoundation\Response;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
 
-abstract class Controller
+abstract class Controller implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
 

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Controller.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Controller.php
@@ -10,13 +10,15 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Controller;
 
-use Symfony\Component\DependencyInjection\ContainerAware;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpFoundation\Response;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
 
-abstract class Controller extends ContainerAware
+abstract class Controller implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * Returns value for $parameterName and fallbacks to $defaultValue if not defined.
      *

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Controller.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Controller.php
@@ -10,12 +10,11 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Controller;
 
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\HttpFoundation\Response;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
 
-abstract class Controller implements ContainerAwareInterface
+abstract class Controller
 {
     use ContainerAwareTrait;
 

--- a/eZ/Publish/Core/REST/Server/Controller.php
+++ b/eZ/Publish/Core/REST/Server/Controller.php
@@ -11,14 +11,17 @@
 namespace eZ\Publish\Core\REST\Server;
 
 use eZ\Publish\API\Repository\Repository;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\Routing\RouterInterface;
 use eZ\Publish\Core\REST\Common\Input\Dispatcher as InputDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use eZ\Publish\Core\REST\Common\RequestParser as RequestParser;
 
-abstract class Controller extends ContainerAware
+abstract class Controller implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * @var \eZ\Publish\Core\REST\Common\Input\Dispatcher
      */

--- a/eZ/Publish/Core/REST/Server/Controller.php
+++ b/eZ/Publish/Core/REST/Server/Controller.php
@@ -11,14 +11,13 @@
 namespace eZ\Publish\Core\REST\Server;
 
 use eZ\Publish\API\Repository\Repository;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\Routing\RouterInterface;
 use eZ\Publish\Core\REST\Common\Input\Dispatcher as InputDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use eZ\Publish\Core\REST\Common\RequestParser as RequestParser;
 
-abstract class Controller implements ContainerAwareInterface
+abstract class Controller
 {
     use ContainerAwareTrait;
 

--- a/eZ/Publish/Core/REST/Server/Controller.php
+++ b/eZ/Publish/Core/REST/Server/Controller.php
@@ -11,13 +11,14 @@
 namespace eZ\Publish\Core\REST\Server;
 
 use eZ\Publish\API\Repository\Repository;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\Routing\RouterInterface;
 use eZ\Publish\Core\REST\Common\Input\Dispatcher as InputDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use eZ\Publish\Core\REST\Common\RequestParser as RequestParser;
 
-abstract class Controller
+abstract class Controller implements ContainerAwareInterface
 {
     use ContainerAwareTrait;
 


### PR DESCRIPTION
> Implements https://jira.ez.no/browse/EZP-25335

Replaces usage of abstract `ContainerAware` with the `ContainerAwareTrait`.