### PR TITLE
Fix EZP-25783: URI SiteAccess matching fails with utf8

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/URI.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/URI.php
@@ -25,7 +25,7 @@ class URI extends Map implements URILexer
     {
         if (!$this->key) {
             sscanf($request->pathinfo, '/%[^/]', $key);
-            $this->setMapKey($key);
+            $this->setMapKey(rawurldecode($key));
         }
 
         parent::setRequest($request);

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterMapURITest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterMapURITest.php
@@ -25,7 +25,7 @@ class RouterMapURITest extends PHPUnit_Framework_TestCase
      */
     public function testSetGetRequest($config, $pathinfo, $expectedMapKey)
     {
-        $request = new SimplifiedRequest(array('pathinfo' => $pathinfo ));
+        $request = new SimplifiedRequest(array('pathinfo' => $pathinfo));
         $matcher = new URIMapMatcher($config);
         $matcher->setRequest($request);
         $this->assertSame($request, $matcher->getRequest());

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterMapURITest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterMapURITest.php
@@ -16,14 +16,20 @@ use PHPUnit_Framework_TestCase;
 
 class RouterMapURITest extends PHPUnit_Framework_TestCase
 {
-    public function testSetGetRequest()
+    /**
+     * @param array  $config
+     * @param string $pathinfo
+     * @param string $expectedMapKey
+     *
+     * @dataProvider setRequestProvider
+     */
+    public function testSetGetRequest($config, $pathinfo, $expectedMapKey)
     {
-        $request = new SimplifiedRequest(array('pathinfo' => '/bar/baz'));
-        $mapKey = 'bar';
-        $matcher = new URIMapMatcher(array('foo' => $mapKey));
+        $request = new SimplifiedRequest(array('pathinfo' => $pathinfo ));
+        $matcher = new URIMapMatcher($config);
         $matcher->setRequest($request);
         $this->assertSame($request, $matcher->getRequest());
-        $this->assertSame($mapKey, $matcher->getMapKey());
+        $this->assertSame($expectedMapKey, $matcher->getMapKey());
     }
 
     /**
@@ -62,10 +68,19 @@ class RouterMapURITest extends PHPUnit_Framework_TestCase
         $this->assertSame($fullUri, $unserializedMatcher->analyseLink($linkUri));
     }
 
+    public function setRequestProvider()
+    {
+        return array(
+            array(array('foo' => 'bar'), '/bar/baz', 'bar'),
+            array(array('foo' => 'Äpfel'), '/%C3%84pfel/foo', 'Äpfel'),
+        );
+    }
+
     public function fixupURIProvider()
     {
         return array(
             array('/foo', '/'),
+            array('/Äpfel', '/'),
             array('/my_siteaccess/foo/bar', '/foo/bar'),
             array('/foo/foo/bar', '/foo/bar'),
             array('/foo/foo/bar?something=foo&bar=toto', '/foo/bar?something=foo&bar=toto'),


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25783

Currently when using `Map\URI` siteaccess matcher the matching fails if the URI has utf8 characters,
while this should be possible (and was in legacy).

This resolves the problem by making sure the matcher map key is not urlencoded 
(`"Äpfel"` != `"%C3%84pfel"` )

TODO:
- [x] Tests and possible fix for UrlAlias generator