### PR TITLE
[Travis] Use branch alias from composer.json as alias for tmp_travis_branch

### DIFF
--- a/bin/.travis/prepare_behat.sh
+++ b/bin/.travis/prepare_behat.sh
@@ -6,6 +6,11 @@
 git fetch --unshallow && git checkout -b tmp_travis_branch
 export BRANCH_BUILD_DIR=$TRAVIS_BUILD_DIR
 export TRAVIS_BUILD_DIR="$HOME/build/ezplatform"
+
+## Get branch alias from composer.json and if not set fallback to using TRAVIS_BRANCH
+ba="\$a['extra']['branch-alias']"
+branch_alias=$(php -r "\$a=json_decode(file_get_contents('composer.json'),true);print isset($ba) ? $ba[key($ba)]: $TRAVIS_BRANCH;")
+
 cd "$HOME/build"
 
 # Checkout meta repo, change the branch and/or remote to use a different ezpublish branch/distro
@@ -13,4 +18,4 @@ git clone --depth 1 --single-branch --branch master https://github.com/ezsystems
 cd ezplatform
 
 # Install everything needed for behat testing, using our local branch of this repo
-./bin/.travis/setup_from_external_repo.sh $BRANCH_BUILD_DIR "ezsystems/ezpublish-kernel:dev-tmp_travis_branch"
+./bin/.travis/setup_from_external_repo.sh $BRANCH_BUILD_DIR "ezsystems/ezpublish-kernel:dev-tmp_travis_branch as ${branch_alias}"

--- a/bin/.travis/prepare_behat.sh
+++ b/bin/.travis/prepare_behat.sh
@@ -6,11 +6,6 @@
 git fetch --unshallow && git checkout -b tmp_travis_branch
 export BRANCH_BUILD_DIR=$TRAVIS_BUILD_DIR
 export TRAVIS_BUILD_DIR="$HOME/build/ezplatform"
-
-## Get branch alias from composer.json and if not set fallback to using TRAVIS_BRANCH
-ba="\$a['extra']['branch-alias']"
-branch_alias=$(php -r "\$a=json_decode(file_get_contents('composer.json'),true);print isset($ba) ? $ba[key($ba)]: $TRAVIS_BRANCH;")
-
 cd "$HOME/build"
 
 # Checkout meta repo, change the branch and/or remote to use a different ezpublish branch/distro
@@ -18,4 +13,4 @@ git clone --depth 1 --single-branch --branch master https://github.com/ezsystems
 cd ezplatform
 
 # Install everything needed for behat testing, using our local branch of this repo
-./bin/.travis/setup_from_external_repo.sh $BRANCH_BUILD_DIR "ezsystems/ezpublish-kernel:dev-tmp_travis_branch as ${branch_alias}"
+./bin/.travis/setup_from_external_repo.sh $BRANCH_BUILD_DIR "ezsystems/ezpublish-kernel:dev-tmp_travis_branch as 6.3.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -59,6 +59,7 @@
         "process-timeout": 3000
     },
     "extra": {
+        "_branch-alias-comment_": "!! Update alias in bin/.travis/prepare_behat.sh on changes/branch-offs !!",
         "branch-alias": {
             "dev-master": "6.3.x-dev"
         }


### PR DESCRIPTION
Motivation: Version number alias here tends to be forgotten on version bumps, so find a way to avoid it.

Aka this is what worked in the past, but needed manual update on version bumps:
`./bin/.travis/setup_from_external_repo.sh $BRANCH_BUILD_DIR "ezsystems/ezpublish-kernel:dev-tmp_travis_branch as 6.2"`

But now the logic takes this from composer.json if present, and otherwise fallback to TRAVIS_BRANCH *(target branch on PR's)*.