### PR TITLE
EZP-19123: Missing SQL to copy ezuser.login to login_normalized

### DIFF
--- a/data/update/mysql/unstable/dbupdate-6.1.0-to-6.2.0rc1.sql
+++ b/data/update/mysql/unstable/dbupdate-6.1.0-to-6.2.0rc1.sql
@@ -7,4 +7,10 @@ UPDATE ezsite_data SET value='6.2.0' WHERE name='ezpublish-version';
 --
 
 ALTER TABLE ezuser ADD COLUMN login_normalized varchar(150) NOT NULL DEFAULT '';
+UPDATE ezuser SET login_normalized=LOWER(login);
+
+-- Note: As part of EZP-19123, it was decided to not allow duplicate login with different case, this should not have
+-- been issue on mysql where code checking for existing use was implicit case-insensitive. However on postgres this was
+-- not the case, meaning you'll need to manually handle conflicts if anyone occurs on the following line because of the
+-- new "UNIQUE" constraint.
 ALTER TABLE ezuser DROP KEY ezuser_login, ADD UNIQUE KEY ezuser_login (login_normalized);

--- a/data/update/mysql/unstable/dbupdate-6.1.0-to-6.2.0rc1.sql
+++ b/data/update/mysql/unstable/dbupdate-6.1.0-to-6.2.0rc1.sql
@@ -6,7 +6,7 @@ UPDATE ezsite_data SET value='6.2.0' WHERE name='ezpublish-version';
 -- EZP-19123: Make ezuser.login case in-sensitive across databases
 --
 
-ALTER TABLE ezuser ADD COLUMN login_normalized varchar(150) NOT NULL DEFAULT '';
+ALTER TABLE ezuser ADD COLUMN login_normalized varchar(150) NOT NULL DEFAULT '' AFTER login;
 UPDATE ezuser SET login_normalized=LOWER(login);
 
 -- Note: As part of EZP-19123, it was decided to not allow duplicate login with different case, this should not have

--- a/data/update/postgres/unstable/dbupdate-6.1.0-to-6.2.0rc1.sql
+++ b/data/update/postgres/unstable/dbupdate-6.1.0-to-6.2.0rc1.sql
@@ -6,4 +6,10 @@ UPDATE ezsite_data SET value='6.2.0' WHERE name='ezpublish-version';
 --
 
 ALTER TABLE ezuser ADD login_normalized character varying(150) DEFAULT ''::character varying NOT NULL;
+UPDATE ezuser SET login_normalized=lower(login);
+
+-- Note: As part of EZP-19123, it was decided to not allow duplicate login with different case, this should not have
+-- been issue on mysql where code checking for existing use was implicit case-insensitive. However on postgres this was
+-- not the case, meaning you'll need to manually handle conflicts if anyone occurs on the following line because of the
+-- new "UNIQUE" constraint.
 ALTER TABLE ezuser DROP CONSTRAINT ezuser_login, ADD CONSTRAINT ezuser_login UNIQUE KEY (login_normalized);


### PR DESCRIPTION
Also better document the issues that can turn up as part of the schema change.

ping @crevillo @emodric 