### PR TITLE
EZP-25717: Fix all alias types cleaning

### DIFF
--- a/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
@@ -261,6 +261,33 @@ class TrashServiceTest extends BaseTrashServiceTest
     }
 
     /**
+     * Test for the trash() method.
+     *
+     * @see \eZ\Publish\API\Repository\TrashService::recover()
+     * @depends eZ\Publish\API\Repository\Tests\TrashServiceTest::testTrash
+     *
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function testNotFoundAliasAfterRemoveIt()
+    {
+        $mediaRemoteId = '75c715a51699d2d309a924eca6a95145';
+
+        $repository = $this->getRepository();
+        $trashService = $repository->getTrashService();
+        $urlAliasService = $repository->getURLAliasService();
+        $locationService = $repository->getLocationService();
+
+        // Double ->lookup() call because there where issue that one call was not enough to spot bug
+        $urlAliasService->lookup('/Media');
+        $urlAliasService->lookup('/Media');
+
+        $mediaLocation = $locationService->loadLocationByRemoteId($mediaRemoteId);
+        $trashService->trash($mediaLocation);
+
+        $urlAliasService->lookup('/Media');
+    }
+
+    /**
      * Test for the recover() method.
      *
      * @see \eZ\Publish\API\Repository\TrashService::recover()
@@ -280,7 +307,6 @@ class TrashServiceTest extends BaseTrashServiceTest
         $trashedLocationAlias = $urlAliasService->lookup('/Media');
 
         $mediaLocation = $locationService->loadLocationByRemoteId($mediaRemoteId);
-        $urlAliasService->reverseLookup($mediaLocation);
         $trashItem = $trashService->trash($mediaLocation);
         $this->assertAliasNotExists($urlAliasService, '/Media');
 

--- a/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
@@ -10,6 +10,8 @@
  */
 namespace eZ\Publish\API\Repository\Tests;
 
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\URLAliasService;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -256,6 +258,50 @@ class TrashServiceTest extends BaseTrashServiceTest
         } catch (NotFoundException $e) {
             // All well
         }
+    }
+
+    /**
+     * Test for the recover() method.
+     *
+     * @see \eZ\Publish\API\Repository\TrashService::recover()
+     * @depends eZ\Publish\API\Repository\Tests\TrashServiceTest::testTrash
+     */
+    public function testAliasesForRemovedItems()
+    {
+        $mediaRemoteId = '75c715a51699d2d309a924eca6a95145';
+
+        $repository = $this->getRepository();
+        $trashService = $repository->getTrashService();
+        $urlAliasService = $repository->getURLAliasService();
+        $locationService = $repository->getLocationService();
+
+        // Double ->lookup() call because there where issue that one call was not enough to spot bug
+        $urlAliasService->lookup('/Media');
+        $trashedLocationAlias = $urlAliasService->lookup('/Media');
+
+        $mediaLocation = $locationService->loadLocationByRemoteId($mediaRemoteId);
+        $urlAliasService->reverseLookup($mediaLocation);
+        $trashItem = $trashService->trash($mediaLocation);
+        $this->assertAliasNotExists($urlAliasService, '/Media');
+
+        $this->createNewContentInPlaceTrashedOne($repository, $mediaLocation->parentLocationId);
+
+        $createdLocationAlias = $urlAliasService->lookup('/Media');
+
+        $this->assertNotEquals(
+            $trashedLocationAlias->destination,
+            $createdLocationAlias->destination,
+            'Destination for /media url should changed'
+        );
+
+        $recoveredLocation = $trashService->recover($trashItem);
+        $recoveredLocationAlias = $urlAliasService->lookup('/Media2');
+        $recoveredLocationAliasReverse = $urlAliasService->reverseLookup($recoveredLocation);
+
+        $this->assertEquals($recoveredLocationAlias->destination, $recoveredLocationAliasReverse->destination);
+
+        $this->assertNotEquals($recoveredLocationAliasReverse->destination, $trashedLocationAlias->destination);
+        $this->assertNotEquals($recoveredLocationAliasReverse->destination, $createdLocationAlias->destination);
     }
 
     /**
@@ -594,5 +640,57 @@ class TrashServiceTest extends BaseTrashServiceTest
         /* END: Inline */
 
         return $remoteIds;
