### PR TITLE
Fix missing languages on first load

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
@@ -13,6 +13,7 @@ services:
     # Helpers
     ezpublish.translation_helper:
         class: %ezpublish.translation_helper.class%
+        lazy: true
         arguments:
             - @ezpublish.config.resolver
             - @ezpublish.api.service.content


### PR DESCRIPTION
Another fix for https://jira.ez.no/browse/EZP-25098

Twig cache warmer loads all Twig extensions, and `ezpublish.twig.extension.content` depends on `ezpublish.translation_helper` which in turn depends on config resolver, meaning that languages will not be populated in config resolver correctly on first load.