### PR TITLE
EZP-26098: Deprecate SearchEngine-specific indexing commands

### DIFF
--- a/eZ/Bundle/EzPublishElasticsearchSearchEngineBundle/Command/ElasticsearchCreateIndexCommand.php
+++ b/eZ/Bundle/EzPublishElasticsearchSearchEngineBundle/Command/ElasticsearchCreateIndexCommand.php
@@ -15,6 +15,9 @@ use Symfony\Component\Console\Input\InputArgument;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use PDO;
 
+/**
+ * @deprecated since 6.7, use ezplatform:reindex command instead.
+ */
 class ElasticsearchCreateIndexCommand extends ContainerAwareCommand
 {
     protected function configure()
@@ -32,6 +35,11 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        @trigger_error(
+            sprintf('%s is deprecated since 6.7. Use ezplatform:reindex command instead', $this->getName()),
+            E_USER_DEPRECATED
+        );
+
         $bulkCount = $input->getArgument('bulk_count');
 
         /** @var \eZ\Publish\SPI\Persistence\Handler $persistenceHandler */

--- a/eZ/Bundle/EzPublishLegacySearchEngineBundle/Command/CreateIndexCommand.php
+++ b/eZ/Bundle/EzPublishLegacySearchEngineBundle/Command/CreateIndexCommand.php
@@ -22,6 +22,8 @@ use RuntimeException;
 use PDO;
 
 /**
+ * @deprecated since 6.7, use ezplatform:reindex command instead.
+ *
  * Console command ezplatform:create_sql_search_index indexes content objects for legacy search
  * engine.
  */
@@ -90,6 +92,11 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        @trigger_error(
+            sprintf('%s is deprecated since 6.7. Use ezplatform:reindex command instead', $this->getName()),
+            E_USER_DEPRECATED
+        );
+
         $bulkCount = $input->getArgument('bulk_count');
         // Indexing Content
         $totalCount = $this->getContentObjectsTotalCount(

--- a/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
@@ -190,15 +190,14 @@ class InstallPlatformCommand extends Command
      */
     private function indexData(OutputInterface $output)
     {
-        if ($this->searchEngine === 'solr') {
-            $output->writeln('Solr search engine configured, executing command ezplatform:solr_create_index');
-            $this->executeCommand($output, 'ezplatform:solr_create_index');
+        if (!in_array($this->searchEngine, ['solr', 'elasticsearch'])) {
+            return;
         }
 
-        if ($this->searchEngine === 'elasticsearch') {
-            $output->writeln('Elasticsearch search engine configured, executing command ezplatform:elasticsearch_create_index');
-            $this->executeCommand($output, 'ezplatform:elasticsearch_create_index');
-        }
+        $output->writeln(
+            sprintf('%s search engine configured, executing command ezplatform:reindex', $this->searchEngine)
+        );
+        $this->executeCommand($output, 'ezplatform:reindex');
     }
 
     /**


### PR DESCRIPTION
> Follow-up on [EZP-26098](https://jira.ez.no/browse/EZP-26098)

This PR deprecates Search Engine-specific indexing commands in favor of `ezplatform:reindex` generic command introduced in #1738.

**TODO**:
- [x] Deprecate `ezplatform:create_sql_search_index` command (b31dae0).
- [x] Deprecate `ezplatform:elasticsearch_create_index` command (b31dae0).
- [x] Update eZ Platform Installer to use `ezplatform:reindex` command (c2d3131).