### PR TITLE
EZP-25849: Content embedded within RichText not available via Relations

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/RelationBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/RelationBaseIntegrationTest.php
@@ -19,6 +19,7 @@ use eZ\Publish\API\Repository\Values\Content\Content;
  * @group integration
  * @group field-type
  * @group relation
+ * @deprecated 6.1 use RelationSearchBaseIntegrationTestTrait instead.
  */
 abstract class RelationBaseIntegrationTest extends BaseIntegrationTest
 {

--- a/eZ/Publish/API/Repository/Tests/FieldType/RichTextIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/RichTextIntegrationTest.php
@@ -31,17 +31,19 @@ class RichTextIntegrationTest extends SearchBaseIntegrationTest
      */
     private $createdDOMValue;
 
+    /**
+     * @var \DOMDocument
+     */
     private $updatedDOMValue;
 
-    protected function setUp()
+    public function __construct($name = null, array $data = array(), $dataName = '')
     {
-        parent::setUp();
         $this->createdDOMValue = new DOMDocument();
         $this->createdDOMValue->loadXML(<<<EOT
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
     <para><link xlink:href="ezlocation://58" xlink:show="none">link1</link></para>
-    <para><link xlink:href="ezcontent://54" xlink:show="none">link2</link></para>
+    <para><link xlink:href="ezcontent://54" xlink:show="none">link2</link> <ezembedinline xlink:href="ezlocation://60" view="embed" xml:id="embed-id-1" ezxhtml:class="embed-class" ezxhtml:align="left"></ezembedinline></para>
 </section>
 EOT
         );
@@ -52,9 +54,18 @@ EOT
 <section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
     <para><link xlink:href="ezlocation://60" xlink:show="none">link1</link></para>
     <para><link xlink:href="ezcontent://56" xlink:show="none">link2</link></para>
+    <ezembed xlink:href="ezcontent://54" view="embed" xml:id="embed-id-1" ezxhtml:class="embed-class" ezxhtml:align="left">
+      <ezconfig>
+        <ezvalue key="size">medium</ezvalue>
+        <ezvalue key="offset">10</ezvalue>
+        <ezvalue key="limit">5</ezvalue>
+      </ezconfig>
+    </ezembed>
 </section>
 EOT
         );
+
+        parent::__construct($name, $data, $dataName);
     }
 
     /**
@@ -79,6 +90,13 @@ EOT
                     'type' => Relation::LINK,
                     'sourceContentInfo' => $content->contentInfo,
                     'destinationContentInfo' => $contentService->loadContentInfo(54),
+                )
+            ),
+            new Relation(
+                array(
+                    'type' => Relation::EMBED,
+                    'sourceContentInfo' => $content->contentInfo,
+                    'destinationContentInfo' => $contentService->loadContentInfo(58),
                 )
             ),
         );
@@ -106,6 +124,15 @@ EOT
                     'type' => Relation::LINK,
                     'sourceContentInfo' => $content->contentInfo,
                     'destinationContentInfo' => $contentService->loadContentInfo(56),
+                )
+            ),
+            new Relation(
+                array(
+                    // @todo Won't be possible to add before we break how we store relations with legacy kernel.
+                    //'sourceFieldDefinitionIdentifier' => 'data',
+                    'type' => Relation::EMBED,
+                    'sourceContentInfo' => $content->contentInfo,
+                    'destinationContentInfo' => $contentService->loadContentInfo(54),
                 )
             ),
         );
@@ -195,23 +222,11 @@ EOT
     /**
      * Get initial field data for valid object creation.
      *
-     * @todo add embeds when implemented
-     *
      * @return mixed
      */
     public function getValidCreationFieldData()
     {
-        $doc = new DOMDocument();
-        $doc->loadXML(<<<EOT
-<?xml version="1.0" encoding="UTF-8"?>
-<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
-    <para><link xlink:href="ezlocation://58" xlink:show="none">link1</link></para>
-    <para><link xlink:href="ezcontent://54" xlink:show="none">link2</link></para>
-</section>
-EOT
-        );
-
-        return new RichTextValue($doc);
+        return new RichTextValue($this->createdDOMValue);
     }
 
     /**
@@ -508,7 +523,7 @@ EOT;
     </para>
 </section>
 ',
-            ), /*, @TODO adapt and enable when embeds are implemented
+            ), /*, @TODO adapt and enable when embeds are implemented with remote id support
             array(
                 // test embed
             '<?xml version="1.0" encoding="utf-8"?>

--- a/eZ/Publish/Core/Base/Exceptions/ContentFieldValidationException.php
+++ b/eZ/Publish/Core/Base/Exceptions/ContentFieldValidationException.php
@@ -44,7 +44,7 @@ class ContentFieldValidationException extends APIContentFieldValidationException
     public function __construct(array $errors)
     {
         $this->errors = $errors;
-        $this->setMessageTemplate('Content fields did not validate');
+        $this->setMessageTemplate('Content fields did not validate' . var_export($errors, true));
         parent::__construct($this->getBaseTranslation());
     }
 

--- a/eZ/Publish/Core/FieldType/RichText/Type.php
+++ b/eZ/Publish/Core/FieldType/RichText/Type.php
@@ -437,35 +437,37 @@ class Type extends FieldType
     }
 
     /**
-     * @todo handle embeds when implemented
+     * {@inheritdoc}
      */
     protected function getRelatedObjectIds(Value $fieldValue, $relationType)
     {
         if ($relationType === Relation::EMBED) {
-            $tagName = 'embed';
+            $tagNames = ['ezembedinline', 'ezembed'];
         } else {
-            $tagName = 'link';
+            $tagNames = ['link', 'ezlink'];
         }
 
         $contentIds = array();
         $locationIds = array();
         $xpath = new \DOMXPath($fieldValue->xml);
         $xpath->registerNamespace('docbook', 'http://docbook.org/ns/docbook');
-        $xpathExpression = "//docbook:{$tagName}[starts-with( @xlink:href, 'ezcontent://' ) or starts-with( @xlink:href, 'ezlocation://' )]";
 
-        /** @var \DOMElement $link */
-        foreach ($xpath->query($xpathExpression) as $link) {
-            preg_match('~^(.+)://([^#]*)?(#.*|\\s*)?$~', $link->getAttribute('xlink:href'), $matches);
-            list(, $scheme, $id) = $matches;
+        foreach ($tagNames as $tagName) {
+            $xpathExpression = "//docbook:{$tagName}[starts-with( @xlink:href, 'ezcontent://' ) or starts-with( @xlink:href, 'ezlocation://' )]";
+            /** @var \DOMElement $element */
+            foreach ($xpath->query($xpathExpression) as $element) {
+                preg_match('~^(.+)://([^#]*)?(#.*|\\s*)?$~', $element->getAttribute('xlink:href'), $matches);
+                list(, $scheme, $id) = $matches;
 
-            if (empty($id)) {
-                continue;
-            }
+                if (empty($id)) {
+                    continue;
+                }
 
-            if ($scheme === 'ezcontent') {
-                $contentIds[] = $id;
-            } elseif ($scheme === 'ezlocation') {
-                $locationIds[] = $id;
+                if ($scheme === 'ezcontent') {
+                    $contentIds[] = $id;
+                } elseif ($scheme === 'ezlocation') {
+                    $locationIds[] = $id;
+                }
             }
         }
 


### PR DESCRIPTION
Make sure to take all tag variants of embed and link into account.


@pspanja Is this correct? From other tests it seemed to be what should be looked for at this stage.

As for embed => ezembed, as far as I understood it getRelations are performed after the input value transformations are done, so it should indeed always be docbook tag names we should expect here, right?

Otherwise: Found several more @todos about embeds, is something missing on embeds as far as you know?

Review ping @bdunogier, @pspanja @alongosz