### PR TITLE
EZP-25377 fix republish modifying publication date

### DIFF
--- a/doc/bc/changes-6.0.md
+++ b/doc/bc/changes-6.0.md
@@ -174,6 +174,9 @@ Changes affecting version compatibility with former or future versions.
   
 * Internal `limitationMap` repository service setting (for `RoleService`) has been renamed to `policyMap`.
 
+* Published date of the content behaviour has been changed to reflect the time of the publishing of the first version.
+  Before, if the publishedDate was not set manually, it was being set to the publishing time of the latest version.
+
 ## Deprecations
 
 * `eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger::purge()` is deprecated and will be removed in v6.1.

--- a/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
@@ -23,7 +23,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read boolean $published true if there exists a published version false otherwise
  * @property-read mixed $ownerId the user id of the owner of the Content object
  * @property-read \DateTime $modificationDate Content object modification date
- * @property-read \DateTime $publishedDate date of the last publish operation
+ * @property-read \DateTime $publishedDate date of the first publish
  * @property-read boolean $alwaysAvailable Indicates if the Content object is shown in the mainlanguage if its not present in an other requested language
  * @property-read string $remoteId a global unique id of the Content object
  * @property-read string $mainLanguageCode The main language code of the Content object. If the available flag is set to true the Content is shown in this language if the requested language does not exist.

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1444,7 +1444,7 @@ class ContentService implements ContentServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is not a draft
      *
      * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
-     * @param int|null $publicationDate
+     * @param int|null $publicationDate If null existing date is kept if there is one, otherwise current time is used.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content
      */
@@ -1454,9 +1454,13 @@ class ContentService implements ContentServiceInterface
             throw new BadStateException('$versionInfo', 'Only versions in draft status can be published.');
         }
 
+        if ($publicationDate === null && $versionInfo->versionNo === 1) {
+            $publicationDate = time();
+        }
+
         $metadataUpdateStruct = new SPIMetadataUpdateStruct();
-        $metadataUpdateStruct->publicationDate = isset($publicationDate) ? $publicationDate : time();
-        $metadataUpdateStruct->modificationDate = $metadataUpdateStruct->publicationDate;
+        $metadataUpdateStruct->publicationDate = $publicationDate;
+        $metadataUpdateStruct->modificationDate = time();
 
         $spiContent = $this->persistenceHandler->contentHandler()->publish(
             $versionInfo->getContentInfo()->id,

--- a/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentBase.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentBase.php
@@ -1544,6 +1544,39 @@ abstract class ContentBase extends BaseServiceTest
         $this->assertGreaterThanOrEqual($time, $publishedContent->contentInfo->modificationDate->getTimestamp());
     }
 
+    public function testPublishVersionDoesNotChangePublishedDate()
+    {
+        list($draftContent, $contentType) = $this->createTestContent();
+
+        $contentService = $this->repository->getContentService();
+
+        $versionInfo = $contentService->loadVersionInfoById(
+            $draftContent->id,
+            $draftContent->getVersionInfo()->versionNo
+        );
+
+        $publishedContent = $contentService->publishVersion($versionInfo);
+
+        sleep(1);
+
+        /* BEGIN: Use Case */
+        $contentDraft = $contentService->createContentDraft($publishedContent->contentInfo);
+        $contentUpdateStruct = $contentService->newContentUpdateStruct();
+        $contentUpdateStruct->initialLanguageCode = 'eng-GB';
+        $contentDraft = $contentService->updateContent($contentDraft->versionInfo, $contentUpdateStruct);
+        $republishedContent = $contentService->publishVersion($contentDraft->versionInfo);
+        /* END: Use Case */
+
+        $this->assertEquals(
+            $publishedContent->contentInfo->publishedDate->getTimestamp(),
+            $republishedContent->contentInfo->publishedDate->getTimestamp()
+        );
+        $this->assertGreaterThan(
+            $publishedContent->contentInfo->modificationDate->getTimestamp(),
+            $republishedContent->contentInfo->modificationDate->getTimestamp()
+        );
+    }
+
     /**
      * Test for the publishVersion() method.
      *

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -5611,9 +5611,13 @@ class ContentTest extends BaseServiceMockTest
                 )
             );
 
+        if ($publicationDate === null && $versionInfoMock->versionNo === 1) {
+            $publicationDate = time();
+        }
+
         // Account for 1 second of test execution time
-        $metadataUpdateStruct->publicationDate = isset($publicationDate) ? $publicationDate : time();
-        $metadataUpdateStruct->modificationDate = $metadataUpdateStruct->publicationDate;
+        $metadataUpdateStruct->publicationDate = $publicationDate;
+        $metadataUpdateStruct->modificationDate = time();
         $metadataUpdateStruct2 = clone $metadataUpdateStruct;
         ++$metadataUpdateStruct2->publicationDate;
         ++$metadataUpdateStruct2->modificationDate;


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-25377

When publishing existing content (creating new version) with the PAPI, the publication date of the content gets the current datetime, same as modification date. While modification date behavior is correct, the publish date of the content should remain unchanged to reflect the original (first) publish date of the content.

Publishing from legacy administration does just that - changes only modification date.

To reproduce:
- load content
- create draft
- modify content with updatestruct
- publish new draft

Expected outcome: original content and republished content have the same publishedDate but different modificationDate.
Actual outcome: republished content has different publishedDate than original content.

I have added the regression test, but please do let me know if it's ok, and in the right place.