### PR TITLE
EZP-25376: Settings based fields groups implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "6.2.x-dev"
+            "dev-master": "6.3.x-dev"
         }
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
@@ -66,8 +66,10 @@ class Configuration extends SiteAccessConfiguration
                     ->example(
                         array(
                             'main' => array(
-                                'engine' => 'legacy',
-                                'connection' => 'my_doctrine_connection_name',
+                                'storage' => array(
+                                    'engine' => 'legacy',
+                                    'connection' => 'my_doctrine_connection_name',
+                                ),
                             ),
                         )
                     )

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
@@ -118,6 +118,14 @@ class Configuration extends SiteAccessConfiguration
                                         $v['search'] = array();
                                     }
 
+                                    if (!isset($v['fields_groups']['list'])) {
+                                        $v['fields_groups']['list'] = ['content'];
+                                    }
+
+                                    if (!isset($v['fields_groups']['default'])) {
+                                        $v['fields_groups']['default'] = 'content';
+                                    }
+
                                     return $v;
                                 }
                             )
@@ -155,6 +163,13 @@ class Configuration extends SiteAccessConfiguration
                                         ->useAttributeAsKey('key')
                                         ->prototype('variable')->end()
                                     ->end()
+                                ->end()
+                            ->end()
+                            ->arrayNode('fields_groups')
+                                ->info('Definitions of fields groups.')
+                                ->children()
+                                    ->arrayNode('list')->prototype('scalar')->end()->end()
+                                    ->scalarNode('default')->defaultValue('content')->end()
                                 ->end()
                             ->end()
                         ->end()

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -69,6 +69,8 @@ parameters:
     ezsettings.default.content.default_ttl: 60          # Default TTL cache value for content
     ezsettings.default.content.tree_root.location_id: 2 # Root locationId for routing and link generation. Useful for multisite apps with one repository.
     ezsettings.default.content.tree_root.excluded_uri_prefixes: [] # URI prefixes that are allowed to be outside the content tree
+    ezsettings.default.content.field_groups.list: ['content', 'metadata']
+    ezsettings.default.content.field_groups.default: 'content'
 
     # FieldType settings
     # Default XSL stylesheets for RichText rendering to HTML5.

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -28,6 +28,8 @@ parameters:
     ezpublish.view_controller_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\ViewControllerListener
     ezpublish.exception_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\ExceptionListener
 
+    ezpublish.fields_groups.list.class: eZ\Publish\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList
+
 services:
     # Siteaccess is injected in the container at runtime
     ezpublish.siteaccess:
@@ -171,3 +173,14 @@ services:
 
     ezpublish.query_type.registry:
         class: eZ\Publish\Core\QueryType\ArrayQueryTypeRegistry
+
+    ezpublish.fields_groups.list:
+        class: %ezpublish.fields_groups.list.class%
+        factory: [@ezpublish.fields_groups.list.repository_settings_factory, "build"]
+        arguments:
+            - @translator
+
+    ezpublish.fields_groups.list.repository_settings_factory:
+        class: eZ\Publish\Core\Helper\FieldsGroups\RepositoryConfigFieldsGroupsListFactory
+        arguments:
+            - @ezpublish.api.repository_configuration_provider

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
@@ -317,6 +317,10 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'engine' => 'elasticsearch',
                     'connection' => 'blabla',
                 ),
+                'fields_groups' => array(
+                    'list' => ['content'],
+                    'default' => 'content',
+                ),
             ),
             'foo' => array(
                 'storage' => array(
@@ -326,6 +330,10 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                 'search' => array(
                     'engine' => 'solr',
                     'connection' => 'lalala',
+                ),
+                'fields_groups' => array(
+                    'list' => ['content'],
+                    'default' => 'content',
                 ),
             ),
         );
@@ -355,6 +363,10 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'engine' => '%ezpublish.api.search_engine.default%',
                     'connection' => null,
                     'config' => array(),
+                ),
+                'fields_groups' => array(
+                    'list' => ['content'],
+                    'default' => 'content',
                 ),
             ),
         );
@@ -389,6 +401,10 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'connection' => null,
                     'config' => array(),
                 ),
+                'fields_groups' => array(
+                    'list' => ['content'],
+                    'default' => 'content',
+                ),
             ),
         );
         $this->load(array('repositories' => $repositories));
@@ -421,6 +437,10 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'engine' => '%ezpublish.api.search_engine.default%',
                     'connection' => null,
                     'config' => array(),
+                ),
+                'fields_groups' => array(
+                    'list' => ['content'],
+                    'default' => 'content',
                 ),
             ),
         );
@@ -465,6 +485,10 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'connection' => 'default',
                     'config' => array(),
                 ),
