### PR TITLE
EZP-26777: Allow injecting arrays as a QueryTypes parameters

### DIFF
--- a/eZ/Publish/Core/QueryType/QueryParameterContentViewQueryTypeMapper.php
+++ b/eZ/Publish/Core/QueryType/QueryParameterContentViewQueryTypeMapper.php
@@ -61,13 +61,22 @@ class QueryParameterContentViewQueryTypeMapper implements ContentViewQueryTypeMa
 
     /**
      * @param ContentView $contentView
-     * @param string $queryParameterValue
+     * @param string|array $queryParameterValue
      *
      * @return mixed
      */
     private function evaluateExpression(ContentView $contentView, $queryParameterValue)
     {
-        if (substr($queryParameterValue, 0, 2) === '@=') {
+        if (is_array($queryParameterValue)) {
+            $queryParameters = [];
+            foreach ($queryParameterValue as $name => $value) {
+                $queryParameters[$name] = $this->evaluateExpression($contentView, $value);
+            }
+
+            return $queryParameters;
+        }
+
+        if (is_string($queryParameterValue) && substr($queryParameterValue, 0, 2) === '@=') {
             $language = new ExpressionLanguage();
 
             return $language->evaluate(
@@ -78,8 +87,8 @@ class QueryParameterContentViewQueryTypeMapper implements ContentViewQueryTypeMa
                     'content' => $contentView->getContent(),
                 ]
             );
-        } else {
-            return $queryParameterValue;
         }
+
+        return $queryParameterValue;
     }
 }

--- a/eZ/Publish/Core/QueryType/QueryParameterContentViewQueryTypeMapper.php
+++ b/eZ/Publish/Core/QueryType/QueryParameterContentViewQueryTypeMapper.php
@@ -87,7 +87,7 @@ class QueryParameterContentViewQueryTypeMapper implements ContentViewQueryTypeMa
      */
     private function evaluateExpression(ContentView $contentView, $queryParameterValue)
     {
-        if (substr($queryParameterValue, 0, 2) === '@=') {
+        if (is_string($queryParameterValue) && substr($queryParameterValue, 0, 2) === '@=') {
             $language = new ExpressionLanguage();
 
             return $language->evaluate(


### PR DESCRIPTION
https://jira.ez.no/browse/EZP-26777

## Step to reproduce

In confguration we can add an array of 'excluded_content_types' on query parameters for a content view.

Here is a sample configuration : 

```yaml
          content_view:
                full:
                    home:
                        controller: ez_query:LocationQueryAction
                        params:
                            query:
                                query_type: AppBundle:Children
                                parameters:
                                    parent_location_id: 2
                                    excluded_content_types:
                                        - layout
                                        - article

```

The results is an error in QueryParameterContentViewQueryTypeMapper::evaluateExpression because an array is passed instead of a string.
