### PR TITLE
Update REST SortClauses XSD schemas

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -7175,6 +7175,13 @@ View XML Schema
         </xsd:restriction>
       </xsd:simpleType>
 
+      <xsd:simpleType name="sortClauseDirectionEnumType">
+        <xsd:restriction base="xsd:string">
+          <xsd:enumeration value="ascending" />
+          <xsd:enumeration value="descending" />
+        </xsd:restriction>
+      </xsd:simpleType>
+
       <xsd:complexType name="fieldCriterionType">
         <xsd:all>
           <xsd:element name="target" type="xsd:string">
@@ -7245,17 +7252,17 @@ View XML Schema
       </xsd:complexType>
 
       <xsd:complexType name="sortClauseType">
-        <xsd:sequence>
-          <xsd:element name="SortClause">
-            <xsd:complexType>
-              <xsd:all>
-                <xsd:element name="SortField" type="sortClauseEnumType" />
-                <xsd:element name="TargetData" type="xsd:anyType"
-                  minOccurs="0" />
-              </xsd:all>
-            </xsd:complexType>
-          </xsd:element>
-        </xsd:sequence>
+        <xsd:choice minOccurs="1" maxOccurs="unbounded">
+          <xsd:element name="ContentId" type="sortClauseDirectionEnumType" />
+          <xsd:element name="ContentName" type="sortClauseDirectionEnumType" />
+          <xsd:element name="DateModified" type="sortClauseDirectionEnumType" />
+          <xsd:element name="DatePublished" type="sortClauseDirectionEnumType" />
+          <xsd:element name="LocationDepth" type="sortClauseDirectionEnumType" />
+          <xsd:element name="LocationPath" type="sortClauseDirectionEnumType" />
+          <xsd:element name="LocationPriority" type="sortClauseDirectionEnumType" />
+          <xsd:element name="SectionIdentifier" type="sortClauseDirectionEnumType" />
+          <xsd:element name="SectionName" type="sortClauseDirectionEnumType" />
+        </xsd:choice>
       </xsd:complexType>
 
       <xsd:complexType name="facetBuilderType">

--- a/doc/specifications/rest/xsd/View.xsd
+++ b/doc/specifications/rest/xsd/View.xsd
@@ -50,17 +50,10 @@
     </xsd:restriction>
   </xsd:simpleType>
 
-  <xsd:simpleType name="sortClauseEnumType">
+  <xsd:simpleType name="sortClauseDirectionEnumType">
     <xsd:restriction base="xsd:string">
-      <xsd:enumeration value="PATH" />
-      <xsd:enumeration value="PATHSTRING" />
-      <xsd:enumeration value="MODIFIED" />
-      <xsd:enumeration value="CREATED" />
-      <xsd:enumeration value="SECTIONIDENTIFER" />
-      <xsd:enumeration value="SECTIONID" />
-      <xsd:enumeration value="FIELD" />
-      <xsd:enumeration value="PRIORITY" />
-      <xsd:enumeration value="NAME" />
+      <xsd:enumeration value="ascending" />
+      <xsd:enumeration value="descending" />
     </xsd:restriction>
   </xsd:simpleType>
 
@@ -134,17 +127,17 @@
   </xsd:complexType>
 
   <xsd:complexType name="sortClauseType">
-    <xsd:sequence>
-      <xsd:element name="SortClause">
-        <xsd:complexType>
-          <xsd:all>
-            <xsd:element name="SortField" type="sortClauseEnumType" />
-            <xsd:element name="TargetData" type="xsd:anyType"
-              minOccurs="0" />
-          </xsd:all>
-        </xsd:complexType>
-      </xsd:element>
-    </xsd:sequence>
+    <xsd:choice minOccurs="1" maxOccurs="unbounded">
+      <xsd:element name="ContentId" type="sortClauseDirectionEnumType" />
+      <xsd:element name="ContentName" type="sortClauseDirectionEnumType" />
+      <xsd:element name="DateModified" type="sortClauseDirectionEnumType" />
+      <xsd:element name="DatePublished" type="sortClauseDirectionEnumType" />
+      <xsd:element name="LocationDepth" type="sortClauseDirectionEnumType" />
+      <xsd:element name="LocationPath" type="sortClauseDirectionEnumType" />
+      <xsd:element name="LocationPriority" type="sortClauseDirectionEnumType" />
+      <xsd:element name="SectionIdentifier" type="sortClauseDirectionEnumType" />
+      <xsd:element name="SectionName" type="sortClauseDirectionEnumType" />
+    </xsd:choice>
   </xsd:complexType>
 
   <xsd:complexType name="facetBuilderType">

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
@@ -65,7 +65,7 @@ parameters:
     ezpublish_rest.input.parser.internal.criterion.UserMetadata.class: eZ\Publish\Core\REST\Server\Input\Parser\Criterion\UserMetadata
     ezpublish_rest.input.parser.internal.criterion.Visibility.class: eZ\Publish\Core\REST\Server\Input\Parser\Criterion\Visibility
 
