### PR TITLE
EZP-26080: Can't register REST routes with different prefix

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/EventListener/RequestListener.php
+++ b/eZ/Bundle/EzPublishRestBundle/EventListener/RequestListener.php
@@ -22,18 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class RequestListener implements EventSubscriberInterface
 {
-    /**
-     * @var string
-     */
-    private $restPrefix;
-
-    /**
-     * @param string $restPrefix
-     */
-    public function __construct($restPrefix)
-    {
-        $this->restPrefix = $restPrefix;
-    }
+    const REST_PREFIX_PATTERN = '/^\/api\/[a-zA-Z0-9-_]+\/v\d+(\.\d+)?\//';
 
     /**
      * @return array
@@ -69,11 +58,6 @@ class RequestListener implements EventSubscriberInterface
      */
     protected function hasRestPrefix(Request $request)
     {
-        return (
-            strpos(
-                $request->getPathInfo(),
-                $this->restPrefix
-            ) === 0
-        );
+        return preg_match(self::REST_PREFIX_PATTERN, $request->getPathInfo());
     }
 }

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
@@ -226,8 +226,6 @@ services:
 
     ezpublish_rest.request_listener:
         class: %ezpublish_rest.request_listener.class%
-        arguments:
-            - %ezpublish_rest.path_prefix%
         tags:
             - { name: kernel.event_subscriber }
 


### PR DESCRIPTION
**JIRA ticket related:** https://jira.ez.no/browse/EZP-26080

Currently `RequestListener` forces developers to use predefined REST prefix for every REST call (it's `/api/ezp/v2` by default) even if custom REST actions are not `ezp` nor `v2`.

Proposed solution is to match prefix with pattern `/api/{name}/v{version}/` and allow to prefix (and version) custom REST routes, without BC break.

`{name}` - only letters (upper and lowercase), digits, underscore and dash
`{version}` - up to two-level version number (for example `1`, `2` but also `1.5`)