### PR TITLE
Escape LIKE wildcards when used for CONTAINS operator

### DIFF
--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler.php
@@ -108,7 +108,9 @@ abstract class Handler
             case Criterion\Operator::CONTAINS:
                 $filter = $query->expr->like(
                     $column,
-                    $query->bindValue('%' . $this->lowercase($criterion->value) . '%')
+                    $query->bindValue(
+                        '%' . $this->prepareLikeString($criterion->value) . '%'
+                    )
                 );
                 break;
 
@@ -117,6 +119,20 @@ abstract class Handler
         }
 
         return $filter;
+    }
+
+    /**
+     * Returns the given $string prepared for use in SQL LIKE clause.
+     *
+     * LIKE clause wildcards '%' and '_' contained in the given $string will be escaped.
+     *
+     * @param $string
+     *
+     * @return string
+     */
+    protected function prepareLikeString($string)
+    {
+        return addcslashes($this->lowercase($string), '%_');
     }
 
     /**

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler/Collection.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler/Collection.php
@@ -58,7 +58,7 @@ class Collection extends Handler
         switch ($criterion->operator) {
             case Criterion\Operator::CONTAINS:
                 $quotedColumn = $this->dbHandler->quoteColumn($column);
-                $value = $this->lowerCase($criterion->value);
+                $value = $this->prepareLikeString($criterion->value);
                 $filter = $query->expr->lOr(
                     array(
                         $query->expr->eq(


### PR DESCRIPTION
A small fix where LIKE clause wildcards (`%`, `_`) were not escaped when handling `CONTAINS` operator in Legacy search engine.