### PR TITLE
EZP-25460: draft preview shows published version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
     - php: 5.6
       env: TEST_CONFIG="phpunit-integration-legacy.xml" SYMFONY_VERSION="~2.7.0"
     - php: 5.6
-      env: BEHAT_OPTS="--profile=core --tags='~@broken'"
+      env: BEHAT_OPTS="--profile=core --tags=~@broken"
 # 7.0
     - php: 7.0
       env: REST_TEST_CONFIG="phpunit-functional-rest.xml"

--- a/bin/.travis/prepare_behat.sh
+++ b/bin/.travis/prepare_behat.sh
@@ -9,7 +9,7 @@ export TRAVIS_BUILD_DIR="$HOME/build/ezplatform"
 cd "$HOME/build"
 
 # Checkout meta repo, change the branch and/or remote to use a different ezpublish branch/distro
-git clone --depth 1 --single-branch --branch master https://github.com/ezsystems/ezplatform.git
+git clone --depth 1 --single-branch --branch v1.1.0 https://github.com/ezsystems/ezplatform.git
 cd ezplatform
 
 # Install everything needed for behat testing, using our local branch of this repo

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Content/content_preview.feature
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Content/content_preview.feature
@@ -4,15 +4,23 @@ Feature: Preview of content drafts
     While I'm editing content
     I need to preview the result before publishing
 
-    Scenario: Previewing the first version of a content works
+    Scenario: Previewing the first version of a content item works
         Given I have "administrator" permissions
           And I create an article draft
          When I preview this draft
          Then the output is valid
 
     @broken
-    Scenario: Previewing the first version of a content with a custom location controller works
+    Scenario: Previewing the first version of a content item with a custom location controller works
         Given I have "administrator" permissions
           And I create a draft for a content type that uses a custom location controller
          When I preview this draft
          Then the output is valid
+
+    Scenario: Previewing a draft of a content item with published version(s) works
+        Given I have "administrator" permissions
+          And I create a draft of an existing content item
+          And I modify a field from the draft
+         When I preview this draft
+         Then the output is valid
+          And I see a preview of this draft

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/ContentContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/ContentContext.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Behat\Context\SnippetAcceptingContext;
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use RuntimeException;
+
+class ContentContext implements Context, SnippetAcceptingContext
+{
+    /** @var \eZ\Publish\API\Repository\Values\Content\Content */
+    private $currentContent;
+
+    /** @var \eZ\Publish\API\Repository\Values\Content\Content */
+    private $currentDraft;
+
+    /** @var \eZ\Publish\API\Repository\Repository */
+    private $repository;
+
+    public function __construct(Repository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * @Given /^I create an article draft$/
+     */
+    public function iCreateAnArticleDraft()
+    {
+        $this->currentDraft = $this->createDraft(
+            'article',
+            [
+                'title' => 'Preview draft ' . date('c'),
+                'intro' => '<?xml version="1.0" encoding="UTF-8"?><section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0"><para>This is a paragraph.</para></section>',
+            ]
+        );
+    }
+
+    /**
+     * @Given /^I create a draft of an existing content item$/
+     */
+    public function iCreateADraftOfAnExistingContentItem()
+    {
+        $this->currentContent = $this->createContentItem(
+            'folder',
+            ['name' => 'BDD preview test']
+        );
+
+        $this->currentDraft = $this->createDraftForContent($this->currentContent);
+    }
+
+    /**
+     * Uses a content type identifier + a hash of fields values
+     * to create and publish a content item below the root location.
+     *
+     * @param string $contentTypeIdentifier
+     * @param array $fields Hash of field def identifier => field value
+     *
+     * @return Content the created content item.
+     */
+    public function createContentItem($contentTypeIdentifier, array $fields)
+    {
+        $draft = $this->createDraft($contentTypeIdentifier, $fields);
+
+        $this->currentContent = $this->repository->sudo(
+            function () use ($draft) {
+                return $this->repository->getContentService()->publishVersion($draft->versionInfo);
+            }
+        );
+
+        $this->currentDraft = null;
+
+        return $this->currentContent;
+    }
+
+    public function createDraftForContent(Content $content)
+    {
+        $this->currentDraft = $this->repository->sudo(
+            function () use ($content) {
+                return $this->repository->getContentService()->createContentDraft($content->contentInfo);
+            }
+        );
+
+        return $this->currentDraft;
+    }
+
+    public function getCurrentDraft()
+    {
+        if ($this->currentDraft === null) {
+            throw new RuntimeException('No current draft has been set');
+        }
+
+        return $this->currentDraft;
+    }
+
+    public function updateDraft($fields)
+    {
+        $contentService = $this->repository->getContentService();
+
+        $updateStruct = $contentService->newContentUpdateStruct();
+        foreach ($fields as $fieldDefIdentifier => $fieldValueUpdate) {
+            $updateStruct->setField($fieldDefIdentifier, $fieldValueUpdate);
+        }
+
+        $updatedDraft = $this->repository->sudo(function () use ($updateStruct) {
+            return $this->repository->getContentService()->updateContent(
+                $this->currentDraft->versionInfo,
+                $updateStruct
+            );
+        });
+
+        return $this->currentDraft = $updatedDraft;
+    }
+
+    /**
+     * Uses a content type identifier + a hash of fields values
+     * to create and publish a draft below the root location.
+     *
+     * @param string $contentTypeIdentifier
+     * @param array $fields Hash of field def identifier => field value
+     *
+     * @return Content the created draft.
+     */
+    public function createDraft($contentTypeIdentifier, array $fields)
+    {
+        $contentService = $this->repository->getContentService();
+
+        $createStruct = $contentService->newContentCreateStruct(
+            $this->repository->getContentTypeService()->loadContentTypeByIdentifier($contentTypeIdentifier),
+            'eng-GB'
+        );
+
+        foreach ($fields as $fieldDefIdentifier => $fieldValue) {
+            $createStruct->setField($fieldDefIdentifier, $fieldValue);
+        }
+
+        $locationCreateStruct = $this->repository->getLocationService()->newLocationCreateStruct(2);
+
+        $this->currentDraft = $this->repository->sudo(
+            function () use ($createStruct, $locationCreateStruct) {
+                return $this->repository->getContentService()->createContent(
+                    $createStruct,
+                    [$locationCreateStruct]
+                );
+            }
+        );
+
+        return $this->currentDraft;
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/behat_suites.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/behat_suites.yml
@@ -13,4 +13,6 @@ core:
                 - vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishCoreBundle/Features/Exception
             contexts:
                 - eZ\Bundle\EzPublishCoreBundle\Features\Context\ContentPreviewContext
+                - eZ\Bundle\EzPublishCoreBundle\Features\Context\ContentContext:
+                    repository: @ezpublish.api.repository
                 - eZ\Bundle\EzPublishCoreBundle\Features\Context\ExceptionContext

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
@@ -156,6 +156,7 @@ EOF;
                 'language' => $language,
             ),
             'location' => $location,
+            'content' => $content,
             'viewType' => ViewManagerInterface::VIEW_TYPE_FULL,
             'layout' => true,
             'params' => array(


### PR DESCRIPTION
> Re-post of #1604 onto `6.1`
> Fixes http://jira.ez.no/browse/EZP-25460

`/content/versionview` works by forwarding a ContentView internal request with a pre-loaded content, in the requested version. The `PreviewController` is only setting `location`, not `content`. The ContentViewBuilder loads the Content item based on parameters, using the published version by default.

The `[travis]` commit removes quotes around the tags. Having those caused problems (when used through env vars) and prevented behat from finding any scenario.

### Testing done
BDD that fails on Travis for this particular case.
