### PR TITLE
[WIP] EZP-25088: Content items not indexed by legacySearchEngine

### DIFF
--- a/eZ/Bundle/EzPublishLegacySearchEngineBundle/Command/LseCreateIndexCommand.php
+++ b/eZ/Bundle/EzPublishLegacySearchEngineBundle/Command/LseCreateIndexCommand.php
@@ -1,0 +1,175 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishLegacySearchEngineBundle\Command;
+
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+use eZ\Publish\SPI\Persistence\Content;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Helper\ProgressHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use eZ\Publish\SPI\Persistence\Content\ContentInfo;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\Search\Legacy\Content\Handler as SearchHandler;
+use RuntimeException;
+use PDO;
+
+/**
+ * Console command ezplatform:lse_create_index indexes content objects for legacy search engine.
+ */
+class LseCreateIndexCommand extends ContainerAwareCommand
+{
+    /**
+     * @var \eZ\Publish\Core\Search\Legacy\Content\Handler
+     */
+    private $searchHandler;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Handler
+     */
+    private $persistenceHandler;
+
+    /**
+     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
+     */
+    private $databaseHandler;
+
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * Initialize objects required by {@see execute()}.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    public function initialize(InputInterface $input, OutputInterface $output)
+    {
+        parent::initialize($input, $output);
+        $this->logger = $this->getContainer()->get('logger');
+        $this->searchHandler = $this->getContainer()->get('ezpublish.spi.search');
+        $this->persistenceHandler = $this->getContainer()->get('ezpublish.api.persistence_handler');
+        $this->databaseHandler = $this->getContainer()->get('ezpublish.connection');
+
+        if (!$this->searchHandler instanceof SearchHandler) {
+            throw new RuntimeException(
+                'Expected to find Search Handler but found something else.'
+            );
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('ezplatform:lse_create_index')
+            ->setDescription('Indexes the configured database for the legacy search engine')
+            ->addArgument('bulk_count', InputArgument::OPTIONAL, 'Number of Content objects indexed at once', 5)
+            ->setHelp(
+                <<<EOT
+The command <info>%command.name%</info> indexes content objects for the legacy search engine.
+EOT
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $bulkCount = $input->getArgument('bulk_count');
+        // Indexing Content
+        $totalCount = $this->getContentObjectsTotalCount($this->databaseHandler, ContentInfo::STATUS_PUBLISHED);
+
+        $query = $this->databaseHandler->createSelectQuery();
+        $query->select('id', 'current_version')
+            ->from('ezcontentobject')
+            ->where($query->expr->eq('status', ContentInfo::STATUS_PUBLISHED));
+
+        $stmt = $query->prepare();
+        $stmt->execute();
+
+        $this->searchHandler->purgeIndex();
+
+        $output->writeln('Indexing Content...');
+
+        /* @var \Symfony\Component\Console\Helper\ProgressHelper $progress */
+        $progress = $this->getHelperSet()->get('progress');
+        $progress->start($output, $totalCount);
+        $i = 0;
+        do {
+            $contentObjects = [];
+            for ($k = 0; $k <= $bulkCount; ++$k) {
+                if (!$row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+                    break;
+                }
+                try {
+                    $contentObjects[] = $this->persistenceHandler->contentHandler()->load(
+                        $row['id'],
+                        $row['current_version']
+                    );
+                } catch (NotFoundException $e) {
+                    $this->logWarning($output, $progress, "Could not load current version of Content with id ${row['id']}, so skipped for indexing. Full exception: " . $e->getMessage());
+                }
+            }
+
+            $this->searchHandler->bulkIndex($contentObjects, function (Content $content, NotFoundException $e) use ($output, $progress) {
+                $this->logWarning($output, $progress, 'Content with id ' . $content->versionInfo->id . ' has missing data, so skipped for indexing. Full exception: ' . $e->getMessage());
+            });
+
+            $progress->advance($k);
+        } while (($i += $bulkCount) < $totalCount);
+
+        // Make changes available for search
+        $this->searchHandler->commit();
+
+        $progress->finish();
+    }
+
+    /**
+     * Get content objects total count.
+     *
+     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $databaseHandler
+     * @param int                                                   $contentObjectStatus ContentInfo constant
+     *
+     * @return int
+     */
+    private function getContentObjectsTotalCount(DatabaseHandler $databaseHandler, $contentObjectStatus)
+    {
+        $query = $databaseHandler->createSelectQuery();
+        $query->select('count(id)')
+            ->from('ezcontentobject')
+            ->where($query->expr->eq('status', $contentObjectStatus));
+        $stmt = $query->prepare();
+        $stmt->execute();
+        $totalCount = $stmt->fetchColumn();
+
+        return $totalCount;
+    }
+
+    /**
+     * Log warning while progress helper is running.
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param \Symfony\Component\Console\Helper\ProgressHelper $progress
+     * @param $message
+     */
+    private function logWarning(OutputInterface $output, ProgressHelper $progress, $message)
+    {
+        $progress->clear();
+        $output->write("\r"); // get rid of padding (side effect of displaying progress bar)
+        $this->logger->warning($message);
+        $progress->display();
+    }
+}

--- a/eZ/Bundle/EzPublishLegacySearchEngineBundle/EzPublishLegacySearchEngineBundle.php
+++ b/eZ/Bundle/EzPublishLegacySearchEngineBundle/EzPublishLegacySearchEngineBundle.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace eZ\Bundle\EzPublishLegacySearchEngineBundle;
 
@@ -15,6 +13,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use eZ\Publish\Core\Base\Container\Compiler\Search\Legacy\CriteriaConverterPass;
 use eZ\Publish\Core\Base\Container\Compiler\Search\Legacy\CriterionFieldValueHandlerRegistryPass;
 use eZ\Publish\Core\Base\Container\Compiler\Search\Legacy\SortClauseConverterPass;
+use eZ\Publish\Core\Base\Container\Compiler\Search\Legacy\AggregateFieldValueMapperPass;
 
 class EzPublishLegacySearchEngineBundle extends Bundle
 {
@@ -25,6 +24,7 @@ class EzPublishLegacySearchEngineBundle extends Bundle
         $container->addCompilerPass(new CriteriaConverterPass());
         $container->addCompilerPass(new CriterionFieldValueHandlerRegistryPass());
         $container->addCompilerPass(new SortClauseConverterPass());
+        $container->addCompilerPass(new AggregateFieldValueMapperPass());
     }
 
     public function getContainerExtension()

--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -4111,6 +4111,47 @@ class SearchServiceTest extends BaseTest
     }
 
     /**
+     * Test for FullText on the findContent() method.
+     *
+     * @see \eZ\Publish\API\Repository\SearchService::findContent()
+     */
+    public function testFullTextOnNewContent()
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+        $contentTypeService = $repository->getContentTypeService();
+        $locationService = $repository->getLocationService();
+        $searchService = $repository->getSearchService();
+
+        $contentCreateStruct = $contentService->newContentCreateStruct(
+            $contentTypeService->loadContentTypeByIdentifier('folder'),
+            'eng-GB'
+        );
+
+        $contentCreateStruct->setField('name', 'foxes');
+
+        $englishContent = $contentService->publishVersion(
+            $contentService->createContent(
+                $contentCreateStruct,
+                array($locationService->newLocationCreateStruct(2))
+            )->versionInfo
+        );
+
+        $this->refreshSearch($repository);
+
+        $query = new Query(
+            array(
+                'query' => new Criterion\FullText('foxes'),
+            )
+        );
+
+        $searchResult = $searchService->findContentInfo($query);
+
+        $this->assertEquals(1, $searchResult->totalCount);
+        $this->assertEquals($englishContent->id, $searchResult->searchHits[0]->valueObject->id);
+    }
+
+    /**
      * Test for the findContent() method.
      *
      * @see \eZ\Publish\API\Repository\SearchService::findContent()

--- a/eZ/Publish/API/Repository/Tests/SetupFactory/Legacy.php
+++ b/eZ/Publish/API/Repository/Tests/SetupFactory/Legacy.php
@@ -19,6 +19,7 @@ use eZ\Publish\Core\Persistence\Legacy\Content\Language\CachingHandler as Cachin
 use Exception;
 use eZ\Publish\Core\Repository\Values\User\UserReference;
 use Symfony\Component\Filesystem\Filesystem;
+use eZ\Publish\Core\Base\Container\Compiler;
 
 /**
  * A Test Factory is used to setup the infrastructure for a tests, based on a
@@ -377,6 +378,10 @@ class Legacy extends SetupFactory
                 'io_root_dir',
                 self::$ioRootDir . '/' . $containerBuilder->getParameter('storage_dir')
             );
+
+            $containerBuilder->addCompilerPass(new Compiler\Search\SignalSlotPass());
+            $containerBuilder->addCompilerPass(new Compiler\Search\Legacy\AggregateFieldValueMapperPass());
+            $containerBuilder->addCompilerPass(new Compiler\Search\FieldRegistryPass());
 
             self::$serviceContainer = new ServiceContainer(
                 $containerBuilder,

--- a/eZ/Publish/Core/Base/Container/Compiler/Search/Legacy/AggregateFieldValueMapperPass.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/Search/Legacy/AggregateFieldValueMapperPass.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * File containing the AggregateFieldValueMapperPass class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Base\Container\Compiler\Search\Legacy;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * This compiler pass will register legacy search engine field value mappers.
+ */
+class AggregateFieldValueMapperPass implements CompilerPassInterface
+{
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (
+            !$container->hasDefinition(
+                'ezpublish.search.legacy.content.field_value_mapper.aggregate'
+            )
+        ) {
+            return;
+        }
+
+        $aggregateFieldValueMapperDefinition = $container->getDefinition(
+            'ezpublish.search.legacy.content.field_value_mapper.aggregate'
+        );
+
+        $taggedServiceIds = $container->findTaggedServiceIds(
+            'ezpublish.search.legacy.content.field_value_mapper'
+        );
+        foreach ($taggedServiceIds as $id => $attributes) {
+            $aggregateFieldValueMapperDefinition->addMethodCall(
+                'addMapper',
+                [new Reference($id)]
+            );
+        }
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LanguageAwareTestCase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LanguageAwareTestCase.php
@@ -5,13 +5,13 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator as LanguageMaskGenerator;
+use eZ\Publish\Core\Persistence;
+use eZ\Publish\Core\Search\Legacy\Content\Mapper\FullTextMapper;
 
 /**
  * Test case for Language aware classes.
@@ -60,5 +60,53 @@ abstract class LanguageAwareTestCase extends TestCase
         }
 
         return $this->languageMaskGenerator;
+    }
+
+    /**
+     * Return definition-based transformation processor instance.
+     *
+     * @return Persistence\TransformationProcessor\DefinitionBased
+     */
+    protected function getDefinitionBasedTransformationProcessor()
+    {
+        return new Persistence\TransformationProcessor\DefinitionBased(
+            new Persistence\TransformationProcessor\DefinitionBased\Parser(),
+            new Persistence\TransformationProcessor\PcreCompiler(
+                new Persistence\Utf8Converter()
+            ),
+            glob(__DIR__ . '/../../../../Persistence/Tests/TransformationProcessor/_fixtures/transformations/*.tr')
+        );
+    }
+
+    /**
+     * @var \eZ\Publish\Core\Search\Common\FieldNameGenerator|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $fieldNameGeneratorMock;
+
+    /**
+     * @return \eZ\Publish\Core\Search\Common\FieldNameGenerator|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getFieldNameGeneratorMock()
+    {
+        if (!isset($this->fieldNameGeneratorMock)) {
+            $this->fieldNameGeneratorMock = $this
+                ->getMockBuilder('eZ\\Publish\\Core\\Search\\Common\\FieldNameGenerator')
+                ->disableOriginalConstructor()
+                ->getMock();
+        }
+
+        return $this->fieldNameGeneratorMock;
+    }
+
+    /**
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler $contentTypeHandler
+     * @return \eZ\Publish\Core\Search\Legacy\Content\Mapper\FullTextMapper
+     */
+    protected function getFullTextMapper(Persistence\Legacy\Content\Type\Handler $contentTypeHandler)
+    {
+        return new FullTextMapper(
+            $this->getMock('\\eZ\\Publish\\Core\\Search\\Common\\FieldRegistry'),
+            $contentTypeHandler
+        );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content;
+
+use eZ\Publish\SPI\Search\Field;
+
+/**
+ * Maps raw document field values to something legacy search engine can index.
+ */
+abstract class FieldValueMapper
+{
+    /**
+     * Check if field can be mapped.
+     *
+     * @param Field $field
+     *
+     * @return bool
+     */
+    abstract public function canMap(Field $field);
+
+    /**
+     * Map field value to a proper search engine representation.
+     *
+     * @param Field $field
+     *
+     * @return mixed|null Returns null on empty value
+     */
+    abstract public function map(Field $field);
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/Aggregate.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/Aggregate.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+
+use eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
+
+/**
+ * Maps raw content field values to something legacy search engine can index.
+ */
+class Aggregate extends FieldValueMapper
+{
+    /**
+     * Array of available mappers.
+     *
+     * @var \eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper[]
+     */
+    protected $mappers = [];
+
+    /**
+     * Construct from optional mapper array.
+     *
+     * @param \eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper[] $mappers
+     */
+    public function __construct(array $mappers = [])
+    {
+        foreach ($mappers as $mapper) {
+            $this->addMapper($mapper);
+        }
+    }
+
+    /**
+     * Adds mapper.
+     *
+     * @param \eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper $mapper
+     */
+    public function addMapper(FieldValueMapper $mapper)
+    {
+        $this->mappers[] = $mapper;
+    }
+
+    /**
+     * Check if field can be mapped.
+     *
+     * @param Field $field
+     *
+     * @return bool
+     */
+    public function canMap(Field $field)
+    {
+        return true;
+    }
+
+    /**
+     * Map field value to a proper representation.
+     *
+     * @param Field $field
+     *
+     * @return mixed
+     *
+     * @throws NotImplementedException
+     */
+    public function map(Field $field)
+    {
+        foreach ($this->mappers as $mapper) {
+            if ($mapper->canMap($field)) {
+                return $mapper->map($field);
+            }
+        }
+
+        throw new NotImplementedException('No mapper available for: ' . get_class($field->type));
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/BooleanMapper.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/BooleanMapper.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+
+use eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Maps raw document field values to something search engine can index.
+ */
+class BooleanMapper extends FieldValueMapper
+{
+    /**
+     * Check if field can be mapped.
+     *
+     * @param Field $field
+     *
+     * @return bool
+     */
+    public function canMap(Field $field)
+    {
+        return $field->type instanceof FieldType\BooleanField;
+    }
+
+    /**
+     * Map field value to a proper search engine representation.
+     *
+     * @param Field $field
+     *
+     * @return mixed
+     */
+    public function map(Field $field)
+    {
+        return $this->convert($field->value);
+    }
+
+    /**
+     * Convert to a proper search engine representation.
+     *
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    protected function convert($value)
+    {
+        return (boolean) $value;
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/DateMapper.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/DateMapper.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+
+use eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+use DateTime;
+use InvalidArgumentException;
+use Exception;
+
+/**
+ * Maps DateField document field values to something legacy search engine can index.
+ */
+class DateMapper extends FieldValueMapper
+{
+    /**
+     * Check if field can be mapped.
+     *
+     * @param Field $field
+     *
+     * @return mixed
+     */
+    public function canMap(Field $field)
+    {
+        return $field->type instanceof FieldType\DateField;
+    }
+
+    /**
+     * Map field value to a proper legacy search engine representation.
+     *
+     * @param \eZ\Publish\SPI\Search\Field $field
+     *
+     * @return mixed
+     */
+    public function map(Field $field)
+    {
+        if (is_numeric($field->value)) {
+            $date = new DateTime("@{$field->value}");
+        } else {
+            try {
+                $date = new DateTime($field->value);
+            } catch (Exception $e) {
+                throw new InvalidArgumentException('Invalid date provided: ' . $field->value);
+            }
+        }
+
+        return $date->getTimestamp();
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/FloatMapper.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/FloatMapper.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+
+use eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Maps FloatField document field values to something legacy search engine can index.
+ */
+class FloatMapper extends FieldValueMapper
+{
+    /**
+     * Check if field can be mapped.
+     *
+     * @param Field $field
+     *
+     * @return bool
+     */
+    public function canMap(Field $field)
+    {
+        return $field->type instanceof FieldType\FloatField;
+    }
+
+    /**
+     * Map field value to a proper legacy search engine representation.
+     *
+     * @param \eZ\Publish\SPI\Search\Field $field
+     *
+     * @return mixed
+     */
+    public function map(Field $field)
+    {
+        return (float) $field->value;
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/GeoLocationMapper.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/GeoLocationMapper.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+
+use eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Maps GeoLocationField document field values to something legacy search engine can index.
+ */
+class GeoLocationMapper extends FieldValueMapper
+{
+    /**
+     * Check if field can be mapped.
+     *
+     * @param \eZ\Publish\SPI\Search\Field $field
+     *
+     * @return bool
+     */
+    public function canMap(Field $field)
+    {
+        return $field->type instanceof FieldType\GeoLocationField;
+    }
+
+    /**
+     * Map field value to a proper legacy search engine representation.
+     *
+     * @param \eZ\Publish\SPI\Search\Field $field
+     *
+     * @return mixed
+     */
+    public function map(Field $field)
+    {
+        return $field->value['latitude'] . ',' . $field->value['longitude'];
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/IdentifierMapper.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/IdentifierMapper.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+
+use eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Maps raw document field values to something search engine can index.
+ */
+class IdentifierMapper extends FieldValueMapper
+{
+    /**
+     * Check if field can be mapped.
+     *
+     * @param Field $field
+     *
+     * @return bool
+     */
+    public function canMap(Field $field)
+    {
+        return $field->type instanceof FieldType\IdentifierField;
+    }
+
+    /**
+     * Map field value to a proper search engine representation.
+     *
+     * @param Field $field
+     *
+     * @return mixed
+     */
+    public function map(Field $field)
+    {
+        return $this->convert($field->value);
+    }
+
+    /**
+     * Convert to a proper search engine representation.
+     *
+     * @param mixed $value
+     *
+     * @return string
+     */
+    protected function convert($value)
+    {
+        // Remove non-printable characters
+        return preg_replace('([^A-Za-z0-9/]+)', '', $value);
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/IntegerMapper.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/IntegerMapper.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+
+use eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Maps raw document field values to something search engine can index.
+ */
+class IntegerMapper extends FieldValueMapper
+{
+    /**
+     * Check if field can be mapped.
+     *
+     * @param Field $field
+     *
+     * @return bool
+     */
+    public function canMap(Field $field)
+    {
+        return $field->type instanceof FieldType\IntegerField;
+    }
+
+    /**
+     * Map field value to a proper search engine representation.
+     *
+     * @param Field $field
+     *
+     * @return mixed
+     */
+    public function map(Field $field)
+    {
+        return $this->convert($field->value);
+    }
+
+    /**
+     * Convert to a proper search engine representation.
+     *
+     * @param mixed $value
+     *
+     * @return string
+     */
+    protected function convert($value)
+    {
+        return (int) $value;
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/MultipleBooleanMapper.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/MultipleBooleanMapper.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Maps raw document field values to something search engine can index.
+ */
+class MultipleBooleanMapper extends BooleanMapper
+{
+    /**
+     * Check if field can be mapped.
+     *
+     * @param Field $field
+     *
+     * @return bool
+     */
+    public function canMap(Field $field)
+    {
+        return $field->type instanceof FieldType\MultipleBooleanField;
+    }
+
+    /**
+     * Map field value to a proper search engine representation.
+     *
+     * @param Field $field
+     *
+     * @return mixed
+     */
+    public function map(Field $field)
+    {
+        $values = array();
+
+        foreach ((array) $field->value as $value) {
+            $values[] = $this->convert($value);
+        }
+
+        return $values;
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/MultipleIdentifierMapper.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/MultipleIdentifierMapper.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Maps raw document field values to something search engine can index.
+ */
+class MultipleIdentifierMapper extends IdentifierMapper
+{
+    /**
+     * Check if field can be mapped.
+     *
+     * @param Field $field
+     *
+     * @return bool
+     */
+    public function canMap(Field $field)
+    {
+        return $field->type instanceof FieldType\MultipleIdentifierField;
+    }
+
+    /**
+     * Map field value to a proper search engine representation.
+     *
+     * @param Field $field
+     *
+     * @return mixed
+     */
+    public function map(Field $field)
+    {
+        $values = array();
+
+        foreach ($field->value as $value) {
+            $values[] = $this->convert($value);
+        }
+
+        return $values;
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/MultipleIntegerMapper.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/MultipleIntegerMapper.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType\MultipleIntegerField;
+
+/**
+ * Maps raw document field values to something search engine can index.
+ */
+class MultipleIntegerMapper extends IntegerMapper
+{
+    /**
+     * Check if field can be mapped.
+     *
+     * @param Field $field
+     *
+     * @return bool
+     */
+    public function canMap(Field $field)
+    {
+        return $field->type instanceof MultipleIntegerField;
+    }
+
+    /**
+     * Map field value to a proper search engine representation.
+     *
+     * @param Field $field
+     *
+     * @return array
+     */
+    public function map(Field $field)
+    {
+        $values = array();
+
+        foreach ((array) $field->value as $value) {
+            $values[] = $this->convert($value);
+        }
+
+        return $values;
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/MultipleStringMapper.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/MultipleStringMapper.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Maps MultipleStringField document field values to something legacy search engine can index.
+ */
+class MultipleStringMapper extends StringMapper
+{
+    /**
+     * Check if field can be mapped.
+     *
+     * @param \eZ\Publish\SPI\Search\Field $field
+     *
+     * @return bool
+     */
+    public function canMap(Field $field)
+    {
+        return
+            $field->type instanceof FieldType\MultipleStringField ||
+            $field->type instanceof FieldType\FullTextField;
+    }
+
+    /**
+     * Map field value to a proper search engine representation.
+     *
+     * @param \eZ\Publish\SPI\Search\Field $field
+     *
+     * @return array
+     */
+    public function map(Field $field)
+    {
+        $values = array();
+
+        foreach ((array) $field->value as $value) {
+            $values[] = $this->convert($value);
+        }
+
+        return $values;
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/PriceMapper.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/PriceMapper.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+
+use eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Maps raw document field values to something search engine can index.
+ */
+class PriceMapper extends FieldValueMapper
+{
+    /**
+     * Check if field can be mapped.
+     *
+     * @param Field $field
+     *
+     * @return bool
+     */
+    public function canMap(Field $field)
+    {
+        return $field->type instanceof FieldType\PriceField;
+    }
+
+    /**
+     * Map field value to a proper search engine representation.
+     *
+     * @param Field $field
+     *
+     * @return mixed
+     */
+    public function map(Field $field)
+    {
+        return (double) $field->value;
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/StringMapper.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/FieldValueMapper/StringMapper.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+
+use eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType;
+
+/**
+ * Maps raw document field values to something legacy search engine can index.
+ */
+class StringMapper extends FieldValueMapper
+{
+    /**
+     * Check if field can be mapped.
+     *
+     * @param Field $field
+     *
+     * @return bool
+     */
+    public function canMap(Field $field)
+    {
+        return
+            $field->type instanceof FieldType\StringField ||
+            $field->type instanceof FieldType\TextField;
+    }
+
+    /**
+     * Map field value to a proper search engine representation.
+     *
+     * @param Field $field
+     *
+     * @return mixed
+     */
+    public function map(Field $field)
+    {
+        return $this->convert($field->value);
+    }
+
+    /**
+     * Convert to a proper legacy search engine representation.
+     *
+     * @param mixed $value
+     *
+     * @return string
+     */
+    protected function convert($value)
+    {
+        // Remove non-printable characters
+        return preg_replace('([\x00-\x09\x0B\x0C\x1E\x1F]+)', '', (string) $value);
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/FullTextData.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/FullTextData.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * Represents full text data of FullTextValue(s) for a Content object.
+ */
+class FullTextData extends ValueObject
+{
+    /**
+     * Content object Id.
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * Content object content type Id.
+     *
+     * @var int
+     */
+    public $contentTypeId;
+
+    /**
+     * Content object section Id.
+     *
+     * @var int
+     */
+    public $sectionId;
+
+    /**
+     * Content object publication timestamp.
+     *
+     * @var int
+     */
+    public $published;
+
+    /**
+     * List of FullTextValue objects corresponding to content object fields (per translation).
+     *
+     * @var \eZ\Publish\Core\Search\Legacy\Content\FullTextValue[];
+     */
+    public $values;
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/FullTextValue.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/FullTextValue.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * Represents full text searchable value of Content object field which can be indexed by the legacy search engine.
+ */
+class FullTextValue extends ValueObject
+{
+    /**
+     * Content object field Id.
+     *
+     * @var int
+     */
+    public $id;
+
+    /**
+     * Content object field definition id.
+     *
+     * @var int
+     */
+    public $fieldDefinitionId;
+
+    /**
+     * @var string
+     */
+    public $languageCode;
+
+    /**
+     * Searchable value.
+     *
+     * @var string
+     */
+    public $value;
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Handler.php
@@ -5,8 +5,6 @@
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
- *
- * @version //autogentag//
  */
 namespace eZ\Publish\Core\Search\Legacy\Content;
 
@@ -16,6 +14,7 @@ use eZ\Publish\SPI\Search\Handler as SearchHandlerInterface;
 use eZ\Publish\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper;
 use eZ\Publish\Core\Search\Legacy\Content\Location\Gateway as LocationGateway;
+use eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway as WordIndexerGateway;
 use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
@@ -25,6 +24,7 @@ use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\SPI\Persistence\Content\Language\Handler as LanguageHandler;
+use eZ\Publish\Core\Search\Legacy\Content\Mapper\FullTextMapper;
 
 /**
  * The Content Search handler retrieves sets of of Content objects, based on a
@@ -64,6 +64,13 @@ class Handler implements SearchHandlerInterface
     protected $locationGateway;
 
     /**
+     * Word indexer gateway.
+     *
+     * @var \eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway
+     */
+    protected $indexerGateway;
+
+    /**
      * Content mapper.
      *
      * @var \eZ\Publish\Core\Persistence\Legacy\Content\Mapper
@@ -85,40 +92,53 @@ class Handler implements SearchHandlerInterface
     protected $languageHandler;
 
     /**
+     * FullText mapper.
+     *
+     * @var \eZ\Publish\Core\Search\Legacy\Content\Mapper\FullTextMapper
+     */
+    protected $mapper;
+
+    /**
      * Creates a new content handler.
      *
      * @param \eZ\Publish\Core\Search\Legacy\Content\Gateway $gateway
      * @param \eZ\Publish\Core\Search\Legacy\Content\Location\Gateway $locationGateway
+     * @param \eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway $indexerGateway
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\Mapper $contentMapper
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper $locationMapper
      * @param \eZ\Publish\SPI\Persistence\Content\Language\Handler $languageHandler
+     * @param \eZ\Publish\Core\Search\Legacy\Content\Mapper\FullTextMapper $mapper
      */
     public function __construct(
         Gateway $gateway,
         LocationGateway $locationGateway,
+        WordIndexerGateway $indexerGateway,
         ContentMapper $contentMapper,
         LocationMapper $locationMapper,
-        LanguageHandler $languageHandler
+        LanguageHandler $languageHandler,
+        FullTextMapper $mapper
     ) {
         $this->gateway = $gateway;
         $this->locationGateway = $locationGateway;
+        $this->indexerGateway = $indexerGateway;
         $this->contentMapper = $contentMapper;
         $this->locationMapper = $locationMapper;
         $this->languageHandler = $languageHandler;
+        $this->mapper = $mapper;
     }
 
     /**
      * Finds content objects for the given query.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if Query criterion is not applicable to its target
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query $query
      * @param array $languageFilter - a map of language related filters specifying languages query will be performed on.
      *        Also used to define which field languages are loaded for the returned content.
      *        Currently supports: <code>array("languages" => array(<language1>,..), "useAlwaysAvailable" => bool)</code>
      *                            useAlwaysAvailable defaults to true to avoid exceptions on missing translations
+     * @return SearchResult if Query criterion is not applicable to its target
      *
-     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
+     * @throws NotImplementedException
      */
     public function findContent(Query $query, array $languageFilter = array())
     {
@@ -294,6 +314,7 @@ class Handler implements SearchHandlerInterface
      * @param string[] $fieldPaths
      * @param int $limit
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $filter
+     * @throws NotImplementedException
      */
     public function suggest($prefix, $fieldPaths = array(), $limit = 10, Criterion $filter = null)
     {
@@ -307,7 +328,29 @@ class Handler implements SearchHandlerInterface
      */
     public function indexContent(Content $content)
     {
-        // Not implemented in Legacy Storage Engine
+        $fullTextValue = $this->mapper->mapContent($content);
+
+        $this->indexerGateway->index($fullTextValue);
+    }
+
+    /**
+     * Bulk index list of content objects.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content[] $contentList
+     * @param callable $errorCallback (Content $content, NotFoundException $e)
+     */
+    public function bulkIndex(array $contentList, callable $errorCallback)
+    {
+        $fullTextBulkData = [];
+        foreach ($contentList as $content) {
+            try {
+                $fullTextBulkData[] = $this->mapper->mapContent($content);
+            } catch (NotFoundException $e) {
+                $errorCallback($content, $e);
+            }
+        }
+
+        $this->indexerGateway->bulkIndex($fullTextBulkData);
     }
 
     /**
@@ -315,7 +358,7 @@ class Handler implements SearchHandlerInterface
      */
     public function indexLocation(Location $location)
     {
-        // Not implemented in Legacy Storage Engine
+        // Not needed with Legacy Storage/Search Engine
     }
 
     /**
@@ -326,7 +369,7 @@ class Handler implements SearchHandlerInterface
      */
     public function deleteContent($contentId, $versionId = null)
     {
-        // Not implemented in Legacy Storage Engine
+        $this->indexerGateway->remove($contentId, $versionId);
     }
 
     /**
@@ -337,6 +380,24 @@ class Handler implements SearchHandlerInterface
      */
     public function deleteLocation($locationId, $contentId)
     {
-        // Not implemented in Legacy Storage Engine
+        // Not needed with Legacy Storage/Search Engine
+    }
+
+    /**
+     * Purges all contents from the index.
+     */
+    public function purgeIndex()
+    {
+        $this->indexerGateway->purgeIndex();
+    }
+
+    /**
+     * Commits the data to the index, making it available for search.
+     *
+     * @param bool $flush
+     */
+    public function commit($flush = false)
+    {
+        // Not needed with Legacy Storage/Search Engine
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Mapper/FullTextMapper.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Mapper/FullTextMapper.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content\Mapper;
+
+use eZ\Publish\Core\Search\Common\FieldRegistry;
+use eZ\Publish\Core\Search\Legacy\Content\FullTextData;
+use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\SPI\Persistence\Content\Type;
+use eZ\Publish\SPI\Search\FieldType;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
+use eZ\Publish\Core\Search\Legacy\Content\FullTextValue;
+
+/**
+ * FullTextMapper maps Content object fields to FullTextValue objects which are searchable and therefore can be indexed by the legacy search engine.
+ */
+class FullTextMapper
+{
+    /**
+     * Field registry.
+     *
+     * @var \eZ\Publish\Core\Search\Common\FieldRegistry
+     */
+    protected $fieldRegistry;
+
+    /**
+     * Content type handler.
+     *
+     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
+     */
+    protected $contentTypeHandler;
+
+    /**
+     * @param \eZ\Publish\Core\Search\Common\FieldRegistry $fieldRegistry
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $contentTypeHandler
+     */
+    public function __construct(
+        FieldRegistry $fieldRegistry,
+        ContentTypeHandler $contentTypeHandler
+    ) {
+        $this->fieldRegistry = $fieldRegistry;
+        $this->contentTypeHandler = $contentTypeHandler;
+    }
+
+    /**
+     * Map given Content to a FullTextValue.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     *
+     * @return \eZ\Publish\Core\Search\Legacy\Content\FullTextData
+     */
+    public function mapContent(Content $content)
+    {
+        return new FullTextData(
+            [
+                'id' => $content->versionInfo->contentInfo->id,
+                'contentTypeId' => $content->versionInfo->contentInfo->contentTypeId,
+                'sectionId' => $content->versionInfo->contentInfo->sectionId,
+                'published' => $content->versionInfo->contentInfo->publicationDate,
+                'values' => $this->getFullTextValues($content),
+            ]
+        );
+    }
+
+    /**
+     * Returns an array of FullTextValue object containing searchable values of content object fields for the given $content.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content $content
+     *
+     * @return \eZ\Publish\Core\Search\Legacy\Content\FullTextValue[]
+     */
+    protected function getFullTextValues(Content $content)
+    {
+        $fullTextValues = [];
+        foreach ($content->fields as $field) {
+            $fieldDefinition = $this->contentTypeHandler->getFieldDefinition($field->fieldDefinitionId, Content\Type::STATUS_DEFINED);
+            if (!$fieldDefinition->isSearchable) {
+                continue;
+            }
+
+            $value = $this->getFullTextFieldValue($field, $fieldDefinition);
+            if (empty($value)) {
+                continue;
+            }
+
+            $fullTextValues[] = new FullTextValue(
+                [
+                    'id' => $field->id,
+                    'fieldDefinitionId' => $field->fieldDefinitionId,
+                    'languageCode' => $field->languageCode,
+                    'value' => !is_array($value) ? $value : implode(' ', $value),
+                ]
+            );
+        }
+
+        return $fullTextValues;
+    }
+
+    /**
+     * Get FullTextField value.
+     *
+     * @param Content\Field $field
+     * @param Type\FieldDefinition $fieldDefinition
+     * @return string
+     */
+    private function getFullTextFieldValue(Content\Field $field, Type\FieldDefinition $fieldDefinition)
+    {
+        $fieldType = $this->fieldRegistry->getType($field->type);
+        $indexFields = $fieldType->getIndexData($field, $fieldDefinition);
+
+        // find value to be returned (stored in FullTextField)
+        $fullTextFieldValue = '';
+        foreach ($indexFields as $field) {
+            /** @var \eZ\Publish\SPI\Search\Field $field */
+            if ($field->type instanceof FieldType\FullTextField) {
+                $fullTextFieldValue = $field->value;
+                break;
+            }
+        }
+
+        return !is_array($fullTextFieldValue) ? $fullTextFieldValue : implode(' ', $fullTextFieldValue); // some full text fields are stored as an array of strings
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * File containing the WordIndexer Gateway class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content\WordIndexer;
+
+use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\Core\Search\Legacy\Content\FullTextData;
+
+/**
+ * The WordIndexer Gateway abstracts indexing of content full text data.
+ */
+abstract class Gateway
+{
+    /**
+     * Index search engine FullTextData objects corresponding to content object field values.
+     *
+     * @param \eZ\Publish\Core\Search\Legacy\Content\FullTextData $fullTextValue
+     */
+    abstract public function index(FullTextData $fullTextValue);
+
+    /**
+     * Remove whole content or a specific version from index.
+     *
+     * @param mixed      $contentId
+     * @param mixed|null $versionId
+     */
+    abstract public function remove($contentId, $versionId = null);
+
+    /**
+     * Indexes an array of FullTextData objects.
+     *
+     * @param \eZ\Publish\Core\Search\Legacy\Content\FullTextData[] $fullTextBulkData
+     */
+    abstract public function bulkIndex(array $fullTextBulkData);
+
+    /**
+     * Remove entire search index.
+     */
+    abstract public function purgeIndex();
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
@@ -1,0 +1,360 @@
+<?php
+/**
+ * File containing the DoctrineDatabase Content search Gateway class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway;
+
+use eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway;
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+use eZ\Publish\Core\Persistence\TransformationProcessor;
+use eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Repository\SearchIndex;
+use eZ\Publish\Core\Search\Legacy\Content\FullTextData;
+use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as SPITypeHandler;
+use eZ\Publish\SPI\Search\Field;
+
+/**
+ * WordIndexer gateway implementation using the Doctrine database.
+ */
+class DoctrineDatabase extends Gateway
+{
+    /**
+     * Database handler.
+     *
+     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
+     */
+    protected $dbHandler;
+
+    /**
+     * SPI Content Type Handler.
+     *
+     * Need this for being able to pick fields that are searchable.
+     *
+     * @var \eZ\Publish\SPI\Persistence\Content\Type\Handler
+     */
+    protected $typeHandler;
+
+    /**
+     * Transformation processor.
+     *
+     * Need this for being able to transform text to searchable value
+     *
+     * @var \eZ\Publish\Core\Persistence\TransformationProcessor
+     */
+    protected $transformationProcessor;
+
+    /**
+     * LegacySearchService.
+     *
+     * Need this for queries on ezsearch* tables
+     *
+     * @var \eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Repository\SearchIndex
+     */
+    protected $searchIndex;
+
+    /**
+     * Construct from handler handler.
+     *
+     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler                     $dbHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler                          $typeHandler
+     * @param \eZ\Publish\Core\Persistence\TransformationProcessor                      $transformationProcessor
+     * @param \eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Repository\SearchIndex $searchIndex
+     */
+    public function __construct(
+        DatabaseHandler $dbHandler,
+        SPITypeHandler $typeHandler,
+        TransformationProcessor $transformationProcessor,
+        SearchIndex $searchIndex
+    ) {
+        $this->dbHandler = $dbHandler;
+        $this->typeHandler = $typeHandler;
+        $this->transformationProcessor = $transformationProcessor;
+        $this->searchIndex = $searchIndex;
+        $this->dbMaxInt = $this->getDbMaxInt($dbHandler->getName());
+    }
+
+    /**
+     * Index search engine full text data corresponding to content object field values.
+     *
+     * Ported from the legacy code
+     * @see https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/search/plugins/ezsearchengine/ezsearchengine.php#L45
+     *
+     * @param \eZ\Publish\Core\Search\Legacy\Content\FullTextData $fullTextData
+     */
+    public function index(FullTextData $fullTextData)
+    {
+        $indexArray = array();
+        $indexArrayOnlyWords = array();
+        $wordCount = 0;
+        $placement = 0;
+
+        foreach ($fullTextData->values as $fullTextValue) {
+            /** @var \eZ\Publish\Core\Search\Legacy\Content\FullTextValue $fullTextValue */
+            if (is_numeric(trim($fullTextValue->value))) {
+                $integerValue = (int)$fullTextValue->value;
+                if ($integerValue > $this->dbMaxInt) {
+                    $integerValue = 0;
+                }
+            } else {
+                $integerValue = 0;
+            }
+            // Split text on whitespace
+            $wordArray = explode(' ', $fullTextValue->value);
+            foreach ($wordArray as $word) {
+                if (trim($word) === '') {
+                    continue;
+                }
+                $word = $this->transformationProcessor->transformByGroup($word, 'lowercase'); // to keep consistency with {@see buildWordIDArray} method
+                // words stored in search index are limited to 150 characters
+                if (mb_strlen($word) > 150) {
+                    $word = mb_substr($word, 0, 150);
+                }
+                $indexArray[] = array('Word' => $word,
+                    'ContentClassAttributeID' => $fullTextValue->fieldDefinitionId,
+                    'identifier' => $fullTextValue->id,
+                    'integer_value' => $integerValue, );
+                $indexArrayOnlyWords[$word] = 1;
+                ++$wordCount;
+                // if we have "www." before word than
+                // treat it as url and add additional entry to the index
+                if (mb_substr(mb_strtolower($word), 0, 4) === 'www.') {
+                    $additionalUrlWord = substr($word, 4);
+                    $indexArray[] = array('Word' => $additionalUrlWord,
+                        'ContentClassAttributeID' => $fullTextValue->fieldDefinitionId,
+                        'identifier' => $fullTextValue->id,
+                        'integer_value' => $integerValue, );
+                    $indexArrayOnlyWords[$additionalUrlWord] = 1;
+                    ++$wordCount;
+                }
+            }
+        }
+
+        $wordIDArray = $this->buildWordIDArray(array_keys($indexArrayOnlyWords));
+        $this->dbHandler->beginTransaction();
+        for ($arrayCount = 0; $arrayCount < $wordCount; $arrayCount += 1000) {
+            $placement = $this->indexWords($fullTextData, array_slice($indexArray, $arrayCount, 1000), $wordIDArray, $placement);
+        }
+        $this->dbHandler->commit();
+    }
+
+    /**
+     * Indexes an array of FullTextData objects.
+     *
+     * Notes:
+     * - On large amounts of data make sure to iterate with several calls to this function with a limited
+     *   set of documents, amount you have memory for depends on server, size of documents, & PHP version.
+     *
+     * @param \eZ\Publish\Core\Search\Legacy\Content\FullTextData[] $fullTextBulkData
+     */
+    public function bulkIndex(array $fullTextBulkData)
+    {
+        foreach ($fullTextBulkData as $fullTextData) {
+            $this->index($fullTextData);
+        }
+    }
+
+    /**
+     * Remove whole content or a specific version from index.
+     *
+     * Ported from the legacy code
+     * @see https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/search/plugins/ezsearchengine/ezsearchengine.php#L386
+     *
+     * @param mixed $contentId
+     * @param mixed|null $versionId
+     *
+     * @return bool
+     */
+    public function remove($contentId, $versionId = null)
+    {
+        $doDelete = false;
+        $this->dbHandler->beginTransaction();
+        // fetch all the words and decrease the object count on all the words
+        $wordIDList = $this->searchIndex->getContentObjectWords($contentId);
+        if (count($wordIDList) > 0) {
+            $this->searchIndex->decrementWordObjectCount($wordIDList);
+            $doDelete = true;
+        }
+        if ($doDelete) {
+            $this->searchIndex->deleteWordsWithoutObjects();
+            $this->searchIndex->deleteObjectWordsLink($contentId);
+        }
+        $this->dbHandler->commit();
+
+        return true;
+    }
+
+    /**
+     * Remove entire search index.
+     */
+    public function purgeIndex()
+    {
+        $this->searchIndex->purge();
+    }
+
+    /**
+     * Index wordIndex.
+     *
+     * Ported from the legacy code
+     *
+     * @see https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/search/plugins/ezsearchengine/ezsearchengine.php#L255
+     *
+     * @param \eZ\Publish\Core\Search\Legacy\Content\FullTextData $fullTextData
+     * @param array $indexArray
+     * @param array $wordIDArray
+     * @param int $placement
+     *
+     * @return int last placement
+     */
+    private function indexWords(FullTextData $fullTextData, array $indexArray, array $wordIDArray, $placement = 0)
+    {
+        $contentId = $fullTextData->id;
+
+        $prevWordId = 0;
+
+        for ($i = 0; $i < count($indexArray); ++$i) {
+            $indexWord = $indexArray[$i]['Word'];
+            $contentFieldId = $indexArray[$i]['ContentClassAttributeID'];
+            $identifier = $indexArray[$i]['identifier'];
+            $integerValue = $indexArray[$i]['integer_value'];
+            $wordId = $wordIDArray[$indexWord];
+
+            if (isset($indexArray[$i + 1])) {
+                $nextIndexWord = $indexArray[$i + 1]['Word'];
+                $nextWordId = $wordIDArray[$nextIndexWord];
+            } else {
+                $nextWordId = 0;
+            }
+            $frequency = 0;
+            $this->searchIndex->addObjectWordLink($wordId, $contentId, $frequency, $placement, $nextWordId, $prevWordId, $fullTextData->contentTypeId, $contentFieldId, $fullTextData->published, $fullTextData->sectionId, $identifier, $integerValue);
+            $prevWordId = $wordId;
+            ++$placement;
+        }
+
+        return $placement;
+    }
+
+    /**
+     * Find first \eZ\Publish\SPI\Search\Field with given name and return its value.
+     *
+     * @param \eZ\Publish\SPI\Search\Field[] $fields
+     * @param string $name
+     * @return mixed
+     */
+    private function getFirstSearchFieldValue(array $fields, $name)
+    {
+        $filtered = array_values(
+            array_filter($fields, function (Field $field) use ($name) {
+                return $field->name === $name;
+            })
+        );
+
+        return isset($filtered[0]) ? $filtered[0]->value : null;
+    }
+
+    /**
+     * Remove duplicated spaces.
+     *
+     * @param string $text
+     *
+     * @return string
+     */
+    private static function removeDuplicatedSpaces($text)
+    {
+        return preg_replace('/\s{2,}/', ' ', $text);
+    }
+
+    /**
+     * Remove single and double quotes, including UTF-8 variations.
+     *
+     * @param string $text
+     *
+     * @return string
+     */
+    private static function removeAllQuotes($text)
+    {
+        return preg_replace('/([\x{2018}-\x{201f}]|\'|")/u', ' ', $text);
+    }
+
+    /**
+     * Build WordIDArray and update ezsearch_word table.
+     *
+     * Ported from the legacy code
+     *
+     * @see https://github.com/ezsystems/ezpublish-legacy/blob/master/kernel/search/plugins/ezsearchengine/ezsearchengine.php#L155
+     *
+     * @param array $indexArrayOnlyWords words for object to add
+     *
+     * @return array wordIDArray
+     */
+    private function buildWordIDArray(array $indexArrayOnlyWords)
+    {
+        $wordCount = count($indexArrayOnlyWords);
+        $wordIDArray = array();
+        $wordArray = array();
+
+        // store the words in the index and remember the ID
+        $this->dbHandler->beginTransaction();
+        for ($arrayCount = 0; $arrayCount < $wordCount; $arrayCount += 500) {
+            // Fetch already indexed words from database
+            $wordArrayChuck = array_slice($indexArrayOnlyWords, $arrayCount, 500);
+            $wordRes = $this->searchIndex->getWords($wordArrayChuck);
+
+            // Build a has of the existing words
+            $wordResCount = count($wordRes);
+            $existingWordArray = array();
+            for ($i = 0; $i < $wordResCount; ++$i) {
+                $wordIDArray[] = $wordRes[$i]['id'];
+                $existingWordArray[] = $wordRes[$i]['word'];
+                $wordArray[$wordRes[$i]['word']] = $wordRes[$i]['id'];
+            }
+
+            // Update the object count of existing words by one
+            if (count($wordIDArray) > 0) {
+                $this->searchIndex->incrementWordObjectCount($wordIDArray);
+            }
+
+            // Insert if there is any news words
+            $newWordArray = array_diff($wordArrayChuck, $existingWordArray);
+            if (count($newWordArray) > 0) {
+                $this->searchIndex->addWords($newWordArray);
+                $newWordRes = $this->searchIndex->getWords($newWordArray);
+                $newWordCount = count($newWordRes);
+                for ($i = 0; $i < $newWordCount; ++$i) {
+                    $wordLowercase = $this->transformationProcessor->transformByGroup($newWordRes[$i]['word'], 'lowercase');
+                    $wordArray[$wordLowercase] = $newWordRes[$i]['id'];
+                }
+            }
+        }
+        $this->dbHandler->commit();
+
+        return $wordArray;
+    }
+
+    /**
+     * Max value of an integer allowed by DB.
+     *
+     * @var int
+     */
+    private $dbMaxInt;
+
+    /**
+     * Get max acceptable INT value depending on $dbName.
+     *
+     * @param $dbName
+     * @return int
+     */
+    private function getDbMaxInt($dbName)
+    {
+        // A Strategy could be used here, but in this case it seems like adding an unnecessary complexity
+        switch ($dbName) {
+            case 'sqlite':
+            case 'oracle': // oracle actually can store up to 38 digits, but PHP can't
+                return 9223372036854775807;
+            default:
+                return 2147483647;
+        }
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Repository/SearchIndex.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Repository/SearchIndex.php
@@ -1,0 +1,249 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Repository;
+
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+use eZ\Publish\Core\Persistence\Database\SelectQuery;
+use PDO;
+
+/**
+ * A service encapsulating database operations on ezsearch* tables.
+ */
+class SearchIndex
+{
+    /**
+     * Database handler.
+     *
+     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
+     */
+    protected $dbHandler;
+
+    /**
+     * SearchIndex constructor.
+     *
+     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
+     */
+    public function __construct(
+        DatabaseHandler $dbHandler
+    ) {
+        $this->dbHandler = $dbHandler;
+    }
+
+    /**
+     * Fetch already indexed words from database (legacy db table: ezsearch_word).
+     *
+     * @param array $words
+     *
+     * @return array
+     */
+    public function getWords(array $words)
+    {
+        $query = $this->dbHandler->createSelectQuery();
+
+        $query->select('*')
+            ->from('ezsearch_word')
+            ->where($query->expr->in('word', array_map('strval', $words))); // some DBMS-es do not cast integers to strings by default
+
+        $stmt = $query->prepare();
+        $stmt->execute();
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Increase the object count of the given words by one.
+     *
+     * @param array $wordId
+     */
+    public function incrementWordObjectCount(array $wordId)
+    {
+        $this->updateWordObjectCount($wordId, ['object_count' => 'object_count + 1']);
+    }
+
+    /**
+     * Decrease the object count of the given words by one.
+     *
+     * @param array $wordId
+     */
+    public function decrementWordObjectCount(array $wordId)
+    {
+        $this->updateWordObjectCount($wordId, ['object_count' => 'object_count - 1']);
+    }
+
+    /**
+     * Insert new words (legacy db table: ezsearch_word).
+     *
+     * @param array $words
+     */
+    public function addWords(array $words)
+    {
+        $query = $this->dbHandler->createInsertQuery();
+        $query->insertInto('ezsearch_word');
+
+        $word = null;
+
+        $query->set(
+            'word',
+            ':word'
+        )->set(
+            'object_count',
+            '1'
+        );
+        $stmt = $query->prepare();
+        foreach ($words as $word) {
+            $stmt->execute(['word' => $word]);
+        }
+    }
+
+    /**
+     * Remove entire search index.
+     */
+    public function purge()
+    {
+        $this->dbHandler->beginTransaction();
+        $query = $this->dbHandler->createDeleteQuery();
+        $tables = ['ezsearch_object_word_link', 'ezsearch_return_count', 'ezsearch_search_phrase', 'ezsearch_word'];
+        foreach ($tables as $tbl) {
+            $query->deleteFrom($tbl);
+            $stmt = $query->prepare();
+            $stmt->execute();
+        }
+        $this->dbHandler->commit();
+    }
+
+    /**
+     * Link word with specific content object (legacy db table: ezsearch_object_word_link).
+     *
+     * @param $wordId
+     * @param $contentId
+     * @param $frequency
+     * @param $placement
+     * @param $nextWordId
+     * @param $prevWordId
+     * @param $contentTypeId
+     * @param $fieldTypeId
+     * @param $published
+     * @param $sectionId
+     * @param $identifier
+     * @param $integerValue
+     */
+    public function addObjectWordLink($wordId, $contentId, $frequency, $placement, $nextWordId, $prevWordId,
+                                      $contentTypeId, $fieldTypeId, $published, $sectionId, $identifier,
+                                      $integerValue)
+    {
+        $assoc = [
+            'word_id' => $wordId,
+            'contentobject_id' => $contentId,
+            'frequency' => $frequency,
+            'placement' => $placement,
+            'next_word_id' => $nextWordId,
+            'prev_word_id' => $prevWordId,
+            'contentclass_id' => $contentTypeId,
+            'contentclass_attribute_id' => $fieldTypeId,
+            'published' => $published,
+            'section_id' => $sectionId,
+            'identifier' => $identifier,
+            'integer_value' => $integerValue,
+        ];
+        $query = $this->dbHandler->createInsertQuery();
+        $query->insertInto('ezsearch_object_word_link');
+        foreach ($assoc as $column => $value) {
+            $query->set($this->dbHandler->quoteColumn($column), $query->bindValue($value));
+        }
+        $stmt = $query->prepare();
+        $stmt->execute();
+    }
+
+    /**
+     * Get all words related to the content object (legacy db table: ezsearch_object_word_link).
+     *
+     * @param $contentId
+     *
+     * @return array
+     */
+    public function getContentObjectWords($contentId)
+    {
+        $query = $this->dbHandler->createSelectQuery();
+
+        $this->setContentObjectWordsSelectQuery($query);
+
+        $stmt = $query->prepare();
+        $stmt->execute(['contentId' => $contentId]);
+
+        $wordIDList = [];
+
+        while (false !== ($row = $stmt->fetch(PDO::FETCH_NUM))) {
+            $wordIDList[] = $row[0];
+        }
+
+        return $wordIDList;
+    }
+
+    /**
+     * Delete words not related to any content object.
+     */
+    public function deleteWordsWithoutObjects()
+    {
+        $query = $this->dbHandler->createDeleteQuery();
+
+        $query->deleteFrom($this->dbHandler->quoteTable('ezsearch_word'))
+            ->where($query->expr->eq($this->dbHandler->quoteColumn('object_count'), ':c'));
+
+        $stmt = $query->prepare();
+        $stmt->execute(['c' => 0]);
+    }
+
+    /**
+     * Delete relation between a word and a content object.
+     *
+     * @param $contentId
+     */
+    public function deleteObjectWordsLink($contentId)
+    {
+        $query = $this->dbHandler->createDeleteQuery();
+        $query->deleteFrom($this->dbHandler->quoteTable('ezsearch_object_word_link'))
+            ->where($query->expr->eq($this->dbHandler->quoteColumn('contentobject_id'), ':contentId'));
+
+        $stmt = $query->prepare();
+        $stmt->execute(['contentId' => $contentId]);
+    }
+
+    /**
+     * Set query selecting word ids for content object (method was extracted to be reusable).
+     *
+     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
+     */
+    private function setContentObjectWordsSelectQuery(SelectQuery $query)
+    {
+        $query->select('word_id')
+            ->from($this->dbHandler->quoteTable('ezsearch_object_word_link'))
+            ->where($query->expr->eq($this->dbHandler->quoteColumn('contentobject_id'), ':contentId'));
+    }
+
+    /**
+     * Update object count for words (legacy db table: ezsearch_word).
+     *
+     * @param array $wordId  list of word IDs
+     * @param array $columns map of columns and values to be updated ([column => value])
+     */
+    private function updateWordObjectCount(array $wordId, array $columns)
+    {
+        $query = $this->dbHandler->createUpdateQuery();
+        $query->update($this->dbHandler->quoteTable('ezsearch_word'));
+
+        foreach ($columns as $column => $value) {
+            $query->set($this->dbHandler->quoteColumn($column), $value);
+        }
+
+        $query->where($query->expr->in($this->dbHandler->quoteColumn('id'), $wordId));
+
+        $stmt = $query->prepare();
+        $stmt->execute();
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentSortTest.php
@@ -99,9 +99,16 @@ class HandlerContentSortTest extends LanguageAwareTestCase
                 $this->getLanguageHandler()
             ),
             $this->getMock('eZ\\Publish\\Core\\Search\\Legacy\\Content\\Location\\Gateway'),
+            new Content\WordIndexer\Gateway\DoctrineDatabase(
+                $this->getDatabaseHandler(),
+                $this->getContentTypeHandler(),
+                $this->getDefinitionBasedTransformationProcessor(),
+                new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseHandler())
+            ),
             $this->getContentMapperMock(),
             $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Mapper'),
-            $this->getLanguageHandler()
+            $this->getLanguageHandler(),
+            $this->getFullTextMapper($this->getContentTypeHandler())
         );
     }
 

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
@@ -218,9 +218,16 @@ class HandlerContentTest extends LanguageAwareTestCase
                 $this->getLanguageHandler()
             ),
             $this->getMock('eZ\\Publish\\Core\\Search\\Legacy\\Content\\Location\\Gateway'),
+            new Content\WordIndexer\Gateway\DoctrineDatabase(
+                $this->getDatabaseHandler(),
+                $this->getContentTypeHandler(),
+                $this->getDefinitionBasedTransformationProcessor(),
+                new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseHandler())
+            ),
             $this->getContentMapperMock(),
             $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Mapper'),
-            $this->getLanguageHandler()
+            $this->getLanguageHandler(),
+            $this->getFullTextMapper($this->getContentTypeHandler())
         );
     }
 

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
@@ -123,9 +123,16 @@ class HandlerLocationSortTest extends LanguageAwareTestCase
                 ),
                 $this->getLanguageHandler()
             ),
+            new Content\WordIndexer\Gateway\DoctrineDatabase(
+                $this->getDatabaseHandler(),
+                $this->getContentTypeHandler(),
+                $this->getDefinitionBasedTransformationProcessor(),
+                new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseHandler())
+            ),
             $this->getMockBuilder('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Mapper')->disableOriginalConstructor()->getMock(),
             $this->getLocationMapperMock(),
-            $this->getLanguageHandler()
+            $this->getLanguageHandler(),
+            $this->getFullTextMapper($this->getContentTypeHandler())
         );
     }
 

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
@@ -191,9 +191,16 @@ class HandlerLocationTest extends LanguageAwareTestCase
                 ),
                 $this->getLanguageHandler()
             ),
+            new Content\WordIndexer\Gateway\DoctrineDatabase(
+                $this->getDatabaseHandler(),
+                $this->getContentTypeHandler(),
+                $transformationProcessor,
+                new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseHandler())
+            ),
             $this->getMockBuilder('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Mapper')->disableOriginalConstructor()->getMock(),
             $this->getLocationMapperMock(),
-            $this->getLanguageHandler()
+            $this->getLanguageHandler(),
+            $this->getFullTextMapper($this->getContentTypeHandler())
         );
     }
 

--- a/eZ/Publish/Core/settings/containerBuilder.php
+++ b/eZ/Publish/Core/settings/containerBuilder.php
@@ -60,4 +60,6 @@ $containerBuilder->addCompilerPass(new Compiler\Search\Legacy\CriteriaConverterP
 $containerBuilder->addCompilerPass(new Compiler\Search\Legacy\CriterionFieldValueHandlerRegistryPass());
 $containerBuilder->addCompilerPass(new Compiler\Search\Legacy\SortClauseConverterPass());
 
+$containerBuilder->addCompilerPass(new Compiler\Search\Legacy\AggregateFieldValueMapperPass());
+
 return $containerBuilder;

--- a/eZ/Publish/Core/settings/search_engines/legacy.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy.yml
@@ -6,6 +6,7 @@ imports:
     - {resource: search_engines/legacy/sort_clause_handlers_common.yml}
     - {resource: search_engines/legacy/sort_clause_handlers_content.yml}
     - {resource: search_engines/legacy/sort_clause_handlers_location.yml}
+    - {resource: search_engines/common.yml}
 
 parameters:
     ezpublish.spi.search.legacy.class: eZ\Publish\Core\Search\Legacy\Content\Handler
@@ -13,6 +14,7 @@ parameters:
     ezpublish.search.legacy.gateway.content.exception_conversion.class: eZ\Publish\Core\Search\Legacy\Content\Gateway\ExceptionConversion
     ezpublish.search.legacy.gateway.location.class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\DoctrineDatabase
     ezpublish.search.legacy.gateway.location.exception_conversion.class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\ExceptionConversion
+    ezpublish.search.legacy.mapper.fulltext.class: eZ\Publish\Core\Search\Legacy\Content\Mapper\FullTextMapper
 
     ezpublish.search.legacy.dbhandler.class: eZ\Publish\Core\Persistence\Doctrine\ConnectionHandler
     ezpublish.search.connection.class: Doctrine\DBAL\Connection
@@ -66,14 +68,25 @@ services:
     ezpublish.search.legacy.gateway.location:
         alias: ezpublish.search.legacy.gateway.location.exception_conversion
 
+    ezpublish.search.legacy.mapper.fulltext:
+        class: %ezpublish.search.legacy.mapper.fulltext.class%
+        arguments:
+            - @ezpublish.search.common.field_registry
+            - @ezpublish.spi.persistence.content_type_handler
+
+    ezpublish.search.legacy.fulltext_mapper:
+        alias: ezpublish.search.legacy.mapper.fulltext
+
     ezpublish.spi.search.legacy:
         class: %ezpublish.spi.search.legacy.class%
         arguments:
             - @ezpublish.search.legacy.gateway.content
             - @ezpublish.search.legacy.gateway.location
+            - @ezpublish.search.legacy.gateway.wordIndexer
             - @ezpublish.persistence.legacy.content.mapper
             - @ezpublish.persistence.legacy.location.mapper
             - @ezpublish.spi.persistence.language_handler
+            - @ezpublish.search.legacy.fulltext_mapper
         tags:
             - {name: ezpublish.searchEngine, alias: legacy}
         lazy: true

--- a/eZ/Publish/Core/settings/search_engines/legacy/field_value_mappers.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/field_value_mappers.yml
@@ -1,0 +1,74 @@
+parameters:
+    ezpublish.search.legacy.content.field_value_mapper.boolean.class: eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper\BooleanMapper
+    ezpublish.search.legacy.content.field_value_mapper.date.class: eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper\DateMapper
+    ezpublish.search.legacy.content.field_value_mapper.geo_location.class: eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper\GeoLocationMapper
+    ezpublish.search.legacy.content.field_value_mapper.float.class: eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper\FloatMapper
+    ezpublish.search.legacy.content.field_value_mapper.identifier.class: eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper\IdentifierMapper
+    ezpublish.search.legacy.content.field_value_mapper.integer.class: eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper\IntegerMapper
+    ezpublish.search.legacy.content.field_value_mapper.multiple_integer.class: eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper\MultipleIntegerMapper
+    ezpublish.search.legacy.content.field_value_mapper.multiple_boolean.class: eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper\MultipleBooleanMapper
+    ezpublish.search.legacy.content.field_value_mapper.multiple_identifier.class: eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper\MultipleIdentifierMapper
+    ezpublish.search.legacy.content.field_value_mapper.multiple_string.class: eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper\MultipleStringMapper
+    ezpublish.search.legacy.content.field_value_mapper.price.class: eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper\PriceMapper
+    ezpublish.search.legacy.content.field_value_mapper.string.class: eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper\StringMapper
+
+services:
+    ezpublish.search.legacy.content.field_value_mapper.boolean:
+        class: %ezpublish.search.legacy.content.field_value_mapper.boolean.class%
+        tags:
+            - {name: ezpublish.search.legacy.content.field_value_mapper}
+
+    ezpublish.search.legacy.content.field_value_mapper.date:
+        class: %ezpublish.search.legacy.content.field_value_mapper.date.class%
+        tags:
+            - {name: ezpublish.search.legacy.content.field_value_mapper}
+
+    ezpublish.search.legacy.content.field_value_mapper.geo_location:
+        class: %ezpublish.search.legacy.content.field_value_mapper.geo_location.class%
+        tags:
+            - {name: ezpublish.search.legacy.content.field_value_mapper}
+
+    ezpublish.search.legacy.content.field_value_mapper.float:
+        class: %ezpublish.search.legacy.content.field_value_mapper.float.class%
+        tags:
+            - {name: ezpublish.search.legacy.content.field_value_mapper}
+
+    ezpublish.search.legacy.content.field_value_mapper.identifier:
+        class: %ezpublish.search.legacy.content.field_value_mapper.identifier.class%
+        tags:
+            - {name: ezpublish.search.legacy.content.field_value_mapper}
+
+    ezpublish.search.legacy.content.field_value_mapper.multiple_integer:
+        class: %ezpublish.search.legacy.content.field_value_mapper.multiple_integer.class%
+        tags:
+            - {name: ezpublish.search.legacy.content.field_value_mapper}
+
+    ezpublish.search.legacy.content.field_value_mapper.integer:
+        class: %ezpublish.search.legacy.content.field_value_mapper.integer.class%
+        tags:
+            - {name: ezpublish.search.legacy.content.field_value_mapper}
+
+    ezpublish.search.legacy.content.field_value_mapper.multiple_boolean:
+        class: %ezpublish.search.legacy.content.field_value_mapper.multiple_boolean.class%
+        tags:
+            - {name: ezpublish.search.legacy.content.field_value_mapper}
+
+    ezpublish.search.legacy.content.field_value_mapper.multiple_identifier:
+        class: %ezpublish.search.legacy.content.field_value_mapper.multiple_identifier.class%
+        tags:
+            - {name: ezpublish.search.legacy.content.field_value_mapper}
+
+    ezpublish.search.legacy.content.field_value_mapper.multiple_string:
+        class: %ezpublish.search.legacy.content.field_value_mapper.multiple_string.class%
+        tags:
+            - {name: ezpublish.search.legacy.content.field_value_mapper}
+
+    ezpublish.search.legacy.content.field_value_mapper.price:
+        class: %ezpublish.search.legacy.content.field_value_mapper.price.class%
+        tags:
+            - {name: ezpublish.search.legacy.content.field_value_mapper}
+
+    ezpublish.search.legacy.content.field_value_mapper.string:
+        class: %ezpublish.search.legacy.content.field_value_mapper.string.class%
+        tags:
+            - {name: ezpublish.search.legacy.content.field_value_mapper}

--- a/eZ/Publish/Core/settings/search_engines/legacy/services.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/services.yml
@@ -1,6 +1,4 @@
 parameters:
-    ezpublish.spi.search.legacy.handler.content.class: eZ\Publish\Core\Search\Legacy\Content\Handler
-    ezpublish.spi.search.legacy.handler.location.class: eZ\Publish\Core\Search\Legacy\Content\Location\Handler
     ezpublish.search.legacy.gateway.content.class: eZ\Publish\Core\Search\Legacy\Content\Gateway\DoctrineDatabase
     ezpublish.search.legacy.gateway.content.exception_conversion.class: eZ\Publish\Core\Search\Legacy\Content\Gateway\ExceptionConversion
     ezpublish.search.legacy.gateway.location.class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\DoctrineDatabase
@@ -40,17 +38,3 @@ services:
     # To disable exception conversion layer override this alias so that it points to inner gateway
     ezpublish.search.legacy.gateway.location:
         alias: ezpublish.search.legacy.gateway.location.exception_conversion
-
-    ezpublish.spi.search.legacy.handler.content:
-        class: %ezpublish.spi.search.legacy.handler.content.class%
-        arguments:
-            - @ezpublish.search.legacy.gateway.content
-            - @ezpublish.persistence.legacy.content.mapper
-        lazy: true
-
-    ezpublish.spi.search.legacy.handler.location:
-        class: %ezpublish.spi.search.legacy.handler.location.class%
-        arguments:
-            - @ezpublish.search.legacy.gateway.location
-            - @ezpublish.persistence.legacy.location.mapper
-        lazy: true

--- a/eZ/Publish/Core/settings/search_engines/legacy/services.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/services.yml
@@ -1,8 +1,11 @@
 parameters:
     ezpublish.search.legacy.gateway.content.class: eZ\Publish\Core\Search\Legacy\Content\Gateway\DoctrineDatabase
     ezpublish.search.legacy.gateway.content.exception_conversion.class: eZ\Publish\Core\Search\Legacy\Content\Gateway\ExceptionConversion
+    ezpublish.search.legacy.gateway.wordIndexer.class: eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway\DoctrineDatabase
     ezpublish.search.legacy.gateway.location.class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\DoctrineDatabase
     ezpublish.search.legacy.gateway.location.exception_conversion.class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\ExceptionConversion
+    ezpublish.search.legacy.repository.searchIndex.class: eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Repository\SearchIndex
+    ezpublish.search.legacy.content.field_value_mapper.aggregate.class: eZ\Publish\Core\Search\Legacy\Content\FieldValueMapper
 
 services:
     ezpublish.search.legacy.gateway.content.inner:
@@ -22,6 +25,15 @@ services:
     ezpublish.search.legacy.gateway.content:
         alias: ezpublish.search.legacy.gateway.content.exception_conversion
 
+
+    ezpublish.search.legacy.gateway.wordIndexer:
+        class: %ezpublish.search.legacy.gateway.wordIndexer.class%
+        arguments:
+            - @ezpublish.api.storage_engine.legacy.dbhandler
+            - @ezpublish.spi.persistence.content_type_handler
+            - @ezpublish.api.storage_engine.transformation_processor
+            - @ezpublish.search.legacy.repository.searchIndex
+
     ezpublish.search.legacy.gateway.location.inner:
         class: %ezpublish.search.legacy.gateway.location.class%
         arguments:
@@ -38,3 +50,13 @@ services:
     # To disable exception conversion layer override this alias so that it points to inner gateway
     ezpublish.search.legacy.gateway.location:
         alias: ezpublish.search.legacy.gateway.location.exception_conversion
+
+    ezpublish.search.legacy.repository.searchIndex:
+        class: %ezpublish.search.legacy.repository.searchIndex.class%
+        arguments:
+            - @ezpublish.api.storage_engine.legacy.dbhandler
+
+    # Note: services tagged with 'ezpublish.search.legacy.content.field_value_mapper'
+    # are registered to this one using compilation pass
+    ezpublish.search.legacy.content.field_value_mapper.aggregate:
+        class: %ezpublish.search.legacy.content.field_value_mapper.aggregate.class%


### PR DESCRIPTION
This PR consists of several parts related to the issue [EZP-25088](https://jira.ez.no/browse/EZP-25088):
- [x] Integration test *(parts from #1533)*
- [x] Implementation WordIndex service *(sceleton from #1533)*
- [x] `ezplatform:lse_create_index` command to recreate legacy search engine index
- [x] Architecture issue: Platform does not seem to have a clear way to retrieve fulltext data from fieldtype like legacy had, there is stuff for Solr but unclear if we can reuse that here as it is specific.
(https://github.com/alongosz/ezpublish-kernel/blob/ezp-25088-content-items-not-indexed-by-legacySearchEngine/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php#L281-L322)
- [ ] Changes ensuring we [index only when needed](#issuecomment-228717949).

Changes excluded from this PR:
- ~~Reusable `ezplatform:reindex` command, ported from Solr, for use by all engines, needs:~~
- ~~New methods on `eZ/Publish/SPI/Search/Handler`, ported and cleaned up from Solr *(changes needed there if any)*~~
- ~~Legacy search engine FieldValueMappers using common parts from #1697~~ - moved to #1701 