### PR TITLE
Fix EZP-26148: String length validation error contains %-symbols

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
@@ -1041,7 +1041,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
         $this->assertEquals(
             new Message(
                 "Validator parameter '%parameter%' value must be of integer type",
-                array('parameter' => 'minIntegerValue')
+                array('%parameter%' => 'minIntegerValue')
             ),
             $validationErrors['temperature'][0]->getTranslatableMessage()
         );
@@ -1423,7 +1423,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
         $this->assertEquals(
             new Message(
                 "Validator parameter '%parameter%' value must be of integer type",
-                array('parameter' => 'maxIntegerValue')
+                array('%parameter%' => 'maxIntegerValue')
             ),
             $validationErrors['temperature'][0]->getTranslatableMessage()
         );

--- a/eZ/Publish/Core/FieldType/BinaryBase/Type.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/Type.php
@@ -301,7 +301,7 @@ abstract class Type extends FieldType
                             'The file size cannot exceed %size% byte.',
                             'The file size cannot exceed %size% bytes.',
                             array(
-                                'size' => $parameters['maxFileSize'],
+                                '%size%' => $parameters['maxFileSize'],
                             ),
                             'fileSize'
                         );
@@ -332,8 +332,8 @@ abstract class Type extends FieldType
                             'Validator %validator% expects parameter %parameter% to be set.',
                             null,
                             array(
-                                'validator' => $validatorIdentifier,
-                                'parameter' => 'maxFileSize',
+                                '%validator%' => $validatorIdentifier,
+                                '%parameter%' => 'maxFileSize',
                             ),
                             "[$validatorIdentifier][maxFileSize]"
                         );
@@ -344,9 +344,9 @@ abstract class Type extends FieldType
                             'Validator %validator% expects parameter %parameter% to be of %type%.',
                             null,
                             array(
-                                'validator' => $validatorIdentifier,
-                                'parameter' => 'maxFileSize',
-                                'type' => 'integer',
+                                '%validator%' => $validatorIdentifier,
+                                '%parameter%' => 'maxFileSize',
+                                '%type%' => 'integer',
                                 "[$validatorIdentifier][maxFileSize]",
                             )
                         );
@@ -357,7 +357,7 @@ abstract class Type extends FieldType
                         "Validator '%validator%' is unknown",
                         null,
                         array(
-                            'validator' => $validatorIdentifier,
+                            '%validator%' => $validatorIdentifier,
                         ),
                         "[$validatorIdentifier]"
                     );

--- a/eZ/Publish/Core/FieldType/Country/Type.php
+++ b/eZ/Publish/Core/FieldType/Country/Type.php
@@ -153,7 +153,7 @@ class Type extends FieldType
                     "Country with Alpha2 code '%alpha2%' is not defined in FieldType settings.",
                     null,
                     array(
-                        'alpha2' => $alpha2,
+                        '%alpha2%' => $alpha2,
                     ),
                     'countries'
                 );
@@ -256,7 +256,7 @@ class Type extends FieldType
                     "Setting '%setting%' is unknown",
                     null,
                     array(
-                        'setting' => $name,
+                        '%setting%' => $name,
                     ),
                     "[$name]"
                 );
@@ -270,7 +270,7 @@ class Type extends FieldType
                             "Setting '%setting%' value must be of boolean type",
                             null,
                             array(
-                                'setting' => $name,
+                                '%setting%' => $name,
                             ),
                             "[$name]"
                         );

--- a/eZ/Publish/Core/FieldType/Date/Type.php
+++ b/eZ/Publish/Core/FieldType/Date/Type.php
@@ -208,7 +208,7 @@ class Type extends FieldType
                     "Setting '%setting%' is unknown",
                     null,
                     array(
-                        'setting' => $name,
+                        '%setting%' => $name,
                     ),
                     "[$name]"
                 );
@@ -226,7 +226,7 @@ class Type extends FieldType
                             "Setting '%setting%' is of unknown type",
                             null,
                             array(
-                                'setting' => $name,
+                                '%setting%' => $name,
                             ),
                             "[$name]"
                         );

--- a/eZ/Publish/Core/FieldType/DateAndTime/Type.php
+++ b/eZ/Publish/Core/FieldType/DateAndTime/Type.php
@@ -271,7 +271,7 @@ class Type extends FieldType
                 $validationErrors[] = new ValidationError(
                     "Setting '%setting%' is unknown",
                     null,
-                    ['setting' => $name],
+                    ['%setting%' => $name],
                     "[$name]"
                 );
             }

--- a/eZ/Publish/Core/FieldType/EmailAddress/Type.php
+++ b/eZ/Publish/Core/FieldType/EmailAddress/Type.php
@@ -47,7 +47,7 @@ class Type extends FieldType
                     "Validator '%validator%' is unknown",
                     null,
                     array(
-                        'validator' => $validatorIdentifier,
+                        '%validator%' => $validatorIdentifier,
                     ),
                     "[$validatorIdentifier]"
                 );

--- a/eZ/Publish/Core/FieldType/Float/Type.php
+++ b/eZ/Publish/Core/FieldType/Float/Type.php
@@ -54,7 +54,7 @@ class Type extends FieldType
                     "Validator '%validator%' is unknown",
                     null,
                     array(
-                        'validator' => $validatorIdentifier,
+                        '%validator%' => $validatorIdentifier,
                     ),
                     "[$validatorIdentifier]"
                 );
