### PR TITLE
Fix EZP-26412: Query error when publishing content on clean eZ Platform install

### DIFF
--- a/data/cleandata.sql
+++ b/data/cleandata.sql
@@ -21,9 +21,6 @@ INSERT INTO `ezcobj_state_link` (`contentobject_id`, `contentobject_state_id`) V
 INSERT INTO `ezcobj_state_link` (`contentobject_id`, `contentobject_state_id`) VALUES (49,1);
 INSERT INTO `ezcobj_state_link` (`contentobject_id`, `contentobject_state_id`) VALUES (50,1);
 INSERT INTO `ezcobj_state_link` (`contentobject_id`, `contentobject_state_id`) VALUES (51,1);
-INSERT INTO `ezcobj_state_link` (`contentobject_id`, `contentobject_state_id`) VALUES (52,1);
-INSERT INTO `ezcobj_state_link` (`contentobject_id`, `contentobject_state_id`) VALUES (54,1);
-INSERT INTO `ezcobj_state_link` (`contentobject_id`, `contentobject_state_id`) VALUES (56,1);
 
 INSERT INTO `ezcontent_language` (`disabled`, `id`, `locale`, `name`) VALUES (0,2,'eng-GB','English (United Kingdom)');
 


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-26412

Largest content ID is 51, but `ezcobj_state_link` table references IDs 52, 54 and 56, which causes create content operation to crash for content which gets those IDs.