### PR TITLE
Allow installation of ocramius/proxy-manager ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "nelmio/cors-bundle": "^1.3.3",
         "hautelook/templated-uri-bundle": "~1.0 | ~2.0",
         "pagerfanta/pagerfanta": "~1.0",
-        "ocramius/proxy-manager": "~1.0",
+        "ocramius/proxy-manager": "^1.0|^2.0",
         "doctrine/doctrine-bundle": "~1.3",
         "liip/imagine-bundle": "~1.0",
         "oneup/flysystem-bundle": "^1.0",


### PR DESCRIPTION
While testing JMS Translation Bundle 2.0 support with Twig 2.1, I got an exception `Cannot bind closure to scope of internal class stdClass`. It turns out this is due to older version of `ocramius/proxy-manager` which does not support PHP 7 correctly.

There is no breaking changes in kernel with Proxy Manager 2.x as far as I can see.