### PR TITLE
Fix EZP-26733: keep the desc attribute when mapping translation catalogs

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Translation/CatalogueMapperFileWriter.php
+++ b/eZ/Publish/Core/MVC/Symfony/Translation/CatalogueMapperFileWriter.php
@@ -118,6 +118,10 @@ class CatalogueMapperFileWriter extends FileWriter
         $newMessage->setSources($message->getSources());
         $newMessage->addNote('key: ' . $message->getId());
 
+        if ($desc = $message->getDesc()) {
+            $newMessage->setDesc($desc);
+        }
+
         return $newMessage;
     }
 }


### PR DESCRIPTION
> [EZP-26733](https://jira.ez.no/browse/EZP-26733)

Tested on PlatformUI, works as expected.