### PR TITLE
[Stash] Update to Stash Bundle v0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
       env: BEHAT_OPTS="--profile=core --tags=~@broken" RUN_INSTALL=1 PHP_IMAGE=ezsystems/php:5.6-v0 SYMFONY_ENV=behat SYMFONY_DEBUG=1
 # 7.0
     - php: 7.0
-      env: REST_TEST_CONFIG="phpunit-functional-rest.xml" RUN_INSTALL=1
+      env: REST_TEST_CONFIG="phpunit-functional-rest.xml" RUN_INSTALL=1 SYMFONY_ENV=dev SYMFONY_DEBUG=1
     - php: 7.0
       env: TEST_CONFIG="phpunit.xml"
     - php: 7.0

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony-cmf/routing": "~1.1",
         "qafoo/rmf": "1.0.*",
         "kriswallsmith/buzz": ">=0.9",
-        "tedivm/stash-bundle": "0.5.*",
+        "tedivm/stash-bundle": "~0.6.1",
         "sensio/distribution-bundle": "^3.0.36|^4.0.6",
         "nelmio/cors-bundle": "^1.3.3",
         "hautelook/templated-uri-bundle": "~1.0 | ~2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6d1c483a1d89fd20d3d5aab6e08a6062",
-    "content-hash": "b6d794dc0ad80144c0ad922255f4f318",
+    "hash": "24022f2c7c8e1fda05eb10449344884c",
+    "content-hash": "fd875ecf5eb2a95fe427126fc76fb4df",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -889,27 +889,28 @@
                 "rest",
                 "web service"
             ],
+            "abandoned": "guzzlehttp/guzzle",
             "time": "2015-03-18 18:23:50"
         },
         {
             "name": "hautelook/templated-uri-bundle",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "target-dir": "Hautelook/TemplatedUriBundle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/hautelook/TemplatedUriBundle.git",
-                "reference": "d5d32ca1c9f13ca170023fd7cb4f1c969d3fd1ad"
+                "reference": "abf784feea984783eab0a822541c7aa3f58d445e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hautelook/TemplatedUriBundle/zipball/d5d32ca1c9f13ca170023fd7cb4f1c969d3fd1ad",
-                "reference": "d5d32ca1c9f13ca170023fd7cb4f1c969d3fd1ad",
+                "url": "https://api.github.com/repos/hautelook/TemplatedUriBundle/zipball/abf784feea984783eab0a822541c7aa3f58d445e",
+                "reference": "abf784feea984783eab0a822541c7aa3f58d445e",
                 "shasum": ""
             },
             "require": {
                 "hautelook/templated-uri-router": "~2.0",
                 "php": ">=5.3.0",
-                "symfony/framework-bundle": "~2.1"
+                "symfony/framework-bundle": "~2.1|~3.0"
             },
             "type": "symfony-bundle",
             "extra": {
@@ -943,7 +944,7 @@
                 "url",
                 "xml"
             ],
-            "time": "2014-07-28 21:56:22"
+            "time": "2016-04-28 22:18:53"
         },
         {
             "name": "hautelook/templated-uri-router",
@@ -1197,16 +1198,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.24",
+            "version": "1.0.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "9aca859a303fdca30370f42b8c611d9cf0dedf4b"
+                "reference": "fb3b30dca320b36931ea878fea17ebe136fba1b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/9aca859a303fdca30370f42b8c611d9cf0dedf4b",
-                "reference": "9aca859a303fdca30370f42b8c611d9cf0dedf4b",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/fb3b30dca320b36931ea878fea17ebe136fba1b0",
+                "reference": "fb3b30dca320b36931ea878fea17ebe136fba1b0",
                 "shasum": ""
             },
             "require": {
@@ -1219,7 +1220,7 @@
                 "ext-fileinfo": "*",
                 "mockery/mockery": "~0.9",
                 "phpspec/phpspec": "^2.2",
-                "phpunit/phpunit": "~4.8 || ~5.0"
+                "phpunit/phpunit": "~4.8"
             },
             "suggest": {
                 "ext-fileinfo": "Required for MimeType",
@@ -1276,29 +1277,30 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2016-06-03 19:11:39"
+            "time": "2016-08-03 09:49:11"
         },
         {
             "name": "liip/imagine-bundle",
-            "version": "1.5.3",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liip/LiipImagineBundle.git",
-                "reference": "b657b6601a24da525645fb5358ce77fdf57889f1"
+                "reference": "cc881beb2daea75068ad75329e6d71963fa95028"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liip/LiipImagineBundle/zipball/b657b6601a24da525645fb5358ce77fdf57889f1",
-                "reference": "b657b6601a24da525645fb5358ce77fdf57889f1",
+                "url": "https://api.github.com/repos/liip/LiipImagineBundle/zipball/cc881beb2daea75068ad75329e6d71963fa95028",
+                "reference": "cc881beb2daea75068ad75329e6d71963fa95028",
                 "shasum": ""
             },
             "require": {
-                "imagine/imagine": "~0.5,<0.7",
+                "imagine/imagine": "^0.6.3,<0.7",
                 "php": "^5.3.9|^7.0",
                 "symfony/filesystem": "~2.3|~3.0",
                 "symfony/finder": "~2.3|~3.0",
                 "symfony/framework-bundle": "~2.3|~3.0",
-                "symfony/options-resolver": "~2.3|~3.0"
+                "symfony/options-resolver": "~2.3|~3.0",
+                "symfony/process": "~2.3|~3.0"
             },
             "require-dev": {
                 "amazonwebservices/aws-sdk-for-php": "~1.0",
@@ -1326,7 +1328,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
@@ -1350,7 +1352,7 @@
                 "image",
                 "imagine"
             ],
