### PR TITLE
EZP-26794 : unable to login in backend

### DIFF
--- a/eZ/Publish/Core/REST/Server/Controller/SessionController.php
+++ b/eZ/Publish/Core/REST/Server/Controller/SessionController.php
@@ -94,6 +94,7 @@ class SessionController extends Controller
         } catch (AuthenticationException $e) {
             throw new UnauthorizedException('Invalid login or password', $request->getPathInfo());
         } catch (AccessDeniedException $e) {
+            $this->authenticator->logout($request);
             throw new UnauthorizedException($e->getMessage(), $request->getPathInfo());
         }
     }


### PR DESCRIPTION
Jira : https://jira.ez.no/browse/EZP-26794

## Description :

Clear unauthorized user authentication if they don't have acces to remove siteaccess unwanted exception

## Test manually

Trying to login using a user whose user group has no assigned role
- Create a user group - Group1
- Under Group1, create a user - user1 _(don't assign any role to Group1)_
- Try to login in admin interface using the user1
- We are unable to do so, because of a "401 - unauthorized" - ok once again
- Right after, try to login as admin

-> i should work

## QA 

    composer require ezsystems/ezpublish-kernel:dev-EZP-26794-unable-to-login