### PR TITLE
[Travis] Force Solr Bundle to v1.1.x (Solr v4 support)

### DIFF
--- a/bin/.travis/prepare_unittest.sh
+++ b/bin/.travis/prepare_unittest.sh
@@ -39,8 +39,8 @@ COMPOSER_UPDATE=""
 
 # solr package search API integration tests
 if [ "$TEST_CONFIG" = "phpunit-integration-legacy-solr.xml" ] ; then
-    echo "> Require ezsystems/ezplatform-solr-search-engine:^1.1.0@dev"
-    composer require --no-update ezsystems/ezplatform-solr-search-engine:^1.1.0@dev
+    echo "> Require ezsystems/ezplatform-solr-search-engine:1.1.*"
+    composer require --no-update ezsystems/ezplatform-solr-search-engine:1.1.*
     COMPOSER_UPDATE="true"
 
     # Because of either some changes in travis, composer or git, composer is not able to pick version for "self" on inclusion of solr anymore, so we force it:


### PR DESCRIPTION
> **Backport**: `6.7`

When preparing PHPUnit tests, composer requires `ezsystems/ezplatform-solr-search-engine:^1.1.0@dev` which matches also current `ezplatform-solr-search-engine` version - `1.2`. However since `1.2` init_solr.sh file has changed a little bit, so we have to force `1.1.*`.

- [x] Force composer for Travis CI to use `ezsystems/ezplatform-solr-search-engine v1.1.*`
- [x] Wait for Travis to agree.
- [ ] Determine if we need to backport it to `6.6` which uses the same statement (and possibly fix older branches with similar problem).