### PR TITLE
Fix EZP-25515: REST route loadRoleDraftByRoleId fails

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
@@ -770,14 +770,6 @@ ezpublish_rest_loadRoleDraft:
     requirements:
         roleId: \d+
 
-ezpublish_rest_loadRoleDraftByRoleId:
-    path: /user/roles/{roleId}/draftByRoleId
-    defaults:
-        _controller: ezpublish_rest.controller.role:loadRoleDraftByRoleId
-    methods: [GET]
-    requirements:
-        roleId: \d+
-
 ezpublish_rest_updateRole:
     path: /user/roles/{roleId}
     defaults:

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RoleTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RoleTest.php
@@ -168,12 +168,12 @@ XML;
 
     /**
      * @depends testCreateRole
-     * @covers GET /user/roles/{roleId}/draftByRoleId
+     * @covers GET /user/roles/{roleId}/draft
      */
     public function testLoadRoleDraftByRoleId($roleHref)
     {
         $response = $this->sendHttpRequest(
-            $this->createHttpRequest('GET', $roleHref)
+            $this->createHttpRequest('GET', $roleHref . '/draft')
         );
 
         self::assertHttpResponseCodeEquals($response, 200);


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-25515
> Status: Ready for review

The route refers to the wrong controller method. The test is also wrong, which is why it wasn't detected.