### PR TITLE
EZP-26705: Keyword field type indexes full text data

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/KeywordIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/KeywordIntegrationTest.php
@@ -335,4 +335,16 @@ class KeywordIntegrationTest extends SearchMultivaluedBaseIntegrationTest
     {
         return ['commit', 'delete'];
     }
+
+    public function checkFullTextSupport()
+    {
+        // Does nothing
+    }
+
+    protected function getFullTextIndexedFieldData()
+    {
+        return [
+            ['add', 'branch'],
+        ];
+    }
 }

--- a/eZ/Publish/Core/FieldType/Keyword/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Keyword/SearchField.php
@@ -31,6 +31,11 @@ class SearchField implements Indexable
                 implode(' ', $field->value->externalData),
                 new Search\FieldType\StringField()
             ),
+            new Search\Field(
+                'fulltext',
+                $field->value->externalData,
+                new Search\FieldType\FullTextField()
+            ),
         );
     }
 


### PR DESCRIPTION
This is additional fix for https://jira.ez.no/browse/EZP-26705

Adds indexing full text data (keywords) + integration tests.