### PR TITLE
EZP-26015 - Ezobjectrelationlist on the frontend misses the links to the objects

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed.html.twig
@@ -3,5 +3,5 @@
 {% if location is defined %}
     <h3><a href="{{ path(location) }}">{{ content_name }}</a></h3>
 {% else %}
-    <h3>{{ content_name }}</h3>
+    <h3><a href="{{ path( "ez_urlalias", {"contentId": content.id} ) }}">{{ content_name }}</a></h3>
 {% endif %}


### PR DESCRIPTION
### EZP-26015 - Ezobjectrelationlist on the frontend misses the links to the objects

Ezobjectrelationlist on the front end won't generate the links to the add objects, however in Platform UI they appear correctly
Steps: 
1. Add Content with a Ezobjectrelationlist and some objects related
2. Send for publishing
3. Verify in Platform UI that the links to the related objects are present and they work
4. Access to the Content in the frontend. The objects names are present but the links are missing