### PR TITLE
Download asset binary only if we need to create a variation

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGenerator.php
@@ -98,14 +98,14 @@ class AliasGenerator implements VariationHandler
 
         $originalPath = $imageValue->id;
 
-        try {
-            $originalBinary = $this->dataLoader->find($originalPath);
-        } catch (NotLoadableException $e) {
-            throw new SourceImageNotFoundException($originalPath, 0, $e);
-        }
-
         // Create the image alias only if it does not already exist.
         if ($variationName !== IORepositoryResolver::VARIATION_ORIGINAL && !$this->ioResolver->isStored($originalPath, $variationName)) {
+            try {
+                $originalBinary = $this->dataLoader->find($originalPath);
+            } catch (NotLoadableException $e) {
+                throw new SourceImageNotFoundException($originalPath, 0, $e);
+            }
+
             if ($this->logger) {
                 $this->logger->debug("Generating '$variationName' variation on $originalPath, field #$fieldId ($fieldDefIdentifier)");
             }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasGeneratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasGeneratorTest.php
@@ -172,21 +172,6 @@ class AliasGeneratorTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('debug');
 
-        $binary = $this->getMock('\Liip\ImagineBundle\Binary\BinaryInterface');
-        $this->dataLoader
-            ->expects($this->once())
-            ->method('find')
-            ->with($originalPath)
-            ->will($this->returnValue($binary));
-        $this->filterManager
-            ->expects($this->never())
-            ->method('applyFilter')
-            ->with($binary, $variationName)
-            ->will($this->returnValue($binary));
-        $this->ioResolver
-            ->expects($this->never())
-            ->method('store')
-            ->with($binary, $originalPath, $variationName);
         $this->ioResolver
             ->expects($this->once())
             ->method('resolve')
@@ -298,7 +283,7 @@ class AliasGeneratorTest extends PHPUnit_Framework_TestCase
             ->method('debug');
 
         $this->dataLoader
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('find');
         $this->filterManager
             ->expects($this->never())
@@ -361,7 +346,7 @@ class AliasGeneratorTest extends PHPUnit_Framework_TestCase
             ->method('debug');
 
         $this->dataLoader
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('find');
         $this->filterManager
             ->expects($this->never())


### PR DESCRIPTION
This pull request fixes a major performance issue: it removes the need of any I/O (downloading the image binary) when simply `get`ing an image variation. As you probably know, this method is called at **every** render of the `ezfield_image`. 

On a "normal" setup with the assets stored on the disk it's not _so_ bad but when storing the assets in S3, we had up to 2 seconds and 60 requests to S3 per page view 😱 