### PR TITLE
Fix EZP-26367: don't cache UrlAlias with history

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -206,8 +206,10 @@ class UrlAliasHandler extends AbstractHandler implements UrlAliasHandlerInterfac
                 $urlAlias = $this->persistenceHandler->urlAliasHandler()->lookup($url);
                 $cache->set($urlAlias->id)->save();
 
-                $urlAliasCache = $this->cache->getItem('urlAlias', $urlAlias->id);
-                $urlAliasCache->set($urlAlias)->save();
+                if (!$urlAlias->isHistory) {
+                    $urlAliasCache = $this->cache->getItem('urlAlias', $urlAlias->id);
+                    $urlAliasCache->set($urlAlias)->save();
+                }
             } catch (APINotFoundException $e) {
                 $cache->set(self::NOT_FOUND)->save();
                 throw $e;


### PR DESCRIPTION
> Fixes [EZP-23267](https://jira.ez.no/browse/EZP-26367)

If lookup is first done on a history alias, the history parts will be cached.
The history aliases will then be returned when listing UrlAlias for the given location.

This prevents history aliases from being stored. Not ideal, but it does fix the issue. My thinking is that we probably want to distinguish caching depending on `UrlAlias::$isHistory`.

[This command](https://gist.github.com/bdunogier/e55ccc1eafda264dc5abb8ee1de3d394) can be used to reproduce this issue:

1. Create a Folder ("Some folder")
2. Create an article in that folder ("Article")
3. Rename the folder ("Some renamed folder")
4. Lookup the old article's URL alias ("/Some-folder/Article").
  It gets resolved to a history URL alias, stored for that path.
  The UrlAlias that was resolved for "Article" is cached (that's what the patch modifies):
```
eZ\Publish\SPI\Persistence\Content\UrlAlias {#2448
  +id: "182-92a2b5cb9c6906035c2864fa225e1940"
  +type: 0
  +destination: "152"
  +pathData: array:2 [
    0 => array:2 [
      "always-available" => false
      "translations" => array:1 [
        "eng-GB" => "Some-folder"
      ]
    ]
    1 => array:2 [
      "always-available" => false
      "translations" => array:1 [
        "eng-GB" => "Article"
      ]
    ]
  ]
  +languageCodes: array:1 [
    0 => "eng-GB"
  ]
  +alwaysAvailable: false
  +isHistory: true
  +isCustom: false
  +forward: false
}
```
5. List the UrlAlias for "Article". Works as expected. The list of UrlAlias id for this location is cached. It works at step 5 (the first time the aliases are loaded) because when there is a cache miss, the persistence handler is used, not the cache handler.
6. List the UrlAliases for "Article" again: it fails. It uses the previously cached UrlAlias id, **then uses `$this->loadUrlAlias` (the one from the Cache handler, unlike above). And this one will return the UrlAlias that was cached at step 4 above, even if it was a history alias.

The reason why the redirection fails (customer issue) is that the redirection URI is set to the history one, as this is what `listLocationUrlAliases()` returns in the `UrlAliasGenerator`.

