### PR TITLE
EZP-26539: Move versionList() ordering logic down to SPI

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -2644,26 +2644,12 @@ class ContentServiceTest extends BaseContentServiceTest
         $versions = $contentService->loadVersions($contentVersion2->contentInfo);
         /* END: Use Case */
 
-        $expectedVersionIds = array(
-            $contentService->loadVersionInfo($contentVersion2->contentInfo, 1)->id => true,
-            $contentService->loadVersionInfo($contentVersion2->contentInfo, 2)->id => true,
-        );
+        $expectedVersionsOrder = [
+            $contentService->loadVersionInfo($contentVersion2->contentInfo, 1),
+            $contentService->loadVersionInfo($contentVersion2->contentInfo, 2),
+        ];
 
-        foreach ($versions as $actualVersion) {
-            if (!isset($expectedVersionIds[$actualVersion->id])) {
-                $this->fail("Unexpected version with ID '{$actualVersion->id}' loaded.");
-            }
-            unset($expectedVersionIds[$actualVersion->id]);
-        }
-
-        if (!empty($expectedVersionIds)) {
-            $this->fail(
-                sprintf(
-                    "Expected versions not loaded: '%s'",
-                    implode("', '", $expectedVersionIds)
-                )
-            );
-        }
+        $this->assertEquals($expectedVersionsOrder, $versions);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
@@ -205,6 +205,8 @@ abstract class Gateway
     /**
      * Returns all version data for the given $contentId.
      *
+     * Result is returned with oldest version first (sorted by created, or version id as long as it's auto increment).
+     *
      * @param mixed $contentId
      *
      * @return string[][]

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
@@ -205,7 +205,7 @@ abstract class Gateway
     /**
      * Returns all version data for the given $contentId.
      *
-     * Result is returned with oldest version first (sorted by created, or version id as long as it's auto increment).
+     * Result is returned with oldest version first (using version id as it has index and is auto increment).
      *
      * @param mixed $contentId
      *

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -992,6 +992,8 @@ class DoctrineDatabase extends Gateway
     /**
      * Returns all version data for the given $contentId.
      *
+     * Result is returned with oldest version first (sorted by created, or version id as long as it's auto increment).
+     *
      * @param mixed $contentId
      *
      * @return string[][]

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -992,7 +992,7 @@ class DoctrineDatabase extends Gateway
     /**
      * Returns all version data for the given $contentId.
      *
-     * Result is returned with oldest version first (sorted by created, or version id as long as it's auto increment).
+     * Result is returned with oldest version first (using version id as it has index and is auto increment).
      *
      * @param mixed $contentId
      *

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
@@ -366,7 +366,7 @@ class ExceptionConversion extends Gateway
     /**
      * Returns all version data for the given $contentId.
      *
-     * Result is returned with oldest version first (sorted by created, or version id as long as it's auto increment).
+     * Result is returned with oldest version first (using version id as it has index and is auto increment).
      *
      * @param mixed $contentId
      *

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
@@ -366,6 +366,8 @@ class ExceptionConversion extends Gateway
     /**
      * Returns all version data for the given $contentId.
      *
+     * Result is returned with oldest version first (sorted by created, or version id as long as it's auto increment).
+     *
      * @param mixed $contentId
      *
      * @return string[][]

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -562,6 +562,8 @@ class Handler implements BaseContentHandler
     /**
      * Returns the versions for $contentId.
      *
+     * Result is returned with oldest version first (sorted by created, alternatively version id if auto increment).
+     *
      * @param int $contentId
      *
      * @return \eZ\Publish\SPI\Persistence\Content\VersionInfo[]

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -562,8 +562,6 @@ class Handler implements BaseContentHandler
     /**
      * Returns the versions for $contentId.
      *
-     * Result is returned with oldest version first (sorted by created, alternatively version id if auto increment).
-     *
      * @param int $contentId
      *
      * @return \eZ\Publish\SPI\Persistence\Content\VersionInfo[]

--- a/eZ/Publish/Core/Persistence/Legacy/Content/TreeHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/TreeHandler.php
@@ -116,6 +116,8 @@ class TreeHandler
     /**
      * Returns the versions for $contentId.
      *
+     * Result is returned with oldest version first (sorted by created, or version id as long as it's auto increment).
+     *
      * @param int $contentId
      *
      * @return \eZ\Publish\SPI\Persistence\Content\VersionInfo[]

--- a/eZ/Publish/Core/Persistence/Legacy/Content/TreeHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/TreeHandler.php
@@ -116,7 +116,7 @@ class TreeHandler
     /**
      * Returns the versions for $contentId.
      *
-     * Result is returned with oldest version first (sorted by created, or version id as long as it's auto increment).
+     * Result is returned with oldest version first (using version id as it has index and is auto increment).
      *
      * @param int $contentId
      *

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1572,17 +1572,6 @@ class ContentService implements ContentServiceInterface
             $versions[] = $versionInfo;
         }
 
-        usort(
-            $versions,
-            function (VersionInfo $a, VersionInfo $b) {
-                if ($a->creationDate->getTimestamp() === $b->creationDate->getTimestamp()) {
-                    return 0;
-                }
-
-                return ($a->creationDate->getTimestamp() < $b->creationDate->getTimestamp()) ? -1 : 1;
-            }
-        );
-
         return $versions;
     }
 

--- a/eZ/Publish/SPI/Persistence/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Handler.php
@@ -170,6 +170,8 @@ interface Handler
     /**
      * Returns the versions for $contentId.
      *
+     * Result is returned with oldest version first (sorted by created, alternatively version id if auto increment).
+     *
      * @param int $contentId
      *
      * @return \eZ\Publish\SPI\Persistence\Content\VersionInfo[]

--- a/eZ/Publish/SPI/Persistence/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Handler.php
@@ -170,7 +170,7 @@ interface Handler
     /**
      * Returns the versions for $contentId.
      *
-     * Result is returned with oldest version first (sorted by created, alternatively version id if auto increment).
+     * Result is returned with oldest version first (sorted by created, alternatively version number or id if auto increment).
      *
      * @param int $contentId
      *


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-26539

Since 3d063d909bb4a69c3d3b8c1d076a921ccc6a80d0, ordering is done by storage engines.
Besides refactoring for removing unneeded code, this will be needed in order for version list to be able to be paged in the future.

- [x] Verify test coverage
- [x] Issue