### PR TITLE
Fix EZP-25375: Error when setting 00:00 on Time FieldType

### DIFF
--- a/eZ/Publish/Core/FieldType/Tests/TimeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/TimeTest.php
@@ -224,6 +224,10 @@ class TimeTest extends FieldTypeTest
                 null,
             ),
             array(
+                new TimeValue(0),
+                0,
+            ),
+            array(
                 new TimeValue(200),
                 200,
             ),
@@ -271,6 +275,10 @@ class TimeTest extends FieldTypeTest
             array(
                 null,
                 new TimeValue(),
+            ),
+            array(
+                0,
+                new TimeValue(0),
             ),
             array(
                 200,
@@ -374,5 +382,67 @@ class TimeTest extends FieldTypeTest
             array($this->getEmptyValueExpectation(), ''),
             array(new TimeValue(200), '12:03:20 am'),
         );
+    }
+
+    /**
+     * @param mixed $inputValue
+     * @param array $expectedResult
+     *
+     * This overrides the FieldTypeTest method until it gets updated and all field types fixed in EZP-25424
+     *
+     * @dataProvider provideInputForToHash
+     */
+    public function testToHash($inputValue, $expectedResult)
+    {
+        $fieldType = $this->getFieldTypeUnderTest();
+
+        $actualResult = $fieldType->toHash($inputValue);
+
+        $this->assertIsValidHashValue($actualResult);
+
+        if (is_object($expectedResult) || is_array($expectedResult)) {
+            $this->assertEquals(
+                $expectedResult,
+                $actualResult,
+                'toHash() method did not create expected result.'
+            );
+        } else {
+            $this->assertSame(
+                $expectedResult,
+                $actualResult,
+                'toHash() method did not create expected result.'
+            );
+        }
+    }
+
+    /**
+     * @param mixed $inputValue
+     * @param array $expectedResult
+     *
+     * This overrides the FieldTypeTest method until it gets updated and all field types fixed in EZP-25424
+     *
+     * @dataProvider provideInputForFromHash
+     */
+    public function testFromHash($inputHash, $expectedResult)
+    {
+        $this->assertIsValidHashValue($inputHash);
+
+        $fieldType = $this->getFieldTypeUnderTest();
+
+        $actualResult = $fieldType->fromHash($inputHash);
+
+        if (is_object($expectedResult) || is_array($expectedResult)) {
+            $this->assertEquals(
+                $expectedResult,
+                $actualResult,
+                'fromHash() method did not create expected result.'
+            );
+        } else {
+            $this->assertSame(
+                $expectedResult,
+                $actualResult,
+                'fromHash() method did not create expected result.'
+            );
+        }
     }
 }

--- a/eZ/Publish/Core/FieldType/Time/Type.php
+++ b/eZ/Publish/Core/FieldType/Time/Type.php
@@ -154,6 +154,23 @@ class Type extends FieldType
     }
 
     /**
+     * Returns if the given $value is considered empty by the field type.
+     *
+     *
+     * @param \eZ\Publish\Core\FieldType\Value $value
+     *
+     * @return bool
+     */
+    public function isEmptyValue(SPIValue $value)
+    {
+        if ($value->time === null) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Converts a $Value to a hash.
      *
      * @param \eZ\Publish\Core\FieldType\Time\Value $value


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-25375

## Description
In order to fix this issue I first created a PR on the PlatformUIBundle https://github.com/ezsystems/PlatformUIBundle/pull/501

Then I ran into the kernel bug on the Time FieldType. I had to override the `isEmptyValue()` to take care of the specificity of the `Value` of the Time FieldType.

Trying to unit test this bug, I ran into an Assert bug on type comparison, which was hiding the actual bug. Fixing the unit test bug led into revealing other FieldType bugs (TextLine, TextBlock and Email) which will be dealt with in https://jira.ez.no/browse/EZP-25424.

## Test
Unit test and manual test on Time field.