### PR TITLE
Revert "[Composer] Bump Proxy manager support"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "nelmio/cors-bundle": "^1.3.3",
         "hautelook/templated-uri-bundle": "~1.0 | ~2.0",
         "pagerfanta/pagerfanta": "~1.0",
-        "ocramius/proxy-manager": "~1.0 | ~2.0",
+        "ocramius/proxy-manager": "~1.0",
         "doctrine/doctrine-bundle": "~1.3",
         "liip/imagine-bundle": "~1.0",
         "oneup/flysystem-bundle": "~0.4",


### PR DESCRIPTION
Reverts ezsystems/ezpublish-kernel#1659

realized this will cause issues if someone updates composer lock on php 7, as 2.0 only support 7.