### PR TITLE
[POC - Behat] Add EzBehatExtension and ArgumentResolver

### DIFF
--- a/doc/behat/README.md
+++ b/doc/behat/README.md
@@ -1,0 +1,14 @@
+##### Accessing eZ Platform / Kernel services
+In order to easily access container services (such as ContentService, SearchService, etc), [EzBehatExtension](Context/Argument/AnnotationArgumentResolver.php)
+can parse annotations in Behat Contexts and use the Argument Resolver to inject the defined services into the constructor, using the following syntax:
+
+``` php
+/**
+ * @injectService $service1 @ezpublish.api.some.service
+ * @injectService $service2 @ezpublish.api.another.service
+ */
+ public function __constructor(SomeService $service1, AnotherService $service2)
+ {
+    ...
+ }
+```

--- a/eZ/Bundle/PlatformBehatBundle/Context/Argument/AnnotationArgumentResolver.php
+++ b/eZ/Bundle/PlatformBehatBundle/Context/Argument/AnnotationArgumentResolver.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace EzSystems\PlatformBehatBundle\Context\Argument;
+
+use Behat\Behat\Context\Argument\ArgumentResolver;
+use ReflectionClass;
+
+/**
+ * Behat Context Argument Resolver.
+ */
+class AnnotationArgumentResolver implements ArgumentResolver
+{
+    /**
+     * Service annotation tag.
+     */
+    const SERVICE_DOC_TAG = 'injectService';
+
+    /**
+     * Resolve service arguments for Behat Context constructor thru annotation.
+     * Symfony2Extension ArgumentResoler will convert service names to actual instances.
+     *
+     * @param ReflectionClass $classReflection
+     * @param array $arguments
+     */
+    public function resolveArguments(ReflectionClass $classReflection, array $arguments = [])
+    {
+        $injArguments = $this->parseAnnotations(
+            $this->getMethodAnnotations($classReflection)
+        );
+
+        if (!empty($injArguments)) {
+            $arguments = [];
+            foreach ($injArguments as $name => $service) {
+                $arguments[$name] = $service;
+            }
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * Returns a array with the method annotations.
+     *
+     * @return array array annotations
+     */
+    private function getMethodAnnotations($refClass, $method = '__construct')
+    {
+        if ($refClass->hasMethod($method)) {
+            $refMethod = $refClass->getMethod($method);
+            preg_match_all('#@(.*?)\n#s', $refMethod->getDocComment(), $matches);
+
+            return $matches[1];
+        } else {
+            return [];
+        }
+    }
+
+    /**
+     * Returns an array with the method arguments service requirements,
+     * if the methods use the service Annotation.
+     *
+     * @return array array of methods and their service dependencies
+     */
+    private function parseAnnotations($annotations)
+    {
+        // parse array from (numeric key => 'annotation <value>') to (annotation => value)
+        $methodServices = [];
+        foreach ($annotations as $annotation) {
+            if (!preg_match('/^(\w+)\s+\$(\w+)\s+([\w\.\@\%]+)/', $annotation, $matches)) {
+                continue;
+            }
+
+            array_shift($matches);
+            $tag = array_shift($matches);
+            if ($tag == self::SERVICE_DOC_TAG) {
+                list($argument, $service) = $matches;
+                $methodServices[$argument] = $service;
+            }
+        }
+
+        return $methodServices;
+    }
+}

--- a/eZ/Bundle/PlatformBehatBundle/Resources/config/services.yml
+++ b/eZ/Bundle/PlatformBehatBundle/Resources/config/services.yml
@@ -1,3 +1,7 @@
 services:
     platform_behat.controller.exception:
         class: eZ\Bundle\PlatformBehatBundle\Controller\ExceptionController
+    platform_behat.context_argument_resolver:
+        class: EzSystems\PlatformBehatBundle\Context\Argument\AnnotationArgumentResolver
+        tags:
+            -  { name: context.argument_resolver }

--- a/eZ/Bundle/PlatformBehatBundle/ServiceContainer/EzBehatExtension.php
+++ b/eZ/Bundle/PlatformBehatBundle/ServiceContainer/EzBehatExtension.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace EzSystems\PlatformBehatBundle\ServiceContainer;
+
+use Behat\Testwork\ServiceContainer\Extension;
+use Behat\Testwork\ServiceContainer\ExtensionManager;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+/**
+ * EzBehatExtension loads extension specific services.
+ */
+class EzBehatExtension implements Extension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigKey()
+    {
+        return 'ezbehatextension';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initialize(ExtensionManager $extensionManager)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configure(ArrayNodeDefinition $builder)
+    {
+    }
+
+    /**
+     * Loads extension services into temporary container.
+     *
+     * @param ContainerBuilder $container
+     * @param array $config
+     */
+    public function load(ContainerBuilder $container, array $config)
+    {
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('services.yml');
+    }
+}


### PR DESCRIPTION
As decided BehatBundle is to be deprecated and separated between the kernel and platformUI bundle. The idea is to make the Behat easier to maintain, having less repo dependencies should help releases and versions also.

This PR moves the EzBehatExtension and AnnotationArgumentResolver into the kernel. This is used to inject into behat the necessary services. Since this is to be used by most contexts it should be in the kernel.

Related PRs:
* Behat browser context #1585
* Add RepositoryContext trait #1584
* Deprecate Behat classes https://github.com/ezsystems/BehatBundle/pull/48