### PR TITLE
EZP-26774: Add regression test for pure negative query handling

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Regression/PureNegativeQueryTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/PureNegativeQueryTest.php
@@ -1,0 +1,291 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\API\Repository\Tests\Regression;
+
+use eZ\Publish\API\Repository\Tests\BaseTest;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+/**
+ * This test will try to execute search queries that might be interpreted as "pure negative"
+ * by the search backend and hence produce incorrect results.
+ *
+ * @group regression
+ */
+class PureNegativeQueryTest extends BaseTest
+{
+    public function providerForTestMatchAll()
+    {
+        $query = new Query(['filter' => new Criterion\MatchAll()]);
+        $result = $this->getRepository()->getSearchService()->findContent($query);
+        // Sanity check
+        $this->assertGreaterThan(0, $result->totalCount);
+        $totalCount = $result->totalCount;
+        $contentId = 12;
+
+        return [
+            [
+                new Criterion\LogicalOr(
+                    [
+                        new Criterion\ContentId($contentId),
+                        new Criterion\MatchNone(),
+                    ]
+                ),
+                1,
+            ],
+            [
+                new Criterion\LogicalAnd(
+                    [
+                        new Criterion\ContentId($contentId),
+                        new Criterion\MatchNone(),
+                    ]
+                ),
+                0,
+            ],
+            [
+                new Criterion\LogicalOr(
+                    [
+                        new Criterion\ContentId($contentId),
+                        new Criterion\LogicalNot(
+                            new Criterion\MatchAll()
+                        ),
+                    ]
+                ),
+                1,
+            ],
+            [
+                new Criterion\LogicalAnd(
+                    [
+                        new Criterion\ContentId($contentId),
+                        new Criterion\LogicalNot(
+                            new Criterion\MatchAll()
+                        ),
+                    ]
+                ),
+                0,
+            ],
+            [
+                new Criterion\LogicalOr(
+                    [
+                        new Criterion\ContentId($contentId),
+                        new Criterion\MatchAll(),
+                    ]
+                ),
+                $totalCount,
+            ],
+            [
+                new Criterion\LogicalAnd(
+                    [
+                        new Criterion\ContentId($contentId),
+                        new Criterion\MatchAll(),
+                    ]
+                ),
+                1,
+            ],
+            [
+                new Criterion\LogicalOr(
+                    [
+                        new Criterion\MatchAll(),
+                        new Criterion\MatchNone(),
+                    ]
+                ),
+                $totalCount,
+            ],
+            [
+                new Criterion\LogicalAnd(
+                    [
+                        new Criterion\MatchAll(),
+                        new Criterion\MatchNone(),
+                    ]
+                ),
+                0,
+            ],
+            [
+                new Criterion\LogicalOr(
+                    [
+                        new Criterion\ContentId($contentId),
+                        new Criterion\LogicalNot(
+                            new Criterion\ContentId($contentId)
+                        ),
+                    ]
+                ),
+                $totalCount,
+            ],
+            [
+                new Criterion\LogicalOr(
+                    [
+                        new Criterion\ContentId($contentId),
+                        new Criterion\LogicalNot(
+                            new Criterion\LogicalNot(
+                                new Criterion\ContentId($contentId)
+                            )
+                        ),
+                    ]
+                ),
+                1,
+            ],
+            [
+                new Criterion\LogicalOr(
+                    [
+                        new Criterion\LogicalNot(
+                            new Criterion\ContentId($contentId)
+                        ),
+                        new Criterion\LogicalNot(
+                            new Criterion\LogicalNot(
+                                new Criterion\ContentId($contentId)
+                            )
+                        ),
+                    ]
+                ),
+                $totalCount,
+            ],
+            [
+                new Criterion\LogicalOr(
+                    [
+                        new Criterion\LogicalNot(
+                            new Criterion\ContentId($contentId)
+                        ),
+                        new Criterion\LogicalNot(
+                            new Criterion\ContentId($contentId)
+                        ),
+                    ]
+                ),
+                $totalCount - 1,
+            ],
+            [
+                new Criterion\LogicalAnd(
+                    [
+                        new Criterion\ContentId($contentId),
+                        new Criterion\LogicalNot(
+                            new Criterion\ContentId($contentId)
+                        ),
+                    ]
+                ),
+                0,
+            ],
+            [
+                new Criterion\LogicalAnd(
+                    [
+
+                        new Criterion\ContentId($contentId),
+                        new Criterion\LogicalNot(
+                            new Criterion\LogicalNot(
+                                new Criterion\ContentId($contentId)
+                            )
+                        ),
+                    ]
+                ),
+                1,
+            ],
+            [
+                new Criterion\LogicalAnd(
+                    [
+                        new Criterion\LogicalNot(
+                            new Criterion\ContentId($contentId)
+                        ),
+                        new Criterion\LogicalNot(
+                            new Criterion\LogicalNot(
+                                new Criterion\ContentId($contentId)
+                            )
+                        ),
+                    ]
+                ),
+                0,
+            ],
+            [
+                new Criterion\LogicalAnd(
+                    [
+                        new Criterion\LogicalNot(
+                            new Criterion\ContentId($contentId)
+                        ),
+                        new Criterion\LogicalNot(
+                            new Criterion\ContentId($contentId)
+                        ),
+                    ]
+                ),
+                $totalCount - 1,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestMatchAll
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param int $totalCount
+     */
+    public function testMatchAllContentInfoQuery($criterion, $totalCount)
+    {
+        $query = new Query(
+            [
+                'query' => $criterion,
+            ]
+        );
+
+        $result = $this->getRepository()->getSearchService()->findContentInfo($query);
+
+        $this->assertEquals($totalCount, $result->totalCount);
+    }
+
+    /**
+     * @dataProvider providerForTestMatchAll
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param int $totalCount
+     */
+    public function testMatchAllContentInfoFilter($criterion, $totalCount)
+    {
+        $query = new Query(
+            [
+                'filter' => $criterion,
+            ]
+        );
+
+        $result = $this->getRepository()->getSearchService()->findContentInfo($query);
+
+        $this->assertEquals($totalCount, $result->totalCount);
+    }
+
+    /**
+     * @dataProvider providerForTestMatchAll
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param int $totalCount
+     */
+    public function testMatchAllLocationQuery($criterion, $totalCount)
+    {
+        $query = new LocationQuery(
+            [
+                'query' => $criterion,
+            ]
+        );
+
+        $result = $this->getRepository()->getSearchService()->findLocations($query);
+
+        $this->assertEquals($totalCount, $result->totalCount);
+    }
+
+    /**
+     * @dataProvider providerForTestMatchAll
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     * @param int $totalCount
+     */
+    public function testMatchAllLocationFilter($criterion, $totalCount)
+    {
+        $query = new LocationQuery(
+            [
+                'filter' => $criterion,
+            ]
+        );
+
+        $result = $this->getRepository()->getSearchService()->findLocations($query);
+
+        $this->assertEquals($totalCount, $result->totalCount);
+    }
+}


### PR DESCRIPTION
This PR resolves https://jira.ez.no/browse/EZP-26774

Counterpart on the Solr search engine: https://github.com/ezsystems/ezplatform-solr-search-engine/pull/81

This adds tests to expose a potentially unhandled "pure negative" query.

Quoting [Solr FAQ](https://wiki.apache.org/solr/FAQ#Why_does_.27foo_AND_-baz.27_match_docs.2C_but_.27foo_AND_.28-bar.29.27_doesn.27t_.3F):

> Boolean queries must have at least one "positive" expression (ie; MUST or SHOULD) in order to match. Solr tries to help with this, and if asked to execute a BooleanQuery that does contains only negatived clauses _at the topmost level_, it adds a match all docs query (ie: *:*)
>
> If the top level BoolenQuery contains somewhere inside of it a nested BooleanQuery which contains only negated clauses, that nested query will not be modified, and it (by definition) an't match any documents -- if it is required, that means the outer query will not match. 

For more info see:
- https://issues.apache.org/jira/browse/SOLR-80
- https://mail-archives.apache.org/mod_mbox/lucene-solr-user/201006.mbox/%3Calpine.DEB.1.10.1006011609080.29455@radix.cryptio.net%3E