### PR TITLE
EZP-26342: Don't throw during on relation list data issue when creating drafts

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -180,7 +180,8 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
     {
         $this->logger->logCall(__METHOD__, array('content' => $contentId));
 
-        // Load reverse field relations first
+        // Load locations and reverse field relations first
+        $locations = $this->persistenceHandler->locationHandler()->loadLocationsByContent($contentId);
         $reverseRelations = $this->persistenceHandler->contentHandler()->loadReverseRelations(
             $contentId,
             APIRelation::FIELD
@@ -197,6 +198,10 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
         $this->cache->clear('content', 'info', $contentId);
         $this->cache->clear('content', 'info', 'remoteId');
         $this->cache->clear('location', 'subtree');
+
+        foreach ($locations as $location) {
+            $this->cache->clear('location', $location->id);
+        }
 
         return $return;
     }

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
@@ -468,6 +468,18 @@ class ContentHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
+        $innerLocationHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler');
+        $this->persistenceHandlerMock
+            ->expects($this->exactly(1))
+            ->method('locationHandler')
+            ->will($this->returnValue($innerLocationHandlerMock));
+
+        $innerLocationHandlerMock
+            ->expects($this->once())
+            ->method('loadLocationsByContent')
+            ->with(2)
+            ->willReturn([new Content\Location(array('id' => 58))]);
+
         $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Handler');
         $this->persistenceHandlerMock
             ->expects($this->exactly(2))
@@ -520,6 +532,12 @@ class ContentHandlerTest extends HandlerTest
             ->expects($this->at(4))
             ->method('clear')
             ->with('location', 'subtree')
+            ->will($this->returnValue(null));
+
+        $this->cacheMock
+            ->expects($this->at(5))
+            ->method('clear')
+            ->with('location', 58)
             ->will($this->returnValue(null));
 
         $handler = $this->persistenceCacheHandler->contentHandler();

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter.php
@@ -23,6 +23,10 @@ interface Converter
     /**
      * Converts data from $value to $storageFieldValue.
      *
+     * Note: You should not throw on validation here, as it is implicitly used by ContentService->createContentDraft().
+     *       Rather allow invalid value or omit it to let validation layer in FieldType handle issues when user tried
+     *       to publish the given draft.
+     *
      * @param \eZ\Publish\SPI\Persistence\Content\FieldValue $value
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue $storageFieldValue
      */


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-26342

Replaces #1788 _(for now does not retain invalid data on purpose in db, we'll need to look at that as a separate feature as it affects to many things)_

In addition work that was done on adding validation to field relations in a generic way was moved to #1796.