### PR TITLE
EZP-26098: An alternative approach to the generic search engine indexing command

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use eZ\Publish\SPI\Search\Indexing;
+use RuntimeException;
+
+class ReindexCommand extends ContainerAwareCommand
+{
+    /**
+     * @var \eZ\Publish\SPI\Search\Indexing
+     */
+    private $searchHandler;
+
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var \eZ\Publish\SPI\Search\IndexerDataProvider
+     */
+    private $dataProvider;
+
+    /**
+     * Initialize objects required by {@see execute()}.
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     */
+    public function initialize(InputInterface $input, OutputInterface $output)
+    {
+        parent::initialize($input, $output);
+        $this->logger = $this->getContainer()->get('logger');
+        $this->searchHandler = $this->getContainer()->get('ezpublish.spi.search');
+        $this->dataProvider = $this->getContainer()->get('ezpublish.search.common.indexer.data_provider');
+        if (!$this->searchHandler instanceof Indexing) {
+            throw new RuntimeException(
+                'Expected to find Search Engine Handler capable of Indexing but found something else.'
+            );
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('ezplatform:reindex')
+            ->setDescription('Recreate search engine index')
+            ->addArgument('bulk_count', InputArgument::OPTIONAL, 'Number of objects to be indexed at once', 5)
+            ->setHelp(
+                <<<EOT
+The command <info>%command.name%</info> indexes current configured database in configured search engine index.
+EOT
+            );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $bulkCount = $input->getArgument('bulk_count');
+
+        $output->writeln('Creating search index for the engine: ' . get_parent_class($this->searchHandler));
+
+        $this->searchHandler->createSearchIndex(
+            $bulkCount,
+            $this->dataProvider,
+            $output,
+            $this->logger
+        );
+
+        $output->writeln(PHP_EOL . 'Finished creating search index for the engine: ' . get_parent_class($this->searchHandler));
+    }
+}

--- a/eZ/Publish/Core/Search/Common/IndexerDataProvider.php
+++ b/eZ/Publish/Core/Search/Common/IndexerDataProvider.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Common;
+
+use eZ\Publish\SPI\Search\IndexerDataProvider as SearchIndexerDataProvider;
+use eZ\Publish\SPI\Persistence\Handler;
+use eZ\Publish\SPI\Persistence\Content\ContentInfo;
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+use PDO;
+
+class IndexerDataProvider implements SearchIndexerDataProvider
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Handler
+     */
+    private $persistenceHandler;
+    /**
+     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
+     */
+    private $databaseHandler;
+
+    public function __construct(Handler $persistenceHandler, DatabaseHandler $databaseHandler)
+    {
+        $this->persistenceHandler = $persistenceHandler;
+        $this->databaseHandler = $databaseHandler;
+    }
+
+    /**
+     * Get a total number of published content objects.
+     *
+     * @return int
+     */
+    public function getPublishedContentCount()
+    {
+        $query = $this->databaseHandler->createSelectQuery();
+        $query->select('count(id)')
+            ->from('ezcontentobject')
+            ->where($query->expr->eq('status', ContentInfo::STATUS_PUBLISHED));
+        $stmt = $query->prepare();
+        $stmt->execute();
+
+        return $stmt->fetchColumn();
+    }
+
+    /**
+     * Get a number of nodes in content object tree.
+     *
+     * @return int
+     */
+    public function getLocationsCount()
+    {
+        $query = $this->databaseHandler->createSelectQuery();
+        $query
+            ->select('count(node_id)')
+            ->from('ezcontentobject_tree')
+            ->where(
+                $query->expr->neq(
+                    $this->databaseHandler->quoteColumn('contentobject_id'),
+                    $query->bindValue(0, null, PDO::PARAM_INT)
+                )
+            );
+        $stmt = $query->prepare();
+        $stmt->execute();
+
+        return intval($stmt->fetchColumn());
+    }
+
+    /**
+     * Get content objects ids (and version ids) generator.
+     *
+     * @return \Generator generating an associative array ('id' => ..., 'current_version' => ...)
+     */
+    public function getContentObjects()
+    {
+        $query = $this->databaseHandler->createSelectQuery();
+        $query->select('id', 'current_version')
+            ->from('ezcontentobject')
+            ->where($query->expr->eq('status', ContentInfo::STATUS_PUBLISHED));
+
+        $stmt = $query->prepare();
+        $stmt->execute();
+
+        while (false !== ($row = $stmt->fetch(PDO::FETCH_ASSOC))) {
+            yield $row;
+        }
+    }
+
+    /**
+     * Get location node ids generator.
+     *
+     * @return \Generator generating node ids (int)
+     */
+    public function getLocations()
+    {
+        $query = $this->databaseHandler->createSelectQuery();
+        $query
+            ->select('node_id')
+            ->from('ezcontentobject_tree')
+            ->where(
+                $query->expr->neq(
+                    $this->databaseHandler->quoteColumn('contentobject_id'),
+                    $query->bindValue(0, null, PDO::PARAM_INT)
+                )
+            );
+
+        $stmt = $query->prepare();
+        $stmt->execute();
+
+        while (false !== ($row = $stmt->fetch(PDO::FETCH_ASSOC))) {
+            yield $row['node_id'];
+        }
+    }
+
+    /**
+     * Get the raw data of a content object identified by $id and $version, in a struct.
+     *
+     * @param int $id
+     * @param int $currentVersion version number
+     * @return \eZ\Publish\SPI\Persistence\Content
+     */
+    public function loadContentObjectVersion($id, $currentVersion)
+    {
+        return $this->persistenceHandler->contentHandler()->load($id, $currentVersion);
+    }
+
+    /**
+     * Load the data for the location identified by $locationId.
+     *
+     * @param int $locationId
+     * @return \eZ\Publish\SPI\Persistence\Content\Location
+     */
+    public function loadLocation($locationId)
+    {
+        return $this->persistenceHandler->locationHandler()->load($locationId);
+    }
+}

