### PR TITLE
Fix EZP-25817: Invalid subtree path when assigning role with subtree limitation

### DIFF
--- a/eZ/Publish/Core/REST/Server/Input/Parser/Limitation/PathStringRouteBasedLimitationParser.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Limitation/PathStringRouteBasedLimitationParser.php
@@ -17,7 +17,7 @@ use eZ\Publish\API\Repository\Values;
 class PathStringRouteBasedLimitationParser extends RouteBasedLimitationParser
 {
     /**
-     * Prefixes the value parsed by the parent with a '/'.
+     * Prefixes the value parsed by the parent with a '/', and ensures it also ends with a '/'.
      *
      * @param $limitationValue
      *
@@ -25,6 +25,6 @@ class PathStringRouteBasedLimitationParser extends RouteBasedLimitationParser
      */
     protected function parseIdFromHref($limitationValue)
     {
-        return '/' . ltrim(parent::parseIdFromHref($limitationValue), '/');
+        return '/' . trim(parent::parseIdFromHref($limitationValue), '/') . '/';
     }
 }

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/Limitation/PathStringRouteBasedLimitationParserTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/Limitation/PathStringRouteBasedLimitationParserTest.php
@@ -25,7 +25,7 @@ class PathStringRouteBasedLimitationParserTest extends BaseTest
         self::assertInstanceOf('stdClass', $result);
         self::assertObjectHasAttribute('limitationValues', $result);
         self::assertArrayHasKey(0, $result->limitationValues);
-        self::assertEquals('/1/2/3/4', $result->limitationValues[0]);
+        self::assertEquals('/1/2/3/4/', $result->limitationValues[0]);
     }
 
     /**


### PR DESCRIPTION
> Fix https://jira.ez.no/browse/EZP-25817
> Status: Ready for review

Ensures that the `_href` ends with a slash, being tolerant of PlatformUI not doing this (yet), to avoid breaking things.

The master fix will throw an exception, requiring a fix in PlatformUI: https://github.com/ezsystems/ezpublish-kernel/pull/1671