### PR TITLE
Fix EZP-26791: Default value "Current datetime" for ezdatetime is wrongly cached

### DIFF
--- a/eZ/Publish/Core/FieldType/DateAndTime/Type.php
+++ b/eZ/Publish/Core/FieldType/DateAndTime/Type.php
@@ -150,8 +150,7 @@ class Type extends FieldType
      *
      * @param mixed $hash Null or associative array containing timestamp and optionally date in RFC850 format,
      *                    and optionally date in parseable string format (e.g. 'now', '+3 days')
-     *
-     * @deprecated timestamp is no longer used and will be removed in a future version.
+     *                    RFC850 date overrides string format, which overrides timestamp.
      *
      * @return \eZ\Publish\Core\FieldType\DateAndTime\Value $value
      */

--- a/eZ/Publish/Core/FieldType/DateAndTime/Type.php
+++ b/eZ/Publish/Core/FieldType/DateAndTime/Type.php
@@ -148,7 +148,10 @@ class Type extends FieldType
     /**
      * Converts an $hash to the Value defined by the field type.
      *
-     * @param mixed $hash Null or associative array containing timestamp and optionally date in RFC850 format.
+     * @param mixed $hash Null or associative array containing timestamp and optionally date in RFC850 format,
+     *                    and optionally date in parseable string format (e.g. 'now', '+3 days')
+     *
+     * @deprecated timestamp is no longer used and will be removed in a future version.
      *
      * @return \eZ\Publish\Core\FieldType\DateAndTime\Value $value
      */
@@ -160,6 +163,10 @@ class Type extends FieldType
 
         if (isset($hash['rfc850']) && $hash['rfc850']) {
             return Value::fromString($hash['rfc850']);
+        }
+
+        if (isset($hash['timestring']) && is_string($hash['timestring'])) {
+            return Value::fromString($hash['timestring']);
         }
 
         return Value::fromTimestamp((int)$hash['timestamp']);

