### PR TITLE
Updated flysystem dependency to ^1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ocramius/proxy-manager": "~1.0",
         "doctrine/doctrine-bundle": "~1.3",
         "liip/imagine-bundle": "~1.0",
-        "oneup/flysystem-bundle": "~0.4",
+        "oneup/flysystem-bundle": "^1.0",
         "friendsofsymfony/http-cache-bundle": ">=1.2, <=1.3.6",
         "sensio/framework-extra-bundle": "~3.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a128bba6c9e1716cd67887c5532ea132",
-    "content-hash": "ef00f4642ded0e37eb231dc9bae760a3",
+    "hash": "6d1c483a1d89fd20d3d5aab6e08a6062",
+    "content-hash": "b6d794dc0ad80144c0ad922255f4f318",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -1197,55 +1197,48 @@
         },
         {
             "name": "league/flysystem",
-            "version": "0.5.12",
+            "version": "1.0.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "e046fe60d761e30691c642c9cc6a4089f724e805"
+                "reference": "9aca859a303fdca30370f42b8c611d9cf0dedf4b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/e046fe60d761e30691c642c9cc6a4089f724e805",
-                "reference": "e046fe60d761e30691c642c9cc6a4089f724e805",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/9aca859a303fdca30370f42b8c611d9cf0dedf4b",
+                "reference": "9aca859a303fdca30370f42b8c611d9cf0dedf4b",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0"
             },
+            "conflict": {
+                "league/flysystem-sftp": "<1.0.6"
+            },
             "require-dev": {
-                "aws/aws-sdk-php": "~2.4",
-                "barracuda/copy": "~1.1.4",
-                "dropbox/dropbox-sdk": "~1.1.1",
                 "ext-fileinfo": "*",
-                "guzzlehttp/guzzle": "~4.0",
-                "league/event": "~1.0",
-                "league/phpunit-coverage-listener": "~1.1",
                 "mockery/mockery": "~0.9",
-                "phpseclib/phpseclib": "~0.3.5",
-                "phpspec/phpspec": "~2.0",
-                "phpunit/phpunit": "~4.0",
-                "predis/predis": "~1.0",
-                "rackspace/php-opencloud": "~1.10.0",
-                "sabre/dav": "~2.0.2",
-                "tedivm/stash": "~0.12.0"
+                "phpspec/phpspec": "^2.2",
+                "phpunit/phpunit": "~4.8 || ~5.0"
             },
             "suggest": {
-                "aws/aws-sdk-php": "Allows you to use AWS S3 storage",
-                "barracuda/copy": "Allows you to use Copy.com storage",
-                "dropbox/dropbox-sdk": "Allows you to use Dropbox storage",
                 "ext-fileinfo": "Required for MimeType",
-                "guzzlehttp/guzzle": "Allows you to use http files (reading only)",
-                "league/event": "Required for EventableFilesystem",
-                "phpseclib/phpseclib": "Allows SFTP server storage",
-                "predis/predis": "Allows you to use Predis for caching",
-                "rackspace/php-opencloud": "Allows you to use Rackspace Cloud Files",
-                "sabre/dav": "Enables WebDav support",
-                "tedivm/stash": "Allows you to use Stash as cache implementation"
+                "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
+                "league/flysystem-aws-s3-v3": "Allows you to use S3 storage with AWS SDK v3",
+                "league/flysystem-azure": "Allows you to use Windows Azure Blob storage",
+                "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
+                "league/flysystem-copy": "Allows you to use Copy.com storage",
+                "league/flysystem-dropbox": "Allows you to use Dropbox storage",
+                "league/flysystem-eventable-filesystem": "Allows you to use EventableFilesystem",
+                "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
+                "league/flysystem-sftp": "Allows you to use SFTP server storage via phpseclib",
+                "league/flysystem-webdav": "Allows you to use WebDAV storage",
+                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.5-dev"
+                    "dev-master": "1.1-dev"
                 }
             },
             "autoload": {
@@ -1263,10 +1256,11 @@
                     "email": "info@frenky.net"
                 }
             ],
