### PR TITLE
[Composer] Drop PHP 5.5 support for 1.7LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,9 @@ env:
 matrix:
   fast_finish: true
   include:
-# 5.5
-    - php: 5.5
-      env: TEST_CONFIG="phpunit.xml" SYMFONY_VERSION="~2.8.0"
-    - php: 5.5
-      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb"
 # 5.6
+    - php: 5.6
+      env: TEST_CONFIG="phpunit.xml" SYMFONY_VERSION="~2.8.0"
     - php: 5.6
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/testdb" SYMFONY_VERSION="~2.7.0"
     - php: 5.6
@@ -50,6 +47,8 @@ matrix:
       env: ELASTICSEARCH_VERSION="1.4.2" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml" SYMFONY_VERSION="~2.8.0"
     - php: 7.0
       env: SOLR_VERSION="4.10.4" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="single" SOLR_CONFS="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml"
+    - php: 7.0
+      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb"
 # hhvm - disabled, no need to enable before travis has newer versions avaiable
 #    - php: hhvm
 #      env: TEST_CONFIG="phpunit.xml"

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php-64bit": "For support of more than 30 languages, a 64bit php installation on all involved prod/dev machines is required"
     },
     "require": {
-        "php": "~5.5|~7.0",
+        "php": "~5.6|~7.0",
         "ext-ctype": "*",
         "ext-fileinfo": "*",
         "ext-intl": "*",


### PR DESCRIPTION
As discussed with some we want to bump PHP requirements for the LTS.
This has been communicated over some time on the requirements already:
https://doc.ez.no/pages/viewpage.action?pageId=31429536

Main arguments:
- To be able to start to take advantage of [PHP 5.6 features](http://php.net/manual/en/migration56.new-features.php)
  - Including class constant expressions/arrays, and Variadic functions / Argument unpacking.
- PHP 5.5 is EOL since 21 Jul 2016, and hence won't be relevant for the support period of the LTS
- All supported platforms by now have access to PHP 5.6 packages or higher.

PHP 5.6 is the closest you get to a PHP LTS, and is supported by PHP until 31 Dec 2018, and most likely further by distros.