### PR TITLE
Fix EZP-26239: Missing update of REST-API-V2.rst about validation

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -9769,6 +9769,39 @@ ErrorMessage XML Schema
           <xsd:element name="errorCode" type="xsd:string"></xsd:element>
           <xsd:element name="errorMessage" type="xsd:string"></xsd:element>
           <xsd:element name="errorDescription" type="xsd:string"></xsd:element>
+          <xsd:element name="errorDetails" minOccurs="0">
+            <xsd:complexType>
+              <xsd:all>
+                <xsd:element name="fields" minOccurs="1">
+                  <xsd:complexType>
+                    <xsd:sequence>
+                      <xsd:element name="field" minOccurs="1" maxOccurs="unbounded">
+                        <xsd:attribute name="fieldTypeId" type="xsd:integer"/>
+                        <xsd:complexType>
+                          <xsd:all>
+                            <xsd:element name="errors" minOccurs="1">
+                              <xsd:complexType>
+                                <xsd:sequence>
+                                  <xsd:element name="error" minOccurs="1" maxOccurs="unbounded">
+                                    <xsd:complexType>
+                                      <xsd:all>
+                                        <xsd:element name="type" type="xsd:string"/>
+                                        <xsd:element name="message" type="xsd:string"/>
+                                      </xsd:all>
+                                    </xsd:complexType>
+                                  </xsd:element>
+                                </xsd:sequence>
+                              </xsd:complexType>
+                            </xsd:element>
+                          </xsd:all>
+                        </xsd:complexType>
+                      </xsd:element>
+                    </xsd:sequence>
+                  </xsd:complexType>
+                </xsd:element>
+              </xsd:all>
+            </xsd:complexType>
+          </xsd:element>
         </xsd:all>
       </xsd:complexType>
       <xsd:element name="ErrorMessage" type="vnd.ez.api.ErrorMessage"></xsd:element>

--- a/doc/specifications/rest/xsd/ErrorMessage.xsd
+++ b/doc/specifications/rest/xsd/ErrorMessage.xsd
@@ -8,6 +8,39 @@
       <xsd:element name="errorCode" type="xsd:string"></xsd:element>
       <xsd:element name="errorMessage" type="xsd:string"></xsd:element>
       <xsd:element name="errorDescription" type="xsd:string"></xsd:element>
+      <xsd:element name="errorDetails" minOccurs="0">
+        <xsd:complexType>
+          <xsd:all>
+            <xsd:element name="fields" minOccurs="1">
+              <xsd:complexType>
+                <xsd:sequence>
+                  <xsd:element name="field" minOccurs="1" maxOccurs="unbounded">
+                    <xsd:attribute name="fieldTypeId" type="xsd:integer"/>
+                    <xsd:complexType>
+                      <xsd:all>
+                        <xsd:element name="errors" minOccurs="1">
+                          <xsd:complexType>
+                            <xsd:sequence>
+                              <xsd:element name="error" minOccurs="1" maxOccurs="unbounded">
+                                <xsd:complexType>
+                                  <xsd:all>
+                                    <xsd:element name="type" type="xsd:string"/>
+                                    <xsd:element name="message" type="xsd:string"/>
+                                  </xsd:all>
+                                </xsd:complexType>
+                              </xsd:element>
+                            </xsd:sequence>
+                          </xsd:complexType>
+                        </xsd:element>
+                      </xsd:all>
+                    </xsd:complexType>
+                  </xsd:element>
+                </xsd:sequence>
+              </xsd:complexType>
+            </xsd:element>
+          </xsd:all>
+        </xsd:complexType>
+      </xsd:element>
     </xsd:all>
   </xsd:complexType>
   <xsd:element name="ErrorMessage" type="vnd.ez.api.ErrorMessage"></xsd:element>


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-26239
> Status: Ready for review

Adds `errorDetails` to the schema.

This reminds me of something...
![Geese](http://2.bp.blogspot.com/-pmDpoh6ECHg/TYkRdiewYuI/AAAAAAAAAX0/rsLUC222HzM/s400/geese%2Bv%2Bformation.jpg)