### PR TITLE
Fix EZP-26148: String length validation error contains %-symbols

### DIFF
--- a/eZ/Publish/Core/FieldType/Tests/StringLengthValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/StringLengthValidatorTest.php
@@ -216,19 +216,19 @@ class StringLengthValidatorTest extends PHPUnit_Framework_TestCase
                 '',
                 'The string can not be shorter than %size% character.',
                 'The string can not be shorter than %size% characters.',
-                array('size' => $this->getMinStringLength()),
+                array('%size%' => $this->getMinStringLength()),
             ),
             array(
                 'Hi!',
                 'The string can not be shorter than %size% character.',
                 'The string can not be shorter than %size% characters.',
-                array('size' => $this->getMinStringLength()),
+                array('%size%' => $this->getMinStringLength()),
             ),
             array(
                 '0123456789!',
                 'The string can not exceed %size% character.',
                 'The string can not exceed %size% characters.',
-                array('size' => $this->getMaxStringLength()),
+                array('%size%' => $this->getMaxStringLength()),
             ),
         );
     }
@@ -315,7 +315,7 @@ class StringLengthValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' value must be of integer type"),
                 array(
-                    array('parameter' => 'minStringLength'),
+                    array('%parameter%' => 'minStringLength'),
                 ),
             ),
             array(
@@ -324,7 +324,7 @@ class StringLengthValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' value must be of integer type"),
                 array(
-                    array('parameter' => 'minStringLength'),
+                    array('%parameter%' => 'minStringLength'),
                 ),
             ),
             array(
@@ -334,7 +334,7 @@ class StringLengthValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' value must be of integer type"),
                 array(
-                    array('parameter' => 'minStringLength'),
+                    array('%parameter%' => 'minStringLength'),
                 ),
             ),
             array(
@@ -344,7 +344,7 @@ class StringLengthValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' value must be of integer type"),
                 array(
-                    array('parameter' => 'maxStringLength'),
+                    array('%parameter%' => 'maxStringLength'),
                 ),
             ),
             array(
@@ -354,7 +354,7 @@ class StringLengthValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' value must be of integer type"),
                 array(
-                    array('parameter' => 'minStringLength'),
+                    array('%parameter%' => 'minStringLength'),
                 ),
             ),
             array(
@@ -367,8 +367,8 @@ class StringLengthValidatorTest extends PHPUnit_Framework_TestCase
                     "Validator parameter '%parameter%' value must be of integer type",
                 ),
                 array(
-                    array('parameter' => 'minStringLength'),
-                    array('parameter' => 'maxStringLength'),
+                    array('%parameter%' => 'minStringLength'),
+                    array('%parameter%' => 'maxStringLength'),
                 ),
             ),
             array(
@@ -377,7 +377,7 @@ class StringLengthValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' is unknown"),
                 array(
-                    array('parameter' => 'brljix'),
+                    array('%parameter%' => 'brljix'),
                 ),
             ),
             array(
@@ -387,7 +387,7 @@ class StringLengthValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' is unknown"),
                 array(
-                    array('parameter' => 'brljix'),
+                    array('%parameter%' => 'brljix'),
                 ),
             ),
         );

--- a/eZ/Publish/Core/FieldType/Tests/TextLineTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/TextLineTest.php
@@ -631,7 +631,7 @@ class TextLineTest extends FieldTypeTest
                         'The string can not be shorter than %size% character.',
                         'The string can not be shorter than %size% characters.',
                         array(
-                            'size' => 5,
+                            '%size%' => 5,
                         ),
                         'text'
                     ),
@@ -652,7 +652,7 @@ class TextLineTest extends FieldTypeTest
                         'The string can not exceed %size% character.',
                         'The string can not exceed %size% characters.',
                         array(
-                            'size' => 10,
+                            '%size%' => 10,
                         ),
                         'text'
                     ),
@@ -673,7 +673,7 @@ class TextLineTest extends FieldTypeTest
                         'The string can not exceed %size% character.',
                         'The string can not exceed %size% characters.',
                         array(
-                            'size' => 5,
+                            '%size%' => 5,
                         ),
                         'text'
                     ),
@@ -681,7 +681,7 @@ class TextLineTest extends FieldTypeTest
                         'The string can not be shorter than %size% character.',
                         'The string can not be shorter than %size% characters.',
                         array(
-                            'size' => 10,
+                            '%size%' => 10,
                         ),
                         'text'
                     ),

