### PR TITLE
EZP-25309: Fix for hardcoded custom fields search field names

### DIFF
--- a/eZ/Publish/Core/Search/Common/FieldNameResolver.php
+++ b/eZ/Publish/Core/Search/Common/FieldNameResolver.php
@@ -208,16 +208,16 @@ class FieldNameResolver
             return null;
         }
 
-        $fieldName = $this->getIndexFieldName(
+        $fieldName = array_keys($this->getIndexFieldName(
             $sortClause,
             $contentTypeIdentifier,
             $fieldDefinitionIdentifier,
             $fieldMap[$contentTypeIdentifier][$fieldDefinitionIdentifier]['field_type_identifier'],
             $name,
             true
-        );
+        ));
 
-        return reset(array_keys($fieldName));
+        return reset($fieldName);
     }
 
     /**

--- a/eZ/Publish/Core/Search/Common/FieldNameResolver.php
+++ b/eZ/Publish/Core/Search/Common/FieldNameResolver.php
@@ -157,7 +157,7 @@ class FieldNameResolver
                 continue;
             }
 
-            $fieldName = $this->getIndexFieldName(
+            $fieldNameWithSearchType = $this->getIndexFieldName(
                 $criterion,
                 $contentTypeIdentifier,
                 $fieldDefinitionIdentifier,
@@ -165,10 +165,11 @@ class FieldNameResolver
                 $name,
                 false
             );
-            $fieldType = $this->fieldRegistry->getType(
-                $fieldIdentifierMap[$fieldDefinitionIdentifier]['field_type_identifier']
-            );
-            $fieldTypeNameMap[$fieldName] = $fieldType;
+
+            $fieldNames = array_keys($fieldNameWithSearchType);
+            $fieldName = reset($fieldNames);
+
+            $fieldTypeNameMap[$fieldName] = $fieldNameWithSearchType[$fieldName];
         }
 
         return $fieldTypeNameMap;
@@ -207,7 +208,7 @@ class FieldNameResolver
             return null;
         }
 
-        return $this->getIndexFieldName(
+        $fieldName = $this->getIndexFieldName(
             $sortClause,
             $contentTypeIdentifier,
             $fieldDefinitionIdentifier,
@@ -215,6 +216,8 @@ class FieldNameResolver
             $name,
             true
         );
+
+        return reset(array_keys($fieldName));
     }
 
     /**
@@ -246,7 +249,7 @@ class FieldNameResolver
                 $fieldDefinitionIdentifier
             )
         ) {
-            return $customFieldName;
+            return [$customFieldName => null];
         }
 
         // Else, generate field name from field type's index definition
@@ -271,7 +274,7 @@ class FieldNameResolver
             );
         }
 
-        return $this->nameGenerator->getTypedName(
+        $field = $this->nameGenerator->getTypedName(
             $this->nameGenerator->getName(
                 $name,
                 $fieldDefinitionIdentifier,
@@ -279,5 +282,7 @@ class FieldNameResolver
             ),
             $indexDefinition[$name]
         );
+
+        return [$field => $indexDefinition[$name]];
     }
 }

--- a/eZ/Publish/Core/Search/Tests/FieldNameResolverTest.php
+++ b/eZ/Publish/Core/Search/Tests/FieldNameResolverTest.php
@@ -100,7 +100,7 @@ class FieldNameResolverTest extends TestCase
                 'field_type_identifier_1',
                 null
             )
-            ->will($this->returnValue('index_field_name_1'));
+            ->will($this->returnValue(['index_field_name_1' => null]));
 
         $mockedFieldNameResolver
             ->expects($this->at(2))
@@ -114,7 +114,7 @@ class FieldNameResolverTest extends TestCase
                 'field_type_identifier_2',
                 null
             )
-            ->will($this->returnValue('index_field_name_2'));
+            ->will($this->returnValue(['index_field_name_2' => null]));
 
         $fieldNames = $mockedFieldNameResolver->getFieldNames(
             $criterionMock,
@@ -174,7 +174,7 @@ class FieldNameResolverTest extends TestCase
                 'field_type_identifier_1',
                 'field_name'
             )
-            ->will($this->returnValue('index_field_name_1'));
+            ->will($this->returnValue(['index_field_name_1' => null]));
 
         $mockedFieldNameResolver
             ->expects($this->at(2))
@@ -188,7 +188,7 @@ class FieldNameResolverTest extends TestCase
                 'field_type_identifier_2',
                 'field_name'
             )
-            ->will($this->returnValue('index_field_name_2'));
+            ->will($this->returnValue(['index_field_name_2' => null]));
 
         $fieldNames = $mockedFieldNameResolver->getFieldNames(
             $criterionMock,
@@ -250,7 +250,7 @@ class FieldNameResolverTest extends TestCase
                 'field_type_identifier_2',
                 null
             )
-            ->will($this->returnValue('index_field_name_1'));
+            ->will($this->returnValue(['index_field_name_1' => null]));
 
         $fieldNames = $mockedFieldNameResolver->getFieldNames(
             $criterionMock,
@@ -311,7 +311,7 @@ class FieldNameResolverTest extends TestCase
                 'field_type_identifier_2',
                 'field_name'
             )
-            ->will($this->returnValue('index_field_name_1'));
+            ->will($this->returnValue(['index_field_name_1' => null]));
 
         $fieldNames = $mockedFieldNameResolver->getFieldNames(
             $criterionMock,
@@ -362,7 +362,7 @@ class FieldNameResolverTest extends TestCase
                 'field_type_identifier',
                 'field_name'
             )
-            ->will($this->returnValue('index_field_name'));
+            ->will($this->returnValue(['index_field_name' => null]));
 
         $fieldName = $mockedFieldNameResolver->getSortFieldName(
             $sortClauseMock,
@@ -432,7 +432,7 @@ class FieldNameResolverTest extends TestCase
             false
         );
 
-        $this->assertEquals('custom_field_name', $customFieldName);
+        $this->assertEquals('custom_field_name', key($customFieldName));
     }
 
     public function testGetIndexFieldNameNamedField()
@@ -494,7 +494,7 @@ class FieldNameResolverTest extends TestCase
             true
         );
 
-        $this->assertEquals('generated_typed_field_name', $fieldName);
+        $this->assertEquals('generated_typed_field_name', key($fieldName));
     }
 
     public function testGetIndexFieldNameDefaultMatchField()
@@ -561,7 +561,7 @@ class FieldNameResolverTest extends TestCase
             false
         );
 
-        $this->assertEquals('generated_typed_field_name', $fieldName);
+        $this->assertEquals('generated_typed_field_name', key($fieldName));
     }
 
     public function testGetIndexFieldNameDefaultSortField()
@@ -628,7 +628,7 @@ class FieldNameResolverTest extends TestCase
             true
         );
 
-        $this->assertEquals('generated_typed_field_name', $fieldName);
+        $this->assertEquals('generated_typed_field_name', key($fieldName));
     }
 
     /**


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-25309

1. This changes the approach from https://github.com/ezsystems/ezpublish-kernel/pull/1551 to return [search field types](https://github.com/ezsystems/ezpublish-kernel/tree/master/eZ/Publish/SPI/Search/FieldType) per field name, instead of field type's Indexable implementation. 

2. For custom fields we now return null, as it is impossible to resolve field type in a programatic way. This means if custom field types are used (by CustomFieldCriterion and custom field interfaces implemented by the field criterion), that the value provided to Criterion needs to be of correct type (and for the custom field value being indexed).