### PR TITLE
Fix to support urls with ommited schemes.

### DIFF
--- a/eZ/Publish/Core/IO/Tests/UrlDecorator/AbsolutePrefixTest.php
+++ b/eZ/Publish/Core/IO/Tests/UrlDecorator/AbsolutePrefixTest.php
@@ -43,6 +43,16 @@ class AbsolutePrefixTest extends PrefixTest
                 'http://static.example.com/',
                 'http://static.example.com/images/file.png',
             ),
+            array(
+                'images/file.png',
+                '//static.example.com',
+                '//static.example.com/images/file.png',
+            ),
+            array(
+                'images/file.png',
+                '//static.example.com/',
+                '//static.example.com/images/file.png',
+            ),
         );
     }
 }

--- a/eZ/Publish/Core/IO/UrlDecorator/AbsolutePrefix.php
+++ b/eZ/Publish/Core/IO/UrlDecorator/AbsolutePrefix.php
@@ -26,7 +26,10 @@ class AbsolutePrefix extends Prefix implements UrlDecorator
     {
         if ($prefix != '') {
             $urlParts = parse_url($prefix);
-            if (isset($urlParts['scheme'])) {
+
+            // Since PHP 5.4.7 parse_url will return host when url scheme is ommited.
+            // This allows urls like //static.example.com to be used
+            if (isset($urlParts['scheme']) || isset($urlParts['host'])) {
                 $prefix = rtrim($prefix, '/') . '/';
             } else {
                 $prefix = '/' . trim($prefix, '/') . '/';


### PR DESCRIPTION
This change allows the usage of absolute urls like

`//static.example.com`

without them being turned into relative urls.