### PR TITLE
EZP-25777: UserMetadata criterion handling in REST Views

### DIFF
--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/UserMetadata.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/UserMetadata.php
@@ -12,6 +12,8 @@ namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
 use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
+use eZ\Publish\Core\REST\Common\Exceptions;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\UserMetadata as UserMetadataCriterion;
 
 /**
  * Parser for ViewInput.
@@ -30,6 +32,28 @@ class UserMetadata extends BaseParser
      */
     public function parse(array $data, ParsingDispatcher $parsingDispatcher)
     {
-        throw new \Exception('@todo implement');
+        if (!isset($data['UserMetadataCriterion'])) {
+            throw new Exceptions\Parser('Invalid <UserMetadataCriterion> format');
+        }
+
+        if (!isset($data['UserMetadataCriterion']['Target'])) {
+            throw new Exceptions\Parser('Invalid <Target> format');
+        }
+
+        $target = $data['UserMetadataCriterion']['Target'];
+
+        if (!isset($data['UserMetadataCriterion']['Value'])) {
+            throw new Exceptions\Parser('Invalid <Value> format');
+        }
+
+        if (!in_array(gettype($data['UserMetadataCriterion']['Value']), ['integer', 'string', 'array'])) {
+            throw new Exceptions\Parser('Invalid <Value> format');
+        }
+
+        $value = is_array($data['UserMetadataCriterion']['Value'])
+            ? $data['UserMetadataCriterion']['Value']
+            : explode(',', $data['UserMetadataCriterion']['Value']);
+
+        return new UserMetadataCriterion($target, null, $value);
     }
 }


### PR DESCRIPTION
**JIRA ticket related**: https://jira.ez.no/browse/EZP-25777

There's currently no way to filter content in REST View by content owner ID. We need to implement UserMetadata criterion handling in REST Views.

Example of use (JSON):
```json
{
  "ViewInput": {
    "identifier": "FilterArticleByOwnerIdExample",
    "Query": {
      "Criteria": {
        "ContentTypeIdentifierCriterion": "article",
        "UserMetadata": {
            "Target": "owner",
            "Value": 14
        }
      },
      "limit": "10",
      "offset": "0"
    }
  }
}
```

**Edit**: PR updated, change of requirements.