### PR TITLE
Fix EZP-25559: Added missing text_linked default view template

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -15,6 +15,7 @@ parameters:
     # Default view templates
     ezplatform.default_view_templates.content.full: 'EzPublishCoreBundle:default:content/full.html.twig'
     ezplatform.default_view_templates.content.line: 'EzPublishCoreBundle:default:content/line.html.twig'
+    ezplatform.default_view_templates.content.text_linked: 'EzPublishCoreBundle:default:content/text_linked.html.twig'
     ezplatform.default_view_templates.content.embed: 'EzPublishCoreBundle:default:content/embed.html.twig'
     ezplatform.default_view_templates.content.embed_image: 'EzPublishCoreBundle:default:content/embed_image.html.twig'
     ezplatform.default_view_templates.block: 'EzPublishCoreBundle:default:block/block.html.twig'
@@ -32,6 +33,10 @@ parameters:
         line:
             default:
                 template: %ezplatform.default_view_templates.content.line%
+                match: []
+        text_linked:
+            default:
+                template: %ezplatform.default_view_templates.content.text_linked%
                 match: []
         embed:
             image:

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/text_linked.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/text_linked.html.twig
@@ -1,0 +1,7 @@
+{% set content_name=ez_content_name(content) %}
+
+{% if location is defined %}
+    <a href="{{ path(location) }}">{{ content_name }}</a>
+{% else %}
+    <p>{{ content_name }}</p>
+{% endif %}


### PR DESCRIPTION
The ezobjectrelation_field template block uses the 'text_linked' view for the related content's sub-request. Since it is not defined by default, rendering fails.

This fixes it by defining a default `content_view` rule for the `text_linked` view type. The template can be customized, like other default view templates, using a container parameter:

```
parameters:
  ezplatform.default_view_templates.content.text_linked: "content/view/text_linked.html.twig"
```