### PR TITLE
Fix EZP-25098: [Symfony 2.8] First load doesn't load the configuration

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Cache/Warmer/ConfigResolverCleanup.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Cache/Warmer/ConfigResolverCleanup.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * File containing the ConfigResolverCleanup class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Cache\Warmer;
+
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
+
+/**
+ * This cache warmer ensures that ConfigResolver is correctly reset after cache warmup process.
+ * @link https://jira.ez.no/browse/EZP-25098
+ */
+class ConfigResolverCleanup implements CacheWarmerInterface
+{
+    use ContainerAwareTrait;
+
+    public function isOptional()
+    {
+        return false;
+    }
+
+    public function warmUp($cacheDir)
+    {
+        $this->container->set('ezpublish.config.resolver.core', null);
+        $this->container->set('ezpublish.config.resolver.chain', null);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/cache.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/cache.yml
@@ -80,3 +80,10 @@ services:
         arguments: [@ezpublish.api.repository]
         tags:
             - { name: ezpublish.http_cache.event_subscriber }
+
+    ezpublish.cache_warmer.config_resolver_cleanup:
+        class: eZ\Bundle\EzPublishCoreBundle\Cache\Warmer\ConfigResolverCleanup
+        calls:
+            - [setContainer, ["@service_container"]]
+        tags:
+            - { name: kernel.cache_warmer }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Cache/Warmer/ConfigResolverCleanupTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Cache/Warmer/ConfigResolverCleanupTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * File containing the ConfigResolverCleanupTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Cache\Warmer;
+
+use eZ\Bundle\EzPublishCoreBundle\Cache\Warmer\ConfigResolverCleanup;
+use PHPUnit_Framework_TestCase;
+use stdClass;
+use Symfony\Component\DependencyInjection\Container;
+
+class ConfigResolverCleanupTest extends PHPUnit_Framework_TestCase
+{
+    public function testIsOptional()
+    {
+        self::assertFalse((new ConfigResolverCleanup())->isOptional());
+    }
+
+    public function testWarmup()
+    {
+        $container = new Container();
+        $container->set('ezpublish.config.resolver.core', new stdClass());
+        $container->set('ezpublish.config.resolver.chain', new stdClass());
+        self::assertTrue($container->initialized('ezpublish.config.resolver.core'));
+        self::assertTrue($container->initialized('ezpublish.config.resolver.chain'));
+
+        $warmer = new ConfigResolverCleanup();
+        $warmer->setContainer($container);
+        $warmer->warmUp('my_cache_dir');
+
+        self::assertFalse($container->initialized('ezpublish.config.resolver.core'));
+        self::assertFalse($container->initialized('ezpublish.config.resolver.chain'));
+    }
+}

--- a/eZ/Publish/Core/FieldType/Tests/FieldTypeMockTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FieldTypeMockTest.php
@@ -27,7 +27,9 @@ class FieldTypeMockTest extends PHPUnit_Framework_TestCase
             false
         );
 
-        $stub->applyDefaultSettings(new \DateTime());
+        $fieldSettings = new \DateTime();
+
+        $stub->applyDefaultSettings($fieldSettings);
     }
 
     /**
@@ -174,7 +176,9 @@ class FieldTypeMockTest extends PHPUnit_Framework_TestCase
             false
         );
 
-        $stub->applyDefaultValidatorConfiguration(new \DateTime());
+        $validatorConfiguration = new \DateTime();
+
+        $stub->applyDefaultValidatorConfiguration($validatorConfiguration);
     }
 
     public function testApplyDefaultValidatorConfigurationEmpty()


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-25098

Reopening #1666 against branch 6.1.

This patch ensures that ConfigResolver is not initialized in the
container after Symfony cache warmup.

This should prevent new similar issues.