-            "description": "Many filesystems, one API.",
+            "description": "Filesystem abstraction: Many filesystems, one API.",
             "keywords": [
                 "Cloud Files",
                 "WebDAV",
+                "abstraction",
                 "aws",
                 "cloud",
                 "copy.com",
@@ -1274,6 +1268,7 @@
                 "file systems",
                 "files",
                 "filesystem",
+                "filesystems",
                 "ftp",
                 "rackspace",
                 "remote",
@@ -1281,7 +1276,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2014-11-05 13:39:29"
+            "time": "2016-06-03 19:11:39"
         },
         {
             "name": "liip/imagine-bundle",
@@ -1479,26 +1474,48 @@
         },
         {
             "name": "oneup/flysystem-bundle",
-            "version": "v0.5.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/1up-lab/OneupFlysystemBundle.git",
-                "reference": "1c017ff194088c55faaa3b5234c86a1b19a671de"
+                "reference": "2459169ed38e38bff1471ce0b25d4b341d0a938f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/1up-lab/OneupFlysystemBundle/zipball/1c017ff194088c55faaa3b5234c86a1b19a671de",
-                "reference": "1c017ff194088c55faaa3b5234c86a1b19a671de",
+                "url": "https://api.github.com/repos/1up-lab/OneupFlysystemBundle/zipball/2459169ed38e38bff1471ce0b25d4b341d0a938f",
+                "reference": "2459169ed38e38bff1471ce0b25d4b341d0a938f",
                 "shasum": ""
             },
             "require": {
-                "league/flysystem": "~0.4",
-                "symfony/framework-bundle": ">=2.0"
+                "league/flysystem": "^1.0.14",
+                "php": ">=5.4.0",
+                "symfony/framework-bundle": "~2.0|~3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "3.7.*",
-                "symfony/browser-kit": ">=2.0",
-                "symfony/finder": ">=2.0"
+                "league/flysystem-aws-s3-v2": "~1.0",
+                "league/flysystem-cached-adapter": "~1.0",
+                "league/flysystem-copy": "~1.0",
+                "league/flysystem-dropbox": "~1.0",
+                "league/flysystem-gridfs": "~1.0",
+                "league/flysystem-rackspace": "~1.0",
+                "league/flysystem-sftp": "~1.0",
+                "league/flysystem-webdav": "~1.0",
+                "league/flysystem-ziparchive": "~1.0",
+                "phpunit/phpunit": "4.4.*",
+                "symfony/browser-kit": "~2.0|~3.0",
+                "symfony/finder": "~2.0|~3.0"
+            },
+            "suggest": {
+                "ext-fileinfo": "Required for MimeType",
+                "league/flysystem-aws-s3-v2": "Use S3 storage with AWS SDK v2",
+                "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
+                "league/flysystem-copy": "Allows you to use Copy.com storage",
+                "league/flysystem-dropbox": "Use Dropbox storage",
+                "league/flysystem-gridfs": "Allows you to use GridFS adapter",
+                "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
+                "league/flysystem-sftp": "Allows SFTP server storage via phpseclib",
+                "league/flysystem-webdav": "Allows you to use WebDAV storage",
+                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter"
             },
             "type": "symfony-bundle",
             "autoload": {
@@ -1526,7 +1543,7 @@
                 "abstraction",
                 "filesystem"
             ],
-            "time": "2015-05-01 10:23:18"
+            "time": "2016-05-31 11:05:39"
         },
         {
             "name": "pagerfanta/pagerfanta",
@@ -1707,17 +1724,17 @@
         },
         {
             "name": "sensio/distribution-bundle",
-            "version": "v4.0.6",
+            "version": "v4.0.7",
             "target-dir": "Sensio/Bundle/DistributionBundle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/SensioDistributionBundle.git",
-                "reference": "181a47c527a04d2d03986a0b3e9c1b86eaacab40"
+                "reference": "d738952285a1a7d969f9338f735108c9f65bb7f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioDistributionBundle/zipball/181a47c527a04d2d03986a0b3e9c1b86eaacab40",
-                "reference": "181a47c527a04d2d03986a0b3e9c1b86eaacab40",
+                "url": "https://api.github.com/repos/sensiolabs/SensioDistributionBundle/zipball/d738952285a1a7d969f9338f735108c9f65bb7f2",
+                "reference": "d738952285a1a7d969f9338f735108c9f65bb7f2",
                 "shasum": ""
             },
             "require": {
@@ -1763,7 +1780,7 @@
                 "configuration",
                 "distribution"
             ],
-            "time": "2016-04-25 20:49:44"
+            "time": "2016-06-23 16:10:25"
         },
         {
             "name": "sensio/framework-extra-bundle",
@@ -4157,16 +4174,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "7ae5513327cb536431847bcc0c10edba2701064e"
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/7ae5513327cb536431847bcc0c10edba2701064e",
-                "reference": "7ae5513327cb536431847bcc0c10edba2701064e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
                 "shasum": ""
             },
             "require": {
@@ -4174,12 +4191,13 @@
                 "sebastian/recursion-context": "~1.0"
             },
             "require-dev": {
+                "ext-mbstring": "*",
                 "phpunit/phpunit": "~4.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.3.x-dev"
                 }
             },
             "autoload": {
@@ -4219,7 +4237,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-06-21 07:55:53"
+            "time": "2016-06-17 09:04:28"
         },
         {
             "name": "sebastian/global-state",

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/IO.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/IO.php
@@ -44,6 +44,17 @@ class IO extends AbstractParser
                         ->info('Prefix added to binary files uris. A host can also be added')
                         ->example('$var_dir$/$storage_dir$, http://static.example.com/')
                     ->end()
+                    ->arrayNode('permissions')
+                        ->info('Permissions applied by the Local flysystem adapter when creating content files and directories in storage.')
+                        ->children()
+                            ->scalarNode('files')
+                                ->defaultValue('0644')
+                            ->end()
+                            ->scalarNode('directories')
+                                ->defaultValue('0755')
+                            ->end()
+                        ->end()
+                    ->end()
                 ->end()
             ->end();
     }
