### PR TITLE
EZP-26000: first implementation of permission lookup API

### DIFF
--- a/eZ/Publish/API/Repository/PermissionResolver.php
+++ b/eZ/Publish/API/Repository/PermissionResolver.php
@@ -65,4 +65,13 @@ interface PermissionResolver
      * @return bool
      */
     public function canUser($module, $function, ValueObject $object, array $targets = []);
+
+    /**
+     * Returns PermissionInfo for the given $object.
+     *
+     * @param \eZ\Publish\API\Repository\Values\ValueObject $object
+     *
+     * @return \eZ\Publish\API\Repository\Values\PermissionInfo
+     */
+    public function getPermissionInfo(ValueObject $object);
 }

--- a/eZ/Publish/API/Repository/Values/PermissionInfo.php
+++ b/eZ/Publish/API/Repository/Values/PermissionInfo.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\API\Repository\Values;
+
+/**
+ * todo
+ *
+ * @property-read string $module
+ * @property-read \eZ\Publish\API\Repository\Values\ValueObject $object
+ * @property-read \eZ\Publish\API\Repository\Values\User\UserReference $userReference
+ */
+abstract class PermissionInfo extends ValueObject
+{
+    /**
+     * @var string
+     */
+    protected $module;
+
+    /**
+     * @var \eZ\Publish\API\Repository\Values\ValueObject
+     */
+    protected $object;
+
+    /**
+     * @var \eZ\Publish\API\Repository\Values\User\UserReference
+     */
+    protected $userReference;
+
+    /**
+     * todo
+     *
+     * @param string $function
+     *
+     * @return boolean
+     */
+    abstract public function canUser($function);
+
+    /**
+     * @return mixed
+     */
+    abstract public function getHash();
+}

--- a/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
+++ b/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
@@ -14,6 +14,9 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue;
 use eZ\Publish\Core\Repository\Helper\LimitationService;
 use eZ\Publish\Core\Repository\Helper\RoleDomainMapper;
+use eZ\Publish\Core\Repository\PermissionResolver\PermissionInfoMapper\Content as ContentPermissionInfoMapper;
+use eZ\Publish\Core\Repository\PermissionResolver\PermissionInfoMapper\Aggregate as PermissionInfoMapper;
+use eZ\Publish\Core\Repository\PermissionResolver\PermissionResolver;
 use eZ\Publish\SPI\Limitation\Type as LimitationType;
 use eZ\Publish\SPI\Persistence\User\Handler as UserHandler;
 use Exception;
@@ -53,6 +56,11 @@ class PermissionResolver implements PermissionResolverInterface
     private $currentUserRef;
 
     /**
+     * @var \eZ\Publish\Core\Repository\PermissionResolver\PermissionInfoMapper
+     */
+    private $permissionInfoMapper;
+
+    /**
      * @param \eZ\Publish\Core\Repository\Helper\RoleDomainMapper $roleDomainMapper
      * @param \eZ\Publish\Core\Repository\Helper\LimitationService $limitationService
      * @param \eZ\Publish\SPI\Persistence\User\Handler $userHandler
@@ -68,6 +76,16 @@ class PermissionResolver implements PermissionResolverInterface
         $this->limitationService = $limitationService;
         $this->userHandler = $userHandler;
         $this->currentUserRef = $userReference;
+
+        // TODO: inject
+        $permissionResolver = new PermissionResolver(
+            $this->roleDomainMapper,
+            $this->limitationService,
+            $this->userHandler
+        );
+        $this->permissionInfoMapper = new PermissionInfoMapper();
+        $contentPermissionInfoMapper = new ContentPermissionInfoMapper($permissionResolver);
+        $this->permissionInfoMapper->addMapper($contentPermissionInfoMapper);
     }
 
     public function getCurrentUserReference()
@@ -222,6 +240,15 @@ class PermissionResolver implements PermissionResolverInterface
         }
 
         return false;// None of the limitation sets wanted to let you in, sorry!
+    }
+
+    public function getPermissionInfo(ValueObject $object, APIUserReference $userReference = null)
+    {
+        if ($userReference === null) {
+            $userReference = $this->getCurrentUserReference();
+        }
+
+        return $this->permissionInfoMapper->map($object, $userReference);
     }
 
     /**

--- a/eZ/Publish/Core/Repository/PermissionResolver/Permission.php
+++ b/eZ/Publish/Core/Repository/PermissionResolver/Permission.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Repository\PermissionResolver;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * todo
+ *
+ * @property-read null|\eZ\Publish\API\Repository\Values\User\Limitation $limitation
+ * @property-read \eZ\Publish\API\Repository\Values\User\Policy[] $policies
+ */
+class Permission extends ValueObject
+{
+    /**
+     * @var null|\eZ\Publish\API\Repository\Values\User\Limitation
+     */
+    protected $limitation;
+
+    /**
+     * @var \eZ\Publish\API\Repository\Values\User\Policy[]
+     */
+    protected $policies = [];
+}

