### PR TITLE
Remove redundant setting of locationId attribute

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Routing/UrlAliasRouterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Routing/UrlAliasRouterTest.php
@@ -136,7 +136,6 @@ class UrlAliasRouterTest extends BaseUrlAliasRouterTest
         );
         $request = $this->getRequestByPathInfo($path);
         $this->assertEquals($expected, $this->router->matchRequest($request));
-        $this->assertSame($locationId, $request->attributes->get('locationId'));
     }
 
     public function testMatchRequestLocationCaseRedirectWithRootLocation()
@@ -190,12 +189,11 @@ class UrlAliasRouterTest extends BaseUrlAliasRouterTest
             'contentId' => 456,
             'viewType' => ViewManager::VIEW_TYPE_FULL,
             'layout' => true,
+            'semanticPathinfo' => $path,
+            'needsRedirect' => true,
         );
         $request = $this->getRequestByPathInfo($requestedPath);
         $this->assertEquals($expected, $this->router->matchRequest($request));
-        $this->assertSame($locationId, $request->attributes->get('locationId'));
-        $this->assertTrue($request->attributes->get('needsRedirect'));
-        $this->assertSame($path, $request->attributes->get('semanticPathinfo'));
     }
 
     public function testMatchRequestLocationCaseRedirectWithRootRootLocation()
@@ -249,12 +247,11 @@ class UrlAliasRouterTest extends BaseUrlAliasRouterTest
             'contentId' => 456,
             'viewType' => ViewManager::VIEW_TYPE_FULL,
             'layout' => true,
+            'semanticPathinfo' => $path,
+            'needsRedirect' => true,
         );
         $request = $this->getRequestByPathInfo($requestedPath);
         $this->assertEquals($expected, $this->router->matchRequest($request));
-        $this->assertSame($locationId, $request->attributes->get('locationId'));
-        $this->assertTrue($request->attributes->get('needsRedirect'));
-        $this->assertSame($path, $request->attributes->get('semanticPathinfo'));
     }
 
     public function testMatchRequestResourceCaseRedirectWithRootLocation()
@@ -298,11 +295,11 @@ class UrlAliasRouterTest extends BaseUrlAliasRouterTest
 
         $expected = array(
             '_route' => UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
+            'semanticPathinfo' => $path,
+            'needsRedirect' => true,
         );
         $request = $this->getRequestByPathInfo($requestedPath);
         $this->assertEquals($expected, $this->router->matchRequest($request));
-        $this->assertTrue($request->attributes->get('needsRedirect'));
-        $this->assertSame($path, $request->attributes->get('semanticPathinfo'));
     }
 
     public function testMatchRequestVirtualCaseRedirectWithRootLocation()
@@ -344,11 +341,11 @@ class UrlAliasRouterTest extends BaseUrlAliasRouterTest
 
         $expected = array(
             '_route' => UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
+            'semanticPathinfo' => $path,
+            'needsRedirect' => true,
         );
         $request = $this->getRequestByPathInfo($requestedPath);
         $this->assertEquals($expected, $this->router->matchRequest($request));
-        $this->assertTrue($request->attributes->get('needsRedirect'));
-        $this->assertSame($path, $request->attributes->get('semanticPathinfo'));
     }
 
     public function testMatchRequestWithRootLocationAndExclusion()
@@ -404,6 +401,5 @@ class UrlAliasRouterTest extends BaseUrlAliasRouterTest
             'layout' => true,
         );
         $this->assertEquals($expected, $this->router->matchRequest($request));
-        $this->assertSame($destinationId, $request->attributes->get('locationId'));
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasRouterTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasRouterTest.php
@@ -200,7 +200,6 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
             'layout' => true,
         );
         $this->assertEquals($expected, $this->router->matchRequest($request));
-        $this->assertSame($destinationId, $request->attributes->get('locationId'));
     }
 
     public function testMatchRequestLocationWithCaseRedirect()
@@ -239,11 +238,10 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
             'contentId' => 456,
             'viewType' => ViewManager::VIEW_TYPE_FULL,
             'layout' => true,
+            'needsRedirect' => true,
+            'semanticPathinfo' => $urlAliasPath,
         );
         $this->assertEquals($expected, $this->router->matchRequest($request));
-        $this->assertTrue($request->attributes->get('needsRedirect'));
-        $this->assertSame($urlAliasPath, $request->attributes->get('semanticPathinfo'));
-        $this->assertSame($destinationId, $request->attributes->get('locationId'));
     }
 
     public function testMatchRequestLocationWrongCaseUriPrefixExcluded()
@@ -282,11 +280,10 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
             'locationId' => $destinationId,
             'viewType' => ViewManager::VIEW_TYPE_FULL,
             'layout' => true,
+            'needsRedirect' => true,
+            'semanticPathinfo' => $urlAliasPath,
         );
         $this->assertEquals($expected, $this->router->matchRequest($request));
