### PR TITLE
EZP-25334: Missing PermissionSubtree Criterion Visitor on Solr

### DIFF
--- a/eZ/Publish/Core/Limitation/Tests/SubtreeLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/SubtreeLimitationTypeTest.php
@@ -558,6 +558,8 @@ class SubtreeLimitationTypeTest extends Base
             $this->getUserMock()
         );
 
+        // Assert that $criterion is instance of API type (for Solr/ES), and internal type(optimization for SQL engines)
+        self::assertInstanceOf('eZ\\Publish\\API\\Repository\\Values\\Content\\Query\\Criterion\\Subtree', $criterion);
         self::assertInstanceOf(
             'eZ\\Publish\\Core\\Repository\\Values\\Content\\Query\\Criterion\\PermissionSubtree',
             $criterion
@@ -580,6 +582,8 @@ class SubtreeLimitationTypeTest extends Base
             $this->getUserMock()
         );
 
+        // Assert that $criterion is instance of API type (for Solr/ES), and internal type(optimization for SQL engines)
+        self::assertInstanceOf('eZ\\Publish\\API\\Repository\\Values\\Content\\Query\\Criterion\\Subtree', $criterion);
         self::assertInstanceOf(
             'eZ\\Publish\\Core\\Repository\\Values\\Content\\Query\\Criterion\\PermissionSubtree',
             $criterion

--- a/eZ/Publish/Core/Repository/Values/Content/Query/Criterion/PermissionSubtree.php
+++ b/eZ/Publish/Core/Repository/Values/Content/Query/Criterion/PermissionSubtree.php
@@ -10,58 +10,19 @@
  */
 namespace eZ\Publish\Core\Repository\Values\Content\Query\Criterion;
 
-use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
-use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
-use InvalidArgumentException;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree as APISubtreeCriterion;
 
 /**
  * Criterion that matches content that belongs to a given (list of) Subtree(s).
  *
  * Content will be matched if it is part of at least one of the given subtree path strings
  *
- * @internal This is intended for use by permission system only!
- *
+ * This is a internal subtree criterion intended for use by permission system (SubtreeLimitationType) only!
+ * And will be applied by SQL based search engines on Content Search to avoid performance problems.
  * @see https://jira.ez.no/browse/EZP-23037
  */
-class PermissionSubtree extends Criterion implements CriterionInterface
+class PermissionSubtree extends APISubtreeCriterion
 {
-    /**
-     * Creates a new SubTree criterion.
-     *
-     * @param string|string[] $value an array of subtree path strings, eg: /1/2/
-     *
-     * @throws InvalidArgumentException if a non path string is given
-     * @throws InvalidArgumentException if the value type doesn't match the operator
-     */
-    public function __construct($value)
-    {
-        foreach ((array)$value as $pathString) {
-            if (preg_match('/^(\/\w+)+\/$/', $pathString) !== 1) {
-                throw new InvalidArgumentException("value '$pathString' must follow the pathString format, eg /1/2/");
-            }
-        }
-
-        parent::__construct(null, null, $value);
-    }
-
-    public function getSpecifications()
-    {
-        return array(
-            new Specifications(
-                Operator::EQ,
-                Specifications::FORMAT_SINGLE,
-                Specifications::TYPE_STRING
-            ),
-            new Specifications(
-                Operator::IN,
-                Specifications::FORMAT_ARRAY,
-                Specifications::TYPE_STRING
-            ),
-        );
-    }
-
     public static function createFromQueryBuilder($target, $operator, $value)
     {
         return new self($value);

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/SubtreeIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/CriterionVisitor/SubtreeIn.php
@@ -14,7 +14,6 @@ use eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher as D
 use eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitor;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
-use eZ\Publish\Core\Repository\Values\Content\Query\Criterion\PermissionSubtree;
 
 /**
  * Visits the Subtree criterion.
@@ -31,7 +30,7 @@ class SubtreeIn extends CriterionVisitor
     public function canVisit(Criterion $criterion)
     {
         return
-            ($criterion instanceof Criterion\Subtree || $criterion instanceof PermissionSubtree) &&
+            $criterion instanceof Criterion\Subtree &&
             (
                 ($criterion->operator ?: Operator::IN) === Operator::IN ||
                 $criterion->operator === Operator::EQ

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/SubtreeIn.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Location/CriterionVisitor/SubtreeIn.php
@@ -14,7 +14,6 @@ use eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitorDispatcher as D
 use eZ\Publish\Core\Search\Elasticsearch\Content\CriterionVisitor;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
-use eZ\Publish\Core\Repository\Values\Content\Query\Criterion\PermissionSubtree;
 
 /**
  * Visits the Subtree criterion.
@@ -31,7 +30,7 @@ class SubtreeIn extends CriterionVisitor
     public function canVisit(Criterion $criterion)
     {
         return
-            ($criterion instanceof Criterion\Subtree || $criterion instanceof PermissionSubtree) &&
+            $criterion instanceof Criterion\Subtree &&
             (
                 ($criterion->operator ?: Operator::IN) === Operator::IN ||
                 $criterion->operator === Operator::EQ

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Subtree.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Subtree.php
@@ -14,7 +14,6 @@ use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\Core\Persistence\Database\SelectQuery;
-use eZ\Publish\Core\Repository\Values\Content\Query\Criterion\PermissionSubtree;
 
 /**
  * Location subtree criterion handler.
@@ -30,7 +29,7 @@ class Subtree extends CriterionHandler
      */
     public function accept(Criterion $criterion)
     {
-        return ($criterion instanceof Criterion\Subtree || $criterion instanceof PermissionSubtree);
+        return $criterion instanceof Criterion\Subtree;
     }
 
     /**

--- a/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_content.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_content.yml
@@ -38,15 +38,18 @@ services:
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
 
-    ezpublish.search.legacy.gateway.criterion_handler.content.subtree:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
-        class: %ezpublish.search.legacy.gateway.criterion_handler.content.subtree.class%
-        tags:
-            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
-
+    # Needs to be before subtree, as permission_subtree extends it.
+    # Only needed for Content Search on SQL engines where applying Permissions Subtree criterion on all possible
+    # locations leads to peformance issues: https://jira.ez.no/browse/EZP-23037
     ezpublish.search.legacy.gateway.criterion_handler.content.permission_subtree:
         parent: ezpublish.search.legacy.gateway.criterion_handler.base
         class: %ezpublish.search.legacy.gateway.criterion_handler.content.permission_subtree.class%
+        tags:
+            - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
+
+    ezpublish.search.legacy.gateway.criterion_handler.content.subtree:
+        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        class: %ezpublish.search.legacy.gateway.criterion_handler.content.subtree.class%
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
 


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-25334

This replaces https://github.com/ezsystems/ezplatform-solr-search-engine/pull/34 by undoing e30d1de5c3ccefa563dc6760dd376199db4b2e4f that was done as part of #912.


Review ping @pspanja, input on how we can test to make sure right handler is used with Legacy SE? And should probably also find a way to cover subtree limitation on content and location search to make sure integration works.

Test ping @harmstyler


- [x] ~~More testing as described above~~
- [x] Can remove `$criterion instanceof Criterion\Subtree || $criterion instanceof PermissionSubtree` from legacy and solr now