### PR TITLE
Make getSortClauseBySortField public

### DIFF
--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -766,7 +766,7 @@ class LocationService implements LocationServiceInterface
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Query\SortClause
      */
-    protected function getSortClauseBySortField($sortField, $sortOrder = APILocation::SORT_ORDER_ASC)
+    public function getSortClauseBySortField($sortField, $sortOrder = APILocation::SORT_ORDER_ASC)
     {
         $sortOrder = $sortOrder == APILocation::SORT_ORDER_DESC ? Query::SORT_DESC : Query::SORT_ASC;
         switch ($sortField) {


### PR DESCRIPTION
Many use cases require building a sort clause based on a provided location in a controller. By making this function public, we reduce redundancy and eliminate potential errors.
