### PR TITLE
EZP-26344: Publishing URL alias does not always respect reserved names

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
@@ -117,8 +117,8 @@ class Handler implements UrlAliasHandlerInterface
         $updatePathIdentificationString = false
     ) {
         $parentId = $this->getRealAliasId($parentLocationId);
-        $uniqueCounter = $this->slugConverter->getUniqueCounterValue($name, $parentId == 0);
         $name = $this->slugConverter->convert($name, 'location_' . $locationId);
+        $uniqueCounter = $this->slugConverter->getUniqueCounterValue($name, $parentId == 0);
         $languageId = $this->languageHandler->loadByLanguageCode($languageCode)->id;
         $languageMask = $languageId | (int)$alwaysAvailable;
         $action = 'eznode:' . $locationId;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
@@ -3073,6 +3073,40 @@ class UrlAliasHandlerTest extends TestCase
         $handler->loadUrlAlias('non-existent');
     }
 
+    public function providerForTestPublishUrlAliasForLocationSkipsReservedWord()
+    {
+        return [
+            [
+                'section',
+                'section2'
+            ],
+            [
+                'claß',
+                'class2'
+            ],
+        ];
+    }
+
+    /**
+     * Test for the publishUrlAliasForLocation() method.
+     *
+     * @dataProvider providerForTestPublishUrlAliasForLocationSkipsReservedWord
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Handler::publishUrlAliasForLocation
+     * @group publish
+     */
+    public function testPublishUrlAliasForLocationSkipsReservedWord($text, $alias)
+    {
+        $handler = $this->getHandler();
+        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/publish_base.php');
+
+        $handler->publishUrlAliasForLocation(314, 2, $text, 'kli-KR');
+
+        $urlAlias = $handler->lookup($alias);
+
+        $this->assertEquals(314, $urlAlias->destination);
+        $this->assertEquals(['kli-KR'], $urlAlias->languageCodes);
+    }
+
     /**
      * @return int
      */

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
@@ -3078,11 +3078,11 @@ class UrlAliasHandlerTest extends TestCase
         return [
             [
                 'section',
-                'section2'
+                'section2',
             ],
             [
                 'claß',
-                'class2'
+                'class2',
             ],
         ];
     }


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-26344

When URL alias is published, it is checked against a list of reserved words, in order to avoid the conflict with app modules.
This is done before URL alias name is converter/sluggified, so it is possible that a reserved name will be published.

Example: `claß` checked against reserved `class` will not match, but it's later converted/sluggified and published as `class`.

Follow up: https://jira.ez.no/browse/EZP-26345