@@ -71,7 +71,7 @@ class Type extends FieldType
                                 "Validator parameter '%parameter%' value must be of numeric type",
                                 null,
                                 array(
-                                    'parameter' => $name,
+                                    '%parameter%' => $name,
                                 ),
                                 "[$validatorIdentifier][$name]"
                             );
@@ -82,7 +82,7 @@ class Type extends FieldType
                             "Validator parameter '%parameter%' is unknown",
                             null,
                             array(
-                                'parameter' => $name,
+                                '%parameter%' => $name,
                             ),
                             "[$validatorIdentifier][$name]"
                         );
@@ -124,7 +124,7 @@ class Type extends FieldType
                 'The value can not be higher than %size%.',
                 null,
                 array(
-                    'size' => $constraints['maxFloatValue'],
+                    '%size%' => $constraints['maxFloatValue'],
                 ),
                 'value'
             );
@@ -136,7 +136,7 @@ class Type extends FieldType
                 'The value can not be lower than %size%.',
                 null,
                 array(
-                    'size' => $constraints['minFloatValue'],
+                    '%size%' => $constraints['minFloatValue'],
                 ),
                 'value'
             );

--- a/eZ/Publish/Core/FieldType/ISBN/Type.php
+++ b/eZ/Publish/Core/FieldType/ISBN/Type.php
@@ -246,7 +246,7 @@ class Type extends FieldType
                     "Setting '%setting%' is unknown",
                     null,
                     array(
-                        'setting' => $name,
+                        '%setting%' => $name,
                     ),
                     "[$name]"
                 );
@@ -260,7 +260,7 @@ class Type extends FieldType
                             "Setting '%setting%' value must be of boolean type",
                             null,
                             array(
-                                'setting' => $name,
+                                '%setting%' => $name,
                             ),
                             "[$name]"
                         );

--- a/eZ/Publish/Core/FieldType/Image/Type.php
+++ b/eZ/Publish/Core/FieldType/Image/Type.php
@@ -179,7 +179,7 @@ class Type extends FieldType
                             'The file size cannot exceed %size% byte.',
                             'The file size cannot exceed %size% bytes.',
                             array(
-                                'size' => $parameters['maxFileSize'],
+                                '%size%' => $parameters['maxFileSize'],
                             ),
                             'fileSize'
                         );
@@ -210,8 +210,8 @@ class Type extends FieldType
                             'Validator %validator% expects parameter %parameter% to be set.',
                             null,
                             array(
-                                'validator' => $validatorIdentifier,
-                                'parameter' => 'maxFileSize',
+                                '%validator%' => $validatorIdentifier,
+                                '%parameter%' => 'maxFileSize',
                             ),
                             "[$validatorIdentifier]"
                         );
@@ -222,9 +222,9 @@ class Type extends FieldType
                             'Validator %validator% expects parameter %parameter% to be of %type%.',
                             null,
                             array(
-                                'validator' => $validatorIdentifier,
-                                'parameter' => 'maxFileSize',
-                                'type' => 'integer',
+                                '%validator%' => $validatorIdentifier,
+                                '%parameter%' => 'maxFileSize',
+                                '%type%' => 'integer',
                             ),
                             "[$validatorIdentifier][maxFileSize]"
                         );
@@ -235,7 +235,7 @@ class Type extends FieldType
                         "Validator '%validator%' is unknown",
                         null,
                         array(
-                            'validator' => $validatorIdentifier,
+                            '%validator%' => $validatorIdentifier,
                         ),
                         "[$validatorIdentifier]"
                     );

--- a/eZ/Publish/Core/FieldType/Integer/Type.php
+++ b/eZ/Publish/Core/FieldType/Integer/Type.php
@@ -54,7 +54,7 @@ class Type extends FieldType
                     "Validator '%validator%' is unknown",
                     null,
                     array(
-                        'validator' => $validatorIdentifier,
+                        '%validator%' => $validatorIdentifier,
                     ),
                     "[$validatorIdentifier]"
                 );
@@ -70,7 +70,7 @@ class Type extends FieldType
                                 "Validator parameter '%parameter%' value must be of integer type",
                                 null,
                                 array(
-                                    'parameter' => $name,
+                                    '%parameter%' => $name,
                                 ),
                                 "[$validatorIdentifier][$name]"
                             );
@@ -81,7 +81,7 @@ class Type extends FieldType
                             "Validator parameter '%parameter%' is unknown",
                             null,
                             array(
-                                'parameter' => $name,
+                                '%parameter%' => $name,
                             ),
                             "[$validatorIdentifier][$name]"
                         );
@@ -127,7 +127,7 @@ class Type extends FieldType
                 'The value can not be higher than %size%.',
                 null,
                 array(
-                    'size' => $constraints['maxIntegerValue'],
+                    '%size%' => $constraints['maxIntegerValue'],
                 ),
                 'value'
             );
@@ -139,7 +139,7 @@ class Type extends FieldType
                 'The value can not be lower than %size%.',
                 null,
                 array(
-                    'size' => $constraints['minIntegerValue'],
+                    '%size%' => $constraints['minIntegerValue'],
                 ),
                 'value'
             );

--- a/eZ/Publish/Core/FieldType/Media/Type.php
+++ b/eZ/Publish/Core/FieldType/Media/Type.php
@@ -99,7 +99,7 @@ class Type extends BaseType
                                 "Setting '%setting%' is of unknown type",
                                 null,
                                 array(
-                                    'setting' => $name,
+                                    '%setting%' => $name,
                                 ),
                                 "[$name]"
                             );
