### PR TITLE
EZP-26494: Error on indexing big content in TextBlock

### DIFF
--- a/eZ/Publish/Core/FieldType/TextBlock/SearchField.php
+++ b/eZ/Publish/Core/FieldType/TextBlock/SearchField.php
@@ -34,7 +34,7 @@ class SearchField implements Indexable
             new Search\Field(
                 'value',
                 $field->value->data,
-                new Search\FieldType\StringField()
+                new Search\FieldType\TextField()
             ),
             new Search\Field(
                 'fulltext',


### PR DESCRIPTION
> Fixes [EZP-26494](https://jira.ez.no/browse/EZP-26494)

**TODO**:
- [x] Index TextBlock with '_t' suffix.
- [ ] Identifiy issues in unit tests.
- [ ] Rebase onto `6.5`.

// edited by @alongosz
