### PR TITLE
Fixed href parsing in REST limitation value

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
@@ -65,6 +65,9 @@ parameters:
     ezpublish_rest.input.parser.internal.criterion.UserMetadata.class: eZ\Publish\Core\REST\Server\Input\Parser\Criterion\UserMetadata
     ezpublish_rest.input.parser.internal.criterion.Visibility.class: eZ\Publish\Core\REST\Server\Input\Parser\Criterion\Visibility
 
+    ezpublish_rest.input.parser.internal.route_based_limitation.class: eZ\Publish\Core\REST\Server\Input\Parser\Limitation\RouteBasedLimitationParser
+    ezpublish_rest.input.parser.internal.path_string_route_based_limitation.class: eZ\Publish\Core\REST\Server\Input\Parser\Limitation\PathStringRouteBasedLimitationParser
+
     # REST client
     ezpublish_rest.input.parser.Content.class: eZ\Publish\Core\REST\Client\Input\Parser\Content
     ezpublish_rest.input.parser.ContentInfo.class: eZ\Publish\Core\REST\Client\Input\Parser\ContentInfo
@@ -563,6 +566,26 @@ services:
         class: %ezpublish_rest.input.parser.internal.criterion.Visibility.class%
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.Visibility }
+
+    # role limitation parsers
+
+    ezpublish_rest.input.parser.internal.limitation.Subtree:
+        parent: ezpublish_rest.input.parser
+        class: %ezpublish_rest.input.parser.internal.path_string_route_based_limitation.class%
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.limitation.Subtree }
+        arguments:
+            - 'locationPath'
+            - 'eZ\Publish\API\Repository\Values\User\Limitation\SubtreeLimitation'
+
+    ezpublish_rest.input.parser.internal.limitation.Section:
+        parent: ezpublish_rest.input.parser
+        class: %ezpublish_rest.input.parser.internal.route_based_limitation.class%
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.limitation.Section }
+        arguments:
+            - 'sectionId'
+            - 'eZ\Publish\API\Repository\Values\User\Limitation\SectionLimitation'
 
     # Rest client
 

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RoleTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RoleTest.php
@@ -683,7 +683,7 @@ XML;
     }
 
     /**
-     * Creates and published a role with $identifier.
+     * Creates and publishes a role with $identifier.
      *
      * @param string $identifier
      *
@@ -706,7 +706,7 @@ XML;
 XML;
         $request = $this->createHttpRequest(
             'POST',
-            '/api/ezp/v2/user/roles?publish=false',
+            '/api/ezp/v2/user/roles',
             'RoleInput+xml',
             'RoleDraft+json'
         );
@@ -716,17 +716,6 @@ XML;
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        $href = $response->getHeader('Location');
-        $this->addCreatedElement($href);
-
-        $roleDraftHref = $href . '/draft';
-
-        $response = $this->sendHttpRequest(
-            $this->createHttpRequest('PUBLISH', $roleDraftHref)
-        );
-
-        self::assertHttpResponseCodeEquals($response, 201);
-
-        return $href;
+        return $response->getHeader('Location');
     }
 }

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RoleTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RoleTest.php
@@ -11,6 +11,7 @@
 namespace eZ\Bundle\EzPublishRestBundle\Tests\Functional;
 
 use eZ\Bundle\EzPublishRestBundle\Tests\Functional\TestCase as RESTFunctionalTestCase;
+use eZ\Publish\API\Repository\Values\User\Limitation;
 
 class RoleTest extends RESTFunctionalTestCase
 {
@@ -385,14 +386,49 @@ XML;
      */
     public function testAssignRoleToUser($roleHref)
     {
-        self::markTestSkipped('@todo fixme');
         $xml = <<< XML
 <?xml version="1.0" encoding="UTF-8"?>
 <RoleAssignInput>
   <Role href="{$roleHref}" media-type="application/vnd.ez.api.RoleAssignInput+xml"/>
-  <limitation identifier="Section">
+</RoleAssignInput>
+XML;
+
+        $request = $this->createHttpRequest(
+            'POST',
+            '/api/ezp/v2/user/users/10/roles',
+            'RoleAssignInput+xml',
+            'RoleAssignmentList+json'
+        );
+        $request->setContent($xml);
+
+        $response = $this->sendHttpRequest($request);
+        $roleAssignmentArray = json_decode($response->getContent(), true);
+
+        self::assertHttpResponseCodeEquals($response, 200);
+
+        return $roleAssignmentArray['RoleAssignmentList']['RoleAssignment'][0]['_href'];
+    }
+
+    /**
+     * @covers       POST /user/users/{userId}/roles
+     *
+     * @param string $roleHref
+     * @param array $limitation
+     *
+     * @return string assigned role href
+     * @dataProvider provideLimitations
+     */
+    public function testAssignRoleToUserWithLimitation(array $limitation)
+    {
+        $roleHref = $this->createAndPublishRole(__METHOD__ . '_' . $limitation['identifier']);
+
+        $xml = <<< XML
+<?xml version="1.0" encoding="UTF-8"?>
+<RoleAssignInput>
+  <Role href="{$roleHref}" media-type="application/vnd.ez.api.RoleAssignInput+xml"/>
+  <limitation identifier="{$limitation['identifier']}">
       <values>
-          <ref href="/api/ezp/v2/content/sections/1" media-type="application/vnd.ez.api.Section+xml" />
+          <ref href="{$limitation['href']}" media-type="application/vnd.ez.api.{$limitation['identifier']}+xml" />
       </values>
   </limitation>
 </RoleAssignInput>
@@ -412,6 +448,14 @@ XML;
         self::assertHttpResponseCodeEquals($response, 200);
 
         return $roleAssignmentArray['RoleAssignmentList']['RoleAssignment'][0]['_href'];
+    }
+
+    public function provideLimitations()
+    {
+        return [
+            [['identifier' => 'Section', 'href' => '/api/ezp/v2/content/sections/1']],
+            [['identifier' => 'Subtree', 'href' => '/api/ezp/v2/content/locations/1/2']],
+        ];
     }
 
     /**
@@ -448,7 +492,6 @@ XML;
      */
     public function testAssignRoleToUserGroup($roleHref)
     {
-        self::markTestSkipped('@todo fixme');
         $xml = <<< XML
 <?xml version="1.0" encoding="UTF-8"?>
 <RoleAssignInput>
@@ -632,5 +675,53 @@ XML;
     private function roleDraftHrefToRoleHref($roleDraftHref)
     {
         return str_replace('/draft', '', $roleDraftHref);
+    }
+
+    /**
+     * Creates and published a role with $identifier.
+     *
+     * @param string $identifier
+     *
+     * @return string The href of the published role
+     */
+    private function createAndPublishRole($identifier)
+    {
+        $xml = <<< XML
+<?xml version="1.0" encoding="UTF-8"?>
+<RoleInput>
+  <identifier>$identifier</identifier>
+  <mainLanguageCode>eng-GB</mainLanguageCode>
+  <names>
+    <value languageCode="eng-GB">$identifier</value>
+  </names>
+  <descriptions>
+    <value languageCode="eng-GB">$identifier description</value>
+  </descriptions>
+</RoleInput>
+XML;
+        $request = $this->createHttpRequest(
+            'POST',
+            '/api/ezp/v2/user/roles?publish=false',
+            'RoleInput+xml',
+            'RoleDraft+json'
+        );
+        $request->setContent($xml);
+        $response = $this->sendHttpRequest($request);
+
+        self::assertHttpResponseCodeEquals($response, 201);
+        self::assertHttpResponseHasHeader($response, 'Location');
+
+        $href = $response->getHeader('Location');
+        $this->addCreatedElement($href);
+
+        $roleDraftHref = $href . '/draft';
+
+        $response = $this->sendHttpRequest(
+            $this->createHttpRequest('PUBLISH', $roleDraftHref)
+        );
+
+        self::assertHttpResponseCodeEquals($response, 201);
+
+        return $href;
     }
 }

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/TestCase.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/TestCase.php
@@ -76,12 +76,13 @@ class TestCase extends PHPUnit_Framework_TestCase
         $responseCode = $response->getStatusCode();
         if ($responseCode != $expected) {
             $errorMessageString = '';
-            if ($response->getHeader('Content-Type') == 'application/vnd.ez.api.ErrorMessage+xml') {
+            if (strpos($response->getHeader('Content-Type'), 'application/vnd.ez.api.ErrorMessage+xml') !== false) {
                 $body = \simplexml_load_string($response->getContent());
                 $errorMessageString = $body->errorDescription;
-            } elseif (($response->getHeader('Content-Type') == 'application/vnd.ez.api.ErrorMessage+json')) {
+            } elseif (strpos($response->getHeader('Content-Type'), 'application/vnd.ez.api.ErrorMessage+json') !== false) {
                 $body = json_decode($response->getContent());
-                $errorMessageString = "Error message: {$body->ErrorMessage->errorDescription}";
+                $errorMessageString = "Error message: {$body->ErrorMessage->errorDescription}\n" .
+                    "In {$body->ErrorMessage->file}:{$body->ErrorMessage->line}";
             }
 
             self::assertEquals($expected, $responseCode, $errorMessageString);

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Limitation/PathStringRouteBasedLimitationParser.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Limitation/PathStringRouteBasedLimitationParser.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Input\Parser\Limitation;
+
+use eZ\Publish\API\Repository\Values;
+
+/**
+ * Generic limitation value parser.
+ *
+ * Instances are built with:
+ * - The name of a route parameter, that will be searched for limitation values
+ *   Example: "sectionId" from "/content/section/{sectionId}"
+ * - The FQN of the limitation value object that the parser builds
+ */
+class PathStringRouteBasedLimitationParser extends RouteBasedLimitationParser
+{
+    /**
+     * Prefixes the value parsed by the parent with a '/'.
+     *
+     * @param $limitationValue
+     *
+     * @return false|mixed
+     */
+    protected function parseIdFromHref($limitationValue)
+    {
+        return '/' . ltrim(parent::parseIdFromHref($limitationValue), '/');
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Limitation/RouteBasedLimitationParser.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Limitation/RouteBasedLimitationParser.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Input\Parser\Limitation;
+
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
+use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
+use eZ\Publish\Core\REST\Common\Exceptions;
+use eZ\Publish\API\Repository\Values;
+
+/**
+ * Generic limitation value parser.
+ *
+ * Instances are built with:
+ * - The name of a route parameter, that will be searched for limitation values
+ *   Example: "sectionId" from "/content/section/{sectionId}"
+ * - The FQN of the limitation value object that the parser builds
+ */
+class RouteBasedLimitationParser extends BaseParser
+{
+    /**
+     * Name of the route parameter.
+     * Example: "sectionId".
+     * @var string
+     */
+    private $limitationRouteParameterName;
+
+    /**
+     * Value object class built by the Parser.
+     * Example: "eZ\Publish\API\Repository\Values\User\Limitation\SectionLimitation".
+     * @var string
+     */
+    private $limitationClass;
+
+    /**
+     * LimitationParser constructor.
+     *
+     * @param string $limitationRouteParameterName
+     * @param string $limitationClass
+     */
+    public function __construct($limitationRouteParameterName, $limitationClass)
+    {
+        $this->limitationRouteParameterName = $limitationRouteParameterName;
+        $this->limitationClass = $limitationClass;
+    }
+
+    /**
+     * Parse input structure.
+     *
+     * @param array $data
+     * @param \eZ\Publish\Core\REST\Common\Input\ParsingDispatcher $parsingDispatcher
+     *
+     * @return \eZ\Publish\API\Repository\Values\ValueObject
+     */
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher)
+    {
+        if (!array_key_exists('_identifier', $data)) {
+            throw new Exceptions\Parser("Missing '_identifier' attribute for Limitation.");
+        }
+
+        $limitationObject = $this->buildLimitation();
+
+        if (!isset($data['values']['ref']) || !is_array($data['values']['ref'])) {
+            throw new Exceptions\Parser('Invalid format for data values in Limitation.');
+        }
+
+        foreach ($data['values']['ref'] as $limitationValue) {
+            if (!array_key_exists('_href', $limitationValue)) {
+                throw new Exceptions\Parser('Invalid format for data values in Limitation.');
+            }
+
+            $limitationObject->limitationValues[] = $this->parseIdFromHref($limitationValue);
+        }
+
+        return $limitationObject;
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\User\Limitation
+     */
+    protected function buildLimitation()
+    {
+        return new $this->limitationClass();
+    }
+
+    /**
+     * @param $limitationValue
+     *
+     * @return false|mixed
+     */
+    protected function parseIdFromHref($limitationValue)
+    {
+        return $this->requestParser->parseHref(
+            $limitationValue['_href'],
+            $this->limitationRouteParameterName
+        );
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Input/Parser/RoleAssignInput.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/RoleAssignInput.php
@@ -65,7 +65,14 @@ class RoleAssignInput extends BaseParser
         // @todo XSD says that limitation is mandatory, but roles can be assigned without limitations
         $limitation = null;
         if (array_key_exists('limitation', $data) && is_array($data['limitation'])) {
-            $limitation = $this->parserTools->parseLimitation($data['limitation']);
+            if (!array_key_exists('_identifier', $data['limitation'])) {
+                throw new Exceptions\Parser("Missing '_identifier' attribute for Limitation.");
+            }
+
+            $limitation = $parsingDispatcher->parse(
+                $data['limitation'],
+                'application/vnd.ez.api.internal.limitation.'  . $data['limitation']['_identifier']
+            );
         }
 
         return new RoleAssignment($roleId, $limitation);

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/Limitation/PathStringRouteBasedLimitationParserTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/Limitation/PathStringRouteBasedLimitationParserTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser\Limitation;
+
+use eZ\Publish\Core\REST\Server\Input\Parser\Limitation\PathStringRouteBasedLimitationParser;
+use eZ\Publish\Core\REST\Server\Tests\Input\Parser\BaseTest;
+
+class PathStringRouteBasedLimitationParserTest extends BaseTest
+{
+    public function testParse()
+    {
+        $inputArray = [
+            '_identifier' => 'Subtree',
+            'values' => [
+                'ref' => [
+                    ['_href' => '/content/locations/1/2/3/4'],
+                ],
+            ],
+        ];
+
+        $result = $this->getParser()->parse($inputArray, $this->getParsingDispatcherMock());
+
+        self::assertInstanceOf('stdClass', $result);
+        self::assertObjectHasAttribute('limitationValues', $result);
+        self::assertArrayHasKey(0, $result->limitationValues);
+        self::assertEquals('/1/2/3/4', $result->limitationValues[0]);
+    }
+
+    /**
+     * Must return the tested parser object.
+     * @return \eZ\Publish\Core\REST\Server\Input\Parser\Limitation\RouteBasedLimitationParser
+     */
+    protected function internalGetParser()
+    {
+        return new PathStringRouteBasedLimitationParser('pathString', 'stdClass');
+    }
+
+    public function getParseHrefExpectationsMap()
+    {
+        return array(
+            array('/content/locations/1/2/3/4', 'pathString', '1/2/3/4'),
+        );
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/Limitation/RouteBasedLimitationParserTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/Limitation/RouteBasedLimitationParserTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser\Limitation;
+
+use eZ\Publish\Core\REST\Server\Input\Parser\Limitation\RouteBasedLimitationParser;
+use eZ\Publish\Core\REST\Server\Tests\Input\Parser\BaseTest;
+
+class RouteBasedLimitationParserTest extends BaseTest
+{
+    public function testParse()
+    {
+        $inputArray = [
+            '_identifier' => 'Section',
+            'values' => [
+                'ref' => [
+                    ['_href' => '/content/sections/42'],
+                ],
+            ],
+        ];
+
+        $result = $this->getParser()->parse($inputArray, $this->getParsingDispatcherMock());
+
+        self::assertInstanceOf('stdClass', $result);
+        self::assertObjectHasAttribute('limitationValues', $result);
+        self::assertArrayHasKey(0, $result->limitationValues);
+        self::assertEquals(42, $result->limitationValues[0]);
+    }
+
+    /**
+     * Must return the tested parser object.
+     * @return \eZ\Publish\Core\REST\Server\Input\Parser\Limitation\RouteBasedLimitationParser
+     */
+    protected function internalGetParser()
+    {
+        return new RouteBasedLimitationParser('sectionId', 'stdClass');
+    }
+
+    public function getParseHrefExpectationsMap()
+    {
+        return array(
+            array('/content/sections/42', 'sectionId', 42),
+        );
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/RoleAssignInputTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/RoleAssignInputTest.php
@@ -10,36 +10,33 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
+use eZ\Publish\API\Repository\Values\User\Limitation\SectionLimitation;
 use eZ\Publish\Core\REST\Server\Input\Parser\RoleAssignInput;
 
-class RoleAssignInputTest extends BaseTest
+class RoleAssignInputTwoDotZeroTest extends BaseTest
 {
     /**
      * Tests the RoleAssignInput parser.
      */
     public function testParse()
     {
-        $inputArray = array(
-            'Role' => array(
-                '_href' => '/user/roles/42',
-            ),
-            'limitation' => array(
-                '_identifier' => 'Section',
-                'values' => array(
-                    'ref' => array(
-                        array(
-                            '_href' => 1,
-                        ),
-                        array(
-                            '_href' => 2,
-                        ),
-                        array(
-                            '_href' => 3,
-                        ),
-                    ),
-                ),
-            ),
-        );
+        $limitation = [
+            '_identifier' => 'Section',
+            'values' => [
+                'ref' => [['_href' => '/content/sections/1']],
+            ],
+        ];
+
+        $inputArray = [
+            'Role' => ['_href' => '/user/roles/42'],
+            'limitation' => $limitation,
+        ];
+
+        $this->getParsingDispatcherMock()
+            ->expects($this->once())
+            ->method('parse')
+            ->with($limitation, 'application/vnd.ez.api.internal.limitation.Section')
+            ->will($this->returnValue(new SectionLimitation()));
 
         $roleAssignInput = $this->getParser();
         $result = $roleAssignInput->parse($inputArray, $this->getParsingDispatcherMock());
@@ -61,18 +58,6 @@ class RoleAssignInputTest extends BaseTest
             $result->limitation,
             'Limitation not created correctly.'
         );
-
-        $this->assertEquals(
-            'Section',
-            $result->limitation->getIdentifier(),
-            'Limitation identifier not created correctly.'
-        );
-
-        $this->assertEquals(
-            array(1, 2, 3),
-            $result->limitation->limitationValues,
-            'Limitation values not created correctly.'
-        );
     }
 
     /**
@@ -89,13 +74,13 @@ class RoleAssignInputTest extends BaseTest
                 'values' => array(
                     'ref' => array(
                         array(
-                            '_href' => 1,
+                            '_href' => '/content/sections/1',
                         ),
                         array(
-                            '_href' => 2,
+                            '_href' => '/content/sections/2',
                         ),
                         array(
-                            '_href' => 3,
+                            '_href' => '/content/sections/3',
                         ),
                     ),
                 ),
@@ -121,13 +106,13 @@ class RoleAssignInputTest extends BaseTest
                 'values' => array(
                     'ref' => array(
                         array(
-                            '_href' => 1,
+                            '_href' => '/content/sections/1',
                         ),
                         array(
-                            '_href' => 2,
+                            '_href' => '/content/sections/2',
                         ),
                         array(
-                            '_href' => 3,
+                            '_href' => '/content/sections/3',
                         ),
                     ),
                 ),
@@ -154,37 +139,16 @@ class RoleAssignInputTest extends BaseTest
                 'values' => array(
                     'ref' => array(
                         array(
-                            '_href' => 1,
+                            '_href' => '/content/sections/1',
                         ),
                         array(
-                            '_href' => 2,
+                            '_href' => '/content/sections/2',
                         ),
                         array(
-                            '_href' => 3,
+                            '_href' => '/content/sections/3',
                         ),
                     ),
                 ),
-            ),
-        );
-
-        $roleAssignInput = $this->getParser();
-        $roleAssignInput->parse($inputArray, $this->getParsingDispatcherMock());
-    }
-
-    /**
-     * Test Limitation parser throwing exception on missing values.
-     *
-     * @expectedException \eZ\Publish\Core\REST\Common\Exceptions\Parser
-     * @expectedExceptionMessage Invalid format for limitation values in Limitation.
-     */
-    public function testParseExceptionOnMissingLimitationValues()
-    {
-        $inputArray = array(
-            'Role' => array(
-                '_href' => '/user/roles/42',
-            ),
-            'limitation' => array(
-                '_identifier' => 'Section',
             ),
         );
 

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/RoleAssignInputTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/RoleAssignInputTest.php
@@ -13,7 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 use eZ\Publish\API\Repository\Values\User\Limitation\SectionLimitation;
 use eZ\Publish\Core\REST\Server\Input\Parser\RoleAssignInput;
 
-class RoleAssignInputTwoDotZeroTest extends BaseTest
+class RoleAssignInputTest extends BaseTest
 {
     /**
      * Tests the RoleAssignInput parser.


### PR DESCRIPTION
> Fixes REST blocker https://jira.ez.no/browse/EZP-25539
> Status: ready for review

REST limitation values reference another value object, depending on the limitation type (section, etc).
The spec says that those references are expected to be hrefs (`/content/sections/2`), but the current implementation uses raw ids (`2`).

### Tech background
This PR fixes it by introducing LimitationValue parsers for `Section` and `Subtree` (limitation types supported by `RoleAssignment` with limitation). They both use a `RouteBasedLimitationParser`, that parses the limitation value id using the router.

### Tasks
- [ ] ~~Fix the same problem in REST responses~~
- [x] Refactor limitation parsing to use dedicated InputParsers instead of a method in `ParserTools`
- [x] Implement the [other parsers](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/REST/Common/Input/ParserTools.php#L230-L267)
- [x] Finish fixing role tests (create a dedicated role for assignment with limitation test)
- [x] Remove `LimitationValue ` parsing from `RoleAssignInputTest` (covered by dedicated services with their own tests)
- [x] ~~Think about BC: even though the current behaviour is wrong, changing it is still a BC break. The easiest option is to create a new version of the media-types affected by this. Might involve quite some changes to the PR.~~