### PR TITLE
EZP-26367: Renaming parent leads to redirect loop

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Regression/EZP26367UrlAliasHistoryRedirectLoopTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP26367UrlAliasHistoryRedirectLoopTest.php
@@ -94,4 +94,86 @@ DOCBOOK
         $this->assertEquals($activePath, $urlAlias->path);
         $this->assertFalse($urlAlias->isHistory);
     }
+
+    public function testLookupHistoryUrlReturnsActiveAlias()
+    {
+        $contentService = $this->getRepository()->getContentService();
+        $contentTypeService = $this->getRepository()->getContentTypeService();
+        $locationService = $this->getRepository()->getLocationService();
+        $urlAliasService = $this->getRepository()->getURLAliasService();
+
+        // Create container for articles
+
+        $contentType = $contentTypeService->loadContentTypeByIdentifier('folder');
+        $locationCreateStruct = $locationService->newLocationCreateStruct(2);
+        $contentCreateStruct = $contentService->newContentCreateStruct($contentType, 'eng-GB');
+
+        $contentCreateStruct->setField('name', 'Articles');
+        $draft = $contentService->createContent($contentCreateStruct, [$locationCreateStruct]);
+        $folder = $contentService->publishVersion($draft->versionInfo);
+
+        // Create one article in the container
+
+        $contentType = $contentTypeService->loadContentTypeByIdentifier('article');
+        $locationCreateStruct = $locationService->newLocationCreateStruct(
+            $folder->contentInfo->mainLocationId
+        );
+        $contentCreateStruct = $contentService->newContentCreateStruct($contentType, 'eng-GB');
+
+        $contentCreateStruct->setField('title', 'Article');
+        $contentCreateStruct->setField(
+            'intro',
+            <<< DOCBOOK
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0-variant ezpublish-1.0">
+    <para>Cache invalidation in eZ</para>
+</section>
+DOCBOOK
+        );
+        $draft = $contentService->createContent($contentCreateStruct, [$locationCreateStruct]);
+        $article = $contentService->publishVersion($draft->versionInfo);
+
+        // Rename article container
+
+        $draft = $contentService->createContentDraft($folder->contentInfo);
+        $contentUpdateStruct = $contentService->newContentUpdateStruct();
+
+        $contentUpdateStruct->setField('name', 'Articles-UPDATED');
+        $draft = $contentService->updateContent($draft->versionInfo, $contentUpdateStruct);
+        $contentService->publishVersion($draft->versionInfo);
+
+        $historyPath = '/Articles/Article';
+        $activePath = '/Articles-UPDATED/Article';
+
+        // Reverse lookup to warm-up URL alias ID cache by Location ID
+
+        $urlAlias = $urlAliasService->reverseLookup(
+            $locationService->loadLocation($article->contentInfo->mainLocationId)
+        );
+
+        $this->assertEquals($activePath, $urlAlias->path);
+        $this->assertFalse($urlAlias->isHistory);
+
+        $urlAlias = $urlAliasService->reverseLookup(
+            $locationService->loadLocation($article->contentInfo->mainLocationId)
+        );
+
+        $this->assertEquals($activePath, $urlAlias->path);
+        $this->assertFalse($urlAlias->isHistory);
+
+        // Lookup history URL one to warm-up URL alias ID cache by URL
+
+        $urlAliasHistorized = $urlAliasService->lookup($historyPath);
+
+        $this->assertEquals($historyPath, $urlAliasHistorized->path);
+        $this->assertTrue($urlAliasHistorized->isHistory);
+
+        // Lookup history URL again to trigger return of URL alias object reverse lookup cache by ID,
+        // through URL alias ID cache by URL
+
+        $urlAliasHistorized = $urlAliasService->lookup($historyPath);
+
+        $this->assertEquals($historyPath, $urlAliasHistorized->path);
+        $this->assertTrue($urlAliasHistorized->isHistory);
+    }
 }

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP26367UrlAliasHistoryRedirectLoopTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP26367UrlAliasHistoryRedirectLoopTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\API\Repository\Tests\Regression;
+
+use eZ\Publish\API\Repository\Tests\BaseTest;
+
+/**
+ * @issue https://jira.ez.no/browse/EZP-26367
+ * @group regression
+ * @group ezp26367
+ * @group cache
+ * @group cache-invalidation
+ * @group cache-spi
+ */
+class EZP26367UrlAliasHistoryRedirectLoopTest extends BaseTest
+{
+    public function testReverseLookupReturnsHistoryAlias()
+    {
+        $contentService = $this->getRepository()->getContentService();
+        $contentTypeService = $this->getRepository()->getContentTypeService();
+        $locationService = $this->getRepository()->getLocationService();
+        $urlAliasService = $this->getRepository()->getURLAliasService();
+
+        // Create container for articles
+
+        $contentType = $contentTypeService->loadContentTypeByIdentifier('folder');
+        $locationCreateStruct = $locationService->newLocationCreateStruct(2);
+        $contentCreateStruct = $contentService->newContentCreateStruct($contentType, 'eng-GB');
+
+        $contentCreateStruct->setField('name', 'Articles');
+        $draft = $contentService->createContent($contentCreateStruct, [$locationCreateStruct]);
+        $folder = $contentService->publishVersion($draft->versionInfo);
+
+        // Create one article in the container
+
+        $contentType = $contentTypeService->loadContentTypeByIdentifier('article');
+        $locationCreateStruct = $locationService->newLocationCreateStruct(
+            $folder->contentInfo->mainLocationId
+        );
+        $contentCreateStruct = $contentService->newContentCreateStruct($contentType, 'eng-GB');
+
+        $contentCreateStruct->setField('title', 'Article');
+        $contentCreateStruct->setField(
+            'intro',
+            <<< DOCBOOK
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" version="5.0-variant ezpublish-1.0">
+    <para>Cache invalidation in eZ</para>
+</section>
+DOCBOOK
+        );
+        $draft = $contentService->createContent($contentCreateStruct, [$locationCreateStruct]);
+        $article = $contentService->publishVersion($draft->versionInfo);
+
+        // Rename article container
+
+        $draft = $contentService->createContentDraft($folder->contentInfo);
+        $contentUpdateStruct = $contentService->newContentUpdateStruct();
+
+        $contentUpdateStruct->setField('name', 'Articles-UPDATED');
+        $draft = $contentService->updateContent($draft->versionInfo, $contentUpdateStruct);
+        $contentService->publishVersion($draft->versionInfo);
+
+        $historyPath = '/Articles/Article';
+        $activePath = '/Articles-UPDATED/Article';
+
+        // Lookup history first to warm-up URL alias object lookup cache by ID
+
+        $urlAliasHistorized = $urlAliasService->lookup($historyPath);
+
+        $this->assertEquals($historyPath, $urlAliasHistorized->path);
+        $this->assertTrue($urlAliasHistorized->isHistory);
+
+        // Reverse lookup once to warm-up URL alias ID cache by Location ID
+
+        $urlAlias = $urlAliasService->reverseLookup(
+            $locationService->loadLocation($article->contentInfo->mainLocationId)
+        );
+
+        $this->assertEquals($activePath, $urlAlias->path);
+        $this->assertFalse($urlAlias->isHistory);
+
+        // Reverse lookup again to trigger return of URL alias object lookup cache by ID,
+        // through URL alias ID cache by Location ID
+
+        $urlAlias = $urlAliasService->reverseLookup(
+            $locationService->loadLocation($article->contentInfo->mainLocationId)
+        );
+
+        $this->assertEquals($activePath, $urlAlias->path);
+        $this->assertFalse($urlAlias->isHistory);
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/URLAlias.php
+++ b/eZ/Publish/API/Repository/Values/Content/URLAlias.php
@@ -35,6 +35,8 @@ class URLAlias extends ValueObject
      * A unique identifier for the alias
      * (in legacy implementation this would be <parentid>-<md5text>).
      *
+     * Note: currently this will only be unique when $isHistory flag is false.
+     *
      * @var string
      */
     protected $id;

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
@@ -690,11 +690,15 @@ class UrlAliasHandlerTest extends HandlerTest
 
     /**
      * @covers eZ\Publish\Core\Persistence\Cache\UrlAliasHandler::lookup
-     * @group justme
      */
-    public function testLookupIsMiss()
+    public function testLookupIsMissActive()
     {
-        $urlAlias = new UrlAlias(array('id' => 55));
+        $urlAlias = new UrlAlias(
+            [
+                'id' => 55,
+                'isHistory' => false,
+            ]
+        );
 
         $this->loggerMock->expects($this->once())->method('logCall');
 
@@ -723,7 +727,7 @@ class UrlAliasHandlerTest extends HandlerTest
         $newUrlAliasCacheItem = $this->getMock('Stash\Interfaces\ItemInterface');
         $newUrlAliasCacheItem
             ->expects($this->once())
-             ->method('set')
+            ->method('set')
             ->with($urlAlias)
             ->will($this->returnValue($newUrlAliasCacheItem));
 
@@ -732,16 +736,105 @@ class UrlAliasHandlerTest extends HandlerTest
             ->method('save')
             ->with();
 
+        $historyUrlAliasCacheItem = $this->getMock('Stash\Interfaces\ItemInterface');
+        $historyUrlAliasCacheItem
+            ->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue(null));
+
+        $historyUrlAliasCacheItem
+            ->expects($this->once())
+            ->method('isMiss')
+            ->will($this->returnValue(true));
+
         $this->cacheMock
-                ->expects($this->at(0))
-                ->method('getItem')
-                ->with('urlAlias', 'url', '/url')
-                ->will($this->returnValue($missedUrlAliasIdCacheItem));
+            ->expects($this->at(0))
+            ->method('getItem')
+            ->with('urlAlias', 'url', '/url')
+            ->will($this->returnValue($missedUrlAliasIdCacheItem));
         $this->cacheMock
-             ->expects($this->at(1))
-                ->method('getItem')
-                ->with('urlAlias', 55)
-                ->will($this->returnValue($newUrlAliasCacheItem));
+            ->expects($this->at(1))
+            ->method('getItem')
+            ->with('urlAlias', 'url', 'history', '/url')
+            ->will($this->returnValue($historyUrlAliasCacheItem));
+        $this->cacheMock
+            ->expects($this->at(2))
+            ->method('getItem')
+            ->with('urlAlias', 55)
+            ->will($this->returnValue($newUrlAliasCacheItem));
+
+        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias\\Handler');
+        $this->persistenceHandlerMock
+            ->expects($this->once())
+            ->method('urlAliasHandler')
+            ->will($this->returnValue($innerHandler));
+
+        $innerHandler
+            ->expects($this->once())
+            ->method('lookup')
+            ->with('/url')
+            ->will($this->returnValue($urlAlias));
+
+        $handler = $this->persistenceCacheHandler->urlAliasHandler();
+        $handler->lookup('/url');
+    }
+
+    /**
+     * @covers eZ\Publish\Core\Persistence\Cache\UrlAliasHandler::lookup
+     */
+    public function testLookupIsMissHistory()
+    {
+        $urlAlias = new UrlAlias(
+            [
+                'id' => 55,
+                'isHistory' => true,
+            ]
+        );
+
+        $this->loggerMock->expects($this->once())->method('logCall');
+
+        $missedUrlAliasIdCacheItem = $this->getMock('Stash\Interfaces\ItemInterface');
+        $missedUrlAliasIdCacheItem
+            ->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue(null));
+
+        $missedUrlAliasIdCacheItem
+            ->expects($this->once())
+            ->method('isMiss')
+            ->will($this->returnValue(true));
+
+        $historyUrlAliasCacheItem = $this->getMock('Stash\Interfaces\ItemInterface');
+        $historyUrlAliasCacheItem
+            ->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue(null));
+
+        $historyUrlAliasCacheItem
+            ->expects($this->once())
+            ->method('isMiss')
+            ->will($this->returnValue(true));
+
+        $historyUrlAliasCacheItem
+            ->expects($this->once())
+            ->method('set')
+            ->with($urlAlias)
+            ->will($this->returnValue($historyUrlAliasCacheItem));
+        $historyUrlAliasCacheItem
+            ->expects($this->once())
+            ->method('save')
+            ->with();
+
+        $this->cacheMock
+            ->expects($this->at(0))
+            ->method('getItem')
+            ->with('urlAlias', 'url', '/url')
+            ->will($this->returnValue($missedUrlAliasIdCacheItem));
+        $this->cacheMock
+            ->expects($this->at(1))
+            ->method('getItem')
+            ->with('urlAlias', 'url', 'history', '/url')
+            ->will($this->returnValue($historyUrlAliasCacheItem));
 
         $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias\\Handler');
         $this->persistenceHandlerMock
