### PR TITLE
EZP-25913: notice in SiteAccess\Router in console command

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Router.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Router.php
@@ -220,7 +220,7 @@ class Router implements SiteAccessRouterInterface, SiteAccessAware
 
         $request = clone $this->request;
         // Be sure to have a clean pathinfo, without SiteAccess part in it.
-        if ($this->siteAccess->matcher instanceof URILexer) {
+        if ($this->siteAccess && $this->siteAccess->matcher instanceof URILexer) {
             $request->setPathinfo($this->siteAccess->matcher->analyseURI($request->pathinfo));
         }
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-25913

When using SiteAccess Router (or a service that depends on it) in a console command ('cli' siteaccess) a notice is thrown (siteAccess property is not matched/set).

Fix: just check the property first.