@@ -111,7 +111,7 @@ class Type extends BaseType
                     "Setting '%setting%' is unknown",
                     null,
                     array(
-                        'setting' => $name,
+                        '%setting%' => $name,
                     ),
                     "[$name]"
                 );

--- a/eZ/Publish/Core/FieldType/Page/Type.php
+++ b/eZ/Publish/Core/FieldType/Page/Type.php
@@ -80,7 +80,7 @@ class Type extends FieldType
                                 "Layout '{$value}' for setting '%setting%' is not available",
                                 null,
                                 array(
-                                    'setting' => $name,
+                                    '%setting%' => $name,
                                 ),
                                 "[$name]"
                             );
@@ -92,7 +92,7 @@ class Type extends FieldType
                     "Setting '%setting%' is unknown",
                     null,
                     array(
-                        'setting' => $name,
+                        '%setting%' => $name,
                     ),
                     "[$name]"
                 );

--- a/eZ/Publish/Core/FieldType/Relation/Type.php
+++ b/eZ/Publish/Core/FieldType/Relation/Type.php
@@ -59,7 +59,7 @@ class Type extends FieldType
                     "Setting '%setting%' is unknown",
                     null,
                     array(
-                        'setting' => $name,
+                        '%setting%' => $name,
                     ),
                     "[$name]"
                 );
@@ -73,9 +73,9 @@ class Type extends FieldType
                             "Setting '%setting%' must be either %selection_browse% or %selection_dropdown%",
                             null,
                             array(
-                                'setting' => $name,
-                                'selection_browse' => self::SELECTION_BROWSE,
-                                'selection_dropdown' => self::SELECTION_DROPDOWN,
+                                '%setting%' => $name,
+                                '%selection_browse%' => self::SELECTION_BROWSE,
+                                '%selection_dropdown%' => self::SELECTION_DROPDOWN,
                             ),
                             "[$name]"
                         );
@@ -87,7 +87,7 @@ class Type extends FieldType
                             "Setting '%setting%' value must be of either null, string or integer",
                             null,
                             array(
-                                'setting' => $name,
+                                '%setting%' => $name,
                             ),
                             "[$name]"
                         );

--- a/eZ/Publish/Core/FieldType/RelationList/Type.php
+++ b/eZ/Publish/Core/FieldType/RelationList/Type.php
@@ -66,7 +66,7 @@ class Type extends FieldType
                     "Setting '%setting%' is unknown",
                     null,
                     array(
-                        'setting' => $name,
+                        '%setting%' => $name,
                     ),
                     "[$name]"
                 );
@@ -80,9 +80,9 @@ class Type extends FieldType
                             "Setting '%setting%' must be either %selection_browse% or %selection_dropdown%",
                             null,
                             array(
-                                'setting' => $name,
-                                'selection_browse' => self::SELECTION_BROWSE,
-                                'selection_dropdown' => self::SELECTION_DROPDOWN,
+                                '%setting%' => $name,
+                                '%selection_browse%' => self::SELECTION_BROWSE,
+                                '%selection_dropdown%' => self::SELECTION_DROPDOWN,
                             ),
                             "[$name]"
                         );
@@ -94,7 +94,7 @@ class Type extends FieldType
                             "Setting '%setting%' value must be of either null, string or integer",
                             null,
                             array(
-                                'setting' => $name,
+                                '%setting%' => $name,
                             ),
                             "[$name]"
                         );
@@ -106,7 +106,7 @@ class Type extends FieldType
                             "Setting '%setting%' value must be of array type",
                             null,
                             array(
-                                'setting' => $name,
+                                '%setting%' => $name,
                             ),
                             "[$name]"
                         );

--- a/eZ/Publish/Core/FieldType/RichText/Type.php
+++ b/eZ/Publish/Core/FieldType/RichText/Type.php
@@ -374,7 +374,7 @@ class Type extends FieldType
                                 "Setting '%setting%' value must be of integer type",
                                 null,
                                 array(
-                                    'setting' => $name,
+                                    '%setting%' => $name,
                                 ),
                                 "[$name]"
                             );
@@ -386,7 +386,7 @@ class Type extends FieldType
                     "Setting '%setting%' is unknown",
                     null,
                     array(
-                        'setting' => $name,
+                        '%setting%' => $name,
                     ),
                     "[$name]"
                 );

--- a/eZ/Publish/Core/FieldType/Selection/Type.php
+++ b/eZ/Publish/Core/FieldType/Selection/Type.php
@@ -62,9 +62,9 @@ class Type extends FieldType
                             "FieldType '%fieldType%' expects setting '%setting%' to be of type '%type%'",
                             null,
                             array(
-                                'fieldType' => $this->getFieldTypeIdentifier(),
-                                'setting' => $settingKey,
-                                'type' => 'bool',
+                                '%fieldType%' => $this->getFieldTypeIdentifier(),
+                                '%setting%' => $settingKey,
+                                '%type%' => 'bool',
                             ),
                             "[$settingKey]"
                         );
@@ -76,9 +76,9 @@ class Type extends FieldType
                             "FieldType '%fieldType%' expects setting '%setting%' to be of type '%type%'",
                             null,
                             array(
-                                'fieldType' => $this->getFieldTypeIdentifier(),
-                                'setting' => $settingKey,
-                                'type' => 'hash',
+                                '%fieldType%' => $this->getFieldTypeIdentifier(),
+                                '%setting%' => $settingKey,
+                                '%type%' => 'hash',
                             ),
                             "[$settingKey]"
                         );
