### PR TITLE
Fix EZP-26243: Default embed templates in rich text field type render the whole page

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/content.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/content.html.twig
@@ -13,7 +13,8 @@
                 {
                     "contentId": embedParams.id,
                     "viewType": embedParams.viewType,
-                    "params": params
+                    "params": params,
+                    "layout": false
                 }
             )
         )

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/content_inline.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/content_inline.html.twig
@@ -12,7 +12,8 @@
             {
                 "contentId": embedParams.id,
                 "viewType": embedParams.viewType,
-                "params": params
+                "params": params,
+                "layout": false
             }
         )
     )

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/location.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/location.html.twig
@@ -13,7 +13,8 @@
                 {
                     "locationId": embedParams.id,
                     "viewType": embedParams.viewType,
-                    "params": params
+                    "params": params,
+                    "layout": false
                 }
             )
         )

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/location_inline.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/location_inline.html.twig
@@ -12,7 +12,8 @@
             {
                 "locationId": embedParams.id,
                 "viewType": embedParams.viewType,
-                "params": params
+                "params": params,
+                "layout": false
             }
         )
     )


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-26243

By default, the embed templates in rich text field type render the entire page. This is something we never want, so this disables the behaviour.

Ofcourse, the specific embed template which user overrides still can control this by not honoring the `noLayout` flag, but by default, the layout should be disabled.