### PR TITLE
Fix EZP-26116: Error trashing an object with multiple locations

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -2055,12 +2055,14 @@ Move Subtree
         HTTP/1.1 201 Created
         Location: /content/locations/<newPath>
 
-or if destination is /content/trash
+or if destination is /content/trash and content only has one location
 
 .. code:: http
 
         HTTP/1.1 201 Created
         Location: /content/trash/<ID>
+
+or if destination is /content/trash and content still has other locations (no trash item is created)
 
 .. code:: http
 

--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -2062,6 +2062,10 @@ or if destination is /content/trash
         HTTP/1.1 201 Created
         Location: /content/trash/<ID>
 
+.. code:: http
+
+        HTTP/1.1 204 No Content
+
 :Error Codes:
     :404: If the  location with the given id does not exist
     :401: If the user is not authorized to move this location

--- a/eZ/Publish/Core/REST/Server/Controller/Location.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Location.php
@@ -206,7 +206,7 @@ class Location extends RestController
      *
      * @throws \eZ\Publish\Core\REST\Server\Exceptions\BadRequestException if the Destination header cannot be parsed as location or trash
      *
-     * @return \eZ\Publish\Core\REST\Server\Values\ResourceCreated
+     * @return \eZ\Publish\Core\REST\Server\Values\ResourceCreated | \eZ\Publish\Core\REST\Server\Values\NoContent
      */
     public function moveSubtree($locationPath, Request $request)
     {
@@ -247,12 +247,17 @@ class Location extends RestController
                 // Trash the subtree
                 $trashItem = $this->trashService->trash($locationToMove);
 
-                return new Values\ResourceCreated(
-                    $this->router->generate(
-                        'ezpublish_rest_loadTrashItem',
-                        array('trashItemId' => $trashItem->id)
-                    )
-                );
+                if (isset($trashItem)) {
+                    return new Values\ResourceCreated(
+                        $this->router->generate(
+                            'ezpublish_rest_loadTrashItem',
+                            array('trashItemId' => $trashItem->id)
+                        )
+                    );
+                } else {
+                    // Only a location has been trashed and not the object
+                    return new Values\NoContent();
+                }
             } catch (Exceptions\InvalidArgumentException $e) {
                 // If that fails, the Destination header is not formatted right
                 // so just throw the BadRequestException


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-26116

## Description
When deleting an object with more than one location using REST, a 500 error is thrown because `$trashItem` is `null`.

It is supposed to be `null` as it is the expected result from the API (no object has been deleted but only one of its location, no trashitem has been created). https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/Repository/TrashService.php#L113

It is safe regarding BC as before it crashed and now it doesn't.

## Tests
Manual test.