### PR TITLE
ContentViewBuilder will load the main location if none was asked

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
@@ -53,3 +53,8 @@ services:
             - "@ezpublish.api.service.location"
             - "@ezpublish.api.service.content"
             - "@ezpublish.spi.persistence.cache.locationHandler"
+
+    ezpublish.content_info_location_loader.main:
+        class: 'eZ\Publish\Core\Helper\ContentInfoLocationLoader\SudoMainLocationLoader'
+        arguments:
+            - "@ezpublish.api.repository"

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -226,6 +226,7 @@ services:
             - "@security.authorization_checker"
             - "@ezpublish.view.configurator"
             - "@ezpublish.view.view_parameters.injector.dispatcher"
+            - "@ezpublish.content_info_location_loader.main"
 
     ezpublish.view_builder.block:
         class: "%ezpublish.view_builder.block.class%"

--- a/eZ/Publish/Core/Helper/ContentInfoLocationLoader.php
+++ b/eZ/Publish/Core/Helper/ContentInfoLocationLoader.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Helper;
+
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+
+/**
+ * Loads a location based on a ContentInfo.
+ */
+interface ContentInfoLocationLoader
+{
+    /**
+     * Loads a location from a ContentInfo.
+     *
+     * @param ContentInfo $contentInfo
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Location
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the location doesn't have a contentId.
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the location failed to load.
+     */
+    public function loadLocation(ContentInfo $contentInfo);
+}