--- a/eZ/Publish/Core/Search/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Handler.php
@@ -27,9 +27,6 @@ use eZ\Publish\SPI\Persistence\Content\Language\Handler as LanguageHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Mapper\FullTextMapper;
 use eZ\Publish\SPI\Search\IndexerDataProvider;
 use eZ\Publish\SPI\Search\Indexing;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * The Content Search handler retrieves sets of of Content objects, based on a
@@ -411,14 +408,20 @@ class Handler implements SearchHandlerInterface, Indexing
      *
      * @param $bulkCount
      * @param \eZ\Publish\SPI\Search\IndexerDataProvider $dataProvider
-     * @param \Symfony\Component\Console\Output\OutputInterface $output
-     * @param \Psr\Log\LoggerInterface $logger
+     * @param callable $onOutput
+     * @param callable $onBatchStarted
+     * @param callable $onBatchFinished
+     * @param callable $onBulkProcessed
+     * @param callable $onError
      */
     public function createSearchIndex(
         $bulkCount,
         IndexerDataProvider $dataProvider,
-        OutputInterface $output,
-        LoggerInterface $logger
+        callable $onOutput,
+        callable $onBatchStarted,
+        callable $onBatchFinished,
+        callable $onBulkProcessed,
+        callable $onError
     ) {
         $this->purgeIndex();
 
@@ -427,9 +430,8 @@ class Handler implements SearchHandlerInterface, Indexing
         // get content objects current version ids generator
         $contentCurrentVersionIds = $dataProvider->getContentObjects();
 
-        /* @var \Symfony\Component\Console\Helper\ProgressBar $progress */
-        $progress = new ProgressBar($output);
-        $progress->start($totalCount);
+        $onOutput('Indexing content...');
+        $onBatchStarted($totalCount);
         $i = 0;
         do {
             $contentObjects = [];
@@ -447,9 +449,7 @@ class Handler implements SearchHandlerInterface, Indexing
                         $row['current_version']
                     );
                 } catch (NotFoundException $e) {
-                    $progress->clear();
-                    $logger->warning("Could not load current version of Content with id ${row['id']}, so skipped for indexing. Full exception: " . $e->getMessage());
-                    $progress->display();
+                    $onError("Could not load current version of Content with id ${row['id']}, so skipped for indexing. Full exception: " . $e->getMessage());
                 }
                 $contentCurrentVersionIds->next();
             }
@@ -458,15 +458,12 @@ class Handler implements SearchHandlerInterface, Indexing
                 try {
                     $this->indexContent($contentObject);
                 } catch (NotFoundException $e) {
-                    $progress->clear();
-                    $logger->warning('Content with id ' . $contentObject->versionInfo->id . ' has missing data, so skipped for indexing. Full exception: ' . $e->getMessage());
-                    $progress->display();
+                    $onError('Content with id ' . $contentObject->versionInfo->id . ' has missing data, so skipped for indexing. Full exception: ' . $e->getMessage());
                 }
             }
-
-            $progress->advance($k);
+            $onBulkProcessed($k);
         } while (($i += $bulkCount) < $totalCount);
 
-        $progress->finish();
+        $onBatchFinished();
     }
 }

--- a/eZ/Publish/Core/settings/search_engines/common.yml
+++ b/eZ/Publish/Core/settings/search_engines/common.yml
@@ -26,6 +26,7 @@ parameters:
         ez_document: 'doc'
         ez_fulltext: 'fulltext'
     ezpublish.search.common.field_value_mapper.aggregate.class: eZ\Publish\Core\Search\Common\FieldValueMapper\Aggregate
