### PR TITLE
Ezp25294 6.1 content view null location

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/View/ContentView.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ContentView.php
@@ -87,7 +87,12 @@ class ContentView extends BaseView implements View, ContentValueView, LocationVa
 
     protected function getInternalParameters()
     {
-        return ['location' => $this->location, 'content' => $this->content];
+        $parameters = ['content' => $this->content];
+        if ($this->location !== null) {
+            $parameters['location'] = $this->location;
+        }
+
+        return $parameters;
     }
 
     /**


### PR DESCRIPTION
> Fixes http://jira.ez.no/browse/EZP-25294
> Replaces #1542

Fixes a fatal error that occurs when an item  is viewed as an embed. The `location` is set to null instead of not being set at all.

This prevents the variable from being set if there is no location, as [suggested by @andrerom](https://github.com/ezsystems/ezpublish-kernel/pull/1542#issuecomment-169713854).