### PR TITLE
Added RichText fielddefinition_setting blocks

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
@@ -27,6 +27,13 @@
 </ul>
 {% endblock %}
 
+{% block ezrichtext_settings %}
+    <ul class="fielddef-settings {{ fielddefinition.fieldTypeIdentifier }}-settings">
+        {% set rows = settings.numRows %}
+        {{ block( 'settings_preferredrows' ) }}
+    </ul>
+{% endblock %}
+
 {% block ezcountry_settings %}
 <ul class="fielddef-settings {{ fielddefinition.fieldTypeIdentifier }}-settings">
     {% set defaultValue = '' %}


### PR DESCRIPTION
> [EZP-26666](http://jira.ez.no/browse/EZP-26666)

FieldType settings display in content type editing. Missing because RichText was implemented after the feature.

No options are exposed, as the `numRows` supported by the FieldType (like TextBlock) isn't implemented, and is planned for removal.