### PR TITLE
EZP-25377: Fix possible timing issues and discrepancies in published/modified dates

### DIFF
--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1454,13 +1454,14 @@ class ContentService implements ContentServiceInterface
             throw new BadStateException('$versionInfo', 'Only versions in draft status can be published.');
         }
 
+        $currentTime = time();
         if ($publicationDate === null && $versionInfo->versionNo === 1) {
-            $publicationDate = time();
+            $publicationDate = $currentTime;
         }
 
         $metadataUpdateStruct = new SPIMetadataUpdateStruct();
         $metadataUpdateStruct->publicationDate = $publicationDate;
-        $metadataUpdateStruct->modificationDate = time();
+        $metadataUpdateStruct->modificationDate = $currentTime;
 
         $spiContent = $this->persistenceHandler->contentHandler()->publish(
             $versionInfo->getContentInfo()->id,

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -5611,13 +5611,14 @@ class ContentTest extends BaseServiceMockTest
                 )
             );
 
+        $currentTime = time();
         if ($publicationDate === null && $versionInfoMock->versionNo === 1) {
-            $publicationDate = time();
+            $publicationDate = $currentTime;
         }
 
         // Account for 1 second of test execution time
         $metadataUpdateStruct->publicationDate = $publicationDate;
-        $metadataUpdateStruct->modificationDate = time();
+        $metadataUpdateStruct->modificationDate = $currentTime;
         $metadataUpdateStruct2 = clone $metadataUpdateStruct;
         ++$metadataUpdateStruct2->publicationDate;
         ++$metadataUpdateStruct2->modificationDate;


### PR DESCRIPTION
This fixes a possible discrepancy in published/modifed dates when publishing content.

This was discovered after some unrelated tests ran in Netgen variant of ezpublish-kernel 2014.12: https://travis-ci.org/netgen/ezpublish-kernel/jobs/111418231 and failed at random times. This looks like a possible solution to that failing test. In any case, the fix doesn't hurt and is "more correct" :)