### PR TITLE
Fix EZP-25294: do not set the location if there isn't one

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/View/ContentView.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ContentView.php
@@ -87,7 +87,12 @@ class ContentView extends BaseView implements View, ContentValueView, LocationVa
 
     protected function getInternalParameters()
     {
-        return ['location' => $this->location, 'content' => $this->content];
+        $parameters = ['content' => $this->content];
+        if ($this->location !== null) {
+            $parameters['location'] = $this->location;
+        }
+
+        return $parameters;
     }
 
     /**

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/ContentViewTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/ContentViewTest.php
@@ -22,7 +22,7 @@ class ContentViewTest extends PHPUnit_Framework_TestCase
      * Params that are always returned by this view.
      * @var array
      */
-    private $valueParams = ['location' => null, 'content' => null];
+    private $valueParams = ['content' => null];
 
     /**
      * @dataProvider constructProvider

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/ViewManagerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/ViewManagerTest.php
@@ -141,7 +141,7 @@ class ViewManagerTest extends PHPUnit_Framework_TestCase
             ->method('render')
             ->with(
                 $templateIdentifier,
-                $params + array('content' => $content, 'location' => null, 'viewbaseLayout' => $this->viewBaseLayout))
+                $params + array('content' => $content, 'viewbaseLayout' => $this->viewBaseLayout))
             ->will($this->returnValue($expectedTemplateResult));
 
         self::assertSame($expectedTemplateResult, $this->viewManager->renderContent($content, 'customViewType', $params));
@@ -171,7 +171,7 @@ class ViewManagerTest extends PHPUnit_Framework_TestCase
 
         // Configuring template engine behaviour
         $params += array('content' => $content, 'viewbaseLayout' => $this->viewBaseLayout);
-        $expectedTemplateResult = array_keys($params + ['location' => null]);
+        $expectedTemplateResult = array_keys($params);
         $this->templateEngineMock
             ->expects($this->never())
             ->method('render');


### PR DESCRIPTION
> Fixes http://jira.ez.no/browse/EZP-25294 and https://jira.ez.no/browse/EZP-25470
> Replaces #1542

Fixes a fatal error that occurs when an item  is viewed as an embed. The `location` is set to null instead of not being set at all. This prevents the variable from being set if there is no location, as [suggested by @andrerom](https://github.com/ezsystems/ezpublish-kernel/pull/1542#issuecomment-169713854).

### Backward compatibility
This should be okay. If a location is being viewed, the variable will be set. If a content is being viewed, users do not expect the variable to exist.

Also fixes the solr integration test failure ([EZP-25470](https://jira.ez.no/browse/EZP-25470)) in pull-requests against 6.1.