### PR TITLE
EZP-23281: Add max archive versions limit & enforce on publish

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
@@ -87,6 +87,8 @@ class RepositoryFactory implements ContainerAwareInterface
      */
     public function buildRepository(PersistenceHandler $persistenceHandler, SearchHandler $searchHandler)
     {
+        $config = $this->container->get('ezpublish.api.repository_configuration_provider')->getRepositoryConfig();
+
         $repository = new $this->repositoryClass(
             $persistenceHandler,
             $searchHandler,
@@ -98,6 +100,7 @@ class RepositoryFactory implements ContainerAwareInterface
                     'policyMap' => $this->policyMap,
                 ),
                 'languages' => $this->configResolver->getParameter('languages'),
+                'content' => ['default_version_archive_limit' => $config['options']['default_version_archive_limit']],
             ),
             new UserReference($this->configResolver->getParameter('anonymous_user_id'))
         );

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
@@ -124,6 +124,10 @@ class Configuration extends SiteAccessConfiguration
                                         $v['fields_groups']['default'] = 'content';
                                     }
 
+                                    if (!isset($v['options'])) {
+                                        $v['options'] = array();
+                                    }
+
                                     return $v;
                                 }
                             )
@@ -168,6 +172,15 @@ class Configuration extends SiteAccessConfiguration
                                 ->children()
                                     ->arrayNode('list')->prototype('scalar')->end()->end()
                                     ->scalarNode('default')->defaultValue('content')->end()
+                                ->end()
+                            ->end()
+                            ->arrayNode('options')
+                                ->info('Options for repository.')
+                                ->children()
+                                    ->scalarNode('default_version_archive_limit')
+                                        ->defaultValue(5)
+                                        ->info('Default version archive limit (0-50), only enforced on publish, not on un-publish.')
+                                    ->end()
                                 ->end()
                             ->end()
                         ->end()

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
@@ -319,6 +319,9 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'list' => ['content'],
                     'default' => 'content',
                 ),
+                'options' => [
+                    'default_version_archive_limit' => 5,
+                ],
             ),
             'foo' => array(
                 'storage' => array(
@@ -333,6 +336,9 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'list' => ['content'],
                     'default' => 'content',
                 ),
+                'options' => [
+                    'default_version_archive_limit' => 5,
+                ],
             ),
         );
         $this->load(array('repositories' => $repositories));
@@ -366,6 +372,9 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'list' => ['content'],
                     'default' => 'content',
                 ),
+                'options' => [
+                    'default_version_archive_limit' => 5,
+                ],
             ),
         );
         $this->load(array('repositories' => $repositories));
@@ -403,6 +412,9 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'list' => ['content'],
                     'default' => 'content',
                 ),
+                'options' => [
+                    'default_version_archive_limit' => 5,
+                ],
             ),
         );
         $this->load(array('repositories' => $repositories));
@@ -440,6 +452,9 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'list' => ['content'],
                     'default' => 'content',
                 ),
+                'options' => [
+                    'default_version_archive_limit' => 5,
+                ],
             ),
         );
         $this->load(array('repositories' => $repositories));
@@ -487,6 +502,9 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'list' => ['content'],
                     'default' => 'content',
                 ),
+                'options' => [
+                    'default_version_archive_limit' => 5,
+                ],
             ),
             'foo' => array(
                 'search' => array(
@@ -503,6 +521,9 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'list' => ['content'],
                     'default' => 'content',
                 ),
+                'options' => [
+                    'default_version_archive_limit' => 5,
+                ],
             ),
         );
         $this->load(array('repositories' => $repositories));
@@ -538,6 +559,9 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'list' => ['content'],
                     'default' => 'content',
                 ),
+                'options' => [
+                    'default_version_archive_limit' => 5,
+                ],
             ),
         );
         $this->load(array('repositories' => $repositories));

