### PR TITLE
EZP-23445: Take SYMFONY_ENV into account in asset dump composer scripts

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
@@ -25,17 +25,18 @@ class ScriptHandler extends DistributionBundleScriptHandler
         $options = self::getOptions($event);
         $appDir = $options['symfony-app-dir'];
         $webDir = $options['symfony-web-dir'];
-        $env = isset($options['ezpublish-asset-dump-env']) ? $options['ezpublish-asset-dump-env'] : '';
+        $command = 'assetic:dump';
 
-        if (!$env) {
-            $env = $event->getIO()->ask(
-                "<question>Which environment would you like to dump production assets for?</question> (Default: 'prod', type 'none' to skip) ",
-                'prod'
-            );
-        }
+        // if not set falls back to default behaviour of console commands (using SYMFONY_ENV or fallback to 'dev')
+        if (!empty($options['ezpublish-asset-dump-env'])) {
+            $event->getIO()->write('<error>Use of `ezpublish-asset-dump-env` is deprecated, use SYMFONY_ENV to set anything other then dev for all commands</error>');
 
-        if ($env === 'none') {
-            return;
+            if ($options['ezpublish-asset-dump-env'] === 'none') {
+                // If asset dumping is skipped, output help text on how to generate it if needed
+                return self::dumpAssetsHelpText($event);
+            }
+
+            $command .= ' --env=' . escapeshellarg($options['ezpublish-asset-dump-env']);
         }
 
         if (!is_dir($appDir)) {
@@ -50,7 +51,7 @@ class ScriptHandler extends DistributionBundleScriptHandler
             return;
         }
 
-        static::executeCommand($event, $appDir, 'assetic:dump --env=' . escapeshellarg($env) . ' ' . escapeshellarg($webDir));
+        static::executeCommand($event, $appDir, $command . ' ' . escapeshellarg($webDir));
     }
 
     /**
@@ -59,11 +60,12 @@ class ScriptHandler extends DistributionBundleScriptHandler
      * Typically to use this instead on composer update as dump command uses prod environment where cache is not cleared,
      * causing it to sometimes crash when cache needs to be cleared.
      *
+     * @deprecated Will be made private in the future for use by dumpAssets.
      * @param $event CommandEvent A instance
      */
     public static function dumpAssetsHelpText(CommandEvent $event)
     {
-        $event->getIO()->write('<info>To dump eZ Publish production assets, execute the following:</info>');
+        $event->getIO()->write('<info>To dump eZ Publish production assets, which is needed for production environment, execute the following:</info>');
         $event->getIO()->write('    php app/console assetic:dump --env=prod web');
         $event->getIO()->write('');
     }


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-23445
Target: **6.3** *(contains deprecations and changes)*

1. With Symfony_ENV being now used most other places as of [eZ Platform 1.0](https://github.com/ezsystems/ezplatform/pull/70), it now makes sense to take it into account here as well.
2. Get rid of the question, behave more like other commands, and use ezpublish-asset-dump-env for bc but deprecate with a error saying use of Symfony_ENV is preferred.