### PR TITLE
Fix EZP-26175: Exception instead of 404 when trying to access a file …

### DIFF
--- a/eZ/Publish/Core/IO/TolerantIOService.php
+++ b/eZ/Publish/Core/IO/TolerantIOService.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\IO;
 
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\IO\Exception\BinaryFileNotFoundException;
 use eZ\Publish\Core\IO\Exception\InvalidBinaryFileIdException;
 use eZ\Publish\Core\IO\Values\BinaryFile;
@@ -94,7 +95,14 @@ class TolerantIOService extends IOService
 
     public function loadBinaryFileByUri($binaryFileUri)
     {
-        $binaryFileId = $this->removeUriPrefix($this->binarydataHandler->getIdFromUri($binaryFileUri));
+        try {
+            $binaryFileId = $this->removeUriPrefix($this->binarydataHandler->getIdFromUri($binaryFileUri));
+        } catch (InvalidArgumentException $e) {
+            $this->logMissingFile($binaryFileUri);
+
+            return new MissingBinaryFile(['uri' => $binaryFileUri]);
+        }
+
         try {
             return $this->loadBinaryFile($binaryFileId);
         } catch (BinaryFileNotFoundException $e) {

--- a/eZ/Publish/Core/IO/TolerantIOService.php
+++ b/eZ/Publish/Core/IO/TolerantIOService.php
@@ -83,7 +83,10 @@ class TolerantIOService extends IOService
         } catch (BinaryFileNotFoundException $e) {
             $this->logMissingFile($binaryFileId);
 
-            return $this->createMissingBinaryFile($binaryFileId);
+            return new MissingBinaryFile([
+                'id' => $binaryFileId,
+                'uri' => $this->binarydataHandler->getUri($this->getPrefixedUri($binaryFileId)),
+            ]);
         }
 
         if (!isset($spiBinaryFile->uri)) {
@@ -108,23 +111,11 @@ class TolerantIOService extends IOService
         } catch (BinaryFileNotFoundException $e) {
             $this->logMissingFile($binaryFileUri);
 
-            return $this->createMissingBinaryFile($binaryFileId);
-        }
-    }
-
-    /**
-     * @param $binaryFileId
-     *
-     * @return \eZ\Publish\Core\IO\Values\MissingBinaryFile
-     */
-    private function createMissingBinaryFile($binaryFileId)
-    {
-        return new MissingBinaryFile(
-            array(
+            return new MissingBinaryFile([
                 'id' => $binaryFileId,
                 'uri' => $this->binarydataHandler->getUri($this->getPrefixedUri($binaryFileId)),
-            )
-        );
+            ]);
+        }
     }
 
     private function logMissingFile($id)


### PR DESCRIPTION
…stored with a non default vardir

> Fixes https://jira.ez.no/browse/EZP-26175
> Status: Ready for review

If you set the var directory to `var/storage` you get an unhandled exception. Using the default VarDir you get a 404, which makes more sense.

Got a working solution now: Throw a Symfony `NotFoundHttpException` from the `StreamFileListener`, this results in a 404 for the end user. It also means that the `MissingBinaryFile` check in `BinaryStreamResponse` is no longer needed, making it cleaner.

- [x] ~~Test the new exception classes~~ Irrelevant after last revert
- [x] ~~Document `throws`~~ Irrelevant after last revert
- [x] ~~Translate the 404 error message~~ Irrelevant after last revert
- [x] ~~Update script for existing content~~ See https://jira.ez.no/browse/EZP-26416