### PR TITLE
EZP-25627 provide default layout template allowing show sf toolbar

### DIFF
--- a/doc/specifications/security/authentication_symfony.md
+++ b/doc/specifications/security/authentication_symfony.md
@@ -52,7 +52,7 @@ Base template used is `EzPublishCoreBundle:Security:login.html.twig` and stands 
 {% endblock %}
 ```
 
-The layout used by default is `%ezpublish.content_view.viewbase_layout%` (empty layout) but can be configured easily
+The layout used by default is `%ezsettings.default.pagelayout%` but can be configured easily
 as well as the login template:
 
 *ezpublish.yml*

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
@@ -93,6 +93,10 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
                     ->booleanNode('cookie_httponly')->end()
                 ->end()
             ->end()
+            ->scalarNode('pagelayout')
+                ->info('The default layout to use')
+                ->example('AppBundle::pagelayout.html.twig')
+            ->end()
             ->scalarNode('index_page')
                 ->info('The page that the index page will show. Default value is null.')
                 ->example('/Getting-Started')
@@ -188,6 +192,9 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
         }
         if (isset($scopeSettings['default_page'])) {
             $contextualizer->setContextualParameter('default_page', $currentScope, '/' . ltrim($scopeSettings['default_page'], '/'));
+        }
+        if (isset($scopeSettings['pagelayout'])) {
+            $contextualizer->setContextualParameter('pagelayout', $currentScope, $scopeSettings['pagelayout']);
         }
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -18,6 +18,8 @@ parameters:
     ezplatform.default_view_templates.content.embed: 'EzPublishCoreBundle:default:content/embed.html.twig'
     ezplatform.default_view_templates.block: 'EzPublishCoreBundle:default:block/block.html.twig'
 
+    ezsettings.default.pagelayout: 'EzPublishCoreBundle::pagelayout.html.twig'
+
     ezsettings.default.content_view_defaults:
         full:
             default:
@@ -136,7 +138,7 @@ parameters:
 
     # Security settings
     ezsettings.default.security.login_template: "EzPublishCoreBundle:Security:login.html.twig"
-    ezsettings.default.security.base_layout: %ezpublish.content_view.viewbase_layout%
+    ezsettings.default.security.base_layout: %ezsettings.default.pagelayout%
 
     # Image settings
     ezsettings.default.image.temporary_dir: imagetmp

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -275,6 +275,8 @@ services:
     ezpublish.view.view_parameters.injector.viewbase_layout:
         class: %ezpublish.view.view_parameters.injector.viewbase_layout.class%
         arguments: [%ezpublish.content_view.viewbase_layout%]
+        calls:
+            - [setPageLayout, [$pagelayout$]]
         tags:
             - { name: kernel.event_subscriber }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/full.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/full.html.twig
@@ -1,5 +1,8 @@
-<h2>{{ ez_content_name(content) }}</h2>
-{% for field in content.fieldsByLanguage %}
-    <h3>{{ field.fieldDefIdentifier }}</h3>
-    {{ ez_render_field(content, field.fieldDefIdentifier) }}
-{% endfor %}
+{% extends noLayout == true ? viewbaseLayout : pagelayout %}
+{% block content %}
+    <h2>{{ ez_content_name(content) }}</h2>
+    {% for field in content.fieldsByLanguage %}
+        <h3>{{ field.fieldDefIdentifier }}</h3>
+        {{ ez_render_field(content, field.fieldDefIdentifier) }}
+    {% endfor %}
+{% endblock %}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/pagelayout.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/pagelayout.html.twig
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="{{ app.request.locale|replace('_', '-') }}">
+<head>
+    <meta charset="utf-8">
+    {% if content is defined and title is not defined %}
+        {% set title = ez_content_name( content ) %}
+    {% endif %}
+    <title>{{ title|default( 'Home' ) }}</title>
+    <meta name="generator" content="eZ Platform"/>
+    {% if content is defined and content.contentInfo.mainLocationId %}
+        <link rel="canonical" href="{{ path( 'ez_urlalias', {'locationId': content.contentInfo.mainLocationId} ) }}" />
+    {% endif %}
+</head>
+<body>
+{% block content %}{% endblock %}
+</body>
+</html>

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/CommonTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/CommonTest.php
@@ -197,7 +197,7 @@ class CommonTest extends AbstractParserTestCase
         $this->load();
         $this->assertConfigResolverParameterValue(
             'security.base_layout',
-            '%ezpublish.content_view.viewbase_layout%',
+            '%ezsettings.default.pagelayout%',
             'ezdemo_site'
         );
         $this->assertConfigResolverParameterValue(

--- a/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/ViewbaseLayout.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/ViewbaseLayout.php
@@ -16,11 +16,21 @@ class ViewbaseLayout implements EventSubscriberInterface
     /**
      * @var string
      */
+    private $pageLayout;
+
+    /**
+     * @var string
+     */
     private $viewbaseLayout;
 
     public function __construct($viewbaseLayout)
     {
         $this->viewbaseLayout = $viewbaseLayout;
+    }
+
+    public function setPageLayout($pageLayout)
+    {
+        $this->pageLayout = $pageLayout;
     }
 
     public static function getSubscribedEvents()
@@ -31,5 +41,6 @@ class ViewbaseLayout implements EventSubscriberInterface
     public function injectViewbaseLayout(FilterViewParametersEvent $event)
     {
         $event->getParameterBag()->set('viewbaseLayout', $this->viewbaseLayout);
+        $event->getParameterBag()->set('pagelayout', $this->pageLayout);
     }
 }


### PR DESCRIPTION
Here's another try to solve this. In this case i create a new `pagelayout.html.twig` template and a new param in `templating.yml` file. i called it `ezpublish.pagelayout`. Better naming suggestions are very welcomed :). 

The `full.html.twig`extends that new `viewBaseLayout`.
One concern about this is what if the user tries something like 
```twig
 {{ render( controller( "ez_content:viewAction", {'contentId': contentId, 'viewType': 'full', 'noLayout': 1} ) ) }}
```
In this case, shouldn't we modify full template to check if ```noLayout``` is true or false?

ping @andrerom @emodric @bdunogier 