### PR TITLE
EZP-26068: Fix broken Google  Maps, adopt google maps APIs v3

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
@@ -65,6 +65,9 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
                 ->example('var/ezdemo_site')
                 ->info('The directory relative to web/ where files are stored. Default value is "var"')
             ->end()
+            ->scalarNode('google_maps_api_key')
+                ->info('Google Maps API Key')
+            ->end()
             ->scalarNode('storage_dir')
                 ->cannotBeEmpty()
                 ->info("Directory where to place new files for storage, it's relative to var directory. Default value is 'storage'")
@@ -158,6 +161,9 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
         }
         if (isset($scopeSettings['binary_dir'])) {
             $contextualizer->setContextualParameter('binary_dir', $currentScope, $scopeSettings['binary_dir']);
+        }
+        if (isset($scopeSettings['google_maps_api_key'])) {
+            $contextualizer->setContextualParameter('google_maps_api_key', $currentScope, $scopeSettings['google_maps_api_key']);
         }
 
         // session_name setting is deprecated in favor of session.name

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
@@ -65,8 +65,13 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
                 ->example('var/ezdemo_site')
                 ->info('The directory relative to web/ where files are stored. Default value is "var"')
             ->end()
-            ->scalarNode('google_maps_api_key')
-                ->info('Google Maps API Key')
+            ->arrayNode('api_keys')
+                ->info('Collection of API keys')
+                ->children()
+                    ->scalarNode('google_maps')
+                        ->info('Google Maps API Key, required as of Google Maps v3 to make sure maps show up correctly.')
+                    ->end()
+                ->end()
             ->end()
             ->scalarNode('storage_dir')
                 ->cannotBeEmpty()
@@ -162,8 +167,8 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
         if (isset($scopeSettings['binary_dir'])) {
             $contextualizer->setContextualParameter('binary_dir', $currentScope, $scopeSettings['binary_dir']);
         }
