### PR TITLE
Fix EZP-24315: Add support for sorting in REST Views

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -2151,7 +2151,7 @@ Create View
 XML Example
 '''''''''''
 
-Perform a query on images withing the media section, sorted by name, limiting results to 10.
+Perform a query on images within the media section, sorted by name, limiting results to 10.
 
 .. code:: http
 
@@ -2173,9 +2173,7 @@ Perform a query on images withing the media section, sorted by name, limiting re
         <limit>10</limit>
         <offset>0</offset>
         <SortClauses>
-          <SortClause>
-            <SortField>NAME</SortField>
-          </SortClause>
+          <ContentName>ascending</ContentName>
         </SortClauses>
         <FacetBuilders>
           <contentTypeFacetBuilder/>
@@ -2204,9 +2202,7 @@ Perform a query on images withing the media section, sorted by name, limiting re
         <limit>10</limit>
         <offset>0</offset>
         <SortClauses>
-          <SortClause>
-            <SortField>NAME</SortField>
-          </SortClause>
+          <ContentName>ascending</ContentName>
         </SortClauses>
         <FacetBuilders>
           <contentTypeFacetBuilder/>

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
@@ -65,6 +65,8 @@ parameters:
     ezpublish_rest.input.parser.internal.criterion.UserMetadata.class: eZ\Publish\Core\REST\Server\Input\Parser\Criterion\UserMetadata
     ezpublish_rest.input.parser.internal.criterion.Visibility.class: eZ\Publish\Core\REST\Server\Input\Parser\Criterion\Visibility
 
+    ezpublish_rest.input.parser.internal.sortclause.GenericDataKey.class: eZ\Publish\Core\REST\Server\Input\Parser\SortClause\GenericDataKey
+
     ezpublish_rest.input.parser.internal.route_based_limitation.class: eZ\Publish\Core\REST\Server\Input\Parser\Limitation\RouteBasedLimitationParser
     ezpublish_rest.input.parser.internal.path_string_route_based_limitation.class: eZ\Publish\Core\REST\Server\Input\Parser\Limitation\PathStringRouteBasedLimitationParser
 
@@ -566,6 +568,15 @@ services:
         class: %ezpublish_rest.input.parser.internal.criterion.Visibility.class%
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.Visibility }
+
+    ezpublish_rest.input.parser.internal.sortclause.DatePublished:
+        parent: ezpublish_rest.input.parser
+        class: '%ezpublish_rest.input.parser.internal.sortclause.GenericDataKey.class%'
+        arguments:
+            - 'DatePublished'
+            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\DatePublished'
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.DatePublished }
 
     # role limitation parsers
 

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
@@ -65,7 +65,7 @@ parameters:
     ezpublish_rest.input.parser.internal.criterion.UserMetadata.class: eZ\Publish\Core\REST\Server\Input\Parser\Criterion\UserMetadata
     ezpublish_rest.input.parser.internal.criterion.Visibility.class: eZ\Publish\Core\REST\Server\Input\Parser\Criterion\Visibility
 
-    ezpublish_rest.input.parser.internal.sortclause.GenericDataKey.class: eZ\Publish\Core\REST\Server\Input\Parser\SortClause\GenericDataKey
+    ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class: eZ\Publish\Core\REST\Server\Input\Parser\SortClause\DataKeyValueObjectClass
 
     ezpublish_rest.input.parser.internal.route_based_limitation.class: eZ\Publish\Core\REST\Server\Input\Parser\Limitation\RouteBasedLimitationParser
     ezpublish_rest.input.parser.internal.path_string_route_based_limitation.class: eZ\Publish\Core\REST\Server\Input\Parser\Limitation\PathStringRouteBasedLimitationParser
@@ -569,14 +569,59 @@ services:
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.Visibility }
 
+    ezpublish_rest.input.parser.internal.sortclause.ContentId:
+        parent: ezpublish_rest.input.parser
+        class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'
+        arguments:
+            - 'ContentId'
+            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentId'
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.ContentId }
+
+    ezpublish_rest.input.parser.internal.sortclause.ContentName:
+        parent: ezpublish_rest.input.parser
+        class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'
+        arguments:
+            - 'ContentName'
+            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentName'
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.ContentName }
+
+    ezpublish_rest.input.parser.internal.sortclause.DateModified:
+        parent: ezpublish_rest.input.parser
+        class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'
+        arguments:
+            - 'DateModified'
+            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\DateModified'
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.DateModified }
+
     ezpublish_rest.input.parser.internal.sortclause.DatePublished:
         parent: ezpublish_rest.input.parser
-        class: '%ezpublish_rest.input.parser.internal.sortclause.GenericDataKey.class%'
+        class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'
         arguments:
             - 'DatePublished'
             - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\DatePublished'
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.DatePublished }
+
+    ezpublish_rest.input.parser.internal.sortclause.SectionIdentifier:
+        parent: ezpublish_rest.input.parser
+        class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'
+        arguments:
+            - 'SectionIdentifier'
+            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\SectionIdentifier'
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.SectionIdentifier }
+
+    ezpublish_rest.input.parser.internal.sortclause.SectionName:
+        parent: ezpublish_rest.input.parser
+        class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'
+        arguments:
+            - 'SectionName'
+            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\SectionName'
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.SectionName }
 
     # role limitation parsers
 

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion.php
@@ -49,6 +49,24 @@ abstract class Criterion extends BaseParser
         }
     }
 
+    /**
+     * Dispatches parsing of a sort clause name + direction to its own parser.
+     *
+     * @param string $sortClauseName
+     * @param string $direction
+     * @param \eZ\Publish\Core\REST\Common\Input\ParsingDispatcher $parsingDispatcher
+     *
+     * @throws \eZ\Publish\Core\REST\Common\Exceptions\Parser
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion
+     */
+    public function dispatchSortClause($sortClauseName, $direction, ParsingDispatcher $parsingDispatcher)
+    {
+        $mediaType = $this->getSortClauseMediaType($sortClauseName);
+
+        return $parsingDispatcher->parse(array($sortClauseName => $direction), $mediaType);
+    }
+
     protected function getCriterionMediaType($criterionName)
     {
         $criterionName = str_replace('Criterion', '', $criterionName);
@@ -57,5 +75,10 @@ abstract class Criterion extends BaseParser
         }
 
         return 'application/vnd.ez.api.internal.criterion.' . $criterionName;
+    }
+
+    protected function getSortClauseMediaType($sortClauseName)
+    {
+        return 'application/vnd.ez.api.internal.sortclause.' . $sortClauseName;
     }
 }

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Query.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Query.php
@@ -57,9 +57,13 @@ abstract class Query extends CriterionParser
         }
 
         // SortClauses
-        // -- SortClause
-        // ---- SortField
+        // -- [SortClauseName: direction|data]
         if (array_key_exists('SortClauses', $data)) {
+            $sortClauses = [];
+            foreach ($data['SortClauses'] as $sortClauseName => $sortClauseData) {
+                $sortClauses[] = $this->dispatchSortClause($sortClauseName, $sortClauseData, $parsingDispatcher);
+            }
+            $query->sortClauses = $sortClauses;
         }
 
         // FacetBuilders

--- a/eZ/Publish/Core/REST/Server/Input/Parser/SortClause/DataKeyValueObjectClass.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/SortClause/DataKeyValueObjectClass.php
@@ -7,19 +7,27 @@ use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
 
-class GenericDataKey extends BaseParser
+class DataKeyValueObjectClass extends BaseParser
 {
-    /** @var string $dataKey */
+    /**
+     * Data key, corresponding to the $valueObjectClass class.
+     * Example: 'DatePublished'.
+     * @var string
+     */
     protected $dataKey;
 
-    /** @var string $valueObjectClass */
+    /**
+     * Value object class, corresponding to the $dataKey.
+     * Example: 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\DatePublished'.
+     * @var string
+     */
     protected $valueObjectClass;
 
     /**
-     * GenericDataKey constructor.
-     * 
-     * @param $dataKey
-     * @param $valueObjectClass
+     * DataKeyValueObjectClass constructor.
+     *
+     * @param string $dataKey
+     * @param string $valueObjectClass
      */
     public function __construct($dataKey, $valueObjectClass)
     {
@@ -37,10 +45,18 @@ class GenericDataKey extends BaseParser
      */
     public function parse(array $data, ParsingDispatcher $parsingDispatcher)
     {
+        if (!class_exists($this->valueObjectClass)) {
+            throw new Exceptions\Parser("Value object class <{$this->valueObjectClass}> is not defined");
+        }
+
+        if (!array_key_exists($this->dataKey, $data)) {
+            throw new Exceptions\Parser("The <{$this->dataKey}> sort clause doesn't exist in the input structure");
+        }
+
         $direction = $data[$this->dataKey];
 
         if (!in_array($direction, [Query::SORT_ASC, Query::SORT_DESC])) {
-            throw new Exceptions\Parser("Invalid direction format in <{$direction}> sort clause");
+            throw new Exceptions\Parser("Invalid direction format in <{$this->dataKey}> sort clause");
         }
 
         return new $this->valueObjectClass($direction);

--- a/eZ/Publish/Core/REST/Server/Input/Parser/SortClause/GenericDataKey.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/SortClause/GenericDataKey.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace eZ\Publish\Core\REST\Server\Input\Parser\SortClause;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\Core\REST\Common\Input\BaseParser;
+use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
+use eZ\Publish\Core\REST\Common\Exceptions;
+
+class GenericDataKey extends BaseParser
+{
+    /** @var string $dataKey */
+    protected $dataKey;
+
+    /** @var string $valueObjectClass */
+    protected $valueObjectClass;
+
+    /**
+     * GenericDataKey constructor.
+     * 
+     * @param $dataKey
+     * @param $valueObjectClass
+     */
+    public function __construct($dataKey, $valueObjectClass)
+    {
+        $this->dataKey = $dataKey;
+        $this->valueObjectClass = $valueObjectClass;
+    }
+
+    /**
+     * Parse input structure.
+     *
+     * @param array $data
+     * @param \eZ\Publish\Core\REST\Common\Input\ParsingDispatcher $parsingDispatcher
+     *
+     * @return \eZ\Publish\API\Repository\Values\ValueObject
+     */
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher)
+    {
+        $direction = $data[$this->dataKey];
+
+        if (!in_array($direction, [Query::SORT_ASC, Query::SORT_DESC])) {
+            throw new Exceptions\Parser("Invalid direction format in <{$direction}> sort clause");
+        }
+
+        return new $this->valueObjectClass($direction);
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/SortClause/DataKeyValueObjectClassTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/SortClause/DataKeyValueObjectClassTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * File containing a test class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ *
+ * @version //autogentag//
+ */
+namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser\SortClause;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\DatePublished;
+use eZ\Publish\Core\REST\Server\Input\Parser\SortClause\DataKeyValueObjectClass;
+use eZ\Publish\Core\REST\Server\Tests\Input\Parser\BaseTest;
+
+class DataKeyValueObjectClassTest extends BaseTest
+{
+    /**
+     * Tests the DataKeyValueObjectClass parser.
+     */
+    public function testParse()
+    {
+        $inputArray = array(
+            'DatePublished' => Query::SORT_ASC,
+        );
+
+        $dataKeyValueObjectClass = $this->getParser();
+        $result = $dataKeyValueObjectClass->parse($inputArray, $this->getParsingDispatcherMock());
+
+        $this->assertEquals(
+            new DatePublished(Query::SORT_ASC),
+            $result,
+            'DataKeyValueObjectClass parser not created correctly.'
+        );
+    }
+
+    /**
+     * Test DataKeyValueObjectClass parser throwing exception on missing sort clause.
+     *
+     * @expectedException \eZ\Publish\Core\REST\Common\Exceptions\Parser
+     * @expectedExceptionMessage The <DatePublished> sort clause doesn't exist in the input structure
+     */
+    public function testParseExceptionOnMissingSortClause()
+    {
+        $inputArray = array(
+            'name' => 'Keep on mocking in the free world',
+        );
+
+        $dataKeyValueObjectClass = $this->getParser();
+        $dataKeyValueObjectClass->parse($inputArray, $this->getParsingDispatcherMock());
+    }
+
+    /**
+     * Test DataKeyValueObjectClass parser throwing exception on invalid direction format.
+     *
+     * @expectedException \eZ\Publish\Core\REST\Common\Exceptions\Parser
+     * @expectedExceptionMessage Invalid direction format in <DatePublished> sort clause
+     */
+    public function testParseExceptionOnInvalidDirectionFormat()
+    {
+        $inputArray = array(
+            'DatePublished' => 'Jailhouse Mock',
+        );
+
+        $dataKeyValueObjectClass = $this->getParser();
+        $dataKeyValueObjectClass->parse($inputArray, $this->getParsingDispatcherMock());
+    }
+
+    /**
+     * Test DataKeyValueObjectClass parser throwing exception on nonexisting value object class.
+     *
+     * @expectedException \eZ\Publish\Core\REST\Common\Exceptions\Parser
+     * @expectedExceptionMessage Value object class <eC\Pubish\APl\Repudiatory\BadValues\Discontent\Queezy\SantaClause\ThisClassIsExistentiallyChallenged> is not defined
+     */
+    public function testParseExceptionOnNonexistingValueObjectClass()
+    {
+        $inputArray = array(
+            'DatePublished' => Query::SORT_ASC,
+        );
+
+        $dataKeyValueObjectClass = new DataKeyValueObjectClass(
+            'DatePublished',
+            'eC\Pubish\APl\Repudiatory\BadValues\Discontent\Queezy\SantaClause\ThisClassIsExistentiallyChallenged'
+        );
+        $dataKeyValueObjectClass->parse($inputArray, $this->getParsingDispatcherMock());
+    }
+
+    /**
+     * Returns the DataKeyValueObjectClass parser.
+     *
+     * @return \eZ\Publish\Core\REST\Server\Input\Parser\SortClause\DataKeyValueObjectClass
+     */
+    protected function internalGetParser()
+    {
+        return new DataKeyValueObjectClass(
+            'DatePublished',
+            'eZ\Publish\API\Repository\Values\Content\Query\SortClause\DatePublished'
+        );
+    }
+}


### PR DESCRIPTION
> Implements https://jira.ez.no/browse/EZP-24315
> Status: Ready for review

Continues on the work from @Nattfarinn in https://github.com/ezsystems/ezpublish-kernel/pull/1651 - Thank you!

- [x] Renamed `GenericDataKey` class to `DataKeyValueObjectClass`
- [x] Added missing docblock param types
- [x] Fixed exception message parameter
- [x] Check if the data key exists before using it, throw if it doesn't
- [x] Docblock description for `$dataKey` and `$valueObjectClass`
- [x] Unit test for the DataKey parser
- [x] Update REST spec