### PR TITLE
EZP-26075: Keyword field type not indexed by Solr Search Engine

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/KeywordIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/KeywordIntegrationTest.php
@@ -19,7 +19,7 @@ use eZ\Publish\API\Repository\Values\Content\Field;
  * @group integration
  * @group field-type
  */
-class KeywordIntegrationTest extends BaseIntegrationTest
+class KeywordIntegrationTest extends SearchMultivaluedBaseIntegrationTest
 {
     /**
      * Get name of tested field type.
@@ -314,5 +314,34 @@ class KeywordIntegrationTest extends BaseIntegrationTest
                 new KeywordValue(array('0')),
             ),
         );
+    }
+
+    protected function getValidSearchValueOne()
+    {
+        return 'add';
+    }
+
+    protected function getValidSearchValueTwo()
+    {
+        return 'branch';
+    }
+
+    protected function getValidMultivaluedSearchValuesOne()
+    {
+        return ['add', 'branch'];
+    }
+
+    protected function getValidMultivaluedSearchValuesTwo()
+    {
+        return ['commit', 'delete'];
+    }
+
+    protected function checkSearchEngineSupport()
+    {
+        if (ltrim(get_class($this->getSetupFactory()), '\\') === 'eZ\\Publish\\API\\Repository\\Tests\\SetupFactory\\Legacy') {
+            $this->markTestSkipped(
+                "Keyword field type is not searchable with Legacy Search Engine"
+            );
+        }
     }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/KeywordIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/KeywordIntegrationTest.php
@@ -335,13 +335,4 @@ class KeywordIntegrationTest extends SearchMultivaluedBaseIntegrationTest
     {
         return ['commit', 'delete'];
     }
-
-    protected function checkSearchEngineSupport()
-    {
-        if (ltrim(get_class($this->getSetupFactory()), '\\') === 'eZ\\Publish\\API\\Repository\\Tests\\SetupFactory\\Legacy') {
-            $this->markTestSkipped(
-                "Keyword field type is not searchable with Legacy Search Engine"
-            );
-        }
-    }
 }

--- a/eZ/Publish/Core/FieldType/Keyword/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Keyword/SearchField.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\Keyword;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
+use eZ\Publish\SPI\FieldType\Indexable;
+use eZ\Publish\SPI\Search;
+
+/**
+ * Indexable definition for Keyword field type.
+ */
+class SearchField implements Indexable
+{
+    public function getIndexData(Field $field, FieldDefinition $fieldDefinition)
+    {
+        return array(
+            new Search\Field(
+                'value',
+                $field->value->externalData,
+                new Search\FieldType\MultipleStringField()
+            ),
+            new Search\Field(
+                'sort_value',
+                implode(' ', $field->value->externalData),
+                new Search\FieldType\StringField()
+            ),
+        );
+    }
+
+    public function getIndexDefinition()
+    {
+        return array(
+            'value' => new Search\FieldType\MultipleStringField(),
+            'sort_value' => new Search\FieldType\StringField(),
+        );
+    }
+
+    public function getDefaultMatchField()
+    {
+        return 'value';
+    }
+
+    public function getDefaultSortField()
+    {
+        return 'sort_value';
+    }
+}

--- a/eZ/Publish/Core/FieldType/Keyword/Type.php
+++ b/eZ/Publish/Core/FieldType/Keyword/Type.php
@@ -100,16 +100,13 @@ class Type extends FieldType
     /**
      * Returns information for FieldValue->$sortKey relevant to the field type.
      *
-     * @todo Review this, created from copy/paste to unblock failing tests!
-     *       According to me (PA) sorting on keywords should not be supported.
-     *
      * @param \eZ\Publish\Core\FieldType\Keyword\Value $value
      *
      * @return array
      */
     protected function getSortInfo(BaseValue $value)
     {
-        return false;
+        return implode(',', $value->values);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/KeywordConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/KeywordConverter.php
@@ -38,6 +38,7 @@ class KeywordConverter implements Converter
      */
     public function toStorageValue(FieldValue $value, StorageFieldValue $storageFieldValue)
     {
+        $storageFieldValue->sortKeyString = $value->sortKey;
     }
 
     /**
@@ -49,6 +50,7 @@ class KeywordConverter implements Converter
     public function toFieldValue(StorageFieldValue $value, FieldValue $fieldValue)
     {
         $fieldValue->data = array();
+        $fieldValue->sortKey = $value->sortKeyString;
     }
 
     /**
@@ -82,6 +84,6 @@ class KeywordConverter implements Converter
      */
     public function getIndexColumn()
     {
-        return false;
+        return 'sort_key_string';
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/KeywordTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/KeywordTest.php
@@ -65,7 +65,7 @@ class KeywordTest extends PHPUnit_Framework_TestCase
 
         $this->converter->toFieldValue($storageFieldValue, $fieldValue);
         $this->assertSame(array(), $fieldValue->data);
-        $this->assertNull($fieldValue->sortKey);
+        $this->assertEquals('', $fieldValue->sortKey);
     }
 
     /**

--- a/eZ/Publish/Core/settings/indexable_fieldtypes.yml
+++ b/eZ/Publish/Core/settings/indexable_fieldtypes.yml
@@ -1,4 +1,5 @@
 parameters:
+    ezpublish.fieldType.indexable.ezkeyword.class: eZ\Publish\Core\FieldType\Keyword\SearchField
     ezpublish.fieldType.indexable.ezauthor.class: eZ\Publish\Core\FieldType\Author\SearchField
     ezpublish.fieldType.indexable.ezstring.class: eZ\Publish\Core\FieldType\TextLine\SearchField
     ezpublish.fieldType.indexable.ezrichtext.class: eZ\Publish\Core\FieldType\RichText\SearchField
@@ -24,6 +25,11 @@ parameters:
     ezpublish.fieldType.indexable.unindexed.class: eZ\Publish\Core\FieldType\Unindexed
 
 services:
+    ezpublish.fieldType.indexable.ezkeyword:
+        class: "%ezpublish.fieldType.indexable.ezkeyword.class%"
+        tags:
+            - {name: ezpublish.fieldType.indexable, alias: ezkeyword}
+
     ezpublish.fieldType.indexable.ezauthor:
         class: "%ezpublish.fieldType.indexable.ezauthor.class%"
         tags:
@@ -140,7 +146,6 @@ services:
         class: "%ezpublish.fieldType.indexable.unindexed.class%"
         tags:
             - {name: ezpublish.fieldType.indexable, alias: ezuser}
-            - {name: ezpublish.fieldType.indexable, alias: ezkeyword}
             - {name: ezpublish.fieldType.indexable, alias: ezinisetting}
             - {name: ezpublish.fieldType.indexable, alias: ezpackage}
             - {name: ezpublish.fieldType.indexable, alias: ezmultioption}

--- a/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
@@ -251,6 +251,7 @@ services:
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_field_value_handler, alias: ezcountry}
             - {name: ezpublish.search.legacy.gateway.criterion_field_value_handler, alias: ezobjectrelationlist}
+            - {name: ezpublish.search.legacy.gateway.criterion_field_value_handler, alias: ezkeyword}
 
     ezpublish.search.legacy.gateway.criterion_field_value_handler.collection.hypen_separated:
         parent: ezpublish.search.legacy.gateway.criterion_field_value_handler.base

--- a/eZ/Publish/SPI/Tests/FieldType/KeywordIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/KeywordIntegrationTest.php
@@ -108,7 +108,7 @@ class KeywordIntegrationTest extends BaseIntegrationTest
             array(
                 'data' => array(),
                 'externalData' => array('foo', 'bar', 'sindelfingen'),
-                'sortKey' => false,
+                'sortKey' => 'foo,bar,sindelfingen',
             )
         );
     }
@@ -130,7 +130,7 @@ class KeywordIntegrationTest extends BaseIntegrationTest
         );
 
         $this->assertEquals(array(), $field->value->data);
-        $this->assertNull($field->value->sortKey);
+        $this->assertEquals('foo,bar,sindelfingen', $field->value->sortKey);
     }
 
     /**
@@ -178,7 +178,7 @@ class KeywordIntegrationTest extends BaseIntegrationTest
             array(
                 'data' => array(),
                 'externalData' => array('sindelfingen', 'baz'),
-                'sortKey' => false,
+                'sortKey' => 'sindelfingen,baz',
             )
         );
     }
@@ -201,6 +201,6 @@ class KeywordIntegrationTest extends BaseIntegrationTest
         );
 
         $this->assertEquals(array(), $field->value->data);
-        $this->assertNull($field->value->sortKey);
+        $this->assertEquals('sindelfingen,baz', $field->value->sortKey);
     }
 }


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-26705

this implements `Indexable` for the `Keyword` field type + integration tests.