### PR TITLE
Fix EZP-25929: incorrect DateModified REST SortClause definition

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
@@ -587,7 +587,7 @@ services:
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.ContentName }
 
-        ezpublish_rest.input.parser.internal.sortclause.date_modified:
+    ezpublish_rest.input.parser.internal.sortclause.date_modified:
         parent: ezpublish_rest.input.parser
         class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'
         arguments:


### PR DESCRIPTION
Title says it all.

The service definition wasn't correctly indented, and the service not defined at all.