### PR TITLE
EZP-25003: clear HTTP cache when trashing and recovering content

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/slot.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/slot.yml
@@ -16,6 +16,7 @@ parameters:
     ezpublish.http_cache.signalslot.update_user.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UpdateUserSlot
     ezpublish.http_cache.signalslot.assign_user_to_user_group.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\AssignUserToUserGroupSlot
     ezpublish.http_cache.signalslot.unassign_user_from_user_group.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UnassignUserFromUserGroupSlot
+    ezpublish.http_cache.signalslot.trash.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\TrashSlot
 
 services:
     ezpublish.http_cache.signalslot.http_cache:
@@ -118,3 +119,9 @@ services:
         parent: ezpublish.http_cache.signalslot.http_cache
         tags:
             - { name: ezpublish.api.slot, signal: UserService\UnAssignUserFromUserGroupSignal }
+
+    ezpublish.http_cache.signalslot.trash:
+        class: "%ezpublish.http_cache.signalslot.trash.class%"
+        parent: ezpublish.http_cache.signalslot.http_cache
+        tags:
+            - { name: ezpublish.api.slot, signal: TrashService\TrashSignal }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/slot.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/slot.yml
@@ -17,6 +17,7 @@ parameters:
     ezpublish.http_cache.signalslot.assign_user_to_user_group.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\AssignUserToUserGroupSlot
     ezpublish.http_cache.signalslot.unassign_user_from_user_group.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UnassignUserFromUserGroupSlot
     ezpublish.http_cache.signalslot.trash.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\TrashSlot
+    ezpublish.http_cache.signalslot.recover.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\RecoverSlot
 
 services:
     ezpublish.http_cache.signalslot.http_cache:
@@ -125,3 +126,9 @@ services:
         parent: ezpublish.http_cache.signalslot.http_cache
         tags:
             - { name: ezpublish.api.slot, signal: TrashService\TrashSignal }
+
+    ezpublish.http_cache.signalslot.recover:
+        class: "%ezpublish.http_cache.signalslot.recover.class%"
+        parent: ezpublish.http_cache.signalslot.http_cache
+        tags:
+            - { name: ezpublish.api.slot, signal: TrashService\RecoverSignal }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/GatewayCachePurger.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/GatewayCachePurger.php
@@ -32,8 +32,9 @@ interface GatewayCachePurger
      * If given content has several locations, cache will be purged for all of them.
      *
      * @param mixed $contentId Content ID.
+     * @param array $locationIds
      */
-    public function purgeForContent($contentId);
+    public function purgeForContent($contentId, $locationIds = []);
 
     /**
      * Triggers the cache purge for all content in cache.

--- a/eZ/Publish/Core/MVC/Symfony/Cache/GatewayCachePurger.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/GatewayCachePurger.php
@@ -16,23 +16,24 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache;
 interface GatewayCachePurger
 {
     /**
-     * Triggers the cache purge of given $cacheElements.
-     * It's up to the implementor to decide whether to purge $cacheElements right away or to delegate to a separate process.
+     * Triggers the cache purge of given $locationIds.
      *
-     * @deprecated as of 6.0. Will be removed in 7.0. Use purgeForContent() instead.
+     * @deprecated as of 6.0, might be removed in a future major version. Use purgeForContent() instead when content exist.
      *
-     * @param mixed $cacheElements
+     * @param array $locationIds
      *
      * @return mixed
      */
-    public function purge($cacheElements);
+    public function purge($locationIds);
 
     /**
-     * Triggers cache purge for given content.
-     * If given content has several locations, cache will be purged for all of them.
+     * Purge Content cache using $locationIds and gather additional relevant cache to clear based on $contentId.
+     *
+     * @deprecated in 6.5, design flaw on deleted/trashed content, use purge() when content does not exist for now.
+     *             See EZP-25696 for potential future feature to solve this.
      *
      * @param mixed $contentId Content ID.
-     * @param array $locationIds
+     * @param array $locationIds Initial location id's from signal to take into account.
      */
     public function purgeForContent($contentId, $locationIds = []);
 

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/InstantCachePurger.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/InstantCachePurger.php
@@ -63,15 +63,26 @@ class InstantCachePurger implements GatewayCachePurger
         $this->purgeClient->purgeAll();
     }
 
