### PR TITLE
EZP-25533: allow newer versions of http-cache-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "doctrine/doctrine-bundle": "~1.3",
         "liip/imagine-bundle": "~1.0",
         "oneup/flysystem-bundle": "~0.4",
-        "friendsofsymfony/http-cache-bundle": ">=1.2, <=1.3.6",
+        "friendsofsymfony/http-cache-bundle": "dev-anonymous_request_hash-1.3",
         "sensio/framework-extra-bundle": "~3.0"
     },
     "require-dev": {
@@ -64,5 +64,11 @@
             "dev-master": "6.5.x-dev",
             "dev-tmp_ci_branch": "6.5.x-dev"
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "git@github.com:bdunogier/FOSHttpCacheBundle.git"
+        }
+    ]
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/cache.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/cache.yml
@@ -64,7 +64,7 @@ services:
         arguments: [@service_container]
 
     fos_http_cache.user_context.anonymous_request_matcher:
-        class: %fos_http_cache.user_context.anonymous_request_matcher.class%
+        class: FOS\HttpCacheBundle\UserContext\AnonymousRequestMatcher
         arguments: [{'session_name_prefix': 'eZSESSID'}]
 
     ezpublish.cache_clear.content.base_locations_listener:

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/cache.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/cache.yml
@@ -63,6 +63,10 @@ services:
         class: %ezpublish.http_cache.event_dispatcher.class%
         arguments: [@service_container]
 
+    fos_http_cache.user_context.anonymous_request_matcher:
+        class: %fos_http_cache.user_context.anonymous_request_matcher.class%
+        arguments: [{'session_name_prefix': 'eZSESSID'}]
+
     ezpublish.cache_clear.content.base_locations_listener:
         class: %ezpublish.http_cache.content.base_locations_listener.class%
         arguments: [@ezpublish.api.service.location]


### PR DESCRIPTION
> Fixes http://jira.ez.no/browse/EZP-25533
> **Requires** https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/pull/289
> Can be merged to 6.0, 6.1 and 6.2.

FosHttpCache uses a hardcoded user hash for anonymous users to maximize performances. The change made in https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/pull/274 made apparent an inconsistency in user hash generation for anonymous users on eZ Platform: calling the HashGenerator on an anonymous request will generate a hash different from the hardcoded one, since the hash depends on the user's role, by essence configurable.

A [change](https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/compare/1.3...bdunogier:anonymous_request_hash-1.3) will be proposed to FosHttpCacheBundle that disables hash verification on anonymous requests. This PR 
introduced `AnonymousRequestMatcher` from FosHttpCacheBundle with our session cookie prefix. 

### Testing
Manual:
- configure symfony to use the internal reverse proxy (can probably be tested with Varnish as well)
- create a `/tmp/SessionInput.json` file with valid credentials (`{"SessionInput":{"login":"admin","password":"publish"}}`)
```
# login and save cookies to tmp
curl -c /tmp/cookies.txt -X POST -v http://php55-vm.ezplatform/api/ezp/v2/user/sessions --data {"SessionInput":{"login":"admin","password":"publish"}} -H 'Content-Type: application/vnd.ez.api.SessionInput+json'

# run an authentified request, check that you get Vary header
curl -b /tmp/cookies.txt -v http://php55-vm.ezplatform/ -o /dev/null

# run an anonymous request, check that you get a Vary header
curl -v http://php55-vm.ezplatform/ -o /dev/null

# run an authentified request, check that you get Vary header, and that it's a hit from the first authentified request
curl -b /tmp/cookies.txt -v http://php55-vm.ezplatform/ -o /dev/null
```

Without the patch, the anon request would invalidate cache, and wouldn't have a vary header.

### TODO
- [ ] Change to use a compiler pass that sets the argument.
- [ ] Get the [FosHttpCacheBundle PR](https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/pull/289) merged