+    }
+
+    /**
+     * @param Repository $repository
+     * @param int $parentLocationId
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content
+     */
+    protected function createNewContentInPlaceTrashedOne(Repository $repository, $parentLocationId)
+    {
+        $contentService = $repository->getContentService();
+        $locationService = $repository->getLocationService();
+        $contentTypeService = $repository->getContentTypeService();
+
+        $contentType = $contentTypeService->loadContentTypeByIdentifier('forum');
+        $newContent = $contentService->newContentCreateStruct($contentType, 'eng-US');
+        $newContent->setField('name', 'Media');
+
+        $location = $locationService->newLocationCreateStruct($parentLocationId);
+
+        $draftContent = $contentService->createContent($newContent, [$location]);
+
+        return $contentService->publishVersion($draftContent->versionInfo);
+    }
+
+    /**
+     * @param URLAliasService $urlAliasService
+     * @param string $urlPath Url alias path
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\URLAlias
+     */
+    private function assertAliasExists(URLAliasService $urlAliasService, $urlPath)
+    {
+        $urlAlias = $urlAliasService->lookup($urlPath);
+
+        $this->assertInstanceOf('\eZ\Publish\API\Repository\Values\Content\URLAlias', $urlAlias);
+
+        return $urlAlias;
+    }
+
+    /**
+     * @param URLAliasService $urlAliasService
+     * @param string $urlPath Url alias path
+     */
+    private function assertAliasNotExists(URLAliasService $urlAliasService, $urlPath)
+    {
+        try {
+            $this->getRepository()->getURLAliasService()->lookup($urlPath);
+            $this->fail(sprintf('Alias [%s] should not exists', $urlPath));
+        } catch (\eZ\Publish\API\Repository\Exceptions\NotFoundException $e) {
+            $this->assertTrue(true);
+        }
     }
 }

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
@@ -98,7 +98,7 @@ class UrlAliasHandlerTest extends HandlerTest
         $this->cacheMock
             ->expects($this->once())
             ->method('clear')
-            ->with('urlAlias', 'location', 44)
+            ->with('urlAlias')
             ->will($this->returnValue(null));
 
         $handler = $this->persistenceCacheHandler->urlAliasHandler();
