### PR TITLE
EZP-26219: Add Integration test coverage to verify search index after operations affecting it

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
@@ -362,9 +362,9 @@ class SearchEngineIndexingTest extends BaseTest
         $contentService = $repository->getContentService();
         $locationService = $repository->getLocationService();
 
-        $publishedContent = $this->createContentWithName('copy-test', [2]);
+        $publishedContent = $this->createContentWithName('copyTest', [2]);
         $this->refreshSearch($repository);
-        $criterion = new Criterion\FullText('copy-test');
+        $criterion = new Criterion\FullText('copyTest');
         $query = new Query(['filter' => $criterion]);
         $result = $searchService->findContent($query);
         $this->assertCount(1, $result->searchHits);
@@ -379,7 +379,7 @@ class SearchEngineIndexingTest extends BaseTest
     }
 
     /**
-     * Will create if not exists an simple content type for test purposes with just one required field name.
+     * Will create if not exists a simple content type for test purposes with just one required field name.
      *
      * @return \eZ\Publish\API\Repository\Values\ContentType\ContentType
      */

--- a/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
@@ -559,6 +559,32 @@ class SearchEngineIndexingTest extends BaseTest
     }
 
     /**
+     * Test that setting object content state to locked and then unlocked does not affect search index.
+     */
+    public function testSetContentState()
+    {
+        $repository = $this->getRepository();
+        $objectStateService = $repository->getObjectStateService();
+
+        // get Object States
+        $stateNotLocked = $objectStateService->loadObjectState(1);
+        $stateLocked = $objectStateService->loadObjectState(2);
+
+        $publishedContent = $this->createContentWithName('setContentStateTest', [2]);
+        $objectStateService->setContentState($publishedContent->contentInfo, $stateLocked->getObjectStateGroup(), $stateLocked);
+        $this->refreshSearch($repository);
+
+        // Setting Content State to "locked" should not affect search index
+        $this->assertContentIdSearch($publishedContent->contentInfo->id, 1);
+
+        $objectStateService->setContentState($publishedContent->contentInfo, $stateNotLocked->getObjectStateGroup(), $stateNotLocked);
+        $this->refreshSearch($repository);
+
+        // Setting Content State back to "not locked" should not affect search index
+        $this->assertContentIdSearch($publishedContent->contentInfo->id, 1);
+    }
+
+    /**
      * Check if FullText indexing works for special cases of text.
      *
      * @param string $text Content Item field value text (to be indexed)

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LanguageAwareTestCase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LanguageAwareTestCase.php
@@ -109,4 +109,49 @@ abstract class LanguageAwareTestCase extends TestCase
             $contentTypeHandler
         );
     }
+
+    /**
+     * Get FullText search configuration.
+     */
+    protected function getFullTextSearchConfiguration()
+    {
+        return [
+            'stopWordThresholdFactor' => 0.66,
+            'enableWildcards' => true,
+            'commands' => [
+                'apostrophe_normalize',
+                'apostrophe_to_doublequote',
+                'ascii_lowercase',
+                'ascii_search_cleanup',
+                'cyrillic_diacritical',
+                'cyrillic_lowercase',
+                'cyrillic_search_cleanup',
+                'cyrillic_transliterate_ascii',
+                'doublequote_normalize',
+                'endline_search_normalize',
+                'greek_diacritical',
+                'greek_lowercase',
+                'greek_normalize',
+                'greek_transliterate_ascii',
+                'hebrew_transliterate_ascii',
+                'hyphen_normalize',
+                'inverted_to_normal',
+                'latin1_diacritical',
+                'latin1_lowercase',
+                'latin1_transliterate_ascii',
+                'latin-exta_diacritical',
+                'latin-exta_lowercase',
+                'latin-exta_transliterate_ascii',
+                'latin_lowercase',
+                'latin_search_cleanup',
+                'latin_search_decompose',
+                'math_to_ascii',
+                'punctuation_normalize',
+                'space_normalize',
+                'special_decompose',
+                'specialwords_search_normalize',
+                'tab_search_normalize',
+            ],
+        ];
+    }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
@@ -107,6 +107,8 @@ class DoctrineDatabase extends Gateway
         $wordCount = 0;
         $placement = 0;
 
