### PR TITLE
EZP-26702: made sure an empty Filter/Criteria doesn't generate an empty LogicalAnd

### DIFF
--- a/eZ/Publish/Core/REST/Server/Input/Parser/Query.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Query.php
@@ -91,10 +91,14 @@ abstract class Query extends CriterionParser
      * @param array $criteriaArray
      * @param ParsingDispatcher $parsingDispatcher
      *
-     * @return CriterionValue
+     * @return CriterionValue|null A criterion, or a LogicalAnd with a set of Criterion, or null if an empty array was given
      */
     private function processCriteriaArray(array $criteriaArray, ParsingDispatcher $parsingDispatcher)
     {
+        if (count($criteriaArray) === 0) {
+            return null;
+        }
+
         $criteria = array();
         foreach ($criteriaArray as $criterionName => $criterionData) {
             $criteria[] = $this->dispatchCriterion($criterionName, $criterionData, $parsingDispatcher);

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ViewInput.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ViewInput.php
@@ -12,7 +12,6 @@ namespace eZ\Publish\Core\REST\Server\Input\Parser;
 
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
-use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\Core\REST\Server\Values\RestViewInput;
 use eZ\Publish\Core\REST\Common\Input\BaseParser;
 

--- a/eZ/Publish/Core/REST/Server/Input/Parser/ViewInputOneDotOne.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/ViewInputOneDotOne.php
@@ -13,7 +13,6 @@ namespace eZ\Publish\Core\REST\Server\Input\Parser;
 use eZ\Publish\Core\REST\Server\Input\Parser\Criterion as CriterionParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use eZ\Publish\Core\REST\Common\Exceptions;
-use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\Core\REST\Server\Values\RestViewInput;
 
 /**

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/QueryParserTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/QueryParserTest.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * File containing the SessionInputTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\Core\REST\Server\Input\Parser\ContentQuery as QueryParser;
+
+class QueryParserTest extends BaseTest
+{
+    public function testParseEmptyQuery()
+    {
+        $inputArray = array(
+            'Filter' => [],
+            'Criteria' => [],
+            'Query' => [],
+        );
+
+        $parsingDispatcher = $this->getParsingDispatcherMock();
+        $parser = $this->getParser();
+
+        $result = $parser->parse($inputArray, $parsingDispatcher);
+
+        $expectedQuery = new Query();
+
+        $this->assertEquals($expectedQuery, $result);
+    }
+
+    public function testDispatchOneFilter()
+    {
+        $inputArray = array(
+            'Filter' => ['ContentTypeIdentifierCriterion' => 'article'],
+            'Criteria' => [],
+            'Query' => [],
+        );
+
+        $parsingDispatcher = $this->getParsingDispatcherMock();
+        $parsingDispatcher
+            ->expects($this->once())
+            ->method('parse')
+            ->with(['ContentTypeIdentifierCriterion' => 'article'])
+            ->will($this->returnValue(new Query\Criterion\ContentTypeIdentifier('article')));
+
+        $parser = $this->getParser();
+
+        $result = $parser->parse($inputArray, $parsingDispatcher);
+
+        $expectedQuery = new Query();
+        $expectedQuery->filter = new Query\Criterion\ContentTypeIdentifier('article');
+
+        $this->assertEquals($expectedQuery, $result);
+    }
+
+    public function testDispatchMoreThanOneFilter()
+    {
+        $inputArray = array(
+            'Filter' => ['ContentTypeIdentifierCriterion' => 'article', 'ParentLocationIdCriterion' => 762],
+            'Criteria' => [],
+            'Query' => [],
+        );
+
+        $parsingDispatcher = $this->getParsingDispatcherMock();
+        $parsingDispatcher
+            ->expects($this->at(0))
+            ->method('parse')
+            ->with(['ContentTypeIdentifierCriterion' => 'article'])
+            ->will($this->returnValue(new Query\Criterion\ContentTypeIdentifier('article')));
+        $parsingDispatcher
+            ->expects($this->at(1))
+            ->method('parse')
+            ->with(['ParentLocationIdCriterion' => 762])
+            ->will($this->returnValue(new Query\Criterion\ParentLocationId(762)));
+
+        $parser = $this->getParser();
+
+        $result = $parser->parse($inputArray, $parsingDispatcher);
+
+        $expectedQuery = new Query();
+        $expectedQuery->filter = new Query\Criterion\LogicalAnd([
+            new Query\Criterion\ContentTypeIdentifier('article'),
+            new Query\Criterion\ParentLocationId(762),
+        ]);
+
+        $this->assertEquals($expectedQuery, $result);
+    }
+
+    public function testDispatchOneQueryItem()
+    {
+        $inputArray = array(
+            'Query' => ['ContentTypeIdentifierCriterion' => 'article'],
+            'Criteria' => [],
+            'Filter' => [],
+        );
+
+        $parsingDispatcher = $this->getParsingDispatcherMock();
+        $parsingDispatcher
+            ->expects($this->once())
+            ->method('parse')
+            ->with(['ContentTypeIdentifierCriterion' => 'article'])
+            ->will($this->returnValue(new Query\Criterion\ContentTypeIdentifier('article')));
+
+        $parser = $this->getParser();
+
+        $result = $parser->parse($inputArray, $parsingDispatcher);
+
+        $expectedQuery = new Query();
+        $expectedQuery->query = new Query\Criterion\ContentTypeIdentifier('article');
+
+        $this->assertEquals($expectedQuery, $result);
+    }
+
+    public function testDispatchMoreThanOneQueryItem()
+    {
+        $inputArray = array(
+            'Query' => ['ContentTypeIdentifierCriterion' => 'article', 'ParentLocationIdCriterion' => 762],
+            'Criteria' => [],
+            'Filter' => [],
+        );
+
+        $parsingDispatcher = $this->getParsingDispatcherMock();
+        $parsingDispatcher
+            ->expects($this->at(0))
+            ->method('parse')
+            ->with(['ContentTypeIdentifierCriterion' => 'article'])
+            ->will($this->returnValue(new Query\Criterion\ContentTypeIdentifier('article')));
+        $parsingDispatcher
+            ->expects($this->at(1))
+            ->method('parse')
+            ->with(['ParentLocationIdCriterion' => 762])
+            ->will($this->returnValue(new Query\Criterion\ParentLocationId(762)));
+
+        $parser = $this->getParser();
+
+        $result = $parser->parse($inputArray, $parsingDispatcher);
+
+        $expectedQuery = new Query();
+        $expectedQuery->query = new Query\Criterion\LogicalAnd([
+            new Query\Criterion\ContentTypeIdentifier('article'),
+            new Query\Criterion\ParentLocationId(762),
+        ]);
+
+        $this->assertEquals($expectedQuery, $result);
+    }
+
+    /**
+     * Returns the session input parser.
+     */
+    protected function internalGetParser()
+    {
+        return new QueryParser();
+    }
+}


### PR DESCRIPTION
> [EZP-26702](http://jira.ez.no/browse/EZP-26702)

Ping @StephaneDiot for testing.

Added a unit test for the Query InputParser.