-            "time": "2016-05-06 06:27:38"
+            "time": "2016-07-22 14:52:30"
         },
         {
             "name": "nelmio/cors-bundle",
@@ -1659,6 +1661,52 @@
                 "random"
             ],
             "time": "2016-04-03 06:00:07"
+        },
+        {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "time": "2016-08-06 20:24:11"
         },
         {
             "name": "psr/log",
@@ -2461,16 +2509,16 @@
         },
         {
             "name": "symfony/symfony",
-            "version": "v2.8.7",
+            "version": "v2.8.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "663b2d6202c3149515b39cfe50a174a130acb8e2"
+                "reference": "df02dd5d3f7decb3a05c6d0f31054b4263625dcb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/663b2d6202c3149515b39cfe50a174a130acb8e2",
-                "reference": "663b2d6202c3149515b39cfe50a174a130acb8e2",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/df02dd5d3f7decb3a05c6d0f31054b4263625dcb",
+                "reference": "df02dd5d3f7decb3a05c6d0f31054b4263625dcb",
                 "shasum": ""
             },
             "require": {
@@ -2544,7 +2592,7 @@
                 "doctrine/dbal": "~2.4",
                 "doctrine/doctrine-bundle": "~1.2",
                 "doctrine/orm": "~2.4,>=2.4.5",
-                "egulias/email-validator": "~1.2",
+                "egulias/email-validator": "~1.2,>=1.2.1",
                 "monolog/monolog": "~1.11",
                 "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
                 "phpdocumentor/reflection": "^1.0.7"
@@ -2591,28 +2639,32 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2016-06-06 16:05:37"
+            "time": "2016-07-30 08:48:52"
         },
         {
             "name": "tedivm/stash",
-            "version": "v0.13.2",
+            "version": "v0.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tedious/Stash.git",
-                "reference": "3489b13bad93c81a898fcb1054ae954575e1a7b6"
+                "reference": "bcb739b08b22571e35589ebe5403af9b89a33394"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tedious/Stash/zipball/3489b13bad93c81a898fcb1054ae954575e1a7b6",
-                "reference": "3489b13bad93c81a898fcb1054ae954575e1a7b6",
+                "url": "https://api.github.com/repos/tedious/Stash/zipball/bcb739b08b22571e35589ebe5403af9b89a33394",
+                "reference": "bcb739b08b22571e35589ebe5403af9b89a33394",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.4|^7.0"
+                "php": "^5.4|^7.0",
+                "psr/cache": "~1.0"
+            },
+            "provide": {
+                "psr/cache-implementation": "1.0.0"
             },
             "require-dev": {
                 "fabpot/php-cs-fixer": "^1.9",
-                "phpunit/phpunit": "4.7.*",
+                "phpunit/phpunit": "4.8.*",
                 "satooshi/php-coveralls": "1.0.*"
             },
             "type": "library",
@@ -2642,23 +2694,25 @@
                 "cache",
                 "caching",
                 "memcached",
+                "psr-6",
+                "psr6",
                 "redis",
                 "sessions"
             ],
-            "time": "2015-12-29 00:07:05"
+            "time": "2016-02-10 22:23:16"
         },
         {
             "name": "tedivm/stash-bundle",
-            "version": "v0.5.3",
+            "version": "v0.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tedious/TedivmStashBundle.git",
-                "reference": "c9ac2259ec8064914e5e20ec690f7c11d1898757"
+                "reference": "99e435e8f61ac165183c0d279e15bfd225eb67c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tedious/TedivmStashBundle/zipball/c9ac2259ec8064914e5e20ec690f7c11d1898757",
-                "reference": "c9ac2259ec8064914e5e20ec690f7c11d1898757",
+                "url": "https://api.github.com/repos/tedious/TedivmStashBundle/zipball/99e435e8f61ac165183c0d279e15bfd225eb67c4",
+                "reference": "99e435e8f61ac165183c0d279e15bfd225eb67c4",
                 "shasum": ""
             },
             "require": {
@@ -2666,7 +2720,7 @@
                 "symfony/config": "~2.1|~3.0",
                 "symfony/dependency-injection": "~2.1|~3.0",
                 "symfony/http-kernel": "~2.1|~3.0",
-                "tedivm/stash": "0.13.*"
+                "tedivm/stash": "0.14.*"
             },
             "require-dev": {
                 "doctrine/cache": "~1.0",
@@ -2706,7 +2760,7 @@
                 "stash",
                 "symfony"
             ],