@@ -583,24 +583,45 @@ class UrlAliasHandlerTest extends HandlerTest
      */
     public function testLookupIsMiss()
     {
+        $uri = '/url';
+        $urlAliasId = 55;
+        $urlAlias = new UrlAlias(array('id' => $urlAliasId));
+
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
-        $this->cacheMock
-            ->expects($this->once())
-            ->method('getItem')
-            ->with('urlAlias', 'url', '/url')
-            ->will($this->returnValue($cacheItemMock));
-
-        $cacheItemMock
+        $urlAliasIdCacheItem = $this->getMock('Stash\Interfaces\ItemInterface');
+        $urlAliasIdCacheItem
             ->expects($this->once())
             ->method('get')
             ->will($this->returnValue(null));
 
-        $cacheItemMock
+        $urlAliasIdCacheItem
             ->expects($this->once())
             ->method('isMiss')
             ->will($this->returnValue(true));
+
+        $urlAliasIdCacheItem
+            ->expects($this->once())
+            ->method('set')
+            ->with($urlAliasId);
+
+        $urlAliasCacheItem = $this->getMock('Stash\Interfaces\ItemInterface');
+        $urlAliasCacheItem
+            ->expects($this->once())
+            ->method('set')
+            ->with($urlAlias);
+
+        $this->cacheMock
+            ->expects($this->at(0))
+            ->method('getItem')
+            ->with('urlAlias', 'url', $uri)
+            ->will($this->returnValue($urlAliasIdCacheItem));
+
+        $this->cacheMock
+            ->expects($this->at(1))
+            ->method('getItem')
+            ->with('urlAlias', $urlAliasId)
+            ->will($this->returnValue($urlAliasCacheItem));
 
         $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias\\Handler');
         $this->persistenceHandlerMock
@@ -611,16 +632,11 @@ class UrlAliasHandlerTest extends HandlerTest
         $innerHandler
             ->expects($this->once())
             ->method('lookup')
-            ->with('/url')
-            ->will($this->returnValue(new UrlAlias(array('id' => 55))));
-
-        $cacheItemMock
-            ->expects($this->once())
-            ->method('set')
-            ->with(55);
+            ->with($uri)
+            ->will($this->returnValue($urlAlias));
 
         $handler = $this->persistenceCacheHandler->urlAliasHandler();
-        $handler->lookup('/url');
+        $handler->lookup($uri);
     }
 
     /**
@@ -810,7 +826,7 @@ class UrlAliasHandlerTest extends HandlerTest
         $this->cacheMock
             ->expects($this->once())
             ->method('clear')
-            ->with('urlAlias', 'location', 44)
+            ->with('urlAlias')
             ->will($this->returnValue(null));
 
         $handler = $this->persistenceCacheHandler->urlAliasHandler();

--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -204,8 +204,7 @@ class UrlAliasHandler extends AbstractHandler implements UrlAliasHandlerInterfac
             try {
                 $this->logger->logCall(__METHOD__, array('url' => $url));
                 $urlAlias = $this->persistenceHandler->urlAliasHandler()->lookup($url);
-                $urlAliasId = $urlAlias->id;
-                $cache->set($urlAliasId);
+                $cache->set($urlAlias->id);
             } catch (APINotFoundException $e) {
                 $cache->set(self::NOT_FOUND);
                 throw $e;
@@ -304,10 +303,9 @@ class UrlAliasHandler extends AbstractHandler implements UrlAliasHandlerInterfac
             // we need to clear all if we don't have location id in cache
             $this->cache->clear('urlAlias');
         } else {
-            $urlAliasesId = $locationCache->get();
-
-            foreach ((array)$urlAliasesId as $eachUrlAliasId) {
-                $this->cache->clear('urlAlias', $eachUrlAliasId);
+            $urlAliasIds = $locationCache->get();
+            foreach ((array) $urlAliasIds as $urlAliasId) {
+                $this->cache->clear('urlAlias', $urlAliasId);
             }
             $this->cache->clear('urlAlias', 'url');
         }


### PR DESCRIPTION
Fixes: https://jira.ez.no/browse/EZP-25717

> Status: TBD

Some status information, for more please watch discussion in #1639.

>So after a long time of investigation, because there were a lot of incosistency with my test behavior (once it worked, and the other time it wasn't) i got an conclusion that the methods are missbehaving on top of how many times there where called.

>So the problem is how many times we hit the ->lookup('/path') method, why?

> 1. The first call loads an urlAlias, and stores it in cache#stash_default#ez_spi#urlalias#url#media.
> 2. The second call, loads from cache cache#stash_default#ez_spi#urlalias#url#media and loads urlPath from persistence mechanism and stores to the cache the alias with cache#stash_default#ez_spi#urlalias#0-62933a2951ef01f4eafd9bdf4d3cd2f0# ID!!
> 3. For the third call we have all information in the caching mechanism so we don't call the persistence mechanism so if there were some changes we don't know about them, and we don't have any cleanups for this cache element (url, and alias-id) so even if we don't have the location we will always get the historical alias.
>So for now this is why my test wasn't consistent. I will now search for solution but to be honest the easiest solution would be to cleanup the whole 'urlAlias' from cache mechanism to be sure about the consistency and not have to deal with all those dependencies.

>Of course I don't know how does this affect the speed and the cache itself so If you have any opinion about this I will be very glad to here about it.

 