@@ -811,6 +904,58 @@ class UrlAliasHandlerTest extends HandlerTest
         $cacheItemMock2
             ->expects($this->never())
             ->method('set');
+
+        $handler = $this->persistenceCacheHandler->urlAliasHandler();
+        $handler->lookup('/url');
+    }
+
+    /**
+     * @covers eZ\Publish\Core\Persistence\Cache\UrlAliasHandler::lookup
+     */
+    public function testLookupHasHistoryCache()
+    {
+        $urlAlias = new UrlAlias(array('id' => 55));
+
+        $this->loggerMock
+            ->expects($this->never())
+            ->method('logCall');
+
+        $missedUrlAliasIdCacheItem = $this->getMock('Stash\Interfaces\ItemInterface');
+        $missedUrlAliasIdCacheItem
+            ->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue(null));
+
+        $missedUrlAliasIdCacheItem
+            ->expects($this->once())
+            ->method('isMiss')
+            ->will($this->returnValue(true));
+
+        $historyUrlAliasCacheItem = $this->getMock('Stash\Interfaces\ItemInterface');
+        $historyUrlAliasCacheItem
+            ->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue($urlAlias));
+
+        $historyUrlAliasCacheItem
+            ->expects($this->once())
+            ->method('isMiss')
+            ->will($this->returnValue(false));
+
+        $this->cacheMock
+            ->expects($this->at(0))
+            ->method('getItem')
+            ->with('urlAlias', 'url', '/url')
+            ->will($this->returnValue($missedUrlAliasIdCacheItem));
+        $this->cacheMock
+            ->expects($this->at(1))
+            ->method('getItem')
+            ->with('urlAlias', 'url', 'history', '/url')
+            ->will($this->returnValue($historyUrlAliasCacheItem));
+
+        $this->persistenceHandlerMock
+            ->expects($this->never())
+            ->method('urlAliasHandler');
 
         $handler = $this->persistenceCacheHandler->urlAliasHandler();
         $handler->lookup('/url');

