### PR TITLE
Fix EZP-25505: match siteaccess in user hash generation

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
@@ -34,7 +34,7 @@ services:
 
     ezpublish.siteaccess_match_listener:
         class: %ezpublish.siteaccess_match_listener.class%
-        arguments: [@ezpublish.siteaccess_router, @event_dispatcher, @fos_http_cache.user_context.request_matcher]
+        arguments: [@ezpublish.siteaccess_router, @event_dispatcher]
         tags:
             - { name: kernel.event_subscriber }
 

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
@@ -12,7 +12,6 @@ namespace eZ\Publish\Core\MVC\Symfony\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router as SiteAccessRouter;
@@ -38,21 +37,10 @@ class SiteAccessMatchListener implements EventSubscriberInterface
      */
     protected $eventDispatcher;
 
-    /**
-     * Request matcher for user context hash requests.
-     *
-     * @var RequestMatcherInterface
-     */
-    private $userContextRequestMatcher;
-
-    public function __construct(
-        SiteAccessRouter $siteAccessRouter,
-        EventDispatcherInterface $eventDispatcher,
-        RequestMatcherInterface $userContextRequestMatcher
-    ) {
+    public function __construct(SiteAccessRouter $siteAccessRouter, EventDispatcherInterface $eventDispatcher)
+    {
         $this->siteAccessRouter = $siteAccessRouter;
         $this->eventDispatcher = $eventDispatcher;
-        $this->userContextRequestMatcher = $userContextRequestMatcher;
     }
 
     public static function getSubscribedEvents()

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
@@ -70,11 +70,6 @@ class SiteAccessMatchListener implements EventSubscriberInterface
     {
         $request = $event->getRequest();
 
-        // Don't try to match when it's a user hash request. SiteAccess is irrelevant in this case.
-        if ($this->userContextRequestMatcher->matches($request) && !$request->attributes->has('_ez_original_request')) {
-            return;
-        }
-
         // We have a serialized siteaccess object from a fragment (sub-request), we need to get it back.
         if ($request->attributes->has('serialized_siteaccess')) {
             $request->attributes->set(

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/SiteAccessMatchListenerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/SiteAccessMatchListenerTest.php
@@ -50,8 +50,7 @@ class SiteAccessMatchListenerTest extends PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
         $this->eventDispatcher = $this->getMock('\Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $this->userHashMatcher = $this->getMock('\Symfony\Component\HttpFoundation\RequestMatcherInterface');
-        $this->listener = new SiteAccessMatchListener($this->saRouter, $this->eventDispatcher, $this->userHashMatcher);
+        $this->listener = new SiteAccessMatchListener($this->saRouter, $this->eventDispatcher);
     }
 
     public function testGetSubscribedEvents()
@@ -60,32 +59,6 @@ class SiteAccessMatchListenerTest extends PHPUnit_Framework_TestCase
             array(KernelEvents::REQUEST => array('onKernelRequest', 45)),
             SiteAccessMatchListener::getSubscribedEvents()
         );
-    }
-
-    public function testOnKernelRequestUserHashNoOriginalRequest()
-    {
-        $request = new Request();
-        $event = new GetResponseEvent(
-            $this->getMock('\Symfony\Component\HttpKernel\HttpKernelInterface'),
-            $request,
-            HttpKernelInterface::MASTER_REQUEST
-        );
-
-        $this->userHashMatcher
-            ->expects($this->once())
-            ->method('matches')
-            ->with($request)
-            ->will($this->returnValue(true));
-
-        $this->saRouter
-            ->expects($this->never())
-            ->method('match');
-        $this->eventDispatcher
-            ->expects($this->never())
-            ->method('dispatch');
-
-        $this->listener->onKernelRequest($event);
-        $this->assertFalse($request->attributes->has('siteaccess'));
     }
 
     public function testOnKernelRequestSerializedSA()
@@ -98,12 +71,6 @@ class SiteAccessMatchListenerTest extends PHPUnit_Framework_TestCase
             $request,
             HttpKernelInterface::MASTER_REQUEST
         );
-
-        $this->userHashMatcher
-            ->expects($this->once())
-            ->method('matches')
-            ->with($request)
-            ->will($this->returnValue(false));
 
         $this->saRouter
             ->expects($this->never())
@@ -130,12 +97,6 @@ class SiteAccessMatchListenerTest extends PHPUnit_Framework_TestCase
             $request,
             HttpKernelInterface::MASTER_REQUEST
         );
-
-        $this->userHashMatcher
-            ->expects($this->once())
-            ->method('matches')
-            ->with($request)
-            ->will($this->returnValue(false));
 
         $this->saRouter
             ->expects($this->never())
@@ -164,12 +125,6 @@ class SiteAccessMatchListenerTest extends PHPUnit_Framework_TestCase
             $request,
             HttpKernelInterface::MASTER_REQUEST
         );
-
-        $this->userHashMatcher
-            ->expects($this->once())
-            ->method('matches')
-            ->with($request)
-            ->will($this->returnValue(false));
 
         $simplifiedRequest = new SimplifiedRequest(
             array(
@@ -213,12 +168,6 @@ class SiteAccessMatchListenerTest extends PHPUnit_Framework_TestCase
             $request,
             HttpKernelInterface::MASTER_REQUEST
         );
-
-        $this->userHashMatcher
-            ->expects($this->once())
-            ->method('matches')
-            ->with($request)
-            ->will($this->returnValue(true));
 
         $simplifiedRequest = new SimplifiedRequest(
             array(


### PR DESCRIPTION
> Fixes http://jira.ez.no/browse/EZP-25505

User hash generation must match the siteaccess to operate properly (see https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/MVC/Symfony/Security/EventListener/SecurityListener.php#L175-L188). This change reverts the change that excluded the user hash route from siteaccess matching.

This check was added to prevent issues when using the Symfony reverse proxy, where a match of the default SA would leak up to the master request. But it does not happen, since matching is done, if it exists, on the the original request that is passed as a request attribute.

Varnish will NOT be able to match a siteaccess using an URI. But this would only be an issue if the URI is required to match a repository. This is easily prevented by enforcing host/port based siteaccess matching.

### Testing done
Manual queries, verify that the user hash does change depending on auth:
```
curl -v -b /tmp/cookies.txt -X GET      http://php55-vm.ezplatform/ -H "Accept: application/vnd.fos.user-context-hash"
```

### TODO
- [x] Validate the way the URI is re-added to the PR. Might require deeper changes
- [ ] Document the n-repo / n-domain multi-site restriction
- [x] Update the varnish VCL accordingly
- [ ] Tests
- [ ] Re-open against the correct branch (6.0 or 6.1)