### PR TITLE
Fix EZP-25280: ParentDepth Limitation fails on content creation

### DIFF
--- a/eZ/Publish/Core/Limitation/Tests/ParentDepthLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/ParentDepthLimitationTypeTest.php
@@ -1,0 +1,435 @@
+<?php
+
+/**
+ * File containing a Test Case for LimitationType class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Limitation\Tests;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\API\Repository\Values\User\Limitation\ParentDepthLimitation;
+use eZ\Publish\API\Repository\Values\User\Limitation\ObjectStateLimitation;
+use eZ\Publish\Core\Limitation\ParentDepthLimitationType;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+use eZ\Publish\Core\Repository\Values\Content\ContentCreateStruct;
+
+/**
+ * Test Case for LimitationType.
+ */
+class ParentDepthLimitationTypeTest extends Base
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Location\Handler|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $locationHandlerMock;
+
+    /**
+     * Setup Location Handler mock.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->locationHandlerMock = $this->getMock(
+            'eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler',
+            [],
+            [],
+            '',
+            false
+        );
+    }
+
+    /**
+     * Tear down Location Handler mock.
+     */
+    public function tearDown()
+    {
+        unset($this->locationHandlerMock);
+        parent::tearDown();
+    }
+
+    /**
+     * @return \eZ\Publish\Core\Limitation\ParentDepthLimitationType
+     */
+    public function testConstruct()
+    {
+        return new ParentDepthLimitationType($this->getPersistenceMock());
+    }
+
+    /**
+     * @return array
+     */
+    public function providerForTestAcceptValue()
+    {
+        return [
+            [new ParentDepthLimitation()],
+            [new ParentDepthLimitation([])],
+            [new ParentDepthLimitation(['limitationValues' => [0, 1, 2, PHP_INT_MAX]])],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestAcceptValue
+     * @depends testConstruct
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation\ParentDepthLimitation $limitation
+     * @param \eZ\Publish\Core\Limitation\ParentDepthLimitationType $limitationType
+     */
+    public function testAcceptValue(ParentDepthLimitation $limitation, ParentDepthLimitationType $limitationType)
+    {
+        $limitationType->acceptValue($limitation);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerForTestAcceptValueException()
+    {
+        return [
+            [new ObjectStateLimitation()],
+            [new ParentDepthLimitation(['limitationValues' => [true]])],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestAcceptValueException
+     * @depends testConstruct
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation $limitation
+     * @param \eZ\Publish\Core\Limitation\ParentDepthLimitationType $limitationType
+     */
+    public function testAcceptValueException(Limitation $limitation, ParentDepthLimitationType $limitationType)
+    {
+        $limitationType->acceptValue($limitation);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerForTestValidatePass()
+    {
+        return [
+            [new ParentDepthLimitation()],
+            [new ParentDepthLimitation([])],
+            [new ParentDepthLimitation(['limitationValues' => [2]])],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestValidatePass
+     * @depends testConstruct
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation\ParentDepthLimitation $limitation
+     */
+    public function testValidatePass(ParentDepthLimitation $limitation, ParentDepthLimitationType $limitationType)
+    {
+        $validationErrors = $limitationType->validate($limitation);
+        self::assertEmpty($validationErrors);
+    }
+
+    /**
+     * @depends testConstruct
+     *
+     * @param \eZ\Publish\Core\Limitation\ParentDepthLimitationType $limitationType
+     */
+    public function testBuildValue(ParentDepthLimitationType $limitationType)
+    {
+        $expected = [2, 7];
+        $value = $limitationType->buildValue($expected);
+
+        self::assertInstanceOf(
+            '\eZ\Publish\API\Repository\Values\User\Limitation\ParentDepthLimitation',
+            $value
+        );
+        self::assertInternalType('array', $value->limitationValues);
+        self::assertEquals($expected, $value->limitationValues);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerForTestEvaluate()
+    {
+        // Mocks for testing Content & VersionInfo objects, should only be used once because of expect rules.
+        $contentMock = $this->getMock(
+            'eZ\\Publish\\API\\Repository\\Values\\Content\\Content',
+            [],
+            [],
+            '',
+            false
+        );
+
+        $versionInfoMock = $this->getMock(
+            'eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo',
+            [],
+            [],
+            '',
+            false
+        );
+
+        $contentMock
+            ->expects($this->once())
+            ->method('getVersionInfo')
+            ->will($this->returnValue($versionInfoMock));
+
+        $versionInfoMock
+            ->expects($this->once())
+            ->method('getContentInfo')
+            ->will($this->returnValue(new ContentInfo(['published' => true])));
+
+        $versionInfoMock2 = $this->getMock(
+            'eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo',
+            [],
+            [],
+            '',
+            false
+        );
+
+        $versionInfoMock2
+            ->expects($this->once())
+            ->method('getContentInfo')
+            ->will($this->returnValue(new ContentInfo(['published' => true])));
+
+        return [
+            // ContentInfo, with targets, no access
+            [
+                'limitation' => new ParentDepthLimitation(),
+                'object' => new ContentInfo(['published' => true]),
+                'targets' => [new Location()],
+                'persistence' => [],
+                'expected' => false,
+            ],
+            // ContentInfo, with targets, no access
+            [
+                'limitation' => new ParentDepthLimitation(['limitationValues' => [2]]),
+                'object' => new ContentInfo(['published' => true]),
+                'targets' => [new Location(['depth' => 55])],
+                'persistence' => [],
+                'expected' => false,
+            ],
+            // ContentInfo, with targets, with access
+            [
+                'limitation' => new ParentDepthLimitation(['limitationValues' => [2]]),
+                'object' => new ContentInfo(['published' => true]),
+                'targets' => [new Location(['depth' => 2])],
+                'persistence' => [],
+                'expected' => true,
+            ],
+            // ContentInfo, no targets, with access
+            [
+                'limitation' => new ParentDepthLimitation(['limitationValues' => [2]]),
+                'object' => new ContentInfo(['published' => true]),
+                'targets' => null,
+                'persistence' => [new Location(['depth' => 2])],
+                'expected' => true,
+            ],
+            // ContentInfo, no targets, no access
+            [
+                'limitation' => new ParentDepthLimitation(['limitationValues' => [2, 43]]),
+                'object' => new ContentInfo(['published' => true]),
+                'targets' => null,
+                'persistence' => [new Location(['depth' => 55])],
+                'expected' => false,
+            ],
+            // ContentInfo, no targets, un-published, with access
+            [
+                'limitation' => new ParentDepthLimitation(['limitationValues' => [2]]),
+                'object' => new ContentInfo(['published' => false]),
+                'targets' => null,
+                'persistence' => [new Location(['depth' => 2])],
+                'expected' => true,
+            ],
+            // ContentInfo, no targets, un-published, no access
+            [
+                'limitation' => new ParentDepthLimitation(['limitationValues' => [2, 43]]),
+                'object' => new ContentInfo(['published' => false]),
+                'targets' => null,
+                'persistence' => [new Location(['depth' => 55])],
+                'expected' => false,
+            ],
+            // Content, with targets, with access
+            [
+                'limitation' => new ParentDepthLimitation(['limitationValues' => [2]]),
+                'object' => $contentMock,
+                'targets' => [new Location(['depth' => 2])],
+                'persistence' => [],
+                'expected' => true,
+            ],
+            // VersionInfo, with targets, with access
+            [
+                'limitation' => new ParentDepthLimitation(['limitationValues' => [2]]),
+                'object' => $versionInfoMock2,
+                'targets' => [new Location(['depth' => 2])],
+                'persistence' => [],
+                'expected' => true,
+            ],
+            // ContentCreateStruct, no targets, no access
+            [
+                'limitation' => new ParentDepthLimitation(['limitationValues' => [2]]),
+                'object' => new ContentCreateStruct(),
+                'targets' => [],
+                'persistence' => [],
+                'expected' => false,
+            ],
+            // ContentCreateStruct, with targets, no access
+            [
+                'limitation' => new ParentDepthLimitation(['limitationValues' => [2, 43]]),
+                'object' => new ContentCreateStruct(),
+                'targets' => [new LocationCreateStruct(['parentLocationId' => 55])],
+                'persistence' => [
+                    55 => new Location(['depth' => 42]),
+                ],
+                'expected' => false,
+            ],
+            // ContentCreateStruct, with targets, with access
+            [
+                'limitation' => new ParentDepthLimitation(['limitationValues' => [2, 42]]),
+                'object' => new ContentCreateStruct(),
+                'targets' => [new LocationCreateStruct(['parentLocationId' => 43])],
+                'persistence' => [
+                    43 => new Location(['depth' => 42]),
+                ],
+                'expected' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestEvaluate
+     */
+    public function testEvaluate(
+        ParentDepthLimitation $limitation,
+        ValueObject $object,
+        $targets,
+        array $persistenceLocations,
+        $expected
+    ) {
+        // Need to create inline instead of depending on testConstruct() to get correct mock instance
+        $limitationType = $this->testConstruct();
+
+        $userMock = $this->getUserMock();
+        $userMock
+            ->expects($this->never())
+            ->method($this->anything());
+
+        $persistenceMock = $this->getPersistenceMock();
+        if (empty($persistenceLocations)) {
+            $persistenceMock
+                ->expects($this->never())
+                ->method($this->anything());
+        } elseif ($object instanceof ContentCreateStruct) {
+            $this->getPersistenceMock()
+                ->expects($this->once())
+                ->method('locationHandler')
+                ->will($this->returnValue($this->locationHandlerMock));
+
+            foreach ($targets as $target) {
+                $this->locationHandlerMock
+                    ->expects($this->once())
+                    ->method('load')
+                    ->with($target->parentLocationId)
+                    ->will($this->returnValue($persistenceLocations[$target->parentLocationId]));
+            }
+        } else {
+            $this->getPersistenceMock()
+                ->expects($this->once())
+                ->method('locationHandler')
+                ->will($this->returnValue($this->locationHandlerMock));
+
+            $this->locationHandlerMock
+                ->expects($this->once())
+                ->method(
+                    $object instanceof ContentInfo && $object->published ?
+                        'loadLocationsByContent' :
+                        'loadParentLocationsForDraftContent'
+                )
+                ->with($object->id)
+                ->will($this->returnValue($persistenceLocations));
+        }
+
+        $value = $limitationType->evaluate(
+            $limitation,
+            $userMock,
+            $object,
+            $targets
+        );
+
+        self::assertInternalType('boolean', $value);
+        self::assertEquals($expected, $value);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerForTestEvaluateInvalidArgument()
+    {
+        return [
+            // invalid limitation
+            [
+                'limitation' => new ObjectStateLimitation(),
+                'object' => new ContentInfo(),
+                'targets' => [new Location()],
+                'persistence' => [],
+            ],
+            // invalid object
+            [
+                'limitation' => new ParentDepthLimitation(),
+                'object' => new ObjectStateLimitation(),
+                'targets' => [new Location()],
+                'persistence' => [],
+            ],
+            // invalid target
+            [
+                'limitation' => new ParentDepthLimitation(),
+                'object' => new ContentInfo(),
+                'targets' => [new ObjectStateLimitation()],
+                'persistence' => [],
+            ],
+            // invalid target when using ContentCreateStruct
+            [
+                'limitation' => new ParentDepthLimitation(),
+                'object' => new ContentCreateStruct(),
+                'targets' => [new Location()],
+                'persistence' => [],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestEvaluateInvalidArgument
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testEvaluateInvalidArgument(
+        Limitation $limitation,
+        ValueObject $object,
+        $targets,
+        array $persistenceLocations
+    ) {
+        // Need to create inline instead of depending on testConstruct() to get correct mock instance
+        $limitationType = $this->testConstruct();
+
+        $userMock = $this->getUserMock();
+        $userMock
+            ->expects($this->never())
+            ->method($this->anything());
+
+        $persistenceMock = $this->getPersistenceMock();
+        $persistenceMock
+            ->expects($this->never())
+            ->method($this->anything());
+
+        $v = $limitationType->evaluate(
+            $limitation,
+            $userMock,
+            $object,
+            $targets
+        );
+        var_dump($v);// intentional, debug in case no exception above
+    }
+}


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-25280

As described in the comment on the issue, the problem comes from missing Location on publishing the first Content draft. Solution is similar to what was already done for [`LocationLimitationType`](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/Limitation/LocationLimitationType.php#L142).

Added failing/fixed integration test and missing unit tests.