-            "time": "2015-12-29 02:22:57"
+            "time": "2016-02-11 01:11:59"
         },
         {
             "name": "twig/twig",
@@ -3880,16 +3934,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.26",
+            "version": "4.8.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "fc1d8cd5b5de11625979125c5639347896ac2c74"
+                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/fc1d8cd5b5de11625979125c5639347896ac2c74",
-                "reference": "fc1d8cd5b5de11625979125c5639347896ac2c74",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c062dddcb68e44b563f66ee319ddae2b5a322a90",
+                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90",
                 "shasum": ""
             },
             "require": {
@@ -3948,7 +4002,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-05-17 03:09:28"
+            "time": "2016-07-21 06:48:14"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/eZ/Publish/Core/Persistence/Cache/CacheServiceDecorator.php
+++ b/eZ/Publish/Core/Persistence/Cache/CacheServiceDecorator.php
@@ -99,7 +99,6 @@ class CacheServiceDecorator
         return str_replace('/', '_', trim($key, '/'));
     }
 
-
     /**
      * Clears the cache for the key, or if none is specified clears the entire cache. The key can be either
      * a series of string arguments, or an array.

--- a/eZ/Publish/Core/Persistence/Cache/CacheServiceDecorator.php
+++ b/eZ/Publish/Core/Persistence/Cache/CacheServiceDecorator.php
@@ -37,8 +37,9 @@ class CacheServiceDecorator
     }
 
     /**
-     * Returns a Cache item for the specified key. The key can be either a series of string arguments,
-     * or an array.
+     * Prepend key with prefix and support array format Stash supported before.
+     *
+     * {@see \Psr\Cache\CacheItemPoolInterface}
      *
      * @internal param array|string $key , $key, $key...
      *
@@ -48,16 +49,44 @@ class CacheServiceDecorator
     {
         $args = func_get_args();
 
-        // check to see if a single array was used instead of multiple arguments, & check empty in case of empty clear()
         if (empty($args)) {
-            $args = array();
-        } elseif (!isset($args[1]) && is_array($args[0])) {
-            $args = $args[0];
+            return $this->cachePool->getItem(self::SPI_CACHE_KEY_PREFIX);
         }
 
-        array_unshift($args, self::SPI_CACHE_KEY_PREFIX);
+        //  Upstream seems to no longer support array, so we flatten it
+        if (!isset($args[1]) && is_array($args[0])) {
+            $key = implode('/', $args[0]);
+        } else {
+            $key = '' . implode('/', $args);
+        }
 
-        return $this->cachePool->getItem($args);
+        $key = trim($key, '/');
+        $key = $key === '' ? self::SPI_CACHE_KEY_PREFIX : self::SPI_CACHE_KEY_PREFIX . '/' . $key;
+
+        return $this->cachePool->getItem($key);
+    }
+
+    /**
+     * Prepend keys with prefix.
+     *
+     * {@see \Psr\Cache\CacheItemPoolInterface}
+     *
+     * @param array $keys
+     * @return \Stash\Interfaces\ItemInterface[]
+     */
+    public function getItems(array $keys = array())
+    {
+        $prefix = self::SPI_CACHE_KEY_PREFIX;
+        $keys = array_map(
+            function ($key) use ($prefix) {
+                $key = trim($key, '/');
+
+                return $key === '' ? $prefix : $prefix . '/' . $key;
+            },
+            $keys
+        );
+
+        return $this->cachePool->getItems($keys);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Cache/Tests/Helpers/IntegrationTestCacheServiceDecorator.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/Helpers/IntegrationTestCacheServiceDecorator.php
@@ -34,6 +34,6 @@ class IntegrationTestCacheServiceDecorator extends CacheServiceDecorator
      */
     public function clearAllTestData()
     {
-        $this->cachePool->flush();
+        $this->cachePool->clear();
     }
 }


### PR DESCRIPTION
Using Stash bundle v0.6 is not safe* without the following fixes, adding this to 6.5 and not 6.4 as stash api changed.

\* Number of integration test failures before fixes on cache decorator _(effectively all)_:
```
FAILURES!
Tests: 972, Assertions: 430, Errors: 587, Failures: 100, Skipped: 7979, Incomplete: 6.
```