### PR TITLE
EZP-25454: Limit sort key string to avoid strict errors on MySQL 5.7

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -697,7 +697,7 @@ class DoctrineDatabase extends Gateway
             $q->bindValue($value->sortKeyInt, null, \PDO::PARAM_INT)
         )->set(
             $this->dbHandler->quoteColumn('sort_key_string'),
-            $q->bindValue($value->sortKeyString)
+            $q->bindValue(mb_substr($value->sortKeyString, 0, 255))
         )->set(
             $this->dbHandler->quoteColumn('language_id'),
             $q->bindValue(
@@ -778,7 +778,7 @@ class DoctrineDatabase extends Gateway
             $q->bindValue($value->sortKeyInt, null, \PDO::PARAM_INT)
         )->set(
             $this->dbHandler->quoteColumn('sort_key_string'),
-            $q->bindValue($value->sortKeyString)
+            $q->bindValue(mb_substr($value->sortKeyString, 0, 255))
         );
     }
 


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-25454

Fixes:
```
  [PDOException]                                                                                           
  SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'sort_key_string' at row 1
```