### PR TITLE
[dependencies] be more flexible on behat-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "0.*",
         "mockery/mockery": "~0.9.4",
         "symfony/assetic-bundle": "~2.3",
-        "ezsystems/behatbundle": "^6.2@dev"
+        "ezsystems/behatbundle": "^6.1@dev"
     },
     "replace": {
         "ezsystems/ezpublish": "*",


### PR DESCRIPTION
Need to accept `ezsystems/behat-bundle` 6.2 (dependencies injection support), even though it is not used by the kernel yet.