### PR TITLE
EZP-23284: adjusted textline to accept a numeric as input-value

### DIFF
--- a/eZ/Publish/Core/FieldType/TextLine/Value.php
+++ b/eZ/Publish/Core/FieldType/TextLine/Value.php
@@ -31,7 +31,7 @@ class Value extends BaseValue
      */
     public function __construct($text = '')
     {
-        $this->text = $text;
+        $this->text = (string)$text;
     }
 
     /**


### PR DESCRIPTION
> issue: https://jira.ez.no/browse/EZP-23284

checkValueStructure function on Type throw an InvalidArgumentType Exception when REST API are used.
20161010 can be a string...
