### PR TITLE
EZP-26706: Resolve translated name from VersionInfo

### DIFF
--- a/eZ/Publish/Core/Helper/Tests/TranslationHelperTest.php
+++ b/eZ/Publish/Core/Helper/Tests/TranslationHelperTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\Helper\Tests;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
 use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use PHPUnit_Framework_TestCase;
@@ -88,14 +89,22 @@ class TranslationHelperTest extends PHPUnit_Framework_TestCase
     {
         return new Content(
             array(
-                'versionInfo' => new VersionInfo(
-                    array(
-                        'names' => $this->translatedNames,
-                        'initialLanguageCode' => 'fre-FR',
-                    )
-                ),
+                'versionInfo' => $this->generateVersionInfo(),
                 'internalFields' => $this->translatedFields,
             )
+        );
+    }
+
+    /**
+     * @return APIVersionInfo
+     */
+    private function generateVersionInfo()
+    {
+        return new VersionInfo(
+            [
+                'names' => $this->translatedNames,
+                'initialLanguageCode' => 'fre-FR',
+            ]
         );
     }
 
@@ -125,7 +134,7 @@ class TranslationHelperTest extends PHPUnit_Framework_TestCase
      */
     public function testGetTranslatedNameByContentInfo(array $prioritizedLanguages, $expectedLocale)
     {
-        $content = $this->generateContent();
+        $versionInfo = $this->generateVersionInfo();
         $contentInfo = new ContentInfo(array('id' => 123));
         $this->configResolver
             ->expects($this->once())
@@ -135,9 +144,9 @@ class TranslationHelperTest extends PHPUnit_Framework_TestCase
 
         $this->contentService
             ->expects($this->once())
-            ->method('loadContentByContentInfo')
+            ->method('loadVersionInfo')
             ->with($contentInfo)
-            ->will($this->returnValue($content));
+            ->will($this->returnValue($versionInfo));
 
         $this->assertSame($this->translatedNames[$expectedLocale], $this->translationHelper->getTranslatedContentNameByContentInfo($contentInfo));
     }
@@ -155,7 +164,7 @@ class TranslationHelperTest extends PHPUnit_Framework_TestCase
 
     public function testGetTranslatedNameByContentInfoForcedLanguage()
     {
-        $content = $this->generateContent();
+        $versionInfo = $this->generateVersionInfo();
         $contentInfo = new ContentInfo(array('id' => 123));
         $this->configResolver
             ->expects($this->never())
@@ -163,9 +172,9 @@ class TranslationHelperTest extends PHPUnit_Framework_TestCase
 
         $this->contentService
             ->expects($this->exactly(2))
-            ->method('loadContentByContentInfo')
+            ->method('loadVersionInfo')
             ->with($contentInfo)
-            ->will($this->returnValue($content));
+            ->will($this->returnValue($versionInfo));
 
         $this->assertSame('My name in english', $this->translationHelper->getTranslatedContentNameByContentInfo($contentInfo, 'eng-GB'));
         $this->assertSame('Mon nom en français', $this->translationHelper->getTranslatedContentNameByContentInfo($contentInfo, 'eng-US'));

--- a/eZ/Publish/Core/Helper/TranslationHelper.php
+++ b/eZ/Publish/Core/Helper/TranslationHelper.php
@@ -12,6 +12,7 @@ use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\API\Repository\Values\ValueObject;
@@ -63,12 +64,31 @@ class TranslationHelper
      */
     public function getTranslatedContentName(Content $content, $forcedLanguage = null)
     {
+        return $this->getTranslatedContentNameByVersionInfo(
+            $content->getVersionInfo(),
+            $forcedLanguage
+        );
+    }
+
+    /**
+     * Returns content name, translated, from a VersionInfo object.
+     * By default this method uses prioritized languages, unless $forcedLanguage is provided.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
+     * @param string $forcedLanguage
+     *
+     * @return string
+     */
+    private function getTranslatedContentNameByVersionInfo(VersionInfo $versionInfo, $forcedLanguage = null)
+    {
         foreach ($this->getLanguages($forcedLanguage) as $lang) {
-            $translatedName = $content->getVersionInfo()->getName($lang);
+            $translatedName = $versionInfo->getName($lang);
             if ($translatedName !== null) {
                 return $translatedName;
             }
         }
+
+        return '';
     }
 
     /**
@@ -88,8 +108,8 @@ class TranslationHelper
             return $contentInfo->name;
         }
 
-        return $this->getTranslatedContentName(
-            $this->contentService->loadContentByContentInfo($contentInfo),
+        return $this->getTranslatedContentNameByVersionInfo(
+            $this->contentService->loadVersionInfo($contentInfo),
             $forcedLanguage
         );
     }


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-26706

When resolving translated `Content` name from `ContentInfo`, `TranslationHelper` will unnecessarily load `Content` in all languages, while only `VersionInfo` is needed. Depending on how much this is used and how many languages a `Content` has, this can be quite a drain on the resources.