### PR TITLE
EZP-25715: Prevent removal of root Locations

### DIFF
--- a/eZ/Publish/API/Repository/LocationService.php
+++ b/eZ/Publish/API/Repository/LocationService.php
@@ -178,6 +178,7 @@ interface LocationService
     /**
      * Deletes $location and all its descendants.
      *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException if the user is trying delete the root location
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user is not allowed to delete this location or a descendant
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -2082,4 +2082,20 @@ class LocationServiceTest extends BaseTest
             $overwrite
         );
     }
+
+    /**
+     * Test for the deleteLocation() method when trying to delete root location.
+     *
+     * @see \eZ\Publish\API\Repository\LocationService::deleteLocation()
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @depends eZ\Publish\API\Repository\Tests\LocationServiceTest::testDeleteLocation
+     */
+    public function testDeleteRootLocationShowThrowForbiddenException()
+    {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        $location = $locationService->loadLocation(2);
+        $locationService->deleteLocation($location);
+    }
 }

--- a/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
@@ -595,4 +595,19 @@ class TrashServiceTest extends BaseTrashServiceTest
 
         return $remoteIds;
     }
+
+    /**
+     * Test trashing root location.
+     *
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @covers \eZ\Publish\API\Repository\TrashService::trash
+     */
+    public function testTrashShouldThrowForbiddenExceptionIfRoot()
+    {
+        $locationService = $this->getRepository()->getLocationService();
+        $trashService = $this->getRepository()->getTrashService();
+
+        $rootLocation = $locationService->loadLocation(2);
+        $trashService->trash($rootLocation);
+    }
 }

--- a/eZ/Publish/API/Repository/TrashService.php
+++ b/eZ/Publish/API/Repository/TrashService.php
@@ -38,6 +38,7 @@ interface TrashService
      *
      * Content is left untouched.
      *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException if the user is trying trash the root location
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to trash the given location
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location

--- a/eZ/Publish/Core/Repository/TrashService.php
+++ b/eZ/Publish/Core/Repository/TrashService.php
@@ -12,6 +12,7 @@ namespace eZ\Publish\Core\Repository;
 
 use eZ\Publish\API\Repository\TrashService as TrashServiceInterface;
 use eZ\Publish\API\Repository\Repository as RepositoryInterface;
+use eZ\Publish\Core\Base\Exceptions\ForbiddenException;
 use eZ\Publish\SPI\Persistence\Handler;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\Repository\Values\Content\TrashItem;
@@ -106,6 +107,7 @@ class TrashService implements TrashServiceInterface
      *
      * Content is left untouched.
      *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException if the user is trying trash the root location
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to trash the given location
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location
@@ -114,6 +116,11 @@ class TrashService implements TrashServiceInterface
      */
     public function trash(Location $location)
     {
+        // children of location 1 is not allowed to be trashed
+        if ($location->parentLocationId === 1) {
+            throw new ForbiddenException('Root location cannot be sent to trash');
+        }
+
         if (!is_numeric($location->id)) {
             throw new InvalidArgumentValue('id', $location->id, 'Location');
         }

--- a/eZ/Publish/Core/SignalSlot/LocationService.php
+++ b/eZ/Publish/Core/SignalSlot/LocationService.php
@@ -323,6 +323,7 @@ class LocationService implements LocationServiceInterface
     /**
      * Deletes $location and all its descendants.
      *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException if the user is trying delete the root location
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user is not allowed to delete this location or a descendant
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location

--- a/eZ/Publish/Core/SignalSlot/TrashService.php
+++ b/eZ/Publish/Core/SignalSlot/TrashService.php
@@ -75,6 +75,7 @@ class TrashService implements TrashServiceInterface
      *
      * Content is left untouched.
      *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException if the user is trying trash the root location
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to trash the given location
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location


### PR DESCRIPTION
Implements https://jira.ez.no/browse/EZP-25715

> status: work-in progress

Adds a check in the trash method and throws a ForbiddenException in case we're trying to trash the Locations. 

> Open questions

i guess this similar check should be added to contentService or locationService? or maybe both?
Thinking in someone doing something wrong in a script and trying to delete the root location directly, without doing the trash first. 

ping @dpobel @andrerom @bdunogier 
