### PR TITLE
EZS-1009: Send for review does not work for draft version

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
@@ -335,6 +335,7 @@ class SearchEngineIndexingTest extends BaseTest
         $searchService = $repository->getSearchService();
 
         $publishedContent = $this->createContentWithName('updateMetadataTest', [2]);
+        $originalMainLocationId = $publishedContent->contentInfo->mainLocationId;
         $newLocationCreateStruct = $locationService->newLocationCreateStruct(60);
         $newLocation = $locationService->createLocation($publishedContent->contentInfo, $newLocationCreateStruct);
 
@@ -365,6 +366,13 @@ class SearchEngineIndexingTest extends BaseTest
         $this->assertEquals($newContentMetadataUpdateStruct->publishedDate, $foundContentInfo->publishedDate);
         $this->assertEquals($newLocation->id, $foundContentInfo->mainLocationId);
         $this->assertEquals($newContentMetadataUpdateStruct->remoteId, $foundContentInfo->remoteId);
+
+        // find Content using old main location
+        $criterion = new Criterion\LocationId($originalMainLocationId);
+        $query = new LocationQuery(['filter' => $criterion]);
+        $results = $searchService->findLocations($query);
+        $this->assertEquals(1, $results->totalCount);
+        $this->assertEquals($newContentMetadataUpdateStruct->remoteId, $results->searchHits[0]->valueObject->contentInfo->remoteId);
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
@@ -368,6 +368,31 @@ class SearchEngineIndexingTest extends BaseTest
     }
 
     /**
+     * Test that updating Content Draft metadata does not affect Search Engine Index.
+     */
+    public function testUpdateContentDraftMetadataIsNotIndexed()
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+        $locationService = $repository->getLocationService();
+
+        $testableContentType = $this->createTestContentType();
+        $rootContentStruct = $contentService->newContentCreateStruct($testableContentType, 'eng-GB');
+        $rootContentStruct->setField('name', 'TestUpdatingContentDraftMetadata');
+
+        $contentDraft = $contentService->createContent($rootContentStruct, [$locationService->newLocationCreateStruct(2)]);
+
+        $newContentMetadataUpdateStruct = $contentService->newContentMetadataUpdateStruct();
+        $newContentMetadataUpdateStruct->ownerId = 10;
+        $newContentMetadataUpdateStruct->remoteId = md5('Test');
+
+        $contentService->updateContentMetadata($contentDraft->contentInfo, $newContentMetadataUpdateStruct);
+
+        $this->refreshSearch($repository);
+        $this->assertContentIdSearch($contentDraft->contentInfo->id, 0);
+    }
+
+    /**
      * Test that assigning section to content object properly affects Search Engine Index.
      */
     public function testAssignSection()

--- a/eZ/Publish/Core/Search/Common/Slot/UpdateContentMetadata.php
+++ b/eZ/Publish/Core/Search/Common/Slot/UpdateContentMetadata.php
@@ -25,6 +25,9 @@ class UpdateContentMetadata extends Slot
         }
 
         $contentInfo = $this->persistenceHandler->contentHandler()->loadContentInfo($signal->contentId);
+        if (!$contentInfo->isPublished) {
+            return;
+        }
         $this->searchHandler->indexContent(
             $this->persistenceHandler->contentHandler()->load($contentInfo->id, $contentInfo->currentVersionNo)
         );


### PR DESCRIPTION
> Status: **Ready for a review**
> Fixes: [EZS-1009](https://jira.ez.no/browse/EZS-1009)

Use case: sending for a review applies to drafts and it triggers `UpdateContentMetadataSignal`. `UpdateContentMetadata` Search Slot introduced in #1779 should ignore drafts.

Looking from the Kernel side - it is possible to update Content Metadata for drafts, so Search Slot should check if content is published before trying to index it.

**TODO**:
- [x] Add test case updating Content draft Metadata (1475f94).
- [x] Ignore drafts when indexing Content draft after updating Metadata (1b4716b).
- [x] Try to find more cases when Search Engine Slots could possibly be called for drafts. // none found