### PR TITLE
Do not use layout when rendering line view in `settings_selectionroot` block

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
@@ -320,7 +320,7 @@
         <div class="ez-fielddefinition-setting-name">Selection root:</div>
         <div class="ez-fielddefinition-setting-value">
         {% if rootLocationId %}
-            {{ render( controller( "ez_content:viewAction", {'locationId': rootLocationId,  'viewType': 'line'} ), {'strategy': 'esi'}) }}
+            {{ render( controller( "ez_content:viewAction", {'locationId': rootLocationId,  'viewType': 'line', 'layout': false} ), {'strategy': 'esi'}) }}
         {% else %}
             <em>No defined root</em>
         {% endif %}


### PR DESCRIPTION
This makes sure to signal to line templates who potentially have a switch to render the layout or not, that layout should not be used in Platform UI when rendering a line view in Relation and RelationList field types.