### PR TITLE
EZP-25453: improve root uri handling in Map\URI siteaccess matcher

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/URI.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/URI.php
@@ -57,8 +57,8 @@ class URI extends Map implements URILexer
      */
     public function analyseLink($linkUri)
     {
-        // Joining slash between uriElements and actual linkUri must be present, except if $linkUri is empty.
-        $joiningSlash = empty($linkUri) ? '' : '/';
+        // Joining slash between uriElements and actual linkUri must be present, except if $linkUri is empty or is just the slash root.
+        $joiningSlash = empty($linkUri) || ($linkUri === '/') ? '' : '/';
         $linkUri = ltrim($linkUri, '/');
         // Removing query string to analyse as SiteAccess might be in it.
         $qsPos = strpos($linkUri, '?');

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/URI.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/URI.php
@@ -45,7 +45,11 @@ class URI extends Map implements URILexer
      */
     public function analyseURI($uri)
     {
-        return substr($uri, strlen("/$this->key"));
+        if (($siteaccessPart = "/$this->key") === $uri) {
+            return '/';
+        }
+
+        return substr($uri, strlen($siteaccessPart));
     }
 
     /**

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterMapURITest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterMapURITest.php
@@ -65,6 +65,7 @@ class RouterMapURITest extends PHPUnit_Framework_TestCase
     public function fixupURIProvider()
     {
         return array(
+            array('/foo', '/'),
             array('/my_siteaccess/foo/bar', '/foo/bar'),
             array('/foo/foo/bar', '/foo/bar'),
             array('/foo/foo/bar?something=foo&bar=toto', '/foo/bar?something=foo&bar=toto'),


### PR DESCRIPTION
> Reopening of #1555 by @Simounet against 6.1

Adds test + a fix for the mirror case (`/foo` => `/`).