### PR TITLE
Fix EZP-26149: PHP notice when using empty view parameter name

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/SiteAccessListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/SiteAccessListener.php
@@ -140,7 +140,7 @@ class SiteAccessListener implements EventSubscriberInterface, ContainerAwareInte
 
         $vpSegments = explode('/', $vpString);
         for ($i = 0, $iMax = count($vpSegments); $i < $iMax; ++$i) {
-            if (!isset($vpSegments[$i])) {
+            if (empty($vpSegments[$i])) {
                 continue;
             }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SiteAccessListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SiteAccessListenerTest.php
@@ -75,6 +75,7 @@ class SiteAccessListenerTest extends PHPUnit_Framework_TestCase
             array('/foo/bar/(some)/thing', '/foo/bar', '/(some)/thing', array('some' => 'thing')),
             array('/foo/bar/(some)/thing/(other)', '/foo/bar', '/(some)/thing/(other)', array('some' => 'thing', 'other' => '')),
             array('/foo/bar/(some)/thing/orphan', '/foo/bar', '/(some)/thing/orphan', array('some' => 'thing/orphan')),
+            array('/foo/bar/(some)/thing//orphan', '/foo/bar', '/(some)/thing//orphan', array('some' => 'thing/orphan')),
             array('/foo/bar/(some)/thing/orphan/(something)/else', '/foo/bar', '/(some)/thing/orphan/(something)/else', array('some' => 'thing/orphan', 'something' => 'else')),
             array('/foo/bar/(some)/thing/orphan/(something)/else/(other)', '/foo/bar', '/(some)/thing/orphan/(something)/else/(other)', array('some' => 'thing/orphan', 'something' => 'else', 'other' => '')),
             array('/foo/bar/(some)/thing/orphan/(other)', '/foo/bar', '/(some)/thing/orphan/(other)', array('some' => 'thing/orphan', 'other' => '')),


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26149

When using an URI string such as `/(p1)/v1//v2` , SiteAccessListener tries to identify the name of the second view parameter:
```php
// We extract it + the value from the following segment (next element in $vpSegments array)
if ($vpSegments[$i]{0} === '(') {
```
If it is an empty string, a PHP notice is generated (Uninitialized string offset: 0).

This skips the process for empty viewParameter segments