### PR TITLE
Content and Location filtering proposal

### DIFF
--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -11,6 +11,7 @@
 namespace eZ\Publish\API\Repository;
 
 use eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct;
+use eZ\Publish\API\Repository\Values\Content\Filter;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\Content\TranslationInfo;
 use eZ\Publish\API\Repository\Values\Content\TranslationValues;
@@ -432,4 +433,34 @@ interface ContentService
      * @return \eZ\Publish\API\Repository\Values\Content\TranslationValues
      */
     public function newTranslationValues();
+
+    /**
+     * Finds ContentInfo items for the given filter.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Filter $filter
+     * @param array $languageSettings
+     * @param boolean $filterOnUserPermissions
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\FilterResult
+     */
+    public function filterContentInfo(
+        Filter $filter,
+        array $languageSettings = [],
+        $filterOnUserPermissions = true
+    );
+
+    /**
+     * Finds Content items for the given filter.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Filter $filter
+     * @param array $languageSettings
+     * @param boolean $filterOnUserPermissions
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\FilterResult
+     */
+    public function filterContent(
+        Filter $filter,
+        array $languageSettings = [],
+        $filterOnUserPermissions = true
+    );
 }

--- a/eZ/Publish/API/Repository/LocationService.php
+++ b/eZ/Publish/API/Repository/LocationService.php
@@ -10,6 +10,7 @@
  */
 namespace eZ\Publish\API\Repository;
 
+use eZ\Publish\API\Repository\Values\Content\LocationFilter;
 use eZ\Publish\API\Repository\Values\Content\LocationUpdateStruct;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -199,4 +200,19 @@ interface LocationService
      * @return \eZ\Publish\API\Repository\Values\Content\LocationUpdateStruct
      */
     public function newLocationUpdateStruct();
+
+    /**
+     * Finds Locations for the given filter.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\LocationFilter $filter
+     * @param array $languageSettings
+     * @param boolean $filterOnUserPermissions
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\FilterResult
+     */
+    public function filterLocations(
+        LocationFilter $filter,
+        array $languageSettings = [],
+        $filterOnUserPermissions = true
+    );
 }

--- a/eZ/Publish/API/Repository/Values/Content/Filter.php
+++ b/eZ/Publish/API/Repository/Values/Content/Filter.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\API\Repository\Values\Content;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * This class is used to perform a Content filter.
+ */
+class Filter extends ValueObject
+{
+    const SORT_ASC = 'ascending';
+
+    const SORT_DESC = 'descending';
+
+    /**
+     * The filter.
+     *
+     * For the storage backend that supports it (Solr) filters the result set
+     * without influencing score. It also offers better performance as filter
+     * part of the Query can be cached.
+     *
+     * Can contain multiple criterion, as items of a logical one (by default
+     * AND)
+     *
+     * @var \eZ\Publish\API\Repository\Values\Content\Query\Criterion
+     */
+    public $filter;
+
+    /**
+     * Query sorting clauses.
+     *
+     * @var \eZ\Publish\API\Repository\Values\Content\Query\SortClause[]
+     */
+    public $sortClauses = [];
+
+    /**
+     * Query offset.
+     *
+     * Sets the offset for search hits, used for paging the results.
+     *
+     * @var int
+     */
+    public $offset = 0;
+
+    /**
+     * Query limit.
+     *
+     * Limit for number of search hits to return.
+     * If value is `0`, search query will not return any search hits, useful for doing a count.
+     *
+     * @var int
+     */
+    public $limit = 25;
+
+    /**
+     * If true, search engine should perform count even if that means extra lookup.
+     *
+     * @var bool
+     */
+    public $performCount = true;
+}

