### PR TITLE
Fix EZP-25432 In Textline fieldtype, is being permitted the "Minimum length" and "Maximum length" to have negative values

### DIFF
--- a/eZ/Publish/Core/FieldType/Tests/TextLineTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/TextLineTest.php
@@ -453,6 +453,14 @@ class TextLineTest extends FieldTypeTest
                     ),
                 ),
             ),
+            array(
+                array(
+                    'StringLengthValidator' => array(
+                        'maxStringLength' => 23,
+                        'minStringLength' => 42,
+                    ),
+                ),
+            ),
         );
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/TextLineTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/TextLineTest.php
@@ -439,6 +439,20 @@ class TextLineTest extends FieldTypeTest
                     ),
                 ),
             ),
+            array(
+                array(
+                    'StringLengthValidator' => array(
+                        'minStringLength' => -23,
+                    ),
+                ),
+            ),
+            array(
+                array(
+                    'StringLengthValidator' => array(
+                        'maxStringLength' => -42,
+                    ),
+                ),
+            ),
         );
     }
 

--- a/eZ/Publish/Core/FieldType/TextLine/Type.php
+++ b/eZ/Publish/Core/FieldType/TextLine/Type.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\FieldType\FieldType;
 use eZ\Publish\Core\FieldType\ValidationError;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\FieldType\Validator\StringLengthValidator;
 use eZ\Publish\SPI\FieldType\Value as SPIValue;
 use eZ\Publish\Core\FieldType\Value as BaseValue;
 
@@ -47,6 +48,7 @@ class Type extends FieldType
     public function validateValidatorConfiguration($validatorConfiguration)
     {
         $validationErrors = array();
+        $validator = new StringLengthValidator();
 
         foreach ($validatorConfiguration as $validatorIdentifier => $constraints) {
             if ($validatorIdentifier !== 'StringLengthValidator') {
@@ -57,34 +59,9 @@ class Type extends FieldType
                         'validator' => $validatorIdentifier,
                     )
                 );
-
                 continue;
             }
-            foreach ($constraints as $name => $value) {
-                switch ($name) {
-                    case 'minStringLength':
-                    case 'maxStringLength':
-                        if ($value !== null && !is_integer($value)) {
-                            $validationErrors[] = new ValidationError(
-                                "Validator parameter '%parameter%' value must be of integer type",
-                                null,
-                                array(
-                                    'parameter' => $name,
-                                ),
-                                "[$validatorIdentifier][$name]"
-                            );
-                        }
-                        break;
-                    default:
-                        $validationErrors[] = new ValidationError(
-                            "Validator parameter '%parameter%' is unknown",
-                            null,
-                            array(
-                                'parameter' => $name,
-                            )
-                        );
-                }
-            }
+            $validationErrors += $validator->validateConstraints($constraints);
         }
 
         return $validationErrors;

--- a/eZ/Publish/Core/FieldType/Validator/StringLengthValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/StringLengthValidator.php
@@ -74,7 +74,33 @@ class StringLengthValidator extends Validator
             }
         }
 
+        // if no errors above, check if minStringLength is shorter or equal than maxStringLength
+        if (empty($validationErrors) && !$this->validateConstraintsOrder($constraints)) {
+            $validationErrors[] = new ValidationError(
+                "Validator parameter 'maxStringLength' can't be shorter than validator parameter 'minStringLength' value",
+                null,
+                array(
+                    'parameter' => 'minStringLength',
+                )
+            );
+        }
+
         return $validationErrors;
+    }
+
+    /**
+     * Check if max string length is greater or equal than min string length in
+     * case both are set. Returns also true in case one of them is not set.
+     *
+     * @param $constraints
+     *
+     * @return bool
+     */
+    protected function validateConstraintsOrder($constraints)
+    {
+        return !isset($constraints['minStringLength']) ||
+            !isset($constraints['maxStringLength']) ||
+            ($constraints['minStringLength'] <= $constraints['maxStringLength']);
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/Validator/StringLengthValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/StringLengthValidator.php
@@ -45,9 +45,17 @@ class StringLengthValidator extends Validator
             switch ($name) {
                 case 'minStringLength':
                 case 'maxStringLength':
-                    if ($value !== false && !is_integer($value)) {
+                    if ($value !== false && !is_integer($value) && !(null === $value)) {
                         $validationErrors[] = new ValidationError(
                             "Validator parameter '%parameter%' value must be of integer type",
+                            null,
+                            array(
+                                'parameter' => $name,
+                            )
+                        );
+                    } elseif ($value < 0) {
+                        $validationErrors[] = new ValidationError(
+                            "Validator parameter '%parameter%' value can't be negative",
                             null,
                             array(
                                 'parameter' => $name,


### PR DESCRIPTION
Fixes https://jira.ez.no/browse/EZP-25342

Related pr https://github.com/ezsystems/repository-forms/pull/66 even is not mandatory to merge one before the other. 

ping @bdunogier @andrerom @lolautruche 