### PR TITLE
EZP-26219: Add missing Search Engine slots

### DIFF
--- a/eZ/Publish/Core/Search/Common/Slot/AssignSection.php
+++ b/eZ/Publish/Core/Search/Common/Slot/AssignSection.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Common\Slot;
+
+use eZ\Publish\Core\Search\Common\Slot;
+use eZ\Publish\Core\SignalSlot\Signal;
+
+class AssignSection extends Slot
+{
+    /**
+     * Receive the given $signal and react on it.
+     *
+     * @param Signal $signal
+     */
+    public function receive(Signal $signal)
+    {
+        if (!$signal instanceof Signal\SectionService\AssignSectionSignal) {
+            return;
+        }
+
+        $contentInfo = $this->persistenceHandler->contentHandler()->loadContentInfo($signal->contentId);
+        $this->searchHandler->indexContent(
+            $this->persistenceHandler->contentHandler()->load($contentInfo->id, $contentInfo->currentVersionNo)
+        );
+    }
+}

--- a/eZ/Publish/Core/Search/Common/Slot/SwapLocation.php
+++ b/eZ/Publish/Core/Search/Common/Slot/SwapLocation.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Common\Slot;
+
+use eZ\Publish\Core\Search\Common\Slot;
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A Search Engine slot handling SwapLocationSignal.
+ */
+class SwapLocation extends Slot
+{
+    /**
+     * Receive the given $signal and react on it.
+     *
+     * @param Signal $signal
+     */
+    public function receive(Signal $signal)
+    {
+        if (!$signal instanceof Signal\LocationService\SwapLocationSignal) {
+            return;
+        }
+        $content1Info = $this->persistenceHandler->contentHandler()->loadContentInfo($signal->content1Id);
+        $content2Info = $this->persistenceHandler->contentHandler()->loadContentInfo($signal->content2Id);
+        $this->searchHandler->indexContent(
+            $this->persistenceHandler->contentHandler()->load($content1Info->id, $content1Info->currentVersionNo)
+        );
+        $this->searchHandler->indexContent(
+            $this->persistenceHandler->contentHandler()->load($content2Info->id, $content2Info->currentVersionNo)
+        );
+        $this->searchHandler->indexLocation($this->persistenceHandler->locationHandler()->load($signal->location1Id));
+        $this->searchHandler->indexLocation($this->persistenceHandler->locationHandler()->load($signal->location2Id));
+    }
+}

--- a/eZ/Publish/Core/Search/Common/Slot/UpdateContentMetadata.php
+++ b/eZ/Publish/Core/Search/Common/Slot/UpdateContentMetadata.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Common\Slot;
+
+use eZ\Publish\Core\Search\Common\Slot;
+use eZ\Publish\Core\SignalSlot\Signal;
+
+class UpdateContentMetadata extends Slot
+{
+    /**
+     * Receive the given $signal and react on it.
+     *
+     * @param Signal $signal
+     */
+    public function receive(Signal $signal)
+    {
+        if (!$signal instanceof Signal\ContentService\UpdateContentMetadataSignal) {
+            return;
+        }
+
+        $contentInfo = $this->persistenceHandler->contentHandler()->loadContentInfo($signal->contentId);
+        $this->searchHandler->indexContent(
+            $this->persistenceHandler->contentHandler()->load($contentInfo->id, $contentInfo->currentVersionNo)
+        );
+        $this->searchHandler->indexLocation($this->persistenceHandler->locationHandler()->load($contentInfo->mainLocationId));
+    }
+}

--- a/eZ/Publish/Core/settings/search_engines/elasticsearch/slots.yml
+++ b/eZ/Publish/Core/settings/search_engines/elasticsearch/slots.yml
@@ -17,6 +17,10 @@ parameters:
     ezpublish.search.elasticsearch.slot.hide_location.class: eZ\Publish\Core\Search\Common\Slot\HideLocation
     ezpublish.search.elasticsearch.slot.unhide_location.class: eZ\Publish\Core\Search\Common\Slot\UnhideLocation
     ezpublish.search.elasticsearch.slot.set_content_state.class: eZ\Publish\Core\Search\Common\Slot\SetContentState
