### PR TITLE
EZP-26683: Make IO exceptions more use friendly

### DIFF
--- a/eZ/Publish/Core/IO/Exception/InvalidBinaryFileIdException.php
+++ b/eZ/Publish/Core/IO/Exception/InvalidBinaryFileIdException.php
@@ -8,12 +8,22 @@
  */
 namespace eZ\Publish\Core\IO\Exception;
 
+use Exception;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue;
 
 class InvalidBinaryFileIdException extends InvalidArgumentValue
 {
     public function __construct($id, $message = null)
     {
-        parent::__construct('BinaryFile::id', $id, 'BinaryFile');
+        $parameters = ['%id%' => $id];
+        $string = "Argument 'BinaryFile::id' is invalid: '%id%' is wrong value";
+        if ($message) {
+            $string .= ', %message%';
+            $parameters['%message%'] = $message;
+        }
+
+        $this->setMessageTemplate($string);
+        $this->setParameters($parameters);
+        Exception::__construct($this->getBaseTranslation(), 0);
     }
 }

--- a/eZ/Publish/Core/IO/IOService.php
+++ b/eZ/Publish/Core/IO/IOService.php
@@ -291,7 +291,10 @@ class IOService implements IOServiceInterface
         }
 
         if (strpos($spiBinaryFileId, $this->settings['prefix'] . '/') !== 0) {
-            throw new InvalidArgumentException('$id', "Prefix {$this->settings['prefix']} not found in {$spiBinaryFileId}");
+            throw new InvalidBinaryFileIdException(
+                $spiBinaryFileId,
+                "it does not contain prefix '{$this->settings['prefix']}'. Is 'var_dir' config correct?"
+            );
         }
 
         return substr($spiBinaryFileId, strlen($this->settings['prefix']) + 1);

--- a/eZ/Publish/Core/IO/TolerantIOService.php
+++ b/eZ/Publish/Core/IO/TolerantIOService.php
@@ -75,7 +75,7 @@ class TolerantIOService extends IOService
         $this->checkBinaryFileId($binaryFileId);
 
         if ($this->isAbsolutePath($binaryFileId)) {
-            throw new InvalidBinaryFileIdException($binaryFileId, 'Binary file ids can not begin with a /');
+            throw new InvalidBinaryFileIdException($binaryFileId, "binary file ids can not begin with a '/'");
         }
 
         try {

--- a/eZ/Publish/Core/IO/UrlDecorator/Prefix.php
+++ b/eZ/Publish/Core/IO/UrlDecorator/Prefix.php
@@ -51,7 +51,10 @@ class Prefix implements UrlDecorator
         }
 
         if (strpos($url, $this->prefix) !== 0) {
-            throw new InvalidBinaryFileIdException($url);
+            throw new InvalidBinaryFileIdException(
+                $url,
+                "it does not contain prefix '{$this->prefix}'. Is 'var_dir' config correct?"
+            );
         }
 
         return trim(substr($url, strlen($this->prefix)), '/');


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-26683

To avoid cryptic IO exceptions when upgrading and merging in wrong var_dir settings or otherwise miss configuring this setting.

Solves:
- `$message` containing important context information, not being passed on to string given to user
- add context information on prefix exceptions