-    public function purgeForContent($contentId)
+    /**
+     * Purge Content cache using location id's returned from ContentCacheClearEvent.
+     *
+     * @deprecated in 6.5, design flaw on deleted/trashed content, use purge() on cases you are affected by this for now.
+     *
+     * @param mixed $contentId
+     * @param array $locationIds Initial location id's from signal to take into account.
+     */
+    public function purgeForContent($contentId, $locationIds = [])
     {
         $contentInfo = $this->contentService->loadContentInfo($contentId);
-        $event = new ContentCacheClearEvent($contentInfo);
-        $this->eventDispatcher->dispatch(MVCEvents::CACHE_CLEAR_CONTENT, $event);
 
-        $locationIds = [];
-        foreach ($event->getLocationsToClear() as $location) {
-            $locationIds[] = $location->id;
+        // Can only gather relevant locations using ContentCacheClearEvent on published content
+        if ($contentInfo->published) {
+            $event = new ContentCacheClearEvent($contentInfo);
+            $this->eventDispatcher->dispatch(MVCEvents::CACHE_CLEAR_CONTENT, $event);
+
+            foreach ($event->getLocationsToClear() as $location) {
+                $locationIds[] = $location->id;
+            }
         }
 
         $this->purgeClient->purge(array_unique($locationIds));

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/InstantCachePurger.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/InstantCachePurger.php
@@ -45,31 +45,25 @@ class InstantCachePurger implements GatewayCachePurger
     }
 
     /**
-     * @deprecated as of 6.0. Will be removed in 7.0. Use purgeForContent() instead.
-     *
-     * @param mixed $cacheElements
-     *
-     * @return mixed
+     * {@inheritdoc}
      */
-    public function purge($cacheElements)
+    public function purge($locationIds)
     {
-        $this->purgeClient->purge((array)$cacheElements);
+        $this->purgeClient->purge((array)$locationIds);
 
-        return $cacheElements;
+        return $locationIds;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function purgeAll()
     {
         $this->purgeClient->purgeAll();
     }
 
     /**
-     * Purge Content cache using location id's returned from ContentCacheClearEvent.
-     *
-     * @deprecated in 6.5, design flaw on deleted/trashed content, use purge() on cases you are affected by this for now.
-     *
-     * @param mixed $contentId
-     * @param array $locationIds Initial location id's from signal to take into account.
+     * {@inheritdoc}
      */
     public function purgeForContent($contentId, $locationIds = [])
     {

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/LocalPurgeClient.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/LocalPurgeClient.php
@@ -30,7 +30,7 @@ class LocalPurgeClient implements PurgeClientInterface
     }
 
     /**
-     * Triggers the cache purge $cacheElements.
+     * Triggers the cache purge $locationIds.
      *
      * @param mixed $locationIds Cache resource(s) to purge (e.g. array of URI to purge in a reverse proxy)
      */

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/DeleteContentSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/DeleteContentSlot.php
@@ -14,8 +14,10 @@ use eZ\Publish\Core\SignalSlot\Signal;
 
 /**
  * A slot handling DeleteContentSignal.
+ *
+ * @todo Change to clear precise cache items on content deletion (implies changes to how this signal is used and emitted).
  */
-class DeleteContentSlot extends PurgeForContentHttpCacheSlot
+class DeleteContentSlot extends PurgeAllHttpCacheSlot
 {
     protected function supports(Signal $signal)
     {

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/DeleteLocationSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/DeleteLocationSlot.php
@@ -10,6 +10,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot;
 
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\Core\SignalSlot\Signal;
 
 /**
@@ -20,5 +21,26 @@ class DeleteLocationSlot extends PurgeForContentHttpCacheSlot
     protected function supports(Signal $signal)
     {
         return $signal instanceof Signal\LocationService\DeleteLocationSignal;
+    }
+
+    /**
+     * Purges relevant location cache.
+     *
+     * @todo Change to be able to clear relations, siblings, ... cache, even when content is already deleted.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal\LocationService\DeleteLocationSignal $signal
+     *
+     * @return mixed
+     */
+    protected function purgeHttpCache(Signal $signal)
+    {
+        try {
+            $locationIds = $this->extractLocationIds($signal);
+
+            return $this->httpCacheClearer->purgeForContent($this->extractContentId($signal), $locationIds);
+        } catch (NotFoundException $e) {
+            // if content was deleted as well by this operation then fall back to clear location and parent location cache.
+            $this->httpCacheClearer->purge($locationIds);
+        }
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/PurgeAllHttpCacheSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/PurgeAllHttpCacheSlot.php
@@ -15,6 +15,8 @@ use eZ\Publish\Core\SignalSlot\Slot;
 
 /**
  * An abstract slot for clearing all http caches.
+ *
+ * @deprecated By design clears all cache, will be removed in favour of more precise cache clearing.
  */
 abstract class PurgeAllHttpCacheSlot extends HttpCacheSlot
 {

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/PurgeForContentHttpCacheSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/PurgeForContentHttpCacheSlot.php
@@ -11,7 +11,6 @@
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
-use eZ\Publish\Core\SignalSlot\Slot;
 
 /**
  * An abstract HTTP Cache purging Slot that purges cache for a Content.

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/PurgeForContentHttpCacheSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/PurgeForContentHttpCacheSlot.php
@@ -30,16 +30,41 @@ abstract class PurgeForContentHttpCacheSlot extends HttpCacheSlot
      */
     protected function purgeHttpCache(Signal $signal)
     {
-        return $this->httpCacheClearer->purgeForContent($this->extractContentId($signal));
+        return $this->httpCacheClearer->purgeForContent($this->extractContentId($signal), $this->extractLocationIds($signal));
     }
 
     /**
      * Default implementation that returns the contentId property's value.
      *
-     * @param \eZ\Publish\Core\SignalSlot\Signal\SectionService\AssignSectionSignal $signal
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return mixed Content ID
      */
     protected function extractContentId(Signal $signal)
     {
         return $signal->contentId;
+    }
+
+    /**
+     * Default implementation that returns the signal location property values.
+     *
+     * This is extracted and provided to purgeForContent in case content is trashed where affected location is no longer returned by API.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return array Location ID's
+     */
+    protected function extractLocationIds(Signal $signal)
+    {
+        $locationIds = [];
+        if (isset($signal->locationId)) {
+            $locationIds[] = $signal->locationId;
+        }
+
+        if (isset($signal->parentLocationId)) {
+            $locationIds[] = $signal->parentLocationId;
+        }
+
+        return $locationIds;
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/RecoverSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/RecoverSlot.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling RecoverSignal.
+ */
+class RecoverSlot extends PurgeForContentHttpCacheSlot
+{
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\TrashService\RecoverSignal;
+    }
+
+    protected function extractLocationIds(Signal $signal)
+    {
+        return [$signal->newParentLocationId];
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/TrashSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/TrashSlot.php
@@ -13,7 +13,7 @@ use eZ\Publish\Core\SignalSlot\Signal;
 /**
  * A slot handling TrashSignal.
  */
-class TrashSlot extends PurgeAllHttpCacheSlot
+class TrashSlot extends PurgeForContentHttpCacheSlot
 {
     protected function supports(Signal $signal)
     {

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/TrashSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/TrashSlot.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling TrashSignal.
+ */
+class TrashSlot extends PurgeAllHttpCacheSlot
+{
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\TrashService\TrashSignal;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/PurgeClientInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/PurgeClientInterface.php
@@ -13,14 +13,18 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache;
 interface PurgeClientInterface
 {
     /**
-     * Triggers the cache purge $cacheElements.
+     * Triggers the cache purge $locationIds.
      *
-     * @param mixed $cacheElements Cache resource(s) to purge (e.g. array of URI to purge in a reverse proxy)
+     * It's up to the implementor to decide whether to purge $locationIds right away or to delegate to a separate process.
+     *
+     * @param array $locationIds Cache resource(s) to purge (e.g. array of URI to purge in a reverse proxy)
      */
-    public function purge($cacheElements);
+    public function purge($locationIds);
 
     /**
      * Purges all content elements currently in cache.
+     *
+     * It's up to the implementor to decide whether to purge $locationIds right away or to delegate to a separate process.
      */
     public function purgeAll();
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/InstantCachePurgerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/InstantCachePurgerTest.php
@@ -69,7 +69,7 @@ class InstantCachePurgerTest extends PHPUnit_Framework_TestCase
     public function testPurgeForContent()
     {
         $contentId = 123;
-        $contentInfo = new ContentInfo(['id' => $contentId]);
+        $contentInfo = new ContentInfo(['id' => $contentId, 'published' => true]);
         // Assume listeners have added locations.
         // Adding duplicates on purpose.
         $locationIds = [123, 456, 789, 234, 567];

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/AbstractPurgeForContentSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/AbstractPurgeForContentSlotTest.php
@@ -10,14 +10,23 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 abstract class AbstractPurgeForContentSlotTest extends AbstractSlotTest implements PurgeForContentExpectation
 {
-    private static $contentId = 42;
+    protected static $contentId = 42;
+    protected static $locationIds = [];
 
     /**
      * @return mixed
      */
     public static function getContentId()
     {
-        return self::$contentId;
+        return static::$contentId;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public static function getLocationIds()
+    {
+        return static::$locationIds;
     }
 
     /**
@@ -25,7 +34,7 @@ abstract class AbstractPurgeForContentSlotTest extends AbstractSlotTest implemen
      */
     public function testReceivePurgesCacheForContent($signal)
     {
-        $this->cachePurgerMock->expects($this->once())->method('purgeForContent')->with(self::getContentId());
+        $this->cachePurgerMock->expects($this->once())->method('purgeForContent')->with(self::getContentId(), self::getLocationIds());
         $this->cachePurgerMock->expects($this->never())->method('purgeAll');
         parent::receive($signal);
     }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/DeleteContentSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/DeleteContentSlotTest.php
@@ -10,11 +10,11 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteContentSignal;
 
-class DeleteContentSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
+class DeleteContentSlotTest extends AbstractPurgeAllSlotTest implements SlotTest, PurgeAllExpectation
 {
     public static function createSignal()
     {
-        return new DeleteContentSignal(['contentId' => self::getContentId()]);
+        return new DeleteContentSignal();
     }
 
     public function getSlotClass()

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/RecoverSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/RecoverSlotTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\TrashService\RecoverSignal;
+
+class RecoverSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
+{
+    protected static $locationIds = [43];
+
+    public static function createSignal()
+    {
+        return new RecoverSignal(['contentId' => self::getContentId(), 'newParentLocationId' => 43]);
+    }
+
+    public function getSlotClass()
+    {
+        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\RecoverSlot';
+    }
+
+    public static function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\TrashService\RecoverSignal'];
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/TrashSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/TrashSlotTest.php
@@ -8,24 +8,24 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
-use eZ\Publish\Core\SignalSlot\Signal\LocationService\DeleteLocationSignal;
+use eZ\Publish\Core\SignalSlot\Signal\TrashService\TrashSignal;
 
-class DeleteLocationSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
+class TrashSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
 {
     protected static $locationIds = [45, 43];
 
     public static function createSignal()
     {
-        return new DeleteLocationSignal(['contentId' => self::getContentId(), 'locationId' => 45, 'parentLocationId' => 43]);
+        return new TrashSignal(['contentId' => self::getContentId(), 'locationId' => 45, 'parentLocationId' => 43]);
     }
 
     public function getSlotClass()
     {
-        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\DeleteLocationSlot';
+        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\TrashSlot';
     }
 
     public static function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\DeleteLocationSignal'];
+        return ['eZ\Publish\Core\SignalSlot\Signal\TrashService\TrashSignal'];
     }
 }

--- a/eZ/Publish/Core/SignalSlot/LocationService.php
+++ b/eZ/Publish/Core/SignalSlot/LocationService.php
@@ -335,6 +335,7 @@ class LocationService implements LocationServiceInterface
                 array(
                     'contentId' => $location->contentId,
                     'locationId' => $location->id,
+                    'parentLocationId' => $location->parentLocationId,
                 )
             )
         );

--- a/eZ/Publish/Core/SignalSlot/Signal/LocationService/DeleteLocationSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/LocationService/DeleteLocationSignal.php
@@ -30,4 +30,11 @@ class DeleteLocationSignal extends Signal
      * @var mixed
      */
     public $locationId;
+
+    /**
+     * Location ID of parent location of the deleted location.
+     *
+     * @var mixed
+     */
+    public $parentLocationId;
 }

--- a/eZ/Publish/Core/SignalSlot/Signal/TrashService/RecoverSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/TrashService/RecoverSignal.php
@@ -25,6 +25,13 @@ class RecoverSignal extends Signal
     public $trashItemId;
 
     /**
+     * Content id.
+     *
+     * @var mixed
+     */
+    public $contentId;
+
+    /**
      * NewParentLocationId.
      *
      * @var mixed

--- a/eZ/Publish/Core/SignalSlot/Signal/TrashService/TrashSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/TrashService/TrashSignal.php
@@ -25,6 +25,13 @@ class TrashSignal extends Signal
     public $locationId;
 
     /**
+     * Location ID of parent location of the trashed location.
+     *
+     * @var mixed
+     */
+    public $parentLocationId;
+
+    /**
      * Content id.
      *
      * @var mixed

--- a/eZ/Publish/Core/SignalSlot/TrashService.php
+++ b/eZ/Publish/Core/SignalSlot/TrashService.php
@@ -116,6 +116,7 @@ class TrashService implements TrashServiceInterface
             new RecoverSignal(
                 array(
                     'trashItemId' => $trashItem->id,
+                    'contentId' => $trashItem->contentId,
                     'newParentLocationId' => $newParentLocation !== null ? $newParentLocation->id : null,
                     'newLocationId' => $newLocation->id,
                 )

--- a/eZ/Publish/Core/SignalSlot/TrashService.php
+++ b/eZ/Publish/Core/SignalSlot/TrashService.php
@@ -88,6 +88,7 @@ class TrashService implements TrashServiceInterface
             new TrashSignal(
                 array(
                     'locationId' => $location->id,
+                    'parentLocationId' => $location->parentLocationId,
                     'contentId' => $location->contentId,
                 )
             )


### PR DESCRIPTION
In theory fixes:
- http://jira.ez.no/browse/EZP-25003
- https://jira.ez.no/browse/EZP-24621
- https://jira.ez.no/browse/EZP-24944
- https://jira.ez.no/browse/EZP-26107

Changes:
- Adds TrashSlot and RecoverSlot
- Adds affected parentLocation on Trash and DeleteLocation signal, pass this to purge function
- Adds affected contentId on Recover signal so cache clearing can clear relevant cache.

Also done but can be moved to other PR if needed:
- Avoid exception on DeleteContent signal  by purging all cache *(for now, afaik UI exposes Trash so should not be to common)* as we don't have affected locations atm, end solution is multi tag and just clear content id related tags as a later follow up feature.
- Some cleanup on argument name for purge().

### TODO
- [x] unit tests coverage for new slots
- [x] functional REST test coverage *(already covered)*
- ~~See if REST functional tests actually use cache given it uses basic auth~~ => *it's not, need BDD coverage*
- ~~REST behat coverage~~ => QA