### PR TITLE
Rest embedding prototype (EZP-26033)

### DIFF
--- a/doc/specifications/proposed/rest_resource_embedding.md
+++ b/doc/specifications/proposed/rest_resource_embedding.md
@@ -1,0 +1,44 @@
+## REST embedding specification
+
+Repository value objects from any REST response can be expanded/embedded
+into the response, by means of custom request parameters.
+
+### Implementation
+
+In order to allow this, generation of links to other value objects gets
+a new, custom API.
+
+A custom value object is added, `LoadableValueObjectReference`. It is
+meant to be created and visited by other value object visitors. It contains
+the name of the value object type to load, as well as parameters for it:
+
+```php
+class LocationValueObjectVisitor extends ValueObjectVisitor
+{
+  public function visit($generator, $visitor, $location)
+  {
+    $generator->startObjectElement('Content');
+    $visitor->visitValueObject(
+      new ValueObjectReference(
+        'Content',
+        ['contentId' => $location->contentInfo->contentId]
+    );
+    $generator->endObjectElement('Content');
+  }
+}
+```
+
+It generates the link to the referenced value object, and add it to the
+generator as an href attribute (the current behaviour of all visitors).
+
+It uses a `valueReferenceLoader` to load the referenced
+value object. If one is loaded, it is visited and added to generated output,
+inside the current objet element.
+
+A `RequestOutputGeneratorValueReferenceLoader` (gasp) uses the request
+properties, as well as the Output Generator, determine if the referenced
+value should be embedded or not.
+
+Generation of value object links is abstracted into a `ValueHrefGenerator`.
+Given an object type name ('User', 'Content', ...), and a set of parameters,
+it is able to return the link to the value object's REST resource.

--- a/eZ/Bundle/EzPublishRestBundle/DependencyInjection/EzPublishRestExtension.php
+++ b/eZ/Bundle/EzPublishRestBundle/DependencyInjection/EzPublishRestExtension.php
@@ -34,6 +34,7 @@ class EzPublishRestExtension extends Extension implements PrependExtensionInterf
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
         $loader->load('value_object_visitors.yml');
+        $loader->load('value_loaders.yml');
         $loader->load('input_parsers.yml');
         $loader->load('security.yml');
         $loader->load('default_settings.yml');

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
@@ -405,3 +405,8 @@ services:
         parent: hautelook.router.template
         calls:
             - [ setOption, [ strict_requirements, ~ ] ]
+
+    ezpublish_rest.value_href_generator:
+        class: eZ\Publish\Core\REST\Server\Output\RouteValueHrefGenerator
+        arguments:
+            - @router

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_loaders.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_loaders.yml
@@ -1,0 +1,24 @@
+services:
+    ezpublish_rest.value_loader_dispatcher.type_map:
+        class: eZ\Publish\Core\REST\Server\ValueLoaders\TypeMapValueLoaderDispatcher
+        arguments:
+            -
+                Content: '@ezpublish_rest.value_loader.content'
+                User: '@ezpublish_rest.value_loader.user'
+
+    ezpublish_rest.value_loader.repository_based:
+        abstract: true
+        calls:
+            - [setRepository, ['@ezpublish.api.repository']]
+
+    ezpublish_rest.value_loader.content:
+        class: eZ\Publish\Core\REST\Server\ValueLoaders\Content
+        parent: ezpublish_rest.value_loader.repository_based
+        tags:
+            - { name: ezplatform.rest.value_loader, type: 'Content' }
+
+    ezpublish_rest.value_loader.user:
+        class: eZ\Publish\Core\REST\Server\ValueLoaders\User
+        parent: ezpublish_rest.value_loader.repository_based
+        tags:
+            - { name: ezplatform.rest.value_loader, type: 'User' }

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -850,3 +850,12 @@ services:
         class: %ezpublish_rest.output.value_object_visitor.ViewInput.class%
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Client\Values\ViewInput }
+
+    ezpublish_rest.output.value_object_visitor.internal.loadable_value_object_reference:
+        parent: ezpublish_rest.output.value_object_visitor.base
+        class: eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\LoadableValueObjectReference
+        tags:
+            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Values\LoadableValueObjectReference }
+        arguments:
+            - '@ezpublish_rest.value_href_generator'
+            - '@ezpublish_rest.value_loader_dispatcher.type_map'

