### PR TITLE
EZP-26831 Make newContentCreateStruct respect ContentType defaultAlwaysAvailable

### DIFF
--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -400,6 +400,8 @@ interface ContentService
     /**
      * Instantiates a new content create struct object.
      *
+     * alwaysAvailable is set to the ContentType's defaultAlwaysAvailable
+     *
      * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
      * @param string $mainLanguageCode
      *

--- a/eZ/Publish/Core/REST/Client/ContentService.php
+++ b/eZ/Publish/Core/REST/Client/ContentService.php
@@ -654,6 +654,8 @@ class ContentService implements APIContentService, Sessionable
     /**
      * Instantiates a new content create struct object.
      *
+     * alwaysAvailable is set to the ContentType's defaultAlwaysAvailable
+     *
      * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
      * @param string $mainLanguageCode
      *

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1895,6 +1895,7 @@ class ContentService implements ContentServiceInterface
             array(
                 'contentType' => $contentType,
                 'mainLanguageCode' => $mainLanguageCode,
+                'alwaysAvailable' => $contentType->defaultAlwaysAvailable,
             )
         );
     }

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1884,6 +1884,8 @@ class ContentService implements ContentServiceInterface
     /**
      * Instantiates a new content create struct object.
      *
+     * alwaysAvailable is set to the ContentType's defaultAlwaysAvailable
+     *
      * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
      * @param string $mainLanguageCode
      *

--- a/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentBase.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Integration/ContentBase.php
@@ -673,7 +673,7 @@ abstract class ContentBase extends BaseServiceTest
             'contentType' => $contentType,
             'sectionId' => null,
             'ownerId' => null,
-            'alwaysAvailable' => null,
+            'alwaysAvailable' => $contentType->defaultAlwaysAvailable,
             'remoteId' => null,
             'mainLanguageCode' => 'eng-GB',
             'modificationDate' => null,

--- a/eZ/Publish/Core/SignalSlot/ContentService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentService.php
@@ -636,6 +636,8 @@ class ContentService implements ContentServiceInterface
     /**
      * Instantiates a new content create struct object.
      *
+     * alwaysAvailable is set to the ContentType's defaultAlwaysAvailable
+     *
      * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType $contentType
      * @param string $mainLanguageCode
      *


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-26831

When creating content the expected behavior would be that alwaysAvailable is set by default from the contentType.