### PR TITLE
EZP-26780 Implement DateMetadata criterion parser in REST

### DIFF
--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/DateMetadata.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/DateMetadata.php
@@ -8,14 +8,27 @@
  */
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
+use eZ\Publish\Core\REST\Common\Exceptions\Parser;
 use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\DateMetadata as DateMetadataCriterion;
 
 /**
  * Parser for ViewInput Criterion.
  */
 class DateMetadata extends BaseParser
 {
+    /** @var array */
+    private $availableOperators = [
+        '=',
+        '>',
+        '>=',
+        '<',
+        '<=',
+        'in',
+        'between',
+    ];
+
     /**
      * Parses input structure to a Criterion object.
      *
@@ -28,6 +41,29 @@ class DateMetadata extends BaseParser
      */
     public function parse(array $data, ParsingDispatcher $parsingDispatcher)
     {
-        throw new \Exception('@todo implement');
+        if (!array_key_exists('DateMetadataCriterion', $data)) {
+            throw new Parser('Invalid <DateMetadataCriterion> format');
+        }
+
+        if (!isset($data['DateMetadataCriterion']['Target'])) {
+            throw new Parser('Invalid <Target> format');
+        }
+        $target = $data['DateMetadataCriterion']['Target'];
+
+        if (!isset($data['DateMetadataCriterion']['Operator'])) {
+            $data['DateMetadataCriterion']['Operator'] = '=';
+        } elseif (!in_array($data['DateMetadataCriterion']['Operator'], $this->availableOperators)) {
+            throw new Parser('Invalid <Operator> format');
+        }
+
+        if (
+            !isset($data['DateMetadataCriterion']['Value']) ||
+            !in_array(gettype($data['DateMetadataCriterion']['Value']), ['integer', 'string', 'array'])
+        ) {
+            throw new Parser('Invalid <Value> format');
+        }
+        $value = $data['DateMetadataCriterion']['Value'];
+
+        return new DateMetadataCriterion($target, $data['DateMetadataCriterion']['Operator'], $value);
     }
 }

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/Criterion/DateMetadataTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/Criterion/DateMetadataTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * File containing a test class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\DateMetadata as DateMetadataCriterion;
+use eZ\Publish\Core\REST\Server\Input\Parser\Criterion\DateMetadata;
+use eZ\Publish\Core\REST\Server\Tests\Input\Parser\BaseTest;
+
+class DateMetadataTest extends BaseTest
+{
+    public function testParseProvider()
+    {
+        return [
+            [
+                ['DateMetadataCriterion' => ['Target' => 'modified', 'Operator' => '=', 'Value' => 1033917596]],
+                new DateMetadataCriterion('modified', '=', 1033917596),
+            ],
+            [
+                ['DateMetadataCriterion' => ['Target' => 'modified', 'Operator' => '<=', 'Value' => 1072180405]],
+                new DateMetadataCriterion('modified', '<=', 1072180405),
+            ],
+            [
+                ['DateMetadataCriterion' => ['Target' => 'created', 'Operator' => '=', 'Value' => 1033920830]],
+                new DateMetadataCriterion('created', '=', 1033920830),
+            ],
+        ];
+    }
+
+    /**
+     * Tests the DateMetadata parser.
+     *
+     * @dataProvider testParseProvider
+     */
+    public function testParse($data, $expected)
+    {
+        $dateMetadata = $this->getParser();
+        $result = $dateMetadata->parse($data, $this->getParsingDispatcherMock());
+
+        $this->assertEquals(
+            $expected,
+            $result,
+            'DateMetadata parser not created correctly.'
+        );
+    }
+
+    /**
+     * Test DateMetadata parser throwing exception on invalid DateMetadataCriterion format.
+     *
+     * @expectedException \eZ\Publish\Core\REST\Common\Exceptions\Parser
+     * @expectedExceptionMessage Invalid <DateMetadataCriterion> format
+     */
+    public function testParseExceptionOnInvalidCriterionFormat()
+    {
+        $inputArray = ['foo'];
+
+        $dataKeyValueObjectClass = $this->getParser();
+        $dataKeyValueObjectClass->parse($inputArray, $this->getParsingDispatcherMock());
+    }
+
+    /**
+     * Test DateMetadata parser throwing exception on invalid target format.
+     *
+     * @expectedException \eZ\Publish\Core\REST\Common\Exceptions\Parser
+     * @expectedExceptionMessage Invalid <Target> format
+     */
+    public function testParseExceptionOnInvalidTargetFormat()
+    {
+        $inputArray = [
+            'DateMetadataCriterion' => [
+                'Targett' => 'modified',
+                'Operator' => '<=',
+                'Value' => 1072180405,
+            ],
+        ];
+
+        $dataKeyValueObjectClass = $this->getParser();
+        $dataKeyValueObjectClass->parse($inputArray, $this->getParsingDispatcherMock());
+    }
+
+    /**
+     * Test DateMetadata Criterion throwing exception on invalid target value.
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Unknown DateMetadata updated
+     */
+    public function testParseExceptionOnInvalidTargetValue()
+    {
+        $inputArray = [
+            'DateMetadataCriterion' => [
+                'Target' => 'updated',
+                'Operator' => '<=',
+                'Value' => 1072180405,
+            ],
+        ];
+
+        $dataKeyValueObjectClass = $this->getParser();
+        $dataKeyValueObjectClass->parse($inputArray, $this->getParsingDispatcherMock());
+    }
+
+    /**
+     * Test DateMetadata parser throwing exception on invalid operator format.
+     *
+     * @expectedException \eZ\Publish\Core\REST\Common\Exceptions\Parser
+     * @expectedExceptionMessage Invalid <Operator> format
+     */
+    public function testParseExceptionOnInvalidOperatorFormat()
+    {
+        $inputArray = [
+            'DateMetadataCriterion' => [
+                'Target' => 'modified',
+                'Operator' => 'LTE',
+                'Value' => 1072180405,
+            ],
+        ];
+
+        $dataKeyValueObjectClass = $this->getParser();
+        $dataKeyValueObjectClass->parse($inputArray, $this->getParsingDispatcherMock());
+    }
+
+    /**
+     * Test if EQ operator is set if none passed.
+     */
+    public function testNoOperator()
+    {
+        $inputArray = [
+            'DateMetadataCriterion' => [
+                'Target' => 'modified',
+                'Value' => 1072180405,
+            ],
+        ];
+
+        $dataKeyValueObjectClass = $this->getParser();
+        $parser = $dataKeyValueObjectClass->parse($inputArray, $this->getParsingDispatcherMock());
+        $this->assertEquals('=', $parser->operator);
+    }
+
+    /**
+     * Test DateMetadata parser throwing exception on invalid value format.
+     *
+     * @expectedException \eZ\Publish\Core\REST\Common\Exceptions\Parser
+     * @expectedExceptionMessage Invalid <Value> format
+     */
+    public function testParseExceptionOnInvalidValueFormat()
+    {
+        $inputArray = [
+            'DateMetadataCriterion' => [
+                'Target' => 'created',
+                'Operator' => '<=',
+                'Value' => 123.456,
+            ],
+        ];
+
+        $dataKeyValueObjectClass = $this->getParser();
+        $dataKeyValueObjectClass->parse($inputArray, $this->getParsingDispatcherMock());
+    }
+
+    /**
+     * Returns the DateMetadata criterion parser.
+     *
+     * @return \eZ\Publish\Core\REST\Server\Input\Parser\Criterion\DateMetadata
+     */
+    protected function internalGetParser()
+    {
+        return new DateMetadata();
+    }
+}


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26780

Currently there's no `OperatorCriterion`, so there's no easy way to set `$operator` for `DateMetadataCriterion` like it's done in other parsers.

That could be done by simply passing a string value to criterion constructor, but that'd omit a specification whitelist. So there's quick check in an array of abstract class reflection constants to validate an operator input before return a criterion object.

Another approach could be to implement an `OperatorCriterion` parser, but that should be another issue(?)
