### PR TITLE
EZP-26499: Fix word boundaries detection in SQL Search Engine FullText Criterion Handler

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
@@ -629,6 +629,8 @@ class SearchEngineIndexingTest extends BaseTest
             ['"quoted text"', 'quoted text'],
             ['ÀÁÂÃÄÅÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖØÙÚÛÜÝ', 'àáâãäåçèéêëìíîïðñòóôõöøùúûüý'],
             ['with boundary.', 'with boundary'],
+            ['Folder1.', 'Folder1.'],
+            ['whitespaces', "     whitespaces  \n \t "],
             // @todo: Remove as soon as elastic is updated to later version not affected
             ["it's", "it's", [LegacyElasticsearch::class]],
             ['with_underscore', 'with_underscore'],

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FullText.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FullText.php
@@ -133,12 +133,7 @@ class FullText extends CriterionHandler
      */
     protected function tokenizeString($string)
     {
-        return array_filter(
-            array_map(
-                'trim',
-                preg_split('(\\p{Z})u', strtr($string, '\'"', ''))
-            )
-        );
+        return preg_split('/[^\w|*]/u', $string, -1, PREG_SPLIT_NO_EMPTY);
     }
 
     /**


### PR DESCRIPTION
> Fixes #1814, related to [EZP-26499](https://jira.ez.no/browse/EZP-26499)
> Component: Legacy/SQL Search Engine

PR #1814 introduced change to `WordIndexer` splitting phrase to be indexed not only by white spaces, but also by word boundaries. 
To properly search using phrases with word boundaries (e.g. `Folder1.`) this change also needs to be reflected on the Legacy/SQL Search Engine `FullText` Criterion Handler.

**TODO**:
- [x] Add test case showing the problem (1ea0562).
- [x] Align Legacy/SQL Search Engine FullText Criterion handler [with change to `WordIndexer`](https://github.com/ezsystems/ezpublish-kernel/commit/ba75da6fd3329fa70a34d66e435a96899cef1d7d#diff-ff08d82dd149d3d924342722a1530470R124) (1ea0562).