### PR TITLE
Fix EZP-24830: REST methods for role drafts

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
@@ -746,6 +746,14 @@ ezpublish_rest_createRole:
     methods: [POST]
     requirements:
 
+ezpublish_rest_createRoleDraft:
+    path: /user/roles/{roleId}
+    defaults:
+        _controller: ezpublish_rest.controller.role:createRoleDraft
+    methods: [POST]
+    requirements:
+        roleId: \d+
+
 ezpublish_rest_loadRole:
     path: /user/roles/{roleId}
     defaults:
@@ -758,6 +766,14 @@ ezpublish_rest_loadRoleDraft:
     path: /user/roles/{roleId}/draft
     defaults:
         _controller: ezpublish_rest.controller.role:loadRoleDraft
+    methods: [GET]
+    requirements:
+        roleId: \d+
+
+ezpublish_rest_loadRoleDraftByRoleId:
+    path: /user/roles/{roleId}/draftByRoleId
+    defaults:
+        _controller: ezpublish_rest.controller.role:loadRoleDraftByRoleId
     methods: [GET]
     requirements:
         roleId: \d+
@@ -794,6 +810,14 @@ ezpublish_rest_deleteRole:
     requirements:
         roleId: \d+
 
+ezpublish_rest_deleteRoleDraft:
+    path: /user/roles/{roleId}/draft
+    defaults:
+        _controller: ezpublish_rest.controller.role:deleteRoleDraft
+    methods: [DELETE]
+    requirements:
+        roleId: \d+
+
 ezpublish_rest_loadPolicies:
     path: /user/roles/{roleId}/policies
     defaults:
@@ -810,6 +834,14 @@ ezpublish_rest_addPolicy:
     requirements:
         roleId: \d+
 
+ezpublish_rest_addPolicyByRoleDraft:
+    path: /user/roles/{roleId}/policiesByRoleDraft
+    defaults:
+        _controller: ezpublish_rest.controller.role:addPolicyByRoleDraft
+    methods: [POST]
+    requirements:
+        roleId: \d+
+
 ezpublish_rest_deletePolicies:
     path: /user/roles/{roleId}/policies
     defaults:
@@ -817,6 +849,15 @@ ezpublish_rest_deletePolicies:
     methods: [DELETE]
     requirements:
         roleId: \d+
+
+ezpublish_rest_removePolicyByRoleDraft:
+    path: /user/roles/{roleId}/policiesByRoleDraft/{policyId}
+    defaults:
+        _controller: ezpublish_rest.controller.role:removePolicyByRoleDraft
+    methods: [DELETE]
+    requirements:
+        roleId: \d+
+        policyId: \d+
 
 ezpublish_rest_loadPolicy:
     path: /user/roles/{roleId}/policies/{policyId}
@@ -831,6 +872,15 @@ ezpublish_rest_updatePolicy:
     path: /user/roles/{roleId}/policies/{policyId}
     defaults:
         _controller: ezpublish_rest.controller.role:updatePolicy
+    methods: [PATCH]
+    requirements:
+        roleId: \d+
+        policyId: \d+
+
+ezpublish_rest_updatePolicyByRoleDraft:
+    path: /user/roles/{roleId}/policiesByRoleDraft/{policyId}
+    defaults:
+        _controller: ezpublish_rest.controller.role:updatePolicyByRoleDraft
     methods: [PATCH]
     requirements:
         roleId: \d+

