### PR TITLE
Ezp24853 enhance rest when failing save create draft

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -8,6 +8,7 @@ parameters:
     ezpublish_rest.output.value_object_visitor.UnauthorizedException.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\UnauthorizedException
     ezpublish_rest.output.value_object_visitor.BadStateException.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\BadStateException
     ezpublish_rest.output.value_object_visitor.BadRequestException.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\BadRequestException
+    ezpublish_rest.output.value_object_visitor.ContentFieldValidationException.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\ContentFieldValidationException
     ezpublish_rest.output.value_object_visitor.ForbiddenException.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\ForbiddenException
     ezpublish_rest.output.value_object_visitor.Exception.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\Exception
     ezpublish_rest.output.value_object_visitor.NotImplementedException.class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\NotImplementedException
@@ -194,6 +195,14 @@ services:
         arguments: [ "%kernel.debug%", "@translator" ]
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Exceptions\BadRequestException }
+            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Common\Exceptions\Parser }
+
+    ezpublish_rest.output.value_object_visitor.ContentFieldValidationException:
+        parent: ezpublish_rest.output.value_object_visitor.BadRequestException
+        class: "%ezpublish_rest.output.value_object_visitor.ContentFieldValidationException.class%"
+        arguments: [ "%kernel.debug%", "@translator" ]
+        tags:
+            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Exceptions\ContentFieldValidationException }
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Common\Exceptions\Parser }
 
     ezpublish_rest.output.value_object_visitor.ForbiddenException:

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -341,7 +341,7 @@ class ContentServiceTest extends BaseContentServiceTest
         // Violates string length constraint
         $contentCreate1->setField('short_name', str_repeat('a', 200));
 
-        // Throws ContentValidationException, since short_name does not pass
+        // Throws ContentFieldValidationException, since short_name does not pass
         // validation of the string length validator
         $draft = $contentService->createContent($contentCreate1);
         /* END: Use Case */
@@ -351,10 +351,10 @@ class ContentServiceTest extends BaseContentServiceTest
      * Test for the createContent() method.
      *
      * @see \eZ\Publish\API\Repository\ContentService::createContent()
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
      * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testCreateContent
      */