--- a/eZ/Publish/Core/FieldType/TextLine/Type.php
+++ b/eZ/Publish/Core/FieldType/TextLine/Type.php
@@ -56,7 +56,7 @@ class Type extends FieldType
                     "Validator '%validator%' is unknown",
                     null,
                     array(
-                        'validator' => $validatorIdentifier,
+                        '%validator%' => $validatorIdentifier,
                     )
                 );
                 continue;
@@ -98,7 +98,7 @@ class Type extends FieldType
                 'The string can not exceed %size% character.',
                 'The string can not exceed %size% characters.',
                 array(
-                    'size' => $constraints['maxStringLength'],
+                    '%size%' => $constraints['maxStringLength'],
                 ),
                 'text'
             );
@@ -112,7 +112,7 @@ class Type extends FieldType
                 'The string can not be shorter than %size% character.',
                 'The string can not be shorter than %size% characters.',
                 array(
-                    'size' => $constraints['minStringLength'],
+                    '%size%' => $constraints['minStringLength'],
                 ),
                 'text'
             );

--- a/eZ/Publish/Core/FieldType/Validator/StringLengthValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/StringLengthValidator.php
@@ -50,7 +50,7 @@ class StringLengthValidator extends Validator
                             "Validator parameter '%parameter%' value must be of integer type",
                             null,
                             array(
-                                'parameter' => $name,
+                                '%parameter%' => $name,
                             )
                         );
                     } elseif ($value < 0) {
@@ -58,7 +58,7 @@ class StringLengthValidator extends Validator
                             "Validator parameter '%parameter%' value can't be negative",
                             null,
                             array(
-                                'parameter' => $name,
+                                '%parameter%' => $name,
                             )
                         );
                     }
@@ -68,7 +68,7 @@ class StringLengthValidator extends Validator
                         "Validator parameter '%parameter%' is unknown",
                         null,
                         array(
-                            'parameter' => $name,
+                            '%parameter%' => $name,
                         )
                     );
             }
@@ -77,11 +77,7 @@ class StringLengthValidator extends Validator
         // if no errors above, check if minStringLength is shorter or equal than maxStringLength
         if (empty($validationErrors) && !$this->validateConstraintsOrder($constraints)) {
             $validationErrors[] = new ValidationError(
-                "Validator parameter 'maxStringLength' can't be shorter than validator parameter 'minStringLength' value",
-                null,
-                array(
-                    'parameter' => 'minStringLength',
-                )
+                "Validator parameter 'maxStringLength' can't be shorter than validator parameter 'minStringLength' value"
             );
         }
 
@@ -123,7 +119,7 @@ class StringLengthValidator extends Validator
                 'The string can not exceed %size% character.',
                 'The string can not exceed %size% characters.',
                 array(
-                    'size' => $this->constraints['maxStringLength'],
+                    '%size%' => $this->constraints['maxStringLength'],
                 )
             );
             $isValid = false;
@@ -135,7 +131,7 @@ class StringLengthValidator extends Validator
                 'The string can not be shorter than %size% character.',
                 'The string can not be shorter than %size% characters.',
                 array(
-                    'size' => $this->constraints['minStringLength'],
+                    '%size%' => $this->constraints['minStringLength'],
                 )
             );
             $isValid = false;


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-26148
> Status: Work in progress

Example: `The string can not exceed %42% characters.` - the `%`'s shouldn't be there. The translation parameters are lacking %-symbols, meaning those that exist in the translation string won't be removed when parameters are inserted.

These strings end up in the Symfony `Translator` which uses [strtr](http://php.net/manual/en/function.strtr.php), and that makes no assumptions about %'s, it simply replaces strings verbatim. So if strings are %-wrapped in the translation string, they must also be so in the parameters: http://symfony.com/doc/2.7/components/translation/usage.html#message-placeholders

UNLESS our kernel is supposed to insert %'s as needed, but that doesn't seem to be happening in the case of https://github.com/ezsystems/ezpublish-kernel/pull/1734 at least. Could something have changed in the way the parameters are interpreted?

There are several more of these errors. So many that I'm wondering if I've misunderstood something. I'm getting no good answer from Travis - the failures are because it expects the parameters to lack %'s. It tests that parameters are what they are, not that the translations are sensible.

- [ ] Do the same for other types/validators
- [x] Reopen PR against 6.3 or thereabouts: See https://github.com/ezsystems/ezpublish-kernel/pull/1749