### PR TITLE
[Tests] Provide more debug info on Functional test server failures

### DIFF
--- a/eZ/Publish/Core/REST/Client/Exceptions/ServerException.php
+++ b/eZ/Publish/Core/REST/Client/Exceptions/ServerException.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * File containing the ServerException class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Publish\Core\REST\Client\Exceptions;
+
+use eZ\Publish\Core\REST\Client\Values\ErrorMessage;
+use Exception;
+
+/**
+ * Wraps a eZ\Publish\Core\REST\Client\Values\ErrorMessage to provide info from server.
+ *
+ * To be used as previous exception when throwing client exceptions for server error response codes.
+ */
+class ServerException extends Exception
+{
+    protected $trace;
+
+    /**
+     * @param ErrorMessage $error
+     */
+    public function __construct(ErrorMessage $error)
+    {
+        parent::__construct($error->message, $error->code);
+
+        // These are only set if server is running in debug mode, but even if not set we want to overwrite the values.
+        $this->file = (string)$error->file;
+        $this->line = (int)$error->line;
+        $this->trace = explode("\n", (array)$error->trace);
+    }
+}

--- a/eZ/Publish/Core/REST/Client/Values/ErrorMessage.php
+++ b/eZ/Publish/Core/REST/Client/Values/ErrorMessage.php
@@ -6,6 +6,14 @@ namespace eZ\Publish\Core\REST\Client\Values;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
 
+/**
+ * @property-read int $code
+ * @property-read string $message
+ * @property-read string $description
+ * @property-read mixed $trace
+ * @property-read string $file
+ * @property-read int $line
+ */
 class ErrorMessage extends ValueObject
 {
     protected $code;


### PR DESCRIPTION
Makes sure exception from server is shown in test output by passing it on.

Note: As always server need to run in debug mode to provide file, line and trace info *(Not included in REST response in prod for security reasons)*.