### PR TITLE
EZP-23000: Add destination content href to Relation(List) REST value

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
@@ -288,11 +288,15 @@ services:
         class: "%ezpublish_rest.field_type_processor.ezobjectrelationlist.class%"
         tags:
             - { name: ezpublish_rest.field_type_processor, alias: ezobjectrelationlist }
+        calls:
+            - [setRouter, ["@router"]]
 
     ezpublish_rest.field_type_processor.ezobjectrelation:
         class: "%ezpublish_rest.field_type_processor.ezobjectrelation.class%"
         tags:
             - { name: ezpublish_rest.field_type_processor, alias: ezobjectrelation }
+        calls:
+            - [setRouter, ["@router"]]
 
     ezpublish_rest.field_type_processor.eztime:
         class: "%ezpublish_rest.field_type_processor.eztime.class%"

--- a/eZ/Publish/Core/REST/Common/FieldTypeProcessor/BaseRelationProcessor.php
+++ b/eZ/Publish/Core/REST/Common/FieldTypeProcessor/BaseRelationProcessor.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Common\FieldTypeProcessor;
+
+class BaseRelationProcessor
+{
+
+}

--- a/eZ/Publish/Core/REST/Common/FieldTypeProcessor/BaseRelationProcessor.php
+++ b/eZ/Publish/Core/REST/Common/FieldTypeProcessor/BaseRelationProcessor.php
@@ -6,9 +6,10 @@
 namespace eZ\Publish\Core\REST\Common\FieldTypeProcessor;
 
 use eZ\Publish\Core\FieldType\Relation\Type;
+use eZ\Publish\Core\REST\Common\FieldTypeProcessor;
 use Symfony\Component\Routing\RouterInterface;
 
-abstract class BaseRelationProcessor
+abstract class BaseRelationProcessor extends FieldTypeProcessor
 {
     /**
      * @var \Symfony\Component\Routing\RouterInterface

--- a/eZ/Publish/Core/REST/Common/FieldTypeProcessor/BaseRelationProcessor.php
+++ b/eZ/Publish/Core/REST/Common/FieldTypeProcessor/BaseRelationProcessor.php
@@ -5,6 +5,7 @@
  */
 namespace eZ\Publish\Core\REST\Common\FieldTypeProcessor;
 
+use eZ\Publish\Core\FieldType\Relation\Type;
 use Symfony\Component\Routing\RouterInterface;
 
 abstract class BaseRelationProcessor
@@ -26,9 +27,36 @@ abstract class BaseRelationProcessor
 
     public function mapToContentHref($contentId)
     {
-        return $this->router->generate(
-            'ezpublish_rest_loadContent',
-            ['contentId' => $contentId]
-        );
+        return $this->router->generate('ezpublish_rest_loadContent', ['contentId' => $contentId]);
+    }
+
+    public function preProcessFieldSettingsHash($incomingSettingsHash)
+    {
+        if (isset($incomingSettingsHash['selectionMethod'])) {
+            switch ($incomingSettingsHash['selectionMethod']) {
+                case 'SELECTION_BROWSE':
+                    $incomingSettingsHash['selectionMethod'] = Type::SELECTION_BROWSE;
+                    break;
+                case 'SELECTION_DROPDOWN':
+                    $incomingSettingsHash['selectionMethod'] = Type::SELECTION_DROPDOWN;
+            }
+        }
+
+        return $incomingSettingsHash;
+    }
+
+    public function postProcessFieldSettingsHash($outgoingSettingsHash)
+    {
+        if (isset($outgoingSettingsHash['selectionMethod'])) {
+            switch ($outgoingSettingsHash['selectionMethod']) {
+                case Type::SELECTION_BROWSE:
+                    $outgoingSettingsHash['selectionMethod'] = 'SELECTION_BROWSE';
+                    break;
+                case Type::SELECTION_DROPDOWN:
+                    $outgoingSettingsHash['selectionMethod'] = 'SELECTION_DROPDOWN';
+            }
+        }
+
+        return $outgoingSettingsHash;
     }
 }

