### PR TITLE
Fix EZP-26551: Content type draft not deleted when content type is

### DIFF
--- a/eZ/Publish/API/Repository/ContentTypeService.php
+++ b/eZ/Publish/API/Repository/ContentTypeService.php
@@ -194,7 +194,9 @@ interface ContentTypeService
     /**
      * Delete a Content Type object.
      *
-     * Deletes a content type if it has no instances
+     * Deletes a content type if it has no instances. If content type in state STATUS_DRAFT is
+     * given, only the draft content type will be deleted. Otherwise, if content type in state
+     * STATUS_DEFINED is given, all content type data will be deleted.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If there exist content objects of this type
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to delete a content type

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP26551DeleteContentTypeDraftTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP26551DeleteContentTypeDraftTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\API\Repository\Tests\Regression;
+
+use eZ\Publish\API\Repository\Tests\BaseTest;
+use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
+
+/**
+ * @issue https://jira.ez.no/browse/EZP-26551
+ * @group regression
+ * @group ezp26551
+ */
+class EZP26551DeleteContentTypeDraftTest extends BaseTest
+{
+    public function testDeleteContentTypeGroup()
+    {
+        $repository = $this->getRepository();
+        $contentTypeService = $repository->getContentTypeService();
+
+        $contentTypeGroupCreateStruct = $contentTypeService->newContentTypeGroupCreateStruct('new-group');
+        $contentTypeGroupCreateStruct->creatorId = $this->generateId('user', $repository->getCurrentUser()->id);
+        $contentTypeGroupCreateStruct->creationDate = $this->createDateTime();
+
+        $contentTypeGroup = $contentTypeService->createContentTypeGroup($contentTypeGroupCreateStruct);
+        $contentType = $contentTypeService->loadContentTypeByIdentifier('comment');
+
+        // Assign the ContentType to the ContentTypeGroup - it will be the only ContentType there
+        $contentTypeService->assignContentTypeGroup($contentType, $contentTypeGroup);
+
+        // Create a draft of the ContentType
+        $contentTypeService->createContentTypeDraft($contentType);
+
+        // Delete ContentType - we're assuming that ContentType draft data will be correctly deleted
+        $contentTypeService->deleteContentType($contentType);
+
+        // Check that it's possible to delete the ContentTypeGroup
+        // (no ContentType draft data interfering with deletion)
+        try {
+            $contentTypeService->deleteContentTypeGroup($contentTypeGroup);
+        } catch (InvalidArgumentException $e) {
+            $this->fail(
+                "ContentTypeGroup can't be deleted because it has ContentType instances"
+            );
+        }
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
@@ -328,7 +328,6 @@ class Handler implements BaseContentTypeHandler
 
     /**
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If type is defined and still has content
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If type is not found
      *
      * @param mixed $contentTypeId
      * @param int $status
@@ -337,16 +336,6 @@ class Handler implements BaseContentTypeHandler
      */
     public function delete($contentTypeId, $status)
     {
-        if (!$this->contentTypeGateway->loadTypeData($contentTypeId, $status)) {
-            throw new NotFoundException(
-                'ContentType',
-                array(
-                    'id' => $contentTypeId,
-                    'status' => $status,
-                )
-            );
-        }
-
         if (Type::STATUS_DEFINED === $status && $this->contentTypeGateway->countInstancesOfType($contentTypeId)) {
             throw new BadStateException(
                 '$contentTypeId',

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/MemoryCachingHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/MemoryCachingHandler.php
@@ -255,7 +255,6 @@ class MemoryCachingHandler implements BaseContentTypeHandler
 
     /**
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If type is defined and still has content
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If type is not found
      *
      * @param mixed $contentTypeId
      * @param int $status

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
@@ -590,17 +590,6 @@ class ContentTypeHandlerTest extends PHPUnit_Framework_TestCase
         $gatewayMock->expects(
             $this->once()
         )->method(
-            'loadTypeData'
-        )->with(
-            $this->equalTo(23),
-            $this->equalTo(0)
-        )->will(
-            $this->returnValue(array(42))
-        );
-
-        $gatewayMock->expects(
-            $this->once()
-        )->method(
             'countInstancesOfType'
         )->with(
             $this->equalTo(23)
@@ -625,47 +614,11 @@ class ContentTypeHandlerTest extends PHPUnit_Framework_TestCase
 
     /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler::delete
-     * @expectedException \eZ\Publish\Core\Base\Exceptions\NotFoundException
-     */
-    public function testDeleteThrowsNotFoundException()
-    {
-        $gatewayMock = $this->getGatewayMock();
-
-        $gatewayMock->expects(
-            $this->once()
-        )->method(
-            'loadTypeData'
-        )->with(
-            $this->equalTo(23),
-            $this->equalTo(0)
-        )->will(
-            $this->returnValue(array())
-        );
-
-        $gatewayMock->expects($this->never())->method('delete');
-
-        $handler = $this->getHandler();
-        $res = $handler->delete(23, 0);
-    }
-
-    /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler::delete
      * @expectedException \eZ\Publish\Core\Base\Exceptions\BadStateException
      */
     public function testDeleteThrowsBadStateException()
     {
         $gatewayMock = $this->getGatewayMock();
-
-        $gatewayMock->expects(
-            $this->once()
-        )->method(
-            'loadTypeData'
-        )->with(
-            $this->equalTo(23),
-            $this->equalTo(0)
-        )->will(
-            $this->returnValue(array(42))
-        );
 
         $gatewayMock->expects(
             $this->once()

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -1140,7 +1140,9 @@ class ContentTypeService implements ContentTypeServiceInterface
     /**
      * Delete a Content Type object.
      *
-     * Deletes a content type if it has no instances
+     * Deletes a content type if it has no instances. If content type in state STATUS_DRAFT is
+     * given, only the draft content type will be deleted. Otherwise, if content type in state
+     * STATUS_DEFINED is given, all content type data will be deleted.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If there exist content objects of this type
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to delete a content type
@@ -1155,10 +1157,18 @@ class ContentTypeService implements ContentTypeServiceInterface
 
         $this->repository->beginTransaction();
         try {
+            if (!$contentType instanceof APIContentTypeDraft) {
+                $this->contentTypeHandler->delete(
+                    $contentType->id,
+                    APIContentTypeDraft::STATUS_DEFINED
+                );
+            }
+
             $this->contentTypeHandler->delete(
                 $contentType->id,
-                $contentType->status
+                APIContentTypeDraft::STATUS_DRAFT
             );
+
             $this->repository->commit();
         } catch (Exception $e) {
             $this->repository->rollback();

--- a/eZ/Publish/SPI/Persistence/Content/Type/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/Handler.php
@@ -130,7 +130,6 @@ interface Handler
      * @param int $status One of Type::STATUS_DEFINED|Type::STATUS_DRAFT|Type::STATUS_MODIFIED
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException If type is defined and still has content
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If type is not found
      */
     public function delete($contentTypeId, $status);
 


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-26551

This fixes the issue by deleting both draft and define (published) ContentType when calling `ContentTypeService::deleteContentType($contentType)` with argument not being an instance of `ContentTypeDraft`. When calling the method with an instance of `ContentTypeDraft`, only the draft will be deleted, which is the same behavior as before.

`NotFound` exception is removed from SPI `ContentTypeHandler::delete($contentTypeId, $status)`. That approach is the same as taken in https://github.com/ezsystems/ezpublish-kernel/pull/1133.

We should eventually switch to use `PDO::MYSQL_ATTR_FOUND_ROWS` and fix this problem for good, but that's maybe something we'll want to do with kernel version 7. For more info on that part see:

- https://github.com/ezsystems/ezpublish-kernel/pull/973
- https://www.drupal.org/node/805858
- https://github.com/backdrop/backdrop-issues/issues/274