--- a/eZ/Publish/API/Repository/Values/Content/LocationFilter.php
+++ b/eZ/Publish/API/Repository/Values/Content/LocationFilter.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\API\Repository\Values\Content;
+
+/**
+ * This class is used to perform a Location filter.
+ */
+class LocationFilter extends Filter
+{
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query.php
@@ -10,39 +10,15 @@
  */
 namespace eZ\Publish\API\Repository\Values\Content;
 
-use eZ\Publish\API\Repository\Values\ValueObject;
-
 /**
  * This class is used to perform a Content query.
  */
-class Query extends ValueObject
+class Query extends Filter
 {
-    const SORT_ASC = 'ascending';
-
-    const SORT_DESC = 'descending';
-
     /**
-     * The Query filter.
+     * The query.
      *
-     * For the storage backend that supports it (Solr) filters the result set
-     * without influencing score. It also offers better performance as filter
-     * part of the Query can be cached.
-     *
-     * In case when the backend does not distinguish between query and filter
-     * (Legacy Storage implementation), it will simply be combined with Query query
-     * using LogicalAnd criterion.
-     *
-     * Can contain multiple criterion, as items of a logical one (by default
-     * AND)
-     *
-     * @var \eZ\Publish\API\Repository\Values\Content\Query\Criterion
-     */
-    public $filter;
-
-    /**
-     * The Query query.
-     *
-     * For the storage backend that supports it (Solr Storage) query will influence
+     * For the storage backend that supports it (Solr Search Engine) query will influence
      * score of the search results.
      *
      * Can contain multiple criterion, as items of a logical one (by default
@@ -53,13 +29,6 @@ class Query extends ValueObject
     public $query;
 
     /**
-     * Query sorting clauses.
-     *
-     * @var \eZ\Publish\API\Repository\Values\Content\Query\SortClause[]
-     */
-    public $sortClauses = array();
-
-    /**
      * An array of facet builders.
      *
      * @var \eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder[]
@@ -67,35 +36,9 @@ class Query extends ValueObject
     public $facetBuilders = array();
 
     /**
-     * Query offset.
-     *
-     * Sets the offset for search hits, used for paging the results.
-     *
-     * @var int
-     */
-    public $offset = 0;
-
-    /**
-     * Query limit.
-     *
-     * Limit for number of search hits to return.
-     * If value is `0`, search query will not return any search hits, useful for doing a count.
-     *
-     * @var int
-     */
-    public $limit = 25;
-
-    /**
      * If true spellcheck suggestions are returned.
      *
      * @var bool
      */
     public $spellcheck;
-
-    /**
-     * If true, search engine should perform count even if that means extra lookup.
-     *
-     * @var bool
-     */
-    public $performCount = true;
 }

--- a/eZ/Publish/API/Repository/Values/Content/Search/FilterHit.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/FilterHit.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * File containing the eZ\Publish\API\Repository\Values\Content\Search\SearchHit class.
+ * This file is part of the eZ Publish Kernel package.
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
@@ -10,29 +10,26 @@
  */
 namespace eZ\Publish\API\Repository\Values\Content\Search;
 
+use eZ\Publish\API\Repository\Values\ValueObject;
+
 /**
  * This class represents a SearchHit matching the query.
  */
-class SearchHit extends FilterHit
+class FilterHit extends ValueObject
 {
     /**
-     * The score of this value;.
+     * The value found by the search.
      *
-     * @var float
+     * @var \eZ\Publish\API\Repository\Values\ValueObject
      */
-    public $score;
+    public $valueObject;
 
     /**
-     * The index identifier where this value was found.
+     * Language code of the Content translation that matched the query.
+     *
+     * @since 5.4.5
      *
      * @var string
      */
-    public $index;
-
-    /**
-     * A representation of the search hit including highlighted terms.
-     *
-     * @var string
-     */
-    public $highlight;
+    public $matchedTranslation;
 }

--- a/eZ/Publish/API/Repository/Values/Content/Search/FilterResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/FilterResult.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\API\Repository\Values\Content\Search;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * This class represents a filter result.
+ */
+class FilterResult extends ValueObject
+{
+    /**
+     * The value objects found for the query.
+     *
+     * @var \eZ\Publish\API\Repository\Values\Content\Search\SearchHit[]
+     */
+    public $searchHits = [];
+
+    /**
+     * The duration of the search processing in ms.
+     *
+     * @var int
+     */
+    public $time;
+
+    /**
+     * The total number of searchHits.
+     *
+     * `null` if Filter->performCount was set to false and search engine avoids search lookup.
+     *
+     * @var int|null
+     */
+    public $totalCount;
+}

--- a/eZ/Publish/API/Repository/Values/Content/Search/SearchResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/SearchResult.php
@@ -10,12 +10,10 @@
  */
 namespace eZ\Publish\API\Repository\Values\Content\Search;
 
-use eZ\Publish\API\Repository\Values\ValueObject;
-
 /**
  * This class represents a search result.
  */
-class SearchResult extends ValueObject
+class SearchResult extends FilterResult
 {
     /**
      * The facets for this search.
@@ -25,26 +23,12 @@ class SearchResult extends ValueObject
     public $facets = array();
 
     /**
-     * The value objects found for the query.
-     *
-     * @var \eZ\Publish\API\Repository\Values\Content\Search\SearchHit[]
-     */
-    public $searchHits = array();
-
-    /**
      * If spellcheck is on this field contains a collated query suggestion where in the appropriate
      * criterions the wrong spelled value is replaced by a corrected one (TBD).
      *
      * @var \eZ\Publish\API\Repository\Values\Content\Query\Criterion
      */
     public $spellSuggestion;
-
-    /**
-     * The duration of the search processing in ms.
-     *
-     * @var int
-     */
-    public $time;
 
     /**
      * Indicates if the search has timed out.
@@ -59,13 +43,4 @@ class SearchResult extends ValueObject
      * @var float
      */
     public $maxScore;
-
-    /**
-     * The total number of searchHits.
-     *
-     * `null` if Query->performCount was set to false and search engine avoids search lookup.
-     *
-     * @var int|null
-     */
-    public $totalCount;
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -10,6 +10,7 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content;
 
+use eZ\Publish\API\Repository\Values\Content\Filter;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway as LocationGateway;
 use eZ\Publish\SPI\Persistence\Content\Handler as BaseContentHandler;
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
@@ -709,5 +710,10 @@ class Handler implements BaseContentHandler
         return $this->mapper->extractRelationsFromRows(
             $this->contentGateway->loadReverseRelations($destinationContentId, $type)
         );
+    }
+
+    public function filter(Filter $filter, array $languageSettings = [])
+    {
+        // TODO: Implement filter() method.
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
@@ -10,6 +10,7 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Location;
 
+use eZ\Publish\API\Repository\Values\Content\LocationFilter;
 use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\Location;
 use eZ\Publish\SPI\Persistence\Content\Location\CreateStruct;
@@ -483,5 +484,10 @@ class Handler implements BaseLocationHandler
     public function changeMainLocation($contentId, $locationId)
     {
         $this->treeHandler->changeMainLocation($contentId, $locationId);
+    }
+
+    public function filter(LocationFilter $filter, array $languageSettings = [])
+    {
+        // TODO: Implement filter() method.
     }
 }

--- a/eZ/Publish/Core/Search/FutureSolrIndexingPlugin.php
+++ b/eZ/Publish/Core/Search/FutureSolrIndexingPlugin.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace eZ\Publish\Core\Search;
+
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as LocationHandler;
+use eZ\Publish\API\Repository\Values\Content\LocationFilter;
+use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+
+class FutureSolrIndexingPlugin
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Location\Handler
+     */
+    protected $locationHandler;
+
+    public function __construct(LocationHandler $locationHandler)
+    {
+        $this->locationHandler = $locationHandler;
+    }
+
+    public function canMap(Content $content, $languageCode)
+    {
+        if (
+            $content->versionInfo->contentInfo->contentTypeId === 42 &&
+            $languageCode === 'cro-HR'
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function mapFields(Content $content, $languageCode)
+    {
+        $filter = new LocationFilter();
+
+        // Something...
+
+        $filterResult = $this->locationHandler->filter($filter);
+
+        $fields = [];
+
+        $fields[] = new Field(
+            'hello_field',
+            $filterResult->searchHits[0]->valueObject->hello,
+            new FieldType\StringField()
+        );
+
+        return $fields;
+    }
+}

--- a/eZ/Publish/SPI/Persistence/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Handler.php
@@ -11,6 +11,7 @@
 namespace eZ\Publish\SPI\Persistence\Content;
 
 // @todo We must verify whether we want to type cast on the "Criterion" interface or abstract class
+use eZ\Publish\API\Repository\Values\Content\Filter;
 use eZ\Publish\SPI\Persistence\Content\Relation\CreateStruct as RelationCreateStruct;
 
 /**
@@ -256,4 +257,14 @@ interface Handler
      * @return \eZ\Publish\SPI\Persistence\Content The published Content
      */
     public function publish($contentId, $versionNo, MetadataUpdateStruct $metaDataUpdateStruct);
+
+    /**
+     * Finds Content items for the given filter.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Filter $filter
+     * @param array $languageSettings
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\FilterResult
+     */
+    public function filter(Filter $filter, array $languageSettings = []);
 }

--- a/eZ/Publish/SPI/Persistence/Content/Location/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location/Handler.php
@@ -11,6 +11,7 @@
 namespace eZ\Publish\SPI\Persistence\Content\Location;
 
 use eZ\Publish\SPI\Persistence\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\LocationFilter;
 
 /**
  * The Location Handler interface defines operations on Location elements in the storage engine.
@@ -193,4 +194,14 @@ interface Handler
      * @param mixed $locationId
      */
     public function changeMainLocation($contentId, $locationId);
+
+    /**
+     * Finds Locations for the given filter.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\LocationFilter $filter
+     * @param array $languageSettings
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\FilterResult
+     */
+    public function filter(LocationFilter $filter, array $languageSettings = []);
 }


