### PR TITLE
[Behat] Add BasicContent, ContentType, Field, Role and User Contexts

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/BasicContentContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/BasicContentContext.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;
+
+use Behat\Behat\Context\Context;
+use EzSystems\PlatformBehatBundle\Context\RepositoryContext;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Repository;
+
+/**
+ * Sentences for simple Contents creation.
+ */
+class BasicContentContext implements Context
+{
+    use RepositoryContext;
+
+    /**
+     * Default language.
+     */
+    const DEFAULT_LANGUAGE = 'eng-GB';
+
+    /**
+     * Content path mapping.
+     */
+    private $contentPaths = array();
+
+    /**
+     * @var eZ\Publish\B\Repository\ContentTypeService
+     */
+    private $contentTypeService;
+
+    /**
+     * @var eZ\Publish\B\Repository\ContentService
+     */
+    private $contentService;
+
+    /**
+     * @injectService $repository @ezpublish.api.repository
+     * @injectService $contentTypeService @ezpublish.api.service.content_type
+     * @injectService $contentService @ezpublish.api.service.content
+     */
+    public function __construct(
+        Repository $repository,
+        ContentTypeService $contentTypeService,
+        ContentService $contentService
+    ) {
+        $this->setRepository($repository);
+        $this->contentTypeService = $contentTypeService;
+        $this->contentService = $contentService;
+    }
+
+    /**
+     * Creates and publishes a Content.
+     *
+     * @param string $contentType
+     * @param array $fields
+     * @param mixed $parentLocationId
+     *
+     * @return mixed The content's main location id
+     */
+    public function createContent($contentType, $fields, $parentLocationId)
+    {
+        $repository = $this->getRepository();
+        $languageCode = self::DEFAULT_LANGUAGE;
+        $content = $this->createContentDraft($parentLocationId, $contentType, $fields, $languageCode);
+        $content = $this->contentService->publishVersion($content->versionInfo);
+
+        return $content->contentInfo->mainLocationId;
+    }
+
+    /**
+     * Publishes a content draft.
+     *
+     * @param Content $content
+     */
+    public function publishDraft(Content $content)
+    {
+        $this->contentService->publishVersion($content->versionInfo->id);
+    }
+
+    /**
+     * Creates a content draft.
+     *
+     * @param Location $parentLocationId
+     * @param string $contentTypeIdentifier
+     * @param string $languageCode
+     * @param array $fields Fields, as primitives understood by setField
+     *
+     *@return Content an unpublished Content draft
+     */
+    public function createContentDraft($parentLocationId, $contentTypeIdentifier, $fields, $languageCode = null)
+    {
+        $languageCode = $languageCode ?: self::DEFAULT_LANGUAGE;
+        $repository = $this->getRepository();
+        $locationCreateStruct = $repository->getLocationService()->newLocationCreateStruct($parentLocationId);
+        $contentTypeIdentifier = $this->contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
+        $contentCreateStruct = $this->contentService->newContentCreateStruct($contentTypeIdentifier, $languageCode);
+        foreach (array_keys($fields) as $key) {
+            $contentCreateStruct->setField($key, $fields[$key]);
+        }
+
+        return $this->contentService->createContent($contentCreateStruct, array($locationCreateStruct));
+    }
+
+    /**
+     * Creates and publishes a content at a given path.
+     * Non-existing path items are created as folders named after the path element.
+     *
+     * @param string $path The content path
+     * @param array $fields
+     * @param mixed $contentType The content type identifier
+     *
+     * @return mixed|string
+     */
+    public function createContentWithPath($path, $fields, $contentType)
+    {
+        $contentsName = explode('/', $path);
+        $currentPath = '';
+        $location = '2';
+        foreach ($contentsName as $name) {
+            if ($name != end($contentsName)) {
+                $location = $this->createContent('folder', ['name' => $name], $location);
+            }
+            if ($currentPath != '') {
+                $currentPath .= '/';
+            }
+            $currentPath .= $name;
+            $this->mapContentPath($currentPath);
+        }
+        $location = $this->createContent($contentType, $fields, $location);
+
+        return $location;
+    }
+
+    /**
+     * Getter for contentPaths.
+     */
+    public function getContentPath($name)
+    {
+        return $this->contentPaths[$name];
+    }
+
+    /**
+     * Maps the path of the content to it's name for later use.
+     */
+    private function mapContentPath($path)
+    {
+        $contentNames = explode('/', $path);
+        $this->contentPaths[end($contentNames)] = $path;
+    }
+
+    /**
+     * @Given a/an :path folder exists
+     */
+    public function createBasicFolder($path)
+    {
+        $fields = array('name' => $this->getTitleFromPath($path));
+
+        return $this->createContentwithPath($path, $fields, 'folder');
+    }
+
+    /**
+     * @Given a/an :path article exists
+     */
+    public function createBasicArticle($path)
+    {
+        $fields = array(
+            'title' => $this->getTitleFromPath($path),
+            'intro' => $this->getDummyXmlText(),
+        );
+
+        return $this->createContentwithPath($path, $fields, 'article');
+    }
+
+    /**
+     * @Given a/an :path article draft exists
+     */
+    public function createArticleDraft($path)
+    {
+        $fields = array(
+            'title' => $this->getTitleFromPath($path),
+            'intro' => $this->getDummyXmlText(),
+        );
+
+        return $this->createContentDraft(2, 'article', $fields);
+    }
+
+    private function getTitleFromPath($path)
+    {
+        $parts = explode('/', rtrim($path, '/'));
+
+        return end($parts);
+    }
+
+    /**
+     * @return string
+     */
+    private function getDummyXmlText()
+    {
+        return '<?xml version="1.0" encoding="UTF-8"?><section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0"><para>This is a paragraph.</para></section>';
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/BasicContentContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/BasicContentContext.php
@@ -30,12 +30,12 @@ class BasicContentContext implements Context
     private $contentPaths = array();
 
     /**
-     * @var eZ\Publish\B\Repository\ContentTypeService
+     * @var eZ\Publish\API\Repository\ContentTypeService
      */
     private $contentTypeService;
 
     /**
-     * @var eZ\Publish\B\Repository\ContentService
+     * @var eZ\Publish\API\Repository\ContentService
      */
     private $contentService;
 
@@ -76,7 +76,7 @@ class BasicContentContext implements Context
     /**
      * Publishes a content draft.
      *
-     * @param Content $content
+     * @param eZ\Publish\API\Repository\Values\Content\Content $content
      */
     public function publishDraft(Content $content)
     {
@@ -86,12 +86,12 @@ class BasicContentContext implements Context
     /**
      * Creates a content draft.
      *
-     * @param Location $parentLocationId
+     * @param eZ\Publish\API\Repository\Values\Content\Location $parentLocationId
      * @param string $contentTypeIdentifier
      * @param string $languageCode
      * @param array $fields Fields, as primitives understood by setField
      *
-     *@return Content an unpublished Content draft
+     * @return eZ\Publish\API\Repository\Values\Content\Content an unpublished Content draft
      */
     public function createContentDraft($parentLocationId, $contentTypeIdentifier, $fields, $languageCode = null)
     {
@@ -115,7 +115,7 @@ class BasicContentContext implements Context
      * @param array $fields
      * @param mixed $contentType The content type identifier
      *
-     * @return mixed|string
+     * @return mixed location id of the created content
      */
     public function createContentWithPath($path, $fields, $contentType)
     {

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/ContentTypeContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/ContentTypeContext.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;
+
+use Behat\Behat\Context\Context;
+use EzSystems\PlatformBehatBundle\Context\RepositoryContext;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Exceptions as ApiExceptions;
+use eZ\Publish\API\Repository\Repository;
+use Behat\Gherkin\Node\TableNode;
+use PHPUnit_Framework_Assert as Assertion;
+
+/**
+ * Sentences for Content Types.
+ */
+class ContentTypeContext implements Context
+{
+    use RepositoryContext;
+
+    /**
+     * Default ContentTypeGroup.
+     */
+    const DEFAULT_GROUP = 'Content';
+
+    /**
+     * Default language code.
+     */
+    const DEFAULT_LANGUAGE = 'eng-GB';
+
+    /**
+     * @var \eZ\Publish\API\Repository\ContentTypeService
+     */
+    protected $contentTypeService;
+
+    /**
+     * @var \EzSystems\BehatBundle\Context\Object\ContentTypeGroup
+     */
+    protected $contentTypeGroupContext;
+
+    /**
+     * @injectService $repository @ezpublish.api.repository
+     * @injectService $contentTypeService @ezpublish.api.service.content_type
+     */
+    public function __construct(Repository $repository, ContentTypeService $contentTypeService)
+    {
+        $this->setRepository($repository);
+        $this->contentTypeService = $contentTypeService;
+    }
+
+    /**
+     * @Given (that) a Content Type exists with identifier :identifier with fields:
+     * @Given (that) a Content Type exists with identifier :identifier in Group with identifier :groupIdentifier with fields:
+     *     |   Identifier   |     Type       |     Name      |
+     *     |  title         |  ezstring      |  Title        |
+     *     |  body          |  ezxml         |  Body         |
+     *
+     * Makes sure a content type with $identifier and with the provided $fields definition.
+     */
+    public function ensureContentTypeWithIndentifier(
+        $identifier,
+        TableNode $fields,
+        $groupIdentifier = self::DEFAULT_GROUP
+    ) {
+        $identifier = strtolower($identifier);
+        $contentType = $this->loadContentTypeByIdentifier($identifier, false);
+
+        if (!$contentType) {
+            $contentType = $this->createContentType($groupIdentifier, $identifier, $fields);
+        }
+
+        return $contentType;
+    }
+
+    /**
+     * @Given (that) a Content Type does not exist with identifier :identifier
+     *
+     * Makes sure a content type with $identifier does not exist.
+     * If it exists deletes it.
+     */
+    public function ensureContentTypeDoesntExist($identifier)
+    {
+        $contentType = $this->loadContentTypeByIdentifier($identifier, false);
+        if ($contentType) {
+            $this->removeContentType($contentType);
+        }
+    }
+
+    /**
+     * @Then Content Type (with identifier) :identifier exists
+     *
+     * Verifies that a content type with $identifier exists.
+     */
+    public function assertContentTypeExistsByIdentifier($identifier)
+    {
+        Assertion::assertTrue(
+            $this->checkContentTypeExistenceByIdentifier($identifier),
+            "Couldn't find a Content Type with identifier '$identifier'."
+        );
+    }
+
+    /**
+     * @Then Content Type (with identifier) :identifier does not exist
+     *
+     * Verifies that a content type with $identifier does not exist.
+     */
+    public function assertContentTypeDoesntExistsByIdentifier($identifier)
+    {
+        Assertion::assertFalse(
+            $this->checkContentTypeExistenceByIdentifier($identifier),
+            "Found a Content Type with identifier '$identifier'."
+        );
+    }
+
+    /**
+     * @Then Content Type (with identifier) :identifier exists in Group with identifier :groupIdentifier
+     *
+     * Verifies that a content type with $identifier exists in group with identifier $groupIdentifier.
+     */
+    public function assertContentTypeExistsByIdentifierOnGroup($identifier, $groupIdentifier)
+    {
+        Assertion::assertTrue(
+            $this->checkContentTypeExistenceByIdentifier($identifier, $groupIdentifier),
+            "Couldn't find Content Type with identifier '$identifier' on '$groupIdentifier."
+        );
+    }
+
+    /**
+     * Load and return a content type by its identifier.
+     *
+     * @param  string  $identifier       content type identifier
+     * @param  bool $throwIfNotFound  if true, throws an exception if it is not found.
+     *
+     * @return \eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup|null
+     */
+    protected function loadContentTypeByIdentifier($identifier, $throwIfNotFound = true)
+    {
+        $contentType = null;
+        try {
+            $contentType = $this->contentTypeService->loadContentTypeByIdentifier($identifier);
+        } catch (ApiExceptions\NotFoundException $e) {
+            $notFoundException = $e;
+        }
+
+        if (!$contentType && $throwIfNotFound) {
+            throw $notFoundException;
+        }
+
+        return $contentType;
+    }
+
+    /**
+     * Creates a content type with $identifier on content type group with identifier $groupIdentifier and with the
+     * given 'fields' definitions.
+     *
+     * @param  string $groupIdentifier content type group identifier
+     * @param  string $identifier      content type identifier
+     * @param  array $fields           content type fields definitions
+     *
+     * @return eZ\Publish\API\Repository\Values\ContentType\ContentType
+     */
+    public function createContentType($groupIdentifier, $identifier, $fields)
+    {
+        $contentTypeService = $this->contentTypeService;
+        $contentTypeGroup = $contentTypeService->loadContentTypeGroupByIdentifier($groupIdentifier);
+        // convert 'some_type' to 'Some Type';
+        $contentTypeName = ucwords(str_replace('_', ' ', $identifier));
+
+        $contentTypeCreateStruct = $contentTypeService->newContentTypeCreateStruct($identifier);
+        $contentTypeCreateStruct->mainLanguageCode = self::DEFAULT_LANGUAGE;
+        $contentTypeCreateStruct->names = array(self::DEFAULT_LANGUAGE => $contentTypeName);
+
+        $fieldPosition = 0;
+        foreach ($fields as $field) {
+            $field = array_change_key_case($field, CASE_LOWER);
+            $fieldPosition += 10;
+
+            $fieldCreateStruct = $contentTypeService
+                ->newFieldDefinitionCreateStruct($field['identifier'], $field['type']);
+            $fieldCreateStruct->names = array(self::DEFAULT_LANGUAGE => $field['name']);
+            $fieldCreateStruct->position = $fieldPosition;
+            if (isset($field['required'])) {
+                $fieldCreateStruct->isRequired = ($field['required'] === 'true');
+            }
+            if (isset($field['validator']) && $field['validator'] !== 'false') {
+                $fieldCreateStruct->validatorConfiguration = $this->processValidator($field['validator']);
+            }
+            if (isset($field['settings']) && $field['settings'] !== 'false') {
+                $fieldCreateStruct->fieldSettings = $this->processSettings($field['settings']);
+            }
+            $contentTypeCreateStruct->addFieldDefinition($fieldCreateStruct);
+        }
+
+        $contentTypeDraft = $contentTypeService->createContentType(
+            $contentTypeCreateStruct,
+            array($contentTypeGroup)
+        );
+        $contentTypeService->publishContentTypeDraft($contentTypeDraft);
+
+        $contentType = $contentTypeService->loadContentTypeByIdentifier($identifier);
+
+        return $contentType;
+    }
+
+    /**
+     * Remove the given 'ContentType' object.
+     *
+     * @param  eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
+     */
+    protected function removeContentType($contentType)
+    {
+        try {
+            $this->contentTypeService->deleteContentType($contentType);
+        } catch (ApiExceptions\NotFoundException $e) {
+            // nothing to do
+        }
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
+     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup $contentTypeGroup
+     */
+    protected function assignContentGroupTypeToContentType($contentType, $contentTypeGroup)
+    {
+        try {
+            $this->contentTypeService->assignContentTypeGroup($contentType, $contentTypeGroup);
+        } catch (ApiExceptions\InvalidArgumentException $exception) {
+            //do nothing
+        }
+    }
+
+    /**
+     * Verifies that a content type with $identifier exists.
+     *
+     * @param string $identifier
+     * @return bool
+     */
+    protected function checkContentTypeExistenceByIdentifier($identifier, $groupIdentifier = null)
+    {
+        $contentType = $this->loadContentTypeByIdentifier($identifier, false);
+        if ($contentType && $groupIdentifier) {
+            $contentTypeGroups = $contentType->getContentTypeGroups();
+            foreach ($contentTypeGroups as $contentTypeGroup) {
+                if ($contentTypeGroup->identifier == $groupIdentifier) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return $contentType ? true : false;
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/FieldTypeContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/FieldTypeContext.php
@@ -212,7 +212,7 @@ class FieldTypeContext implements Context
                 $this->publishContentType();
                 break;
             case self::CONTENT_PUBLISHED:
-                $this->publishContent($field, $value);
+                $this->createAndPublishContent($field, $value);
                 break;
         }
     }
@@ -223,12 +223,13 @@ class FieldTypeContext implements Context
     }
 
     /**
-     * Publishes the content.
+     * Creates and publishes the content with a given field and
+     * based on the internal ContentType.
      *
      * @param string The field name
      * @param mixed The field value
      */
-    private function publishContent($field, $value)
+    private function createAndPublishContent($field, $value)
     {
         $languageCode = self::DEFAULT_LANGUAGE;
 

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/FieldTypeContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/FieldTypeContext.php
@@ -1,0 +1,407 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;
+
+use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\TableNode;
+use EzSystems\PlatformBehatBundle\Context\RepositoryContext;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Repository;
+
+/**
+ * Sentences for Fields.
+ */
+class FieldTypeContext implements Context
+{
+    use RepositoryContext;
+
+    /**
+     * Defines the state of the Construction object, if it's not published, partialy or completely published.
+     */
+    const FIELD_TYPE_NOT_CREATED = -1;
+    const FIELD_TYPE_CREATED = 0;
+    const CONTENT_TYPE_CREATED = 1;
+    const FIELD_TYPE_ASSOCIATED = 2;
+    const CONTENT_TYPE_PUBLISHED = 3;
+    const CONTENT_PUBLISHED = 4;
+
+    /**
+     * Default language.
+     */
+    const DEFAULT_LANGUAGE = 'eng-GB';
+
+    /**
+     * @var array Stores the values needed to build the contentType with the desired fieldTypes,
+     * used to postpone until object is ready for publishing.
+     */
+    private $fieldConstructionObject = array(
+        'contentType' => null,
+        'fieldType' => null,
+        'content' => null,
+        'objectState' => self::FIELD_TYPE_NOT_CREATED,
+    );
+
+    /**
+     * @var array Stores Internal mapping of the fieldType names
+     */
+    private $fieldTypeInternalIdentifier = array(
+        'integer' => 'ezinteger',
+    );
+
+    /**
+     * @var array Maps the validator of the fieldtypes
+     */
+    private $validatorMappings = array(
+        'integer' => 'IntegerValue',
+    );
+
+    /**
+     * @var array Maps the default values of the fieldtypes
+     */
+    private $defaultValues = array(
+        'integer' => 1,
+    );
+
+    /**
+     * @var eZ\Publish\B\Repository\ContentTypeService
+     */
+    private $contentTypeService;
+
+    /**
+     * @var eZ\Publish\B\Repository\ContentService
+     */
+    private $contentService;
+
+    /**
+     * @var eZ\Publish\B\Repository\LocationService
+     */
+    private $locationService;
+
+    /**
+     * @injectService $repository @ezpublish.api.repository
+     * @injectService $contentTypeService @ezpublish.api.service.content_type
+     * @injectService $contentService @ezpublish.api.service.content
+     * @injectService $locationService @ezpublish.api.service.location
+     */
+    public function __construct(
+        Repository $repository,
+        ContentTypeService $contentTypeService,
+        ContentService $contentService,
+        LocationService $locationService
+    ) {
+        $this->setRepository($repository);
+        $this->contentTypeService = $contentTypeService;
+        $this->contentService = $contentService;
+        $this->locationService = $locationService;
+    }
+
+    /**
+     * Getter method for fieldtype internal identifier.
+     *
+     * @param string $identifier Identifier of the field
+     * @return string internal Identifier of the field
+     */
+    public function getFieldTypeInternalIdentifier($identifier)
+    {
+        return $this->fieldTypeInternalIdentifier[$identifier];
+    }
+
+    /**
+     * Getter method for the validator mappings.
+     *
+     * @param string $field Field name
+     * @return string field Validator name
+     */
+    public function getFieldValidator($field)
+    {
+        return $this->validatorMappings[$field];
+    }
+
+    /**
+     * Creates a fieldtype ans stores it for later use.
+     *
+     * @param string $fieldType Type of the field
+     * @param string $name Name of the field, optional, if not specified $fieldType is used
+     * @param bool $required True if the is the field required, optional
+     */
+    public function createField($fieldType, $name = null, $required = false)
+    {
+        $fieldPosition = $this->getActualFieldPosition();
+        $name = ($name == null ? $fieldType : $name);
+        $fieldCreateStruct = $this->contentTypeService->newFieldDefinitionCreateStruct(
+            $name,
+            $this->fieldTypeInternalIdentifier[$fieldType]
+        );
+        $fieldCreateStruct->names = array(self::DEFAULT_LANGUAGE => $name);
+        $fieldCreateStruct->position = $fieldPosition;
+        $fieldCreateStruct->isRequired = $required;
+        $fieldCreateStruct->defaultValue = $this->defaultValues[$fieldType];
+        $this->fieldConstructionObject['fieldType'] = $fieldCreateStruct;
+        $this->fieldConstructionObject['objectState'] = self::FIELD_TYPE_CREATED;
+    }
+
+    /**
+     * Adds a validator to the stored field.
+     *
+     * @param string $fieldType Type of the field
+     * @param string $value Value of the constraint
+     * @param string $constraint Constraint name
+     */
+    public function addValueConstraint($fieldType, $value, $constraint)
+    {
+        $validatorName = $this->getFieldValidator($fieldType);
+        $validatorParent = $validatorName . 'Validator';
+        if ($this->fieldConstructionObject['fieldType']->validatorConfiguration == null) {
+            $this->fieldConstructionObject['fieldType']->validatorConfiguration = array(
+                $validatorParent => array(),
+            );
+        }
+        $value = is_numeric($value) ? $value + 0 : $value;
+
+        $this->fieldConstructionObject['fieldType']
+            ->validatorConfiguration[$validatorParent][$constraint . $validatorName] = $value;
+    }
+
+    /**
+     * Creates a content and publishes it.
+     *
+     * @param string $field Name of the field
+     * @param mixed $value Value of the field
+     */
+    public function createContent($field, $value)
+    {
+        $this->setFieldContentState(self::CONTENT_PUBLISHED, $field, $value);
+    }
+
+    /**
+     * Executes necessary operations to guarantee a given state, recursive
+     * function that calls it self to make sure prerequisites are met.
+     *
+     * @param int $stateFlag Desired state, only predefined constants accepted
+     * @param string $field Name of the field, optional
+     * @param mixed $value Value of the field, optional
+     */
+    public function setFieldContentState($stateFlag, $field = null, $value = null)
+    {
+        if ($stateFlag <= $this->fieldConstructionObject['objectState']
+            || $stateFlag < self::FIELD_TYPE_NOT_CREATED
+        ) {
+            return;
+        }
+
+        // recursively set previous states if necessary
+        $this->setFieldContentState($stateFlag - 1, $field, $value);
+
+        switch ($stateFlag) {
+            case self::FIELD_TYPE_NOT_CREATED:
+                throw new \Exception('A field type must be declared before anything else');
+                break;
+            case self::CONTENT_TYPE_CREATED:
+                $this->createContentType();
+                break;
+            case self::FIELD_TYPE_ASSOCIATED:
+                $this->associateFieldToContentType();
+                break;
+            case self::CONTENT_TYPE_PUBLISHED:
+                $this->publishContentType();
+                break;
+            case self::CONTENT_PUBLISHED:
+                $this->publishContent($field, $value);
+                break;
+        }
+    }
+
+    public function getFieldContentState()
+    {
+        return $this->fieldConstructionObject['objectState'];
+    }
+
+    /**
+     * Publishes the content.
+     *
+     * @param string The field name
+     * @param mixed The field value
+     */
+    private function publishContent($field, $value)
+    {
+        $languageCode = self::DEFAULT_LANGUAGE;
+
+        $locationCreateStruct = $this->locationService->newLocationCreateStruct('2');
+        $contentType = $this->fieldConstructionObject['contentType'];
+        $contentCreateStruct = $this->contentService->newContentCreateStruct($contentType, $languageCode);
+        if ($field != null && $value != null) {
+            $value = ($value == 'empty') ? null : $value;
+            $value = is_numeric($value) ? $value + 0 : $value;
+            $contentCreateStruct->setField($field, $value);
+        }
+        $draft = $this->contentService->createContent($contentCreateStruct, array($locationCreateStruct));
+        $content = $this->contentService->publishVersion($draft->versionInfo);
+
+        $this->fieldConstructionObject['content'] = $content;
+        $this->fieldConstructionObject['objectState'] = self::CONTENT_PUBLISHED;
+    }
+
+    /**
+     * Associates the stored fieldtype to the stored contenttype.
+     */
+    private function associateFieldToContentType()
+    {
+        $fieldCreateStruct = $this->fieldConstructionObject['fieldType'];
+        $this->fieldConstructionObject['contentType']->addFieldDefinition($fieldCreateStruct);
+        $this->fieldConstructionObject['objectState'] = self::FIELD_TYPE_ASSOCIATED;
+    }
+
+    /**
+     * Publishes the stored contenttype.
+     */
+    private function publishContentType()
+    {
+        $contentTypeGroup = $this->contentTypeService->loadContentTypeGroupByIdentifier('Content');
+        $contentTypeCreateStruct = $this->fieldConstructionObject['contentType'];
+        $contentTypeDraft = $this->contentTypeService->createContentType(
+            $contentTypeCreateStruct,
+            array($contentTypeGroup)
+        );
+        $this->contentTypeService->publishContentTypeDraft($contentTypeDraft);
+        $contentTypeIdentifier = $this->fieldConstructionObject['contentType']->identifier;
+        $contentType = $this->contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
+        $this->fieldConstructionObject['contentType'] = $contentType;
+        $this->fieldConstructionObject['objectState'] = self::CONTENT_TYPE_PUBLISHED;
+    }
+
+    /**
+     * Getter method for the name of the stored contenttype.
+     *
+     * @param string $language Language of the name
+     * @return string Name of the contenttype
+     */
+    public function getThisContentTypeName($language = self::DEFAULT_LANGUAGE)
+    {
+        return $this->fieldConstructionObject['contentType']->names[$language];
+    }
+
+    /**
+     * Getter method for the name of the stored content.
+     *
+     * @param string $language Language of the name
+     * @return string Name of the contenttype
+     */
+    public function getThisContentName($language = self::DEFAULT_LANGUAGE)
+    {
+        return $this->fieldConstructionObject['content']->versionInfo->names[$language];
+    }
+
+    /**
+     * Getter method for the name of the stored fieldtype.
+     *
+     * @param string $language Language of the name
+     * @return string Name of the fieldtype
+     */
+    public function getThisFieldTypeName($language = self::DEFAULT_LANGUAGE)
+    {
+        return $this->fieldConstructionObject['fieldType']->names[$language];
+    }
+
+    /**
+     * Getter method for the identifier of the stored fieldtype.
+     *
+     * @return string idenfier of the fieldtype
+     */
+    public function getThisFieldTypeIdentifier()
+    {
+        return $this->fieldConstructionObject['fieldType']->identifier;
+    }
+
+    /**
+     * Get the content id for the published content.
+     *
+     * @return int
+     */
+    public function getThisContentId()
+    {
+        return $this->fieldConstructionObject['content']->id;
+    }
+
+    /**
+     * Creates an instance of a contenttype and stores it for later publishing.
+     */
+    private function createContentType()
+    {
+        $name = $this->fieldConstructionObject['fieldType']->identifier;
+        $name = $name . '#' . uniqid();
+        $identifier = strtolower($name);
+        $contentTypeCreateStruct = $this->contentTypeService->newContentTypeCreateStruct($identifier);
+        $contentTypeCreateStruct->mainLanguageCode = self::DEFAULT_LANGUAGE;
+        $contentTypeCreateStruct->names = array(self::DEFAULT_LANGUAGE => $name);
+        $contentTypeCreateStruct->nameSchema = $name;
+        $this->fieldConstructionObject['contentType'] = $contentTypeCreateStruct;
+        $this->fieldConstructionObject['objectState'] = self::CONTENT_TYPE_CREATED;
+    }
+
+    /**
+     * Getter method for the position of the field, relative to other possible fields.
+     */
+    private function getActualFieldPosition()
+    {
+        if ($this->fieldConstructionObject['fieldType'] == null) {
+            return 10;
+        } else {
+            return $this->fieldConstructionObject['fieldType']->position + 10;
+        }
+    }
+
+    /**
+     * @Given a Content Type with an :fieldType field exists
+     * @Given a Content Type with an :fieldType with field definition name :name exists
+     *
+     * Creates a ContentType with only the desired FieldType.
+     */
+    public function createContentTypeWithFieldType($fieldType, $name = null)
+    {
+        return $this->createField($fieldType, $name);
+    }
+
+    /**
+     * @Given a Content Type with a required :fieldType field exists
+     * @Given a Content Type with a required :fieldType with field definition name :name exists
+     *
+     * Creates a ContentType with only the desired FieldType.
+     */
+    public function createContentTypeWithRequiredFieldType($fieldType, $name = null)
+    {
+        return $this->createField($fieldType, $name, true);
+    }
+
+    /**
+     * @Given a Content of this type exists
+     * @Given a Content of this type exists with :field Field Value set to :value
+     *
+     * Creates a Content with the previously defined ContentType.
+     */
+    public function createContentOfThisType($field = null, $value = null)
+    {
+        return $this->createContent($field, $value);
+    }
+
+    /**
+     * @Given a Content Type with an :fieldType field exists with Properties:
+     * @Given a Content Type with an :fieldType field with name :name exists with Properties:
+     */
+    public function createContentOfThisTypeWithProperties($fieldType, TableNode $properties, $name = null)
+    {
+        $this->createField($fieldType, $name);
+        foreach ($properties as $property) {
+            if ($property['Validator'] == 'maximum value validator') {
+                $this->addValueConstraint($fieldType, $property['Value'], 'max');
+            } elseif ($property['Validator'] == 'minimum value validator') {
+                $this->addValueConstraint($fieldType, $property['Value'], 'min');
+            }
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/RoleContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/RoleContext.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;
+
+use Behat\Behat\Context\Context;
+use PHPUnit_Framework_Assert as Assertion;
+use EzSystems\PlatformBehatBundle\Context\RepositoryContext;
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\RoleService;
+use eZ\Publish\API\Repository\Exceptions as ApiExceptions;
+
+/**
+ * Sentences for Roles.
+ */
+class RoleContext implements Context
+{
+    use RepositoryContext;
+
+    /**
+     * @var \eZ\Publish\API\Repository\roleService
+     */
+    protected $roleService;
+
+    /**
+     * @injectService $repository @ezpublish.api.repository
+     * @injectService $roleService @ezpublish.api.service.role
+     */
+    public function __construct(Repository $repository, RoleService $roleService)
+    {
+        $this->setRepository($repository);
+        $this->roleService = $roleService;
+    }
+
+    /**
+     * Make sure a Role with name $name exists in parent group.
+     *
+     * @param string $name Role identifier
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\Role
+     */
+    public function ensureRoleExists($name)
+    {
+        try {
+            $role = $this->roleService->loadRoleByIdentifier($name);
+        } catch (ApiExceptions\NotFoundException $e) {
+            $roleCreateStruct = $this->roleService->newRoleCreateStruct($name);
+            $roleDraft = $this->roleService->createRole($roleCreateStruct);
+            $this->roleService->publishRoleDraft($roleDraft);
+            $role = $this->roleService->loadRole($roleDraft->id);
+        }
+
+        return $role;
+    }
+
+    /**
+     * Fetches the role with identifier.
+     *
+     * @param string $identifier Role identifier
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\Role
+     */
+    public function getRole($identifier)
+    {
+        $role = null;
+        try {
+            $role = $this->roleService->loadRoleByIdentifier($identifier);
+        } catch (ApiExceptions\NotFoundException $e) {
+            // Role not found, do nothing, returns null
+        }
+
+        return $role;
+    }
+
+    /**
+     * @Given a/an :name role exists
+     *
+     * Ensures a role exists with name ':name', creating a new one if necessary.
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\Role
+     */
+    public function iHaveRole($name)
+    {
+        return $this->ensureRoleExists($name);
+    }
+
+    /**
+     * @Then I see that a/an :name role exists
+     *
+     * Verifies that a role with $name exists.
+     */
+    public function iSeeRole($name)
+    {
+        $role = $this->getRole($name);
+        Assertion::assertNotNull(
+            $role,
+            "Couldn't find Role with name $name"
+        );
+    }
+
+    /**
+     * @Given :name do not have any assigned policies
+     */
+    public function noAssginedPolicies($name)
+    {
+        $role = $this->getRole($name);
+        Assertion::assertNotNull(
+            $role,
+            "Couldn't find Role with name $name"
+        );
+        $policies = $role->getPolicies();
+        Assertion::assertEmpty($policies, "Role $name has policies associated");
+    }
+
+    /**
+     * @Given :name do not have any assigned Users and groups
+     */
+    public function noAssigneGroups($name)
+    {
+        $role = $this->getRole($name);
+        Assertion::assertNotNull(
+            $role,
+            "Couldn't find Role with name $name"
+        );
+        $roleAssigments = $this->roleService->getRoleAssignments($role);
+        Assertion::assertEmpty($roleAssigments, "Role $name has Users or groups associated");
+    }
+
+    /**
+     * @Then I see that a/an :name role does not exists
+     *
+     * Verifies that a role with $name exists.
+     */
+    public function iDontSeeRole($name)
+    {
+        $role = $this->getRole($name);
+        Assertion::assertNull(
+            $role,
+            "Found Role with name $name"
+        );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/UserContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/UserContext.php
@@ -1,0 +1,592 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;
+
+use Behat\Gherkin\Node\TableNode;
+use Behat\Behat\Context\Context;
+use PHPUnit_Framework_Assert as Assertion;
+use EzSystems\PlatformBehatBundle\Context\RepositoryContext;
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\API\Repository\Exceptions as ApiExceptions;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+
+/**
+ * Sentences for Users.
+ */
+class UserContext implements Context
+{
+    use RepositoryContext;
+
+    const DEFAULT_LANGUAGE = 'eng-GB';
+
+    /**
+     * These values are set by the default eZ Publish installation.
+     */
+    const USER_IDENTIFIER = 'user';
+
+    const USERGROUP_ROOT_CONTENT_ID = 4;
+    const USERGROUP_ROOT_LOCATION = 5;
+    const USERGROUP_ROOT_SUBTREE = '/1/5/';
+    const USERGROUP_CONTENT_IDENTIFIER = 'user_group';
+
+    /**
+     * @var \eZ\Publish\API\Repository\UserService
+     */
+    protected $userService;
+
+    /**
+     * @var \eZ\Publish\API\Repository\SearchService
+     */
+    protected $searchService;
+
+    /**
+     * @injectService $repository @ezpublish.api.repository
+     * @injectService $userService @ezpublish.api.service.user
+     * @injectService $searchService @ezpublish.api.service.search
+     */
+    public function __construct(Repository $repository, UserService $userService, SearchService $searchService)
+    {
+        $this->setRepository($repository);
+        $this->userService = $userService;
+        $this->searchService = $searchService;
+    }
+
+    /**
+     * Search User with given username, optionally at given location.
+     *
+     * @param string $username name of User to search for
+     * @param string $parentGroupLocationId where to search, in User Group tree
+     *
+     * @return User found
+     */
+    public function searchUserByLogin($username, $parentGroupId = null)
+    {
+        try {
+            $user = $this->userService->loadUserByLogin($username);
+        } catch (ApiExceptions\NotFoundException $e) {
+            return null;
+        }
+
+        if ($user && $parentGroupId) {
+            $userGroups = $this->userService->loadUserGroupsOfUser($user);
+
+            foreach ($userGroups as $userGroup) {
+                if ($userGroup->getVersionInfo()->getContentInfo()->id == $parentGroupId) {
+                    return $user;
+                }
+            }
+            // user not found in $parentGroupId
+            return null;
+        }
+
+        return $user;
+    }
+
+    /**
+     * Search User Groups with given name.
+     *
+     * @param string $name name of User Group to search for
+     * @param string $parentLocationId (optional) parent location id to search in
+     *
+     * @return search results
+     */
+    public function searchUserGroups($name, $parentLocationId = null)
+    {
+        $criterionArray = array(
+            new Criterion\Subtree(self::USERGROUP_ROOT_SUBTREE),
+            new Criterion\ContentTypeIdentifier(self::USERGROUP_CONTENT_IDENTIFIER),
+            new Criterion\Field('name', Criterion\Operator::EQ, $name),
+        );
+        if ($parentLocationId) {
+            $criterionArray[] = new Criterion\ParentLocationId($parentLocationId);
+        }
+        $query = new Query();
+        $query->filter = new Criterion\LogicalAnd($criterionArray);
+
+        $result = $this->searchService->findContent($query, array(), false);
+
+        return $result->searchHits;
+    }
+
+    /**
+     * Create user inside given User Group; DELETES existing User if login already exists!
+     *
+     * @param $username username of the user to create
+     * @param $email email address of user to create
+     * @param $password account password for user to create
+     * @param $parentGroup pathstring wherein to create user
+     *
+     * @return user created
+     */
+    protected function createUser($username, $email, $password, $parentGroup = null, $fields = array())
+    {
+        $userCreateStruct = $this->userService->newUserCreateStruct(
+            $username,
+            $email,
+            $password,
+            self::DEFAULT_LANGUAGE
+        );
+        $userCreateStruct->setField('first_name', $username);
+        $userCreateStruct->setField('last_name', $username);
+
+        foreach ($fields as $fieldName => $fieldValue) {
+            $userCreateStruct->setField($fieldName, $fieldValue);
+        }
+
+        try {
+            $existingUser = $this->userService->loadUserByLogin($username);
+            $this->userService->deleteUser($existingUser);
+        } catch (NotFoundException $e) {
+            // do nothing
+        }
+
+        if (!$parentGroup) {
+            $parentGroup = $this->userService->loadUserGroup(self::USERGROUP_ROOT_CONTENT_ID);
+        }
+
+        $user = $this->userService->createUser($userCreateStruct, array($parentGroup));
+
+        return $user;
+    }
+
+    /**
+     * Create new User Group inside existing parent User Group.
+     *
+     * @param string $name  User Group name
+     * @param \eZ\Publish\API\Repository\Values\User\UserGroup $parentGroup  (optional) parent user group, defaults to UserGroup "/Users"
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\UserGroup
+     */
+    public function createUserGroup($name, $parentGroup = null)
+    {
+        if (!$parentGroup) {
+            $parentGroup = $this->userService->loadUserGroup(self::USERGROUP_ROOT_CONTENT_ID);
+        }
+
+        $userGroupCreateStruct = $this->userService->newUserGroupCreateStruct('eng-GB');
+        $userGroupCreateStruct->setField('name', $name);
+
+        return $this->userService->createUserGroup($userGroupCreateStruct, $parentGroup);
+    }
+
+    /**
+     * Make sure a User with name $username, $email and $password exists in parent group.
+     *
+     * @param string $username User name
+     * @param string $email User's email
+     * @param string $password User's password
+     * @param string $parentGroupName (optional) name of the parent group to check
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\User
+     */
+    public function ensureUserExists($username, $email, $password, $parentGroupName = null)
+    {
+        if ($parentGroupName) {
+            $parentSearchHits = $this->searchUserGroups($parentGroupName);
+
+            // Found matching Group(s)
+            if (!empty($parentSearchHits)) {
+                $firstGroupId = $parentSearchHits[0]->valueObject->contentInfo->id;
+                foreach ($parentSearchHits as $userGroupHit) {
+                    $groupId = $userGroupHit->valueObject->contentInfo->id;
+                    // Search for user in this group
+                    $user = $this->searchUserByLogin($username, $groupId);
+                    if ($user) {
+                        return $user;
+                    }
+                }
+
+                // create user inside existing parent Group, use first group found
+                $parentGroup = $this->userService->loadUserGroup($firstGroupId);
+
+                return $this->createUser($username, $email, $password, $parentGroup);
+            } // else
+
+            // Parent Group does not exist yet, so create it at "root" User Group.
+            $rootGroup = $this->userService->loadUserGroup(self::USERGROUP_ROOT_CONTENT_ID);
+            $parentGroup = $this->createUserGroup($parentGroupName, $rootGroup);
+
+            return $this->createUser($username, $email, $password, $parentGroup);
+        }
+        // else,
+
+        $user = $this->searchUserByLogin($username);
+        if (!$user) {
+            $user = $this->createUser($username, $email, $password);
+        }
+
+        return $user;
+    }
+
+    /**
+     * Make sure a User with name $username does not exist (in parent group).
+     *
+     * @param string $username          User name
+     * @param string $parentGroupName   (optional) name of the parent group to check
+     */
+    public function ensureUserDoesntExist($username, $parentGroupName = null)
+    {
+        $user = null;
+        if ($parentGroupName) {
+            // find matching Parent Group name
+            $parentSearchHits = $this->searchUserGroups($parentGroupName, self::USERGROUP_ROOT_LOCATION);
+            if (!empty($parentSearchHits)) {
+                foreach ($parentSearchHits as $parentGroupFound) {
+                    $groupId = $parentGroupFound->valueObject->contentInfo->id;
+                    //Search for already existing matching Child user
+                    $user = $this->searchUserByLogin($username, $groupId);
+                    if ($user) {
+                        break;
+                    }
+                }
+            }
+        } else {
+            try {
+                $user = $this->userService->loadUserByLogin($username);
+            } catch (ApiExceptions\NotFoundException $e) {
+                // nothing to do
+            }
+        }
+        if ($user) {
+            try {
+                $this->userService->deleteUser($user);
+            } catch (ApiExceptions\NotFoundException $e) {
+                // nothing to do
+            }
+        }
+    }
+
+    /**
+     * Checks if the User with username $username exists.
+     *
+     * @param string $username User name
+     * @param string $parentGroupName User group name to search inside
+     *
+     * @return bool true if it exists, false if user or group don't exist
+     */
+    public function checkUserExistenceByUsername($username, $parentGroupName = null)
+    {
+        if ($parentGroupName) {
+            // find parent group name
+            $searchResults = $this->searchUserGroups($parentGroupName);
+            if (empty($searchResults)) {
+                // group not found, so return immediately
+                return false;
+            }
+            $groupId = $searchResults[0]->valueObject->contentInfo->id;
+        } else {
+            $groupId = null;
+        }
+        $searchResults = $this->searchUserByLogin($username, $groupId);
+
+        return empty($searchResults) ? false : true;
+    }
+
+    /**
+     * Checks if the User with email $email exists.
+     *
+     * @param string $email User email
+     * @param string $parentGroupName User group name to search inside
+     *
+     * @return bool true if it exists, false if not
+     */
+    public function checkUserExistenceByEmail($email, $parentGroupName = null)
+    {
+        $existingUsers = $this->userService->loadUsersByEmail($email);
+        if (count($existingUsers) == 0) {
+            return false;
+        }
+        if ($parentGroupName) {
+            foreach ($existingUsers as $user) {
+                $userGroups = $this->userService->loadUserGroupsOfUser($user);
+                foreach ($userGroups as $userGroup) {
+                    if ($userGroup->getFieldValue('name') == $parentGroupName) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public function createPasswordHash($login, $password, $type)
+    {
+        switch ($type) {
+            case 2:
+                /* PASSWORD_HASH_MD5_USER */
+                return md5("{$login}\n{$password}");
+            case 3:
+                /* PASSWORD_HASH_MD5_SITE */
+                $site = null;
+
+                return md5("{$login}\n{$password}\n{$site}");
+            case 5:
+                /* PASSWORD_HASH_PLAINTEXT */
+                return $password;
+        }
+        /* PASSWORD_HASH_MD5_PASSWORD (1) */
+        return md5($password);
+    }
+
+    /**
+     * @Given there is a User with name :username
+     *
+     * Ensures a user with username ':username' exists, creating a new one if necessary.
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\User
+     */
+    public function iHaveUser($username)
+    {
+        $email = $this->findNonExistingUserEmail($username);
+        $password = $username;
+        $user = $this->ensureUserExists($username, $email, $password);
+    }
+
+    /**
+     * @Given there is a User with name :username, email :email and password :password
+     *
+     * Ensures a user exists with given username/email/password, creating a new one if necessary.
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\User
+     */
+    public function iHaveUserWithUsernameEmailAndPassword($username, $email, $password)
+    {
+        $this->ensureUserExists($username, $email, $password);
+    }
+    /**
+     * @Given there is a User with name :username in :parentGroup group
+     *
+     * Ensures a user with username ':username' exists as a child of ':parentGroup' user group, can create either one.
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\User
+     */
+    public function iHaveUserInGroup($username, $parentGroupName)
+    {
+        $email = $this->findNonExistingUserEmail($username);
+        $password = $username;
+        $user = $this->ensureUserExists($username, $email, $password, $parentGroupName);
+    }
+    /**
+     * @Given there is a User with name :username, email :email and password :password in :parentGroup group
+     *
+     * Ensures a user with given username/email/password as a child of ':parentGroup' user group, can create either one.
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\User
+     */
+    public function iHaveUserWithUsernameEmailAndPasswordInGroup($username, $email, $password, $parentGroupName)
+    {
+        return $this->ensureUserExists($username, $email, $password, $parentGroupName);
+    }
+
+    /**
+     * @Given there isn't a User with name :username
+     *
+     * Makes sure a user with username ':username' doesn't exist, removing it if necessary.
+     */
+    public function iDontHaveUser($username)
+    {
+        $this->ensureUserDoesntExist($username);
+    }
+    /**
+     * @Given there isn't a User with name :username in :parentGroup group
+     *
+     * Makes sure a user with username ':username' doesn't exist as a chield of group ':parentGroup', removing it if necessary.
+     */
+    public function iDontHaveUserInGroup($username, $parentGroup)
+    {
+        $this->ensureUserDoesntExist($username, $parentGroup);
+    }
+
+    /**
+     * @Given there are the following Users:
+     *
+     * Make sure that users in the provided table exist in their respective parent group. Example:
+     *      | username        | parentGroup      |
+     *      | testUser1       | Members          |
+     *      | testUser2       | Editors          |
+     *      | testUser3       | NewParent        | # Both user and group should be created
+     */
+    public function iHaveTheFollowingUsers(TableNode $table)
+    {
+        $users = $table->getTable();
+        array_shift($users);
+        foreach ($users as $user) {
+            // array( [0] => userName, [1] => groupName );
+            $this->ensureUserExists($user[0], $user[1]);
+        }
+    }
+
+    /**
+     * @Given a User with name :username already exists
+     * @Then User with name :username exists
+     *
+     * Checks that user ':username' exists.
+     */
+    public function assertUserWithNameExists($username)
+    {
+        Assertion::assertTrue(
+            $this->checkUserExistenceByUsername($username),
+            "Couldn't find User with name '$username'."
+        );
+    }
+
+    /**
+     * @Then User with name :username doesn't exist
+     *
+     * Checks that user ':username' does not exist.
+     */
+    public function assertUserWithNameDoesntExist($username)
+    {
+        Assertion::assertFalse(
+            $this->checkUserExistenceByUsername($username),
+            "User with name '$username' was found."
+        );
+    }
+
+    /**
+     * @Then User with name :username exists in group :parentGroup
+     * @Then User with name :username exists in :parentGroup group
+     *
+     * Checks that user ':username' exists as a child of group ':parentGroup'.
+     */
+    public function assertUserWithNameExistsInGroup($username, $parentGroup)
+    {
+        Assertion::assertTrue(
+            $this->checkUserExistenceByUsername($username, $parentGroup),
+            "Couldn't find User with name '$username' in parent group '$parentGroup'."
+        );
+    }
+
+    /**
+     * @Then User with name :username doesn't exist in group :parentGroup
+     * @Then User with name :username doesn't exist in :parentGroup group
+     *
+     * Checks that user ':username' does not exist as a child of group ':parentGroup'.
+     */
+    public function assertUserWithNameDoesntExistInGroup($username, $parentGroup)
+    {
+        Assertion::assertFalse(
+            $this->checkUserExistenceByUsername($username, $parentGroup),
+            "User with name '$username' was found in parent group '$parentGroup'."
+        );
+    }
+
+    /**
+     * @Then User with name :username doesn't exist in the following groups:
+     *
+     * Checks that user ':username' does not exist in any of the provided groups. Example:
+     *      | parentGroup           |
+     *      | Partners              |
+     *      | Anonymous Users       |
+     *      | Editors               |
+     *      | Administrator users   |
+     */
+    public function assertUserWithNameDoesntExistInGroups($username, TableNode $table)
+    {
+        $groups = $table->getTable();
+        array_shift($groups);
+        foreach ($groups as $group) {
+            $parentGroupName = $group[0];
+            Assertion::assertFalse(
+                $this->checkUserExistenceByUsername($username, $parentGroupName),
+                "User with name '$username' was found in parent group '$parentGroupName'."
+            );
+        }
+    }
+
+    /**
+     * @Then User with name :username has the following fields:
+     * @Then User with name :username exists with the following fields:
+     *
+     * Checks that user ':username' exists with the values provided in the field/value table. example:
+     *       | Name          | value           |
+     *       | email         | testuser@ez.no  |
+     *       | password      | testuser        |
+     *       | first_name    | Test            |
+     *       | last_name     | User            |
+     */
+    public function assertUserWithNameExistsWithFields($username, TableNode $table)
+    {
+        Assertion::assertTrue(
+            $this->checkUserExistenceByUsername($username),
+            "Couldn't find User with name '$username'."
+        );
+        $user = $this->userService->loadUserByLogin($username);
+        $fieldsTable = $table->getTable();
+        array_shift($fieldsTable);
+        $updateFields = array();
+        foreach ($fieldsTable as $fieldRow) {
+            $fieldName = $fieldRow[0];
+            $expectedValue = $fieldRow[1];
+            switch ($fieldName) {
+                case 'email':
+                    $fieldValue = $user->email;
+                    break;
+                case 'password':
+                    $fieldValue = $user->passwordHash;
+                    $expectedValue = $this->createPasswordHash($username, $expectedValue, $user->hashAlgorithm);
+                    break;
+                default:
+                    $fieldValue = $user->getFieldValue($fieldName);
+            }
+            Assertion::assertEquals(
+                $expectedValue,
+                $fieldValue,
+                "Field '$fieldName' did not contain expected value '$expectedValue'."
+            );
+        }
+    }
+
+    /**
+     * Find a non existing User email.
+     *
+     * @return string A not used email
+     *
+     * @throws \Exception Possible endless loop
+     */
+    private function findNonExistingUserEmail($username = 'User')
+    {
+        $email = "${username}@ez.no";
+        if ($this->checkUserExistenceByEmail($email)) {
+            return $email;
+        }
+
+        for ($i = 0; $i < 20; ++$i) {
+            $email = 'User#' . uniqid() . '@ez.no';
+            if (!$this->checkUserExistenceByEmail($email)) {
+                return $email;
+            }
+        }
+
+        throw new \Exception('Possible endless loop when attempting to find a new email for User.');
+    }
+
+    /**
+     * Find a non existing User name.
+     *
+     * @return string A not used name
+     *
+     * @throws \Exception Possible endless loop
+     */
+    private function findNonExistingUserName()
+    {
+        for ($i = 0; $i < 20; ++$i) {
+            $username = 'User#' . uniqid();
+            if (!$this->checkUserExistenceByUsername($username)) {
+                return $username;
+            }
+        }
+
+        throw new \Exception('Possible endless loop when attempting to find a new name for User.');
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/UserContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/UserContext.php
@@ -125,7 +125,7 @@ class UserContext implements Context
      * @param $password account password for user to create
      * @param $parentGroup pathstring wherein to create user
      *
-     * @return user created
+     * @return eZ\Publish\API\Repository\Values\User\User
      */
     protected function createUser($username, $email, $password, $parentGroup = null, $fields = array())
     {


### PR DESCRIPTION
In order to deprecate `BehatBundle` repository some Contexts will be moved into the kernel.

Making the Contexts `classes` and not `traits` (as some of them still are in BehatBundle) should improve the overall flexibility and maintainability of the code.

One if the main objectives is to use this Contexts with other Bundles BDD, such as PlatformUI, running each behat suite with the various needed Contexts instead of one with everything.

PS: this PR contains a lot of code but it has already been reviewed before, the code was just moved basically.