-    public function testCreateContentThrowsContentValidationException()
+    public function testCreateContentRequiredFieldMissing()
     {
         $repository = $this->getRepository();
 
@@ -367,7 +367,7 @@ class ContentServiceTest extends BaseContentServiceTest
         $contentCreate1 = $contentService->newContentCreateStruct($contentType, 'eng-US');
         // Required field "name" is not set
 
-        // Throws a ContentValidationException, since a required field is
+        // Throws a ContentFieldValidationException, since a required field is
         // missing
         $draft = $contentService->createContent($contentCreate1);
         /* END: Use Case */
@@ -1418,10 +1418,10 @@ class ContentServiceTest extends BaseContentServiceTest
      * Test for the updateContent() method.
      *
      * @see \eZ\Publish\API\Repository\ContentService::updateContent()
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
      * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testUpdateContent
      */
-    public function testUpdateContentThrowsContentValidationExceptionWhenMandatoryFieldIsEmpty()
+    public function testUpdateContentWhenMandatoryFieldIsEmpty()
     {
         $repository = $this->getRepository();
 
@@ -1437,7 +1437,7 @@ class ContentServiceTest extends BaseContentServiceTest
         // Don't set this, then the above call without languageCode will fail
         $contentUpdateStruct->initialLanguageCode = 'eng-US';
 
-        // This call will fail with a "ContentValidationException", because the
+        // This call will fail with a "ContentFieldValidationException", because the
         // mandatory "name" field is empty.
         $contentService->updateContent(
             $draft->getVersionInfo(),

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -327,10 +327,10 @@ class UserServiceTest extends BaseTest
      * Test for the createUserGroup() method.
      *
      * @see \eZ\Publish\API\Repository\UserService::createUserGroup()
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
      * @depends eZ\Publish\API\Repository\Tests\UserServiceTest::testCreateUserGroup
      */
-    public function testCreateUserGroupThrowsContentValidationException()
+    public function testCreateUserGroupWhenMissingField()
     {
         $repository = $this->getRepository();
 
@@ -346,7 +346,7 @@ class UserServiceTest extends BaseTest
         // Instantiate a new create struct
         $userGroupCreate = $userService->newUserGroupCreateStruct('eng-US');
 
-        // This call will fail with a "ContentValidationException", because the
+        // This call will fail with a "ContentFieldValidationException", because the
         // only mandatory field "name" is not set.
         $userService->createUserGroup($userGroupCreate, $parentUserGroup);
         /* END: Use Case */
@@ -854,10 +854,10 @@ class UserServiceTest extends BaseTest
      * Test for the createUser() method.
      *
      * @see \eZ\Publish\API\Repository\UserService::createUser()
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
      * @depends eZ\Publish\API\Repository\Tests\UserServiceTest::testCreateUser
      */
-    public function testCreateUserThrowsContentValidationExceptionForMissingField()
+    public function testCreateUserWhenMissingField()
     {
         $repository = $this->getRepository();
 
@@ -883,7 +883,7 @@ class UserServiceTest extends BaseTest
         // Load parent group for the user
         $group = $userService->loadUserGroup($editorsGroupId);
 
-        // This call will fail with a "ContentValidationException", because the
+        // This call will fail with a "ContentFieldValidationException", because the
         // mandatory fields "first_name" and "last_name" are not set.
         $userService->createUser($userCreate, array($group));
         /* END: Use Case */
@@ -1544,10 +1544,10 @@ class UserServiceTest extends BaseTest
      * Test for the updateUser() method.
      *
      * @see \eZ\Publish\API\Repository\UserService::updateUser()
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
      * @depends eZ\Publish\API\Repository\Tests\UserServiceTest::testUpdateUser
      */
-    public function testUpdateUserThrowsContentValidationException()
+    public function testUpdateUserWhenMissingField()
     {
         $repository = $this->getRepository();
 
@@ -1569,7 +1569,7 @@ class UserServiceTest extends BaseTest
         // Set the content update struct.
         $userUpdate->contentUpdateStruct = $contentUpdate;
 
-        // This call will fail with a "ContentValidationException" because the
+        // This call will fail with a "ContentFieldValidationException" because the
         // mandatory field "first_name" is set to an empty value.
         $userService->updateUser($user, $userUpdate);
 

--- a/eZ/Publish/Core/REST/Client/HttpClient/ConnectionException.php
+++ b/eZ/Publish/Core/REST/Client/HttpClient/ConnectionException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * File containing the ContentValidationException class.
+ * File containing the ConnectionException class.
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.

--- a/eZ/Publish/Core/REST/Client/Input/Parser/ErrorMessage.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/ErrorMessage.php
@@ -47,6 +47,7 @@ class ErrorMessage extends BaseParser
             'code' => $data['errorCode'],
             'message' => isset($data['errorMessage']) ? $data['errorMessage'] : null,
             'description' => isset($data['errorDescription']) ? $data['errorDescription'] : null,
+            'details' => isset($data['errorDetails']) ? $data['errorDetails'] : null,
             'trace' => isset($data['trace']) ? $data['trace'] : null,
             'file' => isset($data['file']) ? $data['file'] : null,
             'line' => isset($data['line']) ? $data['line'] : null,

--- a/eZ/Publish/Core/REST/Client/Output/ValueObjectVisitor/ViewInput.php
+++ b/eZ/Publish/Core/REST/Client/Output/ValueObjectVisitor/ViewInput.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * File containing the BadRequestException ValueObjectVisitor class.
+ * File containing the ViewInput ValueObjectVisitor class.
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.

--- a/eZ/Publish/Core/REST/Client/Values/ErrorMessage.php
+++ b/eZ/Publish/Core/REST/Client/Values/ErrorMessage.php
@@ -22,6 +22,8 @@ class ErrorMessage extends ValueObject
 
     protected $description;
 
+    protected $details;
+
     protected $trace;
 
     protected $file;

--- a/eZ/Publish/Core/REST/Server/Controller/Content.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Content.php
@@ -21,6 +21,7 @@ use eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException;
 use eZ\Publish\API\Repository\Exceptions\ContentValidationException;
 use eZ\Publish\Core\REST\Server\Exceptions\ForbiddenException;
 use eZ\Publish\Core\REST\Server\Exceptions\BadRequestException;
+use eZ\Publish\Core\REST\Server\Exceptions\ContentFieldValidationException as RESTContentFieldValidationException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -247,7 +248,7 @@ class Content extends RestController
         } catch (ContentValidationException $e) {
             throw new BadRequestException($e->getMessage());
         } catch (ContentFieldValidationException $e) {
-            throw new BadRequestException($e->getMessage());
+            throw new RESTContentFieldValidationException($e);
         }
 
         $contentValue = null;
@@ -476,7 +477,7 @@ class Content extends RestController
         } catch (ContentValidationException $e) {
             throw new BadRequestException($e->getMessage());
         } catch (ContentFieldValidationException $e) {
-            throw new BadRequestException($e->getMessage());
+            throw new RESTContentFieldValidationException($e);
         }
 
         $languages = null;

--- a/eZ/Publish/Core/REST/Server/Exceptions/ContentFieldValidationException.php
+++ b/eZ/Publish/Core/REST/Server/Exceptions/ContentFieldValidationException.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * File containing the ContentFieldValidationException tests.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Exceptions;
+
+use eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException as APIContentFieldValidationException;
+
+/**
+ * Exception thrown if one or more content fields did not validate.
+ */
+class ContentFieldValidationException extends BadRequestException
+{
+    /**
+     * Contains an array of field ValidationError objects indexed with FieldDefinition id and language code.
+     * @see eZ\Publish\Core\Base\Exceptions\ContentFieldValidationException
+     *
+     * @var \eZ\Publish\Core\FieldType\ValidationError[]
+     */
+    protected $errors;
+
+    public function __construct(APIContentFieldValidationException $e)
+    {
+        $this->errors = $e->getFieldErrors();
+
+        parent::__construct($e->getMessage(), $e->getCode(), $e);
+    }
+
+    /**
+     * Returns an array of field validation error messages.
+     *
+     * @return \eZ\Publish\Core\FieldType\ValidationError[]
+     */
+    public function getFieldErrors()
+    {
+        return $this->errors;
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ContentFieldValidationException.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ContentFieldValidationException.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * File containing the ContentFieldValidationException ValueObjectVisitor class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+
+use eZ\Publish\API\Repository\Values\Translation;
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+
+/**
+ * ContentFieldValidationException value object visitor.
+ */
+class ContentFieldValidationException extends BadRequestException
+{
+    /**
+     * Visit struct returned by controllers.
+     *
+     * @param \eZ\Publish\Core\REST\Common\Output\Visitor $visitor
+     * @param \eZ\Publish\Core\REST\Common\Output\Generator $generator
+     * @param \eZ\Publish\Core\REST\Server\Exceptions\ContentFieldValidationException $data
+     */
+    public function visit(Visitor $visitor, Generator $generator, $data)
+    {
+        $generator->startObjectElement('ErrorMessage');
+
+        $statusCode = $this->getStatus();
+        $visitor->setStatus($statusCode);
+        $visitor->setHeader('Content-Type', $generator->getMediaType('ErrorMessage'));
+
+        $generator->startValueElement('errorCode', $statusCode);
+        $generator->endValueElement('errorCode');
+
+        $generator->startValueElement('errorMessage', $this->httpStatusCodes[$statusCode]);
+        $generator->endValueElement('errorMessage');
+
+        $generator->startValueElement('errorDescription', $data->getMessage());
+        $generator->endValueElement('errorDescription');
+
+        $generator->startHashElement('errorDetails');
+        $generator->startList('fields');
+        foreach ($data->getFieldErrors() as $fieldTypeId => $translations) {
+            foreach ($translations as $languageCode => $validationErrors) {
+                if (!is_array($validationErrors)) {
+                    $validationErrors = [$validationErrors];
+                }
+
+                foreach ($validationErrors as $validationError) {
+                    $generator->startHashElement('field');
+                    $generator->startAttribute('fieldTypeId', $fieldTypeId);
+                    $generator->endAttribute('fieldTypeId');
+
+                    $generator->startList('errors');
+                    $generator->startHashElement('error');
+
+                    $generator->startValueElement('type', $validationError->getTarget());
+                    $generator->endValueElement('type');
+
+                    $translation = $validationError->getTranslatableMessage();
+                    $generator->startValueElement(
+                        'message',
+                        $this->translator->trans(
+                            $this->translationToString($translation),
+                            $translation->values,
+                            'repository_exceptions'
+                        )
+                    );
+                    $generator->endValueElement('message');
+
+                    $generator->endHashElement('error');
+                    $generator->endList('errors');
+                    $generator->endHashElement('field');
+                }
+            }
+        }
+        $generator->endList('fields');
+        $generator->endHashElement('errorDetails');
+
+        if ($this->debug) {
+            $generator->startValueElement('trace', $data->getTraceAsString());
+            $generator->endValueElement('trace');
+
+            $generator->startValueElement('file', $data->getFile());
+            $generator->endValueElement('file');
+
+            $generator->startValueElement('line', $data->getLine());
+            $generator->endValueElement('line');
+        }
+
+        $generator->endObjectElement('ErrorMessage');
+    }
+
+    /**
+     * Convert a Translation object to a string, detecting singular/plural as needed.
+     *
+     * @param Translation $translation The Translation object
+     * @return string
+     */
+    private function translationToString(Translation $translation)
+    {
+        $values = $translation->values;
+        if ($translation instanceof Translation\Plural) {
+            if (current($values) === 1) {
+                return $translation->singular;
+            } else {
+                return $translation->plural;
+            }
+        } else {
+            return $translation->message;
+        }
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ContentFieldValidationExceptionTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ContentFieldValidationExceptionTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * File containing a test class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
+
+use eZ\Publish\Core\Base\Exceptions\ContentFieldValidationException as CoreContentFieldValidationException;
+use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Server\Exceptions;
+use Symfony\Component\Translation\Translator;
+
+class ContentFieldValidationExceptionTest extends ExceptionTest
+{
+    /**
+     * Test the ContentFieldValidationException visitor.
+     *
+     * @return string
+     */
+    public function testVisit()
+    {
+        $visitor = $this->getVisitor();
+        $generator = $this->getGenerator();
+
+        $generator->startDocument(null);
+
+        $exception = $this->getException();
+
+        $visitor->visit(
+            $this->getVisitorMock(),
+            $generator,
+            $exception
+        );
+
+        $result = $generator->endDocument(null);
+
+        $this->assertNotNull($result);
+
+        return $result;
+    }
+
+    /**
+     * Test if result contains ErrorMessage element and description.
+     *
+     * @param string $result
+     *
+     * @depends testVisit
+     */
+    public function testResultContainsErrorDescription($result)
+    {
+        $this->assertXMLTag(
+            [
+                'tag' => 'errorDescription',
+                'content' => $this->getExpectedDescription(),
+            ],
+            $result,
+            'Missing <errorDescription> element.'
+        );
+    }
+
+    /**
+     * Test if result contains ErrorMessage element and details.
+     *
+     * @param string $result
+     *
+     * @depends testVisit
+     */
+    public function testResultContainsErrorDetails($result)
+    {
+        $this->assertXMLTag(
+            [
+                'tag' => 'errorDetails',
+            ],
+            $result,
+            'Missing <errorDetails> element.'
+        );
+
+        $this->assertXMLTag(
+            [
+                'tag' => 'field',
+            ],
+            $result,
+            'Missing <field> element.'
+        );
+    }
+
+    /**
+     * Get expected status code.
+     *
+     * @return int
+     */
+    protected function getExpectedStatusCode()
+    {
+        return 400;
+    }
+
+    /**
+     * Get expected message.
+     *
+     * @return string
+     */
+    protected function getExpectedMessage()
+    {
+        return 'Bad Request';
+    }
+
+    /**
+     * Get expected description.
+     *
+     * @return string
+     */
+    protected function getExpectedDescription()
+    {
+        return 'Content fields did not validate';
+    }
+
+    /**
+     * Gets the exception.
+     *
+     * @return \Exception
+     */
+    protected function getException()
+    {
+        return new Exceptions\ContentFieldValidationException(
+            new CoreContentFieldValidationException([
+                1 => [
+                    'eng-GB' => new ValidationError(
+                        "Value for required field definition '%identifier%' with language '%languageCode%' is empty",
+                        null,
+                        ['%identifier%' => 'name', '%languageCode%' => 'eng-GB'],
+                        'empty'
+                    ),
+                ],
+                2 => [
+                    'eng-GB' => new ValidationError(
+                        'The value must be a valid email address.',
+                        null,
+                        [],
+                        'email'
+                    ),
+                ],
+            ])
+        );
+    }
+
+    /**
+     * Gets the exception visitor.
+     *
+     * @return \eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\ContentFieldValidationException
+     */
+    protected function internalGetVisitor()
+    {
+        return new ValueObjectVisitor\ContentFieldValidationException(false, new Translator('eng-GB'));
+    }
+}

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -33,6 +33,7 @@ use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Base\Exceptions\ContentValidationException;
 use eZ\Publish\Core\Base\Exceptions\ContentFieldValidationException;
 use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
+use eZ\Publish\Core\FieldType\ValidationError;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\Core\Repository\Values\Content\ContentUpdateStruct;
@@ -466,11 +467,14 @@ class ContentService implements ContentServiceInterface
      * In 4.x at least one location has to be provided in the location creation array.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to create the content in the given location
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if there is a provided remoteId which exists in the system
-     *                                                                        or there is no location provided (4.x) or multiple locations
-     *                                                                        are under the same parent or if the a field value is not accepted by the field type
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException if a field in the $contentCreateStruct is not valid
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException if a required field is missing or is set to an empty value
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the provided remoteId exists in the system, required properties on
+     *                                                                        struct are missing or invalid, or if multiple locations are under the
+     *                                                                        same parent.
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException if a field in the $contentCreateStruct is not valid,
+     *                                                                               or if a required field is missing / set to an empty value.
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException If field definition does not exist in the ContentType,
+     *                                                                          or value is set for non-translatable field in language
+     *                                                                          other than main.
      *
      * @param \eZ\Publish\API\Repository\Values\Content\ContentCreateStruct $contentCreateStruct
      * @param \eZ\Publish\API\Repository\Values\Content\LocationCreateStruct[] $locationCreateStructs For each location parent under which a location should be created for the content
@@ -572,9 +576,11 @@ class ContentService implements ContentServiceInterface
                 if ($fieldType->isEmptyValue($fieldValue)) {
                     $isEmptyValue = true;
                     if ($fieldDefinition->isRequired) {
-                        throw new ContentValidationException(
+                        $allFieldErrors[$fieldDefinition->id][$languageCode] = new ValidationError(
                             "Value for required field definition '%identifier%' with language '%languageCode%' is empty",
-                            ['%identifier%' => $fieldDefinition->identifier, '%languageCode%' => $languageCode]
+                            null,
+                            ['%identifier%' => $fieldDefinition->identifier, '%languageCode%' => $languageCode],
+                            'empty'
                         );
                     }
                 } else {
@@ -1119,8 +1125,10 @@ class ContentService implements ContentServiceInterface
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the current-user is not allowed to update this version
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the given destination version is not a draft
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException if a required field is set to an empty value
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException if a field in the $translationValues is not valid
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException if a field in the $translationValues is not valid, or if a required field is missing or is set to an empty value.
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException If field definition does not exist in the ContentType
+     *                                                                          or value is set for non-translatable field in language
+     *                                                                          other than main.
      *
      * @param \eZ\Publish\API\Repository\Values\Content\TranslationInfo $translationInfo
      * @param \eZ\Publish\API\Repository\Values\Content\TranslationValues $translationValues
@@ -1140,8 +1148,12 @@ class ContentService implements ContentServiceInterface
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to update this version
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is not a draft
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException if a field in the $contentUpdateStruct is not valid
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException if a required field is set to an empty value
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if a property on the struct is invalid.
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException if a field in the $contentCreateStruct is not valid,
+     *                                                                               or if a required field is missing / set to an empty value.
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException If field definition does not exist in the ContentType,
+     *                                                                          or value is set for non-translatable field in language
+     *                                                                          other than main.
      *
      * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
      * @param \eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct $contentUpdateStruct
@@ -1216,9 +1228,11 @@ class ContentService implements ContentServiceInterface
                 if ($fieldType->isEmptyValue($fieldValue)) {
                     $isEmpty = true;
                     if ($fieldDefinition->isRequired) {
-                        throw new ContentValidationException(
+                        $allFieldErrors[$fieldDefinition->id][$languageCode] = new ValidationError(
                             "Value for required field definition '%identifier%' with language '%languageCode%' is empty",
-                            ['%identifier%' => $fieldDefinition->identifier, '%languageCode%' => $languageCode]
+                            null,
+                            ['%identifier%' => $fieldDefinition->identifier, '%languageCode%' => $languageCode],
+                            'empty'
                         );
                     }
                 } else {

--- a/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentBase.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentBase.php
@@ -1108,11 +1108,11 @@ abstract class ContentBase extends BaseServiceTest
      * Test for the createContent() method.
      *
      * @covers \eZ\Publish\Core\Repository\ContentService::createContent
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
      *
      * @return array
      */
-    public function testCreateContentThrowsContentValidationRequiredFieldDefaultValueEmpty()
+    public function testCreateContentRequiredFieldDefaultValueEmpty()
     {
         $testContentType = $this->createTestContentType();
 
@@ -1434,9 +1434,9 @@ abstract class ContentBase extends BaseServiceTest
      * Test for the updateContent() method.
      *
      * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
      */
-    public function testUpdateContentThrowsContentValidationExceptionRequiredFieldEmpty()
+    public function testUpdateContentRequiredFieldEmpty()
     {
         list($content, $contentType) = $this->createTestContent();
 

--- a/eZ/Publish/Core/Repository/Tests/Service/Integration/UserBase.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Integration/UserBase.php
@@ -177,10 +177,10 @@ abstract class UserBase extends BaseServiceTest
     /**
      * Test creating new user group throwing ContentFieldValidationException.
      *
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
      * @covers \eZ\Publish\API\Repository\UserService::createUserGroup
      */
-    public function testCreateUserGroupThrowsContentValidationException()
+    public function testCreateUserGroupRequiredFieldEmpty()
     {
         $userService = $this->repository->getUserService();
 
@@ -194,12 +194,12 @@ abstract class UserBase extends BaseServiceTest
     }
 
     /**
-     * Test creating new user group throwing ContentValidationException.
+     * Test creating new user group throwing ContentFieldValidationException.
      *
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
      * @covers \eZ\Publish\API\Repository\UserService::createUserGroup
      */
-    public function testCreateUserGroupThrowsContentValidationExceptionVariation()
+    public function testCreateUserGroupRequiredFieldMissing()
     {
         $userService = $this->repository->getUserService();
 
@@ -413,10 +413,10 @@ abstract class UserBase extends BaseServiceTest
     /**
      * Test updating a user group throwing ContentFieldValidationException.
      *
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
      * @covers \eZ\Publish\API\Repository\UserService::updateUserGroup
      */
-    public function testUpdateUserGroupThrowsContentValidationException()
+    public function testUpdateUserGroupRequiredFieldEmpty()
     {
         $userService = $this->repository->getUserService();
         $contentService = $this->repository->getContentService();
@@ -484,12 +484,12 @@ abstract class UserBase extends BaseServiceTest
     }
 
     /**
-     * Test creating a user throwing ContentValidationException.
+     * Test creating a user throwing ContentFieldValidationException.
      *
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
      * @covers \eZ\Publish\API\Repository\UserService::createUser
      */
-    public function testCreateUserThrowsContentValidationException()
+    public function testCreateUserRequiredFieldsEmpty()
     {
         $userService = $this->repository->getUserService();
 

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -2001,7 +2001,7 @@ class ContentTest extends BaseServiceMockTest
     }
 
     /**
-     * Asserts behaviour necessary for testing ContentValidationException because of required
+     * Asserts behaviour necessary for testing ContentFieldValidationException because of required
      * field being empty.
      *
      * @param string $mainLanguageCode
@@ -2010,7 +2010,7 @@ class ContentTest extends BaseServiceMockTest
      *
      * @return mixed
      */
-    protected function assertForTestCreateContentThrowsContentValidationExceptionRequiredField(
+    protected function assertForTestCreateContentRequiredField(
         $mainLanguageCode,
         array $structFields,
         array $fieldDefinitions
@@ -2150,9 +2150,9 @@ class ContentTest extends BaseServiceMockTest
      * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForCreate
      * @covers \eZ\Publish\Core\Repository\ContentService::createContent
      * @dataProvider providerForTestCreateContentThrowsContentValidationExceptionRequiredField
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
      */
-    public function testCreateContentThrowsContentValidationExceptionRequiredField(
+    public function testCreateContentRequiredField(
         $mainLanguageCode,
         $structFields,
         $identifier,
@@ -2170,7 +2170,7 @@ class ContentTest extends BaseServiceMockTest
                 )
             ),
         );
-        $contentCreateStruct = $this->assertForTestCreateContentThrowsContentValidationExceptionRequiredField(
+        $contentCreateStruct = $this->assertForTestCreateContentRequiredField(
             $mainLanguageCode,
             $structFields,
             $fieldDefinitions
@@ -4795,7 +4795,7 @@ class ContentTest extends BaseServiceMockTest
         );
     }
 
-    public function assertForTestUpdateContentThrowsContentValidationExceptionRequiredField(
+    public function assertForTestUpdateContentRequiredField(
         $initialLanguageCode,
         $structFields,
         $existingFields,
@@ -4916,7 +4916,7 @@ class ContentTest extends BaseServiceMockTest
         return array($content->versionInfo, $contentUpdateStruct);
     }
 
-    public function providerForTestUpdateContentThrowsContentValidationExceptionRequiredField()
+    public function providerForTestUpdateContentRequiredField()
     {
         return array(
             array(
@@ -4942,10 +4942,10 @@ class ContentTest extends BaseServiceMockTest
      * @covers \eZ\Publish\Core\Repository\ContentService::getLanguageCodesForUpdate
      * @covers \eZ\Publish\Core\Repository\ContentService::mapFieldsForUpdate
      * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
-     * @dataProvider providerForTestUpdateContentThrowsContentValidationExceptionRequiredField
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @dataProvider providerForTestUpdateContentRequiredField
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
      */
-    public function testUpdateContentThrowsContentValidationExceptionRequiredField(
+    public function testUpdateContentRequiredField(
         $initialLanguageCode,
         $structFields,
         $identifier,
@@ -4974,7 +4974,7 @@ class ContentTest extends BaseServiceMockTest
             ),
         );
         list($versionInfo, $contentUpdateStruct) =
-            $this->assertForTestUpdateContentThrowsContentValidationExceptionRequiredField(
+            $this->assertForTestUpdateContentRequiredField(
                 $initialLanguageCode,
                 $structFields,
                 $existingFields,


### PR DESCRIPTION
> Implement https://jira.ez.no/browse/EZP-24853
> Status: Ready for review

Treat "required field is missing" errors the same as field validation errors, so that both can be dealt with at the same time. Meaning that `ContentValidationException` is no longer thrown on content create/update, only a `ContentFieldValidationException` containing all errors. ~~`ContentFieldValidationException` now extends `ContentValidationException`, to avoid API change.~~ (reverted)

The errors are structured as below. Note: There may be more than one error per field, so that's an array. It's currently not indexing by fielddef identifier as requested, but rather by fielddef ID, since that's what we get from the core `ContentFieldValidationException`. The `type` is what is given by `ValidationError::getTarget()`. I have kept the `errorDescription` unchanged for now.

    {
        "ErrorMessage": {
            "_media-type": "application/vnd.ez.api.ErrorMessage+json"
            "errorCode": 400
            "errorMessage": "Bad Request"
            "errorDescription": "Content fields did not validate"
            "errorDetails": {
                "fields": [3]
                    0: {
                        "_fieldTypeId": 247
                        "errors": [1]
                        0:  {
                            "type": "text"
                            "message": "The string can not be shorter than %10% characters."
                        }
                    }
                    1: {
                        "_fieldTypeId": 249
                        "errors": [1]
                        0:  {
                            "type": "empty"
                            "message": "Value for required field definition 'new_ezstring_4' with language 'eng-GB' is empty"
                        }
                    }
                    2: {
                        "_fieldTypeId": 250
                        "errors": [1]
                        0:  {
                            "type": "email"
                            "message": "The value must be a valid email address."
                        }
                }
            }
        }
    }

- [x] Test the visitor
- [x] ~~Implement the same in `UserService`~~ Not relevant.
- [x] ~~Use fielddef identifier instead of id?~~ Nope, requires extra queries!
- [x] ~~Fix `%`-symbols not being cleared for integer parameters~~ See https://github.com/ezsystems/ezpublish-kernel/pull/1745
- [x] ~~Exception on invalid ValidationError? https://github.com/ezsystems/ezpublish-kernel/pull/1734/commits/02baca172cb202afc731414b5951e7e6ae7e786a#diff-3732291921b7b0ac4f69625ed5edb4a6R67~~ Not needed.
- [x] ~~Find proper way of handling translation messages https://github.com/ezsystems/ezpublish-kernel/pull/1734/commits/8fe1955114fa6edebd9e240bc402a8f74d8dcccc#diff-3732291921b7b0ac4f69625ed5edb4a6R105~~ None found, going with what I have.