### PR TITLE
Fix EZP-25098: [Symfony 2.8] First load doesn't load the configuration

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/HttpCachePass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/HttpCachePass.php
@@ -39,6 +39,9 @@ class HttpCachePass implements CompilerPassInterface
                 'buildProxyClient',
             ]
         );
+        // Set it lazy as it can be loaded during cache warming and factory depends on ConfigResolver while cache warming
+        // occurs before SA matching.
+        $varnishClientDef->setLazy(true);
 
         // Forcing cache manager to use Varnish proxy client, for BAN support.
         $cacheManagerDef = $container->findDefinition('ezpublish.http_cache.cache_manager');

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/IO.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/IO.php
@@ -72,8 +72,6 @@ class IO extends AbstractParser
     public function postMap(array $config, ContextualizerInterface $contextualizer)
     {
         $container = $contextualizer->getContainer();
-        $configResolver = $container->get('ezpublish.config.resolver.core');
-        $configResolver->setContainer($container);
 
         // complex parameters dependencies
         foreach (array_merge($config['siteaccess']['list'], array_keys($config['siteaccess']['groups'])) as $scope) {

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -167,6 +167,7 @@ services:
         arguments:
             - %ezpublish.fieldType.ezrichtext.converter.edit.xhtml5.resources%
             - @ezpublish.config.resolver
+        lazy: true
 
     ezpublish.fieldType.ezrichtext.validator.docbook:
         class: %ezpublish.fieldType.ezrichtext.validator.xml.class%

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -174,6 +174,7 @@ services:
             - [setFieldEditResources, ["$field_edit_templates$"]]
             - [setFieldDefinitionViewResources, ["$fielddefinition_settings_templates$"]]
             - [setFieldDefinitionEditResources, ["$fielddefinition_edit_templates$"]]
+        lazy: true
 
     ezpublish.templating.field_block_renderer:
         alias: ezpublish.templating.field_block_renderer.twig

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/HttpCachePassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/HttpCachePassTest.php
@@ -43,6 +43,7 @@ class HttpCachePassTest extends AbstractCompilerPassTestCase
         $this->assertInstanceOf('Symfony\\Component\\DependencyInjection\\Reference', $factoryArray[0]);
         $this->assertEquals('buildProxyClient', $factoryArray[1]);
         $this->assertEquals('ezpublish.http_cache.proxy_client.varnish.factory', $factoryArray[0]);
+        $this->assertTrue($varnishProxyClient->isLazy());
 
         $this->assertContainerBuilderHasServiceDefinitionWithArgument(
             'ezpublish.http_cache.cache_manager',


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-25098

Fixes an issue with Symfony 2.8+ when container is being compiled just before a regular request. This issue was introduced by the new Twig cache warmer, which loads Twig context and its extensions. Some of them depend indirectly on the `ConfigResolver`, while there is no SiteAccess context yet (cache warming occurs just after container compilation).

The fix consists in marking the affected services as lazy.

I also removed a unused call to the config resolver in IO config parser (separate commit).
IMHO this should also be backported to 5.4 in order to make it compatible with Symfony 2.8