### PR TITLE
Fix EZP-25761: Increase annotation argument resolver priority

### DIFF
--- a/eZ/Bundle/PlatformBehatBundle/Resources/config/services.yml
+++ b/eZ/Bundle/PlatformBehatBundle/Resources/config/services.yml
@@ -4,4 +4,4 @@ services:
     platform_behat.context_argument_resolver:
         class: EzSystems\PlatformBehatBundle\Context\Argument\AnnotationArgumentResolver
         tags:
-            -  { name: context.argument_resolver }
+            -  { name: context.argument_resolver, priority: 100 }


### PR DESCRIPTION
JIra: https://jira.ez.no/browse/EZP-25761

AnnotationArgumentResolver fails in php7 because it is being executed after Symfony2Extension's ArgumentResolver (which creates actual parameter instances).
The problem only happens in php7 because both services have the same priority and sort has a different behavior from php5.

The fix is to tag the service with a higher priority.