--- a/eZ/Publish/Core/REST/Server/Controller/Role.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Role.php
@@ -74,11 +74,16 @@ class Role extends RestController
     /**
      * Create new role.
      *
+     * Defaults to publishing the role, but you can create a draft instead by setting the POST parameter publish=false
+     *
      * @return \eZ\Publish\Core\REST\Server\Values\CreatedRole
      */
     public function createRole(Request $request)
     {
-        $publish = ($request->query->has('publish') && $request->query->get('publish') === 'true');
+        $publish = (
+            !$request->query->has('publish') ||
+            ($request->query->has('publish') && $request->query->get('publish') === 'true')
+        );
 
         try {
             $roleDraft = $this->roleService->createRole(
@@ -104,11 +109,47 @@ class Role extends RestController
         }
 
         if ($publish) {
+            @trigger_error(
+                "Create and publish role in the same operation is deprecated, and will be removed in the future.\n" .
+                'Instead, publish the role draft using Role::publishRoleDraft().',
+                E_USER_DEPRECATED
+            );
+
             $this->roleService->publishRoleDraft($roleDraft);
 
             $role = $this->roleService->loadRole($roleDraft->id);
 
             return new Values\CreatedRole(['role' => new Values\RestRole($role)]);
+        }
+
+        return new Values\CreatedRole(['role' => new Values\RestRole($roleDraft)]);
+    }
+
+    /**
+     * Creates a new RoleDraft for an existing Role.
+     *
+     * @since 6.2
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException if the Role already has a Role Draft that will need to be removed first,
+     *                                                                  or if the authenticated user is not allowed to create a role
+     * @throws \eZ\Publish\Core\REST\Server\Exceptions\BadRequestException if a policy limitation in the $roleCreateStruct is not valid
+     *
+     * @return \eZ\Publish\Core\REST\Server\Values\CreatedRole
+     */
+    public function createRoleDraft($roleId, Request $request)
+    {
+        try {
+            $roleDraft = $this->roleService->createRoleDraft(
+                $this->roleService->loadRole($roleId)
+            );
+        } catch (InvalidArgumentException $e) {
+            throw new ForbiddenException($e->getMessage());
+        } catch (UnauthorizedException $e) {
+            throw new ForbiddenException($e->getMessage());
+        } catch (LimitationValidationException $e) {
+            throw new BadRequestException($e->getMessage());
+        } catch (Exceptions\Parser $e) {
+            throw new BadRequestException($e->getMessage());
         }
 
         return new Values\CreatedRole(['role' => new Values\RestRole($roleDraft)]);
@@ -244,7 +285,7 @@ class Role extends RestController
         $this->roleService->publishRoleDraft($roleDraft);
         $publishedRole = $this->roleService->loadRole($roleDraft->id);
 
-        return new Values\RestRole($publishedRole);
+        return new Values\CreatedRole(['role' => new Values\RestRole($publishedRole)]);
     }
 
     /**
@@ -258,6 +299,24 @@ class Role extends RestController
     {
         $this->roleService->deleteRole(
             $this->roleService->loadRole($roleId)
+        );
+
+        return new Values\NoContent();
+    }
+
+    /**
+     * Delete a role draft by ID.
+     *
+     * @since 6.2
+     *
+     * @param $roleId
+     *
+     * @return \eZ\Publish\Core\REST\Server\Values\NoContent
+     */
+    public function deleteRoleDraft($roleId)
+    {
+        $this->roleService->deleteRoleDraft(
+            $this->roleService->loadRoleDraft($roleId)
         );
 
         return new Values\NoContent();
@@ -342,6 +401,59 @@ class Role extends RestController
             throw new BadRequestException($e->getMessage());
         }
 
+        return new Values\CreatedPolicy(
+            array(
+                'policy' => $this->getLastAddedPolicy($role),
+            )
+        );
+    }
+
+    /**
+     * Adds a policy to a role draft.
+     *
+     * @since 6.2
+     *
+     * @param $roleId
+     *
+     * @return \eZ\Publish\Core\REST\Server\Values\CreatedPolicy
+     */
+    public function addPolicyByRoleDraft($roleId, Request $request)
+    {
+        $createStruct = $this->inputDispatcher->parse(
+            new Message(
+                array('Content-Type' => $request->headers->get('Content-Type')),
+                $request->getContent()
+            )
+        );
+
+        try {
+            $role = $this->roleService->addPolicyByRoleDraft(
+                $this->roleService->loadRoleDraft($roleId),
+                $createStruct
+            );
+        } catch (LimitationValidationException $e) {
+            throw new BadRequestException($e->getMessage());
+        }
+
+        return new Values\CreatedPolicy(
+            array(
+                'policy' => $this->getLastAddedPolicy($role),
+            )
+        );
+    }
+
+    /**
+     * Get the last added policy for $role.
+     *
+     * This is needed because the RoleService addPolicy() and addPolicyByRoleDraft() methods return the role,
+     * not the policy.
+     *
+     * @param $role \eZ\Publish\API\Repository\Values\User\Role
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\Policy
+     */
+    private function getLastAddedPolicy($role)
+    {
         $policies = $role->getPolicies();
 
         $policyToReturn = $policies[0];
@@ -351,11 +463,7 @@ class Role extends RestController
             }
         }
 
