### PR TITLE
Fix EZP-25468: Exception when rendering a RichText field with an embed content

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed.html.twig
@@ -1,6 +1,6 @@
 {% set content_name=ez_content_name(content) %}
 
-{% if location is defined %}
+{% if location %}
     <h3><a href="{{ path(location) }}">{{ content_name }}</a></h3>
 {% else %}
     <h3>{{ content_name }}</h3>


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25468

# Description

When viewing a Content item with a RichText field containing an embed content, an exception is thrown. This is happening because the `location` is set to null and then in the template, we try to generate for it.

# Test

manual test