### PR TITLE
[WIP] EZP-26000: implement permission lookup API

### DIFF
--- a/eZ/Publish/API/Repository/PermissionResolver.php
+++ b/eZ/Publish/API/Repository/PermissionResolver.php
@@ -65,4 +65,23 @@ interface PermissionResolver
      * @return bool
      */
     public function canUser($module, $function, ValueObject $object, array $targets = []);
+
+    /**
+     * Looks up user's permission information for the given module, function and a set
+     * of limitations.
+     *
+     * @param string $module
+     * @param string $function
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation[] $limitations
+     * @param \eZ\Publish\API\Repository\Values\User\UserReference|null $userReference User for
+     *        which the information is returned, current user will be used if null
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\PermissionInfo
+     */
+    public function lookup(
+        $module,
+        $function,
+        array $limitations = [],
+        UserReference $userReference = null
+    );
 }

--- a/eZ/Publish/API/Repository/Values/User/PermissionInfo.php
+++ b/eZ/Publish/API/Repository/Values/User/PermissionInfo.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\API\Repository\Values\User;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * This class represents User's permission information for a module, function and a set
+ * of limitations.
+ *
+ * This value object does not represent an entity, but the information calculated resolving User's
+ * policies and Role limitations against a given module, function and a set of limitations.
+ *
+ * @see \eZ\Publish\API\Repository\PermissionResolver::lookup()
+ *
+ * @property-read string $access One of ACCESS_GRANTED, ACCESS_LIMITED or ACCESS_DENIED constants.
+ * @property-read \eZ\Publish\API\Repository\Values\User\Limitation[][] $limitationSets
+ */
+class PermissionInfo extends ValueObject
+{
+    /**
+     * Indicates full access.
+     */
+    const ACCESS_GRANTED = true;
+
+    /**
+     * Indicates limited access, described by limitation sets.
+     *
+     * @see \eZ\Publish\API\Repository\Values\User\PermissionInfo::$limitationSets
+     */
+    const ACCESS_LIMITED = null;
+
+    /**
+     * Indicates denied access.
+     */
+    const ACCESS_DENIED = false;
+
+    /**
+     * Indicates access rights for the user on a value object on the current module function.
+     *
+     * @var mixed One of ACCESS_GRANTED, ACCESS_LIMITED or ACCESS_DENIED constants.
+     */
+    protected $access;
+
+    /**
+     * Limitation Values here are combinations of limitation values on policies relevant to given
+     * module and function. Limitations are grouped into sets, which are to be evaluated separately.
+     * If any set matches your values, access should be granted.
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\Limitation[][]
+     */
+    protected $limitationSets = [];
+}

--- a/eZ/Publish/Core/Limitation/AbstractPersistenceLimitationType.php
+++ b/eZ/Publish/Core/Limitation/AbstractPersistenceLimitationType.php
@@ -11,9 +11,9 @@ namespace eZ\Publish\Core\Limitation;
 use eZ\Publish\SPI\Persistence\Handler as SPIPersistenceHandler;
 
 /**
- * LocationLimitation is a Content limitation.
+ * Base class for limitation types requiring persistence handler.
  */
