### PR TITLE
Fix EZP-26382: ContentType Draft sets IntegerValueValidator min/max to 0

### DIFF
--- a/doc/bc/changes-6.5.md
+++ b/doc/bc/changes-6.5.md
@@ -1,0 +1,12 @@
+# Backwards compatibility changes
+
+Changes affecting version compatibility with former or future versions.
+
+## Changes
+
+
+## Deprecations
+
+* Integer field type `IntegerValueValidator` has changed to be inline with the Float field type validator.
+ `false` is considered deprecated for `minIntegerValue` and `maxIntegerValue`, and will be removed in 7.0.
+  Use `null` instead of `false` if you want to deactivate these validators.

--- a/eZ/Publish/Core/FieldType/Tests/IntegerValueValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/IntegerValueValidatorTest.php
@@ -81,7 +81,7 @@ class IntegerValueValidatorTest extends PHPUnit_Framework_TestCase
             ),
             'maxIntegerValue' => array(
                 'type' => 'int',
-                'default' => false,
+                'default' => null,
             ),
         );
         $validator = new IntegerValueValidator();
@@ -246,15 +246,15 @@ class IntegerValueValidatorTest extends PHPUnit_Framework_TestCase
                     'maxIntegerValue' => 2,
                 ),
                 array(
-                    'minIntegerValue' => false,
-                    'maxIntegerValue' => false,
+                    'minIntegerValue' => null,
+                    'maxIntegerValue' => null,
                 ),
                 array(
                     'minIntegerValue' => -5,
-                    'maxIntegerValue' => false,
+                    'maxIntegerValue' => null,
                 ),
                 array(
-                    'minIntegerValue' => false,
+                    'minIntegerValue' => null,
                     'maxIntegerValue' => 12,
                 ),
                 array(

--- a/eZ/Publish/Core/FieldType/Validator/IntegerValueValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/IntegerValueValidator.php
@@ -45,9 +45,11 @@ class IntegerValueValidator extends Validator
             switch ($name) {
                 case 'minIntegerValue':
                 case 'maxIntegerValue':
-                    // @deprecated false constraint value, see https://jira.ez.no/browse/EZP-26382
-                    // @TODO: remove false to null conversion
                     if ($value === false) {
+                        @trigger_error(
+                            "The IntegerValueValidator constraint value 'false' is deprecated, and will be removed in 7.0. Use 'null' instead.",
+                            E_USER_DEPRECATED
+                        );
                         $value = null;
                     }
                     if ($value !== null && !is_integer($value)) {

--- a/eZ/Publish/Core/FieldType/Validator/IntegerValueValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/IntegerValueValidator.php
@@ -23,8 +23,8 @@ use eZ\Publish\Core\FieldType\Value as BaseValue;
 class IntegerValueValidator extends Validator
 {
     protected $constraints = array(
-        'minIntegerValue' => false,
-        'maxIntegerValue' => false,
+        'minIntegerValue' => null,
+        'maxIntegerValue' => null,
     );
 
     protected $constraintsSchema = array(
@@ -34,7 +34,7 @@ class IntegerValueValidator extends Validator
         ),
         'maxIntegerValue' => array(
             'type' => 'int',
-            'default' => false,
+            'default' => null,
         ),
     );
 
@@ -45,7 +45,12 @@ class IntegerValueValidator extends Validator
             switch ($name) {
                 case 'minIntegerValue':
                 case 'maxIntegerValue':
-                    if ($value !== false && !is_integer($value)) {
+                    // @deprecated false constraint value, see https://jira.ez.no/browse/EZP-26382
+                    // @TODO: remove false to null conversion
+                    if ($value === false) {
+                        $value = null;
+                    }
+                    if ($value !== null && !is_integer($value)) {
                         $validationErrors[] = new ValidationError(
                             "Validator parameter '%parameter%' value must be of integer type",
                             null,
@@ -86,7 +91,7 @@ class IntegerValueValidator extends Validator
     {
         $isValid = true;
 
-        if ($this->constraints['maxIntegerValue'] !== false && $value->value > $this->constraints['maxIntegerValue']) {
+        if ($this->constraints['maxIntegerValue'] !== null && $value->value > $this->constraints['maxIntegerValue']) {
             $this->errors[] = new ValidationError(
                 'The value can not be higher than %size%.',
                 null,
@@ -97,7 +102,7 @@ class IntegerValueValidator extends Validator
             $isValid = false;
         }
 
-        if ($this->constraints['minIntegerValue'] !== false && $value->value < $this->constraints['minIntegerValue']) {
+        if ($this->constraints['minIntegerValue'] !== null && $value->value < $this->constraints['minIntegerValue']) {
             $this->errors[] = new ValidationError(
                 'The value can not be lower than %size%.',
                 null,

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/IntegerConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/IntegerConverter.php
@@ -69,20 +69,18 @@ class IntegerConverter implements Converter
     {
         if (isset($fieldDef->fieldTypeConstraints->validators[self::FLOAT_VALIDATOR_IDENTIFIER]['minIntegerValue'])) {
             $storageDef->dataInt1 = $fieldDef->fieldTypeConstraints->validators[self::FLOAT_VALIDATOR_IDENTIFIER]['minIntegerValue'];
-            // @deprecated false constraint value, see https://jira.ez.no/browse/EZP-26382
-            // @TODO: remove false to null conversion
-            if ($storageDef->dataInt1 === false) {
-                $storageDef->dataInt1 = null;
-            }
         }
-
         if (isset($fieldDef->fieldTypeConstraints->validators[self::FLOAT_VALIDATOR_IDENTIFIER]['maxIntegerValue'])) {
             $storageDef->dataInt2 = $fieldDef->fieldTypeConstraints->validators[self::FLOAT_VALIDATOR_IDENTIFIER]['maxIntegerValue'];
-            // @deprecated false constraint value, see https://jira.ez.no/browse/EZP-26382
-            // @TODO: remove false to null conversion
-            if ($storageDef->dataInt2 === false) {
-                $storageDef->dataInt2 = null;
-            }
+        }
+
+        if ($storageDef->dataInt1 === false || $storageDef->dataInt2 === false) {
+            @trigger_error(
+                "The IntegerValueValidator constraint value 'false' is deprecated, and will be removed in 7.0. Use 'null' instead.",
+                E_USER_DEPRECATED
+            );
+            $storageDef->dataInt1 = $storageDef->dataInt1 === false ? null : $storageDef->dataInt1;
+            $storageDef->dataInt2 = $storageDef->dataInt2 === false ? null : $storageDef->dataInt2;
         }
 
         // Defining dataInt4 which holds the validator state (min value/max value/minMax value)

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/IntegerConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/IntegerConverter.php
@@ -69,10 +69,20 @@ class IntegerConverter implements Converter
     {
         if (isset($fieldDef->fieldTypeConstraints->validators[self::FLOAT_VALIDATOR_IDENTIFIER]['minIntegerValue'])) {
             $storageDef->dataInt1 = $fieldDef->fieldTypeConstraints->validators[self::FLOAT_VALIDATOR_IDENTIFIER]['minIntegerValue'];
+            // @deprecated false constraint value, see https://jira.ez.no/browse/EZP-26382
+            // @TODO: remove false to null conversion
+            if ($storageDef->dataInt1 === false) {
+                $storageDef->dataInt1 = null;
+            }
         }
 
         if (isset($fieldDef->fieldTypeConstraints->validators[self::FLOAT_VALIDATOR_IDENTIFIER]['maxIntegerValue'])) {
             $storageDef->dataInt2 = $fieldDef->fieldTypeConstraints->validators[self::FLOAT_VALIDATOR_IDENTIFIER]['maxIntegerValue'];
+            // @deprecated false constraint value, see https://jira.ez.no/browse/EZP-26382
+            // @TODO: remove false to null conversion
+            if ($storageDef->dataInt2 === false) {
+                $storageDef->dataInt2 = null;
+            }
         }
 
         // Defining dataInt4 which holds the validator state (min value/max value/minMax value)


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26382

Replaces #1792

This changes the `Integer` Field Type validator default from `false` to `null`, using the same logic as was done in eb5bbcdac288e3e1 for Float, but still allowing deprecated `false` value to be used.
No change to `Core/FieldType/Integer/Type.php` is needed as it was already done in cfd038a5991f7366