### PR TITLE
Remove trailing slash on the siteaccess root route generation

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/URI.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/URI.php
@@ -57,8 +57,8 @@ class URI extends Map implements URILexer
      */
     public function analyseLink($linkUri)
     {
-        // Joining slash between uriElements and actual linkUri must be present, except if $linkUri is empty.
-        $joiningSlash = empty($linkUri) ? '' : '/';
+        // Joining slash between uriElements and actual linkUri must be present, except if $linkUri is empty or is just the slash root.
+        $joiningSlash = empty($linkUri) || ($linkUri === '/') ? '' : '/';
         $linkUri = ltrim($linkUri, '/');
         // Removing query string to analyse as SiteAccess might be in it.
         $qsPos = strpos($linkUri, '?');


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-25453

Case:
When Matching siteaccess by Map\URI
And Generating the root URL
Then Getting a trailing slash

Proposal:
- Adding / to the check of $joiningSlash

Have a nice day.