### PR TITLE
Fix EZP-25610: Publishing a role draft with REST should return HTTP 204

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -5576,18 +5576,17 @@ Update Role draft
 
 Publish Role draft
 ``````````````````
-:Resource: /user/roles/<ID/draft
+:Resource: /user/roles/<ID>/draft
 :Method: PUBLISH or POST with header X-HTTP-Method-Override: PUBLISH
 :Description: Publishes a role draft
 :Response:
 
 .. code:: http
 
-          HTTP/1.1 200 OK
+          HTTP/1.1 204 No Content
+          Location: /api/ezp/v2/user/roles/<ID>
           Content-Type: <depending on accept header>
-          Content-Length: <length>
-.. parsed-literal::
-          Role_
+          Content-Length: 0
 
 :Error Codes:
     :401: If the user is not authorized to publish this content type draft

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -98,6 +98,7 @@ parameters:
     ezpublish_rest.output.value_object_visitor.Policy.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\Policy
     ezpublish_rest.output.value_object_visitor.Role.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\Role
     ezpublish_rest.output.value_object_visitor.CreatedRole.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\CreatedRole
+    ezpublish_rest.output.value_object_visitor.PublishedRole.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\PublishedRole
     ezpublish_rest.output.value_object_visitor.RoleList.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\RoleList
     ezpublish_rest.output.value_object_visitor.RoleCreateStruct.class: eZ\Publish\Core\REST\Client\Output\ValueObjectVisitor\RoleCreateStruct
     ezpublish_rest.output.value_object_visitor.RoleUpdateStruct.class: eZ\Publish\Core\REST\Client\Output\ValueObjectVisitor\RoleUpdateStruct
@@ -556,6 +557,12 @@ services:
         class: %ezpublish_rest.output.value_object_visitor.CreatedRole.class%
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Values\CreatedRole }
+
+    ezpublish_rest.output.value_object_visitor.PublishedRole:
+        parent: ezpublish_rest.output.value_object_visitor.base
+        class: %ezpublish_rest.output.value_object_visitor.PublishedRole.class%
+        tags:
+            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Values\PublishedRole }
 
     ezpublish_rest.output.value_object_visitor.Role:
         parent: ezpublish_rest.output.value_object_visitor.base

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RoleTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RoleTest.php
@@ -603,7 +603,12 @@ XML;
             $this->createHttpRequest('PUBLISH', $roleDraftHref)
         );
 
-        self::assertHttpResponseCodeEquals($response, 201);
+        self::assertHttpResponseCodeEquals($response, 204);
+        self::assertHttpResponseHasHeader(
+            $response,
+            'Location',
+            '/api/ezp/v2/user/roles/' . preg_replace('/.*roles\/(\d+).*/', '$1', $roleDraftHref)
+        );
     }
 
     /**

--- a/eZ/Publish/Core/REST/Server/Controller/Role.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Role.php
@@ -269,7 +269,8 @@ class Role extends RestController
      * Publishes a role draft.
      *
      * @param mixed $roleId Original role ID, or ID of the role draft itself
-     * @return Values\RestRole
+     *
+     * @return \eZ\Publish\Core\REST\Server\Values\PublishedRole
      */
     public function publishRoleDraft($roleId)
     {
@@ -283,9 +284,10 @@ class Role extends RestController
         }
 
         $this->roleService->publishRoleDraft($roleDraft);
-        $publishedRole = $this->roleService->loadRole($roleDraft->id);
 
-        return new Values\CreatedRole(['role' => new Values\RestRole($publishedRole)]);
+        $role = $this->roleService->loadRole($roleId);
+
+        return new Values\PublishedRole(['role' => new Values\RestRole($role)]);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/PublishedRole.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/PublishedRole.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * File containing the PublishedRole ValueObjectVisitor class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+
+/**
+ * PublishedRole value object visitor.
+ *
+ * @todo coverage add unit test
+ */
+class PublishedRole extends Role
+{
+    /**
+     * Visit struct returned by controllers.
+     *
+     * @param \eZ\Publish\Core\REST\Common\Output\Visitor $visitor
+     * @param \eZ\Publish\Core\REST\Common\Output\Generator $generator
+     * @param \eZ\Publish\Core\REST\Server\Values\PublishedRole $data
+     */
+    public function visit(Visitor $visitor, Generator $generator, $data)
+    {
+        parent::visit($visitor, $generator, $data->role);
+        $visitor->setHeader(
+            'Location',
+            $this->router->generate(
+                'ezpublish_rest_loadRole',
+                array('roleId' => $data->role->id)
+            )
+        );
+        $visitor->setStatus(204);
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Values/PublishedRole.php
+++ b/eZ/Publish/Core/REST/Server/Values/PublishedRole.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * File containing the PublishedRole class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\REST\Server\Values;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * Struct representing a published Role.
+ */
+class PublishedRole extends ValueObject
+{
+    /**
+     * The published role.
+     *
+     * @var \eZ\Publish\Core\REST\Server\Values\RestRole
+     */
+    public $role;
+}


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-25610
> Status: Ready for review

Role draft publishing currently returns HTTP 201 Created. This is wrong, it should be used only for newly created resources. Content publishing returns HTTP 204 No Content, we should do the same for roles.

This fixes the return value, and updates the test and api doc.