@@ -89,7 +89,7 @@ class Type extends FieldType
                         "Setting '%setting%' is unknown",
                         null,
                         array(
-                            'setting' => $settingKey,
+                            '%setting%' => $settingKey,
                         ),
                         "[$settingKey]"
                     );
@@ -207,7 +207,7 @@ class Type extends FieldType
                     'Option with index %index% does not exist in the field definition.',
                     null,
                     array(
-                        'index' => $optionIndex,
+                        '%index%' => $optionIndex,
                     ),
                     'selection'
                 );

--- a/eZ/Publish/Core/FieldType/Tests/CountryTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/CountryTest.php
@@ -638,7 +638,7 @@ class CountryTest extends FieldTypeTest
                         "Country with Alpha2 code '%alpha2%' is not defined in FieldType settings.",
                         null,
                         array(
-                            'alpha2' => 'LE',
+                            '%alpha2%' => 'LE',
                         ),
                         'countries'
                     ),

--- a/eZ/Publish/Core/FieldType/Tests/FieldTypeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FieldTypeTest.php
@@ -464,7 +464,7 @@ abstract class FieldTypeTest extends PHPUnit_Framework_TestCase
      *                  "The value can not be lower than %size%.",
      *                  null,
      *                  array(
-     *                      "size" => 5
+     *                      "%size%" => 5
      *                  ),
      *              ),
      *          ),

--- a/eZ/Publish/Core/FieldType/Tests/FileSizeValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FileSizeValidatorTest.php
@@ -218,7 +218,7 @@ class FileSizeValidatorTest extends PHPUnit_Framework_TestCase
                     'The file size cannot exceed %size% byte.',
                     'The file size cannot exceed %size% bytes.',
                 ),
-                array('size' => $this->getMaxFileSize()),
+                array('%size%' => $this->getMaxFileSize()),
             ),
         );
     }
@@ -282,22 +282,22 @@ class FileSizeValidatorTest extends PHPUnit_Framework_TestCase
             array(
                 array('maxFileSize' => true),
                 array("Validator parameter '%parameter%' value must be of integer type"),
-                array('parameter' => 'maxFileSize'),
+                array('%parameter%' => 'maxFileSize'),
             ),
             array(
                 array('maxFileSize' => 'five thousand bytes'),
                 array("Validator parameter '%parameter%' value must be of integer type"),
-                array('parameter' => 'maxFileSize'),
+                array('%parameter%' => 'maxFileSize'),
             ),
             array(
                 array('maxFileSize' => new \DateTime()),
                 array("Validator parameter '%parameter%' value must be of integer type"),
-                array('parameter' => 'maxFileSize'),
+                array('%parameter%' => 'maxFileSize'),
             ),
             array(
                 array('brljix' => 12345),
                 array("Validator parameter '%parameter%' is unknown"),
-                array('parameter' => 'brljix'),
+                array('%parameter%' => 'brljix'),
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/FloatTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FloatTest.php
@@ -527,7 +527,7 @@ class FloatTest extends FieldTypeTest
      *                  "The value can not be lower than %size%.",
      *                  null,
      *                  array(
-     *                      "size" => 5
+     *                      "%size%" => 5
      *                  ),
      *              ),
      *          ),
@@ -582,7 +582,7 @@ class FloatTest extends FieldTypeTest
                         'The value can not be lower than %size%.',
                         null,
                         array(
-                            'size' => 5.1,
+                            '%size%' => 5.1,
                         ),
                         'value'
                     ),
@@ -603,7 +603,7 @@ class FloatTest extends FieldTypeTest
                         'The value can not be higher than %size%.',
                         null,
                         array(
-                            'size' => 10.5,
+                            '%size%' => 10.5,
                         ),
                         'value'
                     ),
@@ -624,7 +624,7 @@ class FloatTest extends FieldTypeTest
                         'The value can not be higher than %size%.',
                         null,
                         array(
-                            'size' => 5.1,
+                            '%size%' => 5.1,
                         ),
                         'value'
                     ),
@@ -632,7 +632,7 @@ class FloatTest extends FieldTypeTest
                         'The value can not be lower than %size%.',
                         null,
                         array(
-                            'size' => 10.5,
+                            '%size%' => 10.5,
                         ),
                         'value'
                     ),

--- a/eZ/Publish/Core/FieldType/Tests/FloatValueValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FloatValueValidatorTest.php
@@ -210,10 +210,10 @@ class FloatValueValidatorTest extends PHPUnit_Framework_TestCase
     public function providerForValidateKO()
     {
         return array(
-            array(-10 / 7, 'The value can not be lower than %size%.', array('size' => $this->getMinFloatValue())),
-            array(0, 'The value can not be lower than %size%.', array('size' => $this->getMinFloatValue())),
-            array(99 / 70, 'The value can not be lower than %size%.', array('size' => $this->getMinFloatValue())),
-            array(111 / 70, 'The value can not be higher than %size%.', array('size' => $this->getMaxFloatValue())),
+            array(-10 / 7, 'The value can not be lower than %size%.', array('%size%' => $this->getMinFloatValue())),
+            array(0, 'The value can not be lower than %size%.', array('%size%' => $this->getMinFloatValue())),
+            array(99 / 70, 'The value can not be lower than %size%.', array('%size%' => $this->getMinFloatValue())),
+            array(111 / 70, 'The value can not be higher than %size%.', array('%size%' => $this->getMaxFloatValue())),
         );
     }
 
