### PR TITLE
Update eZ Platform doc url

### DIFF
--- a/data/cleandata.sql
+++ b/data/cleandata.sql
@@ -1864,9 +1864,9 @@ INSERT INTO `ezsection` (`id`, `identifier`, `locale`, `name`, `navigation_part_
 INSERT INTO `ezsite_data` (`name`, `value`) VALUES ('ezpublish-release','1');
 INSERT INTO `ezsite_data` (`name`, `value`) VALUES ('ezpublish-version','6.0.0');
 
-INSERT INTO `ezurl` (`created`, `id`, `is_valid`, `last_checked`, `modified`, `original_url_md5`, `url`) VALUES (1448832197,23,1,0,1448832197,'b728a39b2818dc1a558b07b9e8b7aef0','https://doc.ez.no/display/USERGUIDE/eZ+User+Manual');
-INSERT INTO `ezurl` (`created`, `id`, `is_valid`, `last_checked`, `modified`, `original_url_md5`, `url`) VALUES (1448832277,24,1,0,1448832277,'d77b69a7ce26e6c87a7253f1fc50fc10','https://doc.ez.no/display/EZP/eZ+Platform+Developer+Documentation');
-INSERT INTO `ezurl` (`created`, `id`, `is_valid`, `last_checked`, `modified`, `original_url_md5`, `url`) VALUES (1448832412,25,1,0,1448832412,'fefcd099533d694500430bed1a32ca5b','https://doc.ez.no/display/EZP/Beginner+Tutorial');
+INSERT INTO `ezurl` (`created`, `id`, `is_valid`, `last_checked`, `modified`, `original_url_md5`, `url`) VALUES (1448832197,23,1,0,1448832197,'b728a39b2818dc1a558b07b9e8b7aef0','https://doc.ez.no/display/USERGUIDE/');
+INSERT INTO `ezurl` (`created`, `id`, `is_valid`, `last_checked`, `modified`, `original_url_md5`, `url`) VALUES (1448832277,24,1,0,1448832277,'d77b69a7ce26e6c87a7253f1fc50fc10','https://doc.ez.no/display/TECHDOC/');
+INSERT INTO `ezurl` (`created`, `id`, `is_valid`, `last_checked`, `modified`, `original_url_md5`, `url`) VALUES (1448832412,25,1,0,1448832412,'fefcd099533d694500430bed1a32ca5b','https://doc.ez.no/display/TECHDOC/Beginner+Tutorial');
 INSERT INTO `ezurl` (`created`, `id`, `is_valid`, `last_checked`, `modified`, `original_url_md5`, `url`) VALUES (1448832436,26,1,0,1448832436,'180577afbb87b0e2cfcb6758c62dfd5f','https://doc.ez.no/display/MAIN/Transitioning+from+eZ+Publish+to+eZ+Platform+and+eZ+Studio%3A+Feature+Comparison');
 INSERT INTO `ezurl` (`created`, `id`, `is_valid`, `last_checked`, `modified`, `original_url_md5`, `url`) VALUES (1448832661,27,1,0,1448832661,'f9bf96304c434139d0ff5773b6eee157','https://github.com/ezsystems');
 INSERT INTO `ezurl` (`created`, `id`, `is_valid`, `last_checked`, `modified`, `original_url_md5`, `url`) VALUES (1448832661,28,1,0,1448832661,'265d537bfba0e5ed4e85fbcd7f30ea84','http://share.ez.no');


### PR DESCRIPTION
Update to use the final place for the technical documentation, also only point to space when pointing to front page to avoid issues if frontpage is renamed.