### PR TITLE
EZP-24315: Handling SortClauses is missing in REST Views (ie. DatePublished)

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
@@ -65,6 +65,8 @@ parameters:
     ezpublish_rest.input.parser.internal.criterion.UserMetadata.class: eZ\Publish\Core\REST\Server\Input\Parser\Criterion\UserMetadata
     ezpublish_rest.input.parser.internal.criterion.Visibility.class: eZ\Publish\Core\REST\Server\Input\Parser\Criterion\Visibility
 
+    ezpublish_rest.input.parser.internal.sortclause.GenericDataKey.class: eZ\Publish\Core\REST\Server\Input\Parser\SortClause\GenericDataKey
+
     ezpublish_rest.input.parser.internal.route_based_limitation.class: eZ\Publish\Core\REST\Server\Input\Parser\Limitation\RouteBasedLimitationParser
     ezpublish_rest.input.parser.internal.path_string_route_based_limitation.class: eZ\Publish\Core\REST\Server\Input\Parser\Limitation\PathStringRouteBasedLimitationParser
 
@@ -566,6 +568,15 @@ services:
         class: %ezpublish_rest.input.parser.internal.criterion.Visibility.class%
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.Visibility }
+
+    ezpublish_rest.input.parser.internal.sortclause.DatePublished:
+        parent: ezpublish_rest.input.parser
+        class: '%ezpublish_rest.input.parser.internal.sortclause.GenericDataKey.class%'
+        arguments:
+            - 'DatePublished'
+            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\DatePublished'
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.DatePublished }
 
     # role limitation parsers
 

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion.php
@@ -49,6 +49,24 @@ abstract class Criterion extends BaseParser
         }
     }
 
+    /**
+     * Dispatches parsing of a sort clause name + direction to its own parser.
+     *
+     * @param string $sortClauseName
+     * @param string $direction
+     * @param \eZ\Publish\Core\REST\Common\Input\ParsingDispatcher $parsingDispatcher
+     *
+     * @throws \eZ\Publish\Core\REST\Common\Exceptions\Parser
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion
+     */
+    public function dispatchSortClause($sortClauseName, $direction, ParsingDispatcher $parsingDispatcher)
+    {
+        $mediaType = $this->getSortClauseMediaType($sortClauseName);
+
+        return $parsingDispatcher->parse(array($sortClauseName => $direction), $mediaType);
+    }
+
     protected function getCriterionMediaType($criterionName)
     {
         $criterionName = str_replace('Criterion', '', $criterionName);
@@ -57,5 +75,10 @@ abstract class Criterion extends BaseParser
         }
 
         return 'application/vnd.ez.api.internal.criterion.' . $criterionName;
+    }
+
+    protected function getSortClauseMediaType($sortClauseName)
+    {
+        return 'application/vnd.ez.api.internal.sortclause.' . $sortClauseName;
     }
 }

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Query.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Query.php
@@ -57,9 +57,13 @@ abstract class Query extends CriterionParser
         }
 
         // SortClauses
-        // -- SortClause
-        // ---- SortField
+        // -- [SortClauseName: direction|data]
         if (array_key_exists('SortClauses', $data)) {
+            $sortClauses = [];
+            foreach ($data['SortClauses'] as $sortClauseName => $sortClauseData) {
+                $sortClauses[] = $this->dispatchSortClause($sortClauseName, $sortClauseData, $parsingDispatcher);
+            }
+            $query->sortClauses = $sortClauses;
         }
 
         // FacetBuilders

--- a/eZ/Publish/Core/REST/Server/Input/Parser/SortClause/GenericDataKey.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/SortClause/GenericDataKey.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace eZ\Publish\Core\REST\Server\Input\Parser\SortClause;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
+use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
+use eZ\Publish\Core\REST\Common\Exceptions;
+
+class GenericDataKey extends BaseParser
+{
+    /** @var string $dataKey */
+    protected $dataKey;
+
+    /** @var string $valueObjectClass */
+    protected $valueObjectClass;
+
+    /**
+     * GenericDataKey constructor.
+     * 
+     * @param $dataKey
+     * @param $valueObjectClass
+     */
+    public function __construct($dataKey, $valueObjectClass)
+    {
+        $this->dataKey = $dataKey;
+        $this->valueObjectClass = $valueObjectClass;
+    }
+
+    /**
+     * Parse input structure.
+     *
+     * @param array $data
+     * @param \eZ\Publish\Core\REST\Common\Input\ParsingDispatcher $parsingDispatcher
+     *
+     * @return \eZ\Publish\API\Repository\Values\ValueObject
+     */
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher)
+    {
+        $direction = $data[$this->dataKey];
+
+        if (!in_array($direction, [Query::SORT_ASC, Query::SORT_DESC])) {
+            throw new Exceptions\Parser("Invalid direction format in <{$direction}> sort clause");
+        }
+
+        return new $this->valueObjectClass($direction);
+    }
+}


### PR DESCRIPTION
**JIRA Ticket related**: https://jira.ez.no/browse/EZP-24315

Example of use (JSON):
```json
{
  "ViewInput": {
    "identifier": "FilterArticleByOwnerIdExample",
    "Query": {
      "Criteria": {
        "ContentTypeIdentifierCriterion": "article"
      },
      "SortClauses": {
        "DatePublished": "ascending"
      },
      "limit": "10",
      "offset": "0"
    }
  }
}
```

**Important**: Implementing every single missing SortClause parser is not part of it.