### PR TITLE
EZP-25522: User is not able to get variation of his profile image

### DIFF
--- a/eZ/Publish/Core/Limitation/OwnerLimitationType.php
+++ b/eZ/Publish/Core/Limitation/OwnerLimitationType.php
@@ -138,10 +138,15 @@ class OwnerLimitationType extends AbstractPersistenceLimitationType implements S
             );
         }
 
+        $userId = $currentUser->getUserId();
+
         /*
          * @var $object ContentInfo
          */
-        return $object->ownerId === $currentUser->getUserId();
+        $isOwner = $object->ownerId === $userId;
+        $isSelf = $object->id === $userId;
+
+        return $isOwner || $isSelf;
     }
 
     /**

--- a/eZ/Publish/Core/Limitation/ParentOwnerLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ParentOwnerLimitationType.php
@@ -136,10 +136,9 @@ class ParentOwnerLimitationType extends AbstractPersistenceLimitationType implem
             }
 
             if ($target instanceof Location) {
-                $ownerId = $target->getContentInfo()->ownerId;
+                $targetContentInfo = $target->getContentInfo();
             } elseif ($target instanceof SPILocation) {
-                $spiContentInfo = $this->persistence->contentHandler()->loadContentInfo($target->contentId);
-                $ownerId = $spiContentInfo->ownerId;
+                $targetContentInfo = $this->persistence->contentHandler()->loadContentInfo($target->contentId);
             } else {
                 throw new InvalidArgumentException(
                     '$targets',
@@ -147,7 +146,12 @@ class ParentOwnerLimitationType extends AbstractPersistenceLimitationType implem
                 );
             }
 
-            if ($ownerId !== $currentUser->getUserId()) {
+            $userId = $currentUser->getUserId();
+
+            $isOwner = $targetContentInfo->ownerId === $userId;
+            $isSelf = $targetContentInfo->id === $userId;
+
+            if (!($isOwner || $isSelf)) {
                 return false;
             }
         }


### PR DESCRIPTION
**JIRA ticket related:** https://jira.ez.no/browse/EZP-25522

It would allow use of `Owner`: `self` limitation that would give user access to its own user content object.

Ie: 
![owner_self](https://cloud.githubusercontent.com/assets/5822569/13459331/0e0e2d4e-e073-11e5-82eb-955f8bb30f12.png)

The problem could be resolved by setting proper roles and limitations from UI without additional backend work.

It still require giving group access to `/1/5/X` location and careful set of editing permissions so editor would not be able to modify other users.