@@ -63,6 +74,14 @@ class IO extends AbstractParser
         }
         if (isset($settings['url_prefix'])) {
             $contextualizer->setContextualParameter('io.url_prefix', $currentScope, $settings['url_prefix']);
+        }
+        if (isset($settings['permissions'])) {
+            if (isset($settings['permissions']['files'])) {
+                $contextualizer->setContextualParameter('io.permissions.files', $currentScope, $settings['permissions']['files']);
+            }
+            if (isset($settings['permissions']['directories'])) {
+                $contextualizer->setContextualParameter('io.permissions.directories', $currentScope, $settings['permissions']['directories']);
+            }
         }
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -77,6 +77,8 @@ parameters:
     ezsettings.default.io.url_prefix: "$var_dir$/$storage_dir$"
     ezsettings.default.io.legacy_url_prefix: "$var_dir$/$storage_dir$"
     ezsettings.default.io.root_dir: "%webroot_dir%/$var_dir$/$storage_dir$"
+    ezsettings.default.io.permissions.files: 0644
+    ezsettings.default.io.permissions.directories: 0755
 
     # Content settings
     ezsettings.default.content.view_cache: true         # Whether to use content view cache or not (Etag/Last-Modified based)

--- a/eZ/Bundle/EzPublishIOBundle/DependencyInjection/Factory/LocalAdapterFactory.php
+++ b/eZ/Bundle/EzPublishIOBundle/DependencyInjection/Factory/LocalAdapterFactory.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * This file is part of the ezplatform package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\DependencyInjection\Factory;
+
+use League\Flysystem\Adapter\Local;
+
+/**
+ * Builds a Local Flysystem Adapter instance with the given permissions configuration.
+ */
+class LocalAdapterFactory
+{
+    /**
+     * @param string $rootDir
+     * @param int $filesPermissions Permissions used when creating files. Example: 0640.
+     * @param int $directoriesPermissions Permissions when creating directories. Example: 0750.
+     * @return Local
+     */
+    public function build($rootDir, $filesPermissions, $directoriesPermissions)
+    {
+        return new Local(
+            $rootDir,
+            LOCK_EX,
+            Local::DISALLOW_LINKS,
+            ['file' => ['public' => $filesPermissions], 'dir' => ['public' => $directoriesPermissions]]
+        );
+    }
+}

--- a/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
+++ b/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
@@ -29,8 +29,14 @@ services:
     # Inject the siteaccess config into a few io services
     ezpublish.core.io.flysystem.default_adapter:
         class: %ezpublish.core.io.flysystem.default_adapter.class%
+        factory: ["@ezpublish.core.io.flysystem.local_adapter_factory", build]
         arguments:
             - "$io.root_dir$"
+            - "$io.permissions.files$"
+            - "$io.permissions.directories$"
+
+    ezpublish.core.io.flysystem.local_adapter_factory:
+        class: eZ\Bundle\EzPublishIOBundle\DependencyInjection\Factory\LocalAdapterFactory
 
     ezpublish.core.io.prefix_url_decorator:
         class: %ezpublish.core.io.url_decorator.absolute_prefix.class%

--- a/eZ/Publish/API/Repository/Tests/SetupFactory/Legacy.php
+++ b/eZ/Publish/API/Repository/Tests/SetupFactory/Legacy.php
@@ -231,9 +231,6 @@ class Legacy extends SetupFactory
 
     protected function cleanupVarDir($sourceDir)
     {
-        if ($this->getServiceContainer()->getInnerContainer()->has('ezpublish.core.io.flysystem.default_filesystem')) {
-            $this->getServiceContainer()->getInnerContainer()->get('ezpublish.core.io.flysystem.default_filesystem')->flushCache();
-        }
         $fs = new Filesystem();
         $varDir = self::$ioRootDir . '/var';
         if ($fs->exists($varDir)) {


### PR DESCRIPTION
> Status: ready for review
> Implements [EZP-25676](https://jira.ez.no/browse/EZP-25676)

This updates the league/flysystem dependency to 1.0, and adds configuration for permissions of generated files.

The default values are `0755` for directories, and `0644` for files.

The values can be customized with siteaccess aware semantic config:
```
ezpublish:
  system:
    default:
      io:
        permissions:
          files: 0750
          directories: 0640
```

### Tasks
- [x] Update flysystem requirement to 1.x
- [x] Remove `flushCache()` calls from tests
- [x] Make permissions configurable
- [x] Add semantic configuration for permissions