### PR TITLE
EZP-26125: Missing language parameter when generating _ez_content_view route

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
@@ -6,8 +6,20 @@ _ezpublishLocation:
         viewType: full
         layout: true
 
-_ez_content_view:
+# This route is deprecated and will be removed in future versions.
+# The purpose of the route is to preserve BC by redirecting from the old format
+# of "_ez_content_view" route with "language" parameter, to the new format without
+# the language parameter. See https://jira.ez.no/browse/EZP-26042 for details.
+_ez_content_view_redirect:
     path: /view/content/{contentId}/{language}/{viewType}/{layout}/{locationId}
+    defaults:
+        _controller: "FrameworkBundle:Redirect:redirect"
+        route: _ez_content_view
+        permanent: true
+        ignoreAttributes: [language]
+
+_ez_content_view:
+    path: /view/content/{contentId}/{viewType}/{layout}/{locationId}
     defaults:
         _controller: ez_content:viewAction
         viewType: full

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
@@ -153,7 +153,6 @@ EOF;
             '_route_params' => array(
                 'contentId' => $content->id,
                 'locationId' => $location->id,
-                'language' => $language,
             ),
             'location' => $location,
             'content' => $content,


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-26125

When trying to generate the URL for content which does not have any of the translations specified for current siteaccess and is not always available, the following error is thrown:

```
Some mandatory parameters are missing ("language") to generate a URL for route "_ez_content_view"
```

The most common reason why this happens (and hardest to debug) is when a content embeds or links to another content which does not have proper translations.

In case of such content, internal route is used to generate the URL to the content, but language cannot be reliably provided to the route. This removes the `language` parameter from the internal route in order not to crash the page. IMO, I'd rather have an internal link showing up than internal server error showing up :)

Alternative would be to use the current siteaccess if siteaccess and thus languages are not provided, but judging by the current code, the functionality is a bit different in that case.