### PR TITLE
[POC / do not merge]: Fix EZP-25913: (pre)set current siteaccess in siteaccess router

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
@@ -83,6 +83,8 @@ services:
             - %ezpublish.siteaccess.match_config%
             - %ezpublish.siteaccess.list%
             - %ezpublish.siteaccess.class%
+        calls:
+            - [setSiteAccess, [@?ezpublish.siteaccess=]]
 
     ezpublish.siteaccess_listener:
         class: %ezpublish.siteaccess_listener.class%


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25913

siteaccess router has no siteaccess instance when running in cli, this updates the service config with the corresponding call