--- a/eZ/Publish/Core/REST/Common/FieldTypeProcessor/BaseRelationProcessor.php
+++ b/eZ/Publish/Core/REST/Common/FieldTypeProcessor/BaseRelationProcessor.php
@@ -5,7 +5,30 @@
  */
 namespace eZ\Publish\Core\REST\Common\FieldTypeProcessor;
 
-class BaseRelationProcessor
-{
+use Symfony\Component\Routing\RouterInterface;
 
+abstract class BaseRelationProcessor
+{
+    /**
+     * @var \Symfony\Component\Routing\RouterInterface
+     */
+    private $router;
+
+    public function setRouter(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    public function canMapContentHref()
+    {
+        return isset($this->router);
+    }
+
+    public function mapToContentHref($contentId)
+    {
+        return $this->router->generate(
+            'ezpublish_rest_loadContent',
+            ['contentId' => $contentId]
+        );
+    }
 }

--- a/eZ/Publish/Core/REST/Common/FieldTypeProcessor/RelationListProcessor.php
+++ b/eZ/Publish/Core/REST/Common/FieldTypeProcessor/RelationListProcessor.php
@@ -10,10 +10,6 @@
  */
 namespace eZ\Publish\Core\REST\Common\FieldTypeProcessor;
 
-use eZ\Publish\Core\REST\Common\FieldTypeProcessor;
-use eZ\Publish\Core\FieldType\RelationList\Type;
-use Symfony\Component\Routing\RouterInterface;
-
 class RelationListProcessor extends BaseRelationProcessor
 {
     /**
@@ -42,41 +38,5 @@ class RelationListProcessor extends BaseRelationProcessor
         );
 
         return $outgoingValueHash;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function preProcessFieldSettingsHash($incomingSettingsHash)
-    {
-        if (isset($incomingSettingsHash['selectionMethod'])) {
-            switch ($incomingSettingsHash['selectionMethod']) {
-                case 'SELECTION_BROWSE':
-                    $incomingSettingsHash['selectionMethod'] = Type::SELECTION_BROWSE;
-                    break;
-                case 'SELECTION_DROPDOWN':
-                    $incomingSettingsHash['selectionMethod'] = Type::SELECTION_DROPDOWN;
-            }
-        }
-
-        return $incomingSettingsHash;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function postProcessFieldSettingsHash($outgoingSettingsHash)
-    {
-        if (isset($outgoingSettingsHash['selectionMethod'])) {
-            switch ($outgoingSettingsHash['selectionMethod']) {
-                case Type::SELECTION_BROWSE:
-                    $outgoingSettingsHash['selectionMethod'] = 'SELECTION_BROWSE';
-                    break;
-                case Type::SELECTION_DROPDOWN:
-                    $outgoingSettingsHash['selectionMethod'] = 'SELECTION_DROPDOWN';
-            }
-        }
-
-        return $outgoingSettingsHash;
     }
 }

--- a/eZ/Publish/Core/REST/Common/FieldTypeProcessor/RelationProcessor.php
+++ b/eZ/Publish/Core/REST/Common/FieldTypeProcessor/RelationProcessor.php
@@ -14,18 +14,8 @@ use eZ\Publish\Core\REST\Common\FieldTypeProcessor;
 use eZ\Publish\Core\FieldType\Relation\Type;
 use Symfony\Component\Routing\RouterInterface;
 
-class RelationProcessor extends FieldTypeProcessor
+class RelationProcessor extends BaseRelationProcessor
 {
-    /**
-     * @var \Symfony\Component\Routing\RouterInterface
-     */
-    private $router;
-
-    public function setRouter(RouterInterface $router)
-    {
-        $this->router = $router;
-    }
-
     /**
      * In addition to the destinationContentId, adds a destinationContentHref entry.
      *
@@ -35,16 +25,13 @@ class RelationProcessor extends FieldTypeProcessor
      */
     public function postProcessValueHash($outgoingValueHash)
     {
-        if (!isset($outgoingValueHash['destinationContentId'])) {
+        if (!isset($outgoingValueHash['destinationContentId']) || !$this->canMapContentHref()) {
             return $outgoingValueHash;
         }
 
-        if (isset($this->router)) {
-            $outgoingValueHash['destinationContentHref'] = $this->router->generate(
-                'ezpublish_rest_loadContent',
-                ['contentId' => $outgoingValueHash['destinationContentId']]
-            );
-        }
+        $outgoingValueHash['destinationContentHref'] = $this->mapToContentHref(
+            $outgoingValueHash['destinationContentId']
+        );
 
         return $outgoingValueHash;
     }

--- a/eZ/Publish/Core/REST/Common/FieldTypeProcessor/RelationProcessor.php
+++ b/eZ/Publish/Core/REST/Common/FieldTypeProcessor/RelationProcessor.php
@@ -10,10 +10,6 @@
  */
 namespace eZ\Publish\Core\REST\Common\FieldTypeProcessor;
 
-use eZ\Publish\Core\REST\Common\FieldTypeProcessor;
-use eZ\Publish\Core\FieldType\Relation\Type;
-use Symfony\Component\Routing\RouterInterface;
-
 class RelationProcessor extends BaseRelationProcessor
 {
     /**
@@ -34,41 +30,5 @@ class RelationProcessor extends BaseRelationProcessor
         );
 
         return $outgoingValueHash;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function preProcessFieldSettingsHash($incomingSettingsHash)
-    {
-        if (isset($incomingSettingsHash['selectionMethod'])) {
-            switch ($incomingSettingsHash['selectionMethod']) {
-                case 'SELECTION_BROWSE':
-                    $incomingSettingsHash['selectionMethod'] = Type::SELECTION_BROWSE;
-                    break;
-                case 'SELECTION_DROPDOWN':
-                    $incomingSettingsHash['selectionMethod'] = Type::SELECTION_DROPDOWN;
-            }
-        }
-
-        return $incomingSettingsHash;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function postProcessFieldSettingsHash($outgoingSettingsHash)
-    {
-        if (isset($outgoingSettingsHash['selectionMethod'])) {
-            switch ($outgoingSettingsHash['selectionMethod']) {
-                case Type::SELECTION_BROWSE:
-                    $outgoingSettingsHash['selectionMethod'] = 'SELECTION_BROWSE';
-                    break;
-                case Type::SELECTION_DROPDOWN:
-                    $outgoingSettingsHash['selectionMethod'] = 'SELECTION_DROPDOWN';
-            }
-        }
-
-        return $outgoingSettingsHash;
     }
 }

--- a/eZ/Publish/Core/REST/Common/FieldTypeProcessor/RelationProcessor.php
+++ b/eZ/Publish/Core/REST/Common/FieldTypeProcessor/RelationProcessor.php
@@ -12,9 +12,43 @@ namespace eZ\Publish\Core\REST\Common\FieldTypeProcessor;
 
 use eZ\Publish\Core\REST\Common\FieldTypeProcessor;
 use eZ\Publish\Core\FieldType\Relation\Type;
+use Symfony\Component\Routing\RouterInterface;
 
 class RelationProcessor extends FieldTypeProcessor
 {
+    /**
+     * @var \Symfony\Component\Routing\RouterInterface
+     */
+    private $router;
+
+    public function setRouter(RouterInterface $router)
+    {
+        $this->router = $router;
+    }
+
+    /**
+     * In addition to the destinationContentId, adds a destinationContentHref entry.
+     *
+     * @param array $outgoingValueHash
+     *
+     * @return array
+     */
+    public function postProcessValueHash($outgoingValueHash)
+    {
+        if (!isset($outgoingValueHash['destinationContentId'])) {
+            return $outgoingValueHash;
+        }
+
+        if (isset($this->router)) {
+            $outgoingValueHash['destinationContentHref'] = $this->router->generate(
+                'ezpublish_rest_loadContent',
+                ['contentId' => $outgoingValueHash['destinationContentId']]
+            );
+        }
+
+        return $outgoingValueHash;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/RelationListProcessorTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/RelationListProcessorTest.php
@@ -61,6 +61,30 @@ class RelationListProcessorTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testPostProcessValueHash()
+    {
+        $processor = $this->getProcessor();
+
+        $routerMock = $this->getMockBuilder('Symfony\Component\Routing\RouterInterface')->getMock();
+        $processor->setRouter($routerMock);
+
+        $routerMock
+            ->expects($this->exactly(2))
+            ->method('generate')
+            ->withConsecutive(
+                ['ezpublish_rest_loadContent', ['contentId' => 42]],
+                ['ezpublish_rest_loadContent', ['contentId' => 300]]
+            )->willReturnOnConsecutiveCalls(
+                '/api/ezp/v2/content/objects/42',
+                '/api/ezp/v2/content/objects/300'
+            );
+
+        $hash = $processor->postProcessValueHash(['destinationContentIds' => [42, 300]]);
+        $this->assertArrayHasKey('destinationContentHrefs', $hash);
+        $this->assertEquals('/api/ezp/v2/content/objects/42', $hash['destinationContentHrefs'][0]);
+        $this->assertEquals('/api/ezp/v2/content/objects/300', $hash['destinationContentHrefs'][1]);
+    }
+
     /**
      * @return \eZ\Publish\Core\REST\Common\FieldTypeProcessor\RelationListProcessor
      */

--- a/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/RelationProcessorTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/RelationProcessorTest.php
@@ -61,6 +61,39 @@ class RelationProcessorTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    public function testPostProcessFieldValueHash()
+    {
+        $processor = $this->getProcessor();
+
+        $routerMock = $this->getMockBuilder('\Symfony\Component\Routing\RouterInterface')->getMock();
+        $processor->setRouter($routerMock);
+
+        $routerMock
+            ->expects($this->once())
+            ->method('generate')
+            ->with('ezpublish_rest_loadContent', ['contentId' => 42])
+            ->will($this->returnValue('/api/ezp/v2/content/objects/42'));
+
+        $hash = $processor->postProcessValueHash(['destinationContentId' => 42]);
+        $this->assertArrayHasKey('destinationContentHref', $hash);
+        $this->assertEquals('/api/ezp/v2/content/objects/42', $hash['destinationContentHref']);
+    }
+
+    public function testPostProcessFieldValueHashNullValue()
+    {
+        $processor = $this->getProcessor();
+
+        $routerMock = $this->getMockBuilder('\Symfony\Component\Routing\RouterInterface')->getMock();
+        $processor->setRouter($routerMock);
+
+        $routerMock
+            ->expects($this->never())
+            ->method('generate');
+
+        $hash = $processor->postProcessValueHash(['destinationContentId' => null]);
+        $this->assertArrayNotHasKey('destinationContentHref', $hash);
+    }
+
     /**
      * @return \eZ\Publish\Core\REST\Common\FieldTypeProcessor\RelationProcessor
      */


### PR DESCRIPTION
> Implements [EZP-23000](http://jira.ez.no/browse/EZP-23000)

Uses the `postProcessValueHash()` method of the `RelationProcessor` and `RelationListProcessor`.

These links aren't really "complete" from an HATEOAS perspective, as they're missing the media-type. Full relation data must be taken from the `Relations` node, using the href + field def identifier to identify the matching `Relation` node.

### Relation
```
<fieldValue>
  <value key="destinationContentId">42</value>
  <value key="destinationContentHref">/api/ezp/v2/content/objects/42</value>
</fieldValue>
```

### RelationList
```
<fieldValue>
  <value key="destinationContentIds">
    <value>42</value>
    <value>300</value>
  </value>
  <value key="destinationContentHrefs">
    <value>/api/ezp/v2/content/objects/42</value>
    <value>/api/ezp/v2/content/objects/300</value>
  </value>
</fieldValue>
```

## TODO
- [x] `RelationListProcessor` coverage
- [ ] Consider refactoring both processors, as most of the code is common.