-class AbstractPersistenceLimitationType
+abstract class AbstractPersistenceLimitationType extends BaseLimitationType
 {
     /**
      * @var \eZ\Publish\SPI\Persistence\Handler

--- a/eZ/Publish/Core/Limitation/BaseLimitationType.php
+++ b/eZ/Publish/Core/Limitation/BaseLimitationType.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Limitation;
+
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\SPI\Limitation\Type as SPILimitationTypeInterface;
+
+/**
+ * Base class for limitation types.
+ */
+abstract class BaseLimitationType implements SPILimitationTypeInterface
+{
+    public function evaluateSingle(Limitation $limitation, $value)
+    {
+        return in_array($value, $limitation->limitationValues);
+    }
+}

--- a/eZ/Publish/Core/Limitation/BlockingLimitationType.php
+++ b/eZ/Publish/Core/Limitation/BlockingLimitationType.php
@@ -17,7 +17,6 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\Core\FieldType\ValidationError;
-use eZ\Publish\SPI\Limitation\Type as SPILimitationTypeInterface;
 
 /**
  * BlockingLimitationType is a limitation type that always says no to the permission system.
@@ -25,7 +24,7 @@ use eZ\Publish\SPI\Limitation\Type as SPILimitationTypeInterface;
  * It is for use in cases where a limitation is not implemented, or limitation is legacy specific
  * and it is then not possible to know when to say yes, so we need to say no.
  */
-class BlockingLimitationType implements SPILimitationTypeInterface
+class BlockingLimitationType extends BaseLimitationType
 {
     /**
      * @var string

--- a/eZ/Publish/Core/Limitation/SiteAccessLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SiteAccessLimitationType.php
@@ -16,12 +16,11 @@ use eZ\Publish\API\Repository\Values\User\Limitation\SiteAccessLimitation as API
 use eZ\Publish\API\Repository\Values\User\Limitation as APILimitationValue;
 use eZ\Publish\Core\FieldType\ValidationError;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
-use eZ\Publish\SPI\Limitation\Type as SPILimitationTypeInterface;
 
 /**
  * SiteAccessLimitation is a User limitation.
  */
-class SiteAccessLimitationType implements SPILimitationTypeInterface
+class SiteAccessLimitationType extends BaseLimitationType
 {
     /**
      * @var array

--- a/eZ/Publish/Core/Limitation/StatusLimitationType.php
+++ b/eZ/Publish/Core/Limitation/StatusLimitationType.php
@@ -16,14 +16,13 @@ use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\API\Repository\Values\User\Limitation\StatusLimitation as APIStatusLimitation;
 use eZ\Publish\API\Repository\Values\User\Limitation as APILimitationValue;
-use eZ\Publish\SPI\Limitation\Type as SPILimitationTypeInterface;
 use eZ\Publish\Core\FieldType\ValidationError;
 use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 
 /**
  * StatusLimitation is a Content Limitation.
  */
-class StatusLimitationType implements SPILimitationTypeInterface
+class StatusLimitationType extends BaseLimitationType
 {
     /**
      * Accepts a Limitation value and checks for structural validity.

--- a/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
@@ -166,7 +166,7 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
 
     public function evaluateSingle(APILimitationValue $limitation, $value)
     {
-        foreach ($value->limitationValues as $limitationPathString) {
+        foreach ($limitation->limitationValues as $limitationPathString) {
             if (strpos($value, $limitationPathString) === 0) {
                 return true;
             }

--- a/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
@@ -164,6 +164,17 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
         return false;
     }
 
+    public function evaluateSingle(APILimitationValue $limitation, $value)
+    {
+        foreach ($value->limitationValues as $limitationPathString) {
+            if (strpos($value, $limitationPathString) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * Evaluate permissions for ContentCreateStruct against LocationCreateStruct placements.
      *

--- a/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
+++ b/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
@@ -330,9 +330,8 @@ class PermissionResolver implements PermissionResolverInterface
              *
              * These are already filtered by hasAccess and given hasAccess did not return boolean
              * there must be some, so only return true if one of them says yes.
-             *
-             * @var \eZ\Publish\API\Repository\Values\User\Policy $policy
              */
+            /** @var \eZ\Publish\API\Repository\Values\User\Policy $policy */
             foreach ($permissionSet['policies'] as $policy) {
                 $policyLimitations = [];
 
@@ -403,7 +402,7 @@ class PermissionResolver implements PermissionResolverInterface
 
         if (!$setPasses) {
             $access = PermissionInfo::ACCESS_DENIED;
-        } else if (empty($limitationSets)) {
+        } elseif (empty($limitationSets)) {
             $access = PermissionInfo::ACCESS_GRANTED;
         }
 

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionTest.php
@@ -1682,9 +1682,7 @@ class PermissionTest extends BaseServiceMockTest
         $this->assertNotEmpty($permissionInfo->limitationSets);
         $this->assertEquals(count($expectedLimitationSets), count($permissionInfo->limitationSets));
 
-        /**
-         * @var \eZ\Publish\API\Repository\Values\User\Limitation[][] $limitationSets
-         */
+        /** @var \eZ\Publish\API\Repository\Values\User\Limitation[][] $limitationSets */
         $limitationSets = $permissionInfo->limitationSets;
 
         foreach ($limitationSets as $i => $limitationSet) {

--- a/eZ/Publish/SPI/Limitation/Type.php
+++ b/eZ/Publish/SPI/Limitation/Type.php
@@ -99,6 +99,16 @@ interface Type
     public function evaluate(APILimitationValue $value, APIUserReference $currentUser, APIValueObject $object, array $targets = null);
 
     /**
+     * Evaluates a single given value against a limitation.
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation $limitation
+     * @param mixed $value
+     *
+     * @return bool
+     */
+    public function evaluateSingle(APILimitationValue $limitation, $value);
+
+    /**
      * Returns Criterion for use in find() query.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException If the limitation does not support

--- a/phpunit-integration-legacy-elasticsearch.xml
+++ b/phpunit-integration-legacy-elasticsearch.xml
@@ -24,6 +24,7 @@
                       all services here.
           -->
           <file>eZ/Publish/API/Repository/Tests/RepositoryTest.php</file>
+          <file>eZ/Publish/API/Repository/Tests/PermissionResolverTest.php</file>
           <file>eZ/Publish/API/Repository/Tests/SectionServiceTest.php</file>
           <file>eZ/Publish/API/Repository/Tests/LanguageServiceTest.php</file>
           <file>eZ/Publish/API/Repository/Tests/LanguageServiceMaximumSupportedLanguagesTest.php</file>

--- a/phpunit-integration-legacy-solr.xml
+++ b/phpunit-integration-legacy-solr.xml
@@ -25,6 +25,7 @@
                         all services here.
             -->
             <file>eZ/Publish/API/Repository/Tests/RepositoryTest.php</file>
+            <file>eZ/Publish/API/Repository/Tests/PermissionResolverTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SectionServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LanguageServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LanguageServiceMaximumSupportedLanguagesTest.php</file>

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -17,7 +17,7 @@
     <testsuites>
         <testsuite name="eZ\Publish\API\Repository">
             <file>eZ/Publish/API/Repository/Tests/RepositoryTest.php</file>
-            <file>eZ/Publish/API/Repository/Tests/PermissionServiceTest.php</file>
+            <file>eZ/Publish/API/Repository/Tests/PermissionResolverTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SectionServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LanguageServiceTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/LanguageServiceMaximumSupportedLanguagesTest.php</file>


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-26000

This adds a new value object [`PermissionInfo`](https://github.com/ezsystems/ezpublish-kernel/pull/1828/files#diff-125db89d83e484b8a9d55d2e3e70cc7b) and a new method [`PermissionResolver::lookup()`](https://github.com/ezsystems/ezpublish-kernel/pull/1828/files#diff-03d5d884dcd351cf6445a5b7a8dc1da1):

```php
/**
 * Looks up user's permission information for the given module, function and a set
 * of limitations.
 *
 * @param string $module
 * @param string $function
 * @param \eZ\Publish\API\Repository\Values\User\Limitation[] $limitations
 * @param \eZ\Publish\API\Repository\Values\User\UserReference|null $userReference User for
 *        which the information is returned, current user will be used if null
 *
 * @return \eZ\Publish\API\Repository\Values\User\PermissionInfo
 */
public function lookup(
    $module,
    $function,
    array $limitations = [],
    UserReference $userReference = null
);
```

Limitations given in the parameter `$limitations` can contain only single value, currently no way is provided to correctly evaluate multiple values. To enable evaluating values given to `PermissionResolver::lookup()`, a new method is added to the SPI Limitation Type, `evaluateSingle(Limitation $limitation, $value)`.

This should be enough for the current REST/UI needs, but might be limiting in the future if we add more Limitation options to a module/function. Also, there is no way to resolve limitation values for a specific value/target, which would enable finding specific Limitation values for a Content in a purely programmatic way.

In the `PermissionInfo` object, Role Limitations will be added to a Limitation set. This is done for the reason of simplicity, implying that if two Limitations of the same type exist in a set, both should be evaluated.

But another limitation is that no way exists to decide when a Role Limitation should be ignored, since the ABSTAIN logic is currently implemented internally in `LimitationType::evaluate()`. That means the implementation will return Role Limitation instead of ignoring it. It should be possible to refactor `PermissionInfo` so that it's possible to filter these out when handling specific cases for REST/UI.

For the limitations described, it might be a good idea to keep this internal for the moment and use it only for the REST/UI needs. Until we decide if/how to refactor the whole permission subsystem.

### TODOs
---
- [ ] Dicsuss
- [x] Add some integration tests
- [x] ~~Implement a way to resolve multiple module permissions with a single call for permission sets~~ can be implemented later as an improvement