@@ -299,7 +299,7 @@ class FloatValueValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' value must be of numeric type"),
                 array(
-                    array('parameter' => 'minFloatValue'),
+                    array('%parameter%' => 'minFloatValue'),
                 ),
             ),
             array(
@@ -308,7 +308,7 @@ class FloatValueValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' value must be of numeric type"),
                 array(
-                    array('parameter' => 'minFloatValue'),
+                    array('%parameter%' => 'minFloatValue'),
                 ),
             ),
             array(
@@ -318,7 +318,7 @@ class FloatValueValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' value must be of numeric type"),
                 array(
-                    array('parameter' => 'minFloatValue'),
+                    array('%parameter%' => 'minFloatValue'),
                 ),
             ),
             array(
@@ -328,7 +328,7 @@ class FloatValueValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' value must be of numeric type"),
                 array(
-                    array('parameter' => 'maxFloatValue'),
+                    array('%parameter%' => 'maxFloatValue'),
                 ),
             ),
             array(
@@ -338,7 +338,7 @@ class FloatValueValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' value must be of numeric type"),
                 array(
-                    array('parameter' => 'minFloatValue'),
+                    array('%parameter%' => 'minFloatValue'),
                 ),
             ),
             array(
@@ -351,8 +351,8 @@ class FloatValueValidatorTest extends PHPUnit_Framework_TestCase
                     "Validator parameter '%parameter%' value must be of numeric type",
                 ),
                 array(
-                    array('parameter' => 'minFloatValue'),
-                    array('parameter' => 'maxFloatValue'),
+                    array('%parameter%' => 'minFloatValue'),
+                    array('%parameter%' => 'maxFloatValue'),
                 ),
             ),
             array(
@@ -361,7 +361,7 @@ class FloatValueValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' is unknown"),
                 array(
-                    array('parameter' => 'brljix'),
+                    array('%parameter%' => 'brljix'),
                 ),
             ),
             array(
@@ -371,7 +371,7 @@ class FloatValueValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' is unknown"),
                 array(
-                    array('parameter' => 'brljix'),
+                    array('%parameter%' => 'brljix'),
                 ),
             ),
         );

--- a/eZ/Publish/Core/FieldType/Tests/ImageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageTest.php
@@ -633,7 +633,7 @@ class ImageTest extends FieldTypeTest
                         'The file size cannot exceed %size% byte.',
                         'The file size cannot exceed %size% bytes.',
                         array(
-                            'size' => 0.01,
+                            '%size%' => 0.01,
                         ),
                         'fileSize'
                     ),
@@ -687,7 +687,7 @@ class ImageTest extends FieldTypeTest
                         'The file size cannot exceed %size% byte.',
                         'The file size cannot exceed %size% bytes.',
                         array(
-                            'size' => 0.01,
+                            '%size%' => 0.01,
                         ),
                         'fileSize'
                     ),

--- a/eZ/Publish/Core/FieldType/Tests/IntegerTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/IntegerTest.php
@@ -572,7 +572,7 @@ class IntegerTest extends FieldTypeTest
                         'The value can not be lower than %size%.',
                         null,
                         array(
-                            'size' => 5,
+                            '%size%' => 5,
                         ),
                         'value'
                     ),
@@ -593,7 +593,7 @@ class IntegerTest extends FieldTypeTest
                         'The value can not be higher than %size%.',
                         null,
                         array(
-                            'size' => 10,
+                            '%size%' => 10,
                         ),
                         'value'
                     ),
@@ -614,7 +614,7 @@ class IntegerTest extends FieldTypeTest
                         'The value can not be higher than %size%.',
                         null,
                         array(
-                            'size' => 5,
+                            '%size%' => 5,
                         ),
                         'value'
                     ),
@@ -622,7 +622,7 @@ class IntegerTest extends FieldTypeTest
                         'The value can not be lower than %size%.',
                         null,
                         array(
-                            'size' => 10,
+                            '%size%' => 10,
                         ),
                         'value'
                     ),

--- a/eZ/Publish/Core/FieldType/Tests/IntegerValueValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/IntegerValueValidatorTest.php
@@ -212,10 +212,10 @@ class IntegerValueValidatorTest extends PHPUnit_Framework_TestCase
     public function providerForValidateKO()
     {
         return array(
-            array(-12, 'The value can not be lower than %size%.', array('size' => $this->getMinIntegerValue())),
-            array(0, 'The value can not be lower than %size%.', array('size' => $this->getMinIntegerValue())),
-            array(9, 'The value can not be lower than %size%.', array('size' => $this->getMinIntegerValue())),
-            array(16, 'The value can not be higher than %size%.', array('size' => $this->getMaxIntegerValue())),
+            array(-12, 'The value can not be lower than %size%.', array('%size%' => $this->getMinIntegerValue())),
+            array(0, 'The value can not be lower than %size%.', array('%size%' => $this->getMinIntegerValue())),
+            array(9, 'The value can not be lower than %size%.', array('%size%' => $this->getMinIntegerValue())),
+            array(16, 'The value can not be higher than %size%.', array('%size%' => $this->getMaxIntegerValue())),
         );
     }
 
