### PR TITLE
Undefined index timestamp when using Adapter/AwsS3

### DIFF
--- a/eZ/Publish/Core/IO/IOMetadataHandler/Flysystem.php
+++ b/eZ/Publish/Core/IO/IOMetadataHandler/Flysystem.php
@@ -59,7 +59,7 @@ class Flysystem implements IOMetadataHandler
         $spiBinaryFile->size = $info['size'];
 
         if (isset($info['timestamp'])) {
-            $spiBinaryFile->mtime = new DateTime('@'.$info['timestamp']);
+            $spiBinaryFile->mtime = new DateTime('@' . $info['timestamp']);
         }
 
         return $spiBinaryFile;

--- a/eZ/Publish/Core/IO/IOMetadataHandler/Flysystem.php
+++ b/eZ/Publish/Core/IO/IOMetadataHandler/Flysystem.php
@@ -55,8 +55,11 @@ class Flysystem implements IOMetadataHandler
 
         $spiBinaryFile = new SPIBinaryFile();
         $spiBinaryFile->id = $spiBinaryFileId;
-        $spiBinaryFile->mtime = new DateTime('@' . $info['timestamp']);
         $spiBinaryFile->size = $info['size'];
+        
+        if (isset($info['timestamp'])) {
+            $spiBinaryFile->mtime = new DateTime('@' . $info['timestamp']);
+        }
 
         return $spiBinaryFile;
     }

--- a/eZ/Publish/Core/IO/IOMetadataHandler/Flysystem.php
+++ b/eZ/Publish/Core/IO/IOMetadataHandler/Flysystem.php
@@ -6,6 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+
 namespace eZ\Publish\Core\IO\IOMetadataHandler;
 
 use DateTime;
@@ -56,9 +57,9 @@ class Flysystem implements IOMetadataHandler
         $spiBinaryFile = new SPIBinaryFile();
         $spiBinaryFile->id = $spiBinaryFileId;
         $spiBinaryFile->size = $info['size'];
-        
+
         if (isset($info['timestamp'])) {
-            $spiBinaryFile->mtime = new DateTime('@' . $info['timestamp']);
+            $spiBinaryFile->mtime = new DateTime('@'.$info['timestamp']);
         }
 
         return $spiBinaryFile;


### PR DESCRIPTION
In some cases $info['timestamp'] is not defined, e.g if 'LastModified' is not set for an S3 object:
https://github.com/thephpleague/flysystem/blob/0.5.12/src/Adapter/AwsS3.php#L486

### TODO
- [ ] Rebase on top of latests master
- [ ] Fix CS
- [ ] Unit test coverage `eZ/Publish/Core/IO/Tests/IOMetadataHandler/FlysystemTest.php`
- [ ] Create JIRA issue. *Ideally Should include some info on reliable way to reproduce.*
- ~~Functional testing  *(thats more of a eZ responsibility, along with maintaining it once it is merged in)*~~
- ~~Update Flysystem *(Followup for someone else: [EZP-25676](https://jira.ez.no/browse/EZP-25676))*~~