### PR TITLE
EZP-25448: RichText field does not accept element with 2 classes

### DIFF
--- a/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng
@@ -611,9 +611,7 @@
     <define name="db.link.attlist" combine="interleave"><ref name="ez.xhtml.class.attribute"/></define>
     <define name="ez.xhtml.class.attribute">
       <optional>
-        <attribute name="ezxhtml:class">
-          <data type="string"><param name="pattern">[A-Za-z][A-Za-z0-9_\-]*</param></data>
-        </attribute>
+        <attribute name="ezxhtml:class"><text/></attribute>
       </optional>
     </define>
   </div>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Validator/DocbookTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Validator/DocbookTest.php
@@ -51,6 +51,14 @@ class DocbookTest extends PHPUnit_Framework_TestCase
 ',
                 array(),
             ),
+            array(
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <para ezxhtml:class="">Nada Surf - Happy Kid</para>
+</section>
+',
+                array(),
+            ),
         );
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Validator/DocbookTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Validator/DocbookTest.php
@@ -43,6 +43,14 @@ class DocbookTest extends PHPUnit_Framework_TestCase
                     'ezlink must not occur in the descendants of link',
                 ),
             ),
+            array(
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <para ezxhtml:class="listening loud indie rock">Nada Surf - Happy Kid</para>
+</section>
+',
+                array(),
+            ),
         );
     }
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25448 (and https://jira.ez.no/browse/EZP-25028)

# Description

While working on https://github.com/ezsystems/PlatformUIBundle/pull/510, I found that the RichText field does not accept element with 2 (or more) classes. This patch fixes that issue by changing the `ezpublish.rng` schema so that the `ezxhtml:class` accepts any `CDATA` (see `class` attribute definition in the XHTML1 DTD https://www.w3.org/TR/xhtml1/dtds.html#a_dtd_XHTML-1.0-Strict and http://relaxng.org/tutorial-20011203.html#IDA0FYR)

This also fixes EZP-25028 because thanks to this schema change, `ezxhtml:class` class also be empty.

# Tests

unit tests + manual test in https://github.com/ezsystems/PlatformUIBundle/pull/510