### PR TITLE
EZP-26110: Can register custom OutputVisitor but can't set its priority

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Tests/DependencyInjection/Compiler/OutputVisitorPassTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/DependencyInjection/Compiler/OutputVisitorPassTest.php
@@ -13,44 +13,105 @@ namespace eZ\Bundle\EzPublishRestBundle\Tests\DependencyInjection\Compiler;
 use eZ\Bundle\EzPublishRestBundle\DependencyInjection\Compiler\OutputVisitorPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
-use PHPUnit_Framework_TestCase;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\Reference;
 
-class OutputVisitorPassTest extends PHPUnit_Framework_TestCase
+class OutputVisitorPassTest extends AbstractCompilerPassTestCase
 {
+    /**
+     * Register the compiler pass under test, just like you would do inside a bundle's load()
+     * method:.
+     *
+     *   $container->addCompilerPass(new MyCompilerPass());
+     */
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new OutputVisitorPass());
+    }
+
     public function testProcess()
     {
-        $regexp1 = array('(^.*/.*$)');
-        $regexp2 = array('(^application/json$)');
-
+        $stringRegexp = '(^.*/.*$)';
         $stringDefinition = new Definition();
-        $stringDefinition->addTag('ezpublish_rest.output.visitor', array('regexps' => 'ezpublish_rest.output.visitor.test1.regexps'));
+        $stringDefinition->addTag('ezpublish_rest.output.visitor', ['regexps' => 'ezpublish_rest.output.visitor.test.regexps']);
+        $this->setParameter('ezpublish_rest.output.visitor.test.regexps', [$stringRegexp]);
+        $this->setDefinition('ezpublish_rest.output.visitor.test_string', $stringDefinition);
 
+        $arrayRegexp = '(^application/json$)';
         $arrayDefinition = new Definition();
-        $arrayDefinition->addTag('ezpublish_rest.output.visitor', array('regexps' => array($regexp1)));
+        $arrayDefinition->addTag('ezpublish_rest.output.visitor', ['regexps' => [$arrayRegexp]]);
+        $this->setDefinition('ezpublish_rest.output.visitor.test_array', $arrayDefinition);
 
-        $containerBuilder = new ContainerBuilder();
-        $containerBuilder->addDefinitions(
-            array(
-                'ezpublish_rest.output.visitor.dispatcher' => new Definition(),
-                'ezpublish_rest.output.visitor.test_string' => $stringDefinition,
-                'ezpublish_rest.output.visitor.test_array' => $arrayDefinition,
-            )
-        );
+        $this->setDefinition('ezpublish_rest.output.visitor.dispatcher', new Definition());
 
-        $containerBuilder->setParameter('ezpublish_rest.output.visitor.test1.regexps', array($regexp2));
+        $this->compile();
 
-        $compilerPass = new OutputVisitorPass();
-        $compilerPass->process($containerBuilder);
+        $visitorsInOrder = $this->getVisitorsInRegistrationOrder();
 
-        $dispatcherMethodCalls = $containerBuilder->getDefinition('ezpublish_rest.output.visitor.dispatcher')->getMethodCalls();
-        self::assertTrue(isset($dispatcherMethodCalls[0][0]));
-        self::assertTrue(isset($dispatcherMethodCalls[0][1]));
-        self::assertEquals('addVisitor', $dispatcherMethodCalls[0][0]);
-        self::assertEquals('addVisitor', $dispatcherMethodCalls[1][0]);
-        self::assertInstanceOf('Symfony\\Component\\DependencyInjection\\Reference', $dispatcherMethodCalls[0][1][1]);
-        self::assertInstanceOf('Symfony\\Component\\DependencyInjection\\Reference', $dispatcherMethodCalls[1][1][1]);
+        self::assertEquals('ezpublish_rest.output.visitor.test_string', $visitorsInOrder[0]);
+        self::assertEquals('ezpublish_rest.output.visitor.test_array', $visitorsInOrder[1]);
+        $this->assertContainerBuilderHasService('ezpublish_rest.output.visitor.test_string');
+        $this->assertContainerBuilderHasService('ezpublish_rest.output.visitor.test_array');
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('ezpublish_rest.output.visitor.dispatcher', 'addVisitor', [
+            $stringRegexp,
+            new Reference('ezpublish_rest.output.visitor.test_string'),
+        ]);
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall('ezpublish_rest.output.visitor.dispatcher', 'addVisitor', [
+            $arrayRegexp,
+            new Reference('ezpublish_rest.output.visitor.test_array'),
+        ]);
+    }
 
-        self::assertEquals('ezpublish_rest.output.visitor.test_string', $dispatcherMethodCalls[0][1][1]->__toString());
-        self::assertEquals('ezpublish_rest.output.visitor.test_array', $dispatcherMethodCalls[1][1][1]->__toString());
+    public function testPriority()
+    {
+        $definitions = [
+            'high' => [
+                'regexps' => ['(^.*/.*$)'],
+                'priority' => 10,
+            ],
+            'low' => [
+                'regexps' => ['(^application/.*$)'],
+                'priority' => -10,
+            ],
+            'normal_defined' => [
+                'regexps' => ['(^application/json$)'],
+                'priority' => 0,
+            ],
+            'normal' => [
+                'regexps' => ['(^application/xml$)'],
+            ],
+        ];
+
+        $expectedPriority = [
+            'high',
+            'normal_defined',
+            'normal',
+            'low',
+        ];
+
+        $this->setDefinition('ezpublish_rest.output.visitor.dispatcher', new Definition());
+
+        foreach ($definitions as $name => $data) {
+            $definition = new Definition();
+            $definition->addTag('ezpublish_rest.output.visitor', $data);
+            $this->setDefinition('ezpublish_rest.output.visitor.test_' . $name, $definition);
+        }
+
+        $this->compile();
+
+        $visitorsInOrder = $this->getVisitorsInRegistrationOrder();
+
+        foreach ($expectedPriority as $index => $priority) {
+            self::assertEquals('ezpublish_rest.output.visitor.test_' . $priority, $visitorsInOrder[$index]);
+        }
+    }
+
+    protected function getVisitorsInRegistrationOrder()
+    {
+        $calls = $this->container->getDefinition('ezpublish_rest.output.visitor.dispatcher')->getMethodCalls();
+
+        return array_map(function ($call) {
+            return (string) $call[1][1];
+        }, $calls);
     }
 }


### PR DESCRIPTION
**JIRA ticket related**: https://jira.ez.no/browse/EZP-26110

You can define custom output visitors and tag it (`name: ezpublish_rest.output.visitor, regexps: something`) but it won't work with current implementation unless you load your bundle before `new eZ\Bundle\EzPublishRestBundle\EzPublishRestBundle(),` (and this way sucks). It's because of order of output visitors passed to compiler pass while kernel configuration contains Pokemon "gotta catch'em all" regexp `(^.*/.*$)` so it always return `application/vnd.ez.api...` regardless of visitors and generators registered after that one.

**Solution**: Proposed solution is to implement `priority` tag attribute similar to ones used in Symfony event listeners or cache warmers with default `0` in case of missing attribute.

**Example of use**:

```yaml
custom.output.visitor.xml:
    class: '%ezpublish_rest.output.visitor.class%'
    arguments:
        - '@custom.output.generator.xml'
        - '@ezpublish_rest.output.value_object_visitor.dispatcher'
    tags:
        - { name: ezpublish_rest.output.visitor, regexps: custom.output.visitor.xml.regexps, priority: 10 }
```
