### PR TITLE
EZP-25940: Improve error when rendering a view without a template

### DIFF
--- a/eZ/Publish/Core/MVC/Exception/NoViewTemplateException.php
+++ b/eZ/Publish/Core/MVC/Exception/NoViewTemplateException.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Exception;
+
+use Exception;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+
+/**
+ * Thrown when a view is attempted to be rendered without a template set.
+ */
+class NoViewTemplateException extends Exception
+{
+    /**
+     * @var View
+     */
+    private $view;
+
+    public function __construct(View $view)
+    {
+        $this->view = $view;
+        parent::__construct(
+            sprintf(
+                "No view template was set to render the view with the '%s' view type. Check your view configuration.",
+                $view->getViewType()
+            )
+        );
+    }
+
+    public function getView()
+    {
+        return $this->view;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/View/Renderer/TemplateRenderer.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Renderer/TemplateRenderer.php
@@ -5,6 +5,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\Renderer;
 
+use eZ\Publish\Core\MVC\Exception\NoViewTemplateException;
 use eZ\Publish\Core\MVC\Symfony\View\Renderer;
 use eZ\Publish\Core\MVC\Symfony\View\View;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -34,6 +35,8 @@ class TemplateRenderer implements Renderer
     /**
      * @param \eZ\Publish\Core\MVC\Symfony\View\View $view
      *
+     * @throws NoViewTemplateException
+     *
      * @return string
      */
     public function render(View $view)
@@ -46,6 +49,10 @@ class TemplateRenderer implements Renderer
         $templateIdentifier = $view->getTemplateIdentifier();
         if ($templateIdentifier instanceof Closure) {
             return $templateIdentifier($view->getParameters());
+        }
+
+        if ($view->getTemplateIdentifier() === null) {
+            throw new NoViewTemplateException($view);
         }
 
         return $this->templateEngine->render(

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/Renderer/TemplateRendererTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/Renderer/TemplateRendererTest.php
@@ -74,6 +74,7 @@ class TemplateRendererTest extends PHPUnit_Framework_TestCase
     protected function createView()
     {
         $view = new ContentView();
+
         return $view;
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/Renderer/TemplateRendererTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/Renderer/TemplateRendererTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\View\Tests\Renderer;
+
+use eZ\Publish\Core\MVC\Symfony\MVCEvents;
+use eZ\Publish\Core\MVC\Symfony\View\ContentView;
+use eZ\Publish\Core\MVC\Symfony\View\Renderer\TemplateRenderer;
+use PHPUnit_Framework_TestCase;
+
+class TemplateRendererTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\View\Renderer\TemplateRenderer
+     */
+    private $renderer;
+
+    /**
+     * @var \Symfony\Component\Templating\EngineInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $templateEngineMock;
+
+    /**
+     * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $eventDispatcherMock;
+
+    public function setUp()
+    {
+        $this->templateEngineMock = $this->getMock('Symfony\Component\Templating\EngineInterface');
+        $this->eventDispatcherMock = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $this->renderer = new TemplateRenderer(
+            $this->templateEngineMock,
+            $this->eventDispatcherMock
+        );
+    }
+    public function testRender()
+    {
+        $view = $this->createView();
+        $view->setTemplateIdentifier('path/to/template.html.twig');
+
+        $this->eventDispatcherMock
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with(
+                MVCEvents::PRE_CONTENT_VIEW,
+                $this->isInstanceOf('\eZ\Publish\Core\MVC\Symfony\Event\PreContentViewEvent')
+            );
+
+        $this->templateEngineMock
+            ->expects($this->once())
+            ->method('render')
+            ->with(
+                'path/to/template.html.twig',
+                $view->getParameters()
+            );
+
+        $this->renderer->render($view);
+    }
+
+    /**
+     * @expectedException \eZ\Publish\Core\MVC\Exception\NoViewTemplateException
+     */
+    public function testRenderNoViewTemplate()
+    {
+        $this->renderer->render($this->createView());
+    }
+
+    /**
+     * @return \eZ\Publish\Core\MVC\Symfony\View\View
+     */
+    protected function createView()
+    {
+        $view = new ContentView();
+        return $view;
+    }
+}


### PR DESCRIPTION
> Implements [EZP-25940](http://jira.ez.no/browse/EZP-25940)
> Status: ready for review

When a view is rendered without a template being set, the error message is not informative enough:
```
An exception has been thrown during the rendering of a template ("Unable to find template """)
```

This changes the message as follows:
```
An exception has been thrown during the rendering of a template ("No view template was set to render the view with the 'text_linked' view type. Check your view configuration.")
```

Also adds a unit test to `TemplateRenderer`, that cover both a standard `render()` and a `render()` without a template.

### Possible improvements
- [ ] It would be nice if the error message could say what kind of view is being render, and what the arguments are (example: `ContentView` object ➡️ `content_view` (configuration)).