### PR TITLE
EZP-26352: skip csrf-token check on POST /content/views

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/EventListener/CsrfListener.php
+++ b/eZ/Bundle/EzPublishRestBundle/EventListener/CsrfListener.php
@@ -104,6 +104,10 @@ class CsrfListener implements EventSubscriberInterface
             return;
         }
 
+        if ($this->isCreateViewRequest($event->getRequest())) {
+            return;
+        }
+
         if ($this->isSessionRoute($event->getRequest()->get('_route'))) {
             return;
         }
@@ -175,5 +179,24 @@ class CsrfListener implements EventSubscriberInterface
                 $request->headers->get(self::CSRF_TOKEN_HEADER)
             )
         );
+    }
+
+    /**
+     * Used to skip csrf token check on POST /content/views. The request is supposed to be unsafe, as it is a post,
+     * but is in reality safe, as it doesn't store anything at the moment (6.5).
+     *
+     * @todo This check needs to be removed when query storage is implemented.
+     *
+     * @param Request $request
+     *
+     * @return bool
+     */
+    private function isCreateViewRequest(Request $request)
+    {
+        if ($request->get('_route') === 'ezpublish_rest_views_create' && $request->getMethod() === 'POST') {
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
> Implements [EZP-26352](http://jira.ez.no/browse/EZP-26352)

A workaround that enables REST search (views) without a csrf-token.

As explained in the JIRA issue, while the HTTP method (`POST`) indicates an unsafe method that needs a CSRF token check, in reality, the route is safe: it doesn't store what the specification says it should / will.

The idea is to remove this check when query storage is implemented.

Until then, the current feature set provides a mediocre developer experience, as it prevents usage of views without creating a session, thus degrading the user experience on mobile / remote apps. Furthermore, having to create the session with REST opens up several questions (which user account ? do users need to register ? can I login as anonymous ?).
### Alternatives
- [ ] Make it possible to get an anonymous csrf token
- [ ] Implement query storage
- [ ] Make it possible to run queries with GET. But how is the query passed without a POST body ?
