### PR TITLE
EZP-25471:  user_identifier_headers should not be changed from the default

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fos_http_cache.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fos_http_cache.yml
@@ -7,5 +7,3 @@ user_context:
     enabled: true
     hash_cache_ttl: 600
     user_hash_header: X-User-Hash
-    user_identifier_headers:
-        - Authorization


### PR DESCRIPTION
> Partially reverts what was done in #1546 ([EZP-25204](https://jira.ez.no/browse/EZP-25204))
> Affects v6.1.0 (15.12.1 release)

`user_identifier_header` should not be changed from default 'Cookies,Authorization'. Symfony cache needs user hash to vary on cookie or it will return the same user hash for every user.  The real issue is fixed by the addition of the `X-User-Hash` to the forwarded request as in the [original PR](#1546).