### PR TITLE
Fix EZP-25452: UTF-8 issue in ContentObject name generation

### DIFF
--- a/eZ/Publish/Core/Repository/Helper/NameSchemaService.php
+++ b/eZ/Publish/Core/Repository/Helper/NameSchemaService.php
@@ -193,7 +193,7 @@ class NameSchemaService
 
             // Make sure length is not longer then $limit unless it's 0
             if ($this->settings['limit'] && strlen($name) > $this->settings['limit']) {
-                $name = rtrim(substr($name, 0, $this->settings['limit'] - strlen($this->settings['sequence']))) . $this->settings['sequence'];
+                $name = rtrim(mb_substr($name, 0, $this->settings['limit'] - strlen($this->settings['sequence']), 'UTF-8')) . $this->settings['sequence'];
             }
 
             $names[$languageCode] = $name;


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-25452

## Description
Name string with trailing UTF-8 characters are now properly handled with `mb_substr` and explicit `UTF-8` encoding