+    ezpublish.search.elasticsearch.slot.swap_location.class: eZ\Publish\Core\Search\Common\Slot\SwapLocation
+    ezpublish.search.elasticsearch.slot.update_content_metadata.class: eZ\Publish\Core\Search\Common\Slot\UpdateContentMetadata
+    ezpublish.search.elasticsearch.slot.assign_section.class: eZ\Publish\Core\Search\Common\Slot\AssignSection
+
 
 services:
     ezpublish.search.elasticsearch.slot:
@@ -128,3 +132,21 @@ services:
         class: "%ezpublish.search.elasticsearch.slot.set_content_state.class%"
         tags:
             - {name: ezpublish.search.elasticsearch.slot, signal: ObjectStateService\SetContentStateSignal}
+
+    ezpublish.search.elasticsearch.slot.swap_location:
+        parent: ezpublish.search.elasticsearch.slot
+        class: "%ezpublish.search.elasticsearch.slot.swap_location.class%"
+        tags:
+            - {name: ezpublish.search.elasticsearch.slot, signal: LocationService\SwapLocationSignal}
+
+    ezpublish.search.elasticsearch.slot.update_content_metadata:
+        parent: ezpublish.search.elasticsearch.slot
+        class: "%ezpublish.search.elasticsearch.slot.update_content_metadata.class%"
+        tags:
+            - {name: ezpublish.search.elasticsearch.slot, signal: ContentService\UpdateContentMetadataSignal}
+
+    ezpublish.search.elasticsearch.slot.assign_section:
+        parent: ezpublish.search.elasticsearch.slot
+        class: "%ezpublish.search.elasticsearch.slot.assign_section.class%"
+        tags:
+            - {name: ezpublish.search.elasticsearch.slot, signal: SectionService\AssignSectionSignal}

--- a/eZ/Publish/Core/settings/search_engines/legacy/slots.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/slots.yml
@@ -7,6 +7,8 @@ parameters:
     ezpublish.search.legacy.slot.copy_subtree.class: eZ\Publish\Core\Search\Common\Slot\CopySubtree
     ezpublish.search.legacy.slot.trash.class: eZ\Publish\Core\Search\Common\Slot\Trash
     ezpublish.search.legacy.slot.recover.class: eZ\Publish\Core\Search\Common\Slot\Recover
+    ezpublish.search.legacy.slot.update_content_metadata.class: eZ\Publish\Core\Search\Common\Slot\UpdateContentMetadata
+    ezpublish.search.legacy.slot.assign_section.class: eZ\Publish\Core\Search\Common\Slot\AssignSection
 
 services:
     ezpublish.search.legacy.slot:
@@ -58,3 +60,15 @@ services:
         class: "%ezpublish.search.legacy.slot.recover.class%"
         tags:
             - {name: ezpublish.search.legacy.slot, signal: TrashService\RecoverSignal}
+
+    ezpublish.search.legacy.slot.update_content_metadata:
+        parent: ezpublish.search.legacy.slot
+        class: "%ezpublish.search.legacy.slot.update_content_metadata.class%"
+        tags:
+            - {name: ezpublish.search.legacy.slot, signal: ContentService\UpdateContentMetadataSignal}
+
+    ezpublish.search.legacy.slot.assign_section:
+        parent: ezpublish.search.legacy.slot
+        class: "%ezpublish.search.legacy.slot.assign_section.class%"
+        tags:
+            - {name: ezpublish.search.legacy.slot, signal: SectionService\AssignSectionSignal}


### PR DESCRIPTION
Status: **Ready for a review**
This PR, related to JIRA issue [EZP-26219](https://jira.ez.no/browse/EZP-26219), adjusts work done in #1779 for 6.5 and up where signals are configured differently.

**TODO**:
- [x] Add configuration per Search Engine for `SwapLocation` Slot.
- [x] Add configuration per Search Engine for `AssignSection` Slot.
- [x] Add configuration per Search Engine for `UpdateContentMetadata` Slot.

