### PR TITLE
EZP-25875: embed image view

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -16,9 +16,13 @@ parameters:
     ezplatform.default_view_templates.content.full: 'EzPublishCoreBundle:default:content/full.html.twig'
     ezplatform.default_view_templates.content.line: 'EzPublishCoreBundle:default:content/line.html.twig'
     ezplatform.default_view_templates.content.embed: 'EzPublishCoreBundle:default:content/embed.html.twig'
+    ezplatform.default_view_templates.content.embed_image: 'EzPublishCoreBundle:default:content/embed_image.html.twig'
     ezplatform.default_view_templates.block: 'EzPublishCoreBundle:default:block/block.html.twig'
 
     ezsettings.default.pagelayout: 'EzPublishCoreBundle::pagelayout.html.twig'
+
+    # List of content type identifiers to display as image when embedded
+    ezplatform.content_view.image_embed_content_types_identifiers: ['image']
 
     ezsettings.default.content_view_defaults:
         full:
@@ -30,6 +34,10 @@ parameters:
                 template: %ezplatform.default_view_templates.content.line%
                 match: []
         embed:
+            image:
+                template: '%ezplatform.default_view_templates.content.embed_image%'
+                match:
+                    Identifier\ContentType: '%ezplatform.content_view.image_embed_content_types_identifiers%'
             default:
                 template: %ezplatform.default_view_templates.content.embed%
                 match: []

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed_image.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed_image.html.twig
@@ -1,0 +1,9 @@
+{% set image_field_identifier = ez_first_filled_image_field_identifier(content) %}
+
+{% if image_field_identifier is not null %}
+    {{ ez_render_field(
+       content,
+       image_field_identifier,
+       { parameters: { alias: objectParameters.size } }
+    ) }}
+{% endif %}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
@@ -97,6 +97,10 @@ class ContentExtension extends Twig_Extension
                 'ez_trans_prop',
                 array($this, 'getTranslatedProperty')
             ),
+            new Twig_SimpleFunction(
+                'ez_first_filled_image_field_identifier',
+                array($this, 'getFirstFilledImageFieldIdentifier')
+            ),
         );
     }
 
@@ -281,5 +285,27 @@ class ContentExtension extends Twig_Extension
         } elseif ($content instanceof ContentInfo) {
             return $this->repository->getContentTypeService()->loadContentType($content->contentTypeId);
         }
+    }
+
+    public function getFirstFilledImageFieldIdentifier(Content $content)
+    {
+        foreach ($content->getFieldsByLanguage() as $field) {
+            $fieldTypeIdentifier = $this->fieldHelper->getFieldDefinition(
+                $content->contentInfo,
+                $field->fieldDefIdentifier
+            )->fieldTypeIdentifier;
+
+            if ($fieldTypeIdentifier !== 'ezimage') {
+                continue;
+            }
+
+            if ($this->fieldHelper->isFieldEmpty($content, $field->fieldDefIdentifier)) {
+                continue;
+            }
+
+            return $field->fieldDefIdentifier;
+        }
+
+        return null;
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -109,6 +109,7 @@ class ContentViewBuilder implements ViewBuilder
             $view->setLocation($location);
         }
 
+        $this->viewParametersInjector->injectViewParameters($view, $parameters);
         $this->viewConfigurator->configure($view);
 
         // deprecated controller actions are replaced with their new equivalent, viewAction and embedAction
@@ -119,8 +120,6 @@ class ContentViewBuilder implements ViewBuilder
                 $view->setControllerReference(new ControllerReference('ez_content:embedAction'));
             }
         }
-
-        $this->viewParametersInjector->injectViewParameters($view, $parameters);
 
         return $view;
     }


### PR DESCRIPTION
> Status: work in progress
> Fixes http://jira.ez.no/browse/EZP-25875

Renders embedded images using a dedicated template.

- Adds a default view configuration that matches embed images by content type identifier. The list of content-types is configurable.
- Adds a default, configurable, `EzPublishCoreBundle:default:content/embed_image.html.twig` template. It displays the first filled image field of the embedded content, using the variation configured in the embed.
- Adds an `ez_first_filled_image_field` twig function that, given a  content, returns the identifier of the first image field that is not empty.

### Customization

There are two main customization use-cases:

### Image content types identifiers
Customizing which content types are considered as images, and rendered as such, is done by setting the `ezplatform.content_view.image_embed_content_types_identifiers` container parameter. It is set to `['image']` by default:

```
parameters:
  ezplatform.content_view.image_embed_content_types_identifiers: ['image', 'photo', 'banner']
```

#### Embed images template
Can be customized by setting the `ezplatform.default_view_templates.content.embed_image` container parameter:

```
parameters:
  ezplatform.default_view_templates.content.embed_image: 'content/view/embed/image.html.twig'
```

### TODO / open questions
- [x] Figure out what is supposed to happen when the embedded content does NOT have a filled image field.
  _Fixed by displaying nothing if there is no image field with a value._
- [x] Bit of testing