### PR TITLE
Missing REST sort clauses

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
@@ -605,6 +605,15 @@ services:
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.DatePublished }
 
+    ezpublish_rest.input.parser.internal.sortclause.Priority:
+        parent: ezpublish_rest.input.parser
+        class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'
+        arguments:
+            - 'LocationPriority'
+            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Priority'
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.LocationPriority }
+
     ezpublish_rest.input.parser.internal.sortclause.SectionIdentifier:
         parent: ezpublish_rest.input.parser
         class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
@@ -614,6 +614,15 @@ services:
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.LocationDepth }
 
+    ezpublish_rest.input.parser.internal.sortclause.Path:
+        parent: ezpublish_rest.input.parser
+        class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'
+        arguments:
+            - 'LocationPath'
+            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Path'
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.LocationPath }
+
     ezpublish_rest.input.parser.internal.sortclause.Priority:
         parent: ezpublish_rest.input.parser
         class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
@@ -605,6 +605,15 @@ services:
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.DatePublished }
 
+    ezpublish_rest.input.parser.internal.sortclause.Depth:
+        parent: ezpublish_rest.input.parser
+        class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'
+        arguments:
+            - 'LocationDepth'
+            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Depth'
+        tags:
+            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.LocationDepth }
+
     ezpublish_rest.input.parser.internal.sortclause.Priority:
         parent: ezpublish_rest.input.parser
         class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'


### PR DESCRIPTION
> Fixes [EZP-25907](https://jira.ez.no/browse/EZP-25907)
> Unblocks ezsystems/PlatformUIBundle#622

Implements missing basic sort clauses.

### TODO
- [x] Priority https://jira.ez.no/browse/EZP-25907
- [x] Path https://jira.ez.no/browse/EZP-25911
- [x] Depth https://jira.ez.no/browse/EZP-25910
- [x] ~~Content Type identifier https://jira.ez.no/browse/EZP-25909~~ (doesn't exist in Public API)
- [x] ~~Content Type name https://jira.ez.no/browse/EZP-25908~~ (doesn't exist in Public API)
- [x] Decide if we prefix them with Location in REST: `LocationPriority` vs `Priority`, `LocationPath` vs `Path`, etc.