-        $this->assertTrue($request->attributes->has('needsRedirect'));
-        $this->assertSame($urlAliasPath, $request->attributes->get('semanticPathinfo'));
-        $this->assertSame($destinationId, $request->attributes->get('locationId'));
     }
 
     public function testMatchRequestLocationCorrectCaseUriPrefixExcluded()
@@ -328,7 +325,6 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $this->router->matchRequest($request));
         $this->assertFalse($request->attributes->has('needsRedirect'));
         $this->assertSame($pathInfo, $request->attributes->get('semanticPathinfo'));
-        $this->assertSame($destinationId, $request->attributes->get('locationId'));
     }
 
     public function testMatchRequestLocationHistory()
@@ -336,7 +332,10 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
         $pathInfo = '/foo/bar';
         $newPathInfo = '/foo/bar-new';
         $destinationId = 123;
-        $destinationLocation = new Location(array('id' => $destinationId, 'contentInfo' => new ContentInfo(array('id' => 456))));
+        $destinationLocation = new Location(array(
+            'id' => $destinationId,
+            'contentInfo' => new ContentInfo(array('id' => 456)),
+        ));
         $urlAlias = new URLAlias(
             array(
                 'path' => $pathInfo,
@@ -368,11 +367,11 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
             'contentId' => 456,
             'viewType' => ViewManager::VIEW_TYPE_FULL,
             'layout' => true,
+            'needsRedirect' => true,
+            'semanticPathinfo' => $newPathInfo,
+            'prependSiteaccessOnRedirect' => false,
         );
         $this->assertEquals($expected, $this->router->matchRequest($request));
-        $this->assertSame($newPathInfo, $request->attributes->get('semanticPathinfo'));
-        $this->assertTrue($request->attributes->get('needsRedirect'));
-        $this->assertFalse($request->attributes->get('prependSiteaccessOnRedirect'));
     }
 
     public function testMatchRequestLocationCustom()
@@ -409,7 +408,6 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
             'layout' => true,
         );
         $this->assertEquals($expected, $this->router->matchRequest($request));
-        $this->assertSame($destinationId, $request->attributes->get('locationId'));
     }
 
     public function testMatchRequestLocationCustomForward()
@@ -417,7 +415,10 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
         $pathInfo = '/foo/bar';
         $newPathInfo = '/foo/bar-new';
         $destinationId = 123;