-        return new Values\CreatedPolicy(
-            array(
-                'policy' => $policyToReturn,
-            )
-        );
+        return $policyToReturn;
     }
 
     /**
@@ -378,6 +486,44 @@ class Role extends RestController
         );
 
         $role = $this->roleService->loadRole($roleId);
+        foreach ($role->getPolicies() as $policy) {
+            if ($policy->id == $policyId) {
+                try {
+                    return $this->roleService->updatePolicy(
+                        $policy,
+                        $updateStruct
+                    );
+                } catch (LimitationValidationException $e) {
+                    throw new BadRequestException($e->getMessage());
+                }
+            }
+        }
+
+        throw new Exceptions\NotFoundException("Policy not found: '{$request->getPathInfo()}'.");
+    }
+
+    /**
+     * Updates a policy.
+     *
+     * @since 6.2
+     *
+     * @param $roleId
+     * @param $policyId
+     *
+     * @throws \eZ\Publish\Core\REST\Common\Exceptions\NotFoundException
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\Policy
+     */
+    public function updatePolicyByRoleDraft($roleId, $policyId, Request $request)
+    {
+        $updateStruct = $this->inputDispatcher->parse(
+            new Message(
+                array('Content-Type' => $request->headers->get('Content-Type')),
+                $request->getContent()
+            )
+        );
+
+        $role = $this->roleService->loadRoleDraft($roleId);
         foreach ($role->getPolicies() as $policy) {
             if ($policy->id == $policyId) {
                 try {
@@ -418,6 +564,39 @@ class Role extends RestController
 
         if ($policy !== null) {
             $this->roleService->deletePolicy($policy);
+
+            return new Values\NoContent();
+        }
+
+        throw new Exceptions\NotFoundException("Policy not found: '{$request->getPathInfo()}'.");
+    }
+
+    /**
+     * Remove a policy from a role draft.
+     *
+     * @since 6.2
+     *
+     * @param $roleId
+     * @param $policyId
+     *
+     * @throws \eZ\Publish\Core\REST\Common\Exceptions\NotFoundException
+     *
+     * @return \eZ\Publish\Core\REST\Server\Values\NoContent
+     */
+    public function removePolicyByRoleDraft($roleId, $policyId, Request $request)
+    {
+        $roleDraft = $this->roleService->loadRoleDraft($roleId);
+
+        $policy = null;
+        foreach ($roleDraft->getPolicies() as $rolePolicy) {
+            if ($rolePolicy->id == $policyId) {
+                $policy = $rolePolicy;
+                break;
+            }
+        }
+
+        if ($policy !== null) {
+            $this->roleService->removePolicyByRoleDraft($roleDraft, $policy);
 
             return new Values\NoContent();
         }


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-24830
> Status: Ready for review

Implements REST methods for new role draft functionality:
- [x] createRoleDraft
- [x] loadRoleDraft
- [x] loadRoleDraftByRoleId
- [x] updateRoleDraft
- [x] addPolicyByRoleDraft
- [x] removePolicyByRoleDraft
- [x] updatePolicyByRoleDraft
- [x] deleteRoleDraft
- [x] publishRoleDraft

NB: For `testCreateRoleDraft()` we have to pass RoleInput-XML even though this is not actually used in the controller. It's a POST, so we have to send some kind of document. Could we send an empty XML doc instead, or something more elegant?

NB2: BD found that we have inadvertently broken BC half a year ago, this is corrected here by ensuring that `createRole` defaults to publishing the role. To return a draft instead (the currently preferred way) pass "publish=false".

NB3: Should the REST API doc be updated now? Or a new V3 created?
https://github.com/ezsystems/ezpublish-kernel/blob/master/doc/specifications/rest/REST-API-V2.rst#user-management