### PR DESCRIPTION
This introduces new public API methods for filtering Content and Locations:

- `ContentService::filterContentInfo(Filter $filter, $languageSettings)`
- `ContentService::filterContent(Filter $filter, $languageSettings)`
- `LocationService::filterLocations(LocationFilter $filter, $languageSettings)`

It also introduces `Filter` and `FilterResult`, which `Query` and `SearchResult` now inherit from.

## Why

There are several problems in regard to how search works and how we use it:

1. Asynchronous/delayed indexing

	Indexing is asynchronous, hence data creation/deletion/update is not immediately visible through search engine. That holds true even for the current implementation, that is not delayed -- results are not immediately available in search. We use search in two places that make that a particular problem:

	- `LocationService::deleteLocation()`
	
		Search is used to determine that the subtree does not contain a Location that the user is not allowed to delete.
	
	- `LocationService::moveSubtree()`
	
		Search is used to determine that the subtree does not contain a Location that the user is not allowed to read.

	Since a Location that user does not ahave a permission to delete might exists in the subtree, but without being yet available in search, the permission system with Solr is effectively broken (even if it is a little bit on the edge side). The only way to handle that properly is making required checks on the storage and not on the search backed.

2. Deep paging in distributed environment.

	A quite known problem of distributed search engines, not to expand on that topic here read this: https://www.elastic.co/guide/en/elasticsearch/guide/current/pagination.html

