### PR TITLE
EZP-26070: PHP API support for new Publish permission

### DIFF
--- a/data/update/mysql/dbupdate-6.7.0-to-6.8.0.sql
+++ b/data/update/mysql/dbupdate-6.7.0-to-6.8.0.sql
@@ -1,0 +1,31 @@
+-- BEGIN script for EZP-26070: PHP API support for new Publish permission
+
+-- Create content/publish policy for roles that have content/create or content/edit policies
+INSERT INTO `ezpolicy` (`module_name`, `function_name`, `original_id`, `role_id`)
+  SELECT DISTINCT 'content', 'publish', `original_id`, `role_id`
+  FROM `ezpolicy`
+  WHERE `module_name` = 'content' AND `function_name` IN ('create', 'edit')
+    AND NOT EXISTS (SELECT 1 FROM `ezpolicy` WHERE `module_name` = 'content' AND `function_name` = 'publish');
+
+-- Create limitations for just created policy (policies)
+INSERT INTO `ezpolicy_limitation` (`identifier`, `policy_id`)
+  SELECT DISTINCT `l0`.`identifier`, `p1`.`id`
+  FROM `ezpolicy_limitation` AS `l0`
+  JOIN `ezpolicy` AS `p0` ON `l0`.`policy_id` = `p0`.`id`
+  JOIN `ezpolicy` AS `p1` ON `p0`.`role_id` = `p1`.`role_id` AND `p1`.`module_name` = 'content' AND `p1`.`function_name` = 'publish'
+  WHERE `p0`.`module_name` = 'content' AND `p0`.`function_name` IN ('create', 'edit');
+
+-- Create content/publish limitation values entries based on existing entries matched by limitation identifier and role
+INSERT INTO `ezpolicy_limitation_value` (`limitation_id`, `value`)
+  SELECT `l1`.`id`, `value`
+  FROM `ezpolicy_limitation` AS `l0`
+  JOIN `ezpolicy_limitation_value` AS `lv0` ON `lv0`.`limitation_id` = `l0`.`id`
+  JOIN `ezpolicy` AS `p0` ON `p0`.`id` = `l0`.`policy_id`
+  JOIN `ezpolicy_limitation` AS `l1` ON `l0`.`identifier` = `l1`.`identifier`
+  JOIN `ezpolicy` AS `p1`
+    ON `l1`.`policy_id` = `p1`.`id`
+    AND `p1`.`module_name` = 'content'
+    AND `p1`.`function_name` = 'publish'
+    AND `p1`.`role_id` = `p0`.`role_id`;
+
+-- END script for EZP-26070

--- a/data/update/postgres/dbupdate-6.7.0-to-6.8.0.sql
+++ b/data/update/postgres/dbupdate-6.7.0-to-6.8.0.sql
@@ -1,0 +1,31 @@
+-- BEGIN script for EZP-26070: PHP API support for new Publish permission
+
+-- Create content/publish policy for roles that have content/create or content/edit policies
+INSERT INTO "ezpolicy" ("module_name", "function_name", "original_id", "role_id")
+  SELECT DISTINCT 'content', 'publish', "original_id", "role_id"
+  FROM "ezpolicy"
+  WHERE "module_name" = 'content' AND "function_name" IN ('create', 'edit')
+    AND NOT EXISTS (SELECT 1 FROM "ezpolicy" WHERE "module_name" = 'content' AND "function_name" = 'publish');
+
+-- Create limitations for just created policy (policies)
+INSERT INTO "ezpolicy_limitation" ("identifier", "policy_id")
+  SELECT DISTINCT "l0"."identifier", "p1"."id"
+  FROM "ezpolicy_limitation" AS "l0"
+  JOIN "ezpolicy" AS "p0" ON "l0"."policy_id" = "p0"."id"
+  JOIN "ezpolicy" AS "p1" ON "p0"."role_id" = "p1"."role_id" AND "p1"."module_name" = 'content' AND "p1"."function_name" = 'publish'
+  WHERE "p0"."module_name" = 'content' AND "p0"."function_name" IN ('create', 'edit');
+
+-- Create content/publish limitation values entries based on existing entries matched by limitation identifier and role
+INSERT INTO "ezpolicy_limitation_value" ("limitation_id", "value")
+  SELECT "l1"."id", "value"
+  FROM "ezpolicy_limitation" AS "l0"
+  JOIN "ezpolicy_limitation_value" AS "lv0" ON "lv0"."limitation_id" = "l0"."id"
+  JOIN "ezpolicy" AS "p0" ON "p0"."id" = "l0"."policy_id"
+  JOIN "ezpolicy_limitation" AS "l1" ON "l0"."identifier" = "l1"."identifier"
+  JOIN "ezpolicy" AS "p1"
+    ON "l1"."policy_id" = "p1"."id"
+    AND "p1"."module_name" = 'content'
+    AND "p1"."function_name" = 'publish'
+    AND "p1"."role_id" = "p0"."role_id";
+
+-- END script for EZP-26070

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/policies.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/policies.yml
@@ -4,6 +4,7 @@ content:
     view_embed: [Class, Section, Owner, Node, Subtree]
     create: [Class, Section, ParentOwner, ParentGroup, ParentClass, ParentDepth, Node, Subtree, Language]
     edit: [Class, Section, Owner, Group, Node, Subtree, Language, State]
