### PR TITLE
Fix EZP-26188: Add twig globals to fields templates

### DIFF
--- a/bin/.travis/prepare_behat.sh
+++ b/bin/.travis/prepare_behat.sh
@@ -8,7 +8,7 @@ export BRANCH_BUILD_DIR=$TRAVIS_BUILD_DIR TRAVIS_BUILD_DIR="$HOME/build/ezplatfo
 cd "$HOME/build"
 
 # Checkout meta repo, change the branch and/or remote to use a different ezpublish branch/distro
-git clone --depth 1 --single-branch --branch master https://github.com/ezsystems/ezplatform.git
+git clone --depth 1 --single-branch --branch 1.4 https://github.com/ezsystems/ezplatform.git
 cd ezplatform
 
 if [ "$REST_TEST_CONFIG" != "" ] ; then

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/FieldBlockRenderer.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/FieldBlockRenderer.php
@@ -176,7 +176,7 @@ class FieldBlockRenderer implements FieldBlockRendererInterface
 
         return $this->baseTemplate->renderBlock(
             $this->getRenderFieldBlockName($fieldTypeIdentifier, $type),
-            $params,
+            $this->twig->mergeGlobals($params),
             $this->getBlocksByField($fieldTypeIdentifier, $type, $localTemplate)
         );
     }
@@ -211,7 +211,7 @@ class FieldBlockRenderer implements FieldBlockRendererInterface
 
         return $this->baseTemplate->renderBlock(
             $this->getRenderFieldDefinitionBlockName($fieldDefinition->fieldTypeIdentifier, $type),
-            $params,
+            $this->twig->mergeGlobals($params),
             $this->getBlocksByFieldDefinition($fieldDefinition, $type)
         );
     }


### PR DESCRIPTION
> Fixes http://jira.ez.no/browse/EZP-26188
> Required by #1726

Merges global twig variables into the context in the `ez_render_*` helpers.

To test, use either app or `ezpublish` variables in `content_edit.html.twig`. Without the patch, an error about a missing variable is thrown.