### PR TITLE
Fixed REST views behat scenario

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,15 +55,11 @@ matrix:
 #      env: TEST_CONFIG="phpunit.xml"
 
 
-# test only master (+ Pull requests)
+# test only master, stable branches and pull requests
 branches:
   only:
     - master
-    - "6.1"
-    - "6.2"
-    - "6.3"
-    - "6.4"
-    - "6.5"
+    - /^\d.\d+$/
 
 # setup requirements for running unit/integration/behat tests
 before_script:

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/Views.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/Views.php
@@ -5,7 +5,7 @@
 namespace eZ\Bundle\EzPublishRestBundle\Features\Context\SubContext;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
-use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeIdentifier;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\Core\REST\Client\Values\View;
 use PHPUnit_Framework_Assert as Assertion;
@@ -51,6 +51,6 @@ trait Views
     public function iSetTheFilterPropertyOfTheQuery($field)
     {
         // @todo this could be improved if setFieldToValue used PropertyAccessor.
-        $this->requestObject->contentQuery->$field = new ContentTypeIdentifier('folder');
+        $this->requestObject->contentQuery->$field = new Criterion\ContentTypeIdentifier('folder');
     }
 }

--- a/eZ/Bundle/EzPublishRestBundle/Features/Views/query.feature
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Views/query.feature
@@ -11,6 +11,7 @@ Feature: Running searches using REST views
          And I set field "contentQuery" to a Query object
          And I set the "filter" property of the Query to a valid Criterion
          And I send the request
-        Then response contains a "eZ\Publish\Core\REST\Client\Values\View" object
+        Then response status code is 200
+         And response contains a "eZ\Publish\Core\REST\Client\Values\View" object
          And the View contains Search Hits
          And the Search Hits are Content objects

--- a/eZ/Publish/Core/REST/Client/Output/ValueObjectVisitor/Criterion/ContentTypeIdentifier.php
+++ b/eZ/Publish/Core/REST/Client/Output/ValueObjectVisitor/Criterion/ContentTypeIdentifier.php
@@ -18,7 +18,13 @@ class ContentTypeIdentifier extends ValueObjectVisitor
      */
     public function visit(Visitor $visitor, Generator $generator, $data)
     {
-        $generator->startValueElement('ContentTypeIdentifierCriterion', $data->value);
-        $generator->endValueElement('ContentTypeIdentifierCriterion');
+        $contentTypeIdentifiers = is_array($data->value) ? $data->value : [$data->value];
+
+        $generator->startList('ContentTypeIdentifierCriterion');
+        foreach ($contentTypeIdentifiers as $contentTypeIdentifier) {
+            $generator->startValueElement('ContentTypeIdentifierCriterion', $contentTypeIdentifier);
+            $generator->endValueElement('ContentTypeIdentifierCriterion');
+        }
+        $generator->endList('ContentTypeIdentifierCriterion');
     }
 }


### PR DESCRIPTION
Fixes array handling in the ContentTypeIdentifierCriterion value object visitor, used by behat to serialize a Query into a REST payload.