+                'fields_groups' => array(
+                    'list' => ['content'],
+                    'default' => 'content',
+                ),
             ),
             'foo' => array(
                 'search' => array(
@@ -476,6 +500,10 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'engine' => 'sqlng',
                     'connection' => 'default',
                     'config' => array(),
+                ),
+                'fields_groups' => array(
+                    'list' => ['content'],
+                    'default' => 'content',
                 ),
             ),
         );
@@ -507,6 +535,10 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'engine' => '%ezpublish.api.search_engine.default%',
                     'connection' => null,
                     'config' => array(),
+                ),
+                'fields_groups' => array(
+                    'list' => ['content'],
+                    'default' => 'content',
                 ),
             ),
         );

--- a/eZ/Publish/Core/Helper/FieldsGroups/ArrayTranslatorFieldsGroupsList.php
+++ b/eZ/Publish/Core/Helper/FieldsGroups/ArrayTranslatorFieldsGroupsList.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * This file is part of the ezpublish-kernel package.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Helper\FieldsGroups;
+
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * A fields groups list implementation based on settings (scalar values) injection.
+ * Human-readable names are obtained using the translator, in the `ezplatform_fields_groups` domain.
+ *
+ * @internal meant to be instantiated by the DIC. Do not inherit from it or instantiate it manually.
+ */
+final class ArrayTranslatorFieldsGroupsList implements FieldsGroupsList
+{
+    /** @var array */
+    private $groups;
+
+    /** @var string */
+    private $defaultGroup;
+
+    /** @var \Symfony\Component\Translation\TranslatorInterface */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator, $defaultGroup, array $groups)
+    {
+        $translatedGroups = [];
+        foreach ($groups as $groupIdentifier) {
+            $translatedGroups[$groupIdentifier] = $translator->trans($groupIdentifier, [], 'ezplatform_fields_groups');
+        }
+        $this->groups = $translatedGroups;
+        $this->defaultGroup = $defaultGroup;
+        $this->translator = $translator;
+    }
+
+    public function getGroups()
+    {
+        return $this->groups;
+    }
+
+    public function getDefaultGroup()
+    {
+        return $this->defaultGroup;
+    }
+}

--- a/eZ/Publish/Core/Helper/FieldsGroups/FieldsGroupsList.php
+++ b/eZ/Publish/Core/Helper/FieldsGroups/FieldsGroupsList.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * This file is part of the ezpublish-kernel package.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Helper\FieldsGroups;
+
+/**
+ * List of content fields groups.
+ *
+ * Used to group fields definitions, and apply this grouping when editing / viewing content.
+ */
+interface FieldsGroupsList
+{
+    /**
+     * Returns the list of fields groups.
+     * The list is a hash, with the group identifier as the key, and the human readable string as the value.
+     * If groups are meant to be translated, they should be translated inside this service.
+     *
+     * @return array hash, with the group identifier as the key, and the human readable string as the value.
+     */
+    public function getGroups();
+
+    /**
+     * Returns the default field group identifier.
+     *
+     * @return string
+     */
+    public function getDefaultGroup();
+}

--- a/eZ/Publish/Core/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactory.php
+++ b/eZ/Publish/Core/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactory.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This file is part of the ezpublish-kernel package.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Helper\FieldsGroups;
+
+use eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Builds a SettingsFieldGroupsList.
+ */
+final class RepositoryConfigFieldsGroupsListFactory
+{
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider
+     */
+    private $configProvider;
+
+    public function __construct(RepositoryConfigurationProvider $configProvider)
+    {
+        $this->configProvider = $configProvider;
+    }
+
+    public function build(TranslatorInterface $translator)
+    {
+        $repositoryConfig = $this->configProvider->getRepositoryConfig();
+
+        return new ArrayTranslatorFieldsGroupsList(
+            $translator,
+            $repositoryConfig['fields_groups']['default'],
+            $repositoryConfig['fields_groups']['list']
+        );
+    }
+}

