### PR TITLE
EZP-26828: Added in-context translation EventSubscriber

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventSubscriber/CrowdinRequestLocaleSubscriber.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventSubscriber/CrowdinRequestLocaleSubscriber.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * If the request has an `ez_in_context_translation` cookie, sets the request accept-language
+ * to the pseudo-locale used to trigger Crowdin's in-context translation UI.
+ */
+class CrowdinRequestLocaleSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::REQUEST => [
+                ['setInContextAcceptLanguage', 100],
+            ],
+        ];
+    }
+
+    public function setInContextAcceptLanguage(GetResponseEvent $e)
+    {
+        if (!$e->getRequest()->cookies->has('ez_in_context_translation')) {
+            return;
+        }
+
+        $e->getRequest()->headers->set('accept-language', 'ach-UG');
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -230,3 +230,8 @@ services:
         class: eZ\Publish\Core\MVC\Symfony\Translation\ValidationErrorFileVisitor
         tags:
             - { name: jms_translation.file_visitor, alias: ez_validation_error }
+
+    ezplatform.core.translation.event_subscriber.crowdin_request_locale:
+        class: eZ\Bundle\EzPublishCoreBundle\EventSubscriber\CrowdinRequestLocaleSubscriber
+        tags:
+            - {name: kernel.event_subscriber}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventSubscriber/CrowdinRequestLocaleSubscriberTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventSubscriber/CrowdinRequestLocaleSubscriberTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventSubscriber;
+
+use eZ\Bundle\EzPublishCoreBundle\EventSubscriber\CrowdinRequestLocaleSubscriber;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class CrowdinRequestLocaleSubscriberTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider testSetRequestsProvider
+     */
+    public function testSetLocale(Request $request, $shouldHaveCustomLocale)
+    {
+        $event = new GetResponseEvent(
+            $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernelInterface')->getMock(),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST
+        );
+
+        $subscriber = new CrowdinRequestLocaleSubscriber();
+        $subscriber->setInContextAcceptLanguage($event);
+
+        $this->assertEquals(
+            $shouldHaveCustomLocale,
+            'ach_UG' === $event->getRequest()->getPreferredLanguage(),
+            'The custom ach_UG locale was expected to be set by the event subscriber'
+        );
+    }
+
+    public function testSetRequestsProvider()
+    {
+        return [
+            'with_ez_in_context_translation_cookie' => [
+                new Request([], [], [], ['ez_in_context_translation' => '1']),
+                true,
+            ],
+            'without_ez_in_context_translation_cookie' => [
+                new Request([], [], [], []),
+                false,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
> [EZP-26828](http://jira.ez.no/browse/EZP-26828)
> Related to https://github.com/ezsystems/PlatformUIBundle/pull/773 and https://github.com/ezsystems/ezplatform/pull/154

If an `ez_in_context_translation` cookie is set with any value, the request's accept-language
is set, using an event subscriber, to ach-UG, the pseudo-locale used by crowdin.

When the locale is ach-UG, the javascript that adds the in-context overlay is loaded.

## Adding the cookie

One way is to open the development console (right click, inspect) and run these lines:
- enable: `document.cookie='ez_in_context_translation=1;path=/;'; location.reload();`
- disable: `document.cookie='ez_in_context_translation=;expires=Mon, 05 Jul 2000 00:00:00 GMT;path=/;'; location.reload();`

An alternative is to create two bookmarks, with the following links:
- enable: `javascript:(function() {document.cookie='ez_in_context_translation=1;path=/;'; location.reload();})()`
- disable: `javascript:(function() {document.cookie='ez_in_context_translation=;expires=Mon, 05 Jul 2000 00:00:00 GMT;path=/;'; location.reload();}()`

Then click on the bookmarks from platform UI to enable/disable in-context.

An alternative we've had in mind is a symfony toolbar button that would do the same. Alternative suggestions are welcome (a specific button in platform-ui would also work, maybe even a specific page to encourage people).