### PR TITLE
On-demand REST resource embedding

### DIFF
--- a/doc/specifications/proposed/rest_resource_embedding.md
+++ b/doc/specifications/proposed/rest_resource_embedding.md
@@ -1,0 +1,185 @@
+# REST resource embedding
+
+Rest embedding allows an API consumer to request references from the
+response to be embedded, in order to avoid extra REST calls.
+
+## Example
+
+A location response contains a reference to the content item's main location:
+
+```
+curl -X GET http://localhost:8000/api/ezp/v2/content/objects/1
+```
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<Content media-type="application/vnd.ez.api.ContentInfo+xml" href="/api/ezp/v2/content/objects/1" remoteId="9459d3c29e15006e45197295722c7ade" id="1">
+ <ContentType media-type="application/vnd.ez.api.ContentType+xml" href="/api/ezp/v2/content/types/1"/>
+ <Name>eZ Platform</Name>
+ <Versions media-type="application/vnd.ez.api.VersionList+xml" href="/api/ezp/v2/content/objects/1/versions"/>
+ <CurrentVersion media-type="application/vnd.ez.api.Version+xml" href="/api/ezp/v2/content/objects/1/currentversion"/>
+ <Section media-type="application/vnd.ez.api.Section+xml" href="/api/ezp/v2/content/sections/1"/>
+ <MainLocation media-type="application/vnd.ez.api.Location+xml" href="/api/ezp/v2/content/locations/1/2"/>
+ <Locations media-type="application/vnd.ez.api.LocationList+xml" href="/api/ezp/v2/content/objects/1/locations"/>
+ <Owner media-type="application/vnd.ez.api.User+xml" href="/api/ezp/v2/user/users/14"/>
+ <lastModificationDate>2015-11-30T13:10:46+00:00</lastModificationDate>
+ <publishedDate>2015-11-30T13:10:46+00:00</publishedDate>
+ <mainLanguageCode>eng-GB</mainLanguageCode>
+ <currentVersionNo>9</currentVersionNo>
+ <alwaysAvailable>true</alwaysAvailable>
+ <ObjectStates media-type="application/vnd.ez.api.ContentObjectStates+xml" href="/api/ezp/v2/content/objects/1/objectstates"/>
+</Content>
+```
+
+By adding an `X-eZ-Embed-Value` header to the request, we can get the
+main location object embedded into the response:
+
+```
+curl -X GET http://localhost:8000/api/ezp/v2/content/objects/1 -H 'x-ez-embed-value: Content.MainLocation'
+```
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<Content media-type="application/vnd.ez.api.ContentInfo+xml" href="/api/ezp/v2/content/objects/1" remoteId="9459d3c29e15006e45197295722c7ade" id="1">
+ <ContentType media-type="application/vnd.ez.api.ContentType+xml" href="/api/ezp/v2/content/types/1"/>
+ <Name>eZ Platform</Name>
+ <Versions media-type="application/vnd.ez.api.VersionList+xml" href="/api/ezp/v2/content/objects/1/versions"/>
+ <CurrentVersion media-type="application/vnd.ez.api.Version+xml" href="/api/ezp/v2/content/objects/1/currentversion"/>
+ <Section media-type="application/vnd.ez.api.Section+xml" href="/api/ezp/v2/content/sections/1"/>
+ <MainLocation media-type="application/vnd.ez.api.Location+xml" href="/api/ezp/v2/content/locations/1/2">
+  <id>2</id>
+  <priority>0</priority>
+  <hidden>false</hidden>
+  <invisible>false</invisible>
+  <ParentLocation media-type="application/vnd.ez.api.Location+xml" href="/api/ezp/v2/content/locations/1"/>
+  <pathString>/1/2/</pathString>
+  <depth>1</depth>
+  <childCount>8</childCount>
+  <remoteId>f3e90596361e31d496d4026eb624c983</remoteId>
+  <Children media-type="application/vnd.ez.api.LocationList+xml" href="/api/ezp/v2/content/locations/1/2/children"/>
+  <Content media-type="application/vnd.ez.api.Content+xml" href="/api/ezp/v2/content/objects/1"/>
+  <sortField>PRIORITY</sortField>
+  <sortOrder>ASC</sortOrder>
+  <UrlAliases media-type="application/vnd.ez.api.UrlAliasRefList+xml" href="/api/ezp/v2/content/locations/1/2/urlaliases"/>
+  <ContentInfo media-type="application/vnd.ez.api.ContentInfo+xml" href="/api/ezp/v2/content/objects/1"/>
+ </MainLocation>
+ <Locations media-type="application/vnd.ez.api.LocationList+xml" href="/api/ezp/v2/content/objects/1/locations"/>
+ <Owner media-type="application/vnd.ez.api.User+xml" href="/api/ezp/v2/user/users/14"/>
+ <lastModificationDate>2015-11-30T13:10:46+00:00</lastModificationDate>
+ <publishedDate>2015-11-30T13:10:46+00:00</publishedDate>
+ <mainLanguageCode>eng-GB</mainLanguageCode>
+ <currentVersionNo>9</currentVersionNo>
+ <alwaysAvailable>true</alwaysAvailable>
+ <ObjectStates media-type="application/vnd.ez.api.ContentObjectStates+xml" href="/api/ezp/v2/content/objects/1/objectstates"/>
+</Content>
+```
+
+### The `X-eZ-Embed-Value` request header
+
+Which resources must be embedded is specified using this request header.
+It accepts several resources separated by commas:
+
+`X-eZ-Embed-Value: Content.MainLocation,Content.Owner.Groups`
+
+A resource is referenced by its "path" from the root of the response.
+Resources from an embedded resource can also be embedded:
+
+- `Content.MainLocation`
+- `Content.ContentType`
+- `Content.Owner.Groups`
+
+### Permissions
+If the user doesn't have the required permissions to load an embedded
+object, the response will be untouched, and no error will be thrown.
+
+### HTTP Caching
+Responses will vary based on the embedded responses.
+
+Thanks to HTTP cache multi-tagging, customized responses will expire as
+expected: each embedded object will tag the response with the HTTP cache
+tags it requires.
+
+### Implementation
+
+#### Resource links generation in value object visitors
+Value object visitors don't use the router directly anymore to generate
+links to resources. Instead, they build and visit a `ResourceRouteReference`
+object with the name of the route and the route's parameters:
+
+```php
+class LocationValueObjectVisitor extends ValueObjectVisitor
+{
+  public function visit($generator, $visitor, $location)
+  {
+    // ...
+    
+    $generator->startObjectElement$generator->startObjectElement('Content');
+    $visitor->visitValueObject(
+      new ResourceRouteReference(
+        'ezpublish_rest_loadContent',
+        ['contentId' => $location->contentInfo->contentId]
+    );
+    $generator->endObjectElement('Content');
+  }
+}
+```
+
+#### The `ResourceRouteReference` value object visitor
+This object's visitor extends the `RestResourceLink` visitor.
+
+It uses the router to generate a link based on the `RestResourceLink`
+properties, and invokes the parent's `visit()` method.
+
+#### The `RestResourceLink` value object visitor
+It first generate an `href` attribute, respecting the REST output that
+existed before this feature.
+
+It then uses a `PathExpansionChecker` to test if the current generator path,
+returned by the `Generator::getStackPath()` method, is requested for expansion.
+A `RequestHeaderPathExpansionChecker` uses the request to test if expansion
+is needed.
+
+If it is, a `ValueReferenceLoader` loads the referenced
+value object. The returned value object it is visited and added to generated
+output, inside the current object element.
+
+#### The `ExpansionGenerator`
+The `RestResourceLink` visitor passes an `ExpansionGenerator` when visiting
+the loaded value object.
+
+This OutputGenerator decorates the actual (XML or JSON) generator. It will
+skip the first objectElement and its attributes generated for the embedded
+object, in order to avoid duplicate nodes. In the example above, the `LocationList`
+object is skipped:
+
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<Location media-type="application/vnd.ez.api.Location+xml" href="/api/ezp/v2/content/locations/1/2">
+ <!-- ... -->
+ <Children media-type="application/vnd.ez.api.LocationList+xml" href="/api/ezp/v2/content/locations/1/2/children">
+  <!-- This is skipped -->
+  <LocationList media-type="application/vnd.ez.api.LocationList+xml" href="/api/ezp/v2/content/locations/1/2/children">
+   <Location media-type="application/vnd.ez.api.Location+xml" href="/api/ezp/v2/content/locations/1/2/55"/>
+  </LocationList>
+ </Children>
+</Location>
+```
+
+### Loading of references
+References are loaded by the `ControllerUriValueLoader`. Given a REST
+resource URI (`/api/ezp/v2/content/objects/1`), it will determine and call
+the REST controller action for that URI.
+
+This implementation ensures that any REST resource that has a controller
+can be embedded without requiring any extra development.
+
+Resources that have multiple representations, such as Content/ContentInfo,
+will use the optional media-type from the RestResourceReference to embed
+the expected representation.
+
+### HTTP caching
+- Requires HTTP cache multi-tagging
+- Response must vary on `x-ez-embed-value`
+- Response must be tagged with all of the included items
+  Since the controllers are used to expand objects, the required cache
+  headers should be included automatically (to check)

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
@@ -406,7 +406,7 @@ services:
             - [ setOption, [ strict_requirements, ~ ] ]
 
     ezpublish_rest.controller_uri_value_loader:
-        class: eZ\Publish\Core\REST\Server\ValueLoaders\ControllerUriValueLoader
+        class: eZ\Publish\Core\REST\Server\Output\PathExpansion\ValueLoaders\ControllerUriValueLoader
         arguments:
             - '@router'
             - '@controller_resolver'

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
@@ -335,6 +335,7 @@ services:
         arguments:
             - "@ezpublish_rest.output.generator.json"
             - "@ezpublish_rest.output.value_object_visitor.dispatcher"
+            - "@router"
         tags:
             - { name: ezpublish_rest.output.visitor, regexps: ezpublish_rest.output.visitor.json.regexps }
 

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
@@ -410,3 +410,8 @@ services:
         arguments:
             - '@router'
             - '@controller_resolver'
+
+    ezpublish_rest.unique_controller_uri_value_loader:
+        class: eZ\Publish\Core\REST\Server\Output\PathExpansion\ValueLoaders\UniqueUriValueLoader
+        arguments:
+            - '@ezpublish_rest.controller_uri_value_loader'

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
@@ -403,3 +403,9 @@ services:
         parent: hautelook.router.template
         calls:
             - [ setOption, [ strict_requirements, ~ ] ]
+
+    ezpublish_rest.controller_uri_value_loader:
+        class: eZ\Publish\Core\REST\Server\ValueLoaders\ControllerUriValueLoader
+        arguments:
+            - '@router'
+            - '@controller_resolver'

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -859,3 +859,23 @@ services:
         class: "%ezpublish_rest.output.value_object_visitor.ViewInput.class%"
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Client\Values\ViewInput }
+
+    ezpublish_rest.output.value_object_visitor.internal.resource_link:
+        parent: ezpublish_rest.output.value_object_visitor.base
+        class: 'eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\ResourceLink'
+        tags:
+            - { name: ezpublish_rest.output.value_object_visitor, type: 'eZ\Publish\Core\REST\Server\Values\ResourceLink' }
+        arguments:
+            - '@ezpublish_rest.controller_uri_value_loader'
+        calls:
+            - [setRequestStack, ['@request_stack']]
+
+    ezpublish_rest.output.value_object_visitor.internal.resource_route_reference:
+        parent: ezpublish_rest.output.value_object_visitor.base
+        class: 'eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\ResourceRouteReference'
+        tags:
+            - { name: ezpublish_rest.output.value_object_visitor, type: 'eZ\Publish\Core\REST\Server\Values\ResourceRouteReference' }
+        arguments:
+            - '@ezpublish_rest.controller_uri_value_loader'
+        calls:
+            - [setRequestStack, ['@request_stack']]

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -866,7 +866,7 @@ services:
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: 'eZ\Publish\Core\REST\Server\Values\ResourceLink' }
         arguments:
-            - '@ezpublish_rest.controller_uri_value_loader'
+            - '@ezpublish_rest.unique_controller_uri_value_loader'
             - '@ezpublish_rest.output.path_expansion_checker.request_header'
             - '@ezpublish_rest.output.value_object_visitor.dispatcher'
 
@@ -881,6 +881,6 @@ services:
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: 'eZ\Publish\Core\REST\Server\Values\ResourceRouteReference' }
         arguments:
-            - '@ezpublish_rest.controller_uri_value_loader'
+            - '@ezpublish_rest.unique_controller_uri_value_loader'
             - '@ezpublish_rest.output.path_expansion_checker.request_header'
             - '@ezpublish_rest.output.value_object_visitor.dispatcher'

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -867,6 +867,10 @@ services:
             - { name: ezpublish_rest.output.value_object_visitor, type: 'eZ\Publish\Core\REST\Server\Values\ResourceLink' }
         arguments:
             - '@ezpublish_rest.controller_uri_value_loader'
+            - '@ezpublish_rest.output.path_expansion_checker.request_header'
+
+    ezpublish_rest.output.path_expansion_checker.request_header:
+        class: 'eZ\Publish\Core\REST\Server\Output\PathExpansion\RequestHeaderPathExpansionChecker'
         calls:
             - [setRequestStack, ['@request_stack']]
 
@@ -877,5 +881,4 @@ services:
             - { name: ezpublish_rest.output.value_object_visitor, type: 'eZ\Publish\Core\REST\Server\Values\ResourceRouteReference' }
         arguments:
             - '@ezpublish_rest.controller_uri_value_loader'
-        calls:
-            - [setRequestStack, ['@request_stack']]
+            - '@ezpublish_rest.output.path_expansion_checker.request_header'

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -868,6 +868,7 @@ services:
         arguments:
             - '@ezpublish_rest.controller_uri_value_loader'
             - '@ezpublish_rest.output.path_expansion_checker.request_header'
+            - '@ezpublish_rest.output.value_object_visitor.dispatcher'
 
     ezpublish_rest.output.path_expansion_checker.request_header:
         class: 'eZ\Publish\Core\REST\Server\Output\PathExpansion\RequestHeaderPathExpansionChecker'
@@ -882,3 +883,4 @@ services:
         arguments:
             - '@ezpublish_rest.controller_uri_value_loader'
             - '@ezpublish_rest.output.path_expansion_checker.request_header'
+            - '@ezpublish_rest.output.value_object_visitor.dispatcher'

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ResourceEmbeddingTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ResourceEmbeddingTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishRestBundle\Tests\Functional;
+
+use eZ\Bundle\EzPublishRestBundle\Tests\Functional\TestCase as RESTFunctionalTestCase;
+use eZ\Publish\Core\REST\Common\Tests\AssertXmlTagTrait;
+
+class ResourceEmbeddingTest extends RESTFunctionalTestCase
+{
+    use AssertXmlTagTrait;
+
+    public function testEmbed()
+    {
+        $request = $this->createHttpRequest('GET', '/api/ezp/v2/content/objects/1');
+        $request->addHeader('x-ez-embed-value: Content.MainLocation,Content.Owner.Section');
+
+        $response = $this->sendHttpRequest($request);
+
+        self::assertHttpResponseCodeEquals($response, 200);
+
+        $doc = new \DOMDocument();
+        $doc->loadXML($response->getContent());
+
+        $this->assertXPath($doc, '/Content/MainLocation/id');
+        $this->assertXPath($doc, '/Content/Owner/name');
+        $this->assertXPath($doc, '/Content/Owner/Section/sectionId');
+    }
+
+    protected function assertXPath(\DOMDocument $document, $xpathExpression)
+    {
+        $xpath = new \DOMXPath($document);
+
+        $this->assertTrue(
+            $xpath->evaluate("boolean({$xpathExpression})"),
+            "XPath expression '{$xpathExpression}' resulted in an empty node set."
+        );
+    }
+}

--- a/eZ/Publish/Core/REST/Common/Output/Generator.php
+++ b/eZ/Publish/Core/REST/Common/Output/Generator.php
@@ -396,4 +396,31 @@ abstract class Generator
      * @return mixed
      */
     abstract public function serializeBool($boolValue);
+
+    /**
+     * Returns a string representation of the current stack of the document.
+     *
+     * Example: "Location.ContentInfo'.
+     * Elements of type 'attribute', 'document' and 'list' are ignored.
+     *
+     * @return string
+     */
+    public function getStackPath()
+    {
+        $relevantNodes = array_filter(
+            $this->stack,
+            function ($value) {
+                return !in_array($value[0], ['attribute', 'document', 'list']);
+            }
+        );
+
+        $names = array_map(
+            function ($value) {
+                return $value[1];
+            },
+            $relevantNodes
+        );
+
+        return implode('.', $names);
+    }
 }

--- a/eZ/Publish/Core/REST/Common/Output/ValueObjectVisitor/ContentObjectStates.php
+++ b/eZ/Publish/Core/REST/Common/Output/ValueObjectVisitor/ContentObjectStates.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 /**
  * ContentObjectStates value object visitor.
@@ -36,17 +37,15 @@ class ContentObjectStates extends ValueObjectVisitor
 
         foreach ($data->states as $state) {
             $generator->startObjectElement('ObjectState');
-            $generator->startAttribute(
-                'href',
-                $this->router->generate(
+            $visitor->visitValueObject(
+                new ResourceRouteReference(
                     'ezpublish_rest_loadObjectState',
-                    array(
+                    [
                         'objectStateGroupId' => $state->groupId,
                         'objectStateId' => $state->objectState->id,
-                    )
+                    ]
                 )
             );
-            $generator->endAttribute('href');
             $generator->endObjectElement('ObjectState');
         }
 

--- a/eZ/Publish/Core/REST/Common/Output/ValueObjectVisitorDispatcher.php
+++ b/eZ/Publish/Core/REST/Common/Output/ValueObjectVisitorDispatcher.php
@@ -59,18 +59,26 @@ class ValueObjectVisitorDispatcher
      *
      * @return mixed
      */
-    public function visit($data)
+    public function visit($data, Generator $generator = null, Visitor $visitor = null)
     {
         if (!is_object($data)) {
             throw new Exceptions\InvalidTypeException($data);
         }
         $checkedClassNames = array();
 
+        if ($visitor === null) {
+            $visitor = $this->outputVisitor;
+        }
+
+        if ($generator === null) {
+            $generator = $this->outputGenerator;
+        }
+
         $className = get_class($data);
         do {
             $checkedClassNames[] = $className;
             if (isset($this->visitors[$className])) {
-                return $this->visitors[$className]->visit($this->outputVisitor, $this->outputGenerator, $data);
+                return $this->visitors[$className]->visit($visitor, $generator, $data);
             }
         } while ($className = get_parent_class($className));
 

--- a/eZ/Publish/Core/REST/Common/Output/Visitor.php
+++ b/eZ/Publish/Core/REST/Common/Output/Visitor.php
@@ -134,12 +134,15 @@ class Visitor
      *
      * @return mixed
      */
-    public function visitValueObject($data)
+    public function visitValueObject($data, Generator $generator = null, Visitor $visitor = null)
     {
         $this->valueObjectVisitorDispatcher->setOutputGenerator($this->generator);
-        $this->valueObjectVisitorDispatcher->setOutputVisitor($this);
 
-        return $this->valueObjectVisitorDispatcher->visit($data);
+        return $this->valueObjectVisitorDispatcher->visit(
+            $data,
+            $generator ?: $this->generator,
+            $visitor ?: $this
+        );
     }
 
     /**

--- a/eZ/Publish/Core/REST/Common/Tests/Output/GeneratorTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Output/GeneratorTest.php
@@ -201,4 +201,48 @@ abstract class GeneratorTest extends PHPUnit_Framework_TestCase
 
         $this->assertFalse($generator->isEmpty());
     }
+
+    public function testGetDocumentStackPath()
+    {
+        $generator = $this->getGenerator();
+
+        $generator->startDocument('test');
+
+        self::assertEquals('', $generator->getStackPath());
+    }
+
+    public function testGetRootStackPath()
+    {
+        $generator = $this->getGenerator();
+
+        $generator->startDocument('test');
+        $generator->startObjectElement('element');
+
+        self::assertEquals('element', $generator->getStackPath());
+    }
+
+    public function testGetElementStackPath()
+    {
+        $generator = $this->getGenerator();
+
+        $generator->startDocument('test');
+        $generator->startObjectElement('element');
+        $generator->startObjectElement('subElement');
+
+        self::assertEquals('element.subElement', $generator->getStackPath());
+    }
+
+    public function testGetListChildrenStackPath()
+    {
+        $generator = $this->getGenerator();
+
+        $generator->startDocument('test');
+        $generator->startObjectElement('listOfElements');
+        $generator->startList('listOfElements');
+        $generator->startObjectElement('child');
+        $generator->startAttribute('href', 'http://google.com');
+        $generator->endAttribute('href');
+
+        self::assertEquals('listOfElements.child', $generator->getStackPath());
+    }
 }

--- a/eZ/Publish/Core/REST/Common/Tests/Output/ValueObjectVisitorBaseTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Output/ValueObjectVisitorBaseTest.php
@@ -195,6 +195,26 @@ abstract class ValueObjectVisitorBaseTest extends Tests\BaseTest
     }
 
     /**
+     * Adds the expectated value object visit calls sequence.
+     *
+     * @param array $valueObjects Array of visited value object, or of phpunit matcher ($this->instanceOf(), etc...) .
+     */
+    protected function setVisitValueObjectExpectations(array $valueObjects)
+    {
+        $consecutiveCalls = [];
+        foreach ($valueObjects as $valueObject) {
+            $consecutiveCalls = [
+                $valueObject,
+                $this->getGenerator(),
+                $this->getVisitorMock(),
+            ];
+        }
+
+        $mocker = $this->getVisitorMock()->expects($this->any())->method('visitValueObject');
+        call_user_func_array([$mocker, 'withConsecutive'], $consecutiveCalls);
+    }
+
+    /**
      * @return \Symfony\Component\Routing\RouterInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     protected function getTemplatedRouterMock()

--- a/eZ/Publish/Core/REST/Server/Output/PathExpansion/Exceptions/MultipleValueLoadException.php
+++ b/eZ/Publish/Core/REST/Server/Output/PathExpansion/Exceptions/MultipleValueLoadException.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Output\PathExpansion\Exceptions;
+
+use Exception;
+
+/**
+ * Thrown when an embedded value was already loaded.
+ */
+class MultipleValueLoadException extends Exception
+{
+    public function __construct()
+    {
+        parent::__construct('Value was already loaded');
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Output/PathExpansion/ExpansionGenerator.php
+++ b/eZ/Publish/Core/REST/Server/Output/PathExpansion/ExpansionGenerator.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Output\PathExpansion;
+
+use eZ\Publish\Core\Base\Exceptions\BadStateException;
+use eZ\Publish\Core\REST\Common\Output\Exceptions\OutputGeneratorException;
+use eZ\Publish\Core\REST\Common\Output\Generator;
+
+/**
+ * A REST output generator meant to expand an existing generator.
+ *
+ * @todo a crappy description for a crappy class name. It all makes sense. Or it will.
+ */
+class ExpansionGenerator extends Generator
+{
+    /**
+     * @var Generator
+     */
+    private $innerGenerator;
+
+    /**
+     * ExpansionGenerator constructor.
+     * @param Generator $generator
+     */
+    public function __construct(Generator $generator)
+    {
+        $this->innerGenerator = $generator;
+    }
+
+    /**
+     * Not supported in this generator, as the context is always within a generated document.
+     *
+     * @param mixed $data
+     *
+     * @throws BadStateException
+     */
+    public function startDocument($data)
+    {
+        throw new BadStateException(
+            'generator',
+            'start/endDocument can not be used with the ExpansionGenerator'
+        );
+    }
+
+    /**
+     * Returns if the document is empty or already contains data.
+     *
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return $this->innerGenerator->isEmpty();
+    }
+
+    /**
+     * Not supported in this generator, as the context is always within a generated document.
+     *
+     * @param mixed $data
+     *
+     * @throws BadStateException
+     */
+    public function endDocument($data)
+    {
+        throw new BadStateException('generator', 'start/endDocument can not be used with the ExpansionGenerator');
+    }
+
+    /**
+     * Start object element.
+     * If the element is the first added to this generator, it is silently skipped.
+     * Subsequent elements are started as expected.
+     *
+     * @param string $name
+     * @param string $mediaTypeName
+     */
+    public function startObjectElement($name, $mediaTypeName = null)
+    {
+        $this->stack[] = $name;
+
+        if (count($this->stack) > 1) {
+            $this->innerGenerator->startObjectElement($name, $mediaTypeName);
+        }
+    }
+
+    /**
+     * End object element.
+     *
+     * @param string $name
+     */
+    public function endObjectElement($name)
+    {
+        $objectElementName = array_pop($this->stack);
+        if (count($this->stack) > 0) {
+            $this->innerGenerator->endObjectElement($name);
+        } else {
+            if ($name !== $objectElementName) {
+                throw new OutputGeneratorException("Closing object element name doesn't match the opening one ($objectElementName)");
+            }
+        }
+    }
+
+    /**
+     * Start hash element.
+     *
+     * @param string $name
+     */
+    public function startHashElement($name)
+    {
+        $this->innerGenerator->startHashElement($name);
+    }
+
+    /**
+     * End hash element.
+     *
+     * @param string $name
+     */
+    public function endHashElement($name)
+    {
+        $this->innerGenerator->endHashElement($name);
+    }
+
+    /**
+     * Start value element.
+     *
+     * @param string $name
+     * @param string $value
+     */
+    public function startValueElement($name, $value)
+    {
+        $this->innerGenerator->startValueElement($name, $value);
+    }
+
+    /**
+     * End value element.
+     *
+     * @param string $name
+     */
+    public function endValueElement($name)
+    {
+        $this->innerGenerator->endValueElement($name);
+    }
+
+    /**
+     * Start list.
+     *
+     * @param string $name
+     */
+    public function startList($name)
+    {
+        $this->innerGenerator->startList($name);
+    }
+
+    /**
+     * End list.
+     *
+     * @param string $name
+     */
+    public function endList($name)
+    {
+        $this->innerGenerator->endList($name);
+    }
+
+    /**
+     * Start attribute.
+     * Skips the href and media-type attribute at stack depth 0.
+     *
+     * @param string $name
+     * @param string $value
+     */
+    public function startAttribute($name, $value)
+    {
+        if (!in_array($name, ['href', 'media-type']) || count($this->stack) > 1) {
+            $this->innerGenerator->startAttribute($name, $value);
+        }
+    }
+
+    /**
+     * End attribute.
+     *
+     * @param string $name
+     */
+    public function endAttribute($name)
+    {
+        if (!in_array($name, ['href', 'media-type']) || count($this->stack) > 1) {
+            $this->innerGenerator->endAttribute($name);
+        }
+    }
+
+    /**
+     * Get media type.
+     *
+     * @param string $name
+     *
+     * @return string
+     */
+    public function getMediaType($name)
+    {
+        return $this->innerGenerator->getMediaType($name);
+    }
+
+    /**
+     * Generates a generic representation of the scalar, hash or list given in
+     * $hashValue into the document, using an element of $hashElementName as
+     * its parent.
+     *
+     * @param string $hashElementName
+     * @param mixed $hashValue
+     */
+    public function generateFieldTypeHash($hashElementName, $hashValue)
+    {
+        $this->innerGenerator->generateFieldTypeHash($hashElementName, $hashValue);
+    }
+
+    /**
+     * Serializes a boolean value.
+     *
+     * @param bool $boolValue
+     *
+     * @return mixed
+     */
+    public function serializeBool($boolValue)
+    {
+        return $this->innerGenerator->serializeBool($boolValue);
+    }
+
+    public function getStackPath()
+    {
+        return $this->innerGenerator->getStackPath();
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Output/PathExpansion/PathExpansionChecker.php
+++ b/eZ/Publish/Core/REST/Server/Output/PathExpansion/PathExpansionChecker.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Output\PathExpansion;
+
+/**
+ * Checks if a REST document path needs expansion.
+ *
+ * The path is the suite of items leading to one element in a REST generator:
+ * ```
+ * <foo>
+ *   <bar>
+ *     <foobar /><!--foo.bar.foobar-->
+ *   </bar>
+ * </foo>
+ * ```
+ */
+interface PathExpansionChecker
+{
+    /**
+     * Tests if the link at $documentPath must be expanded.
+     *
+     * @param string $documentPath Path in a rest generator (example: Content.Owner).
+     *
+     * @return bool
+     */
+    public function needsExpansion($documentPath);
+}

--- a/eZ/Publish/Core/REST/Server/Output/PathExpansion/RequestHeaderPathExpansionChecker.php
+++ b/eZ/Publish/Core/REST/Server/Output/PathExpansion/RequestHeaderPathExpansionChecker.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Output\PathExpansion;
+
+use eZ\Publish\Core\MVC\Symfony\RequestStackAware;
+
+/**
+ * Checks if a resource link needs to be expanded based on the contents of the x-ez-embed-value
+ * header from the master request.
+ */
+class RequestHeaderPathExpansionChecker implements PathExpansionChecker
+{
+    use RequestStackAware;
+
+    /**
+     * Tests if the link at $documentPath must be expanded.
+     *
+     * @param string $documentPath Path in a rest generator (example: Content.Owner).
+     *
+     * @return bool
+     */
+    public function needsExpansion($documentPath)
+    {
+        $request = $this->getRequestStack()->getMasterRequest();
+
+        if (is_null($request)) {
+            return false;
+        }
+        if (!$request->headers->has('x-ez-embed-value')) {
+            return false;
+        }
+
+        $documentPath = strtolower($documentPath);
+        foreach (explode(',', $request->headers->get('x-ez-embed-value')) as $requestedPath) {
+            $requestedPath = strtolower($requestedPath);
+            if ($requestedPath === $documentPath) {
+                return true;
+            }
+            if (substr($requestedPath, 0, strlen($documentPath)) === $documentPath) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Output/PathExpansion/ValueLoaders/ControllerUriValueLoader.php
+++ b/eZ/Publish/Core/REST/Server/Output/PathExpansion/ValueLoaders/ControllerUriValueLoader.php
@@ -5,7 +5,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\REST\Server\ValueLoaders;
+namespace eZ\Publish\Core\REST\Server\Output\PathExpansion\ValueLoaders;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/eZ/Publish/Core/REST/Server/Output/PathExpansion/ValueLoaders/UniqueUriValueLoader.php
+++ b/eZ/Publish/Core/REST/Server/Output/PathExpansion/ValueLoaders/UniqueUriValueLoader.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Output\PathExpansion\ValueLoaders;
+
+use eZ\Publish\Core\REST\Server\Output\PathExpansion\Exceptions\MultipleValueLoadException;
+
+/**
+ * A decorator UriValueLoader that throws an exception when a value is loaded more than one time.
+ */
+class UniqueUriValueLoader implements UriValueLoader
+{
+    private $loadedUris = [];
+
+    /**
+     * @var UriValueLoader
+     */
+    private $innerLoader;
+
+    public function __construct(UriValueLoader $innerLoader)
+    {
+        $this->innerLoader = $innerLoader;
+    }
+
+    /**
+     * @param string $uri REST URI to a value object. Ex: /api/ezp/v2/content/objects/1
+     * @param string $mediaType The media-type to load, default if not specified. Ex: application/vnd.ez.api.Content+xml.
+     *
+     * @return \eZ\Publish\API\Repository\Values\ValueObject
+     *
+     * @throws MultipleValueLoadException When load is called on an URI that was previously loaded (at instance level).
+     */
+    public function load($uri, $mediaType = null)
+    {
+        if (isset($this->loadedUris[$uri]) && array_key_exists($mediaType, $this->loadedUris[$uri])) {
+            throw new MultipleValueLoadException();
+        }
+
+        $this->loadedUris[$uri][$mediaType] = true;
+
+        return $this->innerLoader->load($uri, $mediaType);
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Output/PathExpansion/ValueLoaders/UriValueLoader.php
+++ b/eZ/Publish/Core/REST/Server/Output/PathExpansion/ValueLoaders/UriValueLoader.php
@@ -3,7 +3,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\REST\Server\ValueLoaders;
+namespace eZ\Publish\Core\REST\Server\Output\PathExpansion\ValueLoaders;
 
 /**
  * A value object loader that uses the rest URI as an argument.

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/CachedValue.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/CachedValue.php
@@ -38,7 +38,7 @@ class CachedValue extends ValueObjectVisitor
      */
     public function visit(Visitor $visitor, Generator $generator, $data)
     {
-        $visitor->visitValueObject($data->value);
+        $visitor->visitValueObject($data->value, $generator, $visitor);
 
         if ($this->getParameter('content.view_cache') !== true) {
             return;

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ContentTypeGroup.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ContentTypeGroup.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 /**
  * ContentTypeGroup value object visitor.
@@ -34,10 +35,7 @@ class ContentTypeGroup extends ValueObjectVisitor
 
         $generator->startAttribute(
             'href',
-            $this->router->generate(
-                'ezpublish_rest_loadContentTypeGroup',
-                array('contentTypeGroupId' => $data->id)
-            )
+            $this->router->generate('ezpublish_rest_loadContentTypeGroup', ['contentTypeGroupId' => $data->id])
         );
         $generator->endAttribute('href');
 
@@ -54,30 +52,31 @@ class ContentTypeGroup extends ValueObjectVisitor
         $generator->endValueElement('modified');
 
         $generator->startObjectElement('Creator', 'User');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadUser', array('userId' => $data->creatorId))
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_loadUser', ['userId' => $data->creatorId]),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Creator');
 
         $generator->startObjectElement('Modifier', 'User');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadUser', array('userId' => $data->modifierId))
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_loadUser', ['userId' => $data->modifierId]),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Modifier');
 
         $generator->startObjectElement('ContentTypes', 'ContentTypeInfoList');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
                 'ezpublish_rest_listContentTypesForGroup',
-                array('contentTypeGroupId' => $data->id)
-            )
+                ['contentTypeGroupId' => $data->id],
+                'ContentTypeInfoList'
+            ),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('ContentTypes');
 
         $generator->endObjectElement('ContentTypeGroup');

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ContentTypeGroupRefList.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ContentTypeGroupRefList.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 /**
  * ContentTypeGroupRefList value object visitor.
@@ -48,16 +49,9 @@ class ContentTypeGroupRefList extends ValueObjectVisitor
         foreach ($data->contentTypeGroups as $contentTypeGroup) {
             $generator->startObjectElement('ContentTypeGroupRef', 'ContentTypeGroup');
 
-            $generator->startAttribute(
-                'href',
-                $this->router->generate(
-                    'ezpublish_rest_loadContentTypeGroup',
-                    array(
-                        'contentTypeGroupId' => $contentTypeGroup->id,
-                    )
-                )
+            $visitor->visitValueObject(
+                new ResourceRouteReference('ezpublish_rest_loadContentTypeGroup', ['contentTypeGroupId' => $contentTypeGroup->id])
             );
-            $generator->endAttribute('href');
 
             // Unlinking last group is not allowed
             if ($groupCount > 1) {

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Location.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Location.php
@@ -14,7 +14,7 @@ use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
-use eZ\Publish\Core\REST\Server\Values\RestContent as RestContentValue;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 /**
  * Location value object visitor.
@@ -73,16 +73,12 @@ class Location extends ValueObjectVisitor
 
         $generator->startObjectElement('ParentLocation', 'Location');
         if (trim($location->pathString, '/') !== '1') {
-            $generator->startAttribute(
-                'href',
-                $this->router->generate(
-                    'ezpublish_rest_loadLocation',
-                    array(
-                        'locationPath' => implode('/', array_slice($location->path, 0, count($location->path) - 1)),
-                    )
-                )
+            new ResourceRouteReference(
+                'ezpublish_rest_loadLocation',
+                [
+                    'locationPath' => implode('/', array_slice($location->path, 0, count($location->path) - 1)),
+                ]
             );
-            $generator->endAttribute('href');
         }
         $generator->endObjectElement('ParentLocation');
 
@@ -99,24 +95,17 @@ class Location extends ValueObjectVisitor
         $generator->endValueElement('remoteId');
 
         $generator->startObjectElement('Children', 'LocationList');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
-                'ezpublish_rest_loadLocationChildren',
-                array(
-                    'locationPath' => trim($location->pathString, '/'),
-                )
-            )
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_loadLocationChildren', ['locationPath' => trim($location->pathString, '/')]),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Children');
 
         $generator->startObjectElement('Content');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadContent', array('contentId' => $location->contentId))
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_loadContent', ['contentId' => $location->contentId])
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Content');
 
         $generator->startValueElement('sortField', $this->serializeSortField($location->sortField));
@@ -126,26 +115,19 @@ class Location extends ValueObjectVisitor
         $generator->endValueElement('sortOrder');
 
         $generator->startObjectElement('UrlAliases', 'UrlAliasRefList');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
-                'ezpublish_rest_listLocationURLAliases',
-                array('locationPath' => trim($location->pathString, '/'))
-            )
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_listLocationURLAliases', ['locationPath' => trim($location->pathString, '/')])
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('UrlAliases');
 
         $generator->startObjectElement('ContentInfo', 'ContentInfo');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
-                'ezpublish_rest_loadContent',
-                array('contentId' => $location->contentId)
-            )
+
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_loadContent', ['contentId' => $location->contentId]),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
-        $visitor->visitValueObject(new RestContentValue($location->contentInfo));
+
         $generator->endObjectElement('ContentInfo');
 
         $generator->endObjectElement('Location');

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/LocationList.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/LocationList.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 /**
  * LocationList value object visitor.
@@ -38,14 +39,12 @@ class LocationList extends ValueObjectVisitor
 
         foreach ($data->locations as $restLocation) {
             $generator->startObjectElement('Location');
-            $generator->startAttribute(
-                'href',
-                $this->router->generate(
+            $visitor->visitValueObject(
+                new ResourceRouteReference(
                     'ezpublish_rest_loadLocation',
-                    array('locationPath' => trim($restLocation->location->pathString, '/'))
+                    ['locationPath' => trim($restLocation->location->pathString, '/')]
                 )
             );
-            $generator->endAttribute('href');
             $generator->endObjectElement('Location');
         }
 

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ObjectStateGroup.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ObjectStateGroup.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 /**
  * ObjectStateGroup value object visitor.
@@ -51,11 +52,14 @@ class ObjectStateGroup extends ValueObjectVisitor
         $generator->endValueElement('languageCodes');
 
         $generator->startObjectElement('ObjectStates', 'ObjectStateList');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadObjectStates', array('objectStateGroupId' => $data->id))
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
+                'ezpublish_rest_loadObjectStates',
+                ['objectStateGroupId' => $data->id]
+            ),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('ObjectStates');
 
         $this->visitNamesList($generator, $data->getNames());

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ResourceLink.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ResourceLink.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException as ApiUnauthorizedException;
+use eZ\Publish\Core\MVC\Symfony\RequestStackAware;
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\ValueLoaders\UriValueLoader;
+
+class ResourceLink extends ValueObjectVisitor
+{
+    use RequestStackAware;
+
+    /**
+     * @var UriValueLoader
+     */
+    private $valueLoader;
+
+    public function __construct(UriValueLoader $valueLoader)
+    {
+        $this->valueLoader = $valueLoader;
+    }
+
+    /**
+     * @param Visitor $visitor
+     * @param Generator $generator
+     * @param \eZ\Publish\Core\REST\Server\Values\ResourceLink $data
+     */
+    public function visit(Visitor $visitor, Generator $generator, $data)
+    {
+        $request = $this->getRequestStack()->getMasterRequest();
+        $expandedPathList = [];
+        if ($request->headers->has('x-ez-embed-value')) {
+            $expandedPathList = explode(',', $request->headers->get('x-ez-embed-value'));
+        }
+
+        $generator->startAttribute('href', $data->link);
+        $generator->endAttribute('href');
+
+        if (in_array($generator->getStackPath(), $expandedPathList)) {
+            try {
+                $visitor->visitValueObject($this->valueLoader->load($data->link));
+            } catch (ApiUnauthorizedException $e) {
+            }
+        }
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ResourceLink.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ResourceLink.php
@@ -6,24 +6,28 @@
 namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 
 use eZ\Publish\API\Repository\Exceptions\UnauthorizedException as ApiUnauthorizedException;
-use eZ\Publish\Core\MVC\Symfony\RequestStackAware;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Output\PathExpansion\PathExpansionChecker;
 use eZ\Publish\Core\REST\Server\ValueLoaders\UriValueLoader;
 
 class ResourceLink extends ValueObjectVisitor
 {
-    use RequestStackAware;
+    /**
+     * @var PathExpansionChecker
+     */
+    private $pathExpansionChecker;
 
     /**
      * @var UriValueLoader
      */
     private $valueLoader;
 
-    public function __construct(UriValueLoader $valueLoader)
+    public function __construct(UriValueLoader $valueLoader, PathExpansionChecker $pathExpansionChecker)
     {
         $this->valueLoader = $valueLoader;
+        $this->pathExpansionChecker = $pathExpansionChecker;
     }
 
     /**
@@ -36,30 +40,11 @@ class ResourceLink extends ValueObjectVisitor
         $generator->startAttribute('href', $data->link);
         $generator->endAttribute('href');
 
-        if ($this->needsResourceExpansion($generator->getStackPath())) {
+        if ($this->pathExpansionChecker->needsExpansion($generator->getStackPath())) {
             try {
                 $visitor->visitValueObject($this->valueLoader->load($data->link));
             } catch (ApiUnauthorizedException $e) {
             }
         }
-    }
-
-    /**
-     * Tests if the current $nodePath requires the resource to be expanded,
-     * based on the custom X-eZ-Embed-Value Request header.
-     *
-     * @param string $nodePath
-     *
-     * @return bool
-     */
-    public function needsResourceExpansion($nodePath)
-    {
-        $request = $this->getRequestStack()->getMasterRequest();
-        $expandedPathList = [];
-        if ($request->headers->has('x-ez-embed-value')) {
-            $expandedPathList = explode(',', $request->headers->get('x-ez-embed-value'));
-        }
-
-        return in_array($nodePath, $expandedPathList);
     }
 }

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ResourceLink.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ResourceLink.php
@@ -54,7 +54,7 @@ class ResourceLink extends ValueObjectVisitor
         if ($this->pathExpansionChecker->needsExpansion($generator->getStackPath())) {
             try {
                 $this->visitorDispatcher->visit(
-                    $this->valueLoader->load($data->link),
+                    $this->valueLoader->load($data->link, $data->mediaType ?: null),
                     new ExpansionGenerator($generator),
                     $visitor
                 );

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ResourceLink.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ResourceLink.php
@@ -10,6 +10,7 @@ use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitorDispatcher;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Output\PathExpansion\ExpansionGenerator;
 use eZ\Publish\Core\REST\Server\Output\PathExpansion\PathExpansionChecker;
 use eZ\Publish\Core\REST\Server\ValueLoaders\UriValueLoader;
 
@@ -54,7 +55,7 @@ class ResourceLink extends ValueObjectVisitor
             try {
                 $this->visitorDispatcher->visit(
                     $this->valueLoader->load($data->link),
-                    $generator = new ExpansionGenerator($generator),
+                    new ExpansionGenerator($generator),
                     $visitor
                 );
             } catch (ApiUnauthorizedException $e) {

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ResourceLink.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ResourceLink.php
@@ -12,7 +12,8 @@ use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitorDispatcher;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
 use eZ\Publish\Core\REST\Server\Output\PathExpansion\ExpansionGenerator;
 use eZ\Publish\Core\REST\Server\Output\PathExpansion\PathExpansionChecker;
-use eZ\Publish\Core\REST\Server\ValueLoaders\UriValueLoader;
+use eZ\Publish\Core\REST\Server\Output\PathExpansion\Exceptions\MultipleValueLoadException;
+use eZ\Publish\Core\REST\Server\Output\PathExpansion\ValueLoaders\UriValueLoader;
 
 class ResourceLink extends ValueObjectVisitor
 {
@@ -59,6 +60,11 @@ class ResourceLink extends ValueObjectVisitor
                     $visitor
                 );
             } catch (ApiUnauthorizedException $e) {
+                $generator->startAttribute('embed-error', $e->getMessage());
+                $generator->endAttribute('embed-error');
+            } catch (MultipleValueLoadException $e) {
+                $generator->startAttribute('embed-error', $e->getMessage());
+                $generator->endAttribute('embed-error');
             }
         }
     }

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ResourceRouteReference.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ResourceRouteReference.php
@@ -25,7 +25,8 @@ class ResourceRouteReference extends ResourceLink
                 $this->router->generate(
                     $data->route,
                     $data->loadParameters
-                )
+                ),
+                isset($data->mediaTypeName) ? $generator->getMediaType($data->mediaTypeName) : null
             )
         );
     }

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ResourceRouteReference.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/ResourceRouteReference.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceLink as ResourceLinkValue;
+
+class ResourceRouteReference extends ResourceLink
+{
+    /**
+     * @param Visitor $visitor
+     * @param Generator $generator
+     * @param \eZ\Publish\Core\REST\Server\Values\ResourceRouteReference $data
+     */
+    public function visit(Visitor $visitor, Generator $generator, $data)
+    {
+        parent::visit(
+            $visitor,
+            $generator,
+            new ResourceLinkValue(
+                $this->router->generate(
+                    $data->route,
+                    $data->loadParameters
+                )
+            )
+        );
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContent.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContent.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 use eZ\Publish\Core\REST\Server\Values\Version as VersionValue;
 
 /**
@@ -45,7 +46,7 @@ class RestContent extends ValueObjectVisitor
         $generator->startAttribute(
             'href',
             $data->path === null ?
-                $this->router->generate('ezpublish_rest_loadContent', array('contentId' => $contentInfo->id)) :
+                $this->router->generate('ezpublish_rest_loadContent', ['contentId' => $contentInfo->id]) :
                 $data->path
         );
         $generator->endAttribute('href');
@@ -56,89 +57,99 @@ class RestContent extends ValueObjectVisitor
         $generator->endAttribute('id');
 
         $generator->startObjectElement('ContentType');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
                 'ezpublish_rest_loadContentType',
-                array('contentTypeId' => $contentInfo->contentTypeId)
-            )
+                ['contentTypeId' => $contentInfo->contentTypeId]
+            ),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('ContentType');
 
         $generator->startValueElement('Name', $contentInfo->name);
         $generator->endValueElement('Name');
 
         $generator->startObjectElement('Versions', 'VersionList');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadContentVersions', array('contentId' => $contentInfo->id))
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
+                'ezpublish_rest_loadContentVersions',
+                ['contentId' => $contentInfo->id]
+            )
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Versions');
 
         $generator->startObjectElement('CurrentVersion', 'Version');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
                 'ezpublish_rest_redirectCurrentVersion',
-                array('contentId' => $contentInfo->id)
-            )
+                ['contentId' => $contentInfo->id]
+            ),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
 
         // Embed current version, if available
         if ($currentVersion !== null) {
+            // @todo EZP-26033: this should use rest resource embedding
             $visitor->visitValueObject(
                 new VersionValue(
                     $currentVersion,
                     $contentType,
                     $restContent->relations
-                )
+                ),
+                $generator,
+                $visitor
             );
         }
 
         $generator->endObjectElement('CurrentVersion');
 
         $generator->startObjectElement('Section');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadSection', array('sectionId' => $contentInfo->sectionId))
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
+                'ezpublish_rest_loadSection',
+                ['sectionId' => $contentInfo->sectionId]
+            ),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Section');
 
         // Main location will not exist if we're visiting the content draft
         if ($data->mainLocation !== null) {
             $generator->startObjectElement('MainLocation', 'Location');
-            $generator->startAttribute(
-                'href',
-                $this->router->generate(
+            $visitor->visitValueObject(
+                new ResourceRouteReference(
                     'ezpublish_rest_loadLocation',
-                    array('locationPath' => trim($mainLocation->pathString, '/'))
-                )
+                    ['locationPath' => trim($mainLocation->pathString, '/')]
+                ),
+                $generator,
+                $visitor
             );
-            $generator->endAttribute('href');
             $generator->endObjectElement('MainLocation');
         }
 
         $generator->startObjectElement('Locations', 'LocationList');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
                 'ezpublish_rest_loadLocationsForContent',
-                array('contentId' => $contentInfo->id)
-            )
+                ['contentId' => $contentInfo->id]
+            ),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Locations');
 
         $generator->startObjectElement('Owner', 'User');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadUser', array('userId' => $contentInfo->ownerId))
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
+                'ezpublish_rest_loadUser',
+                ['userId' => $contentInfo->ownerId]
+            ),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Owner');
 
         // Modification date will not exist if we're visiting the content draft
@@ -180,14 +191,14 @@ class RestContent extends ValueObjectVisitor
         $generator->endValueElement('alwaysAvailable');
 
         $generator->startObjectElement('ObjectStates', 'ContentObjectStates');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
                 'ezpublish_rest_getObjectStatesForContent',
-                array('contentId' => $contentInfo->id)
-            )
+                ['contentId' => $contentInfo->id]
+            ),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('ObjectStates');
 
         $generator->endObjectElement('Content');

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContentType.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestContentType.php
@@ -76,47 +76,40 @@ class RestContentType extends RestContentTypeBase
         $generator->endValueElement('modificationDate');
 
         $generator->startObjectElement('Creator', 'User');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
+        // @todo EZP-26033: this sould use rest resource embedding
+        $visitor->visitValueObject(
+            new Values\ResourceRouteReference(
                 'ezpublish_rest_loadUser',
-                array('userId' => $contentType->creatorId)
+                ['userId' => $contentType->creatorId]
             )
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Creator');
 
         $generator->startObjectElement('Modifier', 'User');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
+        $visitor->visitValueObject(
+            new Values\ResourceRouteReference(
                 'ezpublish_rest_loadUser',
-                array('userId' => $contentType->modifierId)
+                ['userId' => $contentType->modifierId]
             )
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Modifier');
 
         $generator->startObjectElement('Groups', 'ContentTypeGroupRefList');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
+        $visitor->visitValueObject(
+            new Values\ResourceRouteReference(
                 'ezpublish_rest_loadGroupsOfContentType',
-                array('contentTypeId' => $contentType->id)
+                ['contentTypeId' => $contentType->id]
             )
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Groups');
 
         $generator->startObjectElement('Draft', 'ContentType');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
+        $visitor->visitValueObject(
+            new Values\ResourceRouteReference(
                 'ezpublish_rest_loadContentTypeDraft',
-                array('contentTypeId' => $contentType->id)
+                ['contentTypeId' => $contentType->id]
             )
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Draft');
 
         $generator->startValueElement('remoteId', $contentType->remoteId);

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestExecutedView.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestExecutedView.php
@@ -18,6 +18,7 @@ use eZ\Publish\Core\REST\Common\Output\Visitor;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 use eZ\Publish\Core\REST\Server\Values\RestContent as RestContentValue;
 
 /**
@@ -89,11 +90,12 @@ class RestExecutedView extends ValueObjectVisitor
 
         // BEGIN Result
         $generator->startObjectElement('Result', 'ViewResult');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_views_load_results', array('viewId' => $data->identifier))
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
+                'ezpublish_rest_views_load_results',
+                ['viewId' => $data->identifier]
+            )
         );
-        $generator->endAttribute('href');
 
         // BEGIN Result metadata
         $generator->startValueElement('count', $data->searchResults->totalCount);

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestLocation.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestLocation.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 use eZ\Publish\Core\REST\Server\Values\RestContent as RestContentValue;
 
 /**
@@ -40,7 +41,7 @@ class RestLocation extends ValueObjectVisitor
             'href',
             $this->router->generate(
                 'ezpublish_rest_loadLocation',
-                array('locationPath' => trim($location->pathString, '/'))
+                ['locationPath' => trim($location->pathString, '/')]
             )
         );
         $generator->endAttribute('href');
@@ -65,16 +66,14 @@ class RestLocation extends ValueObjectVisitor
 
         $generator->startObjectElement('ParentLocation', 'Location');
         if (trim($location->pathString, '/') !== '1') {
-            $generator->startAttribute(
-                'href',
-                $this->router->generate(
+            $visitor->visitValueObject(
+                new ResourceRouteReference(
                     'ezpublish_rest_loadLocation',
-                    array(
-                        'locationPath' => implode('/', array_slice($location->path, 0, count($location->path) - 1)),
-                    )
-                )
+                    ['locationPath' => implode('/', array_slice($location->path, 0, count($location->path) - 1))]
+                ),
+                $generator,
+                $visitor
             );
-            $generator->endAttribute('href');
         }
         $generator->endObjectElement('ParentLocation');
 
@@ -91,24 +90,23 @@ class RestLocation extends ValueObjectVisitor
         $generator->endValueElement('remoteId');
 
         $generator->startObjectElement('Children', 'LocationList');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
                 'ezpublish_rest_loadLocationChildren',
-                array(
-                    'locationPath' => trim($location->pathString, '/'),
-                )
-            )
+                ['locationPath' => trim($location->pathString, '/')]
+            ),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Children');
 
         $generator->startObjectElement('Content');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadContent', array('contentId' => $contentInfo->id))
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
+                'ezpublish_rest_loadContent',
+                ['contentId' => $contentInfo->id]
+            )
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Content');
 
         $generator->startValueElement('sortField', $this->serializeSortField($location->sortField));
@@ -118,25 +116,27 @@ class RestLocation extends ValueObjectVisitor
         $generator->endValueElement('sortOrder');
 
         $generator->startObjectElement('UrlAliases', 'UrlAliasRefList');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
                 'ezpublish_rest_listLocationURLAliases',
-                array('locationPath' => trim($location->pathString, '/'))
-            )
+                ['locationPath' => trim($location->pathString, '/')]
+            ),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('UrlAliases');
 
         $generator->startObjectElement('ContentInfo', 'ContentInfo');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
                 'ezpublish_rest_loadContent',
-                array('contentId' => $contentInfo->id)
-            )
+                ['contentId' => $contentInfo->id],
+                'ContentInfo'
+            ),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
+
         $visitor->visitValueObject(new RestContentValue($contentInfo));
         $generator->endObjectElement('ContentInfo');
 

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestLocation.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestLocation.php
@@ -104,8 +104,11 @@ class RestLocation extends ValueObjectVisitor
         $visitor->visitValueObject(
             new ResourceRouteReference(
                 'ezpublish_rest_loadContent',
-                ['contentId' => $contentInfo->id]
-            )
+                ['contentId' => $contentInfo->id],
+                'Content'
+            ),
+            $generator,
+            $visitor
         );
         $generator->endObjectElement('Content');
 

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestObjectState.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestObjectState.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 /**
  * RestObjectState value object visitor.
@@ -52,11 +53,12 @@ class RestObjectState extends ValueObjectVisitor
 
         $generator->startObjectElement('ObjectStateGroup');
 
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadObjectStateGroup', array('objectStateGroupId' => $data->groupId))
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
+                'ezpublish_rest_loadObjectStateGroup',
+                ['objectStateGroupId' => $data->groupId]
+            )
         );
-        $generator->endAttribute('href');
 
         $generator->endObjectElement('ObjectStateGroup');
 

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestRelation.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestRelation.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
 use eZ\Publish\API\Repository\Values\Content\Relation as RelationValue;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 /**
  * RestRelation value object visitor.
@@ -46,29 +47,21 @@ class RestRelation extends ValueObjectVisitor
         $generator->endAttribute('href');
 
         $generator->startObjectElement('SourceContent', 'ContentInfo');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
                 'ezpublish_rest_loadContent',
-                array(
-                    'contentId' => $data->contentId,
-                )
+                ['contentId' => $data->contentId]
             )
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('SourceContent');
 
         $generator->startObjectElement('DestinationContent', 'ContentInfo');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
                 'ezpublish_rest_loadContent',
-                array(
-                    'contentId' => $data->relation->getDestinationContentInfo()->id,
-                )
+                ['contentId' => $data->relation->getDestinationContentInfo()->id]
             )
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('DestinationContent');
 
         if ($data->relation->sourceFieldDefinitionIdentifier !== null) {

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestTrashItem.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestTrashItem.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 use eZ\Publish\Core\REST\Server\Values\RestContent as RestContentValue;
 
 /**
@@ -63,16 +64,12 @@ class RestTrashItem extends ValueObjectVisitor
         $pathStringParts = array_slice($pathStringParts, 0, count($pathStringParts) - 1);
 
         $generator->startObjectElement('ParentLocation', 'Location');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
                 'ezpublish_rest_loadLocation',
-                array(
-                    'locationPath' => implode('/', $pathStringParts),
-                )
+                ['locationPath' => implode('/', $pathStringParts)]
             )
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('ParentLocation');
 
         $generator->startValueElement('pathString', $trashItem->pathString);
@@ -88,11 +85,12 @@ class RestTrashItem extends ValueObjectVisitor
         $generator->endValueElement('remoteId');
 
         $generator->startObjectElement('Content');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadContent', array('contentId' => $contentInfo->id))
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
+                'ezpublish_rest_loadContent',
+                ['contentId' => $contentInfo->id]
+            )
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Content');
 
         $generator->startValueElement('sortField', $this->serializeSortField($trashItem->sortField));
@@ -102,14 +100,12 @@ class RestTrashItem extends ValueObjectVisitor
         $generator->endValueElement('sortOrder');
 
         $generator->startObjectElement('ContentInfo', 'ContentInfo');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
                 'ezpublish_rest_loadContent',
-                array('contentId' => $contentInfo->id)
+                ['contentId' => $contentInfo->id]
             )
         );
-        $generator->endAttribute('href');
         $visitor->visitValueObject(new RestContentValue($contentInfo));
         $generator->endObjectElement('ContentInfo');
 

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestUser.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestUser.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 use eZ\Publish\Core\REST\Server\Values\Version as VersionValue;
 
 /**
@@ -50,66 +51,69 @@ class RestUser extends ValueObjectVisitor
 
         $generator->startObjectElement('ContentType');
 
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadContentType', array('contentTypeId' => $contentInfo->contentTypeId))
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
+                'ezpublish_rest_loadContentType',
+                ['contentTypeId' => $contentInfo->contentTypeId]
+            )
         );
-        $generator->endAttribute('href');
-
         $generator->endObjectElement('ContentType');
 
         $generator->startValueElement('name', $contentInfo->name);
         $generator->endValueElement('name');
 
         $generator->startObjectElement('Versions', 'VersionList');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadContentVersions', array('contentId' => $contentInfo->id))
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
+                'ezpublish_rest_loadContentVersions',
+                ['contentId' => $contentInfo->id]
+            )
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Versions');
 
         $generator->startObjectElement('Section');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadSection', array('sectionId' => $contentInfo->sectionId))
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
+                'ezpublish_rest_loadSection',
+                ['sectionId' => $contentInfo->sectionId]
+            )
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Section');
 
         $generator->startObjectElement('MainLocation', 'Location');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
                 'ezpublish_rest_loadLocation',
-                array('locationPath' => trim($data->mainLocation->pathString, '/'))
+                ['locationPath' => trim($data->mainLocation->pathString, '/')]
             )
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('MainLocation');
 
         $generator->startObjectElement('Locations', 'LocationList');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadLocationsForContent', array('contentId' => $contentInfo->id))
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
+                'ezpublish_rest_loadLocationsForContent',
+                ['contentId' => $contentInfo->id]
+            )
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Locations');
 
         $generator->startObjectElement('Groups', 'UserGroupRefList');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadUserGroupsOfUser', array('userId' => $contentInfo->id))
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
+                'ezpublish_rest_loadUserGroupsOfUser',
+                ['userId' => $contentInfo->id]
+            )
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Groups');
 
         $generator->startObjectElement('Owner', 'User');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadUser', array('userId' => $contentInfo->ownerId))
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
+                'ezpublish_rest_loadUser',
+                ['userId' => $contentInfo->ownerId]
+            )
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Owner');
 
         $generator->startValueElement('publishDate', $contentInfo->publishedDate->format('c'));
@@ -148,27 +152,15 @@ class RestUser extends ValueObjectVisitor
         $generator->endValueElement('enabled');
 
         $generator->startObjectElement('UserGroups', 'UserGroupList');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
-                'ezpublish_rest_loadUserGroupsOfUser',
-                array('userId' => $contentInfo->id)
-            )
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_loadUserGroupsOfUser', ['userId' => $contentInfo->id])
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('UserGroups');
 
         $generator->startObjectElement('Roles', 'RoleAssignmentList');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
-                'ezpublish_rest_loadRoleAssignmentsForUser',
-                array(
-                    'userId' => $contentInfo->id,
-                )
-            )
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_loadRoleAssignmentsForUser', ['userId' => $contentInfo->id])
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Roles');
 
         $generator->endObjectElement('User');

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestUserGroup.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestUserGroup.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 use eZ\Publish\Core\REST\Server\Values\Version as VersionValue;
 
 /**
@@ -52,14 +53,14 @@ class RestUserGroup extends ValueObjectVisitor
 
         $generator->startObjectElement('ContentType');
 
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
                 'ezpublish_rest_loadContentType',
-                array('contentTypeId' => $contentInfo->contentTypeId)
-            )
+                ['contentTypeId' => $contentInfo->contentTypeId]
+            ),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
 
         $generator->endObjectElement('ContentType');
 
@@ -67,46 +68,44 @@ class RestUserGroup extends ValueObjectVisitor
         $generator->endValueElement('name');
 
         $generator->startObjectElement('Versions', 'VersionList');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadContentVersions', array('contentId' => $contentInfo->id))
+
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_loadContentVersions', ['contentId' => $contentInfo->id]),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Versions');
 
         $generator->startObjectElement('Section');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadSection', array('sectionId' => $contentInfo->sectionId))
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_loadSection', array('sectionId' => $contentInfo->sectionId)),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Section');
 
         $generator->startObjectElement('MainLocation', 'Location');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
-                'ezpublish_rest_loadLocation',
-                array('locationPath' => $mainLocationPath)
-            )
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_loadLocation', ['locationPath' => $mainLocationPath]),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('MainLocation');
 
         $generator->startObjectElement('Locations', 'LocationList');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadLocationsForContent', array('contentId' => $contentInfo->id))
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_loadLocationsForContent', ['contentId' => $contentInfo->id]),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Locations');
 
         $generator->startObjectElement('Owner', 'User');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadUser', array('userId' => $contentInfo->ownerId))
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_loadUser', ['userId' => $contentInfo->ownerId]),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Owner');
 
         $generator->startValueElement('publishDate', $contentInfo->publishedDate->format('c'));
@@ -133,55 +132,38 @@ class RestUserGroup extends ValueObjectVisitor
         );
 
         $generator->startObjectElement('ParentUserGroup', 'UserGroup');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
                 'ezpublish_rest_loadUserGroup',
-                array(
-                    'groupPath' => implode('/', array_slice($mainLocation->path, 0, count($mainLocation->path) - 1)),
-                )
-            )
+                ['groupPath' => implode('/', array_slice($mainLocation->path, 0, count($mainLocation->path) - 1))]
+            ),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('ParentUserGroup');
 
         $generator->startObjectElement('Subgroups', 'UserGroupList');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
-                'ezpublish_rest_loadSubUserGroups',
-                array(
-                    'groupPath' => $mainLocationPath,
-                )
-            )
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_loadSubUserGroups', ['groupPath' => $mainLocationPath]),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Subgroups');
 
         $generator->startObjectElement('Users', 'UserList');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
-                'ezpublish_rest_loadUsersFromGroup',
-                array(
-                    'groupPath' => $mainLocationPath,
-                )
-            )
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_loadUsersFromGroup', ['groupPath' => $mainLocationPath]),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Users');
 
         $generator->startObjectElement('Roles', 'RoleAssignmentList');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate(
-                'ezpublish_rest_loadRoleAssignmentsForUserGroup',
-                array(
-                    'groupPath' => $mainLocationPath,
-                )
-            )
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_loadRoleAssignmentsForUserGroup', ['groupPath' => $mainLocationPath]),
+            $generator,
+            $visitor
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Roles');
 
         $generator->endObjectElement('UserGroup');

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestUserGroupRoleAssignment.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestUserGroupRoleAssignment.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
 use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 /**
  * RestUserGroupRoleAssignment value object visitor.
@@ -53,11 +54,12 @@ class RestUserGroupRoleAssignment extends ValueObjectVisitor
         }
 
         $generator->startObjectElement('Role');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadRole', array('roleId' => $role->id))
+        $visitor->visitValueObject(
+            new ResourceRouteReference(
+                'ezpublish_rest_loadRole',
+                ['roleId' => $role->id]
+            )
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Role');
 
         $generator->endObjectElement('RoleAssignment');

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestUserRoleAssignment.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestUserRoleAssignment.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
 use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 /**
  * RestUserRoleAssignment value object visitor.
@@ -53,11 +54,9 @@ class RestUserRoleAssignment extends ValueObjectVisitor
         }
 
         $generator->startObjectElement('Role');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadRole', array('roleId' => $role->id))
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_loadRole', ['roleId' => $role->id])
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Role');
 
         $generator->endObjectElement('RoleAssignment');

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Role.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Role.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\Values\User\RoleDraft;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 /**
  * Role value object visitor.
@@ -43,11 +44,9 @@ class Role extends ValueObjectVisitor
         $generator->endValueElement('identifier');
 
         $generator->startObjectElement('Policies', 'PolicyList');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadPolicies', array('roleId' => $data->id))
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_loadPolicies', ['roleId' => $data->id])
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Policies');
 
         $generator->endObjectElement('Role');

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/URLAlias.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/URLAlias.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
 use eZ\Publish\API\Repository\Values;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 /**
  * URLAlias value object visitor.
@@ -46,11 +47,9 @@ class URLAlias extends ValueObjectVisitor
 
         if ($data->type === Values\Content\URLAlias::LOCATION) {
             $generator->startObjectElement('location', 'Location');
-            $generator->startAttribute(
-                'href',
-                $this->router->generate('ezpublish_rest_loadLocation', array('locationPath' => $data->destination))
+            $visitor->visitValueObject(
+                new ResourceRouteReference('ezpublish_rest_loadLocation', ['locationPath' => $data->destination])
             );
-            $generator->endAttribute('href');
             $generator->endObjectElement('location');
         } else {
             $generator->startValueElement('resource', $data->destination);

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/UserGroupRefList.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/UserGroupRefList.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 /**
  * UserGroupRefList value object visitor.
@@ -42,31 +43,25 @@ class UserGroupRefList extends ValueObjectVisitor
         foreach ($data->userGroups as $userGroup) {
             $generator->startObjectElement('UserGroup');
 
-            $generator->startAttribute(
-                'href',
-                $this->router->generate(
+            $visitor->visitValueObject(
+                new ResourceRouteReference(
                     'ezpublish_rest_loadUserGroup',
-                    array(
-                        'groupPath' => trim($userGroup->mainLocation->pathString, '/'),
-                    )
+                    ['groupPath' => trim($userGroup->mainLocation->pathString, '/')]
                 )
             );
-            $generator->endAttribute('href');
 
             if ($data->userId !== null && $groupCount > 1) {
                 $generator->startHashElement('unassign');
 
-                $generator->startAttribute(
-                    'href',
-                    $this->router->generate(
+                $visitor->visitValueObject(
+                    new ResourceRouteReference(
                         'ezpublish_rest_unassignUserFromUserGroup',
-                        array(
+                        [
                             'userId' => $data->userId,
                             'groupPath' => $userGroup->mainLocation->path[count($userGroup->mainLocation->path) - 1],
-                        )
+                        ]
                     )
                 );
-                $generator->endAttribute('href');
 
                 $generator->startAttribute('method', 'DELETE');
                 $generator->endAttribute('method');

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/UserRefList.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/UserRefList.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 /**
  * UserRefList value object visitor.
@@ -39,10 +40,9 @@ class UserRefList extends ValueObjectVisitor
         $generator->startList('User');
         foreach ($data->users as $user) {
             $generator->startObjectElement('User');
-
-            $generator->startAttribute('href', $this->router->generate('ezpublish_rest_loadUser', array('userId' => $user->contentInfo->id)));
-            $generator->endAttribute('href');
-
+            $visitor->visitValueObject(
+                new ResourceRouteReference('ezpublish_rest_loadUser', ['userId' => $user->contentInfo->id])
+            );
             $generator->endObjectElement('User');
         }
         $generator->endList('User');

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/UserSession.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/UserSession.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 /**
  * UserSession value object visitor.
@@ -53,11 +54,9 @@ class UserSession extends ValueObjectVisitor
         $generator->endValueElement('csrfToken');
 
         $generator->startObjectElement('User', 'User');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadUser', array('userId' => $data->user->id))
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_loadUser', ['userId' => $data->user->id])
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('User');
 
         $generator->endObjectElement('Session');

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/VersionInfo.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/VersionInfo.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
 use eZ\Publish\API\Repository\Values;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 /**
  * VersionInfo value object visitor.
@@ -52,12 +53,9 @@ class VersionInfo extends ValueObjectVisitor
         $generator->endValueElement('modificationDate');
 
         $generator->startObjectElement('Creator', 'User');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadUser',
-                array('userId' => $versionInfo->creatorId))
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_loadUser', ['userId' => $versionInfo->creatorId])
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Creator');
 
         $generator->startValueElement(
@@ -81,11 +79,9 @@ class VersionInfo extends ValueObjectVisitor
         $this->visitNamesList($generator, $versionInfo->names);
 
         $generator->startObjectElement('Content', 'ContentInfo');
-        $generator->startAttribute(
-            'href',
-            $this->router->generate('ezpublish_rest_loadContent', array('contentId' => $versionInfo->getContentInfo()->id))
+        $visitor->visitValueObject(
+            new ResourceRouteReference('ezpublish_rest_loadContent', ['contentId' => $versionInfo->getContentInfo()->id])
         );
-        $generator->endAttribute('href');
         $generator->endObjectElement('Content');
 
         $generator->endHashElement('VersionInfo');

--- a/eZ/Publish/Core/REST/Server/Tests/Output/PathExpansion/ExpansionGeneratorTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/PathExpansion/ExpansionGeneratorTest.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Tests\Output\PathExpansion;
+
+use eZ\Publish\Core\REST\Server\Output\PathExpansion\ExpansionGenerator;
+use PHPUnit_Framework_TestCase;
+
+class ExpansionGeneratorTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\Core\REST\Common\Output\Generator
+     */
+    protected $innerGeneratorMock;
+
+    /**
+     * @expectedException \eZ\Publish\Core\Base\Exceptions\BadStateException
+     */
+    public function testStartDocument()
+    {
+        $this->buildGenerator()->startDocument('tenant');
+    }
+
+    /**
+     * @expectedException \eZ\Publish\Core\Base\Exceptions\BadStateException
+     */
+    public function testEndDocument()
+    {
+        $this->buildGenerator()->endDocument('tenant');
+    }
+
+    public function testIsEmpty()
+    {
+        $this->getInnerGeneratorMock()
+            ->expects($this->once())
+            ->method('isEmpty');
+
+        $this->buildGenerator()->isEmpty();
+    }
+
+    public function testStartEndObjectElement()
+    {
+        $this->getInnerGeneratorMock()
+            ->expects($this->once())
+            ->method('startObjectElement')
+            ->with('pertwee', 'doctor');
+
+        $this->getInnerGeneratorMock()
+            ->expects($this->once())
+            ->method('endObjectElement')
+            ->with('pertwee');
+
+        $generator = $this->buildGenerator();
+        $generator->startObjectElement('jon', 'doctor');
+        $generator->startObjectElement('pertwee', 'doctor');
+        $generator->endObjectElement('pertwee');
+        $generator->endObjectElement('jon');
+    }
+
+    public function testStartHashElement()
+    {
+        $this->getInnerGeneratorMock()
+            ->expects($this->once())
+            ->method('startHashElement')
+            ->with('baker');
+
+        $this->buildGenerator()->startHashElement('baker');
+    }
+
+    public function testEndHashElement()
+    {
+        $this->getInnerGeneratorMock()
+            ->expects($this->once())
+            ->method('endHashElement')
+            ->with('baker');
+
+        $this->buildGenerator()->endHashElement('baker');
+    }
+
+    public function testStartValueElement()
+    {
+        $this->getInnerGeneratorMock()
+            ->expects($this->once())
+            ->method('startValueElement')
+            ->with('baker', 'paul');
+
+        $this->buildGenerator()->startValueElement('baker', 'paul');
+    }
+
+    public function testEndValueElement()
+    {
+        $this->getInnerGeneratorMock()
+            ->expects($this->once())
+            ->method('endValueElement')
+            ->with('baker');
+
+        $this->buildGenerator()->endValueElement('baker');
+    }
+
+    public function testStartList()
+    {
+        $this->getInnerGeneratorMock()
+            ->expects($this->once())
+            ->method('startList')
+            ->with('hartnell');
+
+        $this->buildGenerator()->startList('hartnell');
+    }
+
+    public function testEndList()
+    {
+        $this->getInnerGeneratorMock()
+            ->expects($this->once())
+            ->method('endList')
+            ->with('hartnell');
+
+        $this->buildGenerator()->endList('hartnell');
+    }
+
+    public function testStartEndAttribute()
+    {
+        $this->getInnerGeneratorMock()
+            ->expects($this->once())
+            ->method('startObjectElement')
+            ->with('eccleston', 'doctor');
+
+        $this->getInnerGeneratorMock()
+            ->expects($this->once())
+            ->method('startAttribute')
+            ->with('jacket', 'leather');
+
+        $generator = $this->buildGenerator();
+
+        $generator->startObjectElement('smith');
+        $generator->startObjectElement('eccleston', 'doctor');
+        $generator->startAttribute('jacket', 'leather');
+    }
+
+    public function testStartEndAttributeAtRoot()
+    {
+        $this->getInnerGeneratorMock()
+            ->expects($this->never())
+            ->method('startObjectElement');
+
+        $this->getInnerGeneratorMock()
+            ->expects($this->once())
+            ->method('startAttribute');
+
+        $this->getInnerGeneratorMock()
+            ->expects($this->never())
+            ->method('endAttribute');
+
+        $this->buildGenerator()->startObjectElement('eccleston');
+        $this->buildGenerator()->startAttribute('href', 'htt://google.cm');
+        $this->buildGenerator()->endAttribute('href');
+        $this->buildGenerator()->startAttribute('jacket', 'leather');
+        $this->buildGenerator()->endAttribute('jacket');
+    }
+
+    public function testGetMediaType()
+    {
+        $this->getInnerGeneratorMock()
+            ->expects($this->once())
+            ->method('getMediaType')
+            ->with('foo')
+            ->willReturn('application/vnd.ez.api.foo');
+
+        self::assertEquals('application/vnd.ez.api.foo', $this->buildGenerator()->getMediaType('foo'));
+    }
+
+    public function testGenerateFieldTypeHash()
+    {
+        $this->getInnerGeneratorMock()
+            ->expects($this->once())
+            ->method('generateFieldTypeHash')
+            ->with('smith', []);
+
+        $this->buildGenerator()->generateFieldTypeHash('smith', []);
+    }
+
+    public function testSerializeBool()
+    {
+        $this->getInnerGeneratorMock()
+            ->expects($this->once())
+            ->method('serializeBool')
+            ->with(true)
+            ->willReturn('true');
+
+        self::assertEquals('true', $this->buildGenerator()->serializeBool(true));
+    }
+
+    /**
+     * @return ExpansionGenerator
+     */
+    protected function buildGenerator()
+    {
+        return new ExpansionGenerator($this->getInnerGeneratorMock());
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\Core\REST\Common\Output\Generator
+     */
+    protected function getInnerGeneratorMock()
+    {
+        if (!isset($this->innerGeneratorMock)) {
+            $this->innerGeneratorMock = $this->getMockBuilder('eZ\Publish\Core\REST\Common\Output\Generator')->getMock();
+        }
+
+        return $this->innerGeneratorMock;
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Tests/Output/PathExpansion/ExpansionGeneratorTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/PathExpansion/ExpansionGeneratorTest.php
@@ -146,15 +146,19 @@ class ExpansionGeneratorTest extends PHPUnit_Framework_TestCase
 
         $this->getInnerGeneratorMock()
             ->expects($this->once())
-            ->method('startAttribute');
+            ->method('startAttribute')
+            ->with('jacket');
 
         $this->getInnerGeneratorMock()
-            ->expects($this->never())
-            ->method('endAttribute');
+            ->expects($this->once())
+            ->method('endAttribute')
+            ->with('jacket');
 
         $this->buildGenerator()->startObjectElement('eccleston');
-        $this->buildGenerator()->startAttribute('href', 'htt://google.cm');
+        $this->buildGenerator()->startAttribute('href', 'http://ez.no');
         $this->buildGenerator()->endAttribute('href');
+        $this->buildGenerator()->startAttribute('media-type', 'application/planet.gallifrey.doctor');
+        $this->buildGenerator()->endAttribute('media-type');
         $this->buildGenerator()->startAttribute('jacket', 'leather');
         $this->buildGenerator()->endAttribute('jacket');
     }

--- a/eZ/Publish/Core/REST/Server/Tests/Output/PathExpansion/RequestHeaderPathExpansionCheckerTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/PathExpansion/RequestHeaderPathExpansionCheckerTest.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Tests\Output\PathExpansion;
+
+use eZ\Publish\Core\REST\Server\Output\PathExpansion\RequestHeaderPathExpansionChecker;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+class RequestHeaderPathExpansionCheckerTest extends PHPUnit_Framework_TestCase
+{
+    public function testNoRequest()
+    {
+        $checker = $this->buildCheckerWithRequestStack(new RequestStack());
+
+        self::assertFalse($checker->needsExpansion('anything'));
+    }
+
+    public function testNoHeader()
+    {
+        $requestStack = new RequestStack();
+        $requestStack->push(new Request());
+
+        $checker = $this->buildCheckerWithRequestStack($requestStack);
+
+        self::assertFalse($checker->needsExpansion('anything'));
+    }
+
+    public function testEmptyHeader()
+    {
+        $checker = $this->buildCheckerWithRequestStack($this->buildRequestStackWithHeader(''));
+
+        self::assertFalse($checker->needsExpansion('anything'));
+    }
+
+    public function testSimpleExpansion()
+    {
+        $checker = $this->buildCheckerWithRequestStack(
+            $this->buildRequestStackWithHeader('Content.MainLocation,Content.Owner')
+        );
+        $checker = $this->buildCheckerWithRequestStack($this->buildRequestStackWithHeader('Content.MainLocation,Content.Owner'));
+
+        self::assertTrue($checker->needsExpansion('Content.MainLocation'));
+        self::assertTrue($checker->needsExpansion('Content.Owner'));
+        self::assertFalse($checker->needsExpansion('Content.SomethingElse'));
+    }
+
+    public function testChildrenExpansion()
+    {
+        $checker = $this->buildCheckerWithRequestStack(
+            $this->buildRequestStackWithHeader('Location.Children.Location.ContentInfo')
+        );
+
+        self::assertTrue($checker->needsExpansion('Location.Children'));
+        self::assertTrue($checker->needsExpansion('Location.Children.Location'));
+        self::assertFalse($checker->needsExpansion('Location.urlAliases'));
+    }
+
+    private function buildRequestStackWithHeader($headerValue)
+    {
+        $requestStack = new RequestStack();
+
+        $request = new Request();
+        $request->headers->set('x-ez-embed-value', $headerValue);
+        $requestStack->push($request);
+
+        return $requestStack;
+    }
+
+    private function buildCheckerWithRequestStack(RequestStack $requestStack)
+    {
+        $checker = new RequestHeaderPathExpansionChecker();
+        $checker->setRequestStack($requestStack);
+
+        return $checker;
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Tests/Output/PathExpansion/ValueLoaders/ControllerUriValueLoaderTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/PathExpansion/ValueLoaders/ControllerUriValueLoaderTest.php
@@ -3,16 +3,16 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\REST\Server\Tests\ValueLoaders;
+namespace eZ\Publish\Core\REST\Server\Tests\Output\PathExpansion\ValueLoaders;
 
-use eZ\Publish\Core\REST\Server\ValueLoaders\ControllerUriValueLoader;
+use eZ\Publish\Core\REST\Server\Output\PathExpansion\ValueLoaders\ControllerUriValueLoader;
 use PHPUnit_Framework_TestCase;
 use Symfony\Component\HttpFoundation\Response;
 
 class ControllerUriValueLoaderTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var \eZ\Publish\Core\REST\Server\ValueLoaders\ControllerUriValueLoader
+     * @var \eZ\Publish\Core\REST\Server\Output\PathExpansion\ValueLoaders\ControllerUriValueLoader
      */
     private $loader;
 

--- a/eZ/Publish/Core/REST/Server/Tests/Output/PathExpansion/ValueLoaders/UniqueUriValueLoaderTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/PathExpansion/ValueLoaders/UniqueUriValueLoaderTest.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Tests\Output\PathExpansion\ValueLoaders;
+
+use eZ\Publish\Core\REST\Server\Output\PathExpansion\ValueLoaders\UniqueUriValueLoader;
+use stdClass;
+
+class UniqueUriValueLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    private $innerLoaderMock;
+
+    /**
+     * @expectedException \eZ\Publish\Core\REST\Server\Output\PathExpansion\Exceptions\MultipleValueLoadException
+     */
+    public function testLoad()
+    {
+        $loader = $this->buildLoader();
+
+        $returnValue = new stdClass();
+
+        $this->getInnerLoaderMock()
+            ->expects($this->exactly(2))
+            ->method('load')
+            ->withConsecutive(
+                ['/doctors/david-tenant', null],
+                ['/doctors/david-tenant', 'application/other-type']
+            )
+            ->will($this->returnValue($returnValue));
+
+        self::assertEquals($returnValue, $loader->load('/doctors/david-tenant'));
+        self::assertEquals($returnValue, $loader->load('/doctors/david-tenant', 'application/other-type'));
+        $loader->load('/doctors/david-tenant');
+    }
+
+    /**
+     * @return \eZ\Publish\Core\REST\Server\Output\PathExpansion\ValueLoaders\UniqueUriValueLoader
+     */
+    protected function buildLoader()
+    {
+        return new UniqueUriValueLoader($this->getInnerLoaderMock());
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\Core\REST\Server\Output\PathExpansion\ValueLoaders\UriValueLoader
+     */
+    protected function getInnerLoaderMock()
+    {
+        if (!isset($this->innerLoaderMock)) {
+            $this->innerLoaderMock = $this
+                ->getMockBuilder('eZ\Publish\Core\REST\Server\Output\PathExpansion\ValueLoaders\UriValueLoader')
+                ->getMock();
+        }
+
+        return $this->innerLoaderMock;
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ContentTypeGroupRefListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ContentTypeGroupRefListTest.php
@@ -15,6 +15,7 @@ use eZ\Publish\Core\Repository\Values\ContentType\ContentTypeGroup;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Server\Values\ContentTypeGroupRefList;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 class ContentTypeGroupRefListTest extends ValueObjectVisitorBaseTest
 {
@@ -60,11 +61,11 @@ class ContentTypeGroupRefListTest extends ValueObjectVisitorBaseTest
         );
 
         // first iteration
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContentTypeGroup',
-            array('contentTypeGroupId' => $contentTypeGroupRefList->contentTypeGroups[0]->id),
-            "/content/typegroups/{$contentTypeGroupRefList->contentTypeGroups[0]->id}"
-        );
+        $this->setVisitValueObjectExpectations([
+            new ResourceRouteReference('ezpublish_rest_loadContentTypeGroup', ['contentTypeGroupId' => $contentTypeGroupRefList->contentTypeGroups[0]->id]),
+            new ResourceRouteReference('ezpublish_rest_loadContentTypeGroup', ['contentTypeGroupId' => $contentTypeGroupRefList->contentTypeGroups[1]->id]),
+        ]);
+
         $this->addRouteExpectation(
             'ezpublish_rest_unlinkContentTypeFromGroup',
             array(
@@ -75,11 +76,6 @@ class ContentTypeGroupRefListTest extends ValueObjectVisitorBaseTest
         );
 
         // second iteration
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContentTypeGroup',
-            array('contentTypeGroupId' => $contentTypeGroupRefList->contentTypeGroups[1]->id),
-            "/content/typegroups/{$contentTypeGroupRefList->contentTypeGroups[1]->id}"
-        );
         $this->addRouteExpectation(
             'ezpublish_rest_unlinkContentTypeFromGroup',
             array(
@@ -120,26 +116,6 @@ class ContentTypeGroupRefListTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisit
      */
-    public function testContentTypeGroupRefListMediaTypeCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/ContentTypeGroupRefList[@media-type="application/vnd.ez.api.ContentTypeGroupRefList+xml"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisit
-     */
-    public function testFirstContentTypeGroupRefHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/ContentTypeGroupRefList/ContentTypeGroupRef[1][@href="/content/typegroups/1"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisit
-     */
     public function testFirstContentTypeGroupRefMediaTypeCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/ContentTypeGroupRefList/ContentTypeGroupRef[1][@media-type="application/vnd.ez.api.ContentTypeGroup+xml"]');
@@ -163,16 +139,6 @@ class ContentTypeGroupRefListTest extends ValueObjectVisitorBaseTest
     public function testFirstContentTypeGroupRefUnlinkMethodCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/ContentTypeGroupRefList/ContentTypeGroupRef[1]/unlink[@method="DELETE"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisit
-     */
-    public function testSecondContentTypeGroupRefHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/ContentTypeGroupRefList/ContentTypeGroupRef[2][@href="/content/typegroups/2"]');
     }
 
     /**

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ContentTypeGroupTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ContentTypeGroupTest.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\Repository\Values\ContentType;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 class ContentTypeGroupTest extends ValueObjectVisitorBaseTest
 {
@@ -50,31 +51,17 @@ class ContentTypeGroupTest extends ValueObjectVisitorBaseTest
             )
         );
 
-        $routerMock = $this->getRouterMock();
-
         $this->addRouteExpectation(
             'ezpublish_rest_loadContentTypeGroup',
-            array('contentTypeGroupId' => $contentTypeGroup->id),
+            ['contentTypeGroupId' => $contentTypeGroup->id],
             "/content/typegroups/{$contentTypeGroup->id}"
         );
 
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadUser',
-            array('userId' => $contentTypeGroup->creatorId),
-            "/user/users/{$contentTypeGroup->creatorId}"
-        );
-
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadUser',
-            array('userId' => $contentTypeGroup->modifierId),
-            "/user/users/{$contentTypeGroup->modifierId}"
-        );
-
-        $this->addRouteExpectation(
-            'ezpublish_rest_listContentTypesForGroup',
-            array('contentTypeGroupId' => $contentTypeGroup->id),
-            "/content/typegroups/{$contentTypeGroup->id}/types"
-        );
+        $this->setVisitValueObjectExpectations([
+            new ResourceRouteReference('ezpublish_rest_loadUser', ['userId' => $contentTypeGroup->creatorId]),
+            new ResourceRouteReference('ezpublish_rest_loadUser', ['userId' => $contentTypeGroup->modifierId]),
+            new ResourceRouteReference('ezpublish_rest_listContentTypesForGroup', ['contentTypeGroupId' => $contentTypeGroup->id], 'ContentTypeInfoList'),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -234,29 +221,6 @@ class ContentTypeGroupTest extends ValueObjectVisitorBaseTest
     }
 
     /**
-     * Test if result contains Creator element attributes.
-     *
-     * @param string $result
-     *
-     * @depends testVisit
-     */
-    public function testResultContainsCreatorAttributes($result)
-    {
-        $this->assertXMLTag(
-            array(
-                'tag' => 'Creator',
-                'attributes' => array(
-                    'href' => '/user/users/14',
-                    'media-type' => 'application/vnd.ez.api.User+xml',
-                ),
-            ),
-            $result,
-            'Invalid <Creator> element attributes.',
-            false
-        );
-    }
-
-    /**
      * Test if result contains Modifier element.
      *
      * @param string $result
@@ -276,29 +240,6 @@ class ContentTypeGroupTest extends ValueObjectVisitorBaseTest
     }
 
     /**
-     * Test if result contains Modifier element attributes.
-     *
-     * @param string $result
-     *
-     * @depends testVisit
-     */
-    public function testResultContainsModifierAttributes($result)
-    {
-        $this->assertXMLTag(
-            array(
-                'tag' => 'Modifier',
-                'attributes' => array(
-                    'href' => '/user/users/13',
-                    'media-type' => 'application/vnd.ez.api.User+xml',
-                ),
-            ),
-            $result,
-            'Invalid <Modifier> element attributes.',
-            false
-        );
-    }
-
-    /**
      * Test if result contains ContentTypes element.
      *
      * @param string $result
@@ -313,29 +254,6 @@ class ContentTypeGroupTest extends ValueObjectVisitorBaseTest
             ),
             $result,
             'Invalid <ContentTypes> element.',
-            false
-        );
-    }
-
-    /**
-     * Test if result contains ContentTypes element attributes.
-     *
-     * @param string $result
-     *
-     * @depends testVisit
-     */
-    public function testResultContainsContentTypesAttributes($result)
-    {
-        $this->assertXMLTag(
-            array(
-                'tag' => 'ContentTypes',
-                'attributes' => array(
-                    'href' => '/content/typegroups/42/types',
-                    'media-type' => 'application/vnd.ez.api.ContentTypeInfoList+xml',
-                ),
-            ),
-            $result,
-            'Invalid <ContentTypes> attributes.',
             false
         );
     }

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ObjectStateGroupTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ObjectStateGroupTest.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\Repository\Values\ObjectState;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 class ObjectStateGroupTest extends ValueObjectVisitorBaseTest
 {
@@ -51,11 +52,9 @@ class ObjectStateGroupTest extends ValueObjectVisitorBaseTest
             "/content/objectstategroups/$objectStateGroup->id"
         );
 
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadObjectStates',
-            array('objectStateGroupId' => $objectStateGroup->id),
-            "/content/objectstategroups/$objectStateGroup->id/objectstates"
-        );
+        $this->setVisitValueObjectExpectations([
+            new ResourceRouteReference('ezpublish_rest_loadObjectStates', ['objectStateGroupId' => $objectStateGroup->id]),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ResourceLinkTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ResourceLinkTest.php
@@ -1,0 +1,268 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
+
+use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
+use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
+use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\ResourceLink;
+use eZ\Publish\Core\REST\Server\Output\PathExpansion\Exceptions\MultipleValueLoadException;
+use eZ\Publish\Core\REST\Server\Values\ResourceLink as ResourceLinkValue;
+
+class ResourceLinkTest extends ValueObjectVisitorBaseTest
+{
+    private $valueLoaderMock;
+    private $pathExpansionCheckerMock;
+    private $valueObjectVisitorDispatcherMock;
+
+    /**
+     * @param ResourceLinkValue $resourceLink
+     * @dataProvider buildValueObject
+     */
+    public function testVisitWithExpansion(ResourceLinkValue $resourceLink)
+    {
+        $visitor = $this->getVisitor();
+        $generator = $this->getGenerator();
+
+        $generator->startDocument(null);
+        $generator->startObjectElement('SomeRoot');
+        $generator->startObjectElement('SomeObject');
+
+        $this->getPathExpansionCheckerMock()
+            ->expects($this->once())
+            ->method('needsExpansion')
+            ->with('SomeRoot.SomeObject')
+            ->will($this->returnValue(true));
+
+        $this->getValueLoaderMock()
+            ->expects($this->once())
+            ->method('load')
+            ->with($resourceLink->link, $resourceLink->mediaType)
+            ->will($this->returnValue($loadedValue = new \stdClass()));
+
+        $this->getValueObjectVisitorDispatcherMock()
+            ->expects($this->once())
+            ->method('visit')
+            ->with(
+                $loadedValue,
+                $this->isInstanceOf('eZ\Publish\Core\REST\Server\Output\PathExpansion\ExpansionGenerator'),
+                $this->getVisitorMock()
+            );
+
+        $visitor->visit($this->getVisitorMock(), $generator, $resourceLink);
+
+        $generator->endObjectElement('SomeObject');
+        $generator->endObjectElement('SomeRoot');
+
+        $result = $generator->endDocument(null);
+
+        $this->assertNotNull($result);
+
+        $dom = new \DOMDocument();
+        $dom->loadXml($result);
+
+        $this->assertXPath($dom, '//SomeObject[@href="' . $resourceLink->link . '"]');
+        $this->assertXPath($dom, '//SomeObject[@media-type="application/vnd.ez.api.SomeObject+xml"]');
+    }
+
+    /**
+     * @param ResourceLinkValue $resourceLink
+     * @dataProvider buildValueObject
+     */
+    public function testVisitWithNoExpansion(ResourceLinkValue $resourceLink)
+    {
+        $visitor = $this->getVisitor();
+        $generator = $this->getGenerator();
+
+        $generator->startDocument(null);
+        $generator->startObjectElement('SomeRoot');
+        $generator->startObjectElement('SomeObject');
+
+        $this->getPathExpansionCheckerMock()
+            ->expects($this->once())
+            ->method('needsExpansion')
+            ->with('SomeRoot.SomeObject')
+            ->will($this->returnValue(false));
+
+        $this->getValueLoaderMock()
+            ->expects($this->never())
+            ->method('load');
+
+        $this->getValueObjectVisitorDispatcherMock()
+            ->expects($this->never())
+            ->method('visit');
+
+        $visitor->visit($this->getVisitorMock(), $generator, $resourceLink);
+
+        $generator->endObjectElement('SomeObject');
+        $generator->endObjectElement('SomeRoot');
+
+        $result = $generator->endDocument(null);
+
+        $this->assertNotNull($result);
+
+        $dom = new \DOMDocument();
+        $dom->loadXml($result);
+
+        $this->assertXPath($dom, '//SomeObject[@href="' . $resourceLink->link . '"]');
+        $this->assertXPath($dom, '//SomeObject[@media-type="application/vnd.ez.api.SomeObject+xml"]');
+    }
+
+    /**
+     * @dataProvider buildValueObject
+     */
+    public function testVisitUnauthorizedException(ResourceLinkValue $resourceLink)
+    {
+        $visitor = $this->getVisitor();
+        $generator = $this->getGenerator();
+
+        $generator->startDocument(null);
+        $generator->startObjectElement('SomeRoot');
+        $generator->startObjectElement('SomeObject');
+
+        $this->getPathExpansionCheckerMock()
+            ->expects($this->once())
+            ->method('needsExpansion')
+            ->with('SomeRoot.SomeObject')
+            ->will($this->returnValue(true));
+
+        $this->getValueLoaderMock()
+            ->expects($this->once())
+            ->method('load')
+            ->will($this->throwException(new UnauthorizedException('something', 'load')));
+
+        $this->getValueObjectVisitorDispatcherMock()
+            ->expects($this->never())
+            ->method('visit');
+
+        $visitor->visit($this->getVisitorMock(), $generator, $resourceLink);
+
+        $generator->endObjectElement('SomeObject');
+        $generator->endObjectElement('SomeRoot');
+
+        $result = $generator->endDocument(null);
+
+        $this->assertNotNull($result);
+
+        $dom = new \DOMDocument();
+        $dom->loadXml($result);
+
+        $this->assertXPath($dom, '//SomeObject[@href="' . $resourceLink->link . '"]');
+        $this->assertXPath($dom, '//SomeObject[@media-type="application/vnd.ez.api.SomeObject+xml"]');
+        $this->assertXPath($dom, '//SomeObject[@embed-error="User does not have access to \'load\' \'something\'"]');
+    }
+
+    /**
+     * @dataProvider buildValueObject
+     */
+    public function testVisitMultipleLoadException(ResourceLinkValue $resourceLink)
+    {
+        $visitor = $this->getVisitor();
+        $generator = $this->getGenerator();
+
+        $generator->startDocument(null);
+        $generator->startObjectElement('SomeRoot');
+        $generator->startObjectElement('SomeObject');
+
+        $this->getPathExpansionCheckerMock()
+            ->expects($this->once())
+            ->method('needsExpansion')
+            ->with('SomeRoot.SomeObject')
+            ->will($this->returnValue(true));
+
+        $this->getValueLoaderMock()
+            ->expects($this->once())
+            ->method('load')
+            ->will($this->throwException(new MultipleValueLoadException()));
+
+        $this->getValueObjectVisitorDispatcherMock()
+            ->expects($this->never())
+            ->method('visit');
+
+        $visitor->visit($this->getVisitorMock(), $generator, $resourceLink);
+
+        $generator->endObjectElement('SomeObject');
+        $generator->endObjectElement('SomeRoot');
+
+        $result = $generator->endDocument(null);
+
+        $this->assertNotNull($result);
+
+        $dom = new \DOMDocument();
+        $dom->loadXml($result);
+
+        $this->assertXPath($dom, '//SomeObject[@href="' . $resourceLink->link . '"]');
+        $this->assertXPath($dom, '//SomeObject[@media-type="application/vnd.ez.api.SomeObject+xml"]');
+        $this->assertXPath($dom, '//SomeObject[@embed-error="Value was already loaded"]');
+    }
+
+    public function testVisitCircularLoadException()
+    {
+        self::markTestIncomplete('@todo Implement feature');
+    }
+
+    public function buildValueObject()
+    {
+        return [
+            [new ResourceLinkValue('/api/ezp/v2/resource')],
+        ];
+    }
+
+    /**
+     * Must return an instance of the tested visitor object.
+     *
+     * @return \eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor
+     */
+    protected function internalGetVisitor()
+    {
+        return new ResourceLink(
+            $this->getValueLoaderMock(),
+            $this->getPathExpansionCheckerMock(),
+            $this->getValueObjectVisitorDispatcherMock()
+        );
+    }
+
+    /**
+     * @return \eZ\Publish\Core\REST\Server\ValueLoaders\UriValueLoader|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getValueLoaderMock()
+    {
+        if ($this->valueLoaderMock === null) {
+            $this->valueLoaderMock = $this
+                ->getMockBuilder('eZ\Publish\Core\REST\Server\ValueLoaders\UriValueLoader')
+                ->getMock();
+        }
+
+        return $this->valueLoaderMock;
+    }
+
+    /**
+     * @return \eZ\Publish\Core\REST\Server\Output\PathExpansion\PathExpansionChecker|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getPathExpansionCheckerMock()
+    {
+        if ($this->pathExpansionCheckerMock === null) {
+            $this->pathExpansionCheckerMock = $this
+                ->getMockBuilder('eZ\Publish\Core\REST\Server\Output\PathExpansion\PathExpansionChecker')
+                ->getMock();
+        }
+
+        return $this->pathExpansionCheckerMock;
+    }
+
+    /**
+     * @return \eZ\Publish\Core\REST\Common\Output\ValueObjectVisitorDispatcher|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getValueObjectVisitorDispatcherMock()
+    {
+        if ($this->valueObjectVisitorDispatcherMock === null) {
+            $this->valueObjectVisitorDispatcherMock = $this
+                ->getMockBuilder('eZ\Publish\Core\REST\Common\Output\ValueObjectVisitorDispatcher')
+                ->getMock();
+        }
+
+        return $this->valueObjectVisitorDispatcherMock;
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ResourceLinkTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ResourceLinkTest.php
@@ -225,13 +225,13 @@ class ResourceLinkTest extends ValueObjectVisitorBaseTest
     }
 
     /**
-     * @return \eZ\Publish\Core\REST\Server\ValueLoaders\UriValueLoader|\PHPUnit_Framework_MockObject_MockObject
+     * @return \eZ\Publish\Core\REST\Server\Output\PathExpansion\ValueLoaders\UriValueLoader|\PHPUnit_Framework_MockObject_MockObject
      */
     protected function getValueLoaderMock()
     {
         if ($this->valueLoaderMock === null) {
             $this->valueLoaderMock = $this
-                ->getMockBuilder('eZ\Publish\Core\REST\Server\ValueLoaders\UriValueLoader')
+                ->getMockBuilder('eZ\Publish\Core\REST\Server\Output\PathExpansion\ValueLoaders\UriValueLoader')
                 ->getMock();
         }
 

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestContentTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestContentTest.php
@@ -11,6 +11,7 @@
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 use eZ\Publish\Core\REST\Server\Values\RestContent;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\Repository\Values;
@@ -30,54 +31,21 @@ class RestContentTest extends ValueObjectVisitorBaseTest
 
         $restContent = $this->getBasicRestContent();
 
-        $this->getVisitorMock()->expects($this->never())
-            ->method('visitValueObject');
-
         $this->addRouteExpectation(
             'ezpublish_rest_loadContent',
             array('contentId' => $restContent->contentInfo->id),
             "/content/objects/{$restContent->contentInfo->id}"
         );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContentType',
-            array('contentTypeId' => $restContent->contentInfo->contentTypeId),
-            "/content/types/{$restContent->contentInfo->contentTypeId}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContentVersions',
-            array('contentId' => $restContent->contentInfo->id),
-            "/content/objects/{$restContent->contentInfo->id}/versions"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_redirectCurrentVersion',
-            array('contentId' => $restContent->contentInfo->id),
-            "/content/objects/{$restContent->contentInfo->id}/currentversion"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadSection',
-            array('sectionId' => $restContent->contentInfo->sectionId),
-            "/content/sections/{$restContent->contentInfo->sectionId}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadLocation',
-            array('locationPath' => $locationPath = trim($restContent->mainLocation->pathString, '/')),
-            "/content/locations/{$locationPath}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadLocationsForContent',
-            array('contentId' => $restContent->contentInfo->id),
-            "/content/objects/{$restContent->contentInfo->id}/locations"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadUser',
-            array('userId' => $restContent->contentInfo->ownerId),
-            "/user/users/{$restContent->contentInfo->ownerId}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_getObjectStatesForContent',
-            array('contentId' => $restContent->contentInfo->id),
-            "/content/objects/{$restContent->contentInfo->id}/objectstates"
-        );
+        $this->setVisitValueObjectExpectations([
+            new ResourceRouteReference('ezpublish_rest_loadContentType', ['contentTypeId' => $restContent->contentInfo->contentTypeId]),
+            new ResourceRouteReference('ezpublish_rest_loadContentVersions', ['contentId' => $restContent->contentInfo->id]),
+            new ResourceRouteReference('ezpublish_rest_redirectCurrentVersion', ['contentId' => $restContent->contentInfo->id]),
+            new ResourceRouteReference('ezpublish_rest_loadSection', ['sectionId' => $restContent->contentInfo->sectionId]),
+            new ResourceRouteReference('ezpublish_rest_loadLocation', ['locationPath' => $locationPath = trim($restContent->mainLocation->pathString, '/')]),
+            new ResourceRouteReference('ezpublish_rest_loadLocationsForContent', ['contentId' => $restContent->contentInfo->id]),
+            new ResourceRouteReference('ezpublish_rest_loadUser', ['userId' => $restContent->contentInfo->ownerId]),
+            new ResourceRouteReference('ezpublish_rest_getObjectStatesForContent', ['contentId' => $restContent->contentInfo->id]),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -169,16 +137,6 @@ class RestContentTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisitWithoutEmbeddedVersion
      */
-    public function testContentTypeHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/Content/ContentType[@href="/content/types/contentType23"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
     public function testContentTypeMediaTypeCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/Content/ContentType[@media-type="application/vnd.ez.api.ContentType+xml"]');
@@ -199,29 +157,9 @@ class RestContentTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisitWithoutEmbeddedVersion
      */
-    public function testVersionsHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/Content/Versions[@href="/content/objects/content23/versions"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
     public function testVersionsMediaTypeCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/Content/Versions[@media-type="application/vnd.ez.api.VersionList+xml"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
-    public function testCurrentVersionHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/Content/CurrentVersion[@href="/content/objects/content23/currentversion"]');
     }
 
     /**
@@ -239,29 +177,9 @@ class RestContentTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisitWithoutEmbeddedVersion
      */
-    public function testSectionHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/Content/Section[@href="/content/sections/section23"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
     public function testSectionMediaTypeCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/Content/Section[@media-type="application/vnd.ez.api.Section+xml"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
-    public function testMainLocationHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/Content/MainLocation[@href="/content/locations/1/2/23"]');
     }
 
     /**
@@ -279,29 +197,9 @@ class RestContentTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisitWithoutEmbeddedVersion
      */
-    public function testLocationsHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/Content/Locations[@href="/content/objects/content23/locations"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
     public function testLocationsMediaTypeCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/Content/Locations[@media-type="application/vnd.ez.api.LocationList+xml"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
-    public function testOwnerHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/Content/Owner[@href="/user/users/user23"]');
     }
 
     /**
@@ -376,51 +274,21 @@ class RestContentTest extends ValueObjectVisitorBaseTest
             'eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType'
         );
 
-        $this->getVisitorMock()->expects($this->once())
-            ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\Core\\REST\\Server\\Values\\Version'));
-
         $this->addRouteExpectation(
             'ezpublish_rest_loadContent',
             array('contentId' => $restContent->contentInfo->id),
             "/content/objects/{$restContent->contentInfo->id}"
         );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContentType',
-            array('contentTypeId' => $restContent->contentInfo->contentTypeId),
-            "/content/types/{$restContent->contentInfo->contentTypeId}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContentVersions',
-            array('contentId' => $restContent->contentInfo->id),
-            "/content/objects/{$restContent->contentInfo->id}/versions"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_redirectCurrentVersion',
-            array('contentId' => $restContent->contentInfo->id),
-            "/content/objects/{$restContent->contentInfo->id}/currentversion"
-        );
-
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadSection',
-            array('sectionId' => $restContent->contentInfo->sectionId),
-            "/content/sections/{$restContent->contentInfo->sectionId}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadLocation',
-            array('locationPath' => $locationPath = trim($restContent->mainLocation->pathString, '/')),
-            "/content/locations/{$locationPath}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadLocationsForContent',
-            array('contentId' => $restContent->contentInfo->id),
-            "/content/objects/{$restContent->contentInfo->id}/locations"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadUser',
-            array('userId' => $restContent->contentInfo->ownerId),
-            "/user/users/{$restContent->contentInfo->ownerId}"
-        );
+        $this->setVisitValueObjectExpectations([
+            new ResourceRouteReference('ezpublish_rest_loadContentType', ['contentTypeId' => $restContent->contentInfo->contentTypeId]),
+            new ResourceRouteReference('ezpublish_rest_loadContentVersions', ['contentId' => $restContent->contentInfo->id]),
+            new ResourceRouteReference('ezpublish_rest_redirectCurrentVersion', ['contentId' => $restContent->contentInfo->id]),
+            $this->isInstanceOf('eZ\Publish\Core\REST\Server\Values\Version'),
+            new ResourceRouteReference('ezpublish_rest_loadSection', ['sectionId' => $restContent->contentInfo->sectionId]),
+            new ResourceRouteReference('ezpublish_rest_loadLocation', ['locationPath' => $locationPath = trim($restContent->mainLocation->pathString, '/')]),
+            new ResourceRouteReference('ezpublish_rest_loadLocationsForContent', ['contentId' => $restContent->contentInfo->id]),
+            new ResourceRouteReference('ezpublish_rest_loadUser', ['userId' => $restContent->contentInfo->ownerId]),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -446,16 +314,6 @@ class RestContentTest extends ValueObjectVisitorBaseTest
     public function testContentMediaTypeWithVersionCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/Content[@media-type="application/vnd.ez.api.Content+xml"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithEmbeddedVersion
-     */
-    public function testEmbeddedCurrentVersionHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/Content/CurrentVersion[@href="/content/objects/content23/currentversion"]');
     }
 
     /**

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestContentTypeTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestContentTypeTest.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\Repository\Values;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 use eZ\Publish\Core\REST\Server\Values\RestContentType;
 
 /**
@@ -33,35 +34,19 @@ class RestContentTypeTest extends ValueObjectVisitorBaseTest
 
         $restContentType = $this->getBasicContentType();
 
-        $this->getVisitorMock()->expects($this->once())
-            ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\Core\\REST\\Server\\Values\\FieldDefinitionList'));
-
         $this->addRouteExpectation(
             'ezpublish_rest_loadContentType',
             array('contentTypeId' => $restContentType->contentType->id),
             "/content/types/{$restContentType->contentType->id}"
         );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadUser',
-            array('userId' => $restContentType->contentType->creatorId),
-            "/user/users/{$restContentType->contentType->creatorId}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadUser',
-            array('userId' => $restContentType->contentType->modifierId),
-            "/user/users/{$restContentType->contentType->modifierId}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadGroupsOfContentType',
-            array('contentTypeId' => $restContentType->contentType->id),
-            "/content/types/{$restContentType->contentType->id}/groups"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContentTypeDraft',
-            array('contentTypeId' => $restContentType->contentType->id),
-            "/content/types/{$restContentType->contentType->id}/draft"
-        );
+
+        $this->setVisitValueObjectExpectations([
+            $this->isInstanceOf('eZ\Publish\Core\REST\Server\Values\FieldDefinitionList'),
+            new ResourceRouteReference('ezpublish_rest_loadUser', ['userId' => $restContentType->contentType->creatorId]),
+            new ResourceRouteReference('ezpublish_rest_loadUser', ['userId' => $restContentType->contentType->modifierId]),
+            new ResourceRouteReference('ezpublish_rest_loadGroupsOfContentType', ['contentTypeId' => $restContentType->contentType->id]),
+            new ResourceRouteReference('ezpublish_rest_loadContentTypeDraft', ['contentTypeId' => $restContentType->contentType->id]),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -109,16 +94,6 @@ class RestContentTypeTest extends ValueObjectVisitorBaseTest
             ),
             array()
         );
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitDefinedType
-     */
-    public function testContentTypeHref(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/ContentType[@href="/content/types/contentTypeId"]');
     }
 
     /**
@@ -226,29 +201,9 @@ class RestContentTypeTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisitDefinedType
      */
-    public function testCreatorHref(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/ContentType/Creator[@href="/user/users/creatorId"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitDefinedType
-     */
     public function testCreatorMediaType(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/ContentType/Creator[@media-type="application/vnd.ez.api.User+xml"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitDefinedType
-     */
-    public function testModifierHref(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/ContentType/Modifier[@href="/user/users/modifierId"]');
     }
 
     /**
@@ -266,29 +221,9 @@ class RestContentTypeTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisitDefinedType
      */
-    public function testDraftHref(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/ContentType/Draft[@href="/content/types/contentTypeId/draft"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitDefinedType
-     */
     public function testDraftType(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/ContentType/Draft[@media-type="application/vnd.ez.api.ContentType+xml"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitDefinedType
-     */
-    public function testGroupsHref(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/ContentType/Groups[@href="/content/types/contentTypeId/groups"]');
     }
 
     /**

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestExecutedViewTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestExecutedViewTest.php
@@ -16,6 +16,7 @@ use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\Repository\Values\Content;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 use eZ\Publish\Core\REST\Server\Values\RestExecutedView;
 use eZ\Publish\Core\Repository\Values\Content as ApiValues;
 
@@ -50,11 +51,9 @@ class RestExecutedViewTest extends ValueObjectVisitorBaseTest
             array('viewId' => $view->identifier),
             "/content/views/{$view->identifier}"
         );
-        $this->addRouteExpectation(
-            'ezpublish_rest_views_load_results',
-            array('viewId' => $view->identifier),
-            "/content/views/{$view->identifier}/results"
-        );
+        $this->setVisitValueObjectExpectations([
+            new ResourceRouteReference('ezpublish_rest_views_load_results', ['viewId' => $view->identifier]),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -84,7 +83,6 @@ class RestExecutedViewTest extends ValueObjectVisitorBaseTest
             array('/View/Query[@media-type="application/vnd.ez.api.Query+xml"]'),
             array('/View/Result'),
             array('/View/Result[@media-type="application/vnd.ez.api.ViewResult+xml"]'),
-            array('/View/Result[@href="/content/views/test_view/results"]'),
         );
     }
 

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestLocationRootNodeTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestLocationRootNodeTest.php
@@ -11,6 +11,7 @@
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 use eZ\Publish\Core\REST\Server\Values\RestLocation;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -60,31 +61,14 @@ class RestLocationRootNodeTest extends RestLocationTest
             array('locationPath' => '1'),
             '/content/locations/1'
         );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadLocationChildren',
-            array('locationPath' => '1'),
-            '/content/locations/1/children'
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContent',
-            array('contentId' => $location->location->contentId),
-            "/content/objects/{$location->location->contentId}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_listLocationURLAliases',
-            array('locationPath' => '1'),
-            '/content/objects/1/urlaliases'
-        );
 
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContent',
-            array('contentId' => $location->location->contentId),
-            "/content/objects/{$location->location->contentId}"
-        );
-
-        $this->getVisitorMock()->expects($this->once())
-            ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\Core\\REST\\Server\\Values\\RestContent'));
+        $this->setVisitValueObjectExpectations([
+            new ResourceRouteReference('ezpublish_rest_loadLocationChildren', array('locationPath' => '1')),
+            new ResourceRouteReference('ezpublish_rest_loadContent', array('contentId' => $location->location->contentId)),
+            new ResourceRouteReference('ezpublish_rest_listLocationURLAliases', array('locationPath' => '1')),
+            new ResourceRouteReference('ezpublish_rest_loadContent', array('contentId' => $location->location->contentId), 'ContentInfo'),
+            $this->isInstanceOf('eZ\Publish\Core\REST\Server\Values\RestContent'),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -195,7 +179,6 @@ class RestLocationRootNodeTest extends RestLocationTest
                 'tag' => 'Children',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.LocationList+xml',
-                    'href' => '/content/locations/1/children',
                 ),
             ),
             $result,
@@ -238,7 +221,6 @@ class RestLocationRootNodeTest extends RestLocationTest
                 'tag' => 'UrlAliases',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.UrlAliasRefList+xml',
-                    'href' => '/content/objects/1/urlaliases',
                 ),
             ),
             $result,

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestLocationTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestLocationTest.php
@@ -12,6 +12,7 @@ namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 use eZ\Publish\Core\REST\Server\Values\RestLocation;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -56,42 +57,15 @@ class RestLocationTest extends ValueObjectVisitorBaseTest
             0
         );
 
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadLocation',
-            array('locationPath' => '1/2/21/42'),
-            '/content/locations/1/2/21/42'
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadLocation',
-            array('locationPath' => '1/2/21'),
-            '/content/locations/1/2/21'
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadLocationChildren',
-            array('locationPath' => '1/2/21/42'),
-            '/content/locations/1/2/21/42/children'
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContent',
-            array('contentId' => $location->location->contentId),
-            "/content/objects/{$location->location->contentId}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_listLocationURLAliases',
-            array('locationPath' => '1/2/21/42'),
-            '/content/objects/1/2/21/42/urlaliases'
-        );
-
-        // Expected twice, second one here for ContentInfo
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContent',
-            array('contentId' => $location->location->contentId),
-            "/content/objects/{$location->location->contentId}"
-        );
-
-        $this->getVisitorMock()->expects($this->once())
-            ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\Core\\REST\\Server\\Values\\RestContent'));
+        $this->setVisitValueObjectExpectations([
+            new ResourceRouteReference('ezpublish_rest_loadLocation', ['locationPath' => '1/2/21/42']),
+            new ResourceRouteReference('ezpublish_rest_loadLocation', ['locationPath' => '1/2/21']),
+            new ResourceRouteReference('ezpublish_rest_loadLocationChildren', ['locationPath' => '1/2/21/42']),
+            new ResourceRouteReference('ezpublish_rest_loadContent', ['contentId' => $location->location->contentId]),
+            new ResourceRouteReference('ezpublish_rest_listLocationURLAliases', ['locationPath' => '1/2/21/42']),
+            new ResourceRouteReference('ezpublish_rest_loadContent', ['contentId' => $location->location->contentId]),
+            $this->isInstanceOf('eZ\Publish\Core\REST\Server\Values\RestContent'),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -139,7 +113,6 @@ class RestLocationTest extends ValueObjectVisitorBaseTest
                 'tag' => 'Location',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.Location+xml',
-                    'href' => '/content/locations/1/2/21/42',
                 ),
             ),
             $result,
@@ -181,7 +154,6 @@ class RestLocationTest extends ValueObjectVisitorBaseTest
                 'tag' => 'ContentInfo',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.ContentInfo+xml',
-                    'href' => '/content/objects/42',
                 ),
             ),
             $result,
@@ -323,7 +295,6 @@ class RestLocationTest extends ValueObjectVisitorBaseTest
                 'tag' => 'Children',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.LocationList+xml',
-                    'href' => '/content/locations/1/2/21/42/children',
                 ),
             ),
             $result,
@@ -365,7 +336,6 @@ class RestLocationTest extends ValueObjectVisitorBaseTest
                 'tag' => 'ParentLocation',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.Location+xml',
-                    'href' => '/content/locations/1/2/21',
                 ),
             ),
             $result,
@@ -407,7 +377,6 @@ class RestLocationTest extends ValueObjectVisitorBaseTest
                 'tag' => 'Content',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.Content+xml',
-                    'href' => '/content/objects/42',
                 ),
             ),
             $result,
@@ -549,7 +518,6 @@ class RestLocationTest extends ValueObjectVisitorBaseTest
                 'tag' => 'UrlAliases',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.UrlAliasRefList+xml',
-                    'href' => '/content/objects/1/2/21/42/urlaliases',
                 ),
             ),
             $result,

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestObjectStateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestObjectStateTest.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\Repository\Values\ObjectState\ObjectState;
 use eZ\Publish\Core\REST\Common\Values;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 class RestObjectStateTest extends ValueObjectVisitorBaseTest
 {
@@ -55,11 +56,9 @@ class RestObjectStateTest extends ValueObjectVisitorBaseTest
             array('objectStateGroupId' => $objectState->groupId, 'objectStateId' => $objectState->objectState->id),
             "/content/objectstategroups/{$objectState->groupId}/objectstates/{$objectState->objectState->id}"
         );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadObjectStateGroup',
-            array('objectStateGroupId' => $objectState->groupId),
-            "/content/objectstategroups/{$objectState->groupId}"
-        );
+        $this->setVisitValueObjectExpectations([
+            new ResourceRouteReference('ezpublish_rest_loadObjectStateGroup', ['objectStateGroupId' => $objectState->groupId]),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -110,7 +109,6 @@ class RestObjectStateTest extends ValueObjectVisitorBaseTest
                 'tag' => 'ObjectState',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.ObjectState+xml',
-                    'href' => '/content/objectstategroups/21/objectstates/42',
                 ),
             ),
             $result,
@@ -152,7 +150,6 @@ class RestObjectStateTest extends ValueObjectVisitorBaseTest
                 'tag' => 'ObjectStateGroup',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.ObjectStateGroup+xml',
-                    'href' => '/content/objectstategroups/21',
                 ),
             ),
             $result,

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestRelationTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestRelationTest.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\Repository\Values\Content;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 use eZ\Publish\Core\REST\Server\Values\RestRelation;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 
@@ -61,16 +62,10 @@ class RestRelationTest extends ValueObjectVisitorBaseTest
             ),
             "/content/objects/{$relation->contentId}/versions/{$relation->versionNo}/relations/{$relation->relation->id}"
         );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContent',
-            array('contentId' => $relation->contentId),
-            "/content/objects/{$relation->contentId}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContent',
-            array('contentId' => $relation->relation->getDestinationContentInfo()->id),
-            "/content/objects/{$relation->relation->getDestinationContentInfo()->id}"
-        );
+        $this->setVisitValueObjectExpectations([
+            new ResourceRouteReference('ezpublish_rest_loadContent', ['contentId' => $relation->contentId]),
+            new ResourceRouteReference('ezpublish_rest_loadContent', ['contentId' => $relation->relation->getDestinationContentInfo()->id]),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -122,7 +117,6 @@ class RestRelationTest extends ValueObjectVisitorBaseTest
                 'tag' => 'Relation',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.Relation+xml',
-                    'href' => '/content/objects/1/versions/1/relations/42',
                 ),
             ),
             $result,
@@ -143,7 +137,6 @@ class RestRelationTest extends ValueObjectVisitorBaseTest
                 'tag' => 'SourceContent',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.ContentInfo+xml',
-                    'href' => '/content/objects/1',
                 ),
             ),
             $result,
@@ -164,7 +157,6 @@ class RestRelationTest extends ValueObjectVisitorBaseTest
                 'tag' => 'DestinationContent',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.ContentInfo+xml',
-                    'href' => '/content/objects/2',
                 ),
             ),
             $result,

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestTrashItemTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestTrashItemTest.php
@@ -12,6 +12,7 @@ namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 use eZ\Publish\Core\REST\Server\Values\RestTrashItem;
 use eZ\Publish\Core\Repository\Values\Content\TrashItem;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -61,28 +62,12 @@ class RestTrashItemTest extends ValueObjectVisitorBaseTest
             array('trashItemId' => $trashItem->trashItem->id),
             "/content/trash/{$trashItem->trashItem->id}"
         );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadLocation',
-            array('locationPath' => '1/2/21'),
-            '/content/locations/1/2/21'
-        );
-
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContent',
-            array('contentId' => $trashItem->trashItem->contentInfo->id),
-            "/content/objects/{$trashItem->trashItem->contentInfo->id}"
-        );
-
-        // Expected twice, second one here for ContentInfo
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContent',
-            array('contentId' => $trashItem->trashItem->contentInfo->id),
-            "/content/objects/{$trashItem->trashItem->contentInfo->id}"
-        );
-
-        $this->getVisitorMock()->expects($this->once())
-            ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\Core\\REST\\Server\\Values\\RestContent'));
+        $this->setVisitValueObjectExpectations([
+            new ResourceRouteReference('ezpublish_rest_loadLocation', ['locationPath' => '1/2/21']),
+            new ResourceRouteReference('ezpublish_rest_loadContent', ['contentId' => $trashItem->trashItem->contentInfo->id]),
+            new ResourceRouteReference('ezpublish_rest_loadContent', ['contentId' => $trashItem->trashItem->contentInfo->id]),
+            $this->isInstanceOf('eZ\Publish\Core\REST\Server\Values\RestContent'),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -133,7 +118,6 @@ class RestTrashItemTest extends ValueObjectVisitorBaseTest
                 'tag' => 'TrashItem',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.TrashItem+xml',
-                    'href' => '/content/trash/42',
                 ),
             ),
             $result,
@@ -175,7 +159,6 @@ class RestTrashItemTest extends ValueObjectVisitorBaseTest
                 'tag' => 'ContentInfo',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.ContentInfo+xml',
-                    'href' => '/content/objects/84',
                 ),
             ),
             $result,
@@ -317,7 +300,6 @@ class RestTrashItemTest extends ValueObjectVisitorBaseTest
                 'tag' => 'ParentLocation',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.Location+xml',
-                    'href' => '/content/locations/1/2/21',
                 ),
             ),
             $result,
@@ -419,7 +401,6 @@ class RestTrashItemTest extends ValueObjectVisitorBaseTest
                 'tag' => 'Content',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.Content+xml',
-                    'href' => '/content/objects/84',
                 ),
             ),
             $result,

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestUserGroupRoleAssignmentTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestUserGroupRoleAssignmentTest.php
@@ -51,11 +51,9 @@ class RestUserGroupRoleAssignmentTest extends ValueObjectVisitorBaseTest
             ),
             "/user/groups/1/5/14/roles/{$userGroupRoleAssignment->roleAssignment->role->id}"
         );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadRole',
-            array('roleId' => $userGroupRoleAssignment->roleAssignment->role->id),
-            "/user/roles/{$userGroupRoleAssignment->roleAssignment->role->id}"
-        );
+        $this->setVisitValueObjectExpectations([
+            new Values\ResourceRouteReference('ezpublish_rest_loadRole', ['roleId' => $userGroupRoleAssignment->roleAssignment->role->id]),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -106,7 +104,6 @@ class RestUserGroupRoleAssignmentTest extends ValueObjectVisitorBaseTest
                 'tag' => 'RoleAssignment',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.RoleAssignment+xml',
-                    'href' => '/user/groups/1/5/14/roles/42',
                 ),
             ),
             $result,
@@ -148,7 +145,6 @@ class RestUserGroupRoleAssignmentTest extends ValueObjectVisitorBaseTest
                 'tag' => 'Role',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.Role+xml',
-                    'href' => '/user/roles/42',
                 ),
             ),
             $result,

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestUserGroupTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestUserGroupTest.php
@@ -11,6 +11,7 @@
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 use eZ\Publish\Core\REST\Server\Values\RestUserGroup;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\Repository\Values;
@@ -30,65 +31,22 @@ class RestUserGroupTest extends ValueObjectVisitorBaseTest
 
         $restUserGroup = $this->getBasicRestUserGroup();
 
-        $this->getVisitorMock()->expects($this->once())
-            ->method('visitValueObject');
-
         $userGroupPath = implode('/', $restUserGroup->mainLocation->path);
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadUserGroup',
-            array('groupPath' => $userGroupPath),
-            "/user/groups/{$userGroupPath}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContentType',
-            array('contentTypeId' => $restUserGroup->contentInfo->contentTypeId),
-            "/content/types/{$restUserGroup->contentInfo->contentTypeId}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContentVersions',
-            array('contentId' => $restUserGroup->contentInfo->id),
-            "/content/objects/{$restUserGroup->contentInfo->id}/versions"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadSection',
-            array('sectionId' => $restUserGroup->contentInfo->sectionId),
-            "/content/sections/{$restUserGroup->contentInfo->sectionId}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadLocation',
-            array('locationPath' => $userGroupPath),
-            "/content/locations/{$userGroupPath}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadLocationsForContent',
-            array('contentId' => $restUserGroup->contentInfo->id),
-            "/content/objects/{$restUserGroup->contentInfo->id}/locations"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadUser',
-            array('userId' => $restUserGroup->contentInfo->ownerId),
-            "/user/users/{$restUserGroup->contentInfo->ownerId}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadUserGroup',
-            array('groupPath' => '1/2'),
-            '/user/groups/1/2'
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadSubUserGroups',
-            array('groupPath' => $userGroupPath),
-            "/user/groups/{$userGroupPath}/subgroups"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadUsersFromGroup',
-            array('groupPath' => $userGroupPath),
-            "/user/groups/{$userGroupPath}/users"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadRoleAssignmentsForUserGroup',
-            array('groupPath' => $userGroupPath),
-            "/user/groups/{$userGroupPath}/roles"
-        );
+
+        $this->setVisitValueObjectExpectations([
+            new ResourceRouteReference('ezpublish_rest_loadUserGroup', ['groupPath' => $userGroupPath]),
+            new ResourceRouteReference('ezpublish_rest_loadContentType', ['contentTypeId' => $restUserGroup->contentInfo->contentTypeId]),
+            new ResourceRouteReference('ezpublish_rest_loadContentVersions', ['contentId' => $restUserGroup->contentInfo->id]),
+            new ResourceRouteReference('ezpublish_rest_loadSection', ['sectionId' => $restUserGroup->contentInfo->sectionId]),
+            new ResourceRouteReference('ezpublish_rest_loadLocation', ['locationPath' => $userGroupPath]),
+            new ResourceRouteReference('ezpublish_rest_loadLocationsForContent', ['contentId' => $restUserGroup->contentInfo->id]),
+            new ResourceRouteReference('ezpublish_rest_loadUser', ['userId' => $restUserGroup->contentInfo->ownerId]),
+            $this->isInstanceOf('eZ\Publish\Core\REST\Server\Values\Version'),
+            new ResourceRouteReference('ezpublish_rest_loadUserGroup', ['groupPath' => '1/2']),
+            new ResourceRouteReference('ezpublish_rest_loadSubUserGroups', ['groupPath' => $userGroupPath]),
+            new ResourceRouteReference('ezpublish_rest_loadUsersFromGroup', ['groupPath' => $userGroupPath]),
+            new ResourceRouteReference('ezpublish_rest_loadRoleAssignmentsForUserGroup', ['groupPath' => $userGroupPath]),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -143,16 +101,6 @@ class RestUserGroupTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisitWithoutEmbeddedVersion
      */
-    public function testUserGroupHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/UserGroup[@href="/user/groups/1/2/23"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
     public function testUserGroupIdCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/UserGroup[@id="content23"]');
@@ -183,16 +131,6 @@ class RestUserGroupTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisitWithoutEmbeddedVersion
      */
-    public function testUserGroupTypeHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/UserGroup/ContentType[@href="/content/types/contentType23"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
     public function testUserGroupTypeMediaTypeCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/UserGroup/ContentType[@media-type="application/vnd.ez.api.ContentType+xml"]');
@@ -213,29 +151,9 @@ class RestUserGroupTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisitWithoutEmbeddedVersion
      */
-    public function testVersionsHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/UserGroup/Versions[@href="/content/objects/content23/versions"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
     public function testVersionsMediaTypeCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/UserGroup/Versions[@media-type="application/vnd.ez.api.VersionList+xml"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
-    public function testSectionHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/UserGroup/Section[@href="/content/sections/section23"]');
     }
 
     /**
@@ -253,16 +171,6 @@ class RestUserGroupTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisitWithoutEmbeddedVersion
      */
-    public function testMainLocationHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/UserGroup/MainLocation[@href="/content/locations/1/2/23"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
     public function testMainLocationMediaTypeCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/UserGroup/MainLocation[@media-type="application/vnd.ez.api.Location+xml"]');
@@ -273,29 +181,9 @@ class RestUserGroupTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisitWithoutEmbeddedVersion
      */
-    public function testLocationsHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/UserGroup/Locations[@href="/content/objects/content23/locations"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
     public function testLocationsMediaTypeCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/UserGroup/Locations[@media-type="application/vnd.ez.api.LocationList+xml"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
-    public function testOwnerHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/UserGroup/Owner[@href="/user/users/user23"]');
     }
 
     /**
@@ -336,46 +224,6 @@ class RestUserGroupTest extends ValueObjectVisitorBaseTest
     public function testAlwaysAvailableCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/UserGroup/alwaysAvailable[text()="true"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
-    public function testParentUserGroupHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/UserGroup/ParentUserGroup[@href="/user/groups/1/2"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
-    public function testSubgroupsHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/UserGroup/Subgroups[@href="/user/groups/1/2/23/subgroups"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
-    public function testUsersHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/UserGroup/Users[@href="/user/groups/1/2/23/users"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
-    public function testRolesHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/UserGroup/Roles[@href="/user/groups/1/2/23/roles"]');
     }
 
     /**

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestUserRoleAssignmentTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestUserRoleAssignmentTest.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\Repository\Values\User;
 use eZ\Publish\Core\REST\Server\Values;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 class RestUserRoleAssignmentTest extends ValueObjectVisitorBaseTest
 {
@@ -52,11 +53,9 @@ class RestUserRoleAssignmentTest extends ValueObjectVisitorBaseTest
             "/user/users/{$userRoleAssignment->id}/roles/{$userRoleAssignment->roleAssignment->role->id}"
         );
 
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadRole',
-            array('roleId' => $userRoleAssignment->roleAssignment->role->id),
-            "/user/roles/{$userRoleAssignment->roleAssignment->role->id}"
-        );
+        $this->setVisitValueObjectExpectations([
+            new ResourceRouteReference('ezpublish_rest_loadRole', ['roleId' => $userRoleAssignment->roleAssignment->role->id]),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -107,7 +106,6 @@ class RestUserRoleAssignmentTest extends ValueObjectVisitorBaseTest
                 'tag' => 'RoleAssignment',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.RoleAssignment+xml',
-                    'href' => '/user/users/14/roles/42',
                 ),
             ),
             $result,
@@ -149,7 +147,6 @@ class RestUserRoleAssignmentTest extends ValueObjectVisitorBaseTest
                 'tag' => 'Role',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.Role+xml',
-                    'href' => '/user/roles/42',
                 ),
             ),
             $result,

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestUserTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestUserTest.php
@@ -11,6 +11,7 @@
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 use eZ\Publish\Core\REST\Server\Values\RestUser;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\Repository\Values;
@@ -30,60 +31,25 @@ class RestUserTest extends ValueObjectVisitorBaseTest
 
         $restUser = $this->getBasicRestUser();
 
-        $this->getVisitorMock()->expects($this->once())
-            ->method('visitValueObject');
-
         $locationPath = implode('/', $restUser->mainLocation->path);
         $this->addRouteExpectation(
             'ezpublish_rest_loadUser',
             array('userId' => $restUser->contentInfo->id),
             "/user/users/{$restUser->contentInfo->id}"
         );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContentType',
-            array('contentTypeId' => $restUser->contentInfo->contentTypeId),
-            "/content/types/{$restUser->contentInfo->contentTypeId}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContentVersions',
-            array('contentId' => $restUser->contentInfo->id),
-            "/content/objects/{$restUser->contentInfo->id}/versions"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadSection',
-            array('sectionId' => $restUser->contentInfo->sectionId),
-            "/content/sections/{$restUser->contentInfo->sectionId}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadLocation',
-            array('locationPath' => $locationPath),
-            "/content/locations/{$locationPath}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadLocationsForContent',
-            array('contentId' => $restUser->contentInfo->id),
-            "/content/objects/{$restUser->contentInfo->id}/locations"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadUserGroupsOfUser',
-            array('userId' => $restUser->contentInfo->id),
-            "/user/users/{$restUser->contentInfo->id}/groups"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadUser',
-            array('userId' => $restUser->contentInfo->ownerId),
-            "/user/users/{$restUser->contentInfo->ownerId}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadUserGroupsOfUser',
-            array('userId' => $restUser->contentInfo->id),
-            "/user/users/{$restUser->contentInfo->id}/groups"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadRoleAssignmentsForUser',
-            array('userId' => $restUser->contentInfo->id),
-            "/user/users/{$restUser->contentInfo->id}/roles"
-        );
+
+        $this->setVisitValueObjectExpectations([
+            new ResourceRouteReference('ezpublish_rest_loadContentType', ['contentTypeId' => $restUser->contentInfo->contentTypeId]),
+            new ResourceRouteReference('ezpublish_rest_loadContentVersions', ['contentId' => $restUser->contentInfo->id]),
+            new ResourceRouteReference('ezpublish_rest_loadSection', ['sectionId' => $restUser->contentInfo->sectionId]),
+            new ResourceRouteReference('ezpublish_rest_loadLocation', ['locationPath' => $locationPath]),
+            new ResourceRouteReference('ezpublish_rest_loadLocationsForContent', ['contentId' => $restUser->contentInfo->id]),
+            new ResourceRouteReference('ezpublish_rest_loadUserGroupsOfUser', ['userId' => $restUser->contentInfo->id]),
+            new ResourceRouteReference('ezpublish_rest_loadUser', ['userId' => $restUser->contentInfo->ownerId]),
+            $this->isInstanceOf('eZ\Publish\Core\REST\Server\Values\Version'),
+            new ResourceRouteReference('ezpublish_rest_loadUserGroupsOfUser', ['userId' => $restUser->contentInfo->id]),
+            new ResourceRouteReference('ezpublish_rest_loadRoleAssignmentsForUser', ['userId' => $restUser->contentInfo->id]),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -178,16 +144,6 @@ class RestUserTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisitWithoutEmbeddedVersion
      */
-    public function testUserTypeHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/User/ContentType[@href="/content/types/contentType23"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
     public function testUserTypeMediaTypeCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/User/ContentType[@media-type="application/vnd.ez.api.ContentType+xml"]');
@@ -208,29 +164,9 @@ class RestUserTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisitWithoutEmbeddedVersion
      */
-    public function testVersionsHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/User/Versions[@href="/content/objects/content23/versions"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
     public function testVersionsMediaTypeCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/User/Versions[@media-type="application/vnd.ez.api.VersionList+xml"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
-    public function testSectionHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/User/Section[@href="/content/sections/section23"]');
     }
 
     /**
@@ -248,16 +184,6 @@ class RestUserTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisitWithoutEmbeddedVersion
      */
-    public function testMainLocationHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/User/MainLocation[@href="/content/locations/1/2/23"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
     public function testMainLocationMediaTypeCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/User/MainLocation[@media-type="application/vnd.ez.api.Location+xml"]');
@@ -268,29 +194,9 @@ class RestUserTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisitWithoutEmbeddedVersion
      */
-    public function testLocationsHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/User/Locations[@href="/content/objects/content23/locations"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
     public function testLocationsMediaTypeCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/User/Locations[@media-type="application/vnd.ez.api.LocationList+xml"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
-    public function testOwnerHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/User/Owner[@href="/user/users/user23"]');
     }
 
     /**
@@ -338,29 +244,9 @@ class RestUserTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisitWithoutEmbeddedVersion
      */
-    public function testUserGroupsHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/User/UserGroups[@href="/user/users/content23/groups"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
     public function testUserGroupsMediaTypeCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/User/UserGroups[@media-type="application/vnd.ez.api.UserGroupList+xml"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisitWithoutEmbeddedVersion
-     */
-    public function testRolesHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/User/Roles[@href="/user/users/content23/roles"]');
     }
 
     /**

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RoleTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RoleTest.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\Repository\Values\User;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 class RoleTest extends ValueObjectVisitorBaseTest
 {
@@ -47,7 +48,9 @@ class RoleTest extends ValueObjectVisitorBaseTest
         );
 
         $this->addRouteExpectation('ezpublish_rest_loadRole', array('roleId' => $role->id), "/user/roles/{$role->id}");
-        $this->addRouteExpectation('ezpublish_rest_loadPolicies', array('roleId' => $role->id), "/user/roles/{$role->id}/policies");
+        $this->setVisitValueObjectExpectations([
+            new ResourceRouteReference('ezpublish_rest_loadPolicies', ['roleId' => $role->id]),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -98,7 +101,6 @@ class RoleTest extends ValueObjectVisitorBaseTest
                 'tag' => 'Role',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.Role+xml',
-                    'href' => '/user/roles/42',
                 ),
             ),
             $result,
@@ -227,7 +229,6 @@ class RoleTest extends ValueObjectVisitorBaseTest
                 'tag' => 'Policies',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.PolicyList+xml',
-                    'href' => '/user/roles/42/policies',
                 ),
             ),
             $result,

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserGroupRefListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserGroupRefListTest.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\Repository\Values\User\UserGroup;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 use eZ\Publish\Core\REST\Server\Values\UserGroupRefList;
 use eZ\Publish\Core\REST\Server\Values\RestUserGroup;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -63,29 +64,12 @@ class UserGroupRefListTest extends ValueObjectVisitorBaseTest
             14
         );
 
-        $groupPath = trim($UserGroupRefList->userGroups[0]->mainLocation->pathString, '/');
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadUserGroup',
-            array('groupPath' => $groupPath),
-            "/user/groups/{$groupPath}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_unassignUserFromUserGroup',
-            array('userId' => $UserGroupRefList->userId, 'groupPath' => 14),
-            '/user/users/14/groups/14'
-        );
-
-        $groupPath = trim($UserGroupRefList->userGroups[1]->mainLocation->pathString, '/');
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadUserGroup',
-            array('groupPath' => '1/5/13'),
-            "/user/groups/{$groupPath}"
-        );
-        $this->addRouteExpectation(
-            'ezpublish_rest_unassignUserFromUserGroup',
-            array('userId' => $UserGroupRefList->userId, 'groupPath' => 13),
-            '/user/users/14/groups/13'
-        );
+        $this->setVisitValueObjectExpectations([
+            new ResourceRouteReference('ezpublish_rest_loadUserGroup', ['groupPath' => '1/5/14']),
+            new ResourceRouteReference('ezpublish_rest_unassignUserFromUserGroup', ['userId' => $UserGroupRefList->userId, 'groupPath' => 14]),
+            new ResourceRouteReference('ezpublish_rest_loadUserGroup', ['groupPath' => '1/5/13']),
+            new ResourceRouteReference('ezpublish_rest_unassignUserFromUserGroup', ['userId' => $UserGroupRefList->userId, 'groupPath' => 13]),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -108,29 +92,9 @@ class UserGroupRefListTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisit
      */
-    public function testUserGroupRefListHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/UserGroupRefList[@href="/some/path"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisit
-     */
     public function testUserGroupRefListMediaTypeCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/UserGroupRefList[@media-type="application/vnd.ez.api.UserGroupRefList+xml"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisit
-     */
-    public function testFirstUserGroupHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/UserGroupRefList/UserGroup[1][@href="/user/groups/1/5/14"]');
     }
 
     /**
@@ -148,16 +112,6 @@ class UserGroupRefListTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisit
      */
-    public function testFirstUserGroupUnassignHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/UserGroupRefList/UserGroup[1]/unassign[@href="/user/users/14/groups/14"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisit
-     */
     public function testFirstUserGroupUnassignMethodCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/UserGroupRefList/UserGroup[1]/unassign[@method="DELETE"]');
@@ -168,29 +122,9 @@ class UserGroupRefListTest extends ValueObjectVisitorBaseTest
      *
      * @depends testVisit
      */
-    public function testSecondUserGroupHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/UserGroupRefList/UserGroup[2][@href="/user/groups/1/5/13"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisit
-     */
     public function testSecondUserGroupMediaTypeCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/UserGroupRefList/UserGroup[2][@media-type="application/vnd.ez.api.UserGroup+xml"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisit
-     */
-    public function testSecondUserGroupUnassignHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/UserGroupRefList/UserGroup[2]/unassign[@href="/user/users/14/groups/13"]');
     }
 
     /**

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserRefListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserRefListTest.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\Repository\Values\User\User;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 use eZ\Publish\Core\REST\Server\Values\UserRefList;
 use eZ\Publish\Core\REST\Server\Values\RestUser;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -49,11 +50,9 @@ class UserRefListTest extends ValueObjectVisitorBaseTest
             '/some/path'
         );
 
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadUser',
-            array('userId' => $UserRefList->users[0]->contentInfo->id),
-            "/user/users/{$UserRefList->users[0]->contentInfo->id}"
-        );
+        $this->setVisitValueObjectExpectations([
+            new ResourceRouteReference('ezpublish_rest_loadUser', ['userId' => $UserRefList->users[0]->contentInfo->id]),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -89,16 +88,6 @@ class UserRefListTest extends ValueObjectVisitorBaseTest
     public function testUserRefListMediaTypeCorrect(\DOMDocument $dom)
     {
         $this->assertXPath($dom, '/UserRefList[@media-type="application/vnd.ez.api.UserRefList+xml"]');
-    }
-
-    /**
-     * @param \DOMDocument $dom
-     *
-     * @depends testVisit
-     */
-    public function testUserHrefCorrect(\DOMDocument $dom)
-    {
-        $this->assertXPath($dom, '/UserRefList/User[@href="/user/users/14"]');
     }
 
     /**

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserSessionCreatedTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserSessionCreatedTest.php
@@ -50,11 +50,9 @@ class UserSessionCreatedTest extends UserSessionTest
             "/user/sessions/{$session->sessionId}"
         );
 
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadUser',
-            array('userId' => $session->user->id),
-            "/user/users/{$session->user->id}"
-        );
+        $this->setVisitValueObjectExpectations([
+            new Values\ResourceRouteReference('ezpublish_rest_loadUser', ['userId' => $session->user->id]),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserSessionTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserSessionTest.php
@@ -52,11 +52,9 @@ class UserSessionTest extends ValueObjectVisitorBaseTest
             "/user/sessions/{$session->sessionId}"
         );
 
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadUser',
-            array('userId' => $session->user->id),
-            "/user/users/{$session->user->id}"
-        );
+        $this->setVisitValueObjectExpectations([
+            new Values\ResourceRouteReference('ezpublish_rest_loadUser', ['userId' => $session->user->id]),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -219,7 +217,6 @@ class UserSessionTest extends ValueObjectVisitorBaseTest
             array(
                 'tag' => 'User',
                 'attributes' => array(
-                    'href' => '/user/users/user123',
                     'media-type' => 'application/vnd.ez.api.User+xml',
                 ),
             ),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/VersionInfoTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/VersionInfoTest.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\Repository\Values\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\REST\Server\Values\ResourceRouteReference;
 
 class VersionInfoTest extends ValueObjectVisitorBaseTest
 {
@@ -63,17 +64,10 @@ class VersionInfoTest extends ValueObjectVisitorBaseTest
             )
         );
 
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadUser',
-            array('userId' => $versionInfo->creatorId),
-            "/user/users/{$versionInfo->creatorId}"
-        );
-
-        $this->addRouteExpectation(
-            'ezpublish_rest_loadContent',
-            array('contentId' => $versionInfo->contentInfo->id),
-            "/content/objects/{$versionInfo->contentInfo->id}"
-        );
+        $this->setVisitValueObjectExpectations([
+            new ResourceRouteReference('ezpublish_rest_loadUser', ['userId' => $versionInfo->creatorId]),
+            new ResourceRouteReference('ezpublish_rest_loadContent', ['contentId' => $versionInfo->contentInfo->id]),
+        ]);
 
         $visitor->visit(
             $this->getVisitorMock(),
@@ -268,7 +262,6 @@ class VersionInfoTest extends ValueObjectVisitorBaseTest
                 'tag' => 'Content',
                 'attributes' => array(
                     'media-type' => 'application/vnd.ez.api.ContentInfo+xml',
-                    'href' => '/content/objects/42',
                 ),
             ),
             $result,

--- a/eZ/Publish/Core/REST/Server/Tests/ValueLoaders/ControllerUriValueLoaderTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/ValueLoaders/ControllerUriValueLoaderTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Tests\ValueLoaders;
+
+use eZ\Publish\Core\REST\Server\ValueLoaders\ControllerUriValueLoader;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class ControllerUriValueLoaderTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \eZ\Publish\Core\REST\Server\ValueLoaders\ControllerUriValueLoader
+     */
+    private $loader;
+
+    /**
+     * @var \Symfony\Component\Routing\RouterInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $routerMock;
+
+    /**
+     * @var \Symfony\Component\Routing\RouterInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $controllerResolverMock;
+
+    public function setUp()
+    {
+        $this->loader = new ControllerUriValueLoader(
+            $this->routerMock = $this->getMock('Symfony\Component\Routing\RouterInterface'),
+            $this->controllerResolverMock = $this->getMock('Symfony\Component\HttpKernel\Controller\ControllerResolverInterface')
+        );
+    }
+
+    /**
+     * Covers the normal behaviour of the load method.
+     */
+    public function testLoad()
+    {
+        $controllerArray = ['_controller' => 'some:controller', 'id' => 1];
+
+        $valueObject = new \stdClass();
+
+        $this->routerMock
+            ->expects($this->once())
+            ->method('match')
+            ->with('/api/ezp/v2/resource/1')
+            ->will($this->returnValue($controllerArray));
+
+        $this->controllerResolverMock
+            ->expects($this->once())
+            ->method('getController')
+            ->will($this->returnValue(
+                function () use ($valueObject) { return $valueObject; }
+            ));
+
+        $this->controllerResolverMock
+            ->expects($this->once())
+            ->method('getArguments')
+            ->will($this->returnValue(['id' => 1]));
+
+        self::assertSame(
+            $valueObject,
+            $this->loader->load('/api/ezp/v2/resource/1')
+        );
+    }
+
+    /**
+     * @expectedException \UnexpectedValueException
+     * @expectedExceptionMessage Expected the controller to return a Value object, got a Response instead
+     */
+    public function testLoadReturnsResponse()
+    {
+        $controllerArray = ['_controller' => 'some:controller', 'id' => 1];
+
+        $valueObject = new Response();
+
+        $this->routerMock
+            ->expects($this->once())
+            ->method('match')
+            ->with('/api/ezp/v2/resource/1')
+            ->will($this->returnValue($controllerArray));
+
+        $this->controllerResolverMock
+            ->expects($this->once())
+            ->method('getController')
+            ->will($this->returnValue(
+                function () use ($valueObject) { return $valueObject; }
+            ));
+
+        $this->controllerResolverMock
+            ->expects($this->once())
+            ->method('getArguments')
+            ->will($this->returnValue(['id' => 1]));
+
+        $this->loader->load('/api/ezp/v2/resource/1');
+    }
+}

--- a/eZ/Publish/Core/REST/Server/ValueLoaders/ControllerUriValueLoader.php
+++ b/eZ/Publish/Core/REST/Server/ValueLoaders/ControllerUriValueLoader.php
@@ -37,10 +37,14 @@ class ControllerUriValueLoader implements UriValueLoader
         $this->controllerResolver = $controllerResolver;
     }
 
-    public function load($restResourceLink)
+    public function load($restResourceLink, $mediaType = null)
     {
         $request = Request::create($restResourceLink);
         $request->attributes->add($this->router->match($restResourceLink));
+
+        if ($mediaType !== null) {
+            $request->headers->set('Accept', $mediaType);
+        }
 
         $controller = $this->controllerResolver->getController($request);
         $arguments = $this->controllerResolver->getArguments($request, $controller);

--- a/eZ/Publish/Core/REST/Server/ValueLoaders/ControllerUriValueLoader.php
+++ b/eZ/Publish/Core/REST/Server/ValueLoaders/ControllerUriValueLoader.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This file is part of the ezplatform package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\ValueLoaders;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\Routing\RouterInterface;
+use UnexpectedValueException;
+
+/**
+ * An URI value loader that uses router to run the matching controller and load the value.
+ *
+ * The URL is matched using the router, the controller configured with the ControllerResolver, and executed.
+ * Since Rest controllers don't return a response but a Value Object, the result can be used directly.
+ */
+class ControllerUriValueLoader implements UriValueLoader
+{
+    /**
+     * @var RouterInterface
+     */
+    private $router;
+
+    /**
+     * @var ControllerResolverInterface
+     */
+    private $controllerResolver;
+
+    public function __construct(RouterInterface $router, ControllerResolverInterface $controllerResolver)
+    {
+        $this->router = $router;
+        $this->controllerResolver = $controllerResolver;
+    }
+
+    public function load($restResourceLink)
+    {
+        $request = Request::create($restResourceLink);
+        $request->attributes->add($this->router->match($restResourceLink));
+
+        $controller = $this->controllerResolver->getController($request);
+        $arguments = $this->controllerResolver->getArguments($request, $controller);
+
+        $value = call_user_func_array($controller, $arguments);
+
+        if ($value instanceof Response) {
+            throw new UnexpectedValueException('Expected the controller to return a Value object, got a Response instead');
+        }
+
+        return $value;
+    }
+}

--- a/eZ/Publish/Core/REST/Server/ValueLoaders/UriValueLoader.php
+++ b/eZ/Publish/Core/REST/Server/ValueLoaders/UriValueLoader.php
@@ -12,8 +12,9 @@ interface UriValueLoader
 {
     /**
      * @param string $uri REST URI to a value object. Ex: /api/ezp/v2/content/objects/1
+     * @param string $mediaType The media-type to load, default if not specified. Ex: application/vnd.ez.api.Content+xml.
      *
      * @return \eZ\Publish\API\Repository\Values\ValueObject
      */
-    public function load($uri);
+    public function load($uri, $mediaType = null);
 }

--- a/eZ/Publish/Core/REST/Server/ValueLoaders/UriValueLoader.php
+++ b/eZ/Publish/Core/REST/Server/ValueLoaders/UriValueLoader.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\ValueLoaders;
+
+/**
+ * A value object loader that uses the rest URI as an argument.
+ */
+interface UriValueLoader
+{
+    /**
+     * @param string $uri REST URI to a value object. Ex: /api/ezp/v2/content/objects/1
+     *
+     * @return \eZ\Publish\API\Repository\Values\ValueObject
+     */
+    public function load($uri);
+}

--- a/eZ/Publish/Core/REST/Server/Values/ResourceLink.php
+++ b/eZ/Publish/Core/REST/Server/Values/ResourceLink.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Values;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * A link to a REST resource.
+ *
+ * @property string $link
+ */
+class ResourceLink extends ValueObject
+{
+    /**
+     * REST resource href.
+     * Example: '/api/ezp/v2/content/objects/1'.
+     *
+     * @var string
+     */
+    protected $link;
+
+    public function __construct($link)
+    {
+        $this->link = $link;
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Values/ResourceLink.php
+++ b/eZ/Publish/Core/REST/Server/Values/ResourceLink.php
@@ -11,6 +11,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * A link to a REST resource.
  *
  * @property string $link
+ * @property string $mediaType
  */
 class ResourceLink extends ValueObject
 {
@@ -22,8 +23,15 @@ class ResourceLink extends ValueObject
      */
     protected $link;
 
-    public function __construct($link)
+    /**
+     * Resource media-type. If not specified, the default one is used.
+     * @var string|null
+     */
+    protected $mediaType;
+
+    public function __construct($link, $mediaType = null)
     {
         $this->link = $link;
+        $this->mediaType = $mediaType;
     }
 }

--- a/eZ/Publish/Core/REST/Server/Values/ResourceRouteReference.php
+++ b/eZ/Publish/Core/REST/Server/Values/ResourceRouteReference.php
@@ -12,6 +12,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  *
  * @property string $route
  * @property array $loadParameters
+ * @property string $mediaTypeName
  */
 class ResourceRouteReference extends ValueObject
 {
@@ -25,9 +26,22 @@ class ResourceRouteReference extends ValueObject
      */
     protected $loadParameters;
 
-    public function __construct($route, $loadParameters)
+    /**
+     * The media-type name (ContentInfo, Location) of the resource. If null, the default will be used.
+     * @var null
+     */
+    protected $mediaTypeName;
+
+    /**
+     * ResourceRouteReference constructor.
+     * @param array $route
+     * @param $loadParameters
+     * @param string $mediaType The media-type name (ContentInfo, Location) of the resource. If null, the default will be used.
+     */
+    public function __construct($route, $loadParameters, $mediaType = null)
     {
         $this->route = $route;
         $this->loadParameters = $loadParameters;
+        $this->mediaTypeName = $mediaType;
     }
 }

--- a/eZ/Publish/Core/REST/Server/Values/ResourceRouteReference.php
+++ b/eZ/Publish/Core/REST/Server/Values/ResourceRouteReference.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Values;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * A reference to a REST resource route.
+ *
+ * @property string $route
+ * @property array $loadParameters
+ */
+class ResourceRouteReference extends ValueObject
+{
+    /**
+     * @var string
+     */
+    protected $route;
+
+    /**
+     * @var array
+     */
+    protected $loadParameters;
+
+    public function __construct($route, $loadParameters)
+    {
+        $this->route = $route;
+        $this->loadParameters = $loadParameters;
+    }
+}


### PR DESCRIPTION
> Implements [EZP-26033](http://jira.ez.no/browse/EZP-26033)
> [Specification](https://github.com/ezsystems/ezpublish-kernel/blob/ezp26033-rest_embedding_prototype-v2_uri_based_value_loading/doc/specifications/proposed/rest_resource_embedding.md)
> Mostly ready for review and testing, one minor (deprecation) todo list item remaining

See the specification for a full technical description of the feature and its implementation.
### TODO
- [x] Rename the value loader, with an interface (`HrefRestResourceLoader` ?)
- [x] Cover multi media-type (example: `Location.Content` loads a `ContentInfo`. The media-type attribute must be used for the value load request. 
- [x] Apply to other visitors once approved
- [x] Update specification
- [x] Design and implement Request format (`x-ez-embed-value` header)
- [x] Add unit test for the loader
- [x] Add support for lists in request format
- [x] Prevent listElement from showing up twice in the `stackPath`
- [x] Update existing tests that break
- [x] Handle automatic parent expansion in request format (ex: `Content.Owner.MainLocation` implies automatic expansion of `Owner` first).
- [x] Add unit test for the `ResourceLink` and `ResourceRouteReference` visitors
- [x] Add a custom attribute to the reference if loading failed (permissions or multiple load).
- [x] Add a recursion protected value loader, that refuses to load the same resource more than once. When it happens, throws an exception.
- [x] Look for remaining `$this->generator->generate()` calls in visitors that need replacing
- [x] Rename the parameters property in `ResourceRouteReference`
- [x] Add unit test for `UniqueUriValueLoader`
- [ ] Deprecate the old way to visit stuff, if it turns out to be necessary
- [ ] Rename to REST include to align with JSON API concept wise where query is used instead of header simplifying use/examples