--- a/eZ/Publish/Core/Repository/PermissionResolver/PermissionInfoMapper.php
+++ b/eZ/Publish/Core/Repository/PermissionResolver/PermissionInfoMapper.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Repository\PermissionResolver;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\API\Repository\Values\User\UserReference;
+
+/**
+ * todo
+ */
+abstract class PermissionInfoMapper
+{
+    /**
+     * todo
+     *
+     * @param \eZ\Publish\API\Repository\Values\ValueObject $object
+     *
+     * @return bool
+     */
+    abstract public function canMap(ValueObject $object);
+
+    /**
+     * todo
+     *
+     * @param \eZ\Publish\API\Repository\Values\ValueObject $object
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $userReference
+     *
+     * @return \eZ\Publish\API\Repository\Values\PermissionInfo
+     */
+    abstract public function map(ValueObject $object, UserReference $userReference);
+}

--- a/eZ/Publish/Core/Repository/PermissionResolver/PermissionInfoMapper/Aggregate.php
+++ b/eZ/Publish/Core/Repository/PermissionResolver/PermissionInfoMapper/Aggregate.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Repository\PermissionResolver\PermissionInfoMapper;
+
+use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
+use eZ\Publish\API\Repository\Values\User\UserReference;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\Repository\PermissionResolver\PermissionInfoMapper;
+
+/**
+ * todo
+ */
+class Aggregate extends PermissionInfoMapper
+{
+    /**
+     * @var \eZ\Publish\Core\Repository\PermissionResolver\PermissionInfoMapper[]
+     */
+    private $mappers;
+
+    /**
+     * @param \eZ\Publish\Core\Repository\PermissionResolver\PermissionInfoMapper[] $mappers
+     */
+    public function __construct(array $mappers = [])
+    {
+        foreach ($mappers as $mapper) {
+            $this->addMapper($mapper);
+        }
+    }
+
+    /**
+     * @param \eZ\Publish\Core\Repository\PermissionResolver\PermissionInfoMapper $mapper
+     */
+    public function addMapper(PermissionInfoMapper $mapper)
+    {
+        $this->mappers[] = $mapper;
+    }
+
+    public function canMap(ValueObject $object)
+    {
+        return true;
+    }
+
+    public function map(ValueObject $object, UserReference $userReference)
+    {
+        foreach ($this->mappers as $mapper) {
+            if ($mapper->canMap($object)) {
+                return $mapper->map($object, $userReference);
+            }
+        }
+
+        throw new NotImplementedException(
+            'No mapper available for: ' . get_class($object)
+        );
+    }
+}

--- a/eZ/Publish/Core/Repository/PermissionResolver/PermissionInfoMapper/Content.php
+++ b/eZ/Publish/Core/Repository/PermissionResolver/PermissionInfoMapper/Content.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Repository\PermissionResolver\PermissionInfoMapper;
+
+use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use eZ\Publish\API\Repository\Values\User\UserReference;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\Repository\PermissionResolver\PermissionInfoMapper;
+use eZ\Publish\Core\Repository\PermissionResolver\PermissionResolver;
+use eZ\Publish\Core\Repository\Values\PermissionInfo;
+
+/**
+ * todo
+ */
+class Content extends PermissionInfoMapper
+{
+    private $permissionResolver;
+
+    public function __construct(PermissionResolver $permissionResolver)
+    {
+        $this->permissionResolver = $permissionResolver;
+    }
+
+    private function getModuleFunctionMap()
+    {
+        return [
+            'read' => [],
+            'edit' => [
+                'LanguageLimitation'
+            ],
+            'remove' => [],
+        ];
+    }
+
+    public function canMap(ValueObject $object)
+    {
+        return (
+            $object instanceof APIContent ||
+            $object instanceof VersionInfo ||
+            $object instanceof ContentInfo
+        );
+    }
+
+    /**
+     * todo
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $userReference
+     *
+     * @return \eZ\Publish\Core\Repository\PermissionResolver\Permission[]
+     */
+    private function getPermissions(UserReference $userReference)
+    {
+        return $this->permissionResolver->getPermissions($userReference, 'content');
+    }
+
+    public function map(ValueObject $object, UserReference $userReference)
+    {
+        $permissions = $this->getPermissions($userReference);
+        $functionMap = $this->getModuleFunctionMap();
+        $permissionMap = [];
+
+        foreach ($functionMap as $function => $limitations) {
+            $permissionMap[$function] = $this->permissionResolver->resolvePermissions(
+                'content',
+                $function,
+                $permissions,
+                $object,
+                $userReference
+            );
+        }
+
+        return new PermissionInfo(
+            [
+                'object' => $object,
+                'userReference' => $userReference,
+                'permissionMap' => $permissionMap,
+            ]
+        );
+    }
+}

