### PR TITLE
EZP-26499: Search index - better word boundaries detection

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
@@ -615,8 +615,11 @@ class SearchEngineIndexingTest extends BaseTest
             ['lowercase text', 'LOWERCASE TEXT'],
             ['text-with-hyphens', 'text-with-hyphens'],
             ['text containing spaces', 'text containing spaces'],
-            ['"quoted text"', '"quoted text"'],
+            ['"quoted text"', 'quoted text'],
             ['ÀÁÂÃÄÅÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝ', 'àáâãäåçèéêëìíîïðñòóôõöøùúûüý'],
+            ['with boundary.', 'with boundary'],
+            ['it\'s', 'it\'s'],
+            ['with_underscore', 'with_underscore'],
         ];
     }
 

--- a/eZ/Publish/Core/Search/Legacy/Content/FullTextValue.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/FullTextValue.php
@@ -30,6 +30,13 @@ class FullTextValue extends ValueObject
     public $fieldDefinitionId;
 
     /**
+     * Content object field identifier.
+     *
+     * @var string
+     */
+    public $fieldDefinitionIdentifier;
+
+    /**
      * @var string
      */
     public $languageCode;

--- a/eZ/Publish/Core/Search/Legacy/Content/Mapper/FullTextMapper.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Mapper/FullTextMapper.php
@@ -96,6 +96,7 @@ class FullTextMapper
                 [
                     'id' => $field->id,
                     'fieldDefinitionId' => $field->fieldDefinitionId,
+                    'fieldDefinitionIdentifier' => $fieldDefinition->identifier,
                     'languageCode' => $field->languageCode,
                     'value' => !is_array($value) ? $value : implode(' ', $value),
                 ]

--- a/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
@@ -130,10 +130,12 @@ class DoctrineDatabase extends Gateway
                 if (mb_strlen($word) > 150) {
                     $word = mb_substr($word, 0, 150);
                 }
-                $indexArray[] = ['Word' => $word,
+                $indexArray[] = [
+                    'Word' => $word,
                     'ContentClassAttributeID' => $fullTextValue->fieldDefinitionId,
-                    'identifier' => $fullTextValue->id,
-                    'integer_value' => $integerValue, ];
+                    'identifier' => $fullTextValue->fieldDefinitionIdentifier,
+                    'integer_value' => $integerValue,
+                ];
                 $indexArrayOnlyWords[$word] = 1;
                 ++$wordCount;
                 // if we have "www." before word than
@@ -142,7 +144,7 @@ class DoctrineDatabase extends Gateway
                     $additionalUrlWord = substr($word, 4);
                     $indexArray[] = ['Word' => $additionalUrlWord,
                         'ContentClassAttributeID' => $fullTextValue->fieldDefinitionId,
-                        'identifier' => $fullTextValue->id,
+                        'identifier' => $fullTextValue->fieldDefinitionIdentifier,
                         'integer_value' => $integerValue, ];
                     $indexArrayOnlyWords[$additionalUrlWord] = 1;
                     ++$wordCount;
@@ -251,7 +253,20 @@ class DoctrineDatabase extends Gateway
                 $nextWordId = 0;
             }
             $frequency = 0;
-            $this->searchIndex->addObjectWordLink($wordId, $contentId, $frequency, $placement, $nextWordId, $prevWordId, $fullTextData->contentTypeId, $contentFieldId, $fullTextData->published, $fullTextData->sectionId, $identifier, $integerValue);
+            $this->searchIndex->addObjectWordLink(
+                $wordId,
+                $contentId,
+                $frequency,
+                $placement,
+                $nextWordId,
+                $prevWordId,
+                $fullTextData->contentTypeId,
+                $contentFieldId,
+                $fullTextData->published,
+                $fullTextData->sectionId,
+                $identifier,
+                $integerValue
+            );
             $prevWordId = $wordId;
             ++$placement;
         }

--- a/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
@@ -119,8 +119,9 @@ class DoctrineDatabase extends Gateway
             } else {
                 $integerValue = 0;
             }
-            // Split transformed text on whitespace
-            $wordArray = explode(' ', $this->transformationProcessor->transform($fullTextValue->value, $this->fullTextSearchConfiguration['commands']));
+            $text = $this->transformationProcessor->transform($fullTextValue->value, $this->fullTextSearchConfiguration['commands']);
+            // split by non-words
+            $wordArray = preg_split('/\W/u', $text, -1, PREG_SPLIT_NO_EMPTY);
             foreach ($wordArray as $word) {
                 if (trim($word) === '') {
                     continue;

--- a/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Repository/SearchIndex.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Repository/SearchIndex.php
@@ -139,10 +139,19 @@ class SearchIndex
      * @param $identifier
      * @param $integerValue
      */
-    public function addObjectWordLink($wordId, $contentId, $frequency, $placement, $nextWordId, $prevWordId,
-                                      $contentTypeId, $fieldTypeId, $published, $sectionId, $identifier,
-                                      $integerValue)
-    {
+    public function addObjectWordLink($wordId,
+                                      $contentId,
+                                      $frequency,
+                                      $placement,
+                                      $nextWordId,
+                                      $prevWordId,
+                                      $contentTypeId,
+                                      $fieldTypeId,
+                                      $published,
+                                      $sectionId,
+                                      $identifier,
+                                      $integerValue
+    ) {
         $assoc = [
             'word_id' => $wordId,
             'contentobject_id' => $contentId,

--- a/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
@@ -39,8 +39,6 @@ parameters:
             - "latin_lowercase"
             - "cyrillic_lowercase"
             - "greek_lowercase"
-            - "apostrophe_normalize"
-            - "apostrophe_to_doublequote"
             - "ascii_search_cleanup"
             - "cyrillic_diacritical"
             - "cyrillic_search_cleanup"


### PR DESCRIPTION
> Fixes: [EZP-26499](https://jira.ez.no/browse/EZP-26499)

This PR fixes `WordIndexer` to exclude any word boundary, not just spaces.
As a side fix, a proper identifier (string) is inserted into `ezsearch_object_word_link` table instead of field id.

**TODO**:
- [x] Improve detection of word boundaries when adding words to the SQL/Legacy Search Engine Index (2c42d39).
- [x] Fix inserting `$fieldDefinition->identifier` instead of `$field->id` into `ezsearch_object_word_link` table (322e29e).
- [x] Discuss issue with parsing apostrophes (to be explained in diff comment).
