### PR TITLE
Fix composer "memory exhausted" during Travis UnitTest preparation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,8 @@ branches:
 
 # setup requirements for running unit/integration/behat tests
 before_script:
+  # Disable memory_limit for composer in PHP 5.6
+  - echo "memory_limit=-1" >> ~/.phpenv/versions/5.6/etc/conf.d/travis.ini
   # Prepare system
   - if [ "$TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_unittest.sh ; fi
   - if [ "$BEHAT_OPTS" != "" ] ; then ./bin/.travis/prepare_behat.sh ; fi


### PR DESCRIPTION
Travis UnitTest preparation fails randomly due to composers high memory consumption. It's recommended by Composer troubleshooting to run it with disabled `memory_limit` in such situations.

Example test fails:
 - https://travis-ci.org/ezsystems/ezpublish-kernel/jobs/184229805#L357
 - https://travis-ci.org/ezsystems/ezpublish-kernel/jobs/184218885#L359

Composer troubleshooting:
 - https://getcomposer.org/doc/articles/troubleshooting.md#memory-limit-errors