### PR TITLE
Fix EZP-25937: Undefined index timestamp when using Adapter/AwsS3

### DIFF
--- a/eZ/Publish/Core/IO/IOMetadataHandler/Flysystem.php
+++ b/eZ/Publish/Core/IO/IOMetadataHandler/Flysystem.php
@@ -55,8 +55,11 @@ class Flysystem implements IOMetadataHandler
 
         $spiBinaryFile = new SPIBinaryFile();
         $spiBinaryFile->id = $spiBinaryFileId;
-        $spiBinaryFile->mtime = new DateTime('@' . $info['timestamp']);
         $spiBinaryFile->size = $info['size'];
+
+        if (isset($info['timestamp'])) {
+            $spiBinaryFile->mtime = new DateTime('@' . $info['timestamp']);
+        }
 
         return $spiBinaryFile;
     }

--- a/eZ/Publish/Core/IO/Tests/IOMetadataHandler/FlysystemTest.php
+++ b/eZ/Publish/Core/IO/Tests/IOMetadataHandler/FlysystemTest.php
@@ -94,6 +94,27 @@ class FlysystemTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * The timestamp index can be unset with some handlers, like AWS/S3.
+     */
+    public function testLoadNoTimestamp()
+    {
+        $this->filesystem
+            ->expects($this->once())
+            ->method('getMetadata')
+            ->with('prefix/my/file.png')
+            ->will(
+                $this->returnValue(
+                    array(
+                        'size' => 123,
+                    )
+                )
+            );
+
+        $spiBinaryFile = $this->handler->load('prefix/my/file.png');
+        $this->assertNull($spiBinaryFile->mtime);
+    }
+
+    /**
      * @expectedException \eZ\Publish\Core\IO\Exception\BinaryFileNotFoundException
      */
     public function testLoadNotFound()


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-25937
> Reboot of #1611 by @ostark

In some cases `$info['timestamp']` is not defined, e.g if 'LastModified' is not set for an S3 object:
https://github.com/thephpleague/flysystem/blob/0.5.12/src/Adapter/AwsS3.php#L486.

Changes from #1611:
- Unit test added
- CS fixed
- Added JIRA issue