### PR TITLE
EZP-26277: Content type copies generated identifiers are too long

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -3784,7 +3784,7 @@ Copy Content Type
 :Resource: /content/types/<ID>
 :Method:      COPY or POST with header: X-HTTP-Method-Override COPY
 :Description: copies a content type. A new remoteId is generated, and the identifier of the copy is set to
-              copy_of_<identifier>_<remoteId> (or another random string).
+              cpy_<identifier>_<remoteId> (or another random string).
 :Response:
 
 .. code:: http

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ContentTypeTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ContentTypeTest.php
@@ -283,7 +283,7 @@ XML;
 
         return $href;
 
-        // @todo test identifier (copy_of_<sourceIdentifier)
+        // @todo test identifier (cpy_<sourceIdentifier)
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
@@ -401,8 +401,8 @@ class Handler implements BaseContentTypeHandler
         $createStruct->modifierId = $userId;
         $createStruct->created = $createStruct->modified = time();
         $createStruct->creatorId = $userId;
-        $createStruct->remoteId = md5(uniqid(get_class($createStruct), true));
-        $createStruct->identifier = 'copy_of_' . $createStruct->identifier . '_' . $createStruct->remoteId;
+        $createStruct->remoteId = substr(sha1(uniqid(get_class($createStruct), true)), 0, 7);
+        $createStruct->identifier = 'cpy_' . $createStruct->identifier . '_' . $createStruct->remoteId;
 
         // Set FieldDefinition ids to null to trigger creating new id
         foreach ($createStruct->fieldDefinitions as $fieldDefinition) {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
@@ -791,7 +791,7 @@ class ContentTypeHandlerTest extends PHPUnit_Framework_TestCase
                         'created'
                     ),
                     $this->attribute(
-                        $this->matchesRegularExpression('/^copy_of_testCopy_([a-z0-9]+)$/'),
+                        $this->matchesRegularExpression('/^cpy_testCopy_([a-z0-9]+)$/'),
                         'identifier'
                     )
                 )

--- a/eZ/Publish/Core/REST/Server/Controller/ContentType.php
+++ b/eZ/Publish/Core/REST/Server/Controller/ContentType.php
@@ -340,7 +340,7 @@ class ContentType extends RestController
 
     /**
      * Copies a content type. The identifier of the copy
-     * is changed to copy_of_<identifier> and a new remoteId is generated.
+     * is changed to cpy_<identifier> and a new remoteId is generated.
      *
      * @param $contentTypeId
      *

--- a/eZ/Publish/SPI/Persistence/Content/Type/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/Handler.php
@@ -154,7 +154,7 @@ interface Handler
      * Copy a Type incl fields and group-relations from a given status to a new Type with status {@link Type::STATUS_DRAFT}.
      *
      * New Content Type will have $userId as creator / modifier, created / modified should be updated, new remoteId created
-     * and identifier should be 'copy_of_<identifier>_' + the new remoteId or another unique number.
+     * and identifier should be 'cpy_<identifier>_' + the new remoteId or another unique number.
      *
      * @param mixed $userId
      * @param mixed $contentTypeId


### PR DESCRIPTION
> Status: **Ready for a review**
> Fixes: [EZP-26277](https://jira.ez.no/browse/EZP-26277)
> Backported to: `6.4`

This PR shortens generated identifiers of content type copies.
Instead of:
`copy_of_<identifier>_<remoteId>`
now we have:
`cpy_<identifier>_<remoteId>`

Also, `<remoteId>` is no longer a `md5` hash but a `sha1` hash shortened to 7 chars. We can't get rid of `<remoteId>` in copied content type identifier because it would be impossible to copy content type several times.

Another possible approaches:
- Make database identifier field longer than 50 chars - as suggested in JIRA issue description. However AFAIK performance of `varchar` varies between DBMS-es and should be tested on large databases (about 2 mln of Content Objects).
- Force API Consumer to specify copied content identifier. This is an API BC break and should not be considered for `6.x` (IMHO).

**TODO**
- [x] Make copied content type identifier shorter.
- [x] Align tests and doc with this change.