### PR TITLE
[PHP] Add testing of PHP 7.1 and adjust tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,14 +40,15 @@ matrix:
     - php: 7.0
       env: REST_TEST_CONFIG="phpunit-functional-rest.xml" RUN_INSTALL=1 SYMFONY_ENV=dev SYMFONY_DEBUG=1
     - php: 7.0
-      env: TEST_CONFIG="phpunit.xml"
-    - php: 7.0
       env: BEHAT_OPTS="--profile=rest --suite=fullJson" RUN_INSTALL=1
     - php: 7.0
       env: ELASTICSEARCH_VERSION="1.4.2" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml" SYMFONY_VERSION="~2.8.0"
     - php: 7.0
       env: SOLR_VERSION="4.10.4" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="single" SOLR_CONFS="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml"
-    - php: 7.0
+# 7.1
+    - php: 7.1
+      env: TEST_CONFIG="phpunit.xml"
+    - php: 7.1
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb"
 # hhvm - disabled, no need to enable before travis has newer versions avaiable
 #    - php: hhvm

--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
@@ -127,12 +127,12 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
             array(
                 'identifier' => $group->identifier,
                 'creatorId' => $group->creatorId,
-                'creationDate' => $group->creationDate,
+                'creationDate' => $group->creationDate->getTimestamp(),
             ),
             array(
                 'identifier' => $createStruct->identifier,
                 'creatorId' => $createStruct->creatorId,
-                'creationDate' => $createStruct->creationDate,
+                'creationDate' => $createStruct->creationDate->getTimestamp(),
             )
         );
         $this->assertNotNull(
@@ -810,10 +810,20 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
                         $contentType->contentTypeGroups
                     );
                     break;
+
+                case 'creationDate':
+                case 'modificationDate':
+                    $this->assertEquals(
+                        $typeCreate->$propertyName->getTimestamp(),
+                        $contentType->$propertyName->getTimestamp()
+                    );
+                    break;
+
                 default:
                     $this->assertEquals(
                         $typeCreate->$propertyName,
-                        $contentType->$propertyName
+                        $contentType->$propertyName,
+                        "Did not assert that property '${propertyName}' is equal on struct and resulting value object"
                     );
                     break;
             }

--- a/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
@@ -969,7 +969,7 @@ class SearchEngineIndexingTest extends BaseTest
         $foundContentInfo = $results->searchHits[0]->valueObject->contentInfo;
         /** @var \eZ\Publish\Core\Repository\Values\Content\Content $foundContentInfo */
         $this->assertEquals($publishedContent->id, $foundContentInfo->id);
-        $this->assertEquals($newContentMetadataUpdateStruct->publishedDate, $foundContentInfo->publishedDate);
+        $this->assertEquals($newContentMetadataUpdateStruct->publishedDate->getTimestamp(), $foundContentInfo->publishedDate->getTimestamp());
         $this->assertEquals($newLocation->id, $foundContentInfo->mainLocationId);
         $this->assertEquals($newContentMetadataUpdateStruct->remoteId, $foundContentInfo->remoteId);
 

--- a/eZ/Publish/Core/REST/Common/Tests/Output/Generator/FieldTypeHashGeneratorBaseTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Output/Generator/FieldTypeHashGeneratorBaseTest.php
@@ -16,6 +16,22 @@ abstract class FieldTypeHashGeneratorBaseTest extends PHPUnit_Framework_TestCase
 
     private $fieldTypeHashGenerator;
 
+    private $iniPrecisions;
+
+    /**
+     * To make sure float values are serialized with same precision across php versions we force precision.
+     */
+    public function setUp()
+    {
+        $this->iniPrecisions = [ini_set('precision', 17), ini_set('serialize_precision', 17)];
+    }
+
+    public function TearDown()
+    {
+        ini_set('precision', $this->iniPrecisions[0]);
+        ini_set('serialize_precision', $this->iniPrecisions[1]);
+    }
+
     /**
      * Initializes the field type hash generator.
      */

--- a/eZ/Publish/Core/REST/Common/Tests/Output/Generator/_fixtures/Json_FieldTypeHashGeneratorTest__testGenerateFloatValue.out
+++ b/eZ/Publish/Core/REST/Common/Tests/Output/Generator/_fixtures/Json_FieldTypeHashGeneratorTest__testGenerateFloatValue.out
@@ -1,1 +1,1 @@
-{"Field":{"fieldValue":23.424242424242}}
+{"Field":{"fieldValue":23.424242424242426}}

--- a/eZ/Publish/Core/Repository/Tests/Service/Integration/Base.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Integration/Base.php
@@ -178,6 +178,14 @@ abstract class Base extends PHPUnit_Framework_TestCase
             $actualValue = $actualValue->getArrayCopy();
         }
 
+        // For PHP 7.1 make sure we just compare the timestamp and not the offset value
+        if ($expectedValue instanceof \DateTimeInterface) {
+            $expectedValue = $expectedValue->getTimestamp();
+        }
+        if ($actualValue instanceof \DateTimeInterface) {
+            $actualValue = $actualValue->getTimestamp();
+        }
+
         if ($equal) {
             $this->assertEquals(
                 $expectedValue,

--- a/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentTypeBase.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentTypeBase.php
@@ -1180,10 +1180,19 @@ abstract class ContentTypeBase extends BaseServiceTest
                     );
                     break;
 
+                case 'creationDate':
+                case 'modificationDate':
+                    $this->assertEquals(
+                        $typeCreate->$propertyName->getTimestamp(),
+                        $contentType->$propertyName->getTimestamp()
+                    );
+                    break;
+
                 default:
                     $this->assertEquals(
                         $typeCreate->$propertyName,
-                        $contentType->$propertyName
+                        $contentType->$propertyName,
+                        "Did not assert that property '${propertyName}' is equal on struct and resulting value object"
                     );
                     break;
             }


### PR DESCRIPTION
Given PHP 7.1 is entering RC state we should start to have some testing
of it in place for v1.6 (16.10) release.
### Todo: Float rounding Issue

Float rounding issue in REST, seems something is causing rounding to behave strangly.
Change in 7.1: https://wiki.php.net/rfc/precise_float_value
23.424242424242424242  _Orignal_
23.424242424242  _Expected (according to PHPUnit on PHP 7.1)_
23.424242424242426 _Actual (according to PHPUnit on PHP 7.1), notice the strange rounding_

```
1) eZ\Publish\Core\REST\Common\Tests\Output\Generator\Json\FieldTypeHashGeneratorTest::testGenerateFloatValue
Failed asserting that two strings are identical.
--- Expected
+++ Actual
@@ @@
-{"Field":{"fieldValue":23.424242424242}}
+{"Field":{"fieldValue":23.424242424242426}}
/home/travis/build/ezsystems/ezpublish-kernel/eZ/Publish/Core/REST/Common/Tests/Output/Generator/FieldTypeHashGeneratorBaseTest.php:197
/home/travis/build/ezsystems/ezpublish-kernel/eZ/Publish/Core/REST/Common/Tests/Output/Generator/FieldTypeHashGeneratorBaseTest.php:70
```
