### PR TITLE
Fix EZP-25337: URIElement SA matcher wrong value

### DIFF
--- a/doc/bc/changes-6.1.md
+++ b/doc/bc/changes-6.1.md
@@ -16,6 +16,9 @@ Changes affecting version compatibility with former or future versions.
   generate system config. Configuration & code generation will be kept separated from database and content installation
   going forward.
 
+* Passing an `int` argument to the `HostElement` and `URIElement` SiteAccess Matchers constructor is deprecated
+  and will be removed in the future, a single-element array ( 'value' => $number ) should be used instead.
+
 
 ## Removed features
 

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/HostElement.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/HostElement.php
@@ -37,10 +37,15 @@ class HostElement implements VersatileMatcher
     /**
      * Constructor.
      *
-     * @param int $elementNumber Number of elements to take into account.
+     * @param array|int $elementNumber Number of elements to take into account.
      */
     public function __construct($elementNumber)
     {
+        if (is_array($elementNumber)) {
+            // DI config parser will create an array with 'value' => number
+            $elementNumber = current($elementNumber);
+        }
+
         $this->elementNumber = (int)$elementNumber;
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIElement.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIElement.php
@@ -39,10 +39,15 @@ class URIElement implements VersatileMatcher, URILexer
     /**
      * Constructor.
      *
-     * @param int $elementNumber Number of elements to take into account.
+     * @param int|array $elementNumber Number of elements to take into account.
      */
     public function __construct($elementNumber)
     {
+        if (is_array($elementNumber)) {
+            // DI config parser will create an array with 'value' => number
+            $elementNumber = current($elementNumber);
+        }
+
         $this->elementNumber = (int)$elementNumber;
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostElementTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostElementTest.php
@@ -38,7 +38,9 @@ class RouterHostElementTest extends PHPUnit_Framework_TestCase
             $this->getMock('Psr\\Log\\LoggerInterface'),
             'default_sa',
             array(
-                'HostElement' => 2,
+                'HostElement' => array(
+                    'value' => 2,
+                ),
                 'Map\\URI' => array(
                     'first_sa' => 'first_sa',
                     'second_sa' => 'second_sa',
@@ -127,7 +129,7 @@ class RouterHostElementTest extends PHPUnit_Framework_TestCase
         $matcher = new HostMapMatcher(array('host' => 'foo'), array());
         $this->assertSame('host:map', $matcher->getName());
 
-        $matcherHostElement = new HostElement(1);
+        $matcherHostElement = new HostElement(array(1));
         $this->assertSame('host:element', $matcherHostElement->getName());
     }
 
@@ -136,7 +138,7 @@ class RouterHostElementTest extends PHPUnit_Framework_TestCase
      */
     public function testReverseMatch($siteAccessName, $elementNumber, SimplifiedRequest $request, $expectedHost)
     {
-        $matcher = new HostElement($elementNumber);
+        $matcher = new HostElement(array($elementNumber));
         $matcher->setRequest($request);
         $result = $matcher->reverseMatch($siteAccessName);
         $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\HostElement', $result);
@@ -155,14 +157,14 @@ class RouterHostElementTest extends PHPUnit_Framework_TestCase
 
     public function testReverseMatchFail()
     {
-        $matcher = new HostElement(3);
+        $matcher = new HostElement(array(3));
         $matcher->setRequest(new SimplifiedRequest(array('host' => 'ez.no')));
         $this->assertNull($matcher->reverseMatch('foo'));
     }
 
     public function testSerialize()
     {
-        $matcher = new HostElement(1);
+        $matcher = new HostElement(array(1));
         $matcher->setRequest(new SimplifiedRequest(array('host' => 'ez.no', 'pathinfo' => '/foo/bar')));
         $sa = new SiteAccess('test', 'test', $matcher);
         $serializedSA1 = serialize($sa);

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElement2Test.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElement2Test.php
@@ -37,7 +37,9 @@ class RouterURIElement2Test extends PHPUnit_Framework_TestCase
             $this->getMock('Psr\\Log\\LoggerInterface'),
             'default_sa',
             array(
-                'URIElement' => 2,
+                'URIElement' => array(
+                    'value' => 2,
+                ),
                 'Map\\URI' => array(
                     'first_sa' => 'first_sa',
                     'second_sa' => 'second_sa',
@@ -123,6 +125,22 @@ class RouterURIElement2Test extends PHPUnit_Framework_TestCase
      */
     public function testAnalyseURI($level, $uri, $expectedFixedUpURI)
     {
+        $matcher = new URIElementMatcher(array($level));
+        $matcher->setRequest(
+            new SimplifiedRequest(array('pathinfo' => $uri))
+        );
+        $this->assertSame($expectedFixedUpURI, $matcher->analyseURI($uri));
+    }
+
+    /**
+     * @param int $level
+     * @param string $uri
+     * @param string $expectedFixedUpURI
+     *
+     * @dataProvider analyseProvider
+     */
+    public function testAnalyseURILevelAsInt($level, $uri, $expectedFixedUpURI)
+    {
         $matcher = new URIElementMatcher($level);
         $matcher->setRequest(
             new SimplifiedRequest(array('pathinfo' => $uri))
@@ -139,7 +157,7 @@ class RouterURIElement2Test extends PHPUnit_Framework_TestCase
      */
     public function testAnalyseLink($level, $fullUri, $linkUri)
     {
-        $matcher = new URIElementMatcher($level);
+        $matcher = new URIElementMatcher(array($level));
         $matcher->setRequest(
             new SimplifiedRequest(array('pathinfo' => $fullUri))
         );
@@ -170,7 +188,7 @@ class RouterURIElement2Test extends PHPUnit_Framework_TestCase
     public function testReverseMatch($siteAccessName, $originalPathinfo)
     {
         $expectedSiteAccessPath = implode('/', explode('_', $siteAccessName));
-        $matcher = new URIElementMatcher(2);
+        $matcher = new URIElementMatcher(array(2));
         $matcher->setRequest(new SimplifiedRequest(array('pathinfo' => $originalPathinfo)));
 
         $result = $matcher->reverseMatch($siteAccessName);
@@ -190,14 +208,14 @@ class RouterURIElement2Test extends PHPUnit_Framework_TestCase
 
     public function testReverseMatchFail()
     {
-        $matcher = new URIElementMatcher(2);
+        $matcher = new URIElementMatcher(array(2));
         $matcher->setRequest(new SimplifiedRequest(array('pathinfo' => '/my/siteaccess/foo/bar')));
         $this->assertNull($matcher->reverseMatch('another_siteaccess_again_dont_tell_me'));
     }
 
     public function testSerialize()
     {
-        $matcher = new URIElementMatcher(2);
+        $matcher = new URIElementMatcher(array(2));
         $matcher->setRequest(new SimplifiedRequest(array('pathinfo' => '/foo/bar')));
         $sa = new SiteAccess('test', 'test', $matcher);
         $serializedSA1 = serialize($sa);

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElementTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElementTest.php
@@ -37,7 +37,9 @@ class RouterURIElementTest extends PHPUnit_Framework_TestCase
             $this->getMock('Psr\\Log\\LoggerInterface'),
             'default_sa',
             array(
-                'URIElement' => 1,
+                'URIElement' => array(
+                    'value' => 1,
+                ),
                 'Map\\URI' => array(
                     'first_sa' => 'first_sa',
                     'second_sa' => 'second_sa',
@@ -116,7 +118,7 @@ class RouterURIElementTest extends PHPUnit_Framework_TestCase
 
     public function testGetName()
     {
-        $matcher = new URIElementMatcher(array(), array());
+        $matcher = new URIElementMatcher(array());
         $this->assertSame('uri:element', $matcher->getName());
     }
 
@@ -128,7 +130,7 @@ class RouterURIElementTest extends PHPUnit_Framework_TestCase
      */
     public function testAnalyseURI($uri, $expectedFixedUpURI)
     {
-        $matcher = new URIElementMatcher(1);
+        $matcher = new URIElementMatcher(array(1));
         $matcher->setRequest(
             new SimplifiedRequest(array('pathinfo' => $uri))
         );
@@ -143,7 +145,7 @@ class RouterURIElementTest extends PHPUnit_Framework_TestCase
      */
     public function testAnalyseLink($fullUri, $linkUri)
     {
-        $matcher = new URIElementMatcher(1);
+        $matcher = new URIElementMatcher(array(1));
         $matcher->setRequest(
             new SimplifiedRequest(array('pathinfo' => $fullUri))
         );
@@ -163,7 +165,7 @@ class RouterURIElementTest extends PHPUnit_Framework_TestCase
      */
     public function testReverseMatch($siteAccessName, $originalPathinfo)
     {
-        $matcher = new URIElementMatcher(1);
+        $matcher = new URIElementMatcher(array(1));
         $matcher->setRequest(new SimplifiedRequest(array('pathinfo' => $originalPathinfo)));
         $result = $matcher->reverseMatch($siteAccessName);
         $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIElement', $result);
@@ -185,7 +187,7 @@ class RouterURIElementTest extends PHPUnit_Framework_TestCase
 
     public function testSerialize()
     {
-        $matcher = new URIElementMatcher(1);
+        $matcher = new URIElementMatcher(array(1));
         $matcher->setRequest(new SimplifiedRequest(array('pathinfo' => '/foo/bar')));
         $sa = new SiteAccess('test', 'test', $matcher);
         $serializedSA1 = serialize($sa);


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25337

This replaces #1476

The problem is that configuration parser always creates arrays out of the matcher settings, which URIElement and HostElement did not take into account see https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php#L217: 
```
// Value passed to the matcher should always be an array.
// If value is not an array, we transform it to a hash, with 'value' as key.
```
The tests still passed because an int was used for the constructor, with the proposed fix no changes should be necessary.