### PR TITLE
EZP-26843: Limit Twig to 1.x due to 2.0 incompatibility with JMS Translation bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "oneup/flysystem-bundle": "^1.0",
         "friendsofsymfony/http-cache-bundle": "~1.2|^1.3.8",
         "sensio/framework-extra-bundle": "~3.0",
-        "jms/translation-bundle": "^1.0"
+        "jms/translation-bundle": "^1.0",
+        "twig/twig": "^1.0"
     },
     "require-dev": {
         "mikey179/vfsStream": "1.1.0",


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-26843

This limits Twig to 1.x, since JMS Translation bundle is not compatible with 2.0. JMS Translation bundle itself doesn't limit the constraint to 1.x, and seems that is half abandoned since no work was done on it in 5 months.