### PR TITLE
Fix EZP-25623: Wrong content object URL path after content update

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/SlugConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/SlugConverter.php
@@ -33,7 +33,6 @@ class SlugConverter
                     'endline_search_normalize',
                     'tab_search_normalize',
                     'specialwords_search_normalize',
-                    'punctuation_normalize',
 
                     //transform
                     'apostrophe_to_doublequote',
@@ -74,7 +73,6 @@ class SlugConverter
                     'endline_search_normalize',
                     'tab_search_normalize',
                     'specialwords_search_normalize',
-                    'punctuation_normalize',
 
                     //transform
                     'apostrophe_to_doublequote',


### PR DESCRIPTION
> Fix https://jira.ez.no/browse/EZP-25623
> Status: Ready for review

This adds tests to https://github.com/ezsystems/ezpublish-kernel/pull/1624 by @clash82, and extends the fix to `urlalias_compat`.

Changes:
- `urlalias`: As described in issue, commas are now removed instead of being converted to dots
  - *NB: After this fix, exclamation marks are no longer removed!* Is this correct? (Answering myself: Yes, I think this is correct. Before and after the fix, the underlying `cleanupText()` by itself would keep the `!`. But `convert()` would remove it, because it would convert it to a dot, which would in turn be removed by `cleanupText()`. So if it is correct to *not* convert the `!`, then it should not be removed either.)
- `urlalias_iri`: No change, not affected by issue
- `urlalias_compat`: No apparent change, commas were removed before this fix already