--- a/eZ/Publish/Core/REST/Common/Output/Generator.php
+++ b/eZ/Publish/Core/REST/Common/Output/Generator.php
@@ -396,4 +396,23 @@ abstract class Generator
      * @return mixed
      */
     abstract public function serializeBool($boolValue);
+
+    /**
+     * Returns a string representation of the current stack of the document.
+     *
+     * Example: "Location.ContentInfo'
+     *
+     * @return string;
+     */
+    public function getStackPath()
+    {
+        $stackNames = array_map(
+            function ($value) {
+                return $value[1];
+            },
+            array_slice($this->stack, 1)
+        );
+
+        return implode('.', $stackNames);
+    }
 }

--- a/eZ/Publish/Core/REST/Server/Output/RouteValueHrefGenerator.php
+++ b/eZ/Publish/Core/REST/Server/Output/RouteValueHrefGenerator.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Output;
+
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use Symfony\Component\Routing\Exception\InvalidParameterException;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * Generates REST links for value object types using the router.
+ */
+class RouteValueHrefGenerator implements ValueHrefGeneratorInterface
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * A map of Value Object Type => Value object route.
+     * Example: ['Content' => 'ezpublish_rest_loadContent'].
+     *
+     * @var array
+     */
+    private $typeRouteMap = [
+        'Content' => 'ezpublish_rest_loadContent',
+        'User' => 'ezpublish_rest_loadUser',
+    ];
+
+    public function __construct(RouterInterface $router, array $typeRouteMap = [])
+    {
+        $this->router = $router;
+    }
+
+    public function generate($type, array $parameters)
+    {
+        if (!isset($this->typeRouteMap[$type])) {
+            throw new InvalidArgumentException('type', "No route map entry for '$type'");
+        }
+
+        try {
+            return $this->router->generate($this->typeRouteMap[$type], $parameters);
+        } catch (InvalidParameterException $e) {
+            throw new InvalidArgumentException('type', "No route map entry for '$type'", $e);
+        }
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Output/ValueHrefGeneratorInterface.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueHrefGeneratorInterface.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Output;
+
+/**
+ * Given a Value Object type as a string, and a set of parameters, generates a
+ * link to a value object's REST representation.
+ */
+interface ValueHrefGeneratorInterface
+{
+    /**
+     * Generates a link to a resource of $type, with $parameters.
+     * @param string $type
+     * @param array $parameters
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException if a link can't be generated for $type
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException if the parameters are invalid
+     *
+     * @return string
+     */
+    public function generate($type, array $parameters);
+}

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/LoadableValueObjectReference.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/LoadableValueObjectReference.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Output\ValueHrefGeneratorInterface;
+use eZ\Publish\Core\REST\Server\ValueLoaders\TypeMapValueLoaderDispatcher;
+use eZ\Publish\Core\REST\Server\ValueLoaders\ValueLoaderInterface;
+
+class LoadableValueObjectReference extends ValueObjectVisitor
+{
+    /**
+     * @var ValueHrefGenerator
+     */
+    private $valueHrefGenerator;
+
+    /**
+     * @var ValueReferenceLoader
+     */
+    private $valueReferenceLoader;
+
+    /**
+     * @var ValueLoaderInterface
+     */
+    private $valueLoader;
+
+    /**
+     * @var array
+     */
+    private $expandedPathList = [
+        'Location.ContentInfo',
+        'Location.ContentInfo.Content.Owner',
+        'Content.Owner',
+    ];
+
+    public function __construct(ValueHrefGeneratorInterface $valueHrefGenerator, TypeMapValueLoaderDispatcher $valueLoader)
+    {
+        $this->valueHrefGenerator = $valueHrefGenerator;
+        $this->valueLoader = $valueLoader;
+    }
+
+    /**
+     * @param Visitor $visitor
+     * @param Generator $generator
+     * @param \eZ\Publish\Core\REST\Server\Values\LoadableValueObjectReference $data
+     */
+    public function visit(Visitor $visitor, Generator $generator, $data)
+    {
+        $generator->startAttribute(
+            'href',
+            $this->valueHrefGenerator->generate($data->type, $data->loadParameters)
+        );
+
+        $generator->endAttribute('href');
+
+        if (in_array($generator->getStackPath(), $this->expandedPathList)) {
+            if ($valueObject = $this->valueLoader->load($data->type, $data->loadParameters)) {
+                $visitor->visitValueObject($valueObject);
+            }
+        }
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Location.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Location.php
@@ -14,7 +14,7 @@ use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
-use eZ\Publish\Core\REST\Server\Values\RestContent as RestContentValue;
+use eZ\Publish\Core\REST\Server\Values\LoadableValueObjectReference;
 
 /**
  * Location value object visitor.
@@ -137,15 +137,13 @@ class Location extends ValueObjectVisitor
         $generator->endObjectElement('UrlAliases');
 
         $generator->startObjectElement('ContentInfo', 'ContentInfo');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
-                'ezpublish_rest_loadContent',
-                array('contentId' => $location->contentId)
+
+        $visitor->visitValueObject(
+            new LoadableValueObjectReference(
+                ['type' => 'Content', 'loadParameters' => ['contentId' => $location->contentId]]
             )
         );
-        $generator->endAttribute('href');
-        $visitor->visitValueObject(new RestContentValue($location->contentInfo));
+
         $generator->endObjectElement('ContentInfo');
 
         $generator->endObjectElement('Location');

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContent.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContent.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Values\LoadableValueObjectReference;
 use eZ\Publish\Core\REST\Server\Values\Version as VersionValue;
 
 /**
@@ -134,11 +135,14 @@ class RestContent extends ValueObjectVisitor
         $generator->endObjectElement('Locations');
 
         $generator->startObjectElement('Owner', 'User');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadUser', array('userId' => $contentInfo->ownerId))
+        $visitor->visitValueObject(
+            new LoadableValueObjectReference(
+                [
+                    'type' => 'User',
+                    'loadParameters' => ['userId' => $contentInfo->ownerId],
+                ]
+            )
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Owner');
 
         // Modification date will not exist if we're visiting the content draft

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestLocation.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestLocation.php
@@ -13,7 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
-use eZ\Publish\Core\REST\Server\Values\RestContent as RestContentValue;
+use eZ\Publish\Core\REST\Server\Values\LoadableValueObjectReference;
 
 /**
  * RestLocation value object visitor.
@@ -129,15 +129,15 @@ class RestLocation extends ValueObjectVisitor
         $generator->endObjectElement('UrlAliases');
 
         $generator->startObjectElement('ContentInfo', 'ContentInfo');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
-                'ezpublish_rest_loadContent',
-                array('contentId' => $contentInfo->id)
+        $visitor->visitValueObject(
+            new LoadableValueObjectReference(
+                [
+                    'type' => 'Content',
+                    'loadParameters' => ['contentId' => $contentInfo->id],
+                ]
             )
         );
-        $generator->endAttribute('href');
-        $visitor->visitValueObject(new RestContentValue($contentInfo));
+
         $generator->endObjectElement('ContentInfo');
 
         $generator->endObjectElement('Location');

--- a/eZ/Publish/Core/REST/Server/ValueLoaders/Content.php
+++ b/eZ/Publish/Core/REST/Server/ValueLoaders/Content.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\ValueLoaders;
+
+use eZ\Publish\Core\REST\Server\Values\RestContent;
+
+class Content extends RepositoryBased implements ValueLoaderInterface
+{
+    /**
+     * @var \eZ\Publish\API\Repository\Repository
+     */
+    private $repository;
+
+    public function load($parameters)
+    {
+        $content = $this->getRepository()->getContentService()->loadContent($parameters['contentId']);
+
+        return new RestContent($content->contentInfo);
+    }
+}

--- a/eZ/Publish/Core/REST/Server/ValueLoaders/RepositoryBased.php
+++ b/eZ/Publish/Core/REST/Server/ValueLoaders/RepositoryBased.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This file is part of the ezplatform package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\ValueLoaders;
+
+use eZ\Publish\API\Repository\Repository;
+
+class RepositoryBased
+{
+    /**
+     * @var Repository
+     */
+    private $repository;
+
+    public function setRepository(Repository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function getRepository()
+    {
+        return $this->repository;
+    }
+}

--- a/eZ/Publish/Core/REST/Server/ValueLoaders/TypeMapValueLoaderDispatcher.php
+++ b/eZ/Publish/Core/REST/Server/ValueLoaders/TypeMapValueLoaderDispatcher.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of the ezplatform package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\ValueLoaders;
+
+class TypeMapValueLoaderDispatcher
+{
+    /**
+     * @var \eZ\Publish\Core\REST\Server\ValueLoaders\ValueLoaderInterface[]
+     */
+    private $typeLoadersMap;
+
+    public function __construct($typeLoadersMap)
+    {
+        $this->typeLoadersMap = $typeLoadersMap;
+    }
+
+    public function load($type, $loadParameters)
+    {
+        return $this->typeLoadersMap[$type]->load($loadParameters);
+    }
+}

--- a/eZ/Publish/Core/REST/Server/ValueLoaders/User.php
+++ b/eZ/Publish/Core/REST/Server/ValueLoaders/User.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\ValueLoaders;
+
+use eZ\Publish\Core\REST\Server\Values\RestUser;
+
+class User extends RepositoryBased implements ValueLoaderInterface
+{
+    /**
+     * @return \eZ\Publish\Core\REST\Server\Values\RestUser
+     */
+    public function load($parameters)
+    {
+        $userService = $this->getRepository()->getUserService();
+        $contentService = $this->getRepository()->getContentService();
+        $contentTypeService = $this->getRepository()->getContentTypeService();
+        $locationService = $this->getRepository()->getLocationService();
+
+        $user = $userService->loadUser($parameters['userId']);
+        $contentType = $contentTypeService->loadContentType($user->contentInfo->contentTypeId);
+        $mainLocation = $locationService->loadLocation($user->contentInfo->mainLocationId);
+        $relations = $contentService->loadRelations($user->versionInfo);
+
+        return new RestUser($user, $contentType, $user->contentInfo, $mainLocation, $relations);
+    }
+}

--- a/eZ/Publish/Core/REST/Server/ValueLoaders/ValueLoaderInterface.php
+++ b/eZ/Publish/Core/REST/Server/ValueLoaders/ValueLoaderInterface.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\ValueLoaders;
+
+interface ValueLoaderInterface
+{
+    public function load($parameters);
+}

--- a/eZ/Publish/Core/REST/Server/Values/LoadableValueObjectReference.php
+++ b/eZ/Publish/Core/REST/Server/Values/LoadableValueObjectReference.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Values;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * A reference to a value object.
+ *
+ * @property string $type
+ * @property array $loadParameters
+ */
+class LoadableValueObjectReference extends ValueObject
+{
+    /**
+     * The value object's type string. Ex: User, Content...
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * Parameters used to load the value object if applicable.
+     * @var array
+     */
+    protected $loadParameters;
+}


### PR DESCRIPTION
> Implements http://jira.ez.no/browse/EZP-26033
> Specification: [doc/specifications/proposed/rest_resource_embedding.md](https://github.com/ezsystems/ezpublish-kernel/blob/ezp26033-rest_embedding_prototype/doc/specifications/proposed/rest_resource_embedding.md)

Adds a new API to generate links to REST resources inside visitors, by creating a `LoadableValueObjectReference` value object, and having it visited:

## What is missing

### Request arguments
REST needs to process extra request arguments that define which objects must be expanded. 

Known options are headers, or get parameters.  

### Dynamic href generation map
Links to REST resources are currently using a hardcoded type <-> route map (example: `['Content' => 'ezpublish_rest_loadContent']`). This must be done differently.

Options:
- manual map in a yaml file
- tagging routes with the resource's name, and processing those
 
## Example

### Value loaders service tag + pass
Value loaders are manually registered in the dispatcher's service definition. A service tag must be added (`ezpublish_rest.value_loader`, with a `type` argument

### Before
Links to value objects were generated using the router, and added as the href attribute of object elements:

```
$generator->startObjectElement('Owner', 'User');
$generator->startAttribute(
  'href',
  $this->router->generate(
    'ezpublish_rest_loadUser',
    ['userId' => $contentInfo->userId]
  )
);
$generator->endAttribute('href');
$generator->endObjectElement('Owner');
```

### After

The href attribute is instead generated by visiting a `LoadableValueObjectReference`:

```
$generator->startObjectElement('Owner', 'User');
$visitor->visitValueObject(
  new LoadableValueObjectReference(
    'User',
    ['userId' => $contentInfo->userId]
  )
);
$generator->endAttribute('href');
$generator->endObjectElement('Owner');
```