### PR TITLE
EZP-25942: Fix errors specific to Microsoft Windows operating system

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/FileBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/FileBaseIntegrationTest.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\API\Repository\Tests\FieldType;
 
 use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
-use FileSystemIterator;
+use FilesystemIterator;
 use UnexpectedValueException;
 
 /**
@@ -115,14 +115,14 @@ abstract class FileBaseIntegrationTest extends BaseIntegrationTest
     /**
      * Returns an iterator over the full storage dir.
      *
-     * @return Iterator
+     * @return \Iterator
      */
     protected static function getStorageDirIterator()
     {
         return new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator(
-                self::$installDir . '/' . self::$storageDir,
-                FileSystemIterator::KEY_AS_PATHNAME | FileSystemIterator::SKIP_DOTS | FilesystemIterator::CURRENT_AS_FILEINFO
+                self::$installDir . DIRECTORY_SEPARATOR . self::$storageDir,
+                FilesystemIterator::KEY_AS_PATHNAME | FilesystemIterator::SKIP_DOTS | FilesystemIterator::CURRENT_AS_FILEINFO
             ),
             RecursiveIteratorIterator::CHILD_FIRST
         );
@@ -130,8 +130,6 @@ abstract class FileBaseIntegrationTest extends BaseIntegrationTest
 
     /**
      * Removes the given directory path recursively.
-     *
-     * @param string $dir
      */
     protected static function cleanupStorageDir()
     {
@@ -160,7 +158,8 @@ abstract class FileBaseIntegrationTest extends BaseIntegrationTest
     protected static function setUpIgnoredPath($ignoredFiles)
     {
         foreach ($ignoredFiles as $ignoredFile) {
-            $pathPartsArray = explode(DIRECTORY_SEPARATOR, $ignoredFile);
+            // Note: do not use here DIRECTORY_SEPARATOR - $ignoredFiles list comes from yaml settings
+            $pathPartsArray = explode('/', $ignoredFile);
             foreach ($pathPartsArray as $index => $directoryPart) {
                 if ($directoryPart == '') {
                     continue;

--- a/eZ/Publish/API/Repository/Tests/FieldType/FileSearchBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/FileSearchBaseIntegrationTest.php
@@ -12,7 +12,7 @@ namespace eZ\Publish\API\Repository\Tests\FieldType;
 
 use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
-use FileSystemIterator;
+use FilesystemIterator;
 use UnexpectedValueException;
 
 /**
@@ -115,14 +115,14 @@ abstract class FileSearchBaseIntegrationTest extends SearchBaseIntegrationTest
     /**
      * Returns an iterator over the full storage dir.
      *
-     * @return Iterator
+     * @return \Iterator
      */
     protected static function getStorageDirIterator()
     {
         return new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator(
-                self::$installDir . '/' . self::$storageDir,
-                FileSystemIterator::KEY_AS_PATHNAME | FileSystemIterator::SKIP_DOTS | FilesystemIterator::CURRENT_AS_FILEINFO
+                self::$installDir . DIRECTORY_SEPARATOR . self::$storageDir,
+                FilesystemIterator::KEY_AS_PATHNAME | FilesystemIterator::SKIP_DOTS | FilesystemIterator::CURRENT_AS_FILEINFO
             ),
             RecursiveIteratorIterator::CHILD_FIRST
         );
@@ -130,8 +130,6 @@ abstract class FileSearchBaseIntegrationTest extends SearchBaseIntegrationTest
 
     /**
      * Removes the given directory path recursively.
-     *
-     * @param string $dir
      */
     protected static function cleanupStorageDir()
     {
@@ -160,7 +158,8 @@ abstract class FileSearchBaseIntegrationTest extends SearchBaseIntegrationTest
     protected static function setUpIgnoredPath($ignoredFiles)
     {
         foreach ($ignoredFiles as $ignoredFile) {
-            $pathPartsArray = explode(DIRECTORY_SEPARATOR, $ignoredFile);
+            // Note: do not use here DIRECTORY_SEPARATOR - $ignoredFiles list comes from yaml settings
+            $pathPartsArray = explode('/', $ignoredFile);
             foreach ($pathPartsArray as $index => $directoryPart) {
                 if ($directoryPart == '') {
                     continue;

--- a/eZ/Publish/Core/IO/IOService.php
+++ b/eZ/Publish/Core/IO/IOService.php
@@ -320,4 +320,15 @@ class IOService implements IOServiceInterface
         $this->metadataHandler->deleteDirectory($prefixedUri);
         $this->binarydataHandler->deleteDirectory($prefixedUri);
     }
+
+    /**
+     * Check if path is absolute, in terms of http or disk (incl if it contains driver letter on Win).
+     *
+     * @param string $path
+     * @return bool
+     */
+    protected function isAbsolutePath($path)
+    {
+        return $path[0] === '/' || (PHP_OS === 'WINNT' && $path[1] === ':');
+    }
 }

--- a/eZ/Publish/Core/IO/IOService.php
+++ b/eZ/Publish/Core/IO/IOService.php
@@ -156,7 +156,7 @@ class IOService implements IOServiceInterface
         $this->checkBinaryFileId($binaryFileId);
 
         // @todo An absolute path can in no case be loaded, but throwing an exception is too much (why ?)
-        if ($binaryFileId[0] === '/') {
+        if ($this->isAbsolutePath($binaryFileId)) {
             return false;
         }
 

--- a/eZ/Publish/Core/IO/TolerantIOService.php
+++ b/eZ/Publish/Core/IO/TolerantIOService.php
@@ -73,7 +73,7 @@ class TolerantIOService extends IOService
     {
         $this->checkBinaryFileId($binaryFileId);
 
-        if ($binaryFileId[0] === '/' || (PHP_OS === 'WINNT' && $binaryFileId[1] === ':')) {
+        if ($this->isAbsolutePath($binaryFileId)) {
             throw new InvalidBinaryFileIdException($binaryFileId, 'Binary file ids can not begin with a /');
         }
 

--- a/eZ/Publish/Core/IO/TolerantIOService.php
+++ b/eZ/Publish/Core/IO/TolerantIOService.php
@@ -73,7 +73,7 @@ class TolerantIOService extends IOService
     {
         $this->checkBinaryFileId($binaryFileId);
 
-        if ($binaryFileId[0] === '/') {
+        if ($binaryFileId[0] === '/' || (PHP_OS === 'WINNT' && $binaryFileId[1] === ':')) {
             throw new InvalidBinaryFileIdException($binaryFileId, 'Binary file ids can not begin with a /');
         }
 

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/LocationAwareStore.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/LocationAwareStore.php
@@ -89,11 +89,11 @@ class LocationAwareStore extends Store implements ContentPurger
         }
 
         $prefix = '';
-        if (($pos = strrpos($key, '/')) !== false) {
+        if (($pos = strrpos($key, DIRECTORY_SEPARATOR)) !== false) {
             $prefix = substr($key, 0, $pos) . DIRECTORY_SEPARATOR;
             $key = substr($key, $pos + 1);
 
-            list($locationCacheDir, $locationId) = explode('/', $prefix);
+            list($locationCacheDir, $locationId) = explode(DIRECTORY_SEPARATOR, $prefix);
             unset($locationCacheDir);
             // If cache purge is in progress, serve stale cache instead of regular cache.
             // We first check for a global cache purge, then for the current location.

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/LocationAwareStoreTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/LocationAwareStoreTest.php
@@ -48,22 +48,22 @@ class LocationAwareStoreTest extends PHPUnit_Framework_TestCase
 
     public function testGetPath()
     {
-        $prefix = LocationAwareStore::LOCATION_CACHE_DIR . '/123/';
-        $path = $this->store->getPath("$prefix/en" . sha1('someContent'));
-        $this->assertTrue(strpos($path, __DIR__ . "/$prefix") === 0);
+        $prefix = LocationAwareStore::LOCATION_CACHE_DIR . DIRECTORY_SEPARATOR . '123' . DIRECTORY_SEPARATOR;
+        $path = $this->store->getPath($prefix . DIRECTORY_SEPARATOR . 'en' . sha1('someContent'));
+        $this->assertTrue(strpos($path, __DIR__ . DIRECTORY_SEPARATOR . $prefix) === 0);
     }
 
     public function testGetStalePath()
     {
         // Generate the lock file to force using the stale cache dir
         $locationId = 123;
-        $prefix = LocationAwareStore::LOCATION_CACHE_DIR . "/$locationId";
-        $prefixStale = LocationAwareStore::LOCATION_STALE_CACHE_DIR . "/$locationId";
+        $prefix = LocationAwareStore::LOCATION_CACHE_DIR . DIRECTORY_SEPARATOR . $locationId;
+        $prefixStale = LocationAwareStore::LOCATION_STALE_CACHE_DIR . DIRECTORY_SEPARATOR . $locationId;
         $lockFile = $this->store->getLocationCacheLockName($locationId);
         file_put_contents($lockFile, getmypid());
 
-        $path = $this->store->getPath("$prefix/en" . sha1('someContent'));
-        $this->assertTrue(strpos($path, __DIR__ . "/$prefixStale") === 0);
+        $path = $this->store->getPath($prefix . DIRECTORY_SEPARATOR . 'en' . sha1('someContent'));
+        $this->assertTrue(strpos($path, __DIR__ . DIRECTORY_SEPARATOR . $prefixStale) === 0);
         @unlink($lockFile);
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIElement.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIElement.php
@@ -141,7 +141,7 @@ class URIElement implements VersatileMatcher, URILexer
         if ($uri == $uriElements) {
             $uri = '';
         } elseif (strpos($uri, $uriElements) === 0) {
-            sscanf($uri, "$uriElements%s", $uri);
+            $uri = mb_substr($uri, mb_strlen($uriElements));
         }
 
         return $uri;


### PR DESCRIPTION
Status: **Ready for review**
To move forward with #1724 we need to fix some errors revealed while running CI tests on Windows.

**TODO**:
- [x] Change hardcoded directory separator to a proper PHP constant ([`LocationAwareStoreTest`](https://ci.appveyor.com/project/alongosz/ezpublish-kernel/build/1.0.18#L449))
- [x] Fix incorrect handling of URI elements with accents ([`RouterURIElement2Test`](https://ci.appveyor.com/project/alongosz/ezpublish-kernel/build/1.0.18#L464))
- [x] Fix checking for absolute filesystem path on Windows ([`ImageIntegrationTest`](https://ci.appveyor.com/project/alongosz/ezpublish-kernel/build/1.0.18#L496))
- [x] Fix warnings occurring while running sqlite integration tests.