### PR TITLE
[PoC][PHPUnit] EZP-26128: Use symfony/phpunit-bridge to display deprecated code warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "liip/imagine-bundle": "~1.0",
         "oneup/flysystem-bundle": "^1.0",
         "friendsofsymfony/http-cache-bundle": ">=1.2, <=1.3.6",
-        "sensio/framework-extra-bundle": "~3.0"
+        "sensio/framework-extra-bundle": "~3.0",
+        "symfony/phpunit-bridge": "^3.1"
     },
     "require-dev": {
         "mikey179/vfsStream": "1.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "986337dbc8fab893be5c4497359ea30a",
-    "content-hash": "9f8b512cff7104b64e133a5c78e40166",
+    "hash": "e2ff335c49a00bb51f4b92c331db5f71",
+    "content-hash": "b4ad95d058ccd6c733513139a89b0701",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -889,7 +889,6 @@
                 "rest",
                 "web service"
             ],
-            "abandoned": "guzzlehttp/guzzle",
             "time": "2015-03-18 18:23:50"
         },
         {
@@ -1986,6 +1985,61 @@
                 "routing"
             ],
             "time": "2016-03-31 09:11:39"
+        },
+        {
+            "name": "symfony/phpunit-bridge",
+            "version": "v3.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/phpunit-bridge.git",
+                "reference": "eeb3bf9a195df7552fdda46f4724a9442d157413"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/eeb3bf9a195df7552fdda46f4724a9442d157413",
+                "reference": "eeb3bf9a195df7552fdda46f4724a9442d157413",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "symfony/debug": "For tracking deprecated interfaces usages at runtime with DebugClassLoader"
+            },
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Bridge\\PhpUnit\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony PHPUnit Bridge",
+            "homepage": "https://symfony.com",
+            "time": "2016-06-29 05:42:25"
         },
         {
             "name": "symfony/polyfill-apcu",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,6 +9,7 @@
   >
   <php>
     <ini name="error_reporting" value="-1" />
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="62" /> <!-- there are 62 known issues that can't cause CI to fail -->
   </php>
   <testsuites>
     <testsuite name="eZ\Publish\Core\Base">


### PR DESCRIPTION
Status: **Proof of concept**
Related to: [EZP-26128](https://jira.ez.no/browse/EZP-26128)

The [`symfony/phpunit-bridge`](http://symfony.com/doc/current/components/phpunit_bridge.html) package provides displaying of deprecated code warnings after `PHPUnit` tests are performed. 

**TODO**:
- [x] Make deprecations not fail entire test (5695603).
- [ ] Check possibilities of removal of deprecated code.