### PR TITLE
EZP-26882: Location swap in some cases not clearing right UrlAlias cache

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -327,23 +327,23 @@ class UrlAliasHandler extends AbstractHandler implements UrlAliasHandlerInterfac
     /**
      * @see \eZ\Publish\SPI\Persistence\Content\UrlAlias\Handler::swap
      */
-    public function locationSwapped($location1ParentId, $location1Id, $location2ParentId, $location2Id)
+    public function locationSwapped($location1Id, $location1ParentId, $location2Id, $location2ParentId)
     {
         $this->logger->logCall(
             __METHOD__,
             [
-                'location1ParentId' => $location1ParentId,
                 'location1Id' => $location1Id,
-                'location2ParentId' => $location2ParentId,
+                'location1ParentId' => $location1ParentId,
                 'location2Id' => $location2Id,
+                'location2ParentId' => $location2ParentId,
             ]
         );
 
         $return = $this->persistenceHandler->urlAliasHandler()->locationSwapped(
-            $location1ParentId,
             $location1Id,
-            $location2ParentId,
-            $location2Id
+            $location1ParentId,
+            $location2Id,
+            $location2ParentId
         );
 
         $this->clearLocation($location1Id);

--- a/eZ/Publish/SPI/Persistence/Content/UrlAlias/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/UrlAlias/Handler.php
@@ -152,7 +152,7 @@ interface Handler
      * @param string|int $location2Id
      * @param string|int $location2ParentId
      */
-    public function locationSwapped($location1ParentId, $location1Id, $location2ParentId, $location2Id);
+    public function locationSwapped($location1Id, $location1ParentId, $location2Id, $location2ParentId);
 
     /**
      * Notifies the underlying engine that a location was deleted or moved to trash.


### PR DESCRIPTION
Introduced in #1781. Legacy handler, phpdoc on interface as seen inline, and parameters passed in repository are done in the "right order".

Todo:
- [x] Create bug, this can have potentially been hiding bugs in cache clearing logic as parent id's where effectively used to clear on and not the actual locations.
- [x] rebase for 6.7