### PR TITLE
Query type pass fixes

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/QueryTypePass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/QueryTypePass.php
@@ -23,6 +23,7 @@ class QueryTypePass implements CompilerPassInterface
         }
 
         $queryTypes = [];
+        $queryTypesClasses = [];
 
         // tagged query types
         $taggedServiceIds = $container->findTaggedServiceIds('ezpublish.query_type');
@@ -34,6 +35,8 @@ class QueryTypePass implements CompilerPassInterface
                 // TODO: Check for duplicates
                 $queryTypes[$queryTypeClass::getName()] = new Reference($taggedServiceId);
             }
+
+            $queryTypesClasses[$queryTypeClass] = true;
         }
 
         // named by convention query types
@@ -57,6 +60,11 @@ class QueryTypePass implements CompilerPassInterface
                         throw new Exception("Expected $queryTypeClassName to be defined in $queryTypeFilePath");
                     }
 
+                    // skip if the class was already registered as a tagged service
+                    if (isset($queryTypesClasses[$queryTypeClassName])) {
+                        continue;
+                    }
+
                     $queryTypeReflectionClass = new ReflectionClass($queryTypeClassName);
                     if (!$queryTypeReflectionClass->implementsInterface('eZ\Publish\Core\QueryType\QueryType')) {
                         throw new Exception("$queryTypeClassName needs to implement eZ\\Publish\\Core\\QueryType\\QueryType");
@@ -67,6 +75,7 @@ class QueryTypePass implements CompilerPassInterface
 
                     $queryTypes[$queryTypeClassName::getName()] = new Reference($serviceId);
                 }
+
                 $container->addDefinitions($queryTypeServices);
             }
         }

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/QueryTypePass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/QueryTypePass.php
@@ -28,7 +28,7 @@ class QueryTypePass implements CompilerPassInterface
         $taggedServiceIds = $container->findTaggedServiceIds('ezpublish.query_type');
         foreach ($taggedServiceIds as $taggedServiceId => $tags) {
             $queryTypeDefinition = $container->getDefinition($taggedServiceId);
-            $queryTypeClass = $queryTypeDefinition->getClass();
+            $queryTypeClass = $container->getParameterBag()->resolveValue($queryTypeDefinition->getClass());
 
             for ($i = 0, $count = count($tags); $i < $count; ++$i) {
                 // TODO: Check for duplicates

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/QueryTypePassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/QueryTypePassTest.php
@@ -75,4 +75,24 @@ class QueryTypePassTest extends AbstractCompilerPassTestCase
             [['Test:Test' => new Reference('ezpublish.query_type.convention.querytypebundle_testquerytype')]]
         );
     }
+
+    public function testConventionSkippedIfTagged()
+    {
+        $this->setParameter('kernel.bundles', ['QueryTypeBundle' => 'eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub\QueryTypeBundle\QueryTypeBundle']);
+
+        $def = new Definition();
+        $def->addTag('ezpublish.query_type');
+        $def->setClass(self::$queryTypeClass);
+        $serviceId = 'test.query_type';
+        $this->setDefinition($serviceId, $def);
+
+        $this->compile();
+
+        $this->assertContainerBuilderNotHasService('ezpublish.query_type.convention.querytypebundle_testquerytype');
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'ezpublish.query_type.registry',
+            'addQueryTypes',
+            [['Test:Test' => new Reference($serviceId)]]
+        );
+    }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/QueryTypePassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/QueryTypePassTest.php
@@ -18,6 +18,8 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class QueryTypePassTest extends AbstractCompilerPassTestCase
 {
+    private static $queryTypeClass = 'eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub\QueryTypeBundle\QueryType\TestQueryType';
+
     protected function setUp()
     {
         parent::setUp();
@@ -33,7 +35,24 @@ class QueryTypePassTest extends AbstractCompilerPassTestCase
     {
         $def = new Definition();
         $def->addTag('ezpublish.query_type');
-        $def->setClass('eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub\QueryTypeBundle\QueryType\TestQueryType');
+        $def->setClass(self::$queryTypeClass);
+        $serviceId = 'test.query_type';
+        $this->setDefinition($serviceId, $def);
+
+        $this->compile();
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'ezpublish.query_type.registry',
+            'addQueryTypes',
+            [['Test:Test' => new Reference($serviceId)]]
+        );
+    }
+
+    public function testRegisterTaggedQueryTypeWithClassAsParameter()
+    {
+        $this->setParameter('query_type_class', self::$queryTypeClass);
+        $def = new Definition();
+        $def->addTag('ezpublish.query_type');
+        $def->setClass('%query_type_class%');
         $serviceId = 'test.query_type';
         $this->setDefinition($serviceId, $def);
 


### PR DESCRIPTION
> Fixes [EZP-26106](https://jira.ez.no/browse/EZP-26106) and [EZP-26086](https://jira.ez.no/browse/EZP-26086)

### Prevent double tag/convention QueryType service registration
If a QueryType is tagged with `ezpublish.query_type`, it will be skipped (using the class name) by the convention registration.

### Fixed error when a QueryType service uses a parameter as the class
The "class" parameter will be correctly interpreted to the actual value in order to retrieve the QueryType's name with the static call.

Both cases are covered by the QueryTypePass's unit test.