+    publish: [Class, Section, Owner, Group, Node, Subtree, Language, State]
     manage_locations: [Class, Section, Owner, Subtree]
     hide: [Class, Section, Owner, Group, Node, Subtree, Language]
     reverserelatedlist: ~

--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -136,7 +136,7 @@ abstract class BaseTest extends PHPUnit_Framework_TestCase
      */
     protected function isVersion4()
     {
-        return (isset($_ENV['backendVersion']) && '4' === $_ENV['backendVersion']);
+        return isset($_ENV['backendVersion']) && '4' === $_ENV['backendVersion'];
     }
 
     /**
@@ -333,6 +333,32 @@ abstract class BaseTest extends PHPUnit_Framework_TestCase
      */
     protected function createCustomUserVersion1($userGroupName, $roleIdentifier, RoleLimitation $roleLimitation = null)
     {
+        return $this->createCustomUserWithLogin(
+            'user',
+            'user@example.com',
+            $userGroupName,
+            $roleIdentifier,
+            $roleLimitation
+        );
+    }
+
+    /**
+     * Create a user with new user group and assign a existing role (optionally with RoleLimitation).
+     *
+     * @param string $login User login
+     * @param string $email User e-mail
+     * @param string $userGroupName Name of the new user group to create
+     * @param string $roleIdentifier Role identifier to assign to the new group
+     * @param RoleLimitation|null $roleLimitation
+     * @return \eZ\Publish\API\Repository\Values\User\User
+     */
+    protected function createCustomUserWithLogin(
+        $login,
+        $email,
+        $userGroupName,
+        $roleIdentifier,
+        RoleLimitation $roleLimitation = null
+    ) {
         $repository = $this->getRepository();
 
         /* BEGIN: Inline */
@@ -359,8 +385,8 @@ abstract class BaseTest extends PHPUnit_Framework_TestCase
 
         // Instantiate a create struct with mandatory properties
         $userCreate = $userService->newUserCreateStruct(
-            'user',
-            'user@example.com',
+            $login,
+            $email,
             'secret',
             'eng-US'
         );
@@ -368,7 +394,7 @@ abstract class BaseTest extends PHPUnit_Framework_TestCase
 
         // Set some fields required by the user ContentType
         $userCreate->setField('first_name', 'Example');
-        $userCreate->setField('last_name', 'User');
+        $userCreate->setField('last_name', ucfirst($login));
 
         // Create a new user instance.
         $user = $userService->createUser($userCreate, array($userGroup));

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -122,14 +122,22 @@ class ContentServiceTest extends BaseContentServiceTest
 
         // Give Anonymous user role additional rights
         $role = $roleService->loadRoleByIdentifier('Anonymous');
+        $roleDraft = $roleService->createRoleDraft($role);
         $policyCreateStruct = $roleService->newPolicyCreateStruct('content', 'create');
         $policyCreateStruct->addLimitation(new SectionLimitation(array('limitationValues' => array(1))));
         $policyCreateStruct->addLimitation(new LocationLimitation(array('limitationValues' => array(2))));
         $policyCreateStruct->addLimitation(new ContentTypeLimitation(array('limitationValues' => array(1))));
-        $roleService->addPolicy($role, $policyCreateStruct);
+        $roleDraft = $roleService->addPolicyByRoleDraft($roleDraft, $policyCreateStruct);
+
+        $policyCreateStruct = $roleService->newPolicyCreateStruct('content', 'publish');
+        $policyCreateStruct->addLimitation(new SectionLimitation(array('limitationValues' => array(1))));
+        $policyCreateStruct->addLimitation(new LocationLimitation(array('limitationValues' => array(2))));
+        $policyCreateStruct->addLimitation(new ContentTypeLimitation(array('limitationValues' => array(1))));
+        $roleDraft = $roleService->addPolicyByRoleDraft($roleDraft, $policyCreateStruct);
+        $roleService->publishRoleDraft($roleDraft);
 
         // Set Anonymous user as current
-        $repository->setCurrentUser($repository->getUserService()->loadUser($anonymousUserId));
+        $repository->getPermissionResolver()->setCurrentUserReference($repository->getUserService()->loadUser($anonymousUserId));
 
         // Create a new content object:
         $contentCreate = $contentService->newContentCreateStruct(

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
@@ -500,9 +500,9 @@ class UserHandlerTest extends TestCase
         );
 
         $this->assertQueryResult(
-            [[implode("\n", array_fill(0, 27, '3, ' . APIRole::STATUS_DEFINED))]],
+            [[implode("\n", array_fill(0, 28, '3, ' . APIRole::STATUS_DEFINED))]],
             $this->handler->createSelectQuery()->select('role_id, original_id')->from('ezpolicy')->where('role_id = 3'),
-            'Expected 27 policies for the published role.'
+            'Expected 28 policies for the published role.'
         );
 
         $this->assertQueryResult(

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1440,12 +1440,8 @@ class ContentService implements ContentServiceInterface
             $versionInfo->versionNo
         );
 
-        if (!$content->getVersionInfo()->getContentInfo()->published) {
-            if (!$this->repository->canUser('content', 'create', $content)) {
-                throw new UnauthorizedException('content', 'create', array('contentId' => $content->id));
-            }
-        } elseif (!$this->repository->canUser('content', 'edit', $content)) {
-            throw new UnauthorizedException('content', 'edit', array('contentId' => $content->id));
+        if (!$this->repository->canUser('content', 'publish', $content)) {
+            throw new UnauthorizedException('content', 'publish', array('contentId' => $content->id));
         }
 
         $this->repository->beginTransaction();

--- a/eZ/Publish/Core/Repository/RoleService.php
+++ b/eZ/Publish/Core/Repository/RoleService.php
@@ -101,6 +101,7 @@ class RoleService implements RoleServiceInterface
                     'view_embed' => array('Class' => true, 'Section' => true, 'Owner' => true, 'Node' => true, 'Subtree' => true),
                     'create' => array('Class' => true, 'Section' => true, 'ParentOwner' => true, 'ParentGroup' => true, 'ParentClass' => true, 'ParentDepth' => true, 'Node' => true, 'Subtree' => true, 'Language' => true),
                     'edit' => array('Class' => true, 'Section' => true, 'Owner' => true, 'Group' => true, 'Node' => true, 'Subtree' => true, 'Language' => true, 'State' => true),
+                    'publish' => array('Class' => true, 'Section' => true, 'Owner' => true, 'Group' => true, 'Node' => true, 'Subtree' => true, 'Language' => true, 'State' => true),
                     'manage_locations' => array('Class' => true, 'Section' => true, 'Owner' => true, 'Subtree' => true),
                     'hide' => array('Class' => true, 'Section' => true, 'Owner' => true, 'Group' => true, 'Node' => true, 'Subtree' => true, 'Language' => true),
                     'translate' => array('Class' => true, 'Section' => true, 'Owner' => true, 'Node' => true, 'Subtree' => true, 'Language' => true),

--- a/eZ/Publish/Core/Repository/Tests/Service/Integration/Legacy/_fixtures/clean_ezdemo_47_dump.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Integration/Legacy/_fixtures/clean_ezdemo_47_dump.php
@@ -8712,6 +8712,13 @@ Country�</literallayout></para></section>
       'original_id' => '0',
       'role_id' => '5',
     ),
+    51 => array(
+      'function_name' => 'publish',
+      'id' => '378',
+      'module_name' => 'content',
+      'original_id' => '0',
+      'role_id' => '3',
+    ),
   ),
   'ezpolicy_limitation' => array(
     0 => array(


### PR DESCRIPTION
> Status: **Ready for a review**
> Implements: [EZP-26070](https://jira.ez.no/browse/EZP-26070)

This PR implements in a very simple way [EZP-26070](https://jira.ez.no/browse/EZP-26070) just by adding new `content/publish` policy. Policies `content/edit` and `content/create` are meant for drafts.

Note: To be able to publish content, at least `content/read`, `content/versionread` and `content/edit` is required as well. We might consider `content/publish` policy to implicitly mean also all other required but I'm not a big fan of this as it would complicate permission system itself and require more extensive changes.

**TODO**:
- [x] Add new publish policy (4e88465).
- [x] Add upgrade script (all existing users with `content/edit` or `content/create` should also have `content/publish policy`) (cb14ce1).
- [x] Add unit tests (20bfe07).
- [ ] ~~Run upgrade script on database dumps _(first clean here in this repo as also used by tests here, then clean & demo of platform and studio in co-op with web team)~~ // see [comment](https://github.com/ezsystems/ezpublish-kernel/pull/1868#issuecomment-267968989)
- [x] Align existing unit tests (20bfe07).