### PR TITLE
EZP-26719 : use ez_content:ViewAction instead of deprecated viewLocation

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
@@ -320,8 +320,7 @@
         <div class="ez-fielddefinition-setting-name">Selection root:</div>
         <div class="ez-fielddefinition-setting-value">
         {% if rootLocationId %}
-            {# TODO: use a dedicated viewType #}
-            {{ render( controller( "ez_content:viewLocation", {'locationId': rootLocationId, 'viewType': 'line'} ), {'strategy': 'esi'} ) }}
+            {{ render( controller( "ez_content:viewAction", {'locationId': rootLocationId,  'viewType': 'line'} ), {'strategy': 'esi'}) }}
         {% else %}
             <em>No defined root</em>
         {% endif %}


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-26719

## Description

This is the first PR to fix the Jira EZP-26719.
Fonctionnaly this PR won't change anything, it's just replacing the deprecated method so I will be able to implement a view matcher in platfom UI

## Test

Manually

Can be tested after this one :https://github.com/ezsystems/PlatformUIBundle/pull/732
Just go on a content type view page with a content having a relation or relatiolist field with a defaut location set