--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -269,6 +269,10 @@ interface ContentService
     /**
      * Publishes a content version.
      *
+     * Publishes a content version and deletes archive versions if they overflow max archive versions.
+     * Max archive versions are currently a configuration for default max limit, by default set to 5.
+     * @todo Introduce null|int ContentType->versionArchiveLimit to be able to let admins override this per type.
+     *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to publish this version
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the version is not a draft
      *

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -1655,6 +1655,71 @@ class ContentServiceTest extends BaseContentServiceTest
     }
 
     /**
+     * Test for the publishVersion() method, and that it creates limited archives.
+     *
+     * @todo Adapt this when per content type archvie limited is added on repository Content Type model.
+     * @see \eZ\Publish\API\Repository\ContentService::publishVersion()
+     * @depe nds \eZ\Publish\API\Repository\Tests\ContentServiceTest::testPublishVersionFromContentDraft
+     */
+    public function testPublishVersionNotCreatingUnlimitedArchives()
+    {
+        $repository = $this->getRepository();
+
+        $contentService = $repository->getContentService();
+
+        $content = $this->createContentVersion1();
+
+        // Create a new draft with versionNo = 2
+        $draftedContentVersion = $contentService->createContentDraft($content->contentInfo);
+        $contentService->publishVersion($draftedContentVersion->getVersionInfo());
+
+        // Create a new draft with versionNo = 3
+        $draftedContentVersion = $contentService->createContentDraft($content->contentInfo);
+        $contentService->publishVersion($draftedContentVersion->getVersionInfo());
+
+        // Create a new draft with versionNo = 4
+        $draftedContentVersion = $contentService->createContentDraft($content->contentInfo);
+        $contentService->publishVersion($draftedContentVersion->getVersionInfo());
+
+        // Create a new draft with versionNo = 5
+        $draftedContentVersion = $contentService->createContentDraft($content->contentInfo);
+        $contentService->publishVersion($draftedContentVersion->getVersionInfo());
+
+        // Create a new draft with versionNo = 6
+        $draftedContentVersion = $contentService->createContentDraft($content->contentInfo);
+        $contentService->publishVersion($draftedContentVersion->getVersionInfo());
+
+        // Create a new draft with versionNo = 7
+        $draftedContentVersion = $contentService->createContentDraft($content->contentInfo);
+        $contentService->publishVersion($draftedContentVersion->getVersionInfo());
+
+        $versionInfoList = $contentService->loadVersions($content->contentInfo);
+
+        $this->assertEquals(6, count($versionInfoList));
+        $this->assertEquals(2, $versionInfoList[0]->versionNo);
+        $this->assertEquals(7, $versionInfoList[5]->versionNo);
+
+        $this->assertEquals(
+            [
+                VersionInfo::STATUS_ARCHIVED,
+                VersionInfo::STATUS_ARCHIVED,
+                VersionInfo::STATUS_ARCHIVED,
+                VersionInfo::STATUS_ARCHIVED,
+                VersionInfo::STATUS_ARCHIVED,
+                VersionInfo::STATUS_PUBLISHED,
+            ],
+            [
+                $versionInfoList[0]->status,
+                $versionInfoList[1]->status,
+                $versionInfoList[2]->status,
+                $versionInfoList[3]->status,
+                $versionInfoList[4]->status,
+                $versionInfoList[5]->status,
+            ]
+        );
+    }
+
+    /**
      * Test for the newContentMetadataUpdateStruct() method.
      *
      * @see \eZ\Publish\API\Repository\ContentService::newContentMetadataUpdateStruct()

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -1657,9 +1657,9 @@ class ContentServiceTest extends BaseContentServiceTest
     /**
      * Test for the publishVersion() method, and that it creates limited archives.
      *
-     * @todo Adapt this when per content type archvie limited is added on repository Content Type model.
+     * @todo Adapt this when per content type archive limited is added on repository Content Type model.
      * @see \eZ\Publish\API\Repository\ContentService::publishVersion()
-     * @depe nds \eZ\Publish\API\Repository\Tests\ContentServiceTest::testPublishVersionFromContentDraft
+     * @depends \eZ\Publish\API\Repository\Tests\ContentServiceTest::testPublishVersionFromContentDraft
      */
     public function testPublishVersionNotCreatingUnlimitedArchives()
     {

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -223,11 +223,11 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
     /**
      * @see \eZ\Publish\SPI\Persistence\Content\Handler::listVersions
      */
-    public function listVersions($contentId)
+    public function listVersions($contentId, $status = null, $limit = -1)
     {
-        $this->logger->logCall(__METHOD__, array('content' => $contentId));
+        $this->logger->logCall(__METHOD__, array('content' => $contentId, 'status' => $status));
 
-        return $this->persistenceHandler->contentHandler()->listVersions($contentId);
+        return $this->persistenceHandler->contentHandler()->listVersions($contentId, $status, $limit);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
@@ -206,10 +206,12 @@ abstract class Gateway
      * Result is returned with oldest version first (using version id as it has index and is auto increment).
      *
      * @param mixed $contentId
+     * @param mixed|null $status Optional argument to filter versions by status, like {@see VersionInfo::STATUS_ARCHIVED}.
+     * @param int $limit Limit for items returned, -1 means none.
      *
      * @return string[][]
      */
-    abstract public function listVersions($contentId);
+    abstract public function listVersions($contentId, $status = null, $limit = -1);
 
     /**
      * Returns all version numbers for the given $contentId.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -988,23 +988,40 @@ class DoctrineDatabase extends Gateway
     }
 
     /**
-     * Returns all version data for the given $contentId.
+     * Returns all version data for the given $contentId, optionally filtered by status.
      *
      * Result is returned with oldest version first (using version id as it has index and is auto increment).
      *
      * @param mixed $contentId
+     * @param mixed|null $status Optional argument to filter versions by status, like {@see VersionInfo::STATUS_ARCHIVED}.
+     * @param int $limit Limit for items returned, -1 means none.
      *
      * @return string[][]
      */
-    public function listVersions($contentId)
+    public function listVersions($contentId, $status = null, $limit = -1)
     {
         $query = $this->queryBuilder->createVersionInfoFindQuery();
-        $query->where(
-            $query->expr->eq(
-                $this->dbHandler->quoteColumn('contentobject_id', 'ezcontentobject_version'),
-                $query->bindValue($contentId, null, \PDO::PARAM_INT)
-            )
+
+        $filter = $query->expr->eq(
+            $this->dbHandler->quoteColumn('contentobject_id', 'ezcontentobject_version'),
+            $query->bindValue($contentId, null, \PDO::PARAM_INT)
         );
+
+        if ($status !== null) {
+            $filter = $query->expr->lAnd(
+                $filter,
+                $query->expr->eq(
+                    $this->dbHandler->quoteColumn('status', 'ezcontentobject_version'),
+                    $query->bindValue($status, null, \PDO::PARAM_INT)
+                )
+            );
+        }
+
+        $query->where($filter);
+
+        if ($limit > 0) {
+            $query->limit($limit);
+        }
 
         return $this->listVersionsHelper($query);
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
@@ -367,13 +367,15 @@ class ExceptionConversion extends Gateway
      * Result is returned with oldest version first (using version id as it has index and is auto increment).
      *
      * @param mixed $contentId
+     * @param mixed|null $status Optional argument to filter versions by status, like {@see VersionInfo::STATUS_ARCHIVED}.
+     * @param int $limit Limit for items returned, -1 means none.
      *
      * @return string[][]
      */
-    public function listVersions($contentId)
+    public function listVersions($contentId, $status = null, $limit = -1)
     {
         try {
-            return $this->innerGateway->listVersions($contentId);
+            return $this->innerGateway->listVersions($contentId, $status, $limit);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -560,13 +560,17 @@ class Handler implements BaseContentHandler
     /**
      * Returns the versions for $contentId.
      *
+     * Result is returned with oldest version first (sorted by created, alternatively version id if auto increment).
+     *
      * @param int $contentId
+     * @param mixed|null $status Optional argument to filter versions by status, like {@see VersionInfo::STATUS_ARCHIVED}.
+     * @param int $limit Limit for items returned, -1 means none.
      *
      * @return \eZ\Publish\SPI\Persistence\Content\VersionInfo[]
      */
-    public function listVersions($contentId)
+    public function listVersions($contentId, $status = null, $limit = -1)
     {
-        return $this->treeHandler->listVersions($contentId);
+        return $this->treeHandler->listVersions($contentId, $status, $limit);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/TreeHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/TreeHandler.php
@@ -116,13 +116,15 @@ class TreeHandler
      *
      * Result is returned with oldest version first (using version id as it has index and is auto increment).
      *
-     * @param int $contentId
+     * @param mixed $contentId
+     * @param mixed|null $status Optional argument to filter versions by status, like {@see VersionInfo::STATUS_ARCHIVED}.
+     * @param int $limit Limit for items returned, -1 means none.
      *
      * @return \eZ\Publish\SPI\Persistence\Content\VersionInfo[]
      */
-    public function listVersions($contentId)
+    public function listVersions($contentId, $status = null, $limit = -1)
     {
-        $rows = $this->contentGateway->listVersions($contentId);
+        $rows = $this->contentGateway->listVersions($contentId, $status, $limit);
         if (empty($rows)) {
             return array();
         }

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -63,7 +63,7 @@ class ContentTest extends BaseServiceMockTest
         $relationProcessorMock = $this->getRelationProcessorMock();
         $nameSchemaServiceMock = $this->getNameSchemaServiceMock();
         $fieldTypeRegistryMock = $this->getFieldTypeRegistryMock();
-        $settings = array('settings');
+        $settings = ['default_version_archive_limit' => 10];
 
         $service = new ContentService(
             $repositoryMock,

--- a/eZ/Publish/SPI/Persistence/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Handler.php
@@ -171,10 +171,12 @@ interface Handler
      * Result is returned with oldest version first (sorted by created, alternatively version number or id if auto increment).
      *
      * @param int $contentId
+     * @param mixed|null $status Optional argument to filter versions by status, like {@see VersionInfo::STATUS_ARCHIVED}.
+     * @param int $limit Limit for items returned, -1 means none.
      *
      * @return \eZ\Publish\SPI\Persistence\Content\VersionInfo[]
      */
-    public function listVersions($contentId);
+    public function listVersions($contentId, $status = null, $limit = -1);
 
     /**
      * Copy Content with Fields, Versions & Relations from $contentId in $version.


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-23281

Approach: Limit archived versions, for now as a flat _default_ setting _(can be per siteaccess/group)_, but could be moved to contentType in the future so it can 1. natuaraly be per content type 2. becomes editorial/changeable via api, hence why there is no per content type setting here.

Todo:
- [x] Discuss approach _(cc @pspanja @alongosz @bdunogier)_
- [x] Inject setting from somewhere _(@bdunogier where would you prefer this?)_
- [x] Tests

For later:
- ~~Script to enforce version limits of archives on config changes(?), and cronjob for evicting dead drafts, both will have to take into account if Content Item has a published item version as well _(if max limit of archives is 0, and no published exists since it's been unpublished, then one item should be kept. Alternative we document minimum archive limit is 1 and avoid the issue)_~~
