### PR TITLE
[Composer] Bump requirements for sensio/distribution-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "qafoo/rmf": "1.0.*",
         "kriswallsmith/buzz": ">=0.9",
         "tedivm/stash-bundle": "0.4.*",
-        "sensio/distribution-bundle": "~3.0",
+        "sensio/distribution-bundle": "^3.0.36|^4.0.6",
         "nelmio/cors-bundle": "^1.3.3",
         "hautelook/templated-uri-bundle": "~1.0 | ~2.0",
         "pagerfanta/pagerfanta": "~1.0",


### PR DESCRIPTION
Because of change done in 9bbde1ad6cab84b213feb1934a0f88a939f09926, caused by break in https://github.com/sensiolabs/SensioDistributionBundle/commit/4fd740b02261672cc4e41a78791af35935424b7f, we need to require higher version of `sensio/distribution-bundle` to avoid error if this is installed with older version of `sensio/distribution-bundle`.

4.0 is same as 3.0 branch but besides ACME bundle code generation stuff, so technically we should be able to support both. 5.0 branch seems to be more for when we switch to Symfony 3.x.

Doing this to avoid further User painted himself into a corner issues, as found [here](https://jira.ez.no/browse/EZP-25774), once 9bbde1ad6cab84b213feb1934a0f88a939f09926 is out in more EE releases and people do composer update on their own.