### PR TITLE
EZP-26219: Add missing Slots for Signals affecting Search Engine Index

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
@@ -325,16 +325,17 @@ class SearchEngineIndexingTest extends BaseTest
     }
 
     /**
-     * Will create if not exists an simple content type for deletion test purpose with just and required field name.
+     * Will create if not exists an simple content type for test purposes with just one required field name.
      *
      * @return \eZ\Publish\API\Repository\Values\ContentType\ContentType
      */
-    protected function createDeletionTestContentType()
+    protected function createTestContentType()
     {
         $repository = $this->getRepository();
         $contentTypeService = $repository->getContentTypeService();
+        $contentTypeIdentifier = 'test-type';
         try {
-            return $contentTypeService->loadContentTypeByIdentifier('deletion-test');
+            return $contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
         } catch (NotFoundException $e) {
             // continue creation process
         }
@@ -345,12 +346,11 @@ class SearchEngineIndexingTest extends BaseTest
         $nameField->isTranslatable = true;
         $nameField->isSearchable = true;
         $nameField->isRequired = true;
-
-        $contentTypeStruct = $contentTypeService->newContentTypeCreateStruct('deletion-test');
+        $contentTypeStruct = $contentTypeService->newContentTypeCreateStruct($contentTypeIdentifier);
         $contentTypeStruct->mainLanguageCode = 'eng-GB';
         $contentTypeStruct->creatorId = 14;
         $contentTypeStruct->creationDate = new DateTime();
-        $contentTypeStruct->names = ['eng-GB' => 'Deletion test'];
+        $contentTypeStruct->names = ['eng-GB' => 'Test Content Type'];
         $contentTypeStruct->addFieldDefinition($nameField);
 
         $contentTypeGroup = $contentTypeService->loadContentTypeGroupByIdentifier('Content');
@@ -358,7 +358,7 @@ class SearchEngineIndexingTest extends BaseTest
         $contentTypeDraft = $contentTypeService->createContentType($contentTypeStruct, [$contentTypeGroup]);
         $contentTypeService->publishContentTypeDraft($contentTypeDraft);
 
-        return $contentTypeService->loadContentTypeByIdentifier('deletion-test');
+        return $contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
     }
 
     /**
@@ -375,7 +375,7 @@ class SearchEngineIndexingTest extends BaseTest
         $contentService = $this->getRepository()->getContentService();
         $locationService = $this->getRepository()->getLocationService();
 
-        $testableContentType = $this->createDeletionTestContentType();
+        $testableContentType = $this->createTestContentType();
 
         $rootContentStruct = $contentService->newContentCreateStruct($testableContentType, 'eng-GB');
         $rootContentStruct->setField('name', $contentName);

--- a/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
@@ -368,6 +368,27 @@ class SearchEngineIndexingTest extends BaseTest
     }
 
     /**
+     * Test that assigning section to content object properly affects Search Engine Index.
+     */
+    public function testAssignSection()
+    {
+        $repository = $this->getRepository();
+        $sectionService = $repository->getSectionService();
+        $searchService = $repository->getSearchService();
+
+        $section = $sectionService->loadSection(2);
+        $content = $this->createContentWithName('testAssignSection', [2]);
+
+        $sectionService->assignSection($content->contentInfo, $section);
+        $this->refreshSearch($repository);
+
+        $criterion = new Criterion\ContentId($content->id);
+        $query = new Query(['filter' => $criterion]);
+        $results = $searchService->findContentInfo($query);
+        $this->assertEquals($section->id, $results->searchHits[0]->valueObject->sectionId);
+    }
+
+    /**
      * Will create if not exists an simple content type for test purposes with just one required field name.
      *
      * @return \eZ\Publish\API\Repository\Values\ContentType\ContentType

--- a/eZ/Publish/Core/Search/Common/Slot/AssignSection.php
+++ b/eZ/Publish/Core/Search/Common/Slot/AssignSection.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Common\Slot;
+
+use eZ\Publish\Core\Search\Common\Slot;
+use eZ\Publish\Core\SignalSlot\Signal;
+
+class AssignSection extends Slot
+{
+    /**
+     * Receive the given $signal and react on it.
+     *
+     * @param Signal $signal
+     */
+    public function receive(Signal $signal)
+    {
+        if (!$signal instanceof Signal\SectionService\AssignSectionSignal) {
+            return;
+        }
+
+        $contentInfo = $this->persistenceHandler->contentHandler()->loadContentInfo($signal->contentId);
+        $this->searchHandler->indexContent(
+            $this->persistenceHandler->contentHandler()->load($contentInfo->id, $contentInfo->currentVersionNo)
+        );
+    }
+}

--- a/eZ/Publish/Core/Search/Common/Slot/SwapLocation.php
+++ b/eZ/Publish/Core/Search/Common/Slot/SwapLocation.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Common\Slot;
+
+use eZ\Publish\Core\Search\Common\Slot;
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A Search Engine slot handling SwapLocationSignal.
+ */
+class SwapLocation extends Slot
+{
+    /**
+     * Receive the given $signal and react on it.
+     *
+     * @param Signal $signal
+     */
+    public function receive(Signal $signal)
+    {
+        if (!$signal instanceof Signal\LocationService\SwapLocationSignal) {
+            return;
+        }
+        $content1Info = $this->persistenceHandler->contentHandler()->loadContentInfo($signal->content1Id);
+        $content2Info = $this->persistenceHandler->contentHandler()->loadContentInfo($signal->content2Id);
+        $this->searchHandler->indexContent(
+            $this->persistenceHandler->contentHandler()->load($content1Info->id, $content1Info->currentVersionNo)
+        );
+        $this->searchHandler->indexContent(
+            $this->persistenceHandler->contentHandler()->load($content2Info->id, $content2Info->currentVersionNo)
+        );
+        $this->searchHandler->indexLocation($this->persistenceHandler->locationHandler()->load($signal->location1Id));
+        $this->searchHandler->indexLocation($this->persistenceHandler->locationHandler()->load($signal->location2Id));
+    }
+}

