### PR TITLE
EZP-26098: Add generic command to recreate search engine index

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/Exception/InvalidSearchEngineIndexer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/Exception/InvalidSearchEngineIndexer.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader\Exception;
+
+use InvalidArgumentException;
+
+class InvalidSearchEngineIndexer extends InvalidArgumentException
+{
+}

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/SearchEngineIndexerFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/SearchEngineIndexerFactory.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;
+
+use eZ\Bundle\EzPublishCoreBundle\ApiLoader\Exception\InvalidSearchEngineIndexer;
+use eZ\Publish\Core\Search\Common\Indexer as SearchEngineIndexer;
+
+/**
+ * The search engine indexer factory.
+ */
+class SearchEngineIndexerFactory
+{
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider
+     */
+    private $repositoryConfigurationProvider;
+
+    /**
+     * Hash of registered search engine indexers.
+     * Key is the search engine identifier, value indexer itself.
+     *
+     * @var \eZ\Publish\Core\Search\Common\Indexer[]
+     */
+    protected $searchEngineIndexers = [];
+
+    public function __construct(RepositoryConfigurationProvider $repositoryConfigurationProvider)
+    {
+        $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
+    }
+
+    /**
+     * Registers $searchEngineIndexer as a valid search engine indexer with identifier $searchEngineIdentifier.
+     *
+     * @note It is strongly recommended to register indexer as a lazy service.
+     *
+     * @param \eZ\Publish\Core\Search\Common\Indexer $searchEngineIndexer
+     * @param string $searchEngineIdentifier
+     */
+    public function registerSearchEngineIndexer(SearchEngineIndexer $searchEngineIndexer, $searchEngineIdentifier)
+    {
+        $this->searchEngineIndexers[$searchEngineIdentifier] = $searchEngineIndexer;
+    }
+
+    /**
+     * Returns registered search engine indexers.
+     *
+     * @return \eZ\Publish\Core\Search\Common\Indexer[]
+     */
+    public function getSearchEngineIndexers()
+    {
+        return $this->searchEngineIndexers;
+    }
+
+    /**
+     * Build search engine indexer identified by its identifier (the "alias" attribute in the service tag),
+     * resolved for current siteaccess.
+     *
+     * @throws \eZ\Bundle\EzPublishCoreBundle\ApiLoader\Exception\InvalidSearchEngineIndexer
+     *
+     * @return \eZ\Publish\Core\Search\Common\Indexer
+     */
+    public function buildSearchEngineIndexer()
+    {
+        $repositoryConfig = $this->repositoryConfigurationProvider->getRepositoryConfig();
+
+        if (
+            !(
+                isset($repositoryConfig['search']['engine'])
+                && isset($this->searchEngineIndexers[$repositoryConfig['search']['engine']])
+            )
+        ) {
+            throw new InvalidSearchEngineIndexer(
+                "Invalid search engine '{$repositoryConfig['search']['engine']}'. " .
+                "Could not find a service tagged as 'ezpublish.searchEngineIndexer' " .
+                "with alias '{$repositoryConfig['search']['engine']}'."
+            );
+        }
+
+        return $this->searchEngineIndexers[$repositoryConfig['search']['engine']];
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use eZ\Publish\Core\Search\Common\Indexer;
+use RuntimeException;
+
+class ReindexCommand extends ContainerAwareCommand
+{
+    /**
+     * @var \eZ\Publish\Core\Search\Common\Indexer
+     */
+    private $searchIndexer;
+
+    /**
+     * Initialize objects required by {@see execute()}.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    public function initialize(InputInterface $input, OutputInterface $output)
+    {
+        parent::initialize($input, $output);
+        $this->searchIndexer = $this->getContainer()->get('ezpublish.spi.search.indexer');
+        if (!$this->searchIndexer instanceof Indexer) {
+            throw new RuntimeException(
+                sprintf('Expected to find Search Engine Indexer but found "%s" instead', get_parent_class($this->searchIndexer))
+            );
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('ezplatform:reindex')
+            ->setDescription('Recreate search engine index')
+            ->addOption('iteration-count', 'c', InputOption::VALUE_OPTIONAL, 'Number of objects to be indexed in a single iteration', 20)
+            ->addOption('no-commit', null, InputOption::VALUE_NONE, 'Do not commit after each iteration')
+            ->setHelp(
+                <<<EOT
+The command <info>%command.name%</info> indexes current configured database in configured search engine index.
+EOT
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $iterationCount = $input->getOption('iteration-count');
+        $noCommit = $input->getOption('no-commit');
+
+        if (!is_numeric($iterationCount) || (int)$iterationCount < 1) {
+            throw new RuntimeException("'bulk_count' argument should be > 0, got '{$iterationCount}'");
+        }
+
+        $this->searchIndexer->createSearchIndex($output, intval($iterationCount), empty($noCommit));
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -65,7 +65,7 @@ EOT
         $noCommit = $input->getOption('no-commit');
 
         if (!is_numeric($iterationCount) || (int)$iterationCount < 1) {
-            throw new RuntimeException("'bulk_count' argument should be > 0, got '{$iterationCount}'");
+            throw new RuntimeException("'--iteration-count' option should be > 0, got '{$iterationCount}'");
         }
 
         $this->searchIndexer->createSearchIndex($output, intval($iterationCount), empty($noCommit));

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/RegisterSearchEngineIndexerPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/RegisterSearchEngineIndexerPass.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use LogicException;
+
+/**
+ * This compiler pass registers eZ Publish search engines indexers.
+ */
+class RegisterSearchEngineIndexerPass implements CompilerPassInterface
+{
+    /**
+     * Container service id of the SearchEngineIndexerFactory.
+     *
+     * @see \eZ\Bundle\EzPublishCoreBundle\ApiLoader\SearchEngineIndexerFactory
+     *
+     * @var string
+     */
+    protected $factoryId = 'ezpublish.api.search_engine.indexer.factory';
+
+    /**
+     * Register all found search engine indexers to the SearchEngineIndexerFactory.
+     *
+     * @throws \LogicException
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition($this->factoryId)) {
+            return;
+        }
+
+        $searchEngineIndexerFactoryDefinition = $container->getDefinition($this->factoryId);
+        foreach ($container->findTaggedServiceIds('ezpublish.searchEngineIndexer') as $id => $attributes) {
+            foreach ($attributes as $attribute) {
+                if (!isset($attribute['alias'])) {
+                    throw new LogicException(
+                        'ezpublish.searchEngineIndexer service tag needs an "alias" attribute to ' .
+                        'identify the search engine. None given.'
+                    );
+                }
+
+                // Register the search engine with the search engine factory
+                $searchEngineIndexerFactoryDefinition->addMethodCall(
+                    'registerSearchEngineIndexer',
+                    [
+                        new Reference($id),
+                        $attribute['alias'],
+                    ]
+                );
+            }
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
@@ -18,6 +18,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\HttpCachePass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\IdentityDefinerPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\ImaginePass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\QueryTypePass;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\RegisterSearchEngineIndexerPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\RegisterSearchEnginePass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\RegisterStorageEnginePass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\LegacyStorageEnginePass;
@@ -62,6 +63,7 @@ class EzPublishCoreBundle extends Bundle
         $container->addCompilerPass(new RegisterLimitationTypePass());
         $container->addCompilerPass(new RegisterStorageEnginePass());
         $container->addCompilerPass(new RegisterSearchEnginePass());
+        $container->addCompilerPass(new RegisterSearchEngineIndexerPass());
         $container->addCompilerPass(new LegacyStorageEnginePass());
         $container->addCompilerPass(new LocalePass());
         $container->addCompilerPass(new ContentViewPass());

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
@@ -6,6 +6,7 @@ parameters:
     ezpublish.api.repository.lazy_factory.class: eZ\Bundle\EzPublishCoreBundle\ApiLoader\LazyRepositoryFactory
     ezpublish.api.storage_engine.factory.class: eZ\Bundle\EzPublishCoreBundle\ApiLoader\StorageEngineFactory
     ezpublish.api.search_engine.factory.class: eZ\Bundle\EzPublishCoreBundle\ApiLoader\SearchEngineFactory
+    ezpublish.api.search_engine.indexer.factory.class: eZ\Bundle\EzPublishCoreBundle\ApiLoader\SearchEngineIndexerFactory
 
     # Symfony event converter Slot
     ezpublish.signalslot.event_converter_slot.class: eZ\Bundle\EzPublishCoreBundle\SignalSlot\Slot\SymfonyEventConverterSlot
@@ -64,12 +65,25 @@ services:
         arguments:
             - "@ezpublish.api.repository_configuration_provider"
 
+    ezpublish.api.search_engine.indexer.factory:
+            class: "%ezpublish.api.search_engine.indexer.factory.class%"
+            arguments:
+                - "@ezpublish.api.repository_configuration_provider"
+
     ezpublish.spi.search:
         alias: ezpublish.spi.search_engine
+
+    ezpublish.spi.search.indexer:
+        alias: ezpublish.spi.search_engine.indexer
 
     ezpublish.spi.search_engine:
         class: "%ezpublish.api.search_engine.class%"
         factory: ["@ezpublish.api.search_engine.factory", buildSearchEngine]
+        public: false
+
+    ezpublish.spi.search_engine.indexer:
+        class: "%ezpublish.search.common.indexer.class%"
+        factory: ["@ezpublish.api.search_engine.indexer.factory", buildSearchEngineIndexer]
         public: false
 
     # Signal Slot API wrapper

--- a/eZ/Bundle/EzPublishElasticsearchSearchEngineBundle/DependencyInjection/EzPublishElasticsearchSearchEngineExtension.php
+++ b/eZ/Bundle/EzPublishElasticsearchSearchEngineBundle/DependencyInjection/EzPublishElasticsearchSearchEngineExtension.php
@@ -114,15 +114,14 @@ class EzPublishElasticsearchSearchEngineExtension extends Extension
         $locationSearchGatewayId = self::LOCATION_SEARCH_GATEWAY_ID . ".$connectionName";
         $container->setDefinition($locationSearchGatewayId, $locationSearchGatewayDef);
 
-        // Search handler
-        $searchEngineDef = new DefinitionDecorator(self::MAIN_SEARCH_ENGINE_ID);
-        $searchEngineDef->replaceArgument(0, new Reference($contentSearchGatewayId));
-        $searchEngineDef->replaceArgument(1, new Reference($locationSearchGatewayId));
-        $searchEngineDef->replaceArgument(4, $connectionParams['document_type_name']['content']);
-        $searchEngineDef->replaceArgument(5, $connectionParams['document_type_name']['location']);
-        $searchEngineId = self::MAIN_SEARCH_ENGINE_ID . ".$connectionName";
-        $container->setDefinition($searchEngineId, $searchEngineDef);
-        $container->setParameter("$alias.connection.$connectionName.engine_id", $searchEngineId);
+        $container->setParameter(
+            "$alias.connection.$connectionName.content_document_type_identifier",
+            $connectionParams['document_type_name']['content']
+        );
+        $container->setParameter(
+            "$alias.connection.$connectionName.location_document_type_identifier",
+            $connectionParams['document_type_name']['location']
+        );
     }
 
     public function getConfiguration(array $config, ContainerBuilder $container)

--- a/eZ/Bundle/EzPublishElasticsearchSearchEngineBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishElasticsearchSearchEngineBundle/Resources/config/services.yml
@@ -8,5 +8,6 @@ services:
         arguments:
             - "@ezpublish.api.repository_configuration_provider"
             - "%ez_search_engine_elasticsearch.default_connection%"
+            - "%ezpublish.spi.search.elasticsearch.class%"
         calls:
             - [setContainer, ["@service_container"]]

--- a/eZ/Publish/Core/Search/Common/Indexer.php
+++ b/eZ/Publish/Core/Search/Common/Indexer.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Common;
+
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+use eZ\Publish\SPI\Persistence\Content\ContentInfo;
+use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
+use eZ\Publish\SPI\Search\Handler as SearchHandler;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\OutputInterface;
+use PDO;
+
+/**
+ * Base class for the Search Engine Indexer Service aimed to recreate Search Engine Index.
+ * Each Search Engine has to extend it on its own.
+ */
+abstract class Indexer
+{
+    const CONTENTOBJECT_TABLE = 'ezcontentobject';
+    const CONTENTOBJECT_TREE_TABLE = 'ezcontentobject_tree';
+
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Handler
+     */
+    protected $persistenceHandler;
+
+    /**
+     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
+     */
+    protected $databaseHandler;
+
+    /**
+     * @var \eZ\Publish\SPI\Search\Handler
+     */
+    protected $searchHandler;
+
+    public function __construct(
+        LoggerInterface $logger,
+        PersistenceHandler $persistenceHandler,
+        DatabaseHandler $databaseHandler,
+        SearchHandler $searchHandler
+    ) {
+        $this->logger = $logger;
+        $this->persistenceHandler = $persistenceHandler;
+        $this->databaseHandler = $databaseHandler;
+        $this->searchHandler = $searchHandler;
+    }
+
+    /**
+     * Create search engine index.
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param int $iterationCount
+     * @param bool $commit commit changes after each iteration
+     */
+    abstract public function createSearchIndex(OutputInterface $output, $iterationCount, $commit);
+
+    /**
+     * Get PDOStatement to fetch metadata about content objects to be indexed.
+     *
+     * @param array $fields Select fields
+     * @return \PDOStatement
+     */
+    protected function getContentDbFieldsStmt(array $fields)
+    {
+        $query = $this->databaseHandler->createSelectQuery();
+        $query->select($fields)
+            ->from($this->databaseHandler->quoteTable(self::CONTENTOBJECT_TABLE))
+            ->where($query->expr->eq('status', ContentInfo::STATUS_PUBLISHED));
+        $stmt = $query->prepare();
+        $stmt->execute();
+
+        return $stmt;
+    }
+
+    /**
+     * Fetch location Ids for the given content object.
+     *
+     * @param int $contentObjectId
+     * @return array Location nodes Ids
+     */
+    protected function getContentLocationIds($contentObjectId)
+    {
+        $query = $this->databaseHandler->createSelectQuery();
+        $query->select('node_id')
+            ->from($this->databaseHandler->quoteTable(self::CONTENTOBJECT_TREE_TABLE))
+            ->where($query->expr->eq('contentobject_id', $contentObjectId));
+        $stmt = $query->prepare();
+        $stmt->execute();
+        $nodeIds = $stmt->fetchAll(PDO::FETCH_COLUMN);
+
+        return is_array($nodeIds) ? array_map('intval', $nodeIds) : [];
+    }
+
+    /**
+     * Log warning while progress bar is shown.
+     *
+     * @param \Symfony\Component\Console\Helper\ProgressBar $progress
+     * @param $message
+     */
+    protected function logWarning(ProgressBar $progress, $message)
+    {
+        $progress->clear();
+        $this->logger->warning($message);
+        $progress->display();
+    }
+}

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Handler.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Handler.php
@@ -12,7 +12,6 @@ use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\SPI\Persistence\Content;
-use eZ\Publish\SPI\Persistence\Content\Type;
 use eZ\Publish\SPI\Search\Handler as SearchHandlerInterface;
 use eZ\Publish\SPI\Persistence\Content\Location;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
@@ -323,8 +322,6 @@ class Handler implements SearchHandlerInterface
 
     /**
      * Purges all contents from the index.
-     *
-     * @todo: Make this public API?
      */
     public function purgeIndex()
     {

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Indexer.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Indexer.php
@@ -32,7 +32,7 @@ class Indexer extends SearchIndexer
      */
     public function createSearchIndex(OutputInterface $output, $iterationCount, $commit)
     {
-        $this->logger->notice('Creating Elasticsearch Search Engine Index...');
+        $output->writeln('Creating Elasticsearch Search Engine Index...');
 
         if (!$this->searchHandler instanceof SearchHandler) {
             throw new RuntimeException(sprintf('Expected to find an instance of %s, but found %s', SearchHandler::class, get_class($this->searchHandler)));
@@ -81,7 +81,7 @@ class Indexer extends SearchIndexer
         $progress->finish();
         $output->writeln('');
 
-        $this->logger->notice('Finished creating Elasticsearch Search Engine Index');
+        $output->writeln('Finished creating Elasticsearch Search Engine Index');
     }
 
     /**

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/Indexer.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/Indexer.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Elasticsearch\Content;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\Core\Search\Common\Indexer as SearchIndexer;
+use eZ\Publish\Core\Search\Elasticsearch\Content\Handler as SearchHandler;
+use PDO;
+use RuntimeException;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Indexer extends SearchIndexer
+{
+    /**
+     * @var \eZ\Publish\Core\Search\Elasticsearch\Content\Handler
+     */
+    protected $searchHandler;
+
+    /**
+     * Create search engine index.
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param int $iterationCount
+     * @param bool $commit commit changes after each iteration
+     */
+    public function createSearchIndex(OutputInterface $output, $iterationCount, $commit)
+    {
+        $this->logger->notice('Creating Elasticsearch Search Engine Index...');
+
+        if (!$this->searchHandler instanceof SearchHandler) {
+            throw new RuntimeException(sprintf('Expected to find an instance of %s, but found %s', SearchHandler::class, get_class($this->searchHandler)));
+        }
+
+        $stmt = $this->getContentDbFieldsStmt(['count(id)']);
+        $totalCount = intval($stmt->fetchColumn());
+        $stmt = $this->getContentDbFieldsStmt(['id', 'current_version']);
+        $this->searchHandler->purgeIndex();
+        /** @var \Symfony\Component\Console\Helper\ProgressBar $progress */
+        $progress = new ProgressBar($output);
+        $progress->start($totalCount);
+        $i = 0;
+        do {
+            $contentObjects = [];
+            for ($k = 0; $k <= $iterationCount; ++$k) {
+                if (!$row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+                    break;
+                }
+                try {
+                    $contentObjects[] = $this->persistenceHandler->contentHandler()->load(
+                        $row['id'],
+                        $row['current_version']
+                    );
+                } catch (NotFoundException $e) {
+                    $this->logWarning($progress, "Could not load current version of Content with id ${row['id']}, so skipped for indexing. Full exception: " . $e->getMessage());
+                }
+            }
+            foreach ($contentObjects as $contentObject) {
+                try {
+                    $this->searchHandler->indexContent($contentObject);
+                    // Skip location indexing if search engine does not use it, or if content does not have locations
+                    if (empty($contentObject->versionInfo->contentInfo->mainLocationId)) {
+                        continue;
+                    }
+                    $this->indexLocations($contentObject->versionInfo->contentInfo->id, $progress);
+                } catch (NotFoundException $e) {
+                    $this->logWarning($progress, 'Content with id ' . $contentObject->versionInfo->id . ' has missing data, so skipped for indexing. Full exception: ' . $e->getMessage());
+                }
+            }
+            if ($commit) {
+                $this->searchHandler->flush();
+            }
+            $progress->advance($k);
+        } while (($i += $iterationCount) < $totalCount);
+        $progress->finish();
+        $output->writeln('');
+
+        $this->logger->notice('Finished creating Elasticsearch Search Engine Index');
+    }
+
+    /**
+     * Index Locations of the given Content Object.
+     *
+     * @param int $contentId Content Object Id
+     * @param \Symfony\Component\Console\Helper\ProgressBar $progress
+     */
+    private function indexLocations($contentId, ProgressBar $progress)
+    {
+        $locationIds = $this->getContentLocationIds($contentId);
+        foreach ($locationIds as $locationId) {
+            try {
+                $location = $this->persistenceHandler->locationHandler()->load($locationId);
+                $this->searchHandler->indexLocation($location);
+            } catch (NotFoundException $e) {
+                $this->logWarning($progress, "Could not load Location with id $locationId, so skipped for indexing. Full exception: " . $e->getMessage());
+            }
+        }
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/Indexer.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Indexer.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Legacy\Content;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\Core\Search\Common\Indexer as SearchIndexer;
+use eZ\Publish\Core\Search\Legacy\Content\Handler as SearchHandler;
+use PDO;
+use RuntimeException;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class Indexer extends SearchIndexer
+{
+    /**
+     * @var \eZ\Publish\Core\Search\Legacy\Content\Handler
+     */
+    protected $searchHandler;
+
+    /**
+     * Create search engine index.
+     *
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param int $iterationCount
+     * @param bool $commit commit changes after each iteration
+     */
+    public function createSearchIndex(OutputInterface $output, $iterationCount, $commit)
+    {
+        $this->logger->notice('Creating Legacy Search Engine Index...');
+
+        if (!$this->searchHandler instanceof SearchHandler) {
+            throw new RuntimeException(sprintf('Expected to find an instance of %s, but found %s', SearchHandler::class, get_class($this->searchHandler)));
+        }
+
+        $stmt = $this->getContentDbFieldsStmt(['count(id)']);
+        $totalCount = intval($stmt->fetchColumn());
+        $stmt = $this->getContentDbFieldsStmt(['id', 'current_version']);
+
+        $this->searchHandler->purgeIndex();
+
+        $progress = new ProgressBar($output);
+        $progress->start($totalCount);
+
+        $i = 0;
+        do {
+            $contentObjects = [];
+            for ($k = 0; $k <= $iterationCount; ++$k) {
+                if (!$row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+                    break;
+                }
+                try {
+                    $contentObjects[] = $this->persistenceHandler->contentHandler()->load(
+                        $row['id'],
+                        $row['current_version']
+                    );
+                } catch (NotFoundException $e) {
+                    $this->logWarning($progress, "Could not load current version of Content with id ${row['id']}, so skipped for indexing. Full exception: " . $e->getMessage());
+                }
+            }
+
+            foreach ($contentObjects as $content) {
+                try {
+                    $this->searchHandler->indexContent($content);
+                } catch (NotFoundException $e) {
+                    // Ignore content objects that have some sort of missing data on it
+                    $this->logWarning($progress, 'Content with id ' . $content->versionInfo->id . ' has missing data, so skipped for indexing. Full exception: ' . $e->getMessage());
+                }
+            }
+
+            $progress->advance($k);
+        } while (($i += $iterationCount) < $totalCount);
+        $progress->finish();
+        $output->writeln('');
+
+        $this->logger->notice('Finished creating Legacy Search Engine Index');
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/Indexer.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Indexer.php
@@ -32,7 +32,7 @@ class Indexer extends SearchIndexer
      */
     public function createSearchIndex(OutputInterface $output, $iterationCount, $commit)
     {
-        $this->logger->notice('Creating Legacy Search Engine Index...');
+        $output->writeln('Creating Legacy Search Engine Index...');
 
         if (!$this->searchHandler instanceof SearchHandler) {
             throw new RuntimeException(sprintf('Expected to find an instance of %s, but found %s', SearchHandler::class, get_class($this->searchHandler)));
@@ -78,6 +78,6 @@ class Indexer extends SearchIndexer
         $progress->finish();
         $output->writeln('');
 
-        $this->logger->notice('Finished creating Legacy Search Engine Index');
+        $output->writeln('Finished creating Legacy Search Engine Index');
     }
 }

--- a/eZ/Publish/Core/settings/containerBuilder.php
+++ b/eZ/Publish/Core/settings/containerBuilder.php
@@ -47,6 +47,7 @@ $loader->load('storage_engines/shortcuts.yml');
 $loader->load('search_engines/common.yml');
 $loader->load('settings.yml');
 $loader->load('utils.yml');
+$loader->load('tests/common.yml');
 
 $containerBuilder->setParameter('ezpublish.kernel.root_dir', $installDir);
 

--- a/eZ/Publish/Core/settings/search_engines/common.yml
+++ b/eZ/Publish/Core/settings/search_engines/common.yml
@@ -26,6 +26,7 @@ parameters:
         ez_document: 'doc'
         ez_fulltext: 'fulltext'
     ezpublish.search.common.field_value_mapper.aggregate.class: eZ\Publish\Core\Search\Common\FieldValueMapper\Aggregate
+    ezpublish.search.common.indexer.class: eZ\Publish\Core\Search\Common\Indexer
 
 services:
     # Note: services tagged with 'ezpublish.fieldType.indexable'

--- a/eZ/Publish/Core/settings/search_engines/elasticsearch.yml
+++ b/eZ/Publish/Core/settings/search_engines/elasticsearch.yml
@@ -15,6 +15,7 @@ parameters:
     ezpublish.search.elasticsearch.connection.document_type_identifier.content: 'content'
     ezpublish.search.elasticsearch.connection.document_type_identifier.location: 'location'
     ezpublish.spi.search.elasticsearch.class: eZ\Publish\Core\Search\Elasticsearch\Content\Handler
+    ezpublish.spi.search.elasticsearch.indexer.class: eZ\Publish\Core\Search\Elasticsearch\Content\Indexer
     ezpublish.search.elasticsearch.serializer.class: eZ\Publish\Core\Search\Elasticsearch\Content\Serializer
     ezpublish.search.elasticsearch.mapper.standard.class: eZ\Publish\Core\Search\Elasticsearch\Content\Mapper\StandardMapper
     ezpublish.search.elasticsearch.gateway.native.class: eZ\Publish\Core\Search\Elasticsearch\Content\Gateway\Native
@@ -89,4 +90,15 @@ services:
             - "%ezpublish.search.elasticsearch.connection.document_type_identifier.location%"
         tags:
             - {name: ezpublish.searchEngine, alias: elasticsearch}
+        lazy: true
+
+    ezpublish.spi.search.elasticsearch.indexer:
+        class: "%ezpublish.spi.search.elasticsearch.indexer.class%"
+        arguments:
+            - "@logger"
+            - "@ezpublish.api.storage_engine"
+            - "@ezpublish.api.storage_engine.legacy.dbhandler"
+            - "@ezpublish.spi.search.elasticsearch"
+        tags:
+            - {name: ezpublish.searchEngineIndexer, alias: elasticsearch}
         lazy: true

--- a/eZ/Publish/Core/settings/search_engines/legacy.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy.yml
@@ -11,6 +11,7 @@ imports:
 
 parameters:
     ezpublish.spi.search.legacy.class: eZ\Publish\Core\Search\Legacy\Content\Handler
+    ezpublish.spi.search.legacy.indexer.class: eZ\Publish\Core\Search\Legacy\Content\Indexer
     ezpublish.search.legacy.gateway.content.class: eZ\Publish\Core\Search\Legacy\Content\Gateway\DoctrineDatabase
     ezpublish.search.legacy.gateway.content.exception_conversion.class: eZ\Publish\Core\Search\Legacy\Content\Gateway\ExceptionConversion
     ezpublish.search.legacy.gateway.location.class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\DoctrineDatabase
@@ -91,4 +92,15 @@ services:
             - "@ezpublish.search.legacy.fulltext_mapper"
         tags:
             - {name: ezpublish.searchEngine, alias: legacy}
+        lazy: true
+
+    ezpublish.spi.search.legacy.indexer:
+        class: "%ezpublish.spi.search.legacy.indexer.class%"
+        arguments:
+            - "@logger"
+            - "@ezpublish.api.storage_engine"
+            - "@ezpublish.api.storage_engine.legacy.dbhandler"
+            - "@ezpublish.spi.search.legacy"
+        tags:
+            - {name: ezpublish.searchEngineIndexer, alias: legacy}
         lazy: true

--- a/eZ/Publish/Core/settings/tests/common.yml
+++ b/eZ/Publish/Core/settings/tests/common.yml
@@ -1,0 +1,3 @@
+services:
+    logger:
+        class: Psr\Log\NullLogger

--- a/eZ/Publish/SPI/Search/Handler.php
+++ b/eZ/Publish/SPI/Search/Handler.php
@@ -104,4 +104,9 @@ interface Handler
      * @param mixed $contentId
      */
     public function deleteLocation($locationId, $contentId);
+
+    /**
+     * Purges all contents from the index.
+     */
+    public function purgeIndex();
 }

--- a/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
@@ -581,6 +581,7 @@ abstract class BaseIntegrationTest extends TestCase
         $loader->load('settings.yml');
         $loader->load('fieldtype_services.yml');
         $loader->load('utils.yml');
+        $loader->load('tests/common.yml');
 
         $containerBuilder->setParameter('ezpublish.kernel.root_dir', $installDir);
 

--- a/eZ/Publish/SPI/Tests/FieldType/FileBaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/FileBaseIntegrationTest.php
@@ -144,6 +144,7 @@ abstract class FileBaseIntegrationTest extends BaseIntegrationTest
         $loader->load('settings.yml');
         $loader->load('fieldtype_services.yml');
         $loader->load('utils.yml');
+        $loader->load('tests/common.yml');
 
         $containerBuilder->setParameter('ezpublish.kernel.root_dir', $installDir);
 


### PR DESCRIPTION
> Status: **Ready for a review**.
> Implements: [EZP-26098](https://jira.ez.no/browse/EZP-26098).

This PR adds generic `ezplatform:reindex` command able to recreate Search Engine Index for any Search Engine extending Search Engine Indexer Service.
The Service should be tagged as `ezpublish.searchEngineIndexer` with an alias corresponding to a specific search engine (legacy, solr, elasticsearch).

**TODO**:
- [x] Add abstract Indexer Service, to be extended by each Search Engine  (af09e66).
- [x] Add `ezplatform:reindex` command to `EzPublishCoreBundle` (2ef2440).
- [x] Add Indexer Service for Legacy Search Engine (d4ff5c4).
- [x] Add Indexer Service for Elasticsearch Search Engine (b3b31f0).
- [x] Fix Elasticsearch Handler service definition (6c4a331).
- [x] Add Indexer Service for Solr ([Solr PR #68](https://github.com/ezsystems/ezplatform-solr-search-engine/pull/68)).

_Note: This PR was rebased, removing any code related to previous approach. Old code is available [here](https://github.com/ezsystems/ezpublish-kernel/compare/master...alongosz:ezp-26098-backup-20160926)._
