### PR TITLE
[POC - Behat] Behat browser context

### DIFF
--- a/eZ/Bundle/PlatformBehatBundle/Context/Browser/Context.php
+++ b/eZ/Bundle/PlatformBehatBundle/Context/Browser/Context.php
@@ -1,0 +1,536 @@
+<?php
+/**
+ * File containing the main context class for Browser.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\PlatformBehatBundle\Context\Browser;
+
+use Behat\Mink\Element\NodeElement;
+use Behat\MinkExtension\Context\MinkAwareContext;
+use EzSystems\PlatformBehatBundle\Context\Browser\SubContext;
+use EzSystems\BehatBundle\Helper\Xpath;
+use PHPUnit_Framework_Assert as Assertion;
+
+/**
+ * Context has wide (generic) browser helper methods and classes
+ */
+class Context implements MinkAwareContext
+{
+    use MinkTrait;
+    use SubContext\CommonActions;
+    use SubContext\Authentication;
+
+    /**
+     * @var \EzSystems\BehatBundle\Helper\Xpath
+     */
+    private $xpath;
+
+    /**
+     * @var array Array to map identifier to urls, should be set by child classes.
+     *
+     * Important:
+     *  this is an associative array( ex: array( 'key' => '/some/url') ) they keys
+     *  should be set (on contexts) as lower cases since the
+     *  FeatureContext::getPathByPageIdentifier() will check for lower case
+     */
+    public $pageIdentifierMap = array();
+
+    /**
+     * This will tell us which containers (design) to search, should be set by child classes.
+     *
+     * ex:
+     * $mainAttributes = array(
+     *      "content"   => "thisIsATag",
+     *      "column"    => array( "class" => "thisIsTheClassOfTheColumns" ),
+     *      "menu"      => "//xpath/for/the[menu]",
+     *      ...
+     * );
+     *
+     * Is possible to define the specific xpath for a block, and all the other
+     * options won't be processed, however this should ONLY be used when testing
+     * content, otherwise if something changes on block it won't work
+     *
+     * @var array This will have a ( identifier => array )
+     */
+    protected $mainAttributes = array();
+
+    /**
+     * @BeforeScenario
+     */
+    public function prepareHelpers()
+    {
+        // initialize Helpers
+        $this->xpath = new Xpath( $this->getSession() );
+    }
+
+    /**
+     * Initialize with generic information
+     */
+    public function __construct()
+    {
+        // add home to the page identifiers
+        $this->pageIdentifierMap += array(
+            'home'   => '/',
+            'login'  => '/login',
+            'logout' => '/logout'
+        );
+    }
+
+    /**
+     * Getter for Xpath
+     *
+     * @return \EzSystems\BehatBundle\Helper\Xpath
+     */
+    public function getXpath()
+    {
+        return $this->xpath;
+    }
+
+    /**
+     * Returns the path associated with $pageIdentifier
+     *
+     * @param string $pageIdentifier
+     *
+     * @return string URL path
+     *
+     * @throws \RuntimeException If $pageIdentifier is not set
+     */
+    public function getPathByPageIdentifier( $pageIdentifier )
+    {
+        if ( !isset( $this->pageIdentifierMap[strtolower( $pageIdentifier )] ) )
+        {
+            throw new \RuntimeException( "Unknown page identifier '{$pageIdentifier}'." );
+        }
+
+        return $this->pageIdentifierMap[strtolower( $pageIdentifier )];
+    }
+
+    /**
+     * This should be seen as a complement to self::getTagsFor() where it will
+     * get the respective tags from there and will make a valid Xpath string with
+     * all OR's needed
+     *
+     * @param array  $tags  Array of tags strings (ex: array( "a", "p", "h3", "table" ) )
+     * @param string $xpath String to be concatenated to each tag
+     *
+     * @return string Final xpath
+     */
+    public function concatTagsWithXpath( array $tags, $xpath = null )
+    {
+        $finalXpath = "";
+        for ( $i = 0; !empty( $tags[$i] ); $i++ )
+        {
+            $finalXpath .= "//{$tags[$i]}$xpath";
+            if ( !empty( $tags[$i + 1] ) )
+            {
+                $finalXpath .= " | ";
+            }
+        }
+
+        return $finalXpath;
+    }
+
+    /**
+     * With this function we get a centralized way to define what are the possible
+     * tags for a type of data
+     *
+     * @param string $type Type of text (ie: if header/title, or list element, ...)
+     *
+     * @return array With element tag names
+     *
+     * @throws \Behat\Behat\Exception\InvalidArgumentException If the $type isn't defined
+     */
+    public function getTagsFor( $type )
+    {
+        switch ( strtolower( $type ) )
+        {
+            case "topic":
+            case "header":
+            case "title":
+                return array( "h1", "h2", "h3" );
+            case "list":
+                return array( "li" );
+            case "input":
+                return array( "input", "select", "textarea", );
+        }
+
+        throw new \InvalidArgumentException( "Tag's for '$type' type not defined" );
+    }
+
+    /**
+     * Returns $url without its query string
+     *
+     * @param string $url
+     *
+     * @return string Complete url without the query string
+     */
+    public function getUrlWithoutQueryString( $url )
+    {
+        if ( strpos( $url, '?' ) !== false )
+        {
+            $url = substr( $url, 0, strpos( $url, '?' ) );
+        }
+
+        return $url;
+    }
+
+    /**
+     * Checks if links exist and in the following order (if intended)
+     * Notice: if there are 3 links and we omit the middle link it will also be
+     *  correct. It only checks order, not if there should be anything in
+     *  between them
+     *
+     * @param array $links Array with link text/title
+     * @param Behat\Mink\Element\NodeElement[] $available
+     * @param boolean $checkOrder Boolean to verify (or not) the link order
+     *
+     * @return void
+     *
+     * @throws \PHPUnit_Framework_AssertionFailedError
+     */
+    protected function checkLinksExistence( array $links, array $available, $checkOrder = false )
+    {
+        $i = $passed = 0;
+        $last = '';
+        $messageAfter = '';
+        foreach ( $links as $link )
+        {
+            if ( ! $checkOrder )
+            {
+                $i = 0;
+            }
+
+            // find the object
+            while (
+                !empty( $available[$i] )
+                && strpos( $available[$i]->getText(), $link ) === false
+            )
+                $i++;
+
+            if ( $checkOrder && ! empty( $last ) )
+            {
+                $messageAfter = "after '$last'";
+            }
+
+            // check if the link was found or the $i >= $count
+            $test = true;
+            if ( empty( $available[$i] ) )
+            {
+                $test = false;
+            }
+            Assertion::assertTrue( $test, "Couldn't find '$link'" . $messageAfter );
+
+            $passed++;
+            $last = $link;
+        }
+
+        Assertion::assertEquals(
+            count( $links ),
+            $passed,
+            "Expected to evaluate '" . count( $links ) . "' links evaluated '{$passed}'"
+        );
+    }
+
+    /**
+     * Fetchs the first integer in the string
+     *
+     * @param string $string Text 
+     *
+     * @return int Integer found on text 
+     *
+     * @throws \PHPUnit_Framework_AssertionFailedError
+     */
+    public function getNumberFromString( $string )
+    {
+        preg_match( '/(?P<digit>\d+)/', $string, $result );
+        Assertion::assertNotEmpty( $result['digit'], "Expected to find a number in '$string' found none" );
+        return (int)$result['digit'];
+    }
+
+    /**
+     * Verifies if a row as the expected columns, position of columns can be added
+     * for a more accurated assertion
+     *
+     * @param \Behat\Mink\Element\NodeElement $row Table row node element
+     * @param string[] $columns Column text to assert
+     * @param string[]|int[] $columnsPositions Columns positions in int or string (number must be in string)
+     *
+     * @return boolean
+     *
+     * @throws \PHPUnit_Framework_AssertionFailedError
+     */
+    public function existTableRow( NodeElement $row, array $columns, array $columnsPositions = null )
+    {
+        // find which kind of column is in this row
+        $elType = $row->find( 'xpath', "/th" );
+        $type = ( empty( $elType ) ) ? '/td' : '/th';
+
+        $max = count( $columns );
+        for ( $i = 0; $i < $max; $i++ )
+        {
+            $position = "";
+            if ( !empty( $columnsPositions[$i] ) )
+            {
+                $position = "[{$this->getNumberFromString( $columnsPositions[$i] )}]";
+            }
+
+            $el = $row->find( "xpath", "$type$position" );
+
+            // check if match with expected if not return false
+            if ( $el === null || $columns[$i] !== $el->getText() )
+            {
+                return false;
+            }
+        }
+
+        // if we're here then it means all have ran as expected
+        return true;
+    }
+
+    /**
+     * Find a(all) table row(s) that match the column text
+     *
+     * @param string        $text       Text to be found
+     * @param string|int    $column     In which column the text should be found
+     * @param string        $tableXpath If there is a specific table
+     *
+     * @return \Behat\Mink\Element\NodeElement[]
+     */
+    public function getTableRow( $text, $column = null, $tableXpath = null )
+    {
+        // check column
+        if ( !empty( $column ) )
+        {
+            if ( is_integer( $column ) )
+            {
+                $columnNumber = "[$column]";
+            }
+            else
+            {
+                $columnNumber = "[{$this->getNumberFromString( $column )}]";
+            }
+        }
+        else
+        {
+            $columnNumber = "";
+        }
+
+        // get all possible elements
+        $elements = array_merge(
+            $this->getXpath()->findXpath( "$tableXpath//tr/th$columnNumber" ),
+            $this->getXpath()->findXpath( "$tableXpath//tr/td$columnNumber" )
+        );
+
+        $foundXpath = array();
+        $total = count( $elements );
+        $i = 0;
+        while ( $i < $total )
+        {
+            if ( strpos( $elements[$i]->getText(), $text ) !== false )
+            {
+                $foundXpath[] = $elements[$i]->getParent();
+            }
+
+            $i++;
+        }
+
+        return $foundXpath;
+    }
+
+    /**
+     * Find and return the row (<tr>) where the passed element is
+     * This is useful when you intend to know if another element is in the same
+     * row
+     *
+     * @param \Behat\Mink\Element\NodeElement $element The element in the intended row
+     *
+     * @return \Behat\Mink\Element\NodeElement The <tr> element node
+     *
+     * @throws \PHPUnit_Framework_AssertionFailedError
+     */
+    public function findRow( NodeElement $element )
+    {
+        $initialTag = $element->getTagName();
+
+        while (
+            strtolower( $element->getTagName() ) !== "tr"
+            && strtolower( $element->getTagName() ) !== "body"
+        )
+        {
+            $element = $element->getParent();
+        }
+
+        Assertion::assertEquals(
+            strtolower( $element->getTagName() ),
+            "tr",
+            "Couldn't find a parent of '$initialTag' that is a table row"
+        );
+
+        return $element;
+    }
+
+    /**
+     * In a list of elements returns a certain element (found through xpath) that
+     * is after a specific element (that is also found through xpath)
+     *
+     * <code>
+     * findElementAfterElement(
+     *      $arrayWithAllCellsOfARow,
+     *      $xpathForALabel
+     *      $xpathForAnInput
+     * );
+     * </code>
+     *
+     * @param array  $elements
+     * @param string $firstXpath
+     * @param string $secondXpath
+     *
+     * @return \Behat\Mink\Element\NodeElement|null Element if found null otherwise
+     */
+    public function findElementAfterElement( array $elements, $firstXpath, $secondXpath )
+    {
+        $foundFirstXpath = false;
+        foreach ( $elements as $element )
+        {
+            // choose what xpath to use
+            if ( ! $foundFirstXpath )
+            {
+                $xpath = $firstXpath;
+            }
+            else
+            {
+                $xpath = $secondXpath;
+            }
+
+            $foundElement = $element->find( "xpath", $xpath );
+
+            // element found, if first start to look for the second one
+            // if second, than return this one
+            if ( !empty( $foundElement) )
+            {
+                if ( !$foundFirstXpath )
+                {
+                    $foundFirstXpath = true;
+                }
+                else
+                {
+                    return $foundElement;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Verifies if the element has 'special' configuration on a attribute (default -> style)
+     *
+     * @param \Behat\Mink\Element\NodeElement $el The element that we want to test
+     * @param string $characteristic Verify a specific characteristic from attribute
+     * @param string $attribute Verify a specific attribute
+     *
+     * @return boolean
+     */
+    public function isElementEmphasized( NodeElement $el, $characteristic = null, $attribute = "style" )
+    {
+        // verify it has the attribute we're looking for
+        if ( !$el->hasAttribute( $attribute ) )
+        {
+            return false;
+        }
+
+        // get the attribute
+        $attr = $el->getAttribute( $attribute );
+
+        // check if want to test specific characteristic and if it is present
+        if ( !empty( $characteristic ) && strpos( $attr, $characteristic ) === false )
+        {
+            return false;
+        }
+
+        // if we're here it is emphasized
+        return true;
+    }
+
+    /**
+     * This method works is a complement to the $mainAttributes var
+     *
+     * @param  string $block This should be an identifier for the block to use
+     *
+     * @return null|string XPath for the 
+     *
+     * @see $this->mainAttributes
+     */
+    public function makeXpathForBlock( $block = null )
+    {
+        if ( empty( $block ) )
+        {
+            return null;
+        }
+
+        $parameter = ( isset( $this->mainAttributes[strtolower( $block )] ) ) ?
+            $this->mainAttributes[strtolower( $block )] :
+            NULL;
+
+        Assertion::assertNotNull( $parameter, "Element {$block} is not defined" );
+
+        $xpath = $this->mainAttributes[strtolower( $block )];
+        // check if value is a composed array
+        if ( is_array( $xpath ) )
+        {
+            // if there is an xpath defined look no more!
+            if ( isset( $xpath['xpath'] ) )
+            {
+                return $xpath['xpath'];
+            }
+
+            $nuXpath = "";
+            // verify if there is a tag
+            if ( isset( $xpath['tag'] ) )
+            {
+                if ( strpos( $xpath['tag'], "/" ) === 0 || strpos( $xpath['tag'], "(" ) === 0 )
+                {
+                    $nuXpath = $xpath['tag'];
+                }
+                else
+                {
+                    $nuXpath = "//" . $xpath['tag'];
+                }
+
+                unset( $xpath['tag'] );
+            }
+            else
+            {
+                $nuXpath = "//*";
+            }
+
+            foreach ( $xpath as $key => $value )
+            {
+                switch ( $key )
+                {
+                    case "text":
+                        $att = "text()";
+                        break;
+                    default:
+                        $att = "@$key";
+                }
+                $nuXpath .= "[contains($att, {$this->getXpath()->literal( $value )})]";
+            }
+
+            return $nuXpath;
+        }
+
+        //  if the string is an Xpath
+        if ( strpos( $xpath, "/" ) === 0 || strpos( $xpath, "(" ) === 0 )
+        {
+            return $xpath;
+        }
+
+        // if xpath is an simple tag
+        return "//$xpath";
+    }
+}

--- a/eZ/Bundle/PlatformBehatBundle/Context/Browser/Context.php
+++ b/eZ/Bundle/PlatformBehatBundle/Context/Browser/Context.php
@@ -6,17 +6,15 @@
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
-
 namespace EzSystems\PlatformBehatBundle\Context\Browser;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\MinkExtension\Context\MinkAwareContext;
-use EzSystems\PlatformBehatBundle\Context\Browser\SubContext;
 use EzSystems\BehatBundle\Helper\Xpath;
 use PHPUnit_Framework_Assert as Assertion;
 
 /**
- * Context has wide (generic) browser helper methods and classes
+ * Context has wide (generic) browser helper methods and classes.
  */
 class Context implements MinkAwareContext
 {
@@ -33,9 +31,8 @@ class Context implements MinkAwareContext
      * @var array Array to map identifier to urls, should be set by child classes.
      *
      * Important:
-     *  this is an associative array( ex: array( 'key' => '/some/url') ) they keys
-     *  should be set (on contexts) as lower cases since the
-     *  FeatureContext::getPathByPageIdentifier() will check for lower case
+     *  this is an associative array( ex: array( 'key' => '/some/url') ) the keys
+     *  should be set on contexts(case insensitive)
      */
     public $pageIdentifierMap = array();
 
@@ -64,24 +61,24 @@ class Context implements MinkAwareContext
     public function prepareHelpers()
     {
         // initialize Helpers
-        $this->xpath = new Xpath( $this->getSession() );
+        $this->xpath = new Xpath($this->getSession());
     }
 
     /**
-     * Initialize with generic information
+     * Initialize with generic information.
      */
     public function __construct()
     {
         // add home to the page identifiers
         $this->pageIdentifierMap += array(
-            'home'   => '/',
-            'login'  => '/login',
-            'logout' => '/logout'
+            'home' => '/',
+            'login' => '/login',
+            'logout' => '/logout',
         );
     }
 
     /**
-     * Getter for Xpath
+     * Getter for Xpath.
      *
      * @return \EzSystems\BehatBundle\Helper\Xpath
      */
@@ -91,7 +88,7 @@ class Context implements MinkAwareContext
     }
 
     /**
-     * Returns the path associated with $pageIdentifier
+     * Returns the path associated with $pageIdentifier.
      *
      * @param string $pageIdentifier
      *
@@ -99,35 +96,32 @@ class Context implements MinkAwareContext
      *
      * @throws \RuntimeException If $pageIdentifier is not set
      */
-    public function getPathByPageIdentifier( $pageIdentifier )
+    public function getPathByPageIdentifier($pageIdentifier)
     {
-        if ( !isset( $this->pageIdentifierMap[strtolower( $pageIdentifier )] ) )
-        {
-            throw new \RuntimeException( "Unknown page identifier '{$pageIdentifier}'." );
+        if (!isset($this->pageIdentifierMap[strtolower($pageIdentifier)])) {
+            throw new \RuntimeException("Unknown page identifier '{$pageIdentifier}'.");
         }
 
-        return $this->pageIdentifierMap[strtolower( $pageIdentifier )];
+        return $this->pageIdentifierMap[strtolower($pageIdentifier)];
     }
 
     /**
      * This should be seen as a complement to self::getTagsFor() where it will
      * get the respective tags from there and will make a valid Xpath string with
-     * all OR's needed
+     * all OR's needed.
      *
      * @param array  $tags  Array of tags strings (ex: array( "a", "p", "h3", "table" ) )
      * @param string $xpath String to be concatenated to each tag
      *
      * @return string Final xpath
      */
-    public function concatTagsWithXpath( array $tags, $xpath = null )
+    public function concatTagsWithXpath(array $tags, $xpath = null)
     {
-        $finalXpath = "";
-        for ( $i = 0; !empty( $tags[$i] ); $i++ )
-        {
+        $finalXpath = '';
+        for ($i = 0; !empty($tags[$i]); ++$i) {
             $finalXpath .= "//{$tags[$i]}$xpath";
-            if ( !empty( $tags[$i + 1] ) )
-            {
-                $finalXpath .= " | ";
+            if (!empty($tags[$i + 1])) {
+                $finalXpath .= ' | ';
             }
         }
 
@@ -136,7 +130,7 @@ class Context implements MinkAwareContext
 
     /**
      * With this function we get a centralized way to define what are the possible
-     * tags for a type of data
+     * tags for a type of data.
      *
      * @param string $type Type of text (ie: if header/title, or list element, ...)
      *
@@ -144,35 +138,33 @@ class Context implements MinkAwareContext
      *
      * @throws \Behat\Behat\Exception\InvalidArgumentException If the $type isn't defined
      */
-    public function getTagsFor( $type )
+    public function getTagsFor($type)
     {
-        switch ( strtolower( $type ) )
-        {
-            case "topic":
-            case "header":
-            case "title":
-                return array( "h1", "h2", "h3" );
-            case "list":
-                return array( "li" );
-            case "input":
-                return array( "input", "select", "textarea", );
+        switch (strtolower($type)) {
+            case 'topic':
+            case 'header':
+            case 'title':
+                return array('h1', 'h2', 'h3');
+            case 'list':
+                return array('li');
+            case 'input':
+                return array('input', 'select', 'textarea');
         }
 
-        throw new \InvalidArgumentException( "Tag's for '$type' type not defined" );
+        throw new \InvalidArgumentException("Tag's for '$type' type not defined");
     }
 
     /**
-     * Returns $url without its query string
+     * Returns $url without its query string.
      *
      * @param string $url
      *
      * @return string Complete url without the query string
      */
-    public function getUrlWithoutQueryString( $url )
+    public function getUrlWithoutQueryString($url)
     {
-        if ( strpos( $url, '?' ) !== false )
-        {
-            $url = substr( $url, 0, strpos( $url, '?' ) );
+        if (strpos($url, '?') !== false) {
+            $url = substr($url, 0, strpos($url, '?'));
         }
 
         return $url;
@@ -182,107 +174,99 @@ class Context implements MinkAwareContext
      * Checks if links exist and in the following order (if intended)
      * Notice: if there are 3 links and we omit the middle link it will also be
      *  correct. It only checks order, not if there should be anything in
-     *  between them
+     *  between them.
      *
      * @param array $links Array with link text/title
      * @param Behat\Mink\Element\NodeElement[] $available
-     * @param boolean $checkOrder Boolean to verify (or not) the link order
-     *
-     * @return void
+     * @param bool $checkOrder Boolean to verify (or not) the link order
      *
      * @throws \PHPUnit_Framework_AssertionFailedError
      */
-    protected function checkLinksExistence( array $links, array $available, $checkOrder = false )
+    protected function checkLinksExistence(array $links, array $available, $checkOrder = false)
     {
         $i = $passed = 0;
         $last = '';
         $messageAfter = '';
-        foreach ( $links as $link )
-        {
-            if ( ! $checkOrder )
-            {
+        foreach ($links as $link) {
+            if (!$checkOrder) {
                 $i = 0;
             }
 
             // find the object
-            while (
-                !empty( $available[$i] )
-                && strpos( $available[$i]->getText(), $link ) === false
-            )
-                $i++;
+            while (!empty($available[$i])
+                && strpos($available[$i]->getText(), $link) === false
+            ) {
+                ++$i;
+            }
 
-            if ( $checkOrder && ! empty( $last ) )
-            {
+            if ($checkOrder && !empty($last)) {
                 $messageAfter = "after '$last'";
             }
 
             // check if the link was found or the $i >= $count
             $test = true;
-            if ( empty( $available[$i] ) )
-            {
+            if (empty($available[$i])) {
                 $test = false;
             }
-            Assertion::assertTrue( $test, "Couldn't find '$link'" . $messageAfter );
+            Assertion::assertTrue($test, "Couldn't find '$link'" . $messageAfter);
 
-            $passed++;
+            ++$passed;
             $last = $link;
         }
 
         Assertion::assertEquals(
-            count( $links ),
+            count($links),
             $passed,
-            "Expected to evaluate '" . count( $links ) . "' links evaluated '{$passed}'"
+            "Expected to evaluate '" . count($links) . "' links evaluated '{$passed}'"
         );
     }
 
     /**
-     * Fetchs the first integer in the string
+     * Fetchs the first integer in the string.
      *
-     * @param string $string Text 
+     * @param string $string Text
      *
-     * @return int Integer found on text 
+     * @return int Integer found on text
      *
      * @throws \PHPUnit_Framework_AssertionFailedError
      */
-    public function getNumberFromString( $string )
+    public function getNumberFromString($string)
     {
-        preg_match( '/(?P<digit>\d+)/', $string, $result );
-        Assertion::assertNotEmpty( $result['digit'], "Expected to find a number in '$string' found none" );
+        preg_match('/(?P<digit>\d+)/', $string, $result);
+        Assertion::assertNotEmpty($result['digit'], "Expected to find a number in '$string' found none");
+
         return (int)$result['digit'];
     }
 
     /**
      * Verifies if a row as the expected columns, position of columns can be added
-     * for a more accurated assertion
+     * for a more accurated assertion.
      *
      * @param \Behat\Mink\Element\NodeElement $row Table row node element
      * @param string[] $columns Column text to assert
      * @param string[]|int[] $columnsPositions Columns positions in int or string (number must be in string)
      *
-     * @return boolean
+     * @return bool
      *
      * @throws \PHPUnit_Framework_AssertionFailedError
      */
-    public function existTableRow( NodeElement $row, array $columns, array $columnsPositions = null )
+    public function existTableRow(NodeElement $row, array $columns, array $columnsPositions = null)
     {
         // find which kind of column is in this row
-        $elType = $row->find( 'xpath', "/th" );
-        $type = ( empty( $elType ) ) ? '/td' : '/th';
+        $elType = $row->find('xpath', '/th');
+        $type = (empty($elType)) ? '/td' : '/th';
 
-        $max = count( $columns );
-        for ( $i = 0; $i < $max; $i++ )
-        {
-            $position = "";
-            if ( !empty( $columnsPositions[$i] ) )
-            {
-                $position = "[{$this->getNumberFromString( $columnsPositions[$i] )}]";
+        $max = count($columns);
+        for ($i = 0; $i < $max; ++$i) {
+            $position = '';
+            if (!empty($columnsPositions[$i])) {
+                $position = "[{$this->getNumberFromString($columnsPositions[$i])}]";
             }
 
-            $el = $row->find( "xpath", "$type$position" );
+            $el = $row->find('xpath', "$type$position");
 
             // check if match with expected if not return false
-            if ( $el === null || $columns[$i] !== $el->getText() )
-            {
+            if ($el === null || $columns[$i] !== $el->getText()) {
                 return false;
             }
         }
@@ -292,7 +276,7 @@ class Context implements MinkAwareContext
     }
 
     /**
-     * Find a(all) table row(s) that match the column text
+     * Find a(all) table row(s) that match the column text.
      *
      * @param string        $text       Text to be found
      * @param string|int    $column     In which column the text should be found
@@ -300,42 +284,34 @@ class Context implements MinkAwareContext
      *
      * @return \Behat\Mink\Element\NodeElement[]
      */
-    public function getTableRow( $text, $column = null, $tableXpath = null )
+    public function getTableRow($text, $column = null, $tableXpath = null)
     {
         // check column
-        if ( !empty( $column ) )
-        {
-            if ( is_integer( $column ) )
-            {
+        if (!empty($column)) {
+            if (is_integer($column)) {
                 $columnNumber = "[$column]";
+            } else {
+                $columnNumber = "[{$this->getNumberFromString($column)}]";
             }
-            else
-            {
-                $columnNumber = "[{$this->getNumberFromString( $column )}]";
-            }
-        }
-        else
-        {
-            $columnNumber = "";
+        } else {
+            $columnNumber = '';
         }
 
         // get all possible elements
         $elements = array_merge(
-            $this->getXpath()->findXpath( "$tableXpath//tr/th$columnNumber" ),
-            $this->getXpath()->findXpath( "$tableXpath//tr/td$columnNumber" )
+            $this->getXpath()->findXpath("$tableXpath//tr/th$columnNumber"),
+            $this->getXpath()->findXpath("$tableXpath//tr/td$columnNumber")
         );
 
         $foundXpath = array();
-        $total = count( $elements );
+        $total = count($elements);
         $i = 0;
-        while ( $i < $total )
-        {
-            if ( strpos( $elements[$i]->getText(), $text ) !== false )
-            {
+        while ($i < $total) {
+            if (strpos($elements[$i]->getText(), $text) !== false) {
                 $foundXpath[] = $elements[$i]->getParent();
             }
 
-            $i++;
+            ++$i;
         }
 
         return $foundXpath;
@@ -344,7 +320,7 @@ class Context implements MinkAwareContext
     /**
      * Find and return the row (<tr>) where the passed element is
      * This is useful when you intend to know if another element is in the same
-     * row
+     * row.
      *
      * @param \Behat\Mink\Element\NodeElement $element The element in the intended row
      *
@@ -352,21 +328,19 @@ class Context implements MinkAwareContext
      *
      * @throws \PHPUnit_Framework_AssertionFailedError
      */
-    public function findRow( NodeElement $element )
+    public function findRow(NodeElement $element)
     {
         $initialTag = $element->getTagName();
 
-        while (
-            strtolower( $element->getTagName() ) !== "tr"
-            && strtolower( $element->getTagName() ) !== "body"
-        )
-        {
+        while (strtolower($element->getTagName()) !== 'tr'
+            && strtolower($element->getTagName()) !== 'body'
+        ) {
             $element = $element->getParent();
         }
 
         Assertion::assertEquals(
-            strtolower( $element->getTagName() ),
-            "tr",
+            strtolower($element->getTagName()),
+            'tr',
             "Couldn't find a parent of '$initialTag' that is a table row"
         );
 
@@ -375,7 +349,7 @@ class Context implements MinkAwareContext
 
     /**
      * In a list of elements returns a certain element (found through xpath) that
-     * is after a specific element (that is also found through xpath)
+     * is after a specific element (that is also found through xpath).
      *
      * <code>
      * findElementAfterElement(
@@ -391,33 +365,25 @@ class Context implements MinkAwareContext
      *
      * @return \Behat\Mink\Element\NodeElement|null Element if found null otherwise
      */
-    public function findElementAfterElement( array $elements, $firstXpath, $secondXpath )
+    public function findElementAfterElement(array $elements, $firstXpath, $secondXpath)
     {
         $foundFirstXpath = false;
-        foreach ( $elements as $element )
-        {
+        foreach ($elements as $element) {
             // choose what xpath to use
-            if ( ! $foundFirstXpath )
-            {
+            if (!$foundFirstXpath) {
                 $xpath = $firstXpath;
-            }
-            else
-            {
+            } else {
                 $xpath = $secondXpath;
             }
 
-            $foundElement = $element->find( "xpath", $xpath );
+            $foundElement = $element->find('xpath', $xpath);
 
             // element found, if first start to look for the second one
             // if second, than return this one
-            if ( !empty( $foundElement) )
-            {
-                if ( !$foundFirstXpath )
-                {
+            if (!empty($foundElement)) {
+                if (!$foundFirstXpath) {
                     $foundFirstXpath = true;
-                }
-                else
-                {
+                } else {
                     return $foundElement;
                 }
             }
@@ -427,28 +393,26 @@ class Context implements MinkAwareContext
     }
 
     /**
-     * Verifies if the element has 'special' configuration on a attribute (default -> style)
+     * Verifies if the element has 'special' configuration on a attribute (default -> style).
      *
      * @param \Behat\Mink\Element\NodeElement $el The element that we want to test
      * @param string $characteristic Verify a specific characteristic from attribute
      * @param string $attribute Verify a specific attribute
      *
-     * @return boolean
+     * @return bool
      */
-    public function isElementEmphasized( NodeElement $el, $characteristic = null, $attribute = "style" )
+    public function isElementEmphasized(NodeElement $el, $characteristic = null, $attribute = 'style')
     {
         // verify it has the attribute we're looking for
-        if ( !$el->hasAttribute( $attribute ) )
-        {
+        if (!$el->hasAttribute($attribute)) {
             return false;
         }
 
         // get the attribute
-        $attr = $el->getAttribute( $attribute );
+        $attr = $el->getAttribute($attribute);
 
         // check if want to test specific characteristic and if it is present
-        if ( !empty( $characteristic ) && strpos( $attr, $characteristic ) === false )
-        {
+        if (!empty($characteristic) && strpos($attr, $characteristic) === false) {
             return false;
         }
 
@@ -457,76 +421,64 @@ class Context implements MinkAwareContext
     }
 
     /**
-     * This method works is a complement to the $mainAttributes var
+     * This method works is a complement to the $mainAttributes var.
      *
      * @param  string $block This should be an identifier for the block to use
      *
-     * @return null|string XPath for the 
+     * @return null|string XPath for the block
      *
      * @see $this->mainAttributes
      */
-    public function makeXpathForBlock( $block = null )
+    public function makeXpathForBlock($block = null)
     {
-        if ( empty( $block ) )
-        {
+        if (empty($block)) {
             return null;
         }
 
-        $parameter = ( isset( $this->mainAttributes[strtolower( $block )] ) ) ?
-            $this->mainAttributes[strtolower( $block )] :
-            NULL;
+        $parameter = (isset($this->mainAttributes[strtolower($block)])) ?
+            $this->mainAttributes[strtolower($block)] :
+            null;
 
-        Assertion::assertNotNull( $parameter, "Element {$block} is not defined" );
+        Assertion::assertNotNull($parameter, "Element {$block} is not defined");
 
-        $xpath = $this->mainAttributes[strtolower( $block )];
+        $xpath = $this->mainAttributes[strtolower($block)];
         // check if value is a composed array
-        if ( is_array( $xpath ) )
-        {
+        if (is_array($xpath)) {
             // if there is an xpath defined look no more!
-            if ( isset( $xpath['xpath'] ) )
-            {
+            if (isset($xpath['xpath'])) {
                 return $xpath['xpath'];
             }
 
-            $nuXpath = "";
+            $nuXpath = '';
             // verify if there is a tag
-            if ( isset( $xpath['tag'] ) )
-            {
-                if ( strpos( $xpath['tag'], "/" ) === 0 || strpos( $xpath['tag'], "(" ) === 0 )
-                {
+            if (isset($xpath['tag'])) {
+                if (strpos($xpath['tag'], '/') === 0 || strpos($xpath['tag'], '(') === 0) {
                     $nuXpath = $xpath['tag'];
-                }
-                else
-                {
-                    $nuXpath = "//" . $xpath['tag'];
+                } else {
+                    $nuXpath = '//' . $xpath['tag'];
                 }
 
-                unset( $xpath['tag'] );
-            }
-            else
-            {
-                $nuXpath = "//*";
+                unset($xpath['tag']);
+            } else {
+                $nuXpath = '//*';
             }
 
-            foreach ( $xpath as $key => $value )
-            {
-                switch ( $key )
-                {
-                    case "text":
-                        $att = "text()";
+            foreach ($xpath as $key => $value) {
+                switch ($key) {
+                    case 'text':
+                        $att = 'text()';
                         break;
                     default:
                         $att = "@$key";
                 }
-                $nuXpath .= "[contains($att, {$this->getXpath()->literal( $value )})]";
+                $nuXpath .= "[contains($att, {$this->getXpath()->literal($value)})]";
             }
 
             return $nuXpath;
         }
 
         //  if the string is an Xpath
-        if ( strpos( $xpath, "/" ) === 0 || strpos( $xpath, "(" ) === 0 )
-        {
+        if (strpos($xpath, '/') === 0 || strpos($xpath, '(') === 0) {
             return $xpath;
         }
 

--- a/eZ/Bundle/PlatformBehatBundle/Context/Browser/MinkTrait.php
+++ b/eZ/Bundle/PlatformBehatBundle/Context/Browser/MinkTrait.php
@@ -1,18 +1,17 @@
 <?php
 /**
- * File containing the MinkTrait
+ * File containing the MinkTrait.
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
-
 namespace EzSystems\PlatformBehatBundle\Context\Browser;
 
 use Behat\Mink\Mink;
 
 /**
- * This makes possible for (mink) contexts to extend other classes than (Raw)MinkContext
+ * This makes possible for (mink) contexts to extend other classes than (Raw)MinkContext.
  */
 trait MinkTrait
 {
@@ -31,7 +30,7 @@ trait MinkTrait
      *
      * @param Mink $mink Mink session manager
      */
-    public function setMink( Mink $mink )
+    public function setMink(Mink $mink)
     {
         $this->mink = $mink;
     }
@@ -61,7 +60,7 @@ trait MinkTrait
      *
      * @param array $parameters
      */
-    public function setMinkParameters( array $parameters )
+    public function setMinkParameters(array $parameters)
     {
         $this->minkParameters = $parameters;
     }
@@ -73,9 +72,9 @@ trait MinkTrait
      *
      * @return mixed
      */
-    public function getMinkParameter( $name )
+    public function getMinkParameter($name)
     {
-        return isset( $this->minkParameters[$name] ) ? $this->minkParameters[$name] : null;
+        return isset($this->minkParameters[$name]) ? $this->minkParameters[$name] : null;
     }
 
     /**
@@ -85,7 +84,7 @@ trait MinkTrait
      * @param string $name  The key of the parameter
      * @param string $value The value of the parameter
      */
-    public function setMinkParameter( $name, $value )
+    public function setMinkParameter($name, $value)
     {
         $this->minkParameters[$name] = $value;
     }
@@ -97,9 +96,9 @@ trait MinkTrait
      *
      * @return Session
      */
-    public function getSession( $name = null )
+    public function getSession($name = null)
     {
-        return $this->getMink()->getSession( $name );
+        return $this->getMink()->getSession($name);
     }
 
     /**
@@ -109,9 +108,9 @@ trait MinkTrait
      *
      * @return WebAssert
      */
-    public function assertSession( $name = null )
+    public function assertSession($name = null)
     {
-        return $this->getMink()->assertSession( $name );
+        return $this->getMink()->assertSession($name);
     }
 
     /**
@@ -122,11 +121,11 @@ trait MinkTrait
      *
      * @return string
      */
-    public function locatePath( $path )
+    public function locatePath($path)
     {
-        $startUrl = rtrim( $this->getMinkParameter( 'base_url' ), '/' ) . '/';
+        $startUrl = rtrim($this->getMinkParameter('base_url'), '/') . '/';
 
-        return 0 !== strpos( $path, 'http' ) ? $startUrl . ltrim( $path, '/' ) : $path;
+        return 0 !== strpos($path, 'http') ? $startUrl . ltrim($path, '/') : $path;
     }
 
     /**
@@ -137,12 +136,19 @@ trait MinkTrait
      * @param string $filepath Desired filepath, defaults to
      *                         upload_tmp_dir, falls back to sys_get_temp_dir()
      */
-    public function saveScreenshot( $filename = null, $filepath = null )
+    public function saveScreenshot($filename = null, $filepath = null)
     {
         // Under Cygwin, uniqid with more_entropy must be set to true.
         // No effect in other environments.
-        $filename = $filename ?: sprintf( '%s_%s_%s.%s', $this->getMinkParameter( 'browser_name' ), date( 'c' ), uniqid( '', true ), 'png' );
-        $filepath = $filepath ? $filepath : ( ini_get( 'upload_tmp_dir' ) ? ini_get( 'upload_tmp_dir' ) : sys_get_temp_dir() );
-        file_put_contents( $filepath . '/' . $filename, $this->getSession()->getScreenshot() );
+        $filename = $filename ?: sprintf(
+            '%s_%s_%s.%s',
+            $this->getMinkParameter('browser_name'),
+            date('c'),
+            uniqid('', true),
+            'png'
+        );
+        $filepath = $filepath ? $filepath :
+            (ini_get('upload_tmp_dir') ? ini_get('upload_tmp_dir') : sys_get_temp_dir());
+        file_put_contents($filepath . '/' . $filename, $this->getSession()->getScreenshot());
     }
 }

--- a/eZ/Bundle/PlatformBehatBundle/Context/Browser/MinkTrait.php
+++ b/eZ/Bundle/PlatformBehatBundle/Context/Browser/MinkTrait.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * File containing the MinkTrait
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\PlatformBehatBundle\Context\Browser;
+
+use Behat\Mink\Mink;
+
+/**
+ * This makes possible for (mink) contexts to extend other classes than (Raw)MinkContext
+ */
+trait MinkTrait
+{
+    /**
+     * @var \Behat\Mink\Mink
+     */
+    private $mink;
+
+    /**
+     * @var array
+     */
+    private $minkParameters;
+
+    /**
+     * Sets Mink instance.
+     *
+     * @param Mink $mink Mink session manager
+     */
+    public function setMink( Mink $mink )
+    {
+        $this->mink = $mink;
+    }
+
+    /**
+     * Returns Mink instance.
+     *
+     * @return Mink
+     */
+    public function getMink()
+    {
+        return $this->mink;
+    }
+
+    /**
+     * Returns the parameters provided for Mink.
+     *
+     * @return array
+     */
+    public function getMinkParameters()
+    {
+        return $this->minkParameters;
+    }
+
+    /**
+     * Sets parameters provided for Mink.
+     *
+     * @param array $parameters
+     */
+    public function setMinkParameters( array $parameters )
+    {
+        $this->minkParameters = $parameters;
+    }
+
+    /**
+     * Returns specific mink parameter.
+     *
+     * @param string $name
+     *
+     * @return mixed
+     */
+    public function getMinkParameter( $name )
+    {
+        return isset( $this->minkParameters[$name] ) ? $this->minkParameters[$name] : null;
+    }
+
+    /**
+     * Applies the given parameter to the Mink configuration. Consider that all parameters get reset for each
+     * feature context.
+     *
+     * @param string $name  The key of the parameter
+     * @param string $value The value of the parameter
+     */
+    public function setMinkParameter( $name, $value )
+    {
+        $this->minkParameters[$name] = $value;
+    }
+
+    /**
+     * Returns Mink session.
+     *
+     * @param string|null $name name of the session OR active session will be used
+     *
+     * @return Session
+     */
+    public function getSession( $name = null )
+    {
+        return $this->getMink()->getSession( $name );
+    }
+
+    /**
+     * Returns Mink session assertion tool.
+     *
+     * @param string|null $name name of the session OR active session will be used
+     *
+     * @return WebAssert
+     */
+    public function assertSession( $name = null )
+    {
+        return $this->getMink()->assertSession( $name );
+    }
+
+    /**
+     * Locates url, based on provided path.
+     * Override to provide custom routing mechanism.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    public function locatePath( $path )
+    {
+        $startUrl = rtrim( $this->getMinkParameter( 'base_url' ), '/' ) . '/';
+
+        return 0 !== strpos( $path, 'http' ) ? $startUrl . ltrim( $path, '/' ) : $path;
+    }
+
+    /**
+     * Save a screenshot of the current window to the file system.
+     *
+     * @param string $filename Desired filename, defaults to
+     *                         <browser_name>_<ISO 8601 date>_<randomId>.png
+     * @param string $filepath Desired filepath, defaults to
+     *                         upload_tmp_dir, falls back to sys_get_temp_dir()
+     */
+    public function saveScreenshot( $filename = null, $filepath = null )
+    {
+        // Under Cygwin, uniqid with more_entropy must be set to true.
+        // No effect in other environments.
+        $filename = $filename ?: sprintf( '%s_%s_%s.%s', $this->getMinkParameter( 'browser_name' ), date( 'c' ), uniqid( '', true ), 'png' );
+        $filepath = $filepath ? $filepath : ( ini_get( 'upload_tmp_dir' ) ? ini_get( 'upload_tmp_dir' ) : sys_get_temp_dir() );
+        file_put_contents( $filepath . '/' . $filename, $this->getSession()->getScreenshot() );
+    }
+}

--- a/eZ/Bundle/PlatformBehatBundle/Context/Browser/SubContext/Authentication.php
+++ b/eZ/Bundle/PlatformBehatBundle/Context/Browser/SubContext/Authentication.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * File containing the Authentication class for Browser contexts.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace EzSystems\PlatformBehatBundle\Context\Browser\SubContext;
+
+/**
+ * Authentication methods
+ */
+trait Authentication
+{
+    /**
+     * @Given I am logged (in) as a(n) :role
+     * @Given I have :role permissions
+     *
+     * Logs in a (new) user with the role identified by ':role' assigned.
+     */
+    public function iAmLoggedInAsAn( $role )
+    {
+        if ( $role == 'Anonymous' )
+        {
+            $this->iAmNotLoggedIn();
+        }
+        else
+        {
+            $credentials = $this->getCredentialsFor( $role );
+            $this->iAmLoggedInAsWithPassword( $credentials['login'], $credentials['password'] );
+        }
+    }
+
+    /**
+     * @Given I am logged in as :user with password :password
+     *
+     * Performs the login action with username ':user' and password ':password'.
+     * Checks that the resulting page is the homepage.
+     */
+    public function iAmLoggedInAsWithPassword( $user, $password )
+    {
+        $this->iAmOnPage( 'login' );
+        $this->fillFieldWithValue( 'Username', $user );
+        $this->fillFieldWithValue( 'Password', $password );
+        $this->iClickAtButton( 'Login' );
+        $this->iShouldBeOnPage( 'home' );
+    }
+
+    /**
+     * @Given I am not logged in
+     * @Given I don't have permissions
+     *
+     * Perform the logout action, checks that the resulting page is the homepage.
+     */
+    public function iAmNotLoggedIn()
+    {
+        $this->iAmOnPage( 'logout' );
+        $this->iShouldBeOnPage( 'home' );
+    }
+}

--- a/eZ/Bundle/PlatformBehatBundle/Context/Browser/SubContext/Authentication.php
+++ b/eZ/Bundle/PlatformBehatBundle/Context/Browser/SubContext/Authentication.php
@@ -9,7 +9,7 @@
 namespace EzSystems\PlatformBehatBundle\Context\Browser\SubContext;
 
 /**
- * Authentication methods
+ * Authentication methods.
  */
 trait Authentication
 {
@@ -19,16 +19,13 @@ trait Authentication
      *
      * Logs in a (new) user with the role identified by ':role' assigned.
      */
-    public function iAmLoggedInAsAn( $role )
+    public function iAmLoggedInAsAn($role)
     {
-        if ( $role == 'Anonymous' )
-        {
+        if ($role == 'Anonymous') {
             $this->iAmNotLoggedIn();
-        }
-        else
-        {
-            $credentials = $this->getCredentialsFor( $role );
-            $this->iAmLoggedInAsWithPassword( $credentials['login'], $credentials['password'] );
+        } else {
+            $credentials = $this->getCredentialsFor($role);
+            $this->iAmLoggedInAsWithPassword($credentials['login'], $credentials['password']);
         }
     }
 
@@ -38,13 +35,13 @@ trait Authentication
      * Performs the login action with username ':user' and password ':password'.
      * Checks that the resulting page is the homepage.
      */
-    public function iAmLoggedInAsWithPassword( $user, $password )
+    public function iAmLoggedInAsWithPassword($user, $password)
     {
-        $this->iAmOnPage( 'login' );
-        $this->fillFieldWithValue( 'Username', $user );
-        $this->fillFieldWithValue( 'Password', $password );
-        $this->iClickAtButton( 'Login' );
-        $this->iShouldBeOnPage( 'home' );
+        $this->iAmOnPage('login');
+        $this->fillFieldWithValue('Username', $user);
+        $this->fillFieldWithValue('Password', $password);
+        $this->iClickAtButton('Login');
+        $this->iShouldBeOnPage('home');
     }
 
     /**
@@ -55,7 +52,7 @@ trait Authentication
      */
     public function iAmNotLoggedIn()
     {
-        $this->iAmOnPage( 'logout' );
-        $this->iShouldBeOnPage( 'home' );
+        $this->iAmOnPage('logout');
+        $this->iShouldBeOnPage('home');
     }
 }

--- a/eZ/Bundle/PlatformBehatBundle/Context/Browser/SubContext/CommonActions.php
+++ b/eZ/Bundle/PlatformBehatBundle/Context/Browser/SubContext/CommonActions.php
@@ -1,0 +1,597 @@
+<?php
+/**
+ * File containing the Common Actions for Browser contexts
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+
+namespace EzSystems\PlatformBehatBundle\Context\Browser\SubContext;
+
+use EzSystems\BehatBundle\Helper\EzAssertion;
+use EzSystems\BehatBundle\Helper\Gherkin as GherkinHelper;
+use Behat\Gherkin\Node\TableNode;
+use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Exception\UnsupportedDriverActionException;
+use PHPUnit_Framework_Assert as Assertion;
+
+/**
+ * Class with the simple actions you can do in a browser
+ *
+ * @method \Behat\Mink\Session getSession
+ */
+trait CommonActions
+{
+    /**
+     * @Given I am on :path
+     * @When  I go to :path
+     *
+     * Visits the path ':path', relative to the configured 'base_url' parameter
+     */
+    public function visit( $path )
+    {
+        $this->getSession()->visit( $this->locatePath( $path ) );
+    }
+
+    /**
+     * @Given I see :id (link/button/form)
+     * @When  I can see :id (link/button/form)
+     *
+     * A "spin function" sentence to wait for a given element to appear.
+     * Waits maximum 3 seconds, tries every 200ms
+     *
+     * @link http://docs.behat.org/en/v2.5/cookbook/using_spin_functions.html
+     */
+    public function iCanSee( $id )
+    {
+        $element = null;
+        $session = $this->getSession();
+        for ($i = 0; $i < 15; $i++) {
+            if ($element = $session->getPage()->findById($id)) {
+                break;
+            }
+
+            usleep(200 * 1000);// 1 million microseconds is 1 second
+        }
+
+        Assertion::assertTrue($element !== null, "Item '{$id}' did not appear on the page within 3 seconds");
+    }
+
+    /**
+     * @Given I am on/at the homepage
+     * @Given I am on/at (the) :page page
+     * @When I go to the homepage
+     * @When  I go to (the) :page page
+     *
+     * Visits the page identified by ':page', or the homepage.
+     * Asserts that http response status code is not >= 400
+     */
+    public function iAmOnPage( $page = 'home' )
+    {
+        $this->visit( $this->getPathByPageIdentifier( $page ) );
+        $this->checkForExceptions();
+    }
+
+    /**
+     * Checks the output of the latest session page for Symfony exceptions.
+     *
+     * If one is found, a failed assertion is executed, with the exception details + formatted stacktrace.
+     */
+    protected function checkForExceptions()
+    {
+        $exceptionElements = $this->getXpath()->findXpath("//div[@class='text-exception']/h1");
+        $exceptionStackTraceItems = $this->getXpath()->findXpath("//ol[@id='traces-0']/li");
+        if (count($exceptionElements) > 0) {
+            $exceptionElement = $exceptionElements[0];
+            $exceptionLines = [$exceptionElement->getText(), ''];
+
+            foreach ($exceptionStackTraceItems as $stackTraceItem) {
+                $html = $stackTraceItem->getHtml();
+                $html = substr($html, 0, strpos($html, '<a href', 1));
+                $html = htmlspecialchars_decode(strip_tags($html));
+                $html = preg_replace('/\s+/', ' ', $html);
+                $html = str_replace('  (', '(', $html);
+                $html = str_replace(' ->', '->', $html);
+                $exceptionLines[] = trim($html);
+            }
+            $message = 'An exception occured during rendering:' . implode("\n", $exceptionLines);
+            Assertion::assertTrue(false, $message);
+        }
+    }
+
+    /**
+     * @Then I should see a :label input field
+     */
+    public function seeInputField($label)
+    {
+        $field = $this->getSession()->getPage()->findField($label);
+        if (!$field) {
+            throw new \Exception("Field '$label' not found");
+        }
+    }
+    /**
+     * @When I fill in :field with :value
+     * @When I set :field as empty
+     *
+     * Fill field identified by ':field' with ':value'
+     */
+    public function fillFieldWithValue( $field, $value = '' )
+    {
+        $this->getSession()->getPage()->fillField( $field, $value );
+    }
+
+    /**
+     * @Then I should be at/on (the) homepage
+     * @Then I should be at/on (the) :page page
+     *
+     * Asserts that the current page is the one identified by ':page', or the homepage.
+     */
+    public function iShouldBeOnPage( $pageIdentifier = 'home' )
+    {
+        $currentUrl = $this->getUrlWithoutQueryString( $this->getSession()->getCurrentUrl() );
+
+        $expectedUrl = $this->locatePath( $this->getPathByPageIdentifier( $pageIdentifier ) );
+
+        Assertion::assertEquals(
+            $expectedUrl,
+            $currentUrl,
+            "Unexpected URL of the current site. Expected: '$expectedUrl'. Actual: '$currentUrl'."
+        );
+    }
+
+    /**
+     * @Given I clicked on/at (the) :button button
+     * @When I click on/at (the) :button button
+     *
+     * Clicks the button identified by ':button'
+     */
+    public function iClickAtButton( $button )
+    {
+        $this->onPageSectionIClickAtButton( $button );
+    }
+
+    /**
+     * @Given on :pageSection I clicked at/on :button button
+     * @When  on :pageSection I click at/on :button button
+     *
+     * Clicks the button identified by ':button', located in section ':section'
+     */
+    public function onPageSectionIClickAtButton( $button, $pageSection = null )
+    {
+        $base = $this->makeXpathForBlock( $pageSection );
+        $el = $this->getXpath()->findButtons( $button, $base );
+        EzAssertion::assertElementFound( $button, $el, $pageSection, 'button' );
+        $el[0]->click();
+    }
+
+    /**
+     * @Given I clicked on/at (the) :link link
+     * @When  I click on/at (the) :link link
+     *
+     * Click a link with text ':link'
+     */
+    public function iClickAtLink( $link )
+    {
+        $this->onPageSectionIClickAtLink( $link );
+    }
+
+    /**
+     * @Given on :pageSection I clicked on/at link link
+     * @When  on :pageSection I click on/at :link link
+     *
+     * Click a link with text ':link' on page section ':pageSection'
+     * Asserts that at least one link element is found.
+     */
+    public function onPageSectionIClickAtLink( $link, $pageSection = null )
+    {
+        $base = $this->makeXpathForBlock( $pageSection );
+        $el = $this->getXpath()->findLinks( $link, $base );
+        EzAssertion::assertElementFound( $link, $el, $pageSection, 'link' );
+        $el[0]->click();
+    }
+
+    /**
+     * @Given I checked :label checkbox
+     * @When  I check :label checkbox
+     *
+     * Toggles the value for the checkbox with name ':label'
+     */
+    public function checkOption( $option )
+    {
+        $fieldElements = $this->getXpath()->findFields( $option );
+        EzAssertion::assertElementFound( $option, $fieldElements, null, 'checkbox' );
+
+        // this is needed for the cases where are checkboxes and radio's
+        // side by side, for main option the radio and the extra being the
+        // checkboxes values
+        if ( strtolower( $fieldElements[0]->getAttribute( 'type' ) ) !== 'checkbox' )
+        {
+            $value = $fieldElements[0]->getAttribute( 'value' );
+            $fieldElements = $this->getXpath()->findXpath( "//input[@type='checkbox' and @value='$value']" );
+            EzAssertion::assertElementFound( $value, $fieldElements, null, 'checkbox' );
+        }
+
+        $fieldElements[0]->check();
+    }
+
+    /**
+     * @When I select :option
+     *
+     * Selects option with value ':value'
+     * IMPORTANT: Will thrown an error if more than 1 select/dropdown is found on page
+     */
+    public function iSelect( $option )
+    {
+        $elements = $this->getXpath()->findXpath( "//select" );
+        Assertion::assertNotEmpty( $elements, "Unable to find a select field" );
+        $elements[0]->selectOption( $option );
+    }
+
+    /**
+     * @Given I selected :label radio button
+     * @When  I select :label radio button
+     *
+     * Selects the radio button with label ':label'
+     */
+    public function iSelectRadioButton( $label )
+    {
+        $el = $this->getSession()->getPage()->findField( $label );
+        Assertion::assertNotNull( $el, "Couldn't find a radio input with '$label'" );
+        $el->check();
+    }
+
+     /**
+     * @Given I filled form with:
+     * @When  I fill form with:
+     *
+     * Fills a form with the provided field/value pairs:
+     *      | field         | value                  |
+     *      | Title         | A title text           |
+     *      | Content       | Some content           |
+     */
+    public function iFillFormWith( TableNode $table )
+    {
+        foreach ( GherkinHelper::convertTableToArrayOfData( $table ) as $field => $value )
+        {
+            $elements = $this->getXpath()->findFields( $field );
+            Assertion::assertNotEmpty( $elements, "Unable to find '{$field}' field" );
+            $elements[0]->setValue( $value );
+        }
+    }
+
+    /**
+     * @Then I see field with value:
+     *
+     * Checks a form for the provided field/value pairs:
+     *      | field         | value                  |
+     *      | Title         | A title text           |
+     *      | Content       | Some content           |
+     */
+    public function formHasValue( TableNode $table )
+    {
+        foreach ( GherkinHelper::convertTableToArrayOfData( $table ) as $field => $value )
+        {
+            $elements = $this->getXpath()->findFields( $field );
+            Assertion::assertNotEmpty( $elements, "Unable to find '{$field}' field" );
+            Assertion::assertEquals( $value, $elements[0]->getValue(), "Field values don't match" );
+        }
+    }
+
+    /**
+     * @Then I (should) see (the) (following) links:
+     *
+     * Asserts that links with the provided text can be found on the page.
+     *      | link          |
+     *      | some link     |
+     *      ...
+     *      | another link  |
+     */
+    public function iSeeLinks( TableNode $table )
+    {
+        $this->onPageSectionISeeLinks( $table );
+    }
+
+    /**
+     * @Then on :pageSection I (should) see (the) (following) links:
+     *
+     */
+    public function onPageSectionISeeLinks( TableNode $table, $pageSection = null )
+    {
+        $rows = $table->getRows();
+        array_shift( $rows );
+
+        foreach ( $rows as $row )
+        {
+            $link = $row[0];
+            $el = $this->getXpath()->findLinks( $link, $this->makeXpathForBlock( $pageSection ) );
+
+            Assertion::assertNotEmpty( $el, "Unexpected link found" );
+        }
+    }
+
+    /**
+     * @Then I shouldn't see (the) (following) links:
+     * @Then I don't see (the) (following) links:
+     *
+     * Asserts that none of the links with the provided text can be found.
+     */
+    public function iDonTSeeLinks( TableNode $table )
+    {
+        $this->onPageSectionIDonTSeeLinks( 'main', $table );
+    }
+
+    /**
+     * @Then on :pageSection I shouldn't see (the) (following) links:
+     * @Then on :pageSection I don't see (the) (following) links:
+     */
+    public function onPageSectionIDonTSeeLinks( TableNode $table, $pageSection = null )
+    {
+        $rows = $table->getRows();
+        array_shift( $rows );
+
+        foreach ( $rows as $row )
+        {
+            $link = $row[0];
+            $el = $this->getXpath()->findLinks( $link, $this->makeXpathForBlock( $pageSection ) );
+
+            Assertion::assertEmpty( $el, "Unexpected link found" );
+        }
+    }
+
+    /**
+     * @Then I (should) see (the) links in the following order:
+     * @Then I (should) see (the) links in this order:
+     *
+     * Checks if links exist, and appear in the specified order
+     */
+    public function iSeeLinksInFollowingOrder( TableNode $table )
+    {
+        // get all links
+        $available = $this->getXpath()->findXpath( "//a[@href]" );
+
+        $rows = $table->getRows();
+        array_shift( $rows );
+
+        // remove links from embeded arrays
+        $links = array();
+        foreach ( $rows as $row )
+        {
+            $links[] = $row[0];
+        }
+
+        // and finaly verify their existence
+        $this->checkLinksExistence( $links, $available );
+    }
+
+    /**
+     * @Then I (should) see (the) (following) links in:
+     *
+     * Example: this is used to see in tag cloud which tags have more results
+     *      | link  | tag   |
+     *      | link1 | title |
+     *      | link2 | list  |
+     *      | link3 | text  |
+     */
+    public function iSeeFollowingLinksIn( TableNode $table )
+    {
+        $session = $this->getSession();
+        $rows = $table->getRows();
+        array_shift( $rows );
+        foreach ( $rows as $row )
+        {
+            Assertion::assertEquals( 2, count( $row ), "The table should be have array with link and tag" );
+
+            // prepare XPath
+            list( $link, $type ) = $row;
+            $tags = $this->getTagsFor( $type );
+            $xpaths = explode( '|', $this->getXpath()->makeElementXpath( 'link', $link ) );
+            $xpath = implode(
+                '|',
+                array_map(
+                    function( $tag ) use( $xpaths )
+                    {
+                        return "//$tag/" . implode( "| //$tag/", $xpaths );
+                    },
+                    $tags
+                )
+            );
+
+            // search and do assertions
+            $el = $this->getXpath()->findXpath( $xpath );
+            EzAssertion::assertSingleElement( $link, $el, $type, 'link' );
+        }
+    }
+
+    /**
+     * @Then I (should) see :title title/topic
+     *
+     * Asserts that a (single) title element exists with the text ':title'
+     */
+    public function iSeeTitle( $title )
+    {
+        $literal = $this->getXpath()->literal( $title );
+        $tags = $this->getTagsFor( "title" );
+        $innerXpath = "[text() = {$literal} or .//*[text() = {$literal}]]";
+        $xpathOptions = array_map(
+            function( $tag ) use( $innerXpath )
+            {
+                return "//$tag$innerXpath";
+            },
+            $tags
+        );
+
+        $xpath = implode( '|', $xpathOptions );
+
+        $el = $this->getXpath()->findXpath( $xpath );
+
+        // assert that message was found
+        EzAssertion::assertSingleElement( $title, $el, null, 'title' );
+    }
+
+    /**
+     * @Then I (should) see table with:
+     *
+     * Asserts that a table exists with specified values.
+     * The table header needs to have the number of the column to which the values belong,
+     * all the other text is optional, normaly using 'Column' for easier understanding:
+     *
+     *      | Column 1 | Column 2 | Column 4 |
+     *      | Value A  | Value B  | Value D  |
+     *      ...
+     *      | Value I  | Value J  | Value L  |
+     */
+    public function iSeeTableWith( TableNode $table )
+    {
+        $rows = $table->getRows();
+        $headers = array_shift( $rows );
+
+        $max = count( $headers );
+        $mainHeader = array_shift( $headers );
+        foreach ( $rows as $row )
+        {
+            $mainColumn = array_shift( $row );
+            $foundRows = $this->getTableRow( $mainColumn, $mainHeader );
+
+            $found = false;
+            $maxFound = count( $foundRows );
+            for ( $i = 0; $i < $maxFound && !$found; $i++ )
+            {
+                if ( $this->existTableRow( $foundRows[$i], $row, $headers ) )
+                {
+                    $found = true;
+                }
+            }
+
+            $message = "Couldn't find row with elements: '" . implode( ",", array_merge( array( $mainColumn ), $row ) ) . "'";
+            Assertion::assertTrue( $found, $message );
+        }
+    }
+
+    /**
+     * @Then I (should) see :text text emphasized
+     *
+     * Checks that an element exists on the page with text ':text' emphasized.
+     */
+    public function iSeeTextEmphasized( $text )
+    {
+        $this->onPageSectionISeeTextEmphasized( $text );
+    }
+
+    /**
+     * @Then on :pageSection I (should) see the :text text emphasized
+     */
+    public function onPageSectionISeeTextEmphasized( $text, $pageSection = null )
+    {
+        // first find the text
+        $base = $this->makeXpathForBlock( $pageSection );
+        $el = $this->getXpath()->findXpath( "$base//*[contains( text(), {$this->getXpath()->literal( $text )} )]" );
+
+        EzAssertion::assertSingleElement( $text, $el, $pageSection, 'emphasized text' );
+
+        // finally verify if it has custom characteristics
+        Assertion::assertTrue(
+            $this->isElementEmphasized( $el[0] ),
+            "The text '$text' isn't emphasized"
+        );
+    }
+
+    /**
+     * @Then I (should) see :message warning/error
+     *
+     * Checks that an element with the class 'warning' or 'error' exists with text ':message'
+     */
+    public function iSeeWarning( $message )
+    {
+        $el = $this->getXpath()->findXpath(
+            "//*[contains( @class, 'warning' ) or contains( @class, 'error' )]"
+            . "//*[text() = {$this->getXpath()->literal( $message )}]"
+        );
+
+        Assertion::assertNotNull( $el, "Couldn't find error/warning message '{$message}'" );
+    }
+
+    /**
+     * @Then I (should) see the exact :text: message/text
+     *
+     * Checks that an element on the page contains the exact text ':text'
+     */
+    public function iSeeText( $text )
+    {
+        $this->onPageSectionISeeText( $text );
+    }
+
+    /**
+     * @Then on :pageSection I (should) see the exact :text message/text
+     */
+    public function onPageSectionISeeText( $text, $pageSection = null )
+    {
+        $base = $this->makeXpathForBlock( $pageSection );
+
+        $literal = $this->getXpath()->literal( $text );
+        $el = $this->getXpath()->findXpath( "$base//*[contains( text(), $literal )]" );
+
+        Assertion::assertNotNull( $el, "Couldn't find '$text' text" );
+        Assertion::assertEquals( trim( $el->getText() ), $text, "Couldn't find '$text' text" );
+    }
+
+    /**
+     * @Then I (should) see :message message/text
+     *
+     * Checks that current page contains text.
+     */
+    public function iSeeMessage( $text )
+    {
+        $this->checkForExceptions();
+        $this->assertSession()->pageTextContains( $text );
+    }
+
+    /**
+     * @Then I don't see :text message/text
+     *
+     * Checks that current page does not contain text.
+     */
+    public function iDonTSeeMessage( $text )
+    {
+        $this->assertSession()->pageTextNotContains( $text );
+    }
+
+    /**
+     * @Then the checkbox :label should be checked
+     */
+    public function isCheckedOption( $label )
+    {
+        $isChecked = $this->getCheckboxChecked( $label );
+        Assertion::assertTrue( $isChecked, "Checkbox $label is not checked" );
+    }
+
+    /**
+     * @Then the checkbox :label should not be checked
+     */
+    public function isNotCheckedOption( $label )
+    {
+        $isChecked = $this->getCheckboxChecked( $label );
+        Assertion::assertFalse( $isChecked, "Checkbox $label is checked" );
+    }
+
+    /**
+     * Helper for checkbox
+     */
+    private function getCheckboxChecked( $option )
+    {
+        $fieldElements = $this->getXpath()->findFields( $option );
+        EzAssertion::assertElementFound( $option, $fieldElements, null, 'checkbox' );
+
+        // this is needed for the cases where are checkboxes and radio's
+        // side by side, for main option the radio and the extra being the
+        // checkboxes values
+        if ( strtolower( $fieldElements[0]->getAttribute( 'type' ) ) !== 'checkbox' )
+        {
+            $value = $fieldElements[0]->getAttribute( 'value' );
+            $fieldElements = $this->getXpath()->findXpath( "//input[@type='checkbox' and @value='$value']" );
+            EzAssertion::assertElementFound( $value, $fieldElements, null, 'checkbox' );
+        }
+
+        return $isChecked = ( $fieldElements[0]->getAttribute( 'checked' ) ) === 'true';
+    }
+}

--- a/eZ/Bundle/PlatformBehatBundle/Context/Browser/SubContext/CommonActions.php
+++ b/eZ/Bundle/PlatformBehatBundle/Context/Browser/SubContext/CommonActions.php
@@ -1,23 +1,20 @@
 <?php
 /**
- * File containing the Common Actions for Browser contexts
+ * File containing the Common Actions for Browser contexts.
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  * @version //autogentag//
  */
-
 namespace EzSystems\PlatformBehatBundle\Context\Browser\SubContext;
 
 use EzSystems\BehatBundle\Helper\EzAssertion;
 use EzSystems\BehatBundle\Helper\Gherkin as GherkinHelper;
 use Behat\Gherkin\Node\TableNode;
-use Behat\Mink\Element\NodeElement;
-use Behat\Mink\Exception\UnsupportedDriverActionException;
 use PHPUnit_Framework_Assert as Assertion;
 
 /**
- * Class with the simple actions you can do in a browser
+ * Class with the simple actions you can do in a browser.
  *
  * @method \Behat\Mink\Session getSession
  */
@@ -29,9 +26,9 @@ trait CommonActions
      *
      * Visits the path ':path', relative to the configured 'base_url' parameter
      */
-    public function visit( $path )
+    public function visit($path)
     {
-        $this->getSession()->visit( $this->locatePath( $path ) );
+        $this->getSession()->visit($this->locatePath($path));
     }
 
     /**
@@ -43,11 +40,11 @@ trait CommonActions
      *
      * @link http://docs.behat.org/en/v2.5/cookbook/using_spin_functions.html
      */
-    public function iCanSee( $id )
+    public function iCanSee($id)
     {
         $element = null;
         $session = $this->getSession();
-        for ($i = 0; $i < 15; $i++) {
+        for ($i = 0; $i < 15; ++$i) {
             if ($element = $session->getPage()->findById($id)) {
                 break;
             }
@@ -67,9 +64,9 @@ trait CommonActions
      * Visits the page identified by ':page', or the homepage.
      * Asserts that http response status code is not >= 400
      */
-    public function iAmOnPage( $page = 'home' )
+    public function iAmOnPage($page = 'home')
     {
-        $this->visit( $this->getPathByPageIdentifier( $page ) );
+        $this->visit($this->getPathByPageIdentifier($page));
         $this->checkForExceptions();
     }
 
@@ -116,9 +113,9 @@ trait CommonActions
      *
      * Fill field identified by ':field' with ':value'
      */
-    public function fillFieldWithValue( $field, $value = '' )
+    public function fillFieldWithValue($field, $value = '')
     {
-        $this->getSession()->getPage()->fillField( $field, $value );
+        $this->getSession()->getPage()->fillField($field, $value);
     }
 
     /**
@@ -127,11 +124,11 @@ trait CommonActions
      *
      * Asserts that the current page is the one identified by ':page', or the homepage.
      */
-    public function iShouldBeOnPage( $pageIdentifier = 'home' )
+    public function iShouldBeOnPage($pageIdentifier = 'home')
     {
-        $currentUrl = $this->getUrlWithoutQueryString( $this->getSession()->getCurrentUrl() );
+        $currentUrl = $this->getUrlWithoutQueryString($this->getSession()->getCurrentUrl());
 
-        $expectedUrl = $this->locatePath( $this->getPathByPageIdentifier( $pageIdentifier ) );
+        $expectedUrl = $this->locatePath($this->getPathByPageIdentifier($pageIdentifier));
 
         Assertion::assertEquals(
             $expectedUrl,
@@ -146,9 +143,9 @@ trait CommonActions
      *
      * Clicks the button identified by ':button'
      */
-    public function iClickAtButton( $button )
+    public function iClickAtButton($button)
     {
-        $this->onPageSectionIClickAtButton( $button );
+        $this->onPageSectionIClickAtButton($button);
     }
 
     /**
@@ -157,11 +154,11 @@ trait CommonActions
      *
      * Clicks the button identified by ':button', located in section ':section'
      */
-    public function onPageSectionIClickAtButton( $button, $pageSection = null )
+    public function onPageSectionIClickAtButton($button, $pageSection = null)
     {
-        $base = $this->makeXpathForBlock( $pageSection );
-        $el = $this->getXpath()->findButtons( $button, $base );
-        EzAssertion::assertElementFound( $button, $el, $pageSection, 'button' );
+        $base = $this->makeXpathForBlock($pageSection);
+        $el = $this->getXpath()->findButtons($button, $base);
+        EzAssertion::assertElementFound($button, $el, $pageSection, 'button');
         $el[0]->click();
     }
 
@@ -171,9 +168,9 @@ trait CommonActions
      *
      * Click a link with text ':link'
      */
-    public function iClickAtLink( $link )
+    public function iClickAtLink($link)
     {
-        $this->onPageSectionIClickAtLink( $link );
+        $this->onPageSectionIClickAtLink($link);
     }
 
     /**
@@ -183,11 +180,11 @@ trait CommonActions
      * Click a link with text ':link' on page section ':pageSection'
      * Asserts that at least one link element is found.
      */
-    public function onPageSectionIClickAtLink( $link, $pageSection = null )
+    public function onPageSectionIClickAtLink($link, $pageSection = null)
     {
-        $base = $this->makeXpathForBlock( $pageSection );
-        $el = $this->getXpath()->findLinks( $link, $base );
-        EzAssertion::assertElementFound( $link, $el, $pageSection, 'link' );
+        $base = $this->makeXpathForBlock($pageSection);
+        $el = $this->getXpath()->findLinks($link, $base);
+        EzAssertion::assertElementFound($link, $el, $pageSection, 'link');
         $el[0]->click();
     }
 
@@ -197,19 +194,18 @@ trait CommonActions
      *
      * Toggles the value for the checkbox with name ':label'
      */
-    public function checkOption( $option )
+    public function checkOption($option)
     {
-        $fieldElements = $this->getXpath()->findFields( $option );
-        EzAssertion::assertElementFound( $option, $fieldElements, null, 'checkbox' );
+        $fieldElements = $this->getXpath()->findFields($option);
+        EzAssertion::assertElementFound($option, $fieldElements, null, 'checkbox');
 
         // this is needed for the cases where are checkboxes and radio's
         // side by side, for main option the radio and the extra being the
         // checkboxes values
-        if ( strtolower( $fieldElements[0]->getAttribute( 'type' ) ) !== 'checkbox' )
-        {
-            $value = $fieldElements[0]->getAttribute( 'value' );
-            $fieldElements = $this->getXpath()->findXpath( "//input[@type='checkbox' and @value='$value']" );
-            EzAssertion::assertElementFound( $value, $fieldElements, null, 'checkbox' );
+        if (strtolower($fieldElements[0]->getAttribute('type')) !== 'checkbox') {
+            $value = $fieldElements[0]->getAttribute('value');
+            $fieldElements = $this->getXpath()->findXpath("//input[@type='checkbox' and @value='$value']");
+            EzAssertion::assertElementFound($value, $fieldElements, null, 'checkbox');
         }
 
         $fieldElements[0]->check();
@@ -221,11 +217,11 @@ trait CommonActions
      * Selects option with value ':value'
      * IMPORTANT: Will thrown an error if more than 1 select/dropdown is found on page
      */
-    public function iSelect( $option )
+    public function iSelect($option)
     {
-        $elements = $this->getXpath()->findXpath( "//select" );
-        Assertion::assertNotEmpty( $elements, "Unable to find a select field" );
-        $elements[0]->selectOption( $option );
+        $elements = $this->getXpath()->findXpath('//select');
+        Assertion::assertNotEmpty($elements, 'Unable to find a select field');
+        $elements[0]->selectOption($option);
     }
 
     /**
@@ -234,14 +230,14 @@ trait CommonActions
      *
      * Selects the radio button with label ':label'
      */
-    public function iSelectRadioButton( $label )
+    public function iSelectRadioButton($label)
     {
-        $el = $this->getSession()->getPage()->findField( $label );
-        Assertion::assertNotNull( $el, "Couldn't find a radio input with '$label'" );
+        $el = $this->getSession()->getPage()->findField($label);
+        Assertion::assertNotNull($el, "Couldn't find a radio input with '$label'");
         $el->check();
     }
 
-     /**
+    /**
      * @Given I filled form with:
      * @When  I fill form with:
      *
@@ -250,13 +246,12 @@ trait CommonActions
      *      | Title         | A title text           |
      *      | Content       | Some content           |
      */
-    public function iFillFormWith( TableNode $table )
+    public function iFillFormWith(TableNode $table)
     {
-        foreach ( GherkinHelper::convertTableToArrayOfData( $table ) as $field => $value )
-        {
-            $elements = $this->getXpath()->findFields( $field );
-            Assertion::assertNotEmpty( $elements, "Unable to find '{$field}' field" );
-            $elements[0]->setValue( $value );
+        foreach (GherkinHelper::convertTableToArrayOfData($table) as $field => $value) {
+            $elements = $this->getXpath()->findFields($field);
+            Assertion::assertNotEmpty($elements, "Unable to find '{$field}' field");
+            $elements[0]->setValue($value);
         }
     }
 
@@ -268,13 +263,12 @@ trait CommonActions
      *      | Title         | A title text           |
      *      | Content       | Some content           |
      */
-    public function formHasValue( TableNode $table )
+    public function formHasValue(TableNode $table)
     {
-        foreach ( GherkinHelper::convertTableToArrayOfData( $table ) as $field => $value )
-        {
-            $elements = $this->getXpath()->findFields( $field );
-            Assertion::assertNotEmpty( $elements, "Unable to find '{$field}' field" );
-            Assertion::assertEquals( $value, $elements[0]->getValue(), "Field values don't match" );
+        foreach (GherkinHelper::convertTableToArrayOfData($table) as $field => $value) {
+            $elements = $this->getXpath()->findFields($field);
+            Assertion::assertNotEmpty($elements, "Unable to find '{$field}' field");
+            Assertion::assertEquals($value, $elements[0]->getValue(), "Field values don't match");
         }
     }
 
@@ -287,26 +281,24 @@ trait CommonActions
      *      ...
      *      | another link  |
      */
-    public function iSeeLinks( TableNode $table )
+    public function iSeeLinks(TableNode $table)
     {
-        $this->onPageSectionISeeLinks( $table );
+        $this->onPageSectionISeeLinks($table);
     }
 
     /**
      * @Then on :pageSection I (should) see (the) (following) links:
-     *
      */
-    public function onPageSectionISeeLinks( TableNode $table, $pageSection = null )
+    public function onPageSectionISeeLinks(TableNode $table, $pageSection = null)
     {
         $rows = $table->getRows();
-        array_shift( $rows );
+        array_shift($rows);
 
-        foreach ( $rows as $row )
-        {
+        foreach ($rows as $row) {
             $link = $row[0];
-            $el = $this->getXpath()->findLinks( $link, $this->makeXpathForBlock( $pageSection ) );
+            $el = $this->getXpath()->findLinks($link, $this->makeXpathForBlock($pageSection));
 
-            Assertion::assertNotEmpty( $el, "Unexpected link found" );
+            Assertion::assertNotEmpty($el, 'Unexpected link found');
         }
     }
 
@@ -316,26 +308,25 @@ trait CommonActions
      *
      * Asserts that none of the links with the provided text can be found.
      */
-    public function iDonTSeeLinks( TableNode $table )
+    public function iDonTSeeLinks(TableNode $table)
     {
-        $this->onPageSectionIDonTSeeLinks( 'main', $table );
+        $this->onPageSectionIDonTSeeLinks('main', $table);
     }
 
     /**
      * @Then on :pageSection I shouldn't see (the) (following) links:
      * @Then on :pageSection I don't see (the) (following) links:
      */
-    public function onPageSectionIDonTSeeLinks( TableNode $table, $pageSection = null )
+    public function onPageSectionIDonTSeeLinks(TableNode $table, $pageSection = null)
     {
         $rows = $table->getRows();
-        array_shift( $rows );
+        array_shift($rows);
 
-        foreach ( $rows as $row )
-        {
+        foreach ($rows as $row) {
             $link = $row[0];
-            $el = $this->getXpath()->findLinks( $link, $this->makeXpathForBlock( $pageSection ) );
+            $el = $this->getXpath()->findLinks($link, $this->makeXpathForBlock($pageSection));
 
-            Assertion::assertEmpty( $el, "Unexpected link found" );
+            Assertion::assertEmpty($el, 'Unexpected link found');
         }
     }
 
@@ -345,23 +336,22 @@ trait CommonActions
      *
      * Checks if links exist, and appear in the specified order
      */
-    public function iSeeLinksInFollowingOrder( TableNode $table )
+    public function iSeeLinksInFollowingOrder(TableNode $table)
     {
         // get all links
-        $available = $this->getXpath()->findXpath( "//a[@href]" );
+        $available = $this->getXpath()->findXpath('//a[@href]');
 
         $rows = $table->getRows();
-        array_shift( $rows );
+        array_shift($rows);
 
         // remove links from embeded arrays
         $links = array();
-        foreach ( $rows as $row )
-        {
+        foreach ($rows as $row) {
             $links[] = $row[0];
         }
 
         // and finaly verify their existence
-        $this->checkLinksExistence( $links, $available );
+        $this->checkLinksExistence($links, $available);
     }
 
     /**
@@ -373,33 +363,31 @@ trait CommonActions
      *      | link2 | list  |
      *      | link3 | text  |
      */
-    public function iSeeFollowingLinksIn( TableNode $table )
+    public function iSeeFollowingLinksIn(TableNode $table)
     {
         $session = $this->getSession();
         $rows = $table->getRows();
-        array_shift( $rows );
-        foreach ( $rows as $row )
-        {
-            Assertion::assertEquals( 2, count( $row ), "The table should be have array with link and tag" );
+        array_shift($rows);
+        foreach ($rows as $row) {
+            Assertion::assertEquals(2, count($row), 'The table should be have array with link and tag');
 
             // prepare XPath
-            list( $link, $type ) = $row;
-            $tags = $this->getTagsFor( $type );
-            $xpaths = explode( '|', $this->getXpath()->makeElementXpath( 'link', $link ) );
+            list($link, $type) = $row;
+            $tags = $this->getTagsFor($type);
+            $xpaths = explode('|', $this->getXpath()->makeElementXpath('link', $link));
             $xpath = implode(
                 '|',
                 array_map(
-                    function( $tag ) use( $xpaths )
-                    {
-                        return "//$tag/" . implode( "| //$tag/", $xpaths );
+                    function ($tag) use ($xpaths) {
+                        return "//$tag/" . implode("| //$tag/", $xpaths);
                     },
                     $tags
                 )
             );
 
             // search and do assertions
-            $el = $this->getXpath()->findXpath( $xpath );
-            EzAssertion::assertSingleElement( $link, $el, $type, 'link' );
+            $el = $this->getXpath()->findXpath($xpath);
+            EzAssertion::assertSingleElement($link, $el, $type, 'link');
         }
     }
 
@@ -408,25 +396,24 @@ trait CommonActions
      *
      * Asserts that a (single) title element exists with the text ':title'
      */
-    public function iSeeTitle( $title )
+    public function iSeeTitle($title)
     {
-        $literal = $this->getXpath()->literal( $title );
-        $tags = $this->getTagsFor( "title" );
+        $literal = $this->getXpath()->literal($title);
+        $tags = $this->getTagsFor('title');
         $innerXpath = "[text() = {$literal} or .//*[text() = {$literal}]]";
         $xpathOptions = array_map(
-            function( $tag ) use( $innerXpath )
-            {
+            function ($tag) use ($innerXpath) {
                 return "//$tag$innerXpath";
             },
             $tags
         );
 
-        $xpath = implode( '|', $xpathOptions );
+        $xpath = implode('|', $xpathOptions);
 
-        $el = $this->getXpath()->findXpath( $xpath );
+        $el = $this->getXpath()->findXpath($xpath);
 
         // assert that message was found
-        EzAssertion::assertSingleElement( $title, $el, null, 'title' );
+        EzAssertion::assertSingleElement($title, $el, null, 'title');
     }
 
     /**
@@ -441,30 +428,28 @@ trait CommonActions
      *      ...
      *      | Value I  | Value J  | Value L  |
      */
-    public function iSeeTableWith( TableNode $table )
+    public function iSeeTableWith(TableNode $table)
     {
         $rows = $table->getRows();
-        $headers = array_shift( $rows );
+        $headers = array_shift($rows);
 
-        $max = count( $headers );
-        $mainHeader = array_shift( $headers );
-        foreach ( $rows as $row )
-        {
-            $mainColumn = array_shift( $row );
-            $foundRows = $this->getTableRow( $mainColumn, $mainHeader );
+        $max = count($headers);
+        $mainHeader = array_shift($headers);
+        foreach ($rows as $row) {
+            $mainColumn = array_shift($row);
+            $foundRows = $this->getTableRow($mainColumn, $mainHeader);
 
             $found = false;
-            $maxFound = count( $foundRows );
-            for ( $i = 0; $i < $maxFound && !$found; $i++ )
-            {
-                if ( $this->existTableRow( $foundRows[$i], $row, $headers ) )
-                {
+            $maxFound = count($foundRows);
+            for ($i = 0; $i < $maxFound && !$found; ++$i) {
+                if ($this->existTableRow($foundRows[$i], $row, $headers)) {
                     $found = true;
                 }
             }
 
-            $message = "Couldn't find row with elements: '" . implode( ",", array_merge( array( $mainColumn ), $row ) ) . "'";
-            Assertion::assertTrue( $found, $message );
+            $message = "Couldn't find row with elements: '"
+                . implode(',', array_merge(array($mainColumn), $row)) . "'";
+            Assertion::assertTrue($found, $message);
         }
     }
 
@@ -473,25 +458,25 @@ trait CommonActions
      *
      * Checks that an element exists on the page with text ':text' emphasized.
      */
-    public function iSeeTextEmphasized( $text )
+    public function iSeeTextEmphasized($text)
     {
-        $this->onPageSectionISeeTextEmphasized( $text );
+        $this->onPageSectionISeeTextEmphasized($text);
     }
 
     /**
      * @Then on :pageSection I (should) see the :text text emphasized
      */
-    public function onPageSectionISeeTextEmphasized( $text, $pageSection = null )
+    public function onPageSectionISeeTextEmphasized($text, $pageSection = null)
     {
         // first find the text
-        $base = $this->makeXpathForBlock( $pageSection );
-        $el = $this->getXpath()->findXpath( "$base//*[contains( text(), {$this->getXpath()->literal( $text )} )]" );
+        $base = $this->makeXpathForBlock($pageSection);
+        $el = $this->getXpath()->findXpath("$base//*[contains( text(), {$this->getXpath()->literal($text)} )]");
 
-        EzAssertion::assertSingleElement( $text, $el, $pageSection, 'emphasized text' );
+        EzAssertion::assertSingleElement($text, $el, $pageSection, 'emphasized text');
 
         // finally verify if it has custom characteristics
         Assertion::assertTrue(
-            $this->isElementEmphasized( $el[0] ),
+            $this->isElementEmphasized($el[0]),
             "The text '$text' isn't emphasized"
         );
     }
@@ -501,14 +486,14 @@ trait CommonActions
      *
      * Checks that an element with the class 'warning' or 'error' exists with text ':message'
      */
-    public function iSeeWarning( $message )
+    public function iSeeWarning($message)
     {
         $el = $this->getXpath()->findXpath(
             "//*[contains( @class, 'warning' ) or contains( @class, 'error' )]"
-            . "//*[text() = {$this->getXpath()->literal( $message )}]"
+            . "//*[text() = {$this->getXpath()->literal($message)}]"
         );
 
-        Assertion::assertNotNull( $el, "Couldn't find error/warning message '{$message}'" );
+        Assertion::assertNotNull($el, "Couldn't find error/warning message '{$message}'");
     }
 
     /**
@@ -516,23 +501,23 @@ trait CommonActions
      *
      * Checks that an element on the page contains the exact text ':text'
      */
-    public function iSeeText( $text )
+    public function iSeeText($text)
     {
-        $this->onPageSectionISeeText( $text );
+        $this->onPageSectionISeeText($text);
     }
 
     /**
      * @Then on :pageSection I (should) see the exact :text message/text
      */
-    public function onPageSectionISeeText( $text, $pageSection = null )
+    public function onPageSectionISeeText($text, $pageSection = null)
     {
-        $base = $this->makeXpathForBlock( $pageSection );
+        $base = $this->makeXpathForBlock($pageSection);
 
-        $literal = $this->getXpath()->literal( $text );
-        $el = $this->getXpath()->findXpath( "$base//*[contains( text(), $literal )]" );
+        $literal = $this->getXpath()->literal($text);
+        $el = $this->getXpath()->findXpath("$base//*[contains( text(), $literal )]");
 
-        Assertion::assertNotNull( $el, "Couldn't find '$text' text" );
-        Assertion::assertEquals( trim( $el->getText() ), $text, "Couldn't find '$text' text" );
+        Assertion::assertNotNull($el, "Couldn't find '$text' text");
+        Assertion::assertEquals(trim($el->getText()), $text, "Couldn't find '$text' text");
     }
 
     /**
@@ -540,10 +525,10 @@ trait CommonActions
      *
      * Checks that current page contains text.
      */
-    public function iSeeMessage( $text )
+    public function iSeeMessage($text)
     {
         $this->checkForExceptions();
-        $this->assertSession()->pageTextContains( $text );
+        $this->assertSession()->pageTextContains($text);
     }
 
     /**
@@ -551,47 +536,46 @@ trait CommonActions
      *
      * Checks that current page does not contain text.
      */
-    public function iDonTSeeMessage( $text )
+    public function iDonTSeeMessage($text)
     {
-        $this->assertSession()->pageTextNotContains( $text );
+        $this->assertSession()->pageTextNotContains($text);
     }
 
     /**
      * @Then the checkbox :label should be checked
      */
-    public function isCheckedOption( $label )
+    public function isCheckedOption($label)
     {
-        $isChecked = $this->getCheckboxChecked( $label );
-        Assertion::assertTrue( $isChecked, "Checkbox $label is not checked" );
+        $isChecked = $this->getCheckboxChecked($label);
+        Assertion::assertTrue($isChecked, "Checkbox $label is not checked");
     }
 
     /**
      * @Then the checkbox :label should not be checked
      */
-    public function isNotCheckedOption( $label )
+    public function isNotCheckedOption($label)
     {
-        $isChecked = $this->getCheckboxChecked( $label );
-        Assertion::assertFalse( $isChecked, "Checkbox $label is checked" );
+        $isChecked = $this->getCheckboxChecked($label);
+        Assertion::assertFalse($isChecked, "Checkbox $label is checked");
     }
 
     /**
-     * Helper for checkbox
+     * Helper for checkbox.
      */
-    private function getCheckboxChecked( $option )
+    private function getCheckboxChecked($option)
     {
-        $fieldElements = $this->getXpath()->findFields( $option );
-        EzAssertion::assertElementFound( $option, $fieldElements, null, 'checkbox' );
+        $fieldElements = $this->getXpath()->findFields($option);
+        EzAssertion::assertElementFound($option, $fieldElements, null, 'checkbox');
 
         // this is needed for the cases where are checkboxes and radio's
         // side by side, for main option the radio and the extra being the
         // checkboxes values
-        if ( strtolower( $fieldElements[0]->getAttribute( 'type' ) ) !== 'checkbox' )
-        {
-            $value = $fieldElements[0]->getAttribute( 'value' );
-            $fieldElements = $this->getXpath()->findXpath( "//input[@type='checkbox' and @value='$value']" );
-            EzAssertion::assertElementFound( $value, $fieldElements, null, 'checkbox' );
+        if (strtolower($fieldElements[0]->getAttribute('type')) !== 'checkbox') {
+            $value = $fieldElements[0]->getAttribute('value');
+            $fieldElements = $this->getXpath()->findXpath("//input[@type='checkbox' and @value='$value']");
+            EzAssertion::assertElementFound($value, $fieldElements, null, 'checkbox');
         }
 
-        return $isChecked = ( $fieldElements[0]->getAttribute( 'checked' ) ) === 'true';
+        return $isChecked = ($fieldElements[0]->getAttribute('checked')) === 'true';
     }
 }


### PR DESCRIPTION
As decided BehatBundle is to be deprecated and separated between the kernel and platformUI bundle. The idea is to make the Behat easier to maintain, having less repo dependencies should help releases and versions also.

This PR moves the Browser Context related classes into the kernel. This is used to interact with the browser using behat and mink. Since this is to might be need for any context that need to interact with the browser.

Related PRs:
* Add RepositoryContext trait #1584
* Add EzBehatExtension and ArgumentResolver #1586
* Deprecate Behat classes https://github.com/ezsystems/BehatBundle/pull/48