--- a/eZ/Publish/Core/Search/Common/Slot/UpdateContentMetadata.php
+++ b/eZ/Publish/Core/Search/Common/Slot/UpdateContentMetadata.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Common\Slot;
+
+use eZ\Publish\Core\Search\Common\Slot;
+use eZ\Publish\Core\SignalSlot\Signal;
+
+class UpdateContentMetadata extends Slot
+{
+    /**
+     * Receive the given $signal and react on it.
+     *
+     * @param Signal $signal
+     */
+    public function receive(Signal $signal)
+    {
+        if (!$signal instanceof Signal\ContentService\UpdateContentMetadataSignal) {
+            return;
+        }
+
+        $contentInfo = $this->persistenceHandler->contentHandler()->loadContentInfo($signal->contentId);
+        $this->searchHandler->indexContent(
+            $this->persistenceHandler->contentHandler()->load($contentInfo->id, $contentInfo->currentVersionNo)
+        );
+        $this->searchHandler->indexLocation($this->persistenceHandler->locationHandler()->load($contentInfo->mainLocationId));
+    }
+}

--- a/eZ/Publish/Core/settings/search_engines/slots.yml
+++ b/eZ/Publish/Core/settings/search_engines/slots.yml
@@ -20,6 +20,7 @@ parameters:
     ezpublish.search.slot.unhide_location.class: eZ\Publish\Core\Search\Common\Slot\UnhideLocation
     ezpublish.search.slot.set_content_state.class: eZ\Publish\Core\Search\Common\Slot\SetContentState
     ezpublish.search.slot.swap_location.class: eZ\Publish\Core\Search\Common\Slot\SwapLocation
+    ezpublish.search.slot.update_content_metadata.class: eZ\Publish\Core\Search\Common\Slot\UpdateContentMetadata
 
 services:
     ezpublish.search.slot:
@@ -149,3 +150,9 @@ services:
         class: "%ezpublish.search.slot.swap_location.class%"
         tags:
             - {name: ezpublish.search.slot, signal: LocationService\SwapLocationSignal}
+
+    ezpublish.search.slot.update_content_metadata:
+        parent: ezpublish.search.slot
+        class: "%ezpublish.search.slot.update_content_metadata.class%"
+        tags:
+            - {name: ezpublish.search.slot, signal: ContentService\UpdateContentMetadataSignal}

--- a/eZ/Publish/Core/settings/search_engines/slots.yml
+++ b/eZ/Publish/Core/settings/search_engines/slots.yml
@@ -19,6 +19,7 @@ parameters:
     ezpublish.search.slot.hide_location.class: eZ\Publish\Core\Search\Common\Slot\HideLocation
     ezpublish.search.slot.unhide_location.class: eZ\Publish\Core\Search\Common\Slot\UnhideLocation
     ezpublish.search.slot.set_content_state.class: eZ\Publish\Core\Search\Common\Slot\SetContentState
+    ezpublish.search.slot.swap_location.class: eZ\Publish\Core\Search\Common\Slot\SwapLocation
 
 services:
     ezpublish.search.slot:
@@ -142,3 +143,9 @@ services:
         class: %ezpublish.search.slot.set_content_state.class%
         tags:
             - {name: ezpublish.search.slot, signal: ObjectStateService\SetContentStateSignal}
+
+    ezpublish.search.slot.swap_location:
+        parent: ezpublish.search.slot
+        class: "%ezpublish.search.slot.swap_location.class%"
+        tags:
+            - {name: ezpublish.search.slot, signal: LocationService\SwapLocationSignal}

--- a/eZ/Publish/Core/settings/search_engines/slots.yml
+++ b/eZ/Publish/Core/settings/search_engines/slots.yml
@@ -21,6 +21,7 @@ parameters:
     ezpublish.search.slot.set_content_state.class: eZ\Publish\Core\Search\Common\Slot\SetContentState
     ezpublish.search.slot.swap_location.class: eZ\Publish\Core\Search\Common\Slot\SwapLocation
     ezpublish.search.slot.update_content_metadata.class: eZ\Publish\Core\Search\Common\Slot\UpdateContentMetadata
+    ezpublish.search.slot.assign_section.class: eZ\Publish\Core\Search\Common\Slot\AssignSection
 
 services:
     ezpublish.search.slot:
@@ -156,3 +157,9 @@ services:
         class: "%ezpublish.search.slot.update_content_metadata.class%"
         tags:
             - {name: ezpublish.search.slot, signal: ContentService\UpdateContentMetadataSignal}
+
+    ezpublish.search.slot.assign_section:
+        parent: ezpublish.search.slot
+        class: "%ezpublish.search.slot.assign_section.class%"
+        tags:
+            - {name: ezpublish.search.slot, signal: SectionService\AssignSectionSignal}


### PR DESCRIPTION
Status: **Ready for a review**
This is a `v6.4` backport of #1776, related to JIRA issue [EZP-26219](https://jira.ez.no/browse/EZP-26219).

This PR adds some missing Search Engine slots for Signals affecting Search Engine Index.

**TODO**:
- [x] Add Search Engine `SwapLocation` Slot + unit test (6a252b0).
- [x] Add Search Engine `UpdateContentMetadata` Slot + unit test (8dfd839).
- [x] Add Search Engine `AssignSection` Slot + unit test (9c5e7fd).
- [x] 6.5 PR: https://github.com/ezsystems/ezpublish-kernel/pull/1776