@@ -301,7 +301,7 @@ class IntegerValueValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' value must be of integer type"),
                 array(
-                    array('parameter' => 'minIntegerValue'),
+                    array('%parameter%' => 'minIntegerValue'),
                 ),
             ),
             array(
@@ -310,7 +310,7 @@ class IntegerValueValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' value must be of integer type"),
                 array(
-                    array('parameter' => 'minIntegerValue'),
+                    array('%parameter%' => 'minIntegerValue'),
                 ),
             ),
             array(
@@ -320,7 +320,7 @@ class IntegerValueValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' value must be of integer type"),
                 array(
-                    array('parameter' => 'minIntegerValue'),
+                    array('%parameter%' => 'minIntegerValue'),
                 ),
             ),
             array(
@@ -330,7 +330,7 @@ class IntegerValueValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' value must be of integer type"),
                 array(
-                    array('parameter' => 'maxIntegerValue'),
+                    array('%parameter%' => 'maxIntegerValue'),
                 ),
             ),
             array(
@@ -340,7 +340,7 @@ class IntegerValueValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' value must be of integer type"),
                 array(
-                    array('parameter' => 'minIntegerValue'),
+                    array('%parameter%' => 'minIntegerValue'),
                 ),
             ),
             array(
@@ -353,8 +353,8 @@ class IntegerValueValidatorTest extends PHPUnit_Framework_TestCase
                     "Validator parameter '%parameter%' value must be of integer type",
                 ),
                 array(
-                    array('parameter' => 'minIntegerValue'),
-                    array('parameter' => 'maxIntegerValue'),
+                    array('%parameter%' => 'minIntegerValue'),
+                    array('%parameter%' => 'maxIntegerValue'),
                 ),
             ),
             array(
@@ -363,7 +363,7 @@ class IntegerValueValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' is unknown"),
                 array(
-                    array('parameter' => 'brljix'),
+                    array('%parameter%' => 'brljix'),
                 ),
             ),
             array(
@@ -373,7 +373,7 @@ class IntegerValueValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' is unknown"),
                 array(
-                    array('parameter' => 'brljix'),
+                    array('%parameter%' => 'brljix'),
                 ),
             ),
         );

--- a/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
@@ -545,7 +545,7 @@ class SelectionTest extends FieldTypeTest
                         'Option with index %index% does not exist in the field definition.',
                         null,
                         array(
-                            'index' => 3,
+                            '%index%' => 3,
                         ),
                         'selection'
                     ),

--- a/eZ/Publish/Core/FieldType/Tests/StringLengthValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/StringLengthValidatorTest.php
@@ -216,19 +216,19 @@ class StringLengthValidatorTest extends PHPUnit_Framework_TestCase
                 '',
                 'The string can not be shorter than %size% character.',
                 'The string can not be shorter than %size% characters.',
-                array('size' => $this->getMinStringLength()),
+                array('%size%' => $this->getMinStringLength()),
             ),
             array(
                 'Hi!',
                 'The string can not be shorter than %size% character.',
                 'The string can not be shorter than %size% characters.',
-                array('size' => $this->getMinStringLength()),
+                array('%size%' => $this->getMinStringLength()),
             ),
             array(
                 '0123456789!',
                 'The string can not exceed %size% character.',
                 'The string can not exceed %size% characters.',
-                array('size' => $this->getMaxStringLength()),
+                array('%size%' => $this->getMaxStringLength()),
             ),
         );
     }
@@ -315,7 +315,7 @@ class StringLengthValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' value must be of integer type"),
                 array(
-                    array('parameter' => 'minStringLength'),
+                    array('%parameter%' => 'minStringLength'),
                 ),
             ),
             array(
@@ -324,7 +324,7 @@ class StringLengthValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' value must be of integer type"),
                 array(
-                    array('parameter' => 'minStringLength'),
+                    array('%parameter%' => 'minStringLength'),
                 ),
             ),
             array(
@@ -334,7 +334,7 @@ class StringLengthValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' value must be of integer type"),
                 array(
-                    array('parameter' => 'minStringLength'),
+                    array('%parameter%' => 'minStringLength'),
                 ),
             ),
             array(
@@ -344,7 +344,7 @@ class StringLengthValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' value must be of integer type"),
                 array(
-                    array('parameter' => 'maxStringLength'),
+                    array('%parameter%' => 'maxStringLength'),
                 ),
             ),
             array(
@@ -354,7 +354,7 @@ class StringLengthValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' value must be of integer type"),
                 array(
-                    array('parameter' => 'minStringLength'),
+                    array('%parameter%' => 'minStringLength'),
                 ),
             ),
             array(
@@ -367,8 +367,8 @@ class StringLengthValidatorTest extends PHPUnit_Framework_TestCase
                     "Validator parameter '%parameter%' value must be of integer type",
                 ),
                 array(
-                    array('parameter' => 'minStringLength'),
-                    array('parameter' => 'maxStringLength'),
+                    array('%parameter%' => 'minStringLength'),
+                    array('%parameter%' => 'maxStringLength'),
                 ),
             ),
             array(
@@ -377,7 +377,7 @@ class StringLengthValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' is unknown"),
                 array(
-                    array('parameter' => 'brljix'),
+                    array('%parameter%' => 'brljix'),
                 ),
             ),
             array(
@@ -387,7 +387,7 @@ class StringLengthValidatorTest extends PHPUnit_Framework_TestCase
                 ),
                 array("Validator parameter '%parameter%' is unknown"),
                 array(
-                    array('parameter' => 'brljix'),
+                    array('%parameter%' => 'brljix'),
                 ),
             ),
         );

