### PR TITLE
EZP-26186: Add integration tests for cases solved

### DIFF
--- a/bin/.travis/prepare_unittest.sh
+++ b/bin/.travis/prepare_unittest.sh
@@ -39,8 +39,8 @@ COMPOSER_UPDATE=""
 
 # solr package search API integration tests
 if [ "$TEST_CONFIG" = "phpunit-integration-legacy-solr.xml" ] ; then
-    echo "> Require ezsystems/ezplatform-solr-search-engine:^1.0.0@dev"
-    composer require --no-update ezsystems/ezplatform-solr-search-engine:^1.0.0@dev
+    echo "> Require ezsystems/ezplatform-solr-search-engine:^1.1.0@dev"
+    composer require --no-update ezsystems/ezplatform-solr-search-engine:"dev-EZP-26186 as 1.1.x-dev"
     COMPOSER_UPDATE="true"
 fi
 

--- a/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
@@ -76,6 +76,52 @@ class SearchEngineIndexingTest extends BaseTest
         $this->assertEquals(0, $result->totalCount);
     }
 
+    /**
+     * EZP-26186: Make sure index is deleted on removal of Users  (affected Solr & Elastic).
+     */
+    public function testDeleteUser()
+    {
+        $repository = $this->getRepository();
+        $userService = $repository->getUserService();
+        $searchService = $repository->getSearchService();
+
+        $anonymousContentId = $this->generateId('user', 10);
+        $user = $userService->loadUser($anonymousContentId);
+
+        $userService->deleteUser($user);
+
+        $this->refreshSearch($repository);
+
+        // Should not be found
+        $criterion = new Criterion\ContentId($user->id);
+        $query = new Query(array('filter' => $criterion));
+        $result = $searchService->findContentInfo($query);
+        $this->assertEquals(0, $result->totalCount);
+    }
+
+    /**
+     * EZP-26186: Make sure index is deleted on removal of UserGroups  (affected Solr & Elastic).
+     */
+    public function testDeleteUserGroup()
+    {
+        $repository = $this->getRepository();
+        $userService = $repository->getUserService();
+        $searchService = $repository->getSearchService();
+
+        $membersContentId = $this->generateId('user_group', 11);
+        $userGroup = $userService->loadUserGroup($membersContentId);
+
+        $userService->deleteUserGroup($userGroup);
+
+        $this->refreshSearch($repository);
+
+        // Should not be found
+        $criterion = new Criterion\ContentId($userGroup->id);
+        $query = new Query(array('filter' => $criterion));
+        $result = $searchService->findContentInfo($query);
+        $this->assertEquals(0, $result->totalCount);
+    }
+
     public function testCreateLocation()
     {
         $repository = $this->getRepository();

--- a/eZ/Publish/Core/settings/search_engines/elasticsearch/slots.yml
+++ b/eZ/Publish/Core/settings/search_engines/elasticsearch/slots.yml
@@ -8,8 +8,10 @@ parameters:
     ezpublish.search.elasticsearch.slot.update_location.class: eZ\Publish\Core\Search\Common\Slot\UpdateLocation
     ezpublish.search.elasticsearch.slot.delete_location.class: eZ\Publish\Core\Search\Common\Slot\DeleteLocation
     ezpublish.search.elasticsearch.slot.create_user.class: eZ\Publish\Core\Search\Common\Slot\CreateUser
+    ezpublish.search.elasticsearch.slot.delete_user.class: eZ\Publish\Core\Search\Common\Slot\DeleteUser
     ezpublish.search.elasticsearch.slot.create_user_group.class: eZ\Publish\Core\Search\Common\Slot\CreateUserGroup
     ezpublish.search.elasticsearch.slot.move_user_group.class: eZ\Publish\Core\Search\Common\Slot\MoveUserGroup
+    ezpublish.search.elasticsearch.slot.delete_user_group.class: eZ\Publish\Core\Search\Common\Slot\DeleteUserGroup
     ezpublish.search.elasticsearch.slot.copy_subtree.class: eZ\Publish\Core\Search\Common\Slot\CopySubtree
     ezpublish.search.elasticsearch.slot.move_subtree.class: eZ\Publish\Core\Search\Common\Slot\MoveSubtree
     ezpublish.search.elasticsearch.slot.trash.class: eZ\Publish\Core\Search\Common\Slot\Trash
@@ -75,6 +77,12 @@ services:
         tags:
             - {name: ezpublish.search.elasticsearch.slot, signal: UserService\CreateUserSignal}
 
+    ezpublish.search.elasticsearch.slot.delete_user:
+        parent: ezpublish.search.elasticsearch.slot
+        class: "%ezpublish.search.elasticsearch.slot.delete_user.class%"
+        tags:
+            - {name: ezpublish.search.elasticsearch.slot, signal: UserService\DeleteUserSignal}
+
     ezpublish.search.elasticsearch.slot.create_user_group:
         parent: ezpublish.search.elasticsearch.slot
         class: "%ezpublish.search.elasticsearch.slot.create_user_group.class%"
@@ -86,6 +94,12 @@ services:
         class: "%ezpublish.search.elasticsearch.slot.move_user_group.class%"
         tags:
             - {name: ezpublish.search.elasticsearch.slot, signal: UserService\MoveUserGroupSignal}
+
+    ezpublish.search.elasticsearch.slot.delete_user_group:
+        parent: ezpublish.search.elasticsearch.slot
+        class: "%ezpublish.search.elasticsearch.slot.delete_user_group.class%"
+        tags:
+            - {name: ezpublish.search.elasticsearch.slot, signal: UserService\DeleteUserGroupSignal}
 
     ezpublish.search.elasticsearch.slot.copy_subtree:
         parent: ezpublish.search.elasticsearch.slot


### PR DESCRIPTION
Adds integration tests for fixes in #1759, these tests fails on Elastic and Solr before fixes in 

Todo:
- [x] Split in two, DeleteVersion and DeleteContent should go back to 6.3, while test coverage for new slots can be master only to not complicate things with Solr _(don't want to force kernel version bump in  Solr 1.0)_
- [x] Need to add config for new slots in Solr to get it to pass as well