### PR TITLE
EZP-26710 : Error on fielddescription without description

### DIFF
--- a/eZ/Publish/Core/Repository/Helper/ContentTypeDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/ContentTypeDomainMapper.php
@@ -224,7 +224,7 @@ class ContentTypeDomainMapper
         $fieldDefinition = new FieldDefinition(
             array(
                 'names' => $spiFieldDefinition->name,
-                'descriptions' => $spiFieldDefinition->description,
+                'descriptions' => (is_array($spiFieldDefinition->description)) ? $spiFieldDefinition->description : [],
                 'id' => $spiFieldDefinition->id,
                 'identifier' => $spiFieldDefinition->identifier,
                 'fieldGroup' => $spiFieldDefinition->fieldGroup,


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-26710

## Description

When you try to call FieldDefinition::getDescription($languageCode) on a FieldDefinition with no description you ends on an 

    Warning: array_key_exists() expects parameter 2 to be array, boolean given"

## Step to reproduce

Go on the new content vie page form a content type folder
https://github.com/ezsystems/PlatformUIBundle/pull/732

## Test

Manually