### PR TITLE
Fix EZP-26554: download filename fallback must be ASCII in Content-Disposition

### DIFF
--- a/eZ/Bundle/EzPublishIOBundle/BinaryStreamResponse.php
+++ b/eZ/Bundle/EzPublishIOBundle/BinaryStreamResponse.php
@@ -120,6 +120,10 @@ class BinaryStreamResponse extends Response
             $filename = $this->file->id;
         }
 
+        if (empty($filenameFallback)) {
+            $filenameFallback = mb_convert_encoding($filename, 'ASCII');
+        }
+
         $dispositionHeader = $this->headers->makeDisposition($disposition, $filename, $filenameFallback);
         $this->headers->set('Content-Disposition', $dispositionHeader);
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26554

Using a non-ascii filename will result in an exception, as Symfony's `ResponseHeaderBag` checks the value but  does not automatically convert it.

This means that the `setContentDisposition()` function must perform this conversion, at least if no fallbakc is provided, according to the doc:


> * @ param string $filenameFallback A fallback filename, containing only ASCII characters. Defaults to an automatically encoded filename