--- a/eZ/Publish/Core/FieldType/Tests/TextLineTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/TextLineTest.php
@@ -631,7 +631,7 @@ class TextLineTest extends FieldTypeTest
                         'The string can not be shorter than %size% character.',
                         'The string can not be shorter than %size% characters.',
                         array(
-                            'size' => 5,
+                            '%size%' => 5,
                         ),
                         'text'
                     ),
@@ -652,7 +652,7 @@ class TextLineTest extends FieldTypeTest
                         'The string can not exceed %size% character.',
                         'The string can not exceed %size% characters.',
                         array(
-                            'size' => 10,
+                            '%size%' => 10,
                         ),
                         'text'
                     ),
@@ -673,7 +673,7 @@ class TextLineTest extends FieldTypeTest
                         'The string can not exceed %size% character.',
                         'The string can not exceed %size% characters.',
                         array(
-                            'size' => 5,
+                            '%size%' => 5,
                         ),
                         'text'
                     ),
@@ -681,7 +681,7 @@ class TextLineTest extends FieldTypeTest
                         'The string can not be shorter than %size% character.',
                         'The string can not be shorter than %size% characters.',
                         array(
-                            'size' => 10,
+                            '%size%' => 10,
                         ),
                         'text'
                     ),

--- a/eZ/Publish/Core/FieldType/TextBlock/Type.php
+++ b/eZ/Publish/Core/FieldType/TextBlock/Type.php
@@ -188,7 +188,7 @@ class Type extends FieldType
                                 "Setting '%setting%' value must be of integer type",
                                 null,
                                 array(
-                                    'setting' => $name,
+                                    '%setting%' => $name,
                                 ),
                                 "[$name]"
                             );
@@ -200,7 +200,7 @@ class Type extends FieldType
                     "Setting '%setting%' is unknown",
                     null,
                     array(
-                        'setting' => $name,
+                        '%setting%' => $name,
                     ),
                     "[$name]"
                 );

--- a/eZ/Publish/Core/FieldType/TextLine/Type.php
+++ b/eZ/Publish/Core/FieldType/TextLine/Type.php
@@ -56,7 +56,7 @@ class Type extends FieldType
                     "Validator '%validator%' is unknown",
                     null,
                     array(
-                        'validator' => $validatorIdentifier,
+                        '%validator%' => $validatorIdentifier,
                     )
                 );
                 continue;
@@ -98,7 +98,7 @@ class Type extends FieldType
                 'The string can not exceed %size% character.',
                 'The string can not exceed %size% characters.',
                 array(
-                    'size' => $constraints['maxStringLength'],
+                    '%size%' => $constraints['maxStringLength'],
                 ),
                 'text'
             );
@@ -112,7 +112,7 @@ class Type extends FieldType
                 'The string can not be shorter than %size% character.',
                 'The string can not be shorter than %size% characters.',
                 array(
-                    'size' => $constraints['minStringLength'],
+                    '%size%' => $constraints['minStringLength'],
                 ),
                 'text'
             );

--- a/eZ/Publish/Core/FieldType/Time/Type.php
+++ b/eZ/Publish/Core/FieldType/Time/Type.php
@@ -213,7 +213,7 @@ class Type extends FieldType
                     "Setting '%setting%' is unknown",
                     null,
                     array(
-                        'setting' => $name,
+                        '%setting%' => $name,
                     ),
                     "[$name]"
                 );
@@ -227,7 +227,7 @@ class Type extends FieldType
                             "Setting '%setting%' value must be of boolean type",
                             null,
                             array(
-                                'setting' => $name,
+                                '%setting%' => $name,
                             ),
                             "[$name]"
                         );
@@ -243,7 +243,7 @@ class Type extends FieldType
                             "Setting '%setting%' is of unknown type",
                             null,
                             array(
-                                'setting' => $name,
+                                '%setting%' => $name,
                             ),
                             "[$name]"
                         );

--- a/eZ/Publish/Core/FieldType/Validator/EmailAddressValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/EmailAddressValidator.php
@@ -52,7 +52,7 @@ class EmailAddressValidator extends Validator
                             "Validator parameter '%parameter%' value must be regex for now",
                             null,
                             array(
-                                'parameter' => $name,
+                                '%parameter%' => $name,
                             ),
                             "[EmailAddressValidator][$name]"
                         );
@@ -63,7 +63,7 @@ class EmailAddressValidator extends Validator
                         "Validator parameter '%parameter%' is unknown",
                         null,
                         array(
-                            'parameter' => $name,
+                            '%parameter%' => $name,
                         ),
                         "[EmailAddressValidator][$name]"
                     );

--- a/eZ/Publish/Core/FieldType/Validator/FileSizeValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/FileSizeValidator.php
@@ -44,7 +44,7 @@ class FileSizeValidator extends Validator
                             "Validator parameter '%parameter%' value must be of integer type",
                             null,
                             array(
-                                'parameter' => $name,
+                                '%parameter%' => $name,
                             )
                         );
                     }
@@ -54,7 +54,7 @@ class FileSizeValidator extends Validator
                         "Validator parameter '%parameter%' is unknown",
                         null,
                         array(
-                            'parameter' => $name,
+                            '%parameter%' => $name,
                         )
                     );
             }
@@ -79,7 +79,7 @@ class FileSizeValidator extends Validator
                 'The file size cannot exceed %size% byte.',
                 'The file size cannot exceed %size% bytes.',
                 array(
-                    'size' => $this->constraints['maxFileSize'],
+                    '%size%' => $this->constraints['maxFileSize'],
                 )
             );
             $isValid = false;