--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -206,8 +206,10 @@ class UrlAliasHandler extends AbstractHandler implements UrlAliasHandlerInterfac
                 $urlAlias = $this->persistenceHandler->urlAliasHandler()->lookup($url);
                 $cache->set($urlAlias->id)->save();
 
-                $urlAliasCache = $this->cache->getItem('urlAlias', $urlAlias->id);
-                $urlAliasCache->set($urlAlias)->save();
+                if (!$urlAlias->isHistory) {
+                    $urlAliasCache = $this->cache->getItem('urlAlias', $urlAlias->id);
+                    $urlAliasCache->set($urlAlias)->save();
+                }
             } catch (APINotFoundException $e) {
                 $cache->set(self::NOT_FOUND)->save();
                 throw $e;

--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -204,9 +204,9 @@ class UrlAliasHandler extends AbstractHandler implements UrlAliasHandlerInterfac
             try {
                 $this->logger->logCall(__METHOD__, array('url' => $url));
                 $urlAlias = $this->persistenceHandler->urlAliasHandler()->lookup($url);
-                $cache->set($urlAlias->id)->save();
 
                 if (!$urlAlias->isHistory) {
+                    $cache->set($urlAlias->id)->save();
                     $urlAliasCache = $this->cache->getItem('urlAlias', $urlAlias->id);
                     $urlAliasCache->set($urlAlias)->save();
                 }


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-26367

This seems to be a design limitation.

`UrlAlias` is identified by composite key `parent-text_md5`, which is defined on a single path element. It can be loaded both by `reverseLookup(Location $location)` and `lookup($path)`. The latter means it's history state for `UrlAlias` is ambiguous as it depends not only on the end path element/Location, but possible on the elements/Locations above as well. For example, history parts are marked with bold style:

- Location 1
  - /one/**two** (history: true)
  - /one/three (history: false)
- Location 2
  - /**two**/three (history: true)
  - /four/three (history: false)

And so on.

The problem here is we use same object (`UrlAlias`) for two different things, lookup and reverse lookup. Some years ago I proposed solving this by introducing `UrlInfo` object which would be returned by `lookup($url)`, but this never got any further from proposal. (See: https://gist.github.com/pspanja/3781309)

For now this will be solved by separating cache of history `UrlAlias` objects returned by `lookup($path)`. We also need to check if the storage redesign of `UrlAlias` subsystem changes anything here, but it does not seem likely. So we should ideally revisit this problem in the future.

### TODOs
- [x] fix cached storage unit tests