+    ezpublish.search.common.indexer.data_provider.class: eZ\Publish\Core\Search\Common\IndexerDataProvider
 
 services:
     # Note: services tagged with 'ezpublish.fieldType.indexable'
@@ -50,3 +51,9 @@ services:
     # are registered to this one using compilation pass
     ezpublish.search.common.field_value_mapper.aggregate:
         class: "%ezpublish.search.common.field_value_mapper.aggregate.class%"
+
+    ezpublish.search.common.indexer.data_provider:
+        class: %ezpublish.search.common.indexer.data_provider.class%
+        arguments:
+            - @ezpublish.api.persistence_handler
+            - @ezpublish.api.storage_engine.legacy.dbhandler

--- a/eZ/Publish/SPI/Search/IndexerDataProvider.php
+++ b/eZ/Publish/SPI/Search/IndexerDataProvider.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\SPI\Search;
+
+interface IndexerDataProvider
+{
+    /**
+     * Get a total number of published content objects.
+     *
+     * @return int
+     */
+    public function getPublishedContentCount();
+
+    /**
+     * Get content objects ids (and version ids) generator.
+     *
+     * @return \Generator generating an associative array ('id' => ..., 'current_version' => ...)
+     */
+    public function getContentObjects();
+
+    /**
+     * Get the raw data of a content object identified by $id and $version, in a struct.
+     *
+     * @param int $id
+     * @param int $currentVersion version number
+     * @return \eZ\Publish\SPI\Persistence\Content
+     */
+    public function loadContentObjectVersion($id, $currentVersion);
+
+    /**
+     * Get a number of nodes in content object tree.
+     *
+     * @return int
+     */
+    public function getLocationsCount();
+
+    /**
+     * Get location node ids generator.
+     *
+     * @return \Generator generating node ids (int)
+     */
+    public function getLocations();
+
+    /**
+     * Load the data for the location identified by $locationId.
+     *
+     * @param int $locationId
+     * @return \eZ\Publish\SPI\Persistence\Content\Location
+     */
+    public function loadLocation($locationId);
+}

--- a/eZ/Publish/SPI/Search/Indexing.php
+++ b/eZ/Publish/SPI/Search/Indexing.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\SPI\Search;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Interface for creating a search index in search handler.
+ */
+interface Indexing
+{
+    /**
+     * Create search engine index.
+     *
+     * @param $bulkCount
+     * @param \eZ\Publish\SPI\Search\IndexerDataProvider $dataProvider
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param \Psr\Log\LoggerInterface $logger
+     */
+    public function createSearchIndex(
+        $bulkCount,
+        IndexerDataProvider $dataProvider,
+        OutputInterface $output,
+        LoggerInterface $logger
+    );
+}

--- a/eZ/Publish/SPI/Search/Indexing.php
+++ b/eZ/Publish/SPI/Search/Indexing.php
@@ -8,9 +8,6 @@
  */
 namespace eZ\Publish\SPI\Search;
 
-use Psr\Log\LoggerInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-
 /**
  * Interface for creating a search index in search handler.
  */
@@ -21,13 +18,19 @@ interface Indexing
      *
      * @param $bulkCount
      * @param \eZ\Publish\SPI\Search\IndexerDataProvider $dataProvider
-     * @param \Symfony\Component\Console\Output\OutputInterface $output
-     * @param \Psr\Log\LoggerInterface $logger
+     * @param callable $onOutput
+     * @param callable $onBatchStarted
+     * @param callable $onBatchFinished
+     * @param callable $onBulkProcessed
+     * @param callable $onError
      */
     public function createSearchIndex(
         $bulkCount,
         IndexerDataProvider $dataProvider,
-        OutputInterface $output,
-        LoggerInterface $logger
+        callable $onOutput,
+        callable $onBatchStarted,
+        callable $onBatchFinished,
+        callable $onBulkProcessed,
+        callable $onError
     );
 }


### PR DESCRIPTION
Status: **Ready for a review**
Implements: [EZP-26098](https://jira.ez.no/browse/EZP-26098).

This is an alternative approach to #1738 - adds the generic `ezplatform:reindex` command in order to recreate search engine index for all configured and capable search engines.

The difference between #1738 and this is that a search engine handler is fully responsible for (re)creating search engine index.

**TODO**:
- [ ] Discuss this approach.
- [x] Rebase after merging #1707, to have an actual ability to recreate the Legacy Search Engine index.
- [x] Implement it in *Legacy Search Engine* Handler
- [x] Implement it in *Elasticsearch* Handler.
- [x] Implement it in *Solr* Handler ([Solr PR #55](https://github.com/ezsystems/ezplatform-solr-search-engine/pull/55)).