-    ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class: eZ\Publish\Core\REST\Server\Input\Parser\SortClause\DataKeyValueObjectClass
+    ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class: eZ\Publish\Core\REST\Server\Input\Parser\SortClause\DataKeyValueObjectClass
 
     ezpublish_rest.input.parser.internal.route_based_limitation.class: eZ\Publish\Core\REST\Server\Input\Parser\Limitation\RouteBasedLimitationParser
     ezpublish_rest.input.parser.internal.path_string_route_based_limitation.class: eZ\Publish\Core\REST\Server\Input\Parser\Limitation\PathStringRouteBasedLimitationParser
@@ -569,72 +569,72 @@ services:
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.Visibility }
 
-    ezpublish_rest.input.parser.internal.sortclause.ContentId:
+    ezpublish_rest.input.parser.internal.sortclause.content_id:
         parent: ezpublish_rest.input.parser
-        class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'
+        class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'
         arguments:
             - 'ContentId'
             - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentId'
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.ContentId }
 
-    ezpublish_rest.input.parser.internal.sortclause.ContentName:
+    ezpublish_rest.input.parser.internal.sortclause.content_name:
         parent: ezpublish_rest.input.parser
-        class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'
+        class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'
         arguments:
             - 'ContentName'
             - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentName'
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.ContentName }
 
-    ezpublish_rest.input.parser.internal.sortclause.DateModified:
+        ezpublish_rest.input.parser.internal.sortclause.date_modified:
         parent: ezpublish_rest.input.parser
-        class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'
+        class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'
         arguments:
             - 'DateModified'
             - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\DateModified'
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.DateModified }
 
-    ezpublish_rest.input.parser.internal.sortclause.DatePublished:
+    ezpublish_rest.input.parser.internal.sortclause.date_published:
         parent: ezpublish_rest.input.parser
-        class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'
+        class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'
         arguments:
             - 'DatePublished'
             - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\DatePublished'
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.DatePublished }
 
-    ezpublish_rest.input.parser.internal.sortclause.Depth:
+    ezpublish_rest.input.parser.internal.sortclause.location_depth:
         parent: ezpublish_rest.input.parser
-        class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'
+        class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'
         arguments:
             - 'LocationDepth'
             - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Depth'
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.LocationDepth }
 
-    ezpublish_rest.input.parser.internal.sortclause.Path:
+    ezpublish_rest.input.parser.internal.sortclause.location_path:
         parent: ezpublish_rest.input.parser
-        class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'
+        class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'
         arguments:
             - 'LocationPath'
             - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Path'
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.LocationPath }
 
-    ezpublish_rest.input.parser.internal.sortclause.Priority:
+    ezpublish_rest.input.parser.internal.sortclause.location_priority:
         parent: ezpublish_rest.input.parser
-        class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'
+        class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'
         arguments:
             - 'LocationPriority'
             - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Priority'
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.LocationPriority }
 
-    ezpublish_rest.input.parser.internal.sortclause.SectionIdentifier:
+    ezpublish_rest.input.parser.internal.sortclause.section_identifier:
         parent: ezpublish_rest.input.parser
-        class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'
+        class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'
         arguments:
             - 'SectionIdentifier'
             - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\SectionIdentifier'
@@ -643,7 +643,7 @@ services:
 
     ezpublish_rest.input.parser.internal.sortclause.SectionName:
         parent: ezpublish_rest.input.parser
-        class: '%ezpublish_rest.input.parser.internal.sortclause.DataKeyValueObjectClass.class%'
+        class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'
         arguments:
             - 'SectionName'
             - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\SectionName'


### PR DESCRIPTION
Updates the XSD schemas forgotten when SortClauses were implemented in REST (#1687, #1677)

Also changes the definition of sort clause services to match the Symfony standards (lowercase services). Other services will have to be fixed as well, but it will take a bit of effort in order not to break BC.