### PR TITLE
EZP-25942: As a Maintainer I want Continuous Integration on Windows so we can move towards better supporting it

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,3 +35,11 @@ install:
     - IF %PHP%==1 appveyor DownloadFile https://getcomposer.org/download/1.1.3/composer.phar
     - cd c:\projects\ezpublish-kernel
     - composer update --no-progress --ansi
+
+test_script:
+    - cd c:\projects\ezpublish-kernel
+    - copy /Y config.php-DEVELOPMENT config.php
+    - SET X=0
+    - vendor/bin/phpunit --colors=never -c phpunit.xml || SET X=!errorlevel!
+    - vendor/bin/phpunit --colors=never -c phpunit-integration-legacy.xml || SET X=!errorlevel!
+    - exit %X%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,37 @@
+build: off
+clone_depth: 30
+clone_folder: c:\projects\ezpublish-kernel
+
+skip_commits:
+    message: /\[skip ci\]/i
+
+init:
+    - SET PATH=c:\php;%PATH%
+    - SET COMPOSER_NO_INTERACTION=1
+    - SET PHP=1
+    - SET ANSICON=121x90 (121x90)
+    - REG ADD "HKEY_CURRENT_USER\Software\Microsoft\Command Processor" /v DelayedExpansion /t REG_DWORD /d 1 /f
+
+install:
+    - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
+    - cd c:\php
+    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-7.0.8-nts-Win32-VC14-x86.zip
+    - IF %PHP%==1 7z x php-7.0.8-nts-Win32-VC14-x86.zip -y >nul
+    - IF %PHP%==1 del /Q *.zip
+    - IF %PHP%==1 copy /Y php.ini-development php.ini
+    - IF %PHP%==1 echo max_execution_time=0 >> php.ini
+    - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
+    - IF %PHP%==1 echo extension=php_intl.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_xsl.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_gd2.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_pdo_sqlite.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_mbstring.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_fileinfo.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_curl.dll >> php.ini
+    - IF %PHP%==1 echo memory_limit=512M >> php.ini
+    - IF %PHP%==1 echo default_charset="utf-8" >> php.ini
+    - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
+    - IF %PHP%==1 appveyor DownloadFile https://getcomposer.org/download/1.1.3/composer.phar
+    - cd c:\projects\ezpublish-kernel
+    - composer update --no-progress --ansi


### PR DESCRIPTION
This PR solves [EZP-25942](https://jira.ez.no/browse/EZP-25942) introducing [AppVeyor](https://appveyor.com/) (continuous integration tool for Windows) project file.

Sample PR presenting working integration: [alongosz/ezpublish-kernel/pull/1](https://github.com/alongosz/ezpublish-kernel/pull/1).

**TODO**:
- [x] Create AppVeyor project file (`appveyor.yml`) with initial configuration (preparing PHP `7.0.x` test environment).
- [x] Add basic unit tests (`phpunit.xml`) to AppVeyor project file.
- [x] Add integration tests with sqlite (`phpunit-integration-legacy.xml`) to AppVeyor project file.
- [x] Fix errors specific to Microsoft Windows operating system (#1725).