--- a/eZ/Publish/Core/FieldType/Validator/FloatValueValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/FloatValueValidator.php
@@ -54,7 +54,7 @@ class FloatValueValidator extends Validator
                             "Validator parameter '%parameter%' value must be of numeric type",
                             null,
                             array(
-                                'parameter' => $name,
+                                '%parameter%' => $name,
                             )
                         );
                     }
@@ -64,7 +64,7 @@ class FloatValueValidator extends Validator
                         "Validator parameter '%parameter%' is unknown",
                         null,
                         array(
-                            'parameter' => $name,
+                            '%parameter%' => $name,
                         )
                     );
             }
@@ -95,7 +95,7 @@ class FloatValueValidator extends Validator
                 'The value can not be higher than %size%.',
                 null,
                 array(
-                    'size' => $this->constraints['maxFloatValue'],
+                    '%size%' => $this->constraints['maxFloatValue'],
                 )
             );
             $isValid = false;
@@ -106,7 +106,7 @@ class FloatValueValidator extends Validator
                 'The value can not be lower than %size%.',
                 null,
                 array(
-                    'size' => $this->constraints['minFloatValue'],
+                    '%size%' => $this->constraints['minFloatValue'],
                 )
             );
             $isValid = false;

--- a/eZ/Publish/Core/FieldType/Validator/IntegerValueValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/IntegerValueValidator.php
@@ -50,7 +50,7 @@ class IntegerValueValidator extends Validator
                             "Validator parameter '%parameter%' value must be of integer type",
                             null,
                             array(
-                                'parameter' => $name,
+                                '%parameter%' => $name,
                             )
                         );
                     }
@@ -60,7 +60,7 @@ class IntegerValueValidator extends Validator
                         "Validator parameter '%parameter%' is unknown",
                         null,
                         array(
-                            'parameter' => $name,
+                            '%parameter%' => $name,
                         )
                     );
             }
@@ -91,7 +91,7 @@ class IntegerValueValidator extends Validator
                 'The value can not be higher than %size%.',
                 null,
                 array(
-                    'size' => $this->constraints['maxIntegerValue'],
+                    '%size%' => $this->constraints['maxIntegerValue'],
                 )
             );
             $isValid = false;
@@ -102,7 +102,7 @@ class IntegerValueValidator extends Validator
                 'The value can not be lower than %size%.',
                 null,
                 array(
-                    'size' => $this->constraints['minIntegerValue'],
+                    '%size%' => $this->constraints['minIntegerValue'],
                 )
             );
             $isValid = false;

--- a/eZ/Publish/Core/FieldType/Validator/StringLengthValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/StringLengthValidator.php
@@ -50,7 +50,7 @@ class StringLengthValidator extends Validator
                             "Validator parameter '%parameter%' value must be of integer type",
                             null,
                             array(
-                                'parameter' => $name,
+                                '%parameter%' => $name,
                             )
                         );
                     } elseif ($value < 0) {
@@ -58,7 +58,7 @@ class StringLengthValidator extends Validator
                             "Validator parameter '%parameter%' value can't be negative",
                             null,
                             array(
-                                'parameter' => $name,
+                                '%parameter%' => $name,
                             )
                         );
                     }
@@ -68,7 +68,7 @@ class StringLengthValidator extends Validator
                         "Validator parameter '%parameter%' is unknown",
                         null,
                         array(
-                            'parameter' => $name,
+                            '%parameter%' => $name,
                         )
                     );
             }
@@ -77,11 +77,7 @@ class StringLengthValidator extends Validator
         // if no errors above, check if minStringLength is shorter or equal than maxStringLength
         if (empty($validationErrors) && !$this->validateConstraintsOrder($constraints)) {
             $validationErrors[] = new ValidationError(
-                "Validator parameter 'maxStringLength' can't be shorter than validator parameter 'minStringLength' value",
-                null,
-                array(
-                    'parameter' => 'minStringLength',
-                )
+                "Validator parameter 'maxStringLength' can't be shorter than validator parameter 'minStringLength' value"
             );
         }
 
@@ -123,7 +119,7 @@ class StringLengthValidator extends Validator
                 'The string can not exceed %size% character.',
                 'The string can not exceed %size% characters.',
                 array(
-                    'size' => $this->constraints['maxStringLength'],
+                    '%size%' => $this->constraints['maxStringLength'],
                 )
             );
             $isValid = false;
@@ -135,7 +131,7 @@ class StringLengthValidator extends Validator
                 'The string can not be shorter than %size% character.',
                 'The string can not be shorter than %size% characters.',
                 array(
-                    'size' => $this->constraints['minStringLength'],
+                    '%size%' => $this->constraints['minStringLength'],
                 )
             );
             $isValid = false;


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-26148
> Status: Ready for review
> Originally: https://github.com/ezsystems/ezpublish-kernel/pull/1745

Example: `The string can not exceed %42% characters.` - the `%`'s shouldn't be there. The translation parameters are lacking %-symbols, meaning those that exist in the translation string won't be removed when parameters are inserted.

These strings end up in the Symfony `Translator` which uses [strtr](http://php.net/manual/en/function.strtr.php), and that makes no assumptions about %'s, it simply replaces strings verbatim. So if strings are %-wrapped in the translation string, they must also be so in the parameters: http://symfony.com/doc/2.7/components/translation/usage.html#message-placeholders

The issue was verified in https://github.com/ezsystems/ezpublish-kernel/pull/1745, see discussion there.

- [x] Do the same for the remaining types/validators