### PR TITLE
EZP-26326: Implement Filter and Query REST Query parameters

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -2176,10 +2176,10 @@ Perform a query on images within the media section, sorted by name, limiting res
     <ViewInput>
       <identifier>TitleView</identifier>
       <ContentQuery>
-        <Criteria>
+        <Filter>
           <ContentTypeIdentifierCriterion>image</ContentTypeIdentifierCriterion>
           <SectionIdentifierCriterion>media</SectionIdentifierCriterion>
-        </Criteria>
+        </Filter>
         <limit>10</limit>
         <offset>0</offset>
         <SortClauses>
@@ -2206,9 +2206,9 @@ Perform a query on images within the media section, sorted by name, limiting res
       <User href="/user/users/14" media-type="vnd.ez.api.User+xml"/>
       <public>false</public>
       <LocationQuery>
-        <Criteria>
+        <Filter>
           <ParentLocationIdCriterion>2</ParentLocationIdCriterion>
-        </Criteria>
+        </Filter>
         <limit>10</limit>
         <offset>0</offset>
         <SortClauses>
@@ -7390,7 +7390,7 @@ View XML Schema
           <xsd:choice>
             <xsd:element name="contentTypeFacetBuilder" type="facetBuilderType" />
             <xsd:element name="criterionFacetBuilder" type="facetBuilderType" />
-            <xsd:element name="dateRangeFacetBulder" type="dateRangeFacetBuilderType" />
+            <xsd:element name="dateRangeFacetBuilder" type="dateRangeFacetBuilderType" />
             <xsd:element name="fieldFacetBuilder" type="fieldFacetBuilderType"></xsd:element>
             <xsd:element name="fieldRangeFacetBuilder" type="fieldRangeFacetBuilderType"></xsd:element>
             <xsd:element name="locationFacetBuilder" type="locationFacetBuilderType" />
@@ -7403,7 +7403,10 @@ View XML Schema
 
       <xsd:complexType name="queryType">
         <xsd:all>
-          <xsd:element name="Criterion" type="criterionType" />
+          <!-- Criteria is deprecated since 6.6.0. Use 'Filter' instead. -->
+          <xsd:element name="Criteria" type="criterionType" />
+          <xsd:element name="Filter" type="criterionType" />
+          <xsd:element name="Query" type="criterionType" />
           <xsd:element name="limit" type="xsd:int" />
           <xsd:element name="offset" type="xsd:int" />
           <xsd:element name="FacetBuilders" type="facetBuilderListType" />

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/Views.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/Views.php
@@ -4,6 +4,8 @@
  */
 namespace eZ\Bundle\EzPublishRestBundle\Features\Context\SubContext;
 
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeIdentifier;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\Core\REST\Client\Values\View;
 use PHPUnit_Framework_Assert as Assertion;
@@ -33,5 +35,22 @@ trait Views
         foreach ($searchHits as $searchHit) {
             Assertion::assertInstanceOf('eZ\Publish\API\Repository\Values\Content\Content', $searchHit->valueObject);
         }
+    }
+
+    /**
+     * @Given /^I set field "([^"]*)" to a Query object$/
+     */
+    public function iSetFieldToAQueryObject($field)
+    {
+        $this->requestObject->$field = new Query();
+    }
+
+    /**
+     * @Given /^I set the "([^"]*)" property of the Query to a valid Criterion$/
+     */
+    public function iSetTheFilterPropertyOfTheQuery($field)
+    {
+        // @todo this could be improved if setFieldToValue used PropertyAccessor.
+        $this->requestObject->contentQuery->$field = new ContentTypeIdentifier('folder');
     }
 }

--- a/eZ/Bundle/EzPublishRestBundle/Features/Views/query.feature
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Views/query.feature
@@ -8,7 +8,8 @@ Feature: Running searches using REST views
          And I set header "accept" for "View" object
          And I make a "ViewInput" object
          And I set field "identifier" to "some_identifier"
