### PR TITLE
Fix test for php 7.0.7

### DIFF
--- a/eZ/Publish/Core/FieldType/Tests/FieldTypeMockTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FieldTypeMockTest.php
@@ -27,7 +27,9 @@ class FieldTypeMockTest extends PHPUnit_Framework_TestCase
             false
         );
 
-        $stub->applyDefaultSettings(new \DateTime());
+        $fieldSettings = new \DateTime();
+
+        $stub->applyDefaultSettings($fieldSettings);
     }
 
     /**
@@ -174,7 +176,9 @@ class FieldTypeMockTest extends PHPUnit_Framework_TestCase
             false
         );
 
-        $stub->applyDefaultValidatorConfiguration(new \DateTime());
+        $validatorConfiguration = new \DateTime();
+
+        $stub->applyDefaultValidatorConfiguration($validatorConfiguration);
     }
 
     public function testApplyDefaultValidatorConfigurationEmpty()


### PR DESCRIPTION
I think this is somehow urgent. We are not able to make travis test green because of an bug fix in php version `7.0.7` where they fixed some issues with passing values as reference into functions.

https://bugs.php.net/bug.php?id=72038

