### PR TITLE
Fix EZP-25522: allow editor to read content of Editors group

### DIFF
--- a/data/cleandata.sql
+++ b/data/cleandata.sql
@@ -1974,6 +1974,7 @@ INSERT INTO `ezuser_role` (`contentobject_id`, `id`, `limit_identifier`, `limit_
 INSERT INTO `ezuser_role` (`contentobject_id`, `id`, `limit_identifier`, `limit_value`, `role_id`) VALUES (42,31,'','',1);
 INSERT INTO `ezuser_role` (`contentobject_id`, `id`, `limit_identifier`, `limit_value`, `role_id`) VALUES (13,32,'Subtree','/1/2/',3);
 INSERT INTO `ezuser_role` (`contentobject_id`, `id`, `limit_identifier`, `limit_value`, `role_id`) VALUES (13,33,'Subtree','/1/43/',3);
+INSERT INTO `ezuser_role` (`contentobject_id`, `id`, `limit_identifier`, `limit_value`, `role_id`) VALUES (13,35,'Subtree','/1/5/14/',3);
 INSERT INTO `ezuser_role` (`contentobject_id`, `id`, `limit_identifier`, `limit_value`, `role_id`) VALUES (12,34,'','',2);
 
 INSERT INTO `ezuser_setting` (`is_enabled`, `max_login`, `user_id`) VALUES (1,1000,10);


### PR DESCRIPTION
> Fixes http://jira.ez.no/browse/EZP-25522

The Editor role in cleandata has full access to `content`. It is assigned to the Editors group limited to the subtrees `Content` and `Media`. This adds another assignment limited to `Users/Editors`.

![editorrole](https://cloud.githubusercontent.com/assets/235928/13458252/9bd98cb0-e06c-11e5-953e-251ad3dad27f.png)

Tested using REST with a manually created editor user:

```bash
# SessionInput.xml contains editor credentials
curl -c /tmp/cookies.txt -X POST http://php55-vm.ezplatform/api/ezp/v2/user/sessions --data-binary @/tmp/SessionInput.xml -H 'Content-Type: application/vnd.ez.api.SessionInput+xml'

# 52 is the editor user id
curl -b /tmp/cookies.txt -X GET http://php55-vm.ezplatform/api/ezp/v2/user/users/52

# the uri is taken from the previous response
curl -b /tmp/cookies.txt -X GET http://php55-vm.ezplatform/api/ezp/v2/content/binary/images/52-185/variations/large