-         And I set field "ContentQuery" to an empty array
+         And I set field "contentQuery" to a Query object
+         And I set the "filter" property of the Query to a valid Criterion
          And I send the request
         Then response contains a "eZ\Publish\Core\REST\Client\Values\View" object
          And the View contains Search Hits

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -858,3 +858,15 @@ services:
         class: "%ezpublish_rest.output.value_object_visitor.ViewInput.class%"
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Client\Values\ViewInput }
+
+    ezpublish_rest.output.value_object_visitor.Query:
+        parent: ezpublish_rest.output.value_object_visitor.base
+        class: 'eZ\Publish\Core\REST\Client\Output\ValueObjectVisitor\Query'
+        tags:
+            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\Content\Query }
+
+    ezpublish_rest.output.value_object_visitor.criterion.content_type_identifier:
+        parent: ezpublish_rest.output.value_object_visitor.base
+        class: 'eZ\Publish\Core\REST\Client\Output\ValueObjectVisitor\Criterion\ContentTypeIdentifier'
+        tags:
+            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeIdentifier }

--- a/eZ/Publish/Core/REST/Client/Output/ValueObjectVisitor/Criterion/ContentTypeIdentifier.php
+++ b/eZ/Publish/Core/REST/Client/Output/ValueObjectVisitor/Criterion/ContentTypeIdentifier.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Client\Output\ValueObjectVisitor\Criterion;
+
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+
+class ContentTypeIdentifier extends ValueObjectVisitor
+{
+    /**
+     * @param Visitor $visitor
+     * @param Generator $generator
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeIdentifier $data
+     */
+    public function visit(Visitor $visitor, Generator $generator, $data)
+    {
+        $generator->startValueElement('ContentTypeIdentifierCriterion', $data->value);
+        $generator->endValueElement('ContentTypeIdentifierCriterion');
+    }
+}

--- a/eZ/Publish/Core/REST/Client/Output/ValueObjectVisitor/Query.php
+++ b/eZ/Publish/Core/REST/Client/Output/ValueObjectVisitor/Query.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Client\Output\ValueObjectVisitor;
+
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\Base\Exceptions;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery as LocationQueryValue;
+use eZ\Publish\API\Repository\Values\Content\Query as ContentQueryValue;
+
+class Query extends ValueObjectVisitor
+{
+    public function visit(Visitor $visitor, Generator $generator, $data)
+    {
+        if ($data instanceof LocationQueryValue) {
+            $rootObjectElement = 'LocationQuery';
+        } else if ($data instanceof ContentQueryValue) {
+            $rootObjectElement = 'ContentQuery';
+        } else {
+            throw new Exceptions\InvalidArgumentException("ViewInput Query", "No content nor location query found in ViewInput");
+        }
+        $generator->startObjectElement($rootObjectElement, 'Query');
+
+        if (isset($data->filter)) {
+            $generator->startHashElement('Filter');
+            $visitor->visitValueObject($data->filter);
+            $generator->endHashElement('Filter');
+        }
+
+        if (isset($data->query)) {
+            $generator->startHashElement('Query');
+            $visitor->visitValueObject($data->query);
+            $generator->endhashElement('Query');
+        }
+
+        // $generator->startObjectElement('SortClauses');
+        // foreach ($data->sortClauses as $sortClause) {
+        //     $visitor->visitValueObject($sortClause);
+        // }
+        // $generator->endObjectElement('SortClauses');
+
+        $generator->endObjectElement($rootObjectElement);
+    }
+}

--- a/eZ/Publish/Core/REST/Client/Output/ValueObjectVisitor/ViewInput.php
+++ b/eZ/Publish/Core/REST/Client/Output/ValueObjectVisitor/ViewInput.php
@@ -14,13 +14,19 @@ use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
 use eZ\Publish\Core\Base\Exceptions;