3. Limited options to find stuff aside from search

	Aside from loading by ID, there is only one way to find stuff and that is search. This will be a particular problem in Solr indexing plugins (yet to be implemented), where we can't use search because of the indexing delay problem described above. That means using indexing plugins to index denormalized data of a complex content model would be way too difficult to be practical.

## How

This would basically be a Legacy Search Engine Lite, but now (again) as a part of storage. In difference to the current state of LSE, it would not support the following:

- FullText criterion
- Field criterion (FieldRelation and MapLocationDistance criteria including)
- Field sort clause (MapLocationDistance sort clause including)

That means we would avoid most causes of bad performance of LSE. We should actually rewrite it from scratch, without basing it on subqueries. That would make the implementation considerably simpler and hopefully considerably more performant as well.

Note that we would also avoid [bit shifting stuff](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldBase.php#L65) as there would not be a need to select proper Content attributes for matching. Instead, it should be enough to calculate bit mask of `$languageSettings` and do a bitwise AND with the language mask on the contentobject table.

## Pros

- stuff already mentioned above
	- correct behaviour for deleting and moving a subtree
	- sane implementation of indexing plugins
	- deep paging
- decoupling of BL from search
- lower barier for users -- Solr would not be needed for simpler sites

## Cons

Makes storage implementation more demanding.

## Alternatives

One alternatvie could be keeping storage-based search engine (Legacy Search Engine) and using it together with Solr.