### PR TITLE
Fix EZP-25918: Download redirect code should not be permanent

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadRedirectionController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadRedirectionController.php
@@ -66,7 +66,7 @@ class DownloadRedirectionController extends Controller
             )
         );
 
-        return new RedirectResponse($downloadUrl, 301);
+        return new RedirectResponse($downloadUrl, 302);
     }
 
     /**


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-25918

## Description
When a file (`content/download`) is requested using REST, information regarding the file is computed in order to call the generic download route. Then a redirect is made.

The issue here is that the redirect is permanent `HTTP 301`. So the web browser stores it. If the file is later modified, the browser will use its redirection cache and call the old URL, so information won't be computed and the user will get an outdated file.

The patch changes the type of redirection to a non permanent one `HTTP 302`.

## Test
Manual tests