--- a/eZ/Publish/Core/Repository/PermissionResolver/PermissionResolver.php
+++ b/eZ/Publish/Core/Repository/PermissionResolver/PermissionResolver.php
@@ -1,0 +1,228 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Repository\PermissionResolver;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\API\Repository\Values\User\UserReference;
+use eZ\Publish\Core\Repository\Helper\LimitationService;
+use eZ\Publish\SPI\Limitation\Type as LimitationType;
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\SPI\Persistence\User\Handler as UserHandler;
+use eZ\Publish\Core\Repository\Helper\RoleDomainMapper;
+
+/**
+ * todo
+ */
+class PermissionResolver
+{
+    /**
+     * @var \eZ\Publish\Core\Repository\Helper\RoleDomainMapper
+     */
+    private $roleDomainMapper;
+
+    /**
+     * @var \eZ\Publish\Core\Repository\Helper\LimitationService
+     */
+    private $limitationService;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\User\Handler
+     */
+    private $userHandler;
+
+    /**
+     * @param \eZ\Publish\Core\Repository\Helper\RoleDomainMapper $roleDomainMapper
+     * @param \eZ\Publish\Core\Repository\Helper\LimitationService $limitationService
+     * @param \eZ\Publish\SPI\Persistence\User\Handler $userHandler
+     */
+    public function __construct(
+        RoleDomainMapper $roleDomainMapper,
+        LimitationService $limitationService,
+        UserHandler $userHandler
+    ) {
+        $this->roleDomainMapper = $roleDomainMapper;
+        $this->limitationService = $limitationService;
+        $this->userHandler = $userHandler;
+    }
+
+    /**
+     * todo
+     *
+     * @param string $module
+     * @param string $function
+     * @param \eZ\Publish\Core\Repository\PermissionResolver\Permission[] $permissions
+     * @param \eZ\Publish\API\Repository\Values\ValueObject $object
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $userReference
+     * @param array $targets
+     *
+     * @return bool
+     */
+    public function resolvePermissions(
+        $module,
+        $function,
+        $permissions,
+        ValueObject $object,
+        UserReference $userReference,
+        array $targets = []
+    ) {
+        foreach ($permissions as $permission) {
+            $access = $this->resolvePermission(
+                $module,
+                $function,
+                $permission,
+                $object,
+                $userReference,
+                $targets
+            );
+
+            if ($access === true) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $module
+     * @param string $function
+     * @param \eZ\Publish\Core\Repository\PermissionResolver\Permission $permission
+     * @param \eZ\Publish\API\Repository\Values\ValueObject $object
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $userReference
+     * @param array $targets
+     *
+     * @return bool
+     */
+    public function resolvePermission(
+        $module,
+        $function,
+        Permission $permission,
+        ValueObject $object,
+        UserReference $userReference,
+        array $targets = []
+    ) {
+        if (empty($targets)) {
+            $targets = null;
+        }
+
+        /**
+         * First deal with Role limitation if any.
+         *
+         * Here we accept ACCESS_GRANTED and ACCESS_ABSTAIN, the latter in cases where $object and $targets
+         * are not supported by limitation.
+         *
+         * @var \eZ\Publish\API\Repository\Values\User\Limitation[]
+         */
+        if ($permission->limitation instanceof Limitation) {
+            $type = $this->limitationService->getLimitationType($permission->limitation->getIdentifier());
+            $accessVote = $type->evaluate($permission->limitation, $userReference, $object, $targets);
+            if ($accessVote === LimitationType::ACCESS_DENIED) {
+                return false;
+            }
+        }
+
+        /**
+         * Loop over all policies.
+         *
+         * These are already filtered by hasAccess and given hasAccess did not return boolean
+         * there must be some, so only return true if one of them says yes.
+         *
+         * @var \eZ\Publish\API\Repository\Values\User\Policy $policy
+         */
+        foreach ($permission->policies as $policy) {
+            if (!($policy->module === $module || $policy->module === '*')) {
+                continue;
+            }
+
+            if (!($policy->function === $function || $policy->function === '*')) {
+                continue;
+            }
+
+            $limitations = $policy->getLimitations();
+
+            /*
+             * Return true if policy gives full access (aka no limitations)
+             */
+            if ($limitations === '*') {
+                return true;
+            }
+
+            /*
+             * Loop over limitations, all must return ACCESS_GRANTED for policy to pass.
+             * If limitations was empty array this means same as '*'
+             */
+            $limitationsPass = true;
+            foreach ($limitations as $limitation) {
+                $type = $this->limitationService->getLimitationType($limitation->getIdentifier());
+                $accessVote = $type->evaluate($limitation, $userReference, $object, $targets);
+                /*
+                 * For policy limitation atm only support ACCESS_GRANTED
+                 *
+                 * Reasoning: Right now, use of a policy limitation not valid for a policy is per definition a
+                 * BadState. To reach this you would have to configure the "policyMap" wrongly, like using
+                 * Node (Location) limitation on state/assign. So in this case Role Limitations will return
+                 * ACCESS_ABSTAIN (== no access here), and other limitations will throw InvalidArgument above,
+                 * both cases forcing dev to investigate to find miss configuration. This might be relaxed in
+                 * the future if valid use cases for ACCESS_ABSTAIN on policy limitations becomes known.
+                 */
+                if ($accessVote !== LimitationType::ACCESS_GRANTED) {
+                    $limitationsPass = false;
+                    break;// Break to next policy, all limitations must pass
+                }
+            }
+            if ($limitationsPass) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * todo
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference $userReference
+     * @param string $module
+     * @param string $function
+     *
+     * @return \eZ\Publish\Core\Repository\PermissionResolver\Permission[]
+     */
+    public function getPermissions(UserReference $userReference, $module = '*', $function = '*')
+    {
+        // Uses SPI to avoid triggering permission checks in Role/User service
+        $permissionSets = [];
+        $spiRoleAssignments = $this->userHandler->loadRoleAssignmentsByGroupId($userReference->getUserId(), true);
+        foreach ($spiRoleAssignments as $spiRoleAssignment) {
+            $permissionSet = ['limitation' => null, 'policies' => []];
+
+            $spiRole = $this->userHandler->loadRole($spiRoleAssignment->roleId);
+            foreach ($spiRole->policies as $spiPolicy) {
+                if (!($spiPolicy->module === $module || $spiPolicy->module === '*' || $module === '*')) {
+                    continue;
+                }
+
+                if (!($spiPolicy->function === $function || $spiPolicy->function === '*' || $function === '*')) {
+                    continue;
+                }
+
+                $permissionSet['policies'][] = $this->roleDomainMapper->buildDomainPolicyObject($spiPolicy);
+            }
+
+            if (!empty($permissionSet['policies'])) {
+                if ($spiRoleAssignment->limitationIdentifier !== null) {
+                    $permissionSet['limitation'] = $this->limitationService
+                        ->getLimitationType($spiRoleAssignment->limitationIdentifier)
+                        ->buildValue($spiRoleAssignment->values);
+                }
+
+                $permissionSets[] = new Permission($permissionSet);
+            }
+        }
+
+        return $permissionSets;
+    }
+}

--- a/eZ/Publish/Core/Repository/Values/PermissionInfo.php
+++ b/eZ/Publish/Core/Repository/Values/PermissionInfo.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Repository\Values;
+
+use eZ\Publish\API\Repository\Values\PermissionInfo as APIPermissionInfo;
+
+class PermissionInfo extends APIPermissionInfo
+{
+    private $permissionMap;
+
+    public function __construct(array $properties)
+    {
+        if (isset($properties['permissionMap'])) {
+            $this->permissionMap = $properties['permissionMap'];
+            unset($properties['permissionMap']);
+        }
+
+        parent::__construct($properties);
+    }
+
+    /**
+     * @param string $function
+     *
+     * @return boolean
+     */
+    public function canUser($function)
+    {
+        if (isset($this->permissionMap['*'])) {
+            return true;
+        }
+
+        return isset($this->permissionMap[$function]);
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getHash()
+    {
+        return $this->permissionMap;
+    }
+}


### PR DESCRIPTION
This resolves https://jira.ez.no/browse/EZP-26000

This is a first implementation of permission lookup API, building on changes from https://github.com/ezsystems/ezpublish-kernel/pull/1720.

New API methods: [`PermissionService::getPermissionInfo($object)`](https://github.com/ezsystems/ezpublish-kernel/pull/1733/files#diff-32f3bf61b6512cb976883222f85da817R76)
New API value object: [`PermissionInfo`](https://github.com/ezsystems/ezpublish-kernel/pull/1733/files#diff-1ba060c9390f1e6ce677e72002d3a390R16)

Permission resolving is extracted from `PermissionService` into new internal service `PermissionResolver`. The logic is adjusted so that it is possible to return permission sets for multiple different permissions on a module. That is done in order to avoid multiple loading to resolve single `PermissionInfo`. The implementation can still be optimized and reused in `PermissionService`.
## TODOs
- [ ] Discuss the approach
