### PR TITLE
EZP-26154: ezplatform:install command is not siteaccess aware

### DIFF
--- a/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
@@ -7,7 +7,8 @@ services:
     ezplatform.installer.db_based_installer:
         abstract: true
         class:  "%ezplatform.installer.db_based_installer.class%"
-        arguments: ["@database_connection"]
+        arguments: [@ezpublish.persistence.connection]
+        lazy: true
 
     ezplatform.installer.clean_installer:
         class: "%ezplatform.installer.clean_installer.class%"

--- a/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
@@ -7,7 +7,7 @@ services:
     ezplatform.installer.db_based_installer:
         abstract: true
         class:  "%ezplatform.installer.db_based_installer.class%"
-        arguments: [@ezpublish.persistence.connection]
+        arguments: ["@ezpublish.persistence.connection"]
         lazy: true
 
     ezplatform.installer.clean_installer:


### PR DESCRIPTION
In order to select active database, both SiteAccess and doctrine.dbal database list were injected into service