### PR TITLE
EZP-25773: Cache warmup for urlAlias object

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -205,6 +205,9 @@ class UrlAliasHandler extends AbstractHandler implements UrlAliasHandlerInterfac
                 $this->logger->logCall(__METHOD__, array('url' => $url));
                 $urlAlias = $this->persistenceHandler->urlAliasHandler()->lookup($url);
                 $cache->set($urlAlias->id);
+
+                $urlAliasCache = $this->cache->getItem('urlAlias', $urlAlias->id);
+                $urlAliasCache->set($urlAlias);
             } catch (APINotFoundException $e) {
                 $cache->set(self::NOT_FOUND);
                 throw $e;


### PR DESCRIPTION
Fixes: https://jira.ez.no/browse/EZP-25773

> Status: Ready for review

Added due to feature request in #1646