### PR TITLE
Fix EZP-25984: FieldTypeNameableCollectionFactory uses ContainerAware

### DIFF
--- a/eZ/Publish/Core/Base/Container/ApiLoader/FieldTypeNameableCollectionFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/FieldTypeNameableCollectionFactory.php
@@ -11,10 +11,13 @@
 namespace eZ\Publish\Core\Base\Container\ApiLoader;
 
 use eZ\Publish\Core\FieldType\NameableFieldTypeFallback;
-use Symfony\Component\DependencyInjection\ContainerAware;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 
-class FieldTypeNameableCollectionFactory extends ContainerAware
+class FieldTypeNameableCollectionFactory implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * Collection of fieldTypes, lazy loaded via a closure.
      *


### PR DESCRIPTION
`FieldTypeNameableCollectionFactory` was introduced at the same time than deprecated `ContainerAware` usage was removed, and still uses it.

Changes it to use `ContainerAwareInterface` + the trait.