--- a/eZ/Publish/Core/Helper/Tests/FieldsGroups/ArrayTranslatorFieldsGroupsListTest.php
+++ b/eZ/Publish/Core/Helper/Tests/FieldsGroups/ArrayTranslatorFieldsGroupsListTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Helper\Tests\FieldsGroups;
+
+use eZ\Publish\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList;
+use PHPUnit_Framework_TestCase;
+
+class ArrayTranslatorFieldsGroupsListTest extends PHPUnit_Framework_TestCase
+{
+    private $translatorMock;
+
+    public function testTranslatesGroups()
+    {
+        $groups = ['slayer', 'system_of_a_down'];
+        $default = 'system_of_a_down';
+
+        $this->getTranslatorMock()
+            ->expects($this->any())
+            ->method('trans')
+            ->will(
+                $this->returnValueMap([
+                    ['slayer', [], 'ezplatform_fields_groups', null, 'Slayer'],
+                    ['system_of_a_down', [], 'ezplatform_fields_groups', null, 'System of a down'],
+                ])
+            );
+
+        $list = $this->buildList($groups, $default);
+
+        self::assertEquals(
+            [
+                'slayer' => 'Slayer',
+                'system_of_a_down' => 'System of a down',
+            ],
+            $list->getGroups()
+        );
+    }
+
+    public function testReturnsDefault()
+    {
+        $list = $this->buildList([], 'A');
+
+        self::assertEquals('A', $list->getDefaultGroup());
+    }
+
+    public function testUsesIdentifierIfNoTranslation()
+    {
+        $groups = ['slayer', 'system_of_a_down'];
+        $default = 'system_of_a_down';
+
+        $this->getTranslatorMock()
+            ->expects($this->any())
+            ->method('trans')
+            ->will($this->returnArgument(0));
+
+        $list = $this->buildList($groups, $default);
+
+        self::assertEquals(
+            [
+                'slayer' => 'slayer',
+                'system_of_a_down' => 'system_of_a_down',
+            ],
+            $list->getGroups()
+        );
+    }
+
+    private function buildList($groups, $default)
+    {
+        return new ArrayTranslatorFieldsGroupsList(
+            $this->getTranslatorMock(),
+            $default,
+            $groups
+        );
+    }
+
+    /**
+     * @return \Symfony\Component\Translation\TranslatorInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getTranslatorMock()
+    {
+        if ($this->translatorMock === null) {
+            $this->translatorMock = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        }
+
+        return $this->translatorMock;
+    }
+}

--- a/eZ/Publish/Core/Helper/Tests/FieldsGroups/RepositoryConfigFieldsGroupsListFactoryTest.php
+++ b/eZ/Publish/Core/Helper/Tests/FieldsGroups/RepositoryConfigFieldsGroupsListFactoryTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Helper\Tests\FieldsGroups;
+
+use eZ\Publish\Core\Helper\FieldsGroups\RepositoryConfigFieldsGroupsListFactory;
+use PHPUnit_Framework_TestCase;
+
+class RepositoryConfigFieldsGroupsListFactoryTest extends PHPUnit_Framework_TestCase
+{
+    private $repositoryConfigMock;
+
+    private $translatorMock;
+
+    public function testBuild()
+    {
+        $this->getRepositoryConfigMock()
+            ->expects($this->once())
+            ->method('getRepositoryConfig')
+            ->willReturn(['fields_groups' => ['list' => ['group_a', 'group_b'], 'default' => 'group_a']]);
+
+        $this->getTranslatorMock()
+            ->expects($this->any())
+            ->method('trans')
+            ->will($this->returnArgument(0));
+
+        $factory = new RepositoryConfigFieldsGroupsListFactory($this->getRepositoryConfigMock());
+        $list = $factory->build($this->getTranslatorMock());
+
+        self::assertEquals(['group_a' => 'group_a', 'group_b' => 'group_b'], $list->getGroups());
+        self::assertEquals('group_a', $list->getDefaultGroup());
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider
+     */
+    protected function getRepositoryConfigMock()
+    {
+        if (!isset($this->repositoryConfigMock)) {
+            $this->repositoryConfigMock = $this
+                ->getMockBuilder('eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider')
+                ->disableOriginalConstructor()
+                ->getMock();
+        }
+
+        return $this->repositoryConfigMock;
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\Translation\TranslatorInterface
+     */
+    protected function getTranslatorMock()
+    {
+        if (!isset($this->translatorMock)) {
+            $this->translatorMock = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        }
+
+        return $this->translatorMock;
+    }
+}


### PR DESCRIPTION
> Status: ready for review
> Implements http://jira.ez.no/browse/EZP-25376
> Version change: adds a new feature, bumps master to `6.3.x-dev`

New settings are added to define available content fields groups identifiers for a repository:

```
ezpublish:
  repositories:
    default:
      fields_groups:
        list: ["content", "metadata"]
        default: "content"
```

The entries are groups identifiers.

An `@ezpublish.fields_groups.list` service gives access to the values.

It uses an `ArrayTranslator` implementation of the newly added `FieldsGroupsList` interface. It is constructed by `@ezpublish.fields_groups.list.repository_settings_factory`, a `RepositoryConfigFieldsGroupsListFactory`, that reads settings using `@ezpublish.api.repository_configuration_provider`

### Tasks
- [x] Move settings to the repository section
- [x] ~~Add validation to semantic config~~
- [x] ~~Think about translation/human readable versions of fields groups names (could maybe be done in repository-forms, but it wouldn't make it easier for PlatformUI to access those)~~
- [x] ~~Think about how PlatformUI could use those~~