### PR TITLE
EZP-26476: [fix v2] Wider roles being ignored if you define more restrictive roles

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/RolePolicyLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/RolePolicyLimitationTest.php
@@ -1,0 +1,177 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\API\Repository\Tests\Values\User\Limitation;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\User\Limitation\ContentTypeLimitation;
+use eZ\Publish\API\Repository\Values\User\Limitation\SectionLimitation;
+use eZ\Publish\API\Repository\Values\User\Limitation\SubtreeLimitation;
+use eZ\Publish\API\Repository\Values\User\RoleCreateStruct;
+use eZ\Publish\API\Repository\Values\User\UserGroup;
+
+class RolePolicyLimitationTest extends BaseLimitationTest
+{
+    /**
+     * Data provider for {@see testRolePoliciesWithOverlappingLimitations}.
+     */
+    public function providerForTestRolePoliciesWithOverlappingLimitations()
+    {
+        // get actual locations count for the given subtree when user is (by default) an admin
+        $actualSubtreeLocationsCount = $this->getSubtreeLocationsCount('/1/2/');
+        $this->assertGreaterThan(0, $actualSubtreeLocationsCount);
+
+        return [
+            [$actualSubtreeLocationsCount, 'content', '*'],
+            [$actualSubtreeLocationsCount, 'content', 'read'],
+            [$actualSubtreeLocationsCount, '*', '*'],
+            // different module / all functions should not overlap other policies
+            [0, 'user', '*'],
+        ];
+    }
+
+    /**
+     * Test if role with wider policy is not overlapped by limitation (uncovered in EZP-26476).
+     *
+     * @dataProvider providerForTestRolePoliciesWithOverlappingLimitations
+     * @param int $expectedSubtreeLocationsCount
+     * @param string $widePolicyModule
+     * @param string $widePolicyFunction
+     */
+    public function testRolePoliciesWithOverlappingLimitations(
+        $expectedSubtreeLocationsCount,
+        $widePolicyModule,
+        $widePolicyFunction
+    ) {
+        $repository = $this->getRepository();
+        $roleService = $repository->getRoleService();
+
+        $subtreePathString = '/1/2/';
+
+        // EZP-26476 use case:
+
+        // create new role with overlapping limitation
+        $roleName = 'role_with_overlapping_policies';
+        $roleCreateStruct = $roleService->newRoleCreateStruct($roleName);
+
+        $this->addPolicyToNewRole($roleCreateStruct, $widePolicyModule, $widePolicyFunction, []);
+        $this->addPolicyToNewRole($roleCreateStruct, 'user', 'login', []);
+        $this->addPolicyToNewRole($roleCreateStruct, 'content', 'read', [
+            new ContentTypeLimitation([
+                'limitationValues' => [4, 3],
+            ]),
+            new SectionLimitation([
+                'limitationValues' => [2],
+            ]),
+        ]);
+
+        $roleService->publishRoleDraft(
+            $roleService->createRole($roleCreateStruct)
+        );
+
+        $role = $roleService->loadRoleByIdentifier($roleName);
+
+        // create group and assign new role to that group, limited by subtree
+        $userGroup = $this->createGroup('Test group', 'eng-US', 4);
+        $roleService->assignRoleToUserGroup($role, $userGroup, new SubtreeLimitation([
+            'limitationValues' => [$subtreePathString],
+        ]));
+
+        // create user assigned to the just created group
+        $user = $this->createUserInGroup($userGroup);
+        $repository->setCurrentUser($user);
+
+        $this->refreshSearch($repository);
+
+        // check if searching by subtree returns the same result as for an admin
+        $this->assertEquals($expectedSubtreeLocationsCount, $this->getSubtreeLocationsCount($subtreePathString));
+    }
+
+    /**
+     * Perform search by the Subtree Criterion for the given subtree path and return results count.
+     *
+     * @param $subtreePathString
+     * @return int|null
+     */
+    protected function getSubtreeLocationsCount($subtreePathString)
+    {
+        $criterion = new Criterion\Subtree($subtreePathString);
+        $query = new LocationQuery(['filter' => $criterion]);
+
+        $result = $this->getRepository()->getSearchService()->findLocations($query);
+
+        return $result->totalCount;
+    }
+
+    /**
+     * Create test User in the given User Group.
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\UserGroup $group
+     * @return \eZ\Publish\API\Repository\Values\User\User
+     */
+    protected function createUserInGroup(UserGroup $group)
+    {
+        $userService = $this->getRepository()->getUserService();
+
+        // Instantiate a create struct with mandatory properties
+        $userCreateStruct = $userService->newUserCreateStruct(
+            'user',
+            'user@example.com',
+            'secret',
+            'eng-US'
+        );
+        $userCreateStruct->enabled = true;
+
+        // Set some fields required by the user ContentType
+        $userCreateStruct->setField('first_name', 'Example');
+        $userCreateStruct->setField('last_name', 'User');
+
+        // Create a new user instance.
+        $user = $userService->createUser($userCreateStruct, [$group]);
+
+        return $user;
+    }
+
+    /**
+     * Add policy to a new role.
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleCreateStruct $roleCreateStruct
+     * @param string $module
+     * @param string $function
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation[] $limitations
+     */
+    protected function addPolicyToNewRole(RoleCreateStruct $roleCreateStruct, $module, $function, array $limitations)
+    {
+        $roleService = $this->getRepository()->getRoleService();
+        $policyCreateStruct = $roleService->newPolicyCreateStruct($module, $function);
+        foreach ($limitations as $limitation) {
+            $policyCreateStruct->addLimitation($limitation);
+        }
+        $roleCreateStruct->addPolicy($policyCreateStruct);
+    }
+
+    /**
+     * Create User Group.
+     *
+     * @param string $groupName
+     * @param string $mainLanguageCode
+     * @param int $parentGroupId
+     * @return \eZ\Publish\API\Repository\Values\User\UserGroup
+     */
+    protected function createGroup($groupName, $mainLanguageCode, $parentGroupId)
+    {
+        $userService = $this->getRepository()->getUserService();
+
+        $userGroupCreateStruct = $userService->newUserGroupCreateStruct($mainLanguageCode);
+        $usersGroup = $userService->loadUserGroup($parentGroupId);
+        $userGroupCreateStruct->setField('name', $groupName);
+
+        return $userService->createUserGroup($userGroupCreateStruct, $usersGroup);
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/RolePolicyLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/RolePolicyLimitationTest.php
@@ -91,6 +91,9 @@ class RolePolicyLimitationTest extends BaseLimitationTest
 
         // check if searching by subtree returns the same result as for an admin
         $this->assertEquals($expectedSubtreeLocationsCount, $this->getSubtreeLocationsCount($subtreePathString));
+
+        // check if searching by subtree which is not a part of role assignment limitation does not return results
+        $this->assertEquals(0, $this->getSubtreeLocationsCount('/1/5/'));
     }
 
     /**

--- a/eZ/Publish/Core/Repository/PermissionsCriterionHandler.php
+++ b/eZ/Publish/Core/Repository/PermissionsCriterionHandler.php
@@ -118,6 +118,7 @@ class PermissionsCriterionHandler
             foreach ($permissionSet['policies'] as $policy) {
                 $limitations = $policy->getLimitations();
                 if ($limitations === '*' || empty($limitations)) {
+                    $policyOrCriteria[] = new Criterion\MatchAll();
                     continue;
                 }
 

--- a/eZ/Publish/Core/Repository/PermissionsCriterionHandler.php
+++ b/eZ/Publish/Core/Repository/PermissionsCriterionHandler.php
@@ -118,7 +118,10 @@ class PermissionsCriterionHandler
             foreach ($permissionSet['policies'] as $policy) {
                 $limitations = $policy->getLimitations();
                 if ($limitations === '*' || empty($limitations)) {
-                    continue;
+                    // Given policy gives full access, optimize away all role policies (but not role limitation if any)
+                    // This should be optimized on create/update of Roles, however we keep this here for bc with older data
+                    $policyOrCriteria = [];
+                    break;
                 }
 
                 $limitationsAndCriteria = array();

--- a/eZ/Publish/Core/Repository/PermissionsCriterionHandler.php
+++ b/eZ/Publish/Core/Repository/PermissionsCriterionHandler.php
@@ -118,7 +118,6 @@ class PermissionsCriterionHandler
             foreach ($permissionSet['policies'] as $policy) {
                 $limitations = $policy->getLimitations();
                 if ($limitations === '*' || empty($limitations)) {
-                    $policyOrCriteria[] = new Criterion\MatchAll();
                     continue;
                 }
 

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionsCriterionHandlerTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionsCriterionHandlerTest.php
@@ -162,7 +162,7 @@ class PermissionsCriterionHandlerTest extends BaseServiceMockTest
                         'policies' => array(new Policy(array('limitations' => '*')), $policy1),
                     ),
                 ),
-                $criterionMock,
+                new Criterion\LogicalOr(array(new Criterion\MatchAll(), $criterionMock)),
             ),
             array(
                 $criterionMock,
@@ -173,7 +173,7 @@ class PermissionsCriterionHandlerTest extends BaseServiceMockTest
                         'policies' => array(new Policy(array('limitations' => array())), $policy1),
                     ),
                 ),
-                $criterionMock,
+                new Criterion\LogicalOr(array(new Criterion\MatchAll(), $criterionMock)),
             ),
             array(
                 $criterionMock,
@@ -292,7 +292,7 @@ class PermissionsCriterionHandlerTest extends BaseServiceMockTest
                         'policies' => array(new Policy(array('limitations' => '*'))),
                     ),
                 ),
-                $criterionMock,
+                new Criterion\LogicalAnd(array($criterionMock, new Criterion\MatchAll())),
             ),
             array(
                 $criterionMock,
@@ -307,7 +307,12 @@ class PermissionsCriterionHandlerTest extends BaseServiceMockTest
                         'policies' => array(new Policy(array('limitations' => '*'))),
                     ),
                 ),
-                new Criterion\LogicalOr(array($criterionMock, $criterionMock)),
+                new Criterion\LogicalOr(
+                    array(
+                        new Criterion\LogicalAnd(array($criterionMock, new Criterion\MatchAll())),
+                        new Criterion\LogicalAnd(array($criterionMock, new Criterion\MatchAll())),
+                    )
+                ),
             ),
         );
     }

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionsCriterionHandlerTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionsCriterionHandlerTest.php
@@ -162,7 +162,7 @@ class PermissionsCriterionHandlerTest extends BaseServiceMockTest
                         'policies' => array(new Policy(array('limitations' => '*')), $policy1),
                     ),
                 ),
-                new Criterion\LogicalOr(array(new Criterion\MatchAll(), $criterionMock)),
+                $criterionMock,
             ),
             array(
                 $criterionMock,
@@ -173,7 +173,7 @@ class PermissionsCriterionHandlerTest extends BaseServiceMockTest
                         'policies' => array(new Policy(array('limitations' => array())), $policy1),
                     ),
                 ),
-                new Criterion\LogicalOr(array(new Criterion\MatchAll(), $criterionMock)),
+                $criterionMock,
             ),
             array(
                 $criterionMock,
@@ -292,7 +292,7 @@ class PermissionsCriterionHandlerTest extends BaseServiceMockTest
                         'policies' => array(new Policy(array('limitations' => '*'))),
                     ),
                 ),
-                new Criterion\LogicalAnd(array($criterionMock, new Criterion\MatchAll())),
+                $criterionMock,
             ),
             array(
                 $criterionMock,
@@ -307,12 +307,7 @@ class PermissionsCriterionHandlerTest extends BaseServiceMockTest
                         'policies' => array(new Policy(array('limitations' => '*'))),
                     ),
                 ),
-                new Criterion\LogicalOr(
-                    array(
-                        new Criterion\LogicalAnd(array($criterionMock, new Criterion\MatchAll())),
-                        new Criterion\LogicalAnd(array($criterionMock, new Criterion\MatchAll())),
-                    )
-                ),
+                new Criterion\LogicalOr(array($criterionMock, $criterionMock)),
             ),
         );
     }

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionsCriterionHandlerTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionsCriterionHandlerTest.php
@@ -155,25 +155,25 @@ class PermissionsCriterionHandlerTest extends BaseServiceMockTest
             ),
             array(
                 $criterionMock,
-                1,
+                0,
                 array(
                     array(
                         'limitation' => null,
                         'policies' => array(new Policy(array('limitations' => '*')), $policy1),
                     ),
                 ),
-                $criterionMock,
+                false,
             ),
             array(
                 $criterionMock,
-                1,
+                0,
                 array(
                     array(
                         'limitation' => null,
                         'policies' => array(new Policy(array('limitations' => array())), $policy1),
                     ),
                 ),
-                $criterionMock,
+                false,
             ),
             array(
                 $criterionMock,


### PR DESCRIPTION
> Fixes: [EZP-26476](https://jira.ez.no/browse/EZP-26476)
> Alternative to: #1819
> Backport: `6.6`

This PR revisits #1819 using simple one-line fix provided by @pspanja.
~`Criterion\MatchAll` is added for policies without limitations when creating `PermissionCriterion`.~

**TODO**:
- [x] Add integration test case showing the problem (befad1f).
- [x] Apply fix given by @pspanja to solve the problem (c5c315c).
- [x] Align `PermisionCriterionHandlerTest` with the change (0f5a7d6).