-        if (isset($scopeSettings['google_maps_api_key'])) {
-            $contextualizer->setContextualParameter('google_maps_api_key', $currentScope, $scopeSettings['google_maps_api_key']);
+        if (isset($scopeSettings['api_keys']['google_maps'])) {
+            $contextualizer->setContextualParameter('api_keys.google_maps', $currentScope, $scopeSettings['api_keys']['google_maps']);
         }
 
         // session_name setting is deprecated in favor of session.name

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -70,6 +70,7 @@ parameters:
     ezsettings.default.storage_dir: "storage"           # Where to place new files for storage, it's relative to var directory
     ezsettings.default.binary_dir: "original"
     ezsettings.default.anonymous_user_id: 10            # The ID of the user to be used for everyone who is not logged in
+    ezsettings.default.google_maps_api_key: ~           # Google Maps APIs v3 key (https://developers.google.com/maps/documentation/javascript/get-api-key)
 
     # IO
     ezsettings.default.io.metadata_handler: "default"

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -70,7 +70,7 @@ parameters:
     ezsettings.default.storage_dir: "storage"           # Where to place new files for storage, it's relative to var directory
     ezsettings.default.binary_dir: "original"
     ezsettings.default.anonymous_user_id: 10            # The ID of the user to be used for everyone who is not logged in
-    ezsettings.default.google_maps_api_key: ~           # Google Maps APIs v3 key (https://developers.google.com/maps/documentation/javascript/get-api-key)
+    ezsettings.default.api_keys: { google_maps: ~ }     # Google Maps APIs v3 key (https://developers.google.com/maps/documentation/javascript/get-api-key)
 
     # IO
     ezsettings.default.io.metadata_handler: "default"

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -352,7 +352,7 @@
         <script>
             if (typeof(mapsScriptLoaded) == 'undefined') {
                 var myScript = document.createElement('script');
-                myScript.src = '//maps.googleapis.com/maps/api/js?key={{ ezpublish.configResolver.parameter('google_maps_api_key') }}';
+                myScript.src = '//maps.googleapis.com/maps/api/js?key={{ ezpublish.configResolver.parameter('api_keys.google_maps') }}';
                 mapsScriptLoaded = true;
                 document.body.appendChild(myScript);
             }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -299,6 +299,7 @@
     {% set defaultZoom = 13 %}
     {% set defaultMapType = 'ROADMAP' %}
     {% set defaultDraggable = 'true' %}
+    {% set defaultScrollWheel = 'true' %}
 
     {% set hasContent = field.value is not null %}
     {% set latitude = field.value.latitude|default( 0 ) %}
@@ -308,6 +309,7 @@
 
     {% set zoom = parameters.zoom|default( defaultZoom ) %}
     {% set mapType = parameters.mapType|default( defaultMapType ) %}
+    {% set scrollWheel = parameters.scrollWheel|default( defaultScrollWheel ) %}
 
     {% set mapWidth, mapHeight = defaultWidth, defaultHeight %}
     {% if parameters.width is defined %}
@@ -347,7 +349,14 @@
     {% endif %}
 
     {% if hasContent and showMap %}
-        <script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=true"></script>
+        <script>
+            if (typeof(mapsScriptLoaded) == 'undefined') {
+                var myScript = document.createElement('script');
+                myScript.src = '//maps.googleapis.com/maps/api/js?key={{ ezpublish.configResolver.parameter('google_maps_api_key') }}';
+                mapsScriptLoaded = true;
+                document.body.appendChild(myScript);
+            }
+        </script>
         <script type="text/javascript">
         (function(win, doc) {
             var mapView = function (mapId, latitude, longitude) {
@@ -361,6 +370,7 @@
                         center: startPoint,
                         zoom: zoom,
                         draggable: draggable,
+                        scrollwheel: {{ scrollWheel }},
                         mapTypeId: google.maps.MapTypeId.{{ mapType }}
                     }),
                     position: startPoint

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -286,8 +286,11 @@
  # - boolean draggable whether to enable or not draggable map (useful on mobile / responsive layout), default is true
  # - string|false width the width of the rendered map with its unit (ie "500px" or "50em"),
  #                      set to false to not set any width style inline, default is 500px
- # - string|boolean height the height of the rendered map with its unit (ie "200px" or "20em"),
+ # - string|false height the height of the rendered map with its unit (ie "200px" or "20em"),
  #                         set to false to not set any height style inline, default is 200px
+ # - boolean scrollWheel If false, disables scrollwheel zooming on the map. Enabled by default.
+ #
+ # For further reading: https://developers.google.com/maps/documentation/javascript/reference
  #}
 {% spaceless %}
 <div {{ block( 'field_attributes' ) }}>

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -274,7 +274,6 @@
 {% endblock %}
 
 {# @todo:
- # - include Gmaps JS only once if the field is used several times in the page
  # - add translate filter
  #}
 {% block ezgmaplocation_field %}
@@ -350,11 +349,13 @@
 
     {% if hasContent and showMap %}
         <script>
-            if (typeof(mapsScriptLoaded) == 'undefined') {
-                var myScript = document.createElement('script');
-                myScript.src = '//maps.googleapis.com/maps/api/js?key={{ ezpublish.configResolver.parameter('api_keys.google_maps') }}';
-                mapsScriptLoaded = true;
-                document.body.appendChild(myScript);
+            if (typeof(window.ezgmaplocationMapsScriptLoaded) == 'undefined') {
+                (function (win, doc) {
+                    var myScript = document.createElement('script');
+                    myScript.src = '//maps.googleapis.com/maps/api/js?key={{ ezpublish.configResolver.parameter('api_keys.google_maps') }}';
+                    win.ezgmaplocationMapsScriptLoaded = true;
+                    doc.body.appendChild(myScript);
+                })(window, document)
             }
         </script>
         <script type="text/javascript">


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-26068 _(& https://jira.ez.no/browse/EZP-26555)_
> _Use of GMap blocked now since Google started requiring api key, this blocks use on tutorial, (..)._

Solves:
- maps now broken as api key is now required
 - [ ] ~~Get api key we can use (@janit)~~ _(we can't, but at least with this change people can configure api key themselves)_
- does not load script several times in case there are several gmap fields
- exposes scrollwheel parameter to be able to disable it on the map

replaces #1726