+        // Remove previously indexed content if exists to avoid keeping in index removed field values
+        $this->remove($fullTextData->id);
         foreach ($fullTextData->values as $fullTextValue) {
             /** @var \eZ\Publish\Core\Search\Legacy\Content\FullTextValue $fullTextValue */
             if (is_numeric(trim($fullTextValue->value))) {

--- a/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
@@ -63,23 +63,33 @@ class DoctrineDatabase extends Gateway
     protected $searchIndex;
 
     /**
+     * Full text search configuration options.
+     *
+     * @var array
+     */
+    protected $fullTextSearchConfiguration;
+
+    /**
      * Construct from handler handler.
      *
      * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
      * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $typeHandler
      * @param \eZ\Publish\Core\Persistence\TransformationProcessor $transformationProcessor
      * @param \eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Repository\SearchIndex $searchIndex
+     * @param array $fullTextSearchConfiguration
      */
     public function __construct(
         DatabaseHandler $dbHandler,
         SPITypeHandler $typeHandler,
         TransformationProcessor $transformationProcessor,
-        SearchIndex $searchIndex
+        SearchIndex $searchIndex,
+        array $fullTextSearchConfiguration
     ) {
         $this->dbHandler = $dbHandler;
         $this->typeHandler = $typeHandler;
         $this->transformationProcessor = $transformationProcessor;
         $this->searchIndex = $searchIndex;
+        $this->fullTextSearchConfiguration = $fullTextSearchConfiguration;
     }
 
     /**
@@ -107,13 +117,12 @@ class DoctrineDatabase extends Gateway
             } else {
                 $integerValue = 0;
             }
-            // Split text on whitespace
-            $wordArray = explode(' ', $fullTextValue->value);
+            // Split transformed text on whitespace
+            $wordArray = explode(' ', $this->transformationProcessor->transform($fullTextValue->value, $this->fullTextSearchConfiguration['commands']));
             foreach ($wordArray as $word) {
                 if (trim($word) === '') {
                     continue;
                 }
-                $word = $this->transformationProcessor->transformByGroup($word, 'lowercase');
                 // words stored in search index are limited to 150 characters
                 if (mb_strlen($word) > 150) {
                     $word = mb_substr($word, 0, 150);

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentSortTest.php
@@ -103,7 +103,8 @@ class HandlerContentSortTest extends LanguageAwareTestCase
                 $this->getDatabaseHandler(),
                 $this->getContentTypeHandler(),
                 $this->getDefinitionBasedTransformationProcessor(),
-                new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseHandler())
+                new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseHandler()),
+                $this->getFullTextSearchConfiguration()
             ),
             $this->getContentMapperMock(),
             $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Mapper'),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
@@ -222,7 +222,8 @@ class HandlerContentTest extends LanguageAwareTestCase
                 $this->getDatabaseHandler(),
                 $this->getContentTypeHandler(),
                 $this->getDefinitionBasedTransformationProcessor(),
-                new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseHandler())
+                new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseHandler()),
+                $this->getFullTextSearchConfiguration()
             ),
             $this->getContentMapperMock(),
             $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Mapper'),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
@@ -127,7 +127,8 @@ class HandlerLocationSortTest extends LanguageAwareTestCase
                 $this->getDatabaseHandler(),
                 $this->getContentTypeHandler(),
                 $this->getDefinitionBasedTransformationProcessor(),
-                new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseHandler())
+                new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseHandler()),
+                $this->getFullTextSearchConfiguration()
             ),
             $this->getMockBuilder('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Mapper')->disableOriginalConstructor()->getMock(),
             $this->getLocationMapperMock(),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
@@ -195,7 +195,8 @@ class HandlerLocationTest extends LanguageAwareTestCase
                 $this->getDatabaseHandler(),
                 $this->getContentTypeHandler(),
                 $transformationProcessor,
-                new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseHandler())
+                new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseHandler()),
+                $this->getFullTextSearchConfiguration()
             ),
             $this->getMockBuilder('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Mapper')->disableOriginalConstructor()->getMock(),
             $this->getLocationMapperMock(),

--- a/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
@@ -28,6 +28,44 @@ parameters:
     ezpublish.search.legacy.gateway.criterion_field_value_handler.composite.class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler\Composite
     ezpublish.search.legacy.gateway.criterion_field_value_handler.simple.class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler\Simple
 
+    # Full text search configuration options.
+    ezpublish.search.legacy.criterion_handler.full_text.configuration:
+        stopWordThresholdFactor: 0.66
+        enableWildcards: true
+        commands:
+            - "apostrophe_normalize"
+            - "apostrophe_to_doublequote"
+            - "ascii_lowercase"
+            - "ascii_search_cleanup"
+            - "cyrillic_diacritical"
+            - "cyrillic_lowercase"
+            - "cyrillic_search_cleanup"
+            - "cyrillic_transliterate_ascii"
+            - "doublequote_normalize"
+            - "endline_search_normalize"
+            - "greek_diacritical"
+            - "greek_lowercase"
+            - "greek_normalize"
+            - "greek_transliterate_ascii"
+            - "hebrew_transliterate_ascii"
+            - "hyphen_normalize"
+            - "inverted_to_normal"
+            - "latin1_diacritical"
+            - "latin1_lowercase"
+            - "latin1_transliterate_ascii"
+            - "latin-exta_diacritical"
+            - "latin-exta_lowercase"
+            - "latin-exta_transliterate_ascii"
+            - "latin_lowercase"
+            - "latin_search_cleanup"
+            - "latin_search_decompose"
+            - "math_to_ascii"
+            - "punctuation_normalize"
+            - "space_normalize"
+            - "special_decompose"
+            - "specialwords_search_normalize"
+            - "tab_search_normalize"
+
 services:
     ezpublish.search.legacy.gateway.criterion_handler.base:
         abstract: true
@@ -103,6 +141,7 @@ services:
         arguments:
             - "@ezpublish.api.storage_engine.legacy.dbhandler"
             - "@ezpublish.api.storage_engine.transformation_processor"
+            - "%ezpublish.search.legacy.criterion_handler.full_text.configuration%"
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}

--- a/eZ/Publish/Core/settings/search_engines/legacy/services.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/services.yml
@@ -32,6 +32,7 @@ services:
             - "@ezpublish.spi.persistence.content_type_handler"
             - "@ezpublish.api.storage_engine.transformation_processor"
             - "@ezpublish.search.legacy.repository.searchIndex"
+            - "%ezpublish.search.legacy.criterion_handler.full_text.configuration%"
 
     ezpublish.search.legacy.gateway.location.inner:
         class: "%ezpublish.search.legacy.gateway.location.class%"


### PR DESCRIPTION
Status: **Ready for a review**
JIRA issue: [EZP-26219](https://jira.ez.no/browse/EZP-26219)

- [x] Test search index integrity after publishing Content (82f89df).
- [x] Test search index integrity after recovering Location from Trash (c303f48).
- [x] Test search index integrity after copying Content (72a5822).
- [x] Test search index integrity after creating user and user group (5e2291e).
- [x] Test search index integrity after operations affecting Locations (72a5822).
- [x] Test search index integrity after changing Content Object State (5a9e11b).
- [x] Test Content with special cases of phrases is available for FullText search (e69d27a).
- [x] Test search index integrity after removing Content Object field value (a85916e).
- [x] Apply FullText `TransformationProcessor` in `WordIndexer` for the Legacy Search Engine Index (01d3ad7).
- [x] Fix Legacy/SQL Search Engine `WordIndexer` bug uncovered in a85916e (3edb220).