### PR TITLE
EZP-25482: Do not use CSRF token manager if not available

### DIFF
--- a/eZ/Publish/Core/REST/Server/Controller/User.php
+++ b/eZ/Publish/Core/REST/Server/Controller/User.php
@@ -1006,7 +1006,7 @@ class User extends RestController
             $token = $authenticator->authenticate($request);
             // If CSRF token has not been generated yet (i.e. session not started), we generate it now.
             // This will seamlessly start the session.
-            if (!$csrfToken) {
+            if ($csrfTokenManager && !$csrfToken) {
                 $csrfToken = $csrfTokenManager->getToken(
                     $this->container->getParameter('ezpublish_rest.csrf_token_intention')
                 )->getValue();


### PR DESCRIPTION
When CSRF protection is disabled with `framework.csrf_protection.enabled` flag set to false, site crashes with an exception about missing `security.csrf.token_manager` service.

Required by: https://github.com/ezsystems/PlatformUIBundle/pull/515