-use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor\Exception;
+use eZ\Publish\Core\REST\Server\Values\RestViewInput;
 
 /**
  * ViewInput value object visitor.
  */
 class ViewInput extends ValueObjectVisitor
 {
+    /**
+     * @param Visitor $visitor
+     * @param Generator $generator
+     * @param \eZ\Publish\Core\REST\Client\Values\ViewInput $data
+     * @throws Exceptions\InvalidArgumentException
+     */
     public function visit(Visitor $visitor, Generator $generator, $data)
     {
         $generator->startObjectElement('ViewInput');
@@ -29,15 +35,14 @@ class ViewInput extends ValueObjectVisitor
         $generator->endValueElement('identifier');
 
         if ($data->locationQuery !== null ) {
-            $queryElementName = 'LocationQuery';
+            $queryElementName = 'locationQuery';
         } elseif ($data->contentQuery !== null ) {
-            $queryElementName = 'ContentQuery';
+            $queryElementName = 'contentQuery';
         } else {
             throw new Exceptions\InvalidArgumentException("ViewInput Query", "No content nor location query found in ViewInput");
         }
 
-        $generator->startObjectElement($queryElementName);
-        $generator->endObjectElement($queryElementName);
+        $visitor->visitValueObject($data->$queryElementName);
 
         $generator->endObjectElement('ViewInput');
     }

--- a/eZ/Publish/Core/REST/Client/Values/ViewInput.php
+++ b/eZ/Publish/Core/REST/Client/Values/ViewInput.php
@@ -10,7 +10,13 @@ class ViewInput extends ValueObject
 {
     public $identifier;
 
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\Query
+     */
     public $contentQuery;
 
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\LocationQuery
+     */
     public $locationQuery;
 }

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/ContentTypeIdentifier.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/ContentTypeIdentifier.php
@@ -48,8 +48,17 @@ class ContentTypeIdentifier extends BaseParser
         if (!array_key_exists('ContentTypeIdentifierCriterion', $data)) {
             throw new Exceptions\Parser('Invalid <ContentTypeIdCriterion> format');
         }
-        $contentType = $this->contentTypeService->loadContentTypeByIdentifier($data['ContentTypeIdentifierCriterion']);
+        if (!is_array($data['ContentTypeIdentifierCriterion'])) {
+            $data['ContentTypeIdentifierCriterion'] = [$data['ContentTypeIdentifierCriterion']];
+        }
 
-        return new ContentTypeIdCriterion($contentType->id);
+        return new ContentTypeIdCriterion(
+            array_map(
+                function ($contentTypeIdentifier) {
+                    return $this->contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier)->id;
+                },
+                $data['ContentTypeIdentifierCriterion']
+            )
+        );
     }
 }

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Query.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Query.php
@@ -10,7 +10,7 @@ namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Server\Input\Parser\Criterion as CriterionParser;
-use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd as LogicalAndCriterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion as CriterionValue;
 
 /**
  * Content/Location Query Parser.
@@ -25,7 +25,7 @@ abstract class Query extends CriterionParser
      *
      * @throws \eZ\Publish\Core\REST\Common\Exceptions\Parser
      *
-     * @return \eZ\Publish\Core\REST\Server\Values\RestViewInput
+     * @return \eZ\Publish\API\Repository\Values\Content\Query
      */
     public function parse(array $data, ParsingDispatcher $parsingDispatcher)
     {
@@ -34,16 +34,23 @@ abstract class Query extends CriterionParser
         // Criteria
         // -- FullTextCriterion
         if (array_key_exists('Criteria', $data) && is_array($data['Criteria'])) {
-            $criteria = array();
-            foreach ($data['Criteria'] as $criterionName => $criterionData) {
-                $criteria[] = $this->dispatchCriterion($criterionName, $criterionData, $parsingDispatcher);
+            $message = 'The Criteria element is deprecated since ezpublish-kernel 6.6.0, and will be removed in 7.0. Use Filter instead.';
+            if (array_key_exists('Filter', $data) && is_array($data['Filter'])) {
+                $message .= ' The Criteria element will be merged into Filter.';
+                $data['Filter'] = array_merge($data['Filter'], $data['Criteria']);
+            } else {
+                $data['Filter'] = $data['Criteria'];
             }
 
-            if (count($criteria) === 1) {
-                $query->filter = $criteria[0];
-            } else {
-                $query->filter = new LogicalAndCriterion($criteria);
-            }
+            @trigger_error($message, E_USER_DEPRECATED);
+        }
+
+        if (array_key_exists('Filter', $data) && is_array($data['Filter'])) {
+            $query->filter = $this->processCriteriaArray($data['Filter'], $parsingDispatcher);
+        }
+
+        if (array_key_exists('Query', $data) && is_array($data['Query'])) {
+            $query->query = $this->processCriteriaArray($data['Query'], $parsingDispatcher);
         }
 
         // limit
@@ -79,4 +86,20 @@ abstract class Query extends CriterionParser
      * @return \eZ\Publish\API\Repository\Values\Content\Query
      */
     abstract protected function buildQuery();
+
+    /**
+     * @param array $criteria
+     * @param ParsingDispatcher $parsingDispatcher
+     *
+     * @return CriterionValue
+     */
+    private function processCriteriaArray(array $criteria, ParsingDispatcher $parsingDispatcher)
+    {
+        $criteria = array();
+        foreach ($criteria as $criterionName => $criterionData) {
+            $criteria[] = $this->dispatchCriterion($criterionName, $criterionData, $parsingDispatcher);
+        }
+
+        return (count($criteria) === 1) ? $criteria[0] : new CriterionValue\LogicalAnd($criteria);
+    }
 }

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Query.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Query.php
@@ -88,15 +88,15 @@ abstract class Query extends CriterionParser
     abstract protected function buildQuery();
 
     /**
-     * @param array $criteria
+     * @param array $criteriaArray
      * @param ParsingDispatcher $parsingDispatcher
      *
      * @return CriterionValue
      */
-    private function processCriteriaArray(array $criteria, ParsingDispatcher $parsingDispatcher)
+    private function processCriteriaArray(array $criteriaArray, ParsingDispatcher $parsingDispatcher)
     {
         $criteria = array();
-        foreach ($criteria as $criterionName => $criterionData) {
+        foreach ($criteriaArray as $criterionName => $criterionData) {
             $criteria[] = $this->dispatchCriterion($criterionName, $criterionData, $parsingDispatcher);
         }
 

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestExecutedView.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/RestExecutedView.php
@@ -116,10 +116,10 @@ class RestExecutedView extends ValueObjectVisitor
         foreach ($data->searchResults->searchHits as $searchHit) {
             $generator->startObjectElement('searchHit');
 
-            $generator->startAttribute('score', 0);
+            $generator->startAttribute('score', (float)$searchHit->score);
             $generator->endAttribute('score');
 
-            $generator->startAttribute('index', 0);
+            $generator->startAttribute('index', (string)$searchHit->index);
             $generator->endAttribute('index');
 
             $generator->startObjectElement('value');

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestExecutedViewTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestExecutedViewTest.php
@@ -85,6 +85,8 @@ class RestExecutedViewTest extends ValueObjectVisitorBaseTest
             array('/View/Result'),
             array('/View/Result[@media-type="application/vnd.ez.api.ViewResult+xml"]'),
             array('/View/Result[@href="/content/views/test_view/results"]'),
+            array('/View/Result/searchHits/searchHit[@score="0.123" and @index="alexandria"]'),
+            array('/View/Result/searchHits/searchHit[@score="0.234" and @index="waze"]'),
         );
     }
 
@@ -144,6 +146,8 @@ class RestExecutedViewTest extends ValueObjectVisitorBaseTest
     protected function buildContentSearchHit()
     {
         return new SearchHit([
+            'score' => 0.123,
+            'index' => 'alexandria',
             'valueObject' => new ApiValues\Content([
                 'versionInfo' => new Content\VersionInfo(['contentInfo' => new ContentInfo()]),
             ]),
@@ -155,6 +159,10 @@ class RestExecutedViewTest extends ValueObjectVisitorBaseTest
      */
     protected function buildLocationSearchHit()
     {
-        return new SearchHit(['valueObject' => new ApiValues\Location()]);
+        return new SearchHit([
+            'score' => 0.234,
+            'index' => 'waze',
+            'valueObject' => new ApiValues\Location(),
+        ]);
     }
 }


### PR DESCRIPTION
> Implements [EZP-26326](http://jira.ez.no/browse/EZP-26326)
> Status: ready for review.

`Criteria` is deprecated in favour of `Filter`.

This also integrates basic Criterion testing to the REST behat suite. This implies improvements to the Query ValueObjectVisitor, as well as base work for CriterionVisitors. Those are used to build REST payloads based on value objects. _As a bonus, they can also be used by the REST client :)_

### TODO
- [x] Squash