### PR TITLE
[POC - Behat] Add RepositoryContext trait

### DIFF
--- a/doc/behat/README.md
+++ b/doc/behat/README.md
@@ -27,4 +27,23 @@ use EzSystems\PlatformBehatBundle\Context\SubContext\DeprecationNoticeSupressor;
 class MyContextUsesDeprecatedCode implements Context
 {
     use DeprecationNoticeSupressor;
+...
+```
+
+##### Using the Repository
+To ease the usage and maintainability of the repository dependent
+Behat Contexts a trait called `RespositoryContext` was created.
+This trait includes all the methods, variables related directly
+with the repository. To use this all that is needed is to use it
+in your own Contexts. Ex:
+
+``` php
+...
+/**
+ * My very own Behat Context
+ */
+class MyContext implements Context
+{
+    use RepositoryContext;
+...
 ```

--- a/eZ/Bundle/PlatformBehatBundle/Context/RepositoryContext.php
+++ b/eZ/Bundle/PlatformBehatBundle/Context/RepositoryContext.php
@@ -28,14 +28,22 @@ trait RepositoryContext
     /**
      * @var eZ\Publish\API\Repository\Repository
      */
-    protected $repository;
+    private $repository;
 
     /**
-     * @param eZ\Publish\API\Repository\Repository $repository
+     * @param $repository eZ\Publish\API\Repository\Repository $repository
      */
-    public function setRepository(Repository $repository)
+    protected function setRepository(Repository $repository)
     {
         $this->repository = $repository;
+    }
+
+    /**
+     * @return eZ\Publish\API\Repository\Repository $repository
+     */
+    public function getRepository()
+    {
+        return $this->repository;
     }
 
     /**

--- a/eZ/Bundle/PlatformBehatBundle/Context/RepositoryContext.php
+++ b/eZ/Bundle/PlatformBehatBundle/Context/RepositoryContext.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * File containing the Repository Context class for EzBehatBundle.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\PlatformBehatBundle\Context;
+
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\Core\Repository\Values\User\UserReference;
+
+/**
+ * Repository Context Trait.
+ * Everything repository related should go here.
+ * To be used by all the other behat contexts that need the repository.
+ * Any Context tha uses this trait will automatically login the admin user,
+ * so any operation that needs admin permissions can be executed.
+ */
+trait RepositoryContext
+{
+    /**
+     * Default Administrator user id.
+     */
+    private $adminUserId = 14;
+
+    /**
+     * @var eZ\Publish\API\Repository\Repository
+     */
+    protected $repository;
+
+    /**
+     * @param eZ\Publish\API\Repository\Repository $repository
+     */
+    public function setRepository(Repository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * @BeforeScenario
+     */
+    public function loginAdmin($event)
+    {
+        $this->repository->setCurrentUser(new UserReference($this->adminUserId));
+    }
+}


### PR DESCRIPTION
As decided BehatBundle is to be deprecated and separated between the kernel and platformUI bundle. The idea is to make the Behat easier to maintain, having less repo dependencies should help releases and versions also.

This PR moves the RepositoryContext trait into the kernel. This is trait contains all the methods related to the repo . Since this is to be used by any contexts that need the repo it should be in the kernel to be easily included and not duplicate.

Related PRs:
* Behat browser context #1585
* Add EzBehatExtension and ArgumentResolver #1586
* Deprecate Behat classes https://github.com/ezsystems/BehatBundle/pull/48
