### PR TITLE
EZP-26281 Missing language for PreviewController

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/full.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/full.html.twig
@@ -1,7 +1,7 @@
 {% extends noLayout == true ? viewbaseLayout : pagelayout %}
 {% block content %}
     <h2>{{ ez_content_name(content) }}</h2>
-    {% for field in content.fieldsByLanguage %}
+    {% for field in content.fieldsByLanguage(language|default(null)) %}
         <h3>{{ field.fieldDefIdentifier }}</h3>
         {{ ez_render_field(content, field.fieldDefIdentifier) }}
     {% endfor %}

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
@@ -162,6 +162,7 @@ EOF;
                 'content' => $content,
                 'location' => $location,
                 'isPreview' => true,
+                'language' => $language,
             ),
             'siteaccess' => $previewSiteAccess,
             'semanticPathinfo' => $request->attributes->get('semanticPathinfo'),


### PR DESCRIPTION
Jira: https://jira.ez.no/browse/EZP-26281
Missing language in full.html.twig for PreviewController

This fix corrects problem of missing language in full.html.twig for PreviewController.
In full.html.twig is used eZ\Publish\Core\Repository\Values\Content\Content method getFieldsByLanguage without $languageCode parameter.
When we use this template in other languages than mainLanguageCode, method getFieldsByLanguage is returned empty array.