### PR TITLE
BDD: improved feedback on session creation errors

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/Authentication.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/Authentication.php
@@ -10,12 +10,10 @@
  */
 namespace eZ\Bundle\EzPublishRestBundle\Features\Context\SubContext;
 
-use eZ\Publish\Core\REST\Server\Values\SessionInput;
-
 trait Authentication
 {
     /**
-     * @var eZ\Publish\Core\REST\Server\Values\UserSession
+     * @var \eZ\Publish\Core\REST\Server\Values\UserSession
      */
     protected $userSession;
 
@@ -79,6 +77,23 @@ trait Authentication
         $this->sendRequest();
 
         $this->userSession = $this->getResponseObject();
+
+        if (!$this->userSession instanceof \eZ\Publish\Core\REST\Server\Values\UserSession) {
+            if ($this->userSession instanceof \eZ\Publish\Core\REST\Client\Values\ErrorMessage) {
+                $message = sprintf(
+                    "Unexpected '%s' in HTTP request response: %s",
+                    $this->userSession->message,
+                    $this->userSession->description
+                );
+            } else {
+                $message = false;
+            }
+            throw new \RuntimeException(
+                $message ?: 'UserSession value expected, got ' . get_class($this->userSession),
+                0,
+                isset($exceptionValue) ? $exceptionValue : null
+            );
+        }
 
         $this->resetDriver();
 


### PR DESCRIPTION
Improves error output when session creation fails. If an error ocurred, an exception will be thrown instead of "Undefined property".

### Output without the patch
```
Given I have "administrator" permissions # eZ\Bundle\EzPublishRestBundle\Features\Context\RestContext::usePermissionsOfRole()
  Notice: Undefined property: eZ\Publish\Core\REST\Common\Exceptions\Parser::$sessionName in vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/Authentication.php line 86
```

### Output with the patch

```
Given I have "administrator" permissions # eZ\Bundle\EzPublishRestBundle\Features\Context\RestContext::usePermissionsOfRole()
  Unexpected 'Internal Server Error' in HTTP request response: A Token was not found in the TokenStorage. (RuntimeException)
```