--- a/eZ/Publish/Core/FieldType/Tests/DateAndTimeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/DateAndTimeTest.php
@@ -218,6 +218,35 @@ class DateAndTimeTest extends FieldTypeTest
     }
 
     /**
+     * @param mixed $inputValue
+     * @param array $expectedResult
+     *
+     * @dataProvider provideInputForFromHash
+     */
+    public function testFromHash($inputHash, $expectedResult)
+    {
+        $this->assertIsValidHashValue($inputHash);
+
+        $fieldType = $this->getFieldTypeUnderTest();
+
+        $actualResult = $fieldType->fromHash($inputHash);
+
+        // Tests may run slowly. Allow 20 seconds margin of error.
+        $this->assertGreaterThanOrEqual(
+            $expectedResult,
+            $actualResult,
+            'fromHash() method did not create expected result.'
+        );
+        if ($expectedResult->value !== null) {
+            $this->assertLessThan(
+                $expectedResult->value->getTimestamp() + 20,
+                $actualResult->value->getTimestamp(),
+                'fromHash() method did not create expected result.'
+            );
+        }
+    }
+
+    /**
      * Provide input to fromHash() method.
      *
      * Returns an array of data provider sets with 2 arguments: 1. The valid
@@ -273,6 +302,18 @@ class DateAndTimeTest extends FieldTypeTest
                     'timestamp' => $date->getTimeStamp(),
                 ),
                 DateAndTimeValue::fromTimestamp($date->getTimeStamp()),
+            ),
+            array(
+                array(
+                    'timestring' => 'now',
+                ),
+                DateAndTimeValue::fromTimestamp(time()),
+            ),
+            array(
+                array(
+                    'timestring' => '+42 seconds',
+                ),
+                DateAndTimeValue::fromTimestamp(time() + 42),
             ),
         );
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
@@ -111,7 +111,8 @@ class DateAndTimeConverter implements Converter
             case DateAndTimeType::DEFAULT_CURRENT_DATE:
                 $data = array(
                     'rfc850' => null,
-                    'timestamp' => time(),
+                    'timestamp' => time(), // @deprecated timestamp is no longer used and will be removed in a future version.
+                    'timestring' => 'now',
                 );
                 break;
 
@@ -123,7 +124,8 @@ class DateAndTimeConverter implements Converter
                 $date->add($dateInterval);
                 $data = array(
                     'rfc850' => null,
-                    'timestamp' => $date->getTimestamp(),
+                    'timestamp' => $date->getTimestamp(), // @deprecated timestamp is no longer used and will be removed in a future version.
+                    'timestring' => sprintf('%+d seconds', $date->getTimestamp() - time()),
                 );
                 break;
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/DateAndTimeTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/DateAndTimeTest.php
@@ -256,10 +256,14 @@ class DateAndTimeTest extends PHPUnit_Framework_TestCase
         );
 
         $this->converter->toFieldDefinition($storageDef, $fieldDef);
+        sleep(1);
+        $dateTimeFromString = new DateTime($fieldDef->defaultValue->data['timestring']);
+
         self::assertInternalType('array', $fieldDef->defaultValue->data);
-        self::assertCount(2, $fieldDef->defaultValue->data);
+        self::assertCount(3, $fieldDef->defaultValue->data);
         self::assertNull($fieldDef->defaultValue->data['rfc850']);
         self::assertGreaterThanOrEqual($time, $fieldDef->defaultValue->data['timestamp']);
+        self::assertEquals($time + 1, $dateTimeFromString->getTimestamp());
     }
 
     /**
@@ -284,12 +288,16 @@ class DateAndTimeTest extends PHPUnit_Framework_TestCase
         );
 
         $this->converter->toFieldDefinition($storageDef, $fieldDef);
+        $dateTimeFromString = new DateTime($fieldDef->defaultValue->data['timestring']);
+
         self::assertInternalType('array', $fieldDef->defaultValue->data);
-        self::assertCount(2, $fieldDef->defaultValue->data);
+        self::assertCount(3, $fieldDef->defaultValue->data);
         self::assertNull($fieldDef->defaultValue->data['rfc850']);
         self::assertGreaterThanOrEqual($timestamp, $fieldDef->defaultValue->data['timestamp']);
+        self::assertGreaterThanOrEqual($timestamp, $dateTimeFromString->getTimestamp());
         // Giving a margin of 1 second for test execution
         self::assertLessThanOrEqual($timestamp + 1, $fieldDef->defaultValue->data['timestamp']);
+        self::assertLessThanOrEqual($timestamp + 1, $dateTimeFromString->getTimestamp());
     }
 
     /**
@@ -316,12 +324,16 @@ class DateAndTimeTest extends PHPUnit_Framework_TestCase
         );
 
         $this->converter->toFieldDefinition($storageDef, $fieldDef);
+        $dateTimeFromString = new DateTime($fieldDef->defaultValue->data['timestring']);
+
         self::assertInternalType('array', $fieldDef->defaultValue->data);
-        self::assertCount(2, $fieldDef->defaultValue->data);
+        self::assertCount(3, $fieldDef->defaultValue->data);
         self::assertNull($fieldDef->defaultValue->data['rfc850']);
         self::assertGreaterThanOrEqual($timestamp, $fieldDef->defaultValue->data['timestamp']);
+        self::assertGreaterThanOrEqual($timestamp, $dateTimeFromString->getTimestamp());
         // Giving a margin of 1 second for test execution
         self::assertLessThanOrEqual($timestamp + 1, $fieldDef->defaultValue->data['timestamp']);
+        self::assertLessThanOrEqual($timestamp + 1, $dateTimeFromString->getTimestamp());
     }
 
     /**


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-26791
> Status: Ready to merge

Field definitions can be cached by Stash. When a DateAndTime is set to default to either the current time or an offset of the current time, this is saved as a timestamp which is cached and can go stale.

This adds a `timestring` to the default value hash the DateAndTimeConverter makes. This contains the time or offset in a string parseable by PHPs DateTime class, which the DateAndTime Type can use when converting with `fromHash()`. The existing timestamp is kept, and will work as before.

- [x] Basic tests
- [x] ~~Integration tests~~ Honestly, I don't know how to set this up and am very pressed for time. Sending to review as is.