-        $destinationLocation = new Location(array('id' => $destinationId, 'contentInfo' => new ContentInfo(array('id' => 456))));
+        $destinationLocation = new Location(array(
+            'id' => $destinationId,
+            'contentInfo' => new ContentInfo(array('id' => 456)),
+        ));
         $urlAlias = new URLAlias(
             array(
                 'path' => $pathInfo,
@@ -458,11 +459,11 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
             'contentId' => 456,
             'viewType' => ViewManager::VIEW_TYPE_FULL,
             'layout' => true,
+            'needsRedirect' => true,
+            'semanticPathinfo' => $newPathInfo,
+            'prependSiteaccessOnRedirect' => false,
         );
         $this->assertEquals($expected, $this->router->matchRequest($request));
-        $this->assertSame($newPathInfo, $request->attributes->get('semanticPathinfo'));
-        $this->assertTrue($request->attributes->get('needsRedirect'));
-        $this->assertFalse($request->attributes->get('prependSiteaccessOnRedirect'));
     }
 
     /**
@@ -500,9 +501,10 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
 
         $expected = array(
             '_route' => UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
+            'semanticPathinfo' => $destination,
+            'needsForward' => true,
         );
         $this->assertEquals($expected, $this->router->matchRequest($request));
-        $this->assertSame($destination, $request->attributes->get('semanticPathinfo'));
     }
 
     public function testMatchRequestResourceWithRedirect()
@@ -526,10 +528,10 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
 
         $expected = array(
             '_route' => UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
+            'needsRedirect' => true,
+            'semanticPathinfo' => $destination,
         );
         $this->assertEquals($expected, $this->router->matchRequest($request));
-        $this->assertTrue($request->attributes->get('needsRedirect'));
-        $this->assertSame($destination, $request->attributes->get('semanticPathinfo'));
     }
 
     public function testMatchRequestResourceWithCaseRedirect()
@@ -559,10 +561,10 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
 
         $expected = array(
             '_route' => UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
+            'semanticPathinfo' => $urlAliasPath,
+            'needsRedirect' => true,
         );
         $this->assertEquals($expected, $this->router->matchRequest($request));
-        $this->assertTrue($request->attributes->get('needsRedirect'));
-        $this->assertSame($urlAliasPath, $request->attributes->get('semanticPathinfo'));
     }
 
     /**
@@ -591,10 +593,10 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
 
         $expected = array(
             '_route' => UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
+            'semanticPathinfo' => $destination,
+            'needsRedirect' => true,
         );
         $this->assertEquals($expected, $this->router->matchRequest($request));
-        $this->assertTrue($request->attributes->get('needsRedirect'));
-        $this->assertSame($destination, $request->attributes->get('semanticPathinfo'));
     }
 
     public function testMatchRequestVirtual()
@@ -615,10 +617,10 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
 
         $expected = array(
             '_route' => UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
+            'semanticPathinfo' => '/',
+            'needsForward' => true,
         );
         $this->assertEquals($expected, $this->router->matchRequest($request));
-        $this->assertTrue($request->attributes->get('needsForward'));
-        $this->assertSame('/', $request->attributes->get('semanticPathinfo'));
     }
 
     public function testMatchRequestVirtualWithCaseRedirect()
@@ -645,10 +647,10 @@ class UrlAliasRouterTest extends PHPUnit_Framework_TestCase
 
         $expected = array(
             '_route' => UrlAliasRouter::URL_ALIAS_ROUTE_NAME,
+            'semanticPathinfo' => $urlAliasPath,
+            'needsRedirect' => true,
         );
         $this->assertEquals($expected, $this->router->matchRequest($request));
-        $this->assertTrue($request->attributes->get('needsRedirect'));
-        $this->assertSame($urlAliasPath, $request->attributes->get('semanticPathinfo'));
     }
 
     /**

--- a/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
@@ -144,20 +144,22 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
                         'layout' => true,
                     );
 
-                    $request->attributes->set('locationId', $urlAlias->destination);
-
                     // For Location alias setup 301 redirect to Location's current URL when:
                     // 1. alias is history
                     // 2. alias is custom with forward flag true
                     // 3. requested URL is not case-sensitive equal with the one loaded
                     if ($urlAlias->isHistory === true || ($urlAlias->isCustom === true && $urlAlias->forward === true)) {
-                        $request->attributes->set('semanticPathinfo', $this->generate($location));
-                        $request->attributes->set('needsRedirect', true);
-                        // Specify not to prepend siteaccess while redirecting when applicable since it would be already present (see UrlAliasGenerator::doGenerate())
-                        $request->attributes->set('prependSiteaccessOnRedirect', false);
+                        $params += array(
+                            'semanticPathinfo' => $this->generate($location),
+                            'needsRedirect' => true,
+                            // Specify not to prepend siteaccess while redirecting when applicable since it would be already present (see UrlAliasGenerator::doGenerate())
+                            'prependSiteaccessOnRedirect' => false,
+                        );
                     } elseif ($this->needsCaseRedirect($urlAlias, $requestedPath, $pathPrefix)) {
-                        $request->attributes->set('semanticPathinfo', $this->removePathPrefix($urlAlias->path, $pathPrefix));
-                        $request->attributes->set('needsRedirect', true);
+                        $params += array(
+                            'semanticPathinfo' => $this->removePathPrefix($urlAlias->path, $pathPrefix),
+                            'needsRedirect' => true,
+                        );
                     }
 
                     if (isset($this->logger)) {
@@ -169,15 +171,21 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
                 case URLAlias::RESOURCE:
                     // In URLAlias terms, "forward" means "redirect".
                     if ($urlAlias->forward) {
-                        $request->attributes->set('semanticPathinfo', '/' . trim($urlAlias->destination, '/'));
-                        $request->attributes->set('needsRedirect', true);
+                        $params += array(
+                            'semanticPathinfo' => '/' . trim($urlAlias->destination, '/'),
+                            'needsRedirect' => true,
+                        );
                     } elseif ($this->needsCaseRedirect($urlAlias, $requestedPath, $pathPrefix)) {
                         // Handle case-correction redirect
-                        $request->attributes->set('semanticPathinfo', $this->removePathPrefix($urlAlias->path, $pathPrefix));
-                        $request->attributes->set('needsRedirect', true);
+                        $params += array(
+                            'semanticPathinfo' => $this->removePathPrefix($urlAlias->path, $pathPrefix),
+                            'needsRedirect' => true,
+                        );
                     } else {
-                        $request->attributes->set('semanticPathinfo', '/' . trim($urlAlias->destination, '/'));
-                        $request->attributes->set('needsForward', true);
+                        $params += array(
+                            'semanticPathinfo' => '/' . trim($urlAlias->destination, '/'),
+                            'needsForward' => true,
+                        );
                     }
 
                     break;
@@ -185,12 +193,16 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
                 case URLAlias::VIRTUAL:
                     // Handle case-correction redirect
                     if ($this->needsCaseRedirect($urlAlias, $requestedPath, $pathPrefix)) {
-                        $request->attributes->set('semanticPathinfo', $this->removePathPrefix($urlAlias->path, $pathPrefix));
-                        $request->attributes->set('needsRedirect', true);
+                        $params += array(
+                            'semanticPathinfo' => $this->removePathPrefix($urlAlias->path, $pathPrefix),
+                            'needsRedirect' => true,
+                        );
                     } else {
                         // Virtual aliases should load the Content at homepage URL
-                        $request->attributes->set('semanticPathinfo', '/');
-                        $request->attributes->set('needsForward', true);
+                        $params += array(
+                            'semanticPathinfo' => '/',
+                            'needsForward' => true,
+                        );
                     }
 
                     break;


### PR DESCRIPTION
As the location is already set in the parameters the routerlistener will add the location to the request attributes