--- a/eZ/Publish/Core/Helper/ContentInfoLocationLoader/SudoMainLocationLoader.php
+++ b/eZ/Publish/Core/Helper/ContentInfoLocationLoader/SudoMainLocationLoader.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Helper\ContentInfoLocationLoader;
+
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\Helper\ContentInfoLocationLoader;
+use eZ\Publish\API\Repository\Repository;
+use Exception;
+
+/**
+ * Loads the main location of a given ContentInfo using sudo().
+ */
+class SudoMainLocationLoader implements ContentInfoLocationLoader
+{
+    /**
+     * @var \eZ\Publish\API\Repository\Repository|\eZ\Publish\Core\Repository\Repository
+     */
+    private $repository;
+
+    public function __construct(Repository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function loadLocation(ContentInfo $contentInfo)
+    {
+        if (is_null($contentInfo->mainLocationId)) {
+            throw new NotFoundException('main location of content', $contentInfo->id);
+        }
+
+        try {
+            return $this->repository->sudo(
+                function (Repository $repository) use ($contentInfo) {
+                    return $repository->getLocationService()->loadLocation($contentInfo->mainLocationId);
+                }
+            );
+        } catch (Exception $e) {
+            throw new NotFoundException('main location of content', $contentInfo->id);
+        }
+    }
+}

--- a/eZ/Publish/Core/Helper/Tests/ContentInfoLocationLoader/SudoMainLocationLoaderTest.php
+++ b/eZ/Publish/Core/Helper/Tests/ContentInfoLocationLoader/SudoMainLocationLoaderTest.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Helper\Tests\ContentInfoLocationLoader;
+
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\Helper\ContentInfoLocationLoader\SudoMainLocationLoader;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+use PHPUnit_Framework_TestCase;
+
+class SudoMainLocationLoaderTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \eZ\Publish\Core\Helper\ContentInfoLocationLoader\SudoMainLocationLoader
+     */
+    private $loader;
+
+    public function setUp()
+    {
+        $this->loader = new SudoMainLocationLoader($this->getRepositoryMock());
+    }
+
+    /**
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function testLoadLocationNoMainLocation()
+    {
+        $contentInfo = new ContentInfo();
+
+        $this->getLocationServiceMock()
+            ->expects($this->never())
+            ->method('loadLocation');
+
+        $this->loader->loadLocation($contentInfo);
+    }
+
+    public function testLoadLocation()
+    {
+        $contentInfo = new ContentInfo(['mainLocationId' => 42]);
+        $location = new Location();
+
+        $this->getRepositoryMock()
+            ->expects($this->any())
+            ->method('getPermissionResolver')
+            ->will($this->returnValue($this->getPermissionResolverMock()));
+
+        $this->getRepositoryMock()
+            ->expects($this->any())
+            ->method('getLocationService')
+            ->will($this->returnValue($this->getLocationServiceMock()));
+
+        $this->getLocationServiceMock()
+            ->expects($this->once())
+            ->method('loadLocation')
+            ->with(42)
+            ->will($this->returnValue($location));
+
+        $this->assertSame($location, $this->loader->loadLocation($contentInfo));
+    }
+
+    /**
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function testLoadLocationError()
+    {
+        $contentInfo = new ContentInfo(['mainLocationId' => 42]);
+        $location = new Location();
+
+        $this->getRepositoryMock()
+            ->expects($this->any())
+            ->method('getPermissionResolver')
+            ->will($this->returnValue($this->getPermissionResolverMock()));
+
+        $this->getRepositoryMock()
+            ->expects($this->any())
+            ->method('getLocationService')
+            ->will($this->returnValue($this->getLocationServiceMock()));
+
+        $this->getLocationServiceMock()
+            ->expects($this->once())
+            ->method('loadLocation')
+            ->with(42)
+            ->will(
+                $this->throwException(new NotFoundException('main location of content', 42))
+            );
+
+        $this->assertSame($location, $this->loader->loadLocation($contentInfo));
+    }
+
+    /**
+     * @return \eZ\Publish\Core\Repository\Repository|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getRepositoryMock()
+    {
+        static $repositoryMock;
+
+        if ($repositoryMock === null) {
+            $repositoryClass = 'eZ\Publish\Core\Repository\Repository';
+
+            $repositoryMock = $this
+                ->getMockBuilder($repositoryClass)
+                ->disableOriginalConstructor()
+                ->setMethods(
+                    array_diff(
+                        get_class_methods($repositoryClass),
+                        array('sudo')
+                    )
+                )
+                ->getMock();
+        }
+
+        return $repositoryMock;
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\LocationService|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getLocationServiceMock()
+    {
+        static $mock;
+
+        if ($mock === null) {
+            $mock = $this
+                ->getMockBuilder('eZ\Publish\API\Repository\LocationService')
+                ->getMock();
+        }
+
+        return $mock;
+    }
+
+    /**
+     * @return \eZ\Publish\Core\Repository\Permission\PermissionResolver|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getPermissionResolverMock()
+    {
+        return $this
+            ->getMockBuilder('eZ\Publish\Core\Repository\Permission\PermissionResolver')
+            ->setMethods(null)
+            ->setConstructorArgs(
+                [
+                    $this
+                        ->getMockBuilder('eZ\Publish\Core\Repository\Helper\RoleDomainMapper')
+                        ->disableOriginalConstructor()
+                        ->getMock(),
+                    $this
+                        ->getMockBuilder('eZ\Publish\Core\Repository\Helper\LimitationService')
+                        ->getMock(),
+                    $this
+                        ->getMockBuilder('eZ\Publish\SPI\Persistence\User\Handler')
+                        ->getMock(),
+                    $this
+                        ->getMockBuilder('eZ\Publish\API\Repository\Values\User\UserReference')
+                        ->getMock(),
+                ]
+            )
+            ->getMock();
+    }
+}


### PR DESCRIPTION
> Fixes [EZP-26381](https://jira.ez.no/browse/EZP-26381)

Makes the `ContentViewBuilder` load the main Location if none was asked / provided as an argument.

Fixes display of relation field values, as they use a ContentView with the `text_linked` view type, and the template only generates a link to the related content if a location is provided.

An alternative fix would be to use the content and mainLocationId as arguments in the text_linked template (tested works as well):
```
<a href="{{ path( "ez_urlalias", {"locationId": content.contentInfo.mainLocationId} ) }}">{{ content_name }}</a>
```

But I believe that there is nothing wrong with making the main location available.

### TODO
- [x] Some kind of testing (unit tested the `SudoMainLocationLoader`)
- [x] Think about permissions on the location in the ViewBuilder (covered by usage of `sudo()`)

