### PR TITLE
WIP: Http multi-tagging signal slots

### DIFF
--- a/doc/specifications/cache/repository_cache_tags.md
+++ b/doc/specifications/cache/repository_cache_tags.md
@@ -1,0 +1,70 @@
+## Tags
+
+As the system is extensible, important part of this is to document the used tags to avoid wrong use, or conflicts.
+If you add own tag types, please prefix with 1-3 letters abbreviating your *(company/full)* name.
+
+The tags needs to be made in a way so that cache can be cleared using nothing but what info is available on signal,
+and the signals will need to be expanded to contain the relevant info depending on operation they correspond to.
+
+#### Content Tags
+
+
+Tags applied to Content View and Content REST Object:
+
+- `content-<content-id>`
+
+    *Tagging*: Used for tagging content responses with id.
+    
+    *Clearing*: When a operation is specifically affecting just given content.
+
+- `content-type-<content-type-id>`
+
+    *Tagging*: Used for tagging content responses with type id.
+    
+    *Clearing*: When a operation is specifically affecting content type, typically soft purge all affected content.
+
+#### Location and Content Location Tags
+
+
+- `location-<location-id>`
+
+    If content has locations we need additional tags on the content response to be able to clear on operations affecting a
+    given location or a tree.
+    
+    *Tagging*: Used for tagging content responses with all it's locations.
+    
+    *Clearing*: When a operation is specifically affecting one or several locations, on tree operations `path` is more relevant.
+
+
+- `parent-<parent-location-id>`
+
+    *Tagging*: Used for tagging content responses with all it's direct parents.
+    
+    *Clearing*: When a operation is specifically affecting parent location(s), on tree operations `path` is more relevant.
+
+- `path-<path-location-id>`
+
+##### Content Relations
+
+
+
+- `relation-<relation-content-id>`
+
+*Tagging*: Used for tagging content responses with all it's relations, where content id is the id of the other side of relation.
+*Clearing*: When operations also affect reverse relations we can clear them using content id of self.
+
+_Note: These tags are mainly relevant for field (field, embed, link) relations as change like deletion of realtion has an
+effect on the output of the given content (it should not render links to the given relation anymore)._
+
+
+
+#### Other eZ Repository domains
+
+Other domains in the Repository also have tags which follows it's name, e.g.:
+- `content-type-<id>`
+- `content-type-group-<id>`
+- `section-<id>`
+- `object-state-<id>`
+- `object-state-group-<id>`
+- `role-<id>`
+- _(..)_

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/slot.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/slot.yml
@@ -1,5 +1,5 @@
 parameters:
-    ezpublish.http_cache.signalslot.http_cache.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\HttpCacheSlot
+    ezpublish.http_cache.signalslot.abstract_content.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\AbstractContentSlot
     ezpublish.http_cache.signalslot.assign_section.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\AssignSectionSlot
     ezpublish.http_cache.signalslot.copy_content.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\CopyContentSlot
     ezpublish.http_cache.signalslot.create_location.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\CreateLocationSlot
@@ -19,116 +19,130 @@ parameters:
     ezpublish.http_cache.signalslot.trash.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\TrashSlot
     ezpublish.http_cache.signalslot.recover.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\RecoverSlot
 
+    ezpublish.http_cache.signalslot.publish_content_type.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\PublishContentTypeSlot
+    ezpublish.http_cache.signalslot.delete_content_type.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\DeleteContentTypeSlot
+
 services:
-    ezpublish.http_cache.signalslot.http_cache:
+    # Content
+    ezpublish.http_cache.signalslot.abstract_content:
         abstract: true
-        class: "%ezpublish.http_cache.signalslot.http_cache.class%"
-        arguments: ["@ezpublish.http_cache.purger"]
+        arguments: ["@ezpublish.http_cache.purge_client"]
 
     ezpublish.http_cache.signalslot.assign_section:
         class: "%ezpublish.http_cache.signalslot.assign_section.class%"
-        parent: ezpublish.http_cache.signalslot.http_cache
+        parent: ezpublish.http_cache.signalslot.abstract_content
         tags:
             - { name: ezpublish.api.slot, signal: SectionService\AssignSectionSignal }
 
     ezpublish.http_cache.signalslot.copy_content:
         class: "%ezpublish.http_cache.signalslot.copy_content.class%"
-        parent: ezpublish.http_cache.signalslot.http_cache
+        parent: ezpublish.http_cache.signalslot.abstract_content
         tags:
             - { name: ezpublish.api.slot, signal: ContentService\CopyContentSignal }
 
     ezpublish.http_cache.signalslot.create_location:
         class: "%ezpublish.http_cache.signalslot.create_location.class%"
-        parent: ezpublish.http_cache.signalslot.http_cache
+        parent: ezpublish.http_cache.signalslot.abstract_content
         tags:
             - { name: ezpublish.api.slot, signal: LocationService\CreateLocationSignal }
 
     ezpublish.http_cache.signalslot.delete_content:
         class: "%ezpublish.http_cache.signalslot.delete_content.class%"
-        parent: ezpublish.http_cache.signalslot.http_cache
+        parent: ezpublish.http_cache.signalslot.abstract_content
         tags:
             - { name: ezpublish.api.slot, signal: ContentService\DeleteContentSignal }
 
     ezpublish.http_cache.signalslot.delete_location:
         class: "%ezpublish.http_cache.signalslot.delete_location.class%"
-        parent: ezpublish.http_cache.signalslot.http_cache
+        parent: ezpublish.http_cache.signalslot.abstract_content
         tags:
             - { name: ezpublish.api.slot, signal: LocationService\DeleteLocationSignal }
 
     ezpublish.http_cache.signalslot.delete_version:
         class: "%ezpublish.http_cache.signalslot.delete_version.class%"
-        parent: ezpublish.http_cache.signalslot.http_cache
+        parent: ezpublish.http_cache.signalslot.abstract_content
         tags:
             - { name: ezpublish.api.slot, signal: ContentService\DeleteVersionSignal }
 
     ezpublish.http_cache.signalslot.hide_location:
         class: "%ezpublish.http_cache.signalslot.hide_location.class%"
-        parent: ezpublish.http_cache.signalslot.http_cache
+        parent: ezpublish.http_cache.signalslot.abstract_content
         tags:
             - { name: ezpublish.api.slot, signal: LocationService\HideLocationSignal }
 
     ezpublish.http_cache.signalslot.move_subtree:
         class: "%ezpublish.http_cache.signalslot.move_subtree.class%"
-        parent: ezpublish.http_cache.signalslot.http_cache
+        parent: ezpublish.http_cache.signalslot.abstract_content
         tags:
             - { name: ezpublish.api.slot, signal: LocationService\MoveSubtreeSignal }
 
     ezpublish.http_cache.signalslot.publish_version:
         class: "%ezpublish.http_cache.signalslot.publish_version.class%"
-        parent: ezpublish.http_cache.signalslot.http_cache
+        arguments: ["@ezpublish.http_cache.purge_client", "@ezpublish.spi.persistence.cache.locationHandler"]
         tags:
             - { name: ezpublish.api.slot, signal: ContentService\PublishVersionSignal }
 
     ezpublish.http_cache.signalslot.set_content_state:
         class: "%ezpublish.http_cache.signalslot.set_content_state.class%"
-        parent: ezpublish.http_cache.signalslot.http_cache
+        parent: ezpublish.http_cache.signalslot.abstract_content
         tags:
             - { name: ezpublish.api.slot, signal: ObjectStateService\SetContentStateSignal }
 
     ezpublish.http_cache.signalslot.swap_location:
         class: "%ezpublish.http_cache.signalslot.swap_location.class%"
-        parent: ezpublish.http_cache.signalslot.http_cache
+        parent: ezpublish.http_cache.signalslot.abstract_content
         tags:
             - { name: ezpublish.api.slot, signal: LocationService\SwapLocationSignal }
 
     ezpublish.http_cache.signalslot.unhide_location:
         class: "%ezpublish.http_cache.signalslot.unhide_location.class%"
-        parent: ezpublish.http_cache.signalslot.http_cache
+        parent: ezpublish.http_cache.signalslot.abstract_content
         tags:
             - { name: ezpublish.api.slot, signal: LocationService\UnhideLocationSignal }
 
     ezpublish.http_cache.signalslot.update_location:
         class: "%ezpublish.http_cache.signalslot.update_location.class%"
-        parent: ezpublish.http_cache.signalslot.http_cache
+        parent: ezpublish.http_cache.signalslot.abstract_content
         tags:
             - { name: ezpublish.api.slot, signal: LocationService\UpdateLocationSignal }
 
     ezpublish.http_cache.signalslot.update_user:
         class: "%ezpublish.http_cache.signalslot.update_user.class%"
-        parent: ezpublish.http_cache.signalslot.http_cache
+        parent: ezpublish.http_cache.signalslot.abstract_content
         tags:
             - { name: ezpublish.api.slot, signal: UserService\UpdateUserSignal }
 
     ezpublish.http_cache.signalslot.assign_user_to_user_group:
         class: "%ezpublish.http_cache.signalslot.assign_user_to_user_group.class%"
-        parent: ezpublish.http_cache.signalslot.http_cache
+        parent: ezpublish.http_cache.signalslot.abstract_content
         tags:
             - { name: ezpublish.api.slot, signal: UserService\AssignUserToUserGroupSignal }
 
     ezpublish.http_cache.signalslot.unassign_user_from_user_group:
         class: "%ezpublish.http_cache.signalslot.unassign_user_from_user_group.class%"
-        parent: ezpublish.http_cache.signalslot.http_cache
+        parent: ezpublish.http_cache.signalslot.abstract_content
         tags:
             - { name: ezpublish.api.slot, signal: UserService\UnAssignUserFromUserGroupSignal }
 
     ezpublish.http_cache.signalslot.trash:
         class: "%ezpublish.http_cache.signalslot.trash.class%"
-        parent: ezpublish.http_cache.signalslot.http_cache
+        parent: ezpublish.http_cache.signalslot.abstract_content
         tags:
             - { name: ezpublish.api.slot, signal: TrashService\TrashSignal }
 
     ezpublish.http_cache.signalslot.recover:
         class: "%ezpublish.http_cache.signalslot.recover.class%"
-        parent: ezpublish.http_cache.signalslot.http_cache
+        parent: ezpublish.http_cache.signalslot.abstract_content
         tags:
             - { name: ezpublish.api.slot, signal: TrashService\RecoverSignal }
+
+    # Content Type
+    ezpublish.http_cache.signalslot.publish_content_type:
+        class: "%ezpublish.http_cache.signalslot.publish_content_type.class%"
+        arguments: ["@ezpublish.http_cache.purge_client"]
+        tags: [{ name: ezpublish.api.slot, signal: ContentTypeService\PublishContentTypeDraftSignal }]
+
+    ezpublish.http_cache.signalslot.delete_content_type:
+        class: "%ezpublish.http_cache.signalslot.delete_content_type.class%"
+        arguments: ["@ezpublish.http_cache.purge_client"]
+        tags: [{ name: ezpublish.api.slot, signal: ContentTypeService\DeleteContentTypeSignal }]

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/AbstractContentSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/AbstractContentSlot.php
@@ -27,7 +27,7 @@ abstract class AbstractContentSlot extends AbstractSlot
      */
     protected function purgeHttpCache(Signal $signal)
     {
-        return $this->purgeClient->purgeByTags($this->generateTags($signal));
+        return $this->purgeClient->purge($this->generateTags($signal));
     }
 
     /**

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/AbstractContentSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/AbstractContentSlot.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * An abstract HTTP Cache purging Slot that purges cache for a Content.
+ *
+ * Will by default use the contentId property of the signal object, as it is the most common. Set generateTags()
+ * method in case of different signals or need to clear more then the defaults.
+ */
+abstract class AbstractContentSlot extends AbstractSlot
+{
+    /**
+     * Purges relevant HTTP cache for $signal.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return mixed
+     */
+    protected function purgeHttpCache(Signal $signal)
+    {
+        return $this->purgeClient->purgeByTags($this->generateTags($signal));
+    }
+
+    /**
+     * Default provides tags to clear content, relation, location, parent and sibling cache.
+     *
+     * Overload for tree operations where you also need to clear whole path.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return array
+     */
+    protected function generateTags(Signal $signal)
+    {
+        $tags = [];
+
+        if (isset($signal->contentId)) {
+            // self in all forms (also withouth locations)
+            $tags[] = 'content-' . $signal->contentId;
+            // reverse relations
+            $tags[] = 'relation-' . $signal->contentId;
+        }
+
+        if (isset($signal->locationId)) {
+            // self
+            $tags[] = 'location-' . $signal->locationId;
+            // direct children
+            $tags[] = 'parent-' . $signal->locationId;
+        }
+
+        if (isset($signal->parentLocationId)) {
+            // direct parent
+            $tags[] = 'location-' . $signal->parentLocationId;
+            // direct siblings
+            $tags[] = 'parent-' . $signal->parentLocationId;
+        }
+
+        return $tags;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/AbstractSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/AbstractSlot.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot;
+
+use eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface;
+use eZ\Publish\Core\SignalSlot\Signal;
+use eZ\Publish\Core\SignalSlot\Slot;
+
+/**
+ * A abstract legacy slot covering common functions needed for legacy slots.
+ */
+abstract class AbstractSlot extends Slot
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface
+     */
+    protected $purgeClient;
+
+    /**
+     * @param \eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface $purgeClient
+     */
+    public function __construct(PurgeClientInterface $purgeClient)
+    {
+        $this->purgeClient = $purgeClient;
+    }
+
+    public function receive(Signal $signal)
+    {
+        if (!$this->supports($signal)) {
+            return;
+        }
+
+        $this->purgeHttpCache($signal);
+    }
+
+    /**
+     * Checks if $signal is supported by this handler.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return bool
+     */
+    abstract protected function supports(Signal $signal);
+
+    /**
+     * Purges relevant HTTP cache for $signal.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal $signal
+     *
+     * @return mixed
+     */
+    abstract protected function purgeHttpCache(Signal $signal);
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/AssignSectionSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/AssignSectionSlot.php
@@ -13,7 +13,7 @@ use eZ\Publish\Core\SignalSlot\Signal;
 /**
  * A slot handling AssignSectionSignal.
  */
-class AssignSectionSlot extends PurgeForContentHttpCacheSlot
+class AssignSectionSlot extends AbstractContentSlot
 {
     protected function supports(Signal $signal)
     {

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/AssignUserToUserGroupSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/AssignUserToUserGroupSlot.php
@@ -15,14 +15,14 @@ use eZ\Publish\Core\SignalSlot\Signal;
  *
  * @todo This might be incomplete: what about the user's own http cache (user hash) ?
  */
-class AssignUserToUserGroupSlot extends PurgeForContentHttpCacheSlot
+class AssignUserToUserGroupSlot extends AbstractContentSlot
 {
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal\UserService\AssignUserToUserGroupSignal $signal
      */
-    protected function extractContentId(Signal $signal)
+    protected function generateTags(Signal $signal)
     {
-        return $signal->userId;
+        return ['content-' . $signal->userId, 'content-' . $signal->userGroupId];
     }
 
     protected function supports(Signal $signal)

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/CopyContentSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/CopyContentSlot.php
@@ -13,14 +13,14 @@ use eZ\Publish\Core\SignalSlot\Signal;
 /**
  * A slot handling CopyContentSignal.
  */
-class CopyContentSlot extends PurgeForContentHttpCacheSlot
+class CopyContentSlot extends AbstractContentSlot
 {
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal\ContentService\CopyContentSignal $signal
      */
-    protected function extractContentId(Signal $signal)
+    protected function generateTags(Signal $signal)
     {
-        return $signal->dstContentId;
+        return ['content-' . $signal->dstContentId, 'location-' . $signal->dstParentLocationId, 'path-' . $signal->dstParentLocationId];
     }
 
     protected function supports(Signal $signal)

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/CreateLocationSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/CreateLocationSlot.php
@@ -13,7 +13,7 @@ use eZ\Publish\Core\SignalSlot\Signal;
 /**
  * A slot handling CreateLocationSignal.
  */
-class CreateLocationSlot extends PurgeForContentHttpCacheSlot
+class CreateLocationSlot extends AbstractContentSlot
 {
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal $signal

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/DeleteContentSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/DeleteContentSlot.php
@@ -12,11 +12,22 @@ use eZ\Publish\Core\SignalSlot\Signal;
 
 /**
  * A slot handling DeleteContentSignal.
- *
- * @todo Change to clear precise cache items on content deletion (implies changes to how this signal is used and emitted).
  */
-class DeleteContentSlot extends PurgeAllHttpCacheSlot
+class DeleteContentSlot extends AbstractContentSlot
 {
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteContentSignal $signal
+     */
+    protected function generateTags(Signal $signal)
+    {
+        $tags = parent::generateTags($signal);
+        foreach ($signal->affectedLocationIds as $locationId) {
+            $tags[] = 'path-' . $locationId;
+        }
+
+        return $tags;
+    }
+
     protected function supports(Signal $signal)
     {
         return $signal instanceof Signal\ContentService\DeleteContentSignal;

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/DeleteContentTypeSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/DeleteContentTypeSlot.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling DeleteContentTypeSlot.
+ */
+class DeleteContentTypeSlot extends AbstractSlot
+{
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\ContentTypeService\DeleteContentTypeSignal;
+    }
+
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\DeleteContentTypeSignal $signal
+     *
+     * @return mixed
+     */
+    protected function purgeHttpCache(Signal $signal)
+    {
+        return $this->purgeClient->purgeByTags(['content-type-' . $signal->contentTypeId]);
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/DeleteContentTypeSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/DeleteContentTypeSlot.php
@@ -27,6 +27,6 @@ class DeleteContentTypeSlot extends AbstractSlot
      */
     protected function purgeHttpCache(Signal $signal)
     {
-        return $this->purgeClient->purgeByTags(['content-type-' . $signal->contentTypeId]);
+        return $this->purgeClient->purge(['content-type-' . $signal->contentTypeId]);
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/DeleteLocationSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/DeleteLocationSlot.php
@@ -8,37 +8,26 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot;
 
-use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\Core\SignalSlot\Signal;
 
 /**
  * A slot handling DeleteLocationSignal.
  */
-class DeleteLocationSlot extends PurgeForContentHttpCacheSlot
+class DeleteLocationSlot extends AbstractContentSlot
 {
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\LocationService\DeleteLocationSignal $signal
+     */
+    protected function generateTags(Signal $signal)
+    {
+        $tags = parent::generateTags($signal);
+        $tags[] = 'path-' . $signal->locationId;
+
+        return $tags;
+    }
+
     protected function supports(Signal $signal)
     {
         return $signal instanceof Signal\LocationService\DeleteLocationSignal;
-    }
-
-    /**
-     * Purges relevant location cache.
-     *
-     * @todo Change to be able to clear relations, siblings, ... cache, even when content is already deleted.
-     *
-     * @param \eZ\Publish\Core\SignalSlot\Signal\LocationService\DeleteLocationSignal $signal
-     *
-     * @return mixed
-     */
-    protected function purgeHttpCache(Signal $signal)
-    {
-        try {
-            $locationIds = $this->extractLocationIds($signal);
-
-            return $this->httpCacheClearer->purgeForContent($this->extractContentId($signal), $locationIds);
-        } catch (NotFoundException $e) {
-            // if content was deleted as well by this operation then fall back to clear location and parent location cache.
-            $this->httpCacheClearer->purge($locationIds);
-        }
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/DeleteVersionSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/DeleteVersionSlot.php
@@ -13,7 +13,7 @@ use eZ\Publish\Core\SignalSlot\Signal;
 /**
  * A slot handling DeleteVersionSignal.
  */
-class DeleteVersionSlot extends PurgeForContentHttpCacheSlot
+class DeleteVersionSlot extends AbstractContentSlot
 {
     protected function supports(Signal $signal)
     {

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/HideLocationSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/HideLocationSlot.php
@@ -13,8 +13,19 @@ use eZ\Publish\Core\SignalSlot\Signal;
 /**
  * A slot handling HideLocationSignal.
  */
-class HideLocationSlot extends PurgeForContentHttpCacheSlot
+class HideLocationSlot extends AbstractContentSlot
 {
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\LocationService\HideLocationSignal $signal
+     */
+    protected function generateTags(Signal $signal)
+    {
+        $tags = parent::generateTags($signal);
+        $tags[] = 'path-' . $signal->locationId;
+
+        return $tags;
+    }
+
     protected function supports(Signal $signal)
     {
         return $signal instanceof Signal\LocationService\HideLocationSignal;

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/MoveSubtreeSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/MoveSubtreeSlot.php
@@ -13,8 +13,21 @@ use eZ\Publish\Core\SignalSlot\Signal;
 /**
  * A slot handling MoveSubtreeSignal.
  */
-class MoveSubtreeSlot extends PurgeAllHttpCacheSlot
+class MoveSubtreeSlot extends AbstractContentSlot
 {
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\LocationService\MoveSubtreeSignal $signal
+     */
+    protected function generateTags(Signal $signal)
+    {
+        // @todo Missing info to clear sibling and parent cache of old parent!
+        return [
+            'path-' . $signal->locationId,
+            'location-' . $signal->newParentLocationId,
+            'parent-' . $signal->newParentLocationId,
+        ];
+    }
+
     protected function supports(Signal $signal)
     {
         return $signal instanceof Signal\LocationService\MoveSubtreeSignal;

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/PublishContentTypeSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/PublishContentTypeSlot.php
@@ -27,6 +27,6 @@ class PublishContentTypeSlot extends AbstractSlot
      */
     protected function purgeHttpCache(Signal $signal)
     {
-        return $this->purgeClient->purgeByTags(['content-type-' . $signal->contentTypeDraftId]);
+        return $this->purgeClient->purge(['content-type-' . $signal->contentTypeDraftId]);
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/PublishContentTypeSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/PublishContentTypeSlot.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling PublishContentTypeDraftSignal.
+ */
+class PublishContentTypeSlot extends AbstractSlot
+{
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\ContentTypeService\PublishContentTypeDraftSignal;
+    }
+
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\PublishContentTypeDraftSignal $signal
+     *
+     * @return mixed
+     */
+    protected function purgeHttpCache(Signal $signal)
+    {
+        return $this->purgeClient->purgeByTags(['content-type-' . $signal->contentTypeDraftId]);
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/PublishVersionSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/PublishVersionSlot.php
@@ -8,13 +8,56 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot;
 
+use eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface;
 use eZ\Publish\Core\SignalSlot\Signal;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler;
 
 /**
  * A slot handling PublishVersionSignal.
  */
-class PublishVersionSlot extends PurgeForContentHttpCacheSlot
+class PublishVersionSlot extends AbstractContentSlot
 {
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Location\Handler
+     */
+    private $locationHandler;
+
+    /**
+     * @param \eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface $purgeClient
+     * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $spiLocationHandler
+     */
+    public function __construct(PurgeClientInterface $purgeClient, Handler $spiLocationHandler)
+    {
+        parent::__construct($purgeClient);
+        $this->locationHandler = $spiLocationHandler;
+    }
+
+    /**
+     * Default provides tags to clear content, relation, location, parent and sibling cache.
+     *
+     * Overload for tree operations where you also need to clear whole path.
+     *
+     * @param \eZ\Publish\Core\SignalSlot\Signal\ContentService\PublishVersionSignal $signal
+     *
+     * @return array
+     */
+    protected function generateTags(Signal $signal)
+    {
+        $tags = parent::generateTags($signal);
+        foreach ($this->locationHandler->loadLocationsByContent($signal->contentId) as $location) {
+            // self
+            $tags[] = 'location-' . $location->id;
+            // children
+            $tags[] = 'parent-' . $location->id;
+            // parent
+            $tags[] = 'location-' . $location->parentId;
+            // siblings
+            $tags[] = 'parent-' . $location->parentId;
+        }
+
+        return $tags;
+    }
+
     protected function supports(Signal $signal)
     {
         return $signal instanceof Signal\ContentService\PublishVersionSignal;

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/RecoverSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/RecoverSlot.php
@@ -13,15 +13,22 @@ use eZ\Publish\Core\SignalSlot\Signal;
 /**
  * A slot handling RecoverSignal.
  */
-class RecoverSlot extends PurgeForContentHttpCacheSlot
+class RecoverSlot extends AbstractContentSlot
 {
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\TrashService\RecoverSignal $signal
+     */
+    protected function generateTags(Signal $signal)
+    {
+        $tags = parent::generateTags($signal);
+        $tags[] = 'location-' . $signal->newParentLocationId;
+        $tags[] = 'parent-' . $signal->newParentLocationId;
+
+        return $tags;
+    }
+
     protected function supports(Signal $signal)
     {
         return $signal instanceof Signal\TrashService\RecoverSignal;
-    }
-
-    protected function extractLocationIds(Signal $signal)
-    {
-        return [$signal->newParentLocationId];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/SetContentStateSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/SetContentStateSlot.php
@@ -13,7 +13,7 @@ use eZ\Publish\Core\SignalSlot\Signal;
 /**
  * A slot handling SetContentStateSignal.
  */
-class SetContentStateSlot extends PurgeForContentHttpCacheSlot
+class SetContentStateSlot extends AbstractContentSlot
 {
     protected function supports(Signal $signal)
     {

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/SwapLocationSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/SwapLocationSlot.php
@@ -13,27 +13,23 @@ use eZ\Publish\Core\SignalSlot\Signal;
 /**
  * A slot handling SwapLocationSignal.
  */
-class SwapLocationSlot extends HttpCacheSlot
+class SwapLocationSlot extends AbstractContentSlot
 {
     /**
-     * Not required by this implementation.
+     * @param \eZ\Publish\Core\SignalSlot\Signal\LocationService\SwapLocationSignal $signal
      */
-    protected function extractContentId(Signal $signal)
+    protected function generateTags(Signal $signal)
     {
-        return null;
+        return [
+            'location-' . $signal->location1Id,
+            'parent-' . $signal->location1Id,
+            'location-' . $signal->location1Id,
+            'parent-' . $signal->location2Id,
+        ];
     }
 
     protected function supports(Signal $signal)
     {
         return $signal instanceof Signal\LocationService\SwapLocationSignal;
-    }
-
-    /**
-     * @param \eZ\Publish\Core\SignalSlot\Signal\LocationService\SwapLocationSignal $signal
-     */
-    protected function purgeHttpCache(Signal $signal)
-    {
-        $this->httpCacheClearer->purgeForContent($signal->content1Id);
-        $this->httpCacheClearer->purgeForContent($signal->content2Id);
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/SwapLocationSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/SwapLocationSlot.php
@@ -23,7 +23,7 @@ class SwapLocationSlot extends AbstractContentSlot
         return [
             'location-' . $signal->location1Id,
             'parent-' . $signal->location1Id,
-            'location-' . $signal->location1Id,
+            'location-' . $signal->location2Id,
             'parent-' . $signal->location2Id,
         ];
     }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/TrashSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/TrashSlot.php
@@ -13,7 +13,7 @@ use eZ\Publish\Core\SignalSlot\Signal;
 /**
  * A slot handling TrashSignal.
  */
-class TrashSlot extends PurgeForContentHttpCacheSlot
+class TrashSlot extends AbstractContentSlot
 {
     protected function supports(Signal $signal)
     {

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/UnassignUserFromUserGroupSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/UnassignUserFromUserGroupSlot.php
@@ -18,8 +18,16 @@ use eZ\Publish\Core\SignalSlot\Signal;
  * The User's Content's HTTP cache must be cleared, yes.
  * And the user must be logged out, or its user hash cleared (not sure we can without clearing for all users)
  */
-class UnassignUserFromUserGroupSlot extends PurgeAllHttpCacheSlot
+class UnassignUserFromUserGroupSlot extends AbstractContentSlot
 {
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\UserService\UnAssignUserFromUserGroupSignal $signal
+     */
+    protected function generateTags(Signal $signal)
+    {
+        return ['content-' . $signal->userId, 'content-' . $signal->userGroupId];
+    }
+
     protected function supports(Signal $signal)
     {
         return $signal instanceof Signal\UserService\UnAssignUserFromUserGroupSignal;

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/UnhideLocationSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/UnhideLocationSlot.php
@@ -13,8 +13,19 @@ use eZ\Publish\Core\SignalSlot\Signal;
 /**
  * A slot handling UnhideLocationSignal.
  */
-class UnhideLocationSlot extends PurgeForContentHttpCacheSlot
+class UnhideLocationSlot extends AbstractContentSlot
 {
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\LocationService\UnhideLocationSignal $signal
+     */
+    protected function generateTags(Signal $signal)
+    {
+        $tags = parent::generateTags($signal);
+        $tags[] = 'path-' . $signal->locationId;
+
+        return $tags;
+    }
+
     protected function supports(Signal $signal)
     {
         return $signal instanceof Signal\LocationService\UnhideLocationSignal;

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/UpdateLocationSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/UpdateLocationSlot.php
@@ -12,8 +12,10 @@ use eZ\Publish\Core\SignalSlot\Signal;
 
 /**
  * A slot handling UpdateLocationSignal.
+ *
+ * @todo Signal missing info on parent location, which is relevant if priority of location was updated.
  */
-class UpdateLocationSlot extends PurgeForContentHttpCacheSlot
+class UpdateLocationSlot extends AbstractContentSlot
 {
     protected function supports(Signal $signal)
     {

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/UpdateUserSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/UpdateUserSlot.php
@@ -13,14 +13,14 @@ use eZ\Publish\Core\SignalSlot\Signal;
 /**
  * A slot handling UpdateUserSignal.
  */
-class UpdateUserSlot extends PurgeForContentHttpCacheSlot
+class UpdateUserSlot extends AbstractContentSlot
 {
     /**
      * @param \eZ\Publish\Core\SignalSlot\Signal\UserService\UpdateUserSignal $signal
      */
-    protected function extractContentId(Signal $signal)
+    protected function generateTags(Signal $signal)
     {
-        return $signal->userId;
+        return ['content-' . $signal->userId];
     }
 
     protected function supports(Signal $signal)

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/AbstractContentSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/AbstractContentSlotTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
+
+abstract class AbstractContentSlotTest extends AbstractSlotTest
+{
+    protected $contentId = 42;
+    protected $locationId = null;
+    protected $parentLocationId = null;
+
+    /**
+     * @return array
+     */
+    public function generateTags()
+    {
+        $tags = [];
+        if ($this->contentId) {
+            $tags = ['content-' . $this->contentId, 'relation-' . $this->contentId];
+        }
+
+        if ($this->locationId) {
+            // self(s)
+            $tags[] = 'location-' . $this->locationId;
+            // children
+            $tags[] = 'parent-' . $this->locationId;
+        }
+
+        if ($this->parentLocationId) {
+            // parent(s)
+            $tags[] = 'location-' . $this->parentLocationId;
+            // siblings
+            $tags[] = 'parent-' . $this->parentLocationId;
+        }
+
+        return $tags;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/AbstractSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/AbstractSlotTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
+use eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface;
 use PHPUnit_Framework_TestCase;
 
 abstract class AbstractSlotTest extends PHPUnit_Framework_TestCase
@@ -22,7 +23,7 @@ abstract class AbstractSlotTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->purgeClientMock = $this->getMock('eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface');
+        $this->purgeClientMock = $this->getMock(PurgeClientInterface::class);
         $this->slot = $this->createSlot();
         $this->signal = $this->createSignal();
     }
@@ -40,7 +41,6 @@ abstract class AbstractSlotTest extends PHPUnit_Framework_TestCase
     public function testDoesNotReceiveOtherSignals($signal)
     {
         $this->purgeClientMock->expects($this->never())->method('purge');
-        $this->purgeClientMock->expects($this->never())->method('purgeByTags');
         $this->purgeClientMock->expects($this->never())->method('purgeAll');
 
         $this->slot->receive($signal);
@@ -51,7 +51,7 @@ abstract class AbstractSlotTest extends PHPUnit_Framework_TestCase
      */
     public function testReceivePurgesCacheForTags($signal)
     {
-        $this->purgeClientMock->expects($this->once())->method('purgeByTags')->with($this->generateTags());
+        $this->purgeClientMock->expects($this->once())->method('purge')->with($this->generateTags());
         $this->purgeClientMock->expects($this->never())->method('purgeAll');
         $this->receive($signal);
     }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/AbstractSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/AbstractSlotTest.php
@@ -10,38 +10,28 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use PHPUnit_Framework_TestCase;
 
-abstract class AbstractSlotTest extends PHPUnit_Framework_TestCase implements SlotTest
+abstract class AbstractSlotTest extends PHPUnit_Framework_TestCase
 {
-    /** @var \eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\AssignSectionSlot */
+    /** @var \eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\AbstractSlot */
     protected $slot;
 
-    /** @var \eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger|\PHPUnit_Framework_MockObject_MockObject */
-    protected $cachePurgerMock;
+    /** @var \eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface|\PHPUnit_Framework_MockObject_MockObject */
+    protected $purgeClientMock;
 
-    private $contentId = 42;
-
-    private static $signal;
+    private $signal;
 
     public function setUp()
     {
-        $this->cachePurgerMock = $this->getMock('eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger');
+        $this->purgeClientMock = $this->getMock('eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface');
         $this->slot = $this->createSlot();
-        self::$signal = $this->createSignal();
+        $this->signal = $this->createSignal();
     }
 
     protected function createSlot()
     {
         $class = $this->getSlotClass();
 
-        return new $class($this->cachePurgerMock);
-    }
-
-    /**
-     * @return \eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger|\PHPUnit_Framework_MockObject_MockObject
-     */
-    protected function getCachePurger()
-    {
-        return $this->cachePurgerMock;
+        return new $class($this->purgeClientMock);
     }
 
     /**
@@ -49,34 +39,50 @@ abstract class AbstractSlotTest extends PHPUnit_Framework_TestCase implements Sl
      */
     public function testDoesNotReceiveOtherSignals($signal)
     {
-        $this->cachePurgerMock->expects($this->never())->method('purgeForContent');
-        $this->cachePurgerMock->expects($this->never())->method('purgeAll');
+        $this->purgeClientMock->expects($this->never())->method('purge');
+        $this->purgeClientMock->expects($this->never())->method('purgeByTags');
+        $this->purgeClientMock->expects($this->never())->method('purgeAll');
 
         $this->slot->receive($signal);
     }
+
+    /**
+     * @dataProvider getReceivedSignals
+     */
+    public function testReceivePurgesCacheForTags($signal)
+    {
+        $this->purgeClientMock->expects($this->once())->method('purgeByTags')->with($this->generateTags());
+        $this->purgeClientMock->expects($this->never())->method('purgeAll');
+        $this->receive($signal);
+    }
+
+    /**
+     * @return array
+     */
+    abstract public function generateTags();
 
     protected function receive($signal)
     {
         $this->slot->receive($signal);
     }
 
-    public static function getReceivedSignals()
+    public function getReceivedSignals()
     {
-        return [[static::createSignal()]];
+        return [[$this->createSignal()]];
     }
 
     /**
      * All existing SignalSlots.
      */
-    public static function getUnreceivedSignals()
+    public function getUnreceivedSignals()
     {
-        static $arguments = [];
+        $arguments = [];
 
         if (empty($arguments)) {
-            $signals = self::getAllSignals();
+            $signals = $this->getAllSignals();
 
             foreach ($signals as $signalClass) {
-                if (in_array($signalClass, static::getReceivedSignalClasses())) {
+                if (in_array($signalClass, $this->getReceivedSignalClasses())) {
                     continue;
                 }
                 $arguments[] = [new $signalClass()];
@@ -89,7 +95,7 @@ abstract class AbstractSlotTest extends PHPUnit_Framework_TestCase implements Sl
     /**
      * @return array
      */
-    private static function getAllSignals()
+    private function getAllSignals()
     {
         return array(
             'eZ\Publish\Core\SignalSlot\Signal\URLAliasService\CreateUrlAliasSignal',

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/AssignSectionSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/AssignSectionSlotTest.php
@@ -10,11 +10,11 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\SectionService\AssignSectionSignal;
 
-class AssignSectionSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
+class AssignSectionSlotTest extends AbstractContentSlotTest
 {
-    public static function createSignal()
+    public function createSignal()
     {
-        return new AssignSectionSignal(['contentId' => self::getContentId()]);
+        return new AssignSectionSignal(['contentId' => $this->contentId]);
     }
 
     public function getSlotClass()
@@ -22,7 +22,7 @@ class AssignSectionSlotTest extends AbstractPurgeForContentSlotTest implements S
         return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\AssignSectionSlot';
     }
 
-    public static function getReceivedSignalClasses()
+    public function getReceivedSignalClasses()
     {
         return ['eZ\Publish\Core\SignalSlot\Signal\SectionService\AssignSectionSignal'];
     }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/AssignUserToUserGroupSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/AssignUserToUserGroupSlotTest.php
@@ -8,6 +8,27 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
-class AssignUserToUserGroupSlotTest
+use eZ\Publish\Core\SignalSlot\Signal\UserService\AssignUserToUserGroupSignal;
+
+class AssignUserToUserGroupSlotTest extends AbstractContentSlotTest
 {
+    public function createSignal()
+    {
+        return new AssignUserToUserGroupSignal(['userId' => $this->contentId, 'userGroupId' => 99]);
+    }
+
+    public function generateTags()
+    {
+        return ['content-' . $this->contentId, 'content-99'];
+    }
+
+    public function getSlotClass()
+    {
+        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\AssignUserToUserGroupSlot';
+    }
+
+    public function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\UserService\AssignUserToUserGroupSignal'];
+    }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/CopyContentSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/CopyContentSlotTest.php
@@ -10,11 +10,18 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\ContentService\CopyContentSignal;
 
-class CopyContentSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
+class CopyContentSlotTest extends AbstractContentSlotTest
 {
-    public static function createSignal()
+    protected $parentLocationId = 59;
+
+    public function createSignal()
     {
-        return new CopyContentSignal(['srcContentId' => 66, 'dstContentId' => self::getContentId()]);
+        return new CopyContentSignal(['dstContentId' => $this->contentId, 'dstParentLocationId' => $this->parentLocationId]);
+    }
+
+    public function generateTags()
+    {
+        return ['content-' . $this->contentId, 'location-' . $this->parentLocationId, 'path-' . $this->parentLocationId];
     }
 
     public function getSlotClass()
@@ -22,7 +29,7 @@ class CopyContentSlotTest extends AbstractPurgeForContentSlotTest implements Slo
         return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\CopyContentSlot';
     }
 
-    public static function getReceivedSignalClasses()
+    public function getReceivedSignalClasses()
     {
         return ['eZ\Publish\Core\SignalSlot\Signal\ContentService\CopyContentSignal'];
     }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/CreateLocationSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/CreateLocationSlotTest.php
@@ -10,11 +10,11 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\LocationService\CreateLocationSignal;
 
-class CreateLocationSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
+class CreateLocationSlotTest extends AbstractContentSlotTest
 {
-    public static function createSignal()
+    public function createSignal()
     {
-        return new CreateLocationSignal(['contentId' => self::getContentId()]);
+        return new CreateLocationSignal(['contentId' => $this->contentId]);
     }
 
     public function getSlotClass()
@@ -22,7 +22,7 @@ class CreateLocationSlotTest extends AbstractPurgeForContentSlotTest implements 
         return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\CreateLocationSlot';
     }
 
-    public static function getReceivedSignalClasses()
+    public function getReceivedSignalClasses()
     {
         return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\CreateLocationSignal'];
     }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/DeleteContentSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/DeleteContentSlotTest.php
@@ -10,11 +10,20 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteContentSignal;
 
-class DeleteContentSlotTest extends AbstractPurgeAllSlotTest implements SlotTest, PurgeAllExpectation
+class DeleteContentSlotTest extends AbstractContentSlotTest
 {
-    public static function createSignal()
+    public function createSignal()
     {
-        return new DeleteContentSignal();
+        return new DeleteContentSignal(['contentId' => $this->contentId, 'affectedLocationIds' => [45, 55]]);
+    }
+
+    public function generateTags()
+    {
+        $tags = parent::generateTags();
+        $tags[] = 'path-45';
+        $tags[] = 'path-55';
+
+        return $tags;
     }
 
     public function getSlotClass()
@@ -22,7 +31,7 @@ class DeleteContentSlotTest extends AbstractPurgeAllSlotTest implements SlotTest
         return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\DeleteContentSlot';
     }
 
-    public static function getReceivedSignalClasses()
+    public function getReceivedSignalClasses()
     {
         return ['eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteContentSignal'];
     }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/DeleteLocationSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/DeleteLocationSlotTest.php
@@ -10,13 +10,28 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\LocationService\DeleteLocationSignal;
 
-class DeleteLocationSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
+class DeleteLocationSlotTest extends AbstractContentSlotTest
 {
-    protected static $locationIds = [45, 43];
+    protected $locationId = 45;
+    protected $parentLocationId = 43;
 
-    public static function createSignal()
+    public function createSignal()
     {
-        return new DeleteLocationSignal(['contentId' => self::getContentId(), 'locationId' => 45, 'parentLocationId' => 43]);
+        return new DeleteLocationSignal(
+            [
+                'contentId' => $this->contentId,
+                'locationId' => $this->locationId,
+                'parentLocationId' => $this->parentLocationId,
+            ]
+        );
+    }
+
+    public function generateTags()
+    {
+        $tags = parent::generateTags();
+        $tags[] = 'path-' . $this->locationId;
+
+        return $tags;
     }
 
     public function getSlotClass()
@@ -24,7 +39,7 @@ class DeleteLocationSlotTest extends AbstractPurgeForContentSlotTest implements 
         return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\DeleteLocationSlot';
     }
 
-    public static function getReceivedSignalClasses()
+    public function getReceivedSignalClasses()
     {
         return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\DeleteLocationSignal'];
     }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/DeleteVersionSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/DeleteVersionSlotTest.php
@@ -10,11 +10,11 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteVersionSignal;
 
-class DeleteVersionSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
+class DeleteVersionSlotTest extends AbstractContentSlotTest
 {
-    public static function createSignal()
+    public function createSignal()
     {
-        return new DeleteVersionSignal(['contentId' => self::getContentId()]);
+        return new DeleteVersionSignal(['contentId' => $this->contentId]);
     }
 
     public function getSlotClass()
@@ -22,7 +22,7 @@ class DeleteVersionSlotTest extends AbstractPurgeForContentSlotTest implements S
         return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\DeleteVersionSlot';
     }
 
-    public static function getReceivedSignalClasses()
+    public function getReceivedSignalClasses()
     {
         return ['eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteVersionSignal'];
     }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/HideLocationSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/HideLocationSlotTest.php
@@ -10,11 +10,26 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\LocationService\HideLocationSignal;
 
-class HideLocationSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
+class HideLocationSlotTest extends AbstractContentSlotTest
 {
-    public static function createSignal()
+    protected $locationId = 99;
+
+    public function createSignal()
     {
-        return new HideLocationSignal(['contentId' => self::getContentId()]);
+        return new HideLocationSignal(
+            [
+                'contentId' => $this->contentId,
+                'locationId' => $this->locationId,
+            ]
+        );
+    }
+
+    public function generateTags()
+    {
+        $tags = parent::generateTags();
+        $tags[] = 'path-' . $this->locationId;
+
+        return $tags;
     }
 
     public function getSlotClass()
@@ -22,7 +37,7 @@ class HideLocationSlotTest extends AbstractPurgeForContentSlotTest implements Sl
         return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\HideLocationSlot';
     }
 
-    public static function getReceivedSignalClasses()
+    public function getReceivedSignalClasses()
     {
         return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\HideLocationSignal'];
     }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/MoveSubtreeSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/MoveSubtreeSlotTest.php
@@ -10,11 +10,24 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\LocationService\MoveSubtreeSignal;
 
-class MoveSubtreeSlotTest extends AbstractPurgeAllSlotTest implements SlotTest
+class MoveSubtreeSlotTest extends AbstractContentSlotTest
 {
-    public static function createSignal()
+    protected $locationId = 45;
+    protected $parentLocationId = 43;
+
+    public function createSignal()
     {
-        return new MoveSubtreeSignal();
+        return new MoveSubtreeSignal(
+            [
+                'locationId' => $this->locationId,
+                'newParentLocationId' => $this->parentLocationId,
+            ]
+        );
+    }
+
+    public function generateTags()
+    {
+        return ['path-' . $this->locationId, 'location-' . $this->parentLocationId, 'parent-' . $this->parentLocationId];
     }
 
     public function getSlotClass()
@@ -22,7 +35,7 @@ class MoveSubtreeSlotTest extends AbstractPurgeAllSlotTest implements SlotTest
         return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\MoveSubtreeSlot';
     }
 
-    public static function getReceivedSignalClasses()
+    public function getReceivedSignalClasses()
     {
         return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\MoveSubtreeSignal'];
     }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/PublishVersionSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/PublishVersionSlotTest.php
@@ -50,7 +50,6 @@ class PublishVersionSlotTest extends AbstractContentSlotTest
     public function testDoesNotReceiveOtherSignals($signal)
     {
         $this->purgeClientMock->expects($this->never())->method('purge');
-        $this->purgeClientMock->expects($this->never())->method('purgeByTags');
         $this->purgeClientMock->expects($this->never())->method('purgeAll');
 
         $this->spiLocationHandlerMock->expects($this->never())->method('loadLocationsByContent');
@@ -73,7 +72,7 @@ class PublishVersionSlotTest extends AbstractContentSlotTest
                 ]
             );
 
-        $this->purgeClientMock->expects($this->once())->method('purgeByTags')->with($this->generateTags());
+        $this->purgeClientMock->expects($this->once())->method('purge')->with($this->generateTags());
         $this->purgeClientMock->expects($this->never())->method('purgeAll');
         parent::receive($signal);
     }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/PublishVersionSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/PublishVersionSlotTest.php
@@ -9,21 +9,72 @@
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\ContentService\PublishVersionSignal;
+use eZ\Publish\SPI\Persistence\Content\Location;
 
-class PublishVersionSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
+class PublishVersionSlotTest extends AbstractContentSlotTest
 {
+    protected $locationId = 45;
+    protected $parentLocationId = 32;
+
+    /** @var \eZ\Publish\SPI\Persistence\Content\Location\Handler|\PHPUnit_Framework_MockObject_MockObject */
+    protected $spiLocationHandlerMock;
+
     public function getSlotClass()
     {
         return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\PublishVersionSlot';
     }
 
-    public static function createSignal()
+    public function createSignal()
     {
-        return new PublishVersionSignal(['contentId' => self::getContentId()]);
+        return new PublishVersionSignal(['contentId' => $this->contentId]);
     }
 
-    public static function getReceivedSignalClasses()
+    public function getReceivedSignalClasses()
     {
         return ['eZ\Publish\Core\SignalSlot\Signal\ContentService\PublishVersionSignal'];
+    }
+
+    protected function createSlot()
+    {
+        $class = $this->getSlotClass();
+        if ($this->spiLocationHandlerMock === null) {
+            $this->spiLocationHandlerMock = $this->getMock('eZ\Publish\SPI\Persistence\Content\Location\Handler');
+        }
+
+        return new $class($this->purgeClientMock, $this->spiLocationHandlerMock);
+    }
+
+    /**
+     * @dataProvider getUnreceivedSignals
+     */
+    public function testDoesNotReceiveOtherSignals($signal)
+    {
+        $this->purgeClientMock->expects($this->never())->method('purge');
+        $this->purgeClientMock->expects($this->never())->method('purgeByTags');
+        $this->purgeClientMock->expects($this->never())->method('purgeAll');
+
+        $this->spiLocationHandlerMock->expects($this->never())->method('loadLocationsByContent');
+
+        $this->slot->receive($signal);
+    }
+
+    /**
+     * @dataProvider getReceivedSignals
+     */
+    public function testReceivePurgesCacheForTags($signal)
+    {
+        $this->spiLocationHandlerMock
+            ->expects($this->once())
+            ->method('loadLocationsByContent')
+            ->with($this->contentId)
+            ->willReturn(
+                [
+                    new Location(['id' => $this->locationId, 'parentId' => $this->parentLocationId]),
+                ]
+            );
+
+        $this->purgeClientMock->expects($this->once())->method('purgeByTags')->with($this->generateTags());
+        $this->purgeClientMock->expects($this->never())->method('purgeAll');
+        parent::receive($signal);
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/RecoverSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/RecoverSlotTest.php
@@ -10,13 +10,30 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\TrashService\RecoverSignal;
 
-class RecoverSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
+class RecoverSlotTest extends AbstractContentSlotTest
 {
-    protected static $locationIds = [43];
+    protected $locationId = 43;
+    protected $parentLocationId = 45;
 
-    public static function createSignal()
+    public function createSignal()
     {
-        return new RecoverSignal(['contentId' => self::getContentId(), 'newParentLocationId' => 43]);
+        return new RecoverSignal(
+            [
+                'contentId' => $this->contentId,
+                'newLocationId' => $this->locationId,
+                'newParentLocationId' => $this->parentLocationId,
+            ]
+        );
+    }
+
+    public function generateTags()
+    {
+        return [
+            'content-' . $this->contentId,
+            'relation-' . $this->contentId,
+            'location-' . $this->parentLocationId,
+            'parent-' . $this->parentLocationId,
+        ];
     }
 
     public function getSlotClass()
@@ -24,7 +41,7 @@ class RecoverSlotTest extends AbstractPurgeForContentSlotTest implements SlotTes
         return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\RecoverSlot';
     }
 
-    public static function getReceivedSignalClasses()
+    public function getReceivedSignalClasses()
     {
         return ['eZ\Publish\Core\SignalSlot\Signal\TrashService\RecoverSignal'];
     }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/SetContentStateSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/SetContentStateSlotTest.php
@@ -10,11 +10,11 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\SetContentStateSignal;
 
-class SetContentStateSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
+class SetContentStateSlotTest extends AbstractContentSlotTest
 {
-    public static function createSignal()
+    public function createSignal()
     {
-        return new SetContentStateSignal(['contentId' => self::getContentId()]);
+        return new SetContentStateSignal(['contentId' => $this->contentId]);
     }
 
     public function getSlotClass()
@@ -22,7 +22,7 @@ class SetContentStateSlotTest extends AbstractPurgeForContentSlotTest implements
         return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\SetContentStateSlot';
     }
 
-    public static function getReceivedSignalClasses()
+    public function getReceivedSignalClasses()
     {
         return ['eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\SetContentStateSignal'];
     }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/SwapLocationSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/SwapLocationSlotTest.php
@@ -10,19 +10,16 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\LocationService\SwapLocationSignal;
 
-/**
- * @todo Fixme
- */
-class SwapLocationSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
+class SwapLocationSlotTest extends AbstractContentSlotTest
 {
     public function setUp()
     {
-        self::markTestIncomplete('fixme');
+        $this->markTestIncomplete('fixme');
     }
 
-    public static function createSignal()
+    public function createSignal()
     {
-        return new SwapLocationSignal(['content1Id' => self::getContentId()]);
+        return new SwapLocationSignal(['content1Id' => $this->contentId]);
     }
 
     public function getSlotClass()
@@ -30,7 +27,7 @@ class SwapLocationSlotTest extends AbstractPurgeForContentSlotTest implements Sl
         return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\SetContentStateSlot';
     }
 
-    public static function getReceivedSignalClasses()
+    public function getReceivedSignalClasses()
     {
         return ['eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\SetContentStateSignal'];
     }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/TrashSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/TrashSlotTest.php
@@ -10,13 +10,20 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\TrashService\TrashSignal;
 
-class TrashSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
+class TrashSlotTest extends AbstractContentSlotTest
 {
-    protected static $locationIds = [45, 43];
+    protected $locationId = 45;
+    protected $parentLocationId = 43;
 
-    public static function createSignal()
+    public function createSignal()
     {
-        return new TrashSignal(['contentId' => self::getContentId(), 'locationId' => 45, 'parentLocationId' => 43]);
+        return new TrashSignal(
+            [
+                'contentId' => $this->contentId,
+                'locationId' => $this->locationId,
+                'parentLocationId' => $this->parentLocationId,
+            ]
+        );
     }
 
     public function getSlotClass()
@@ -24,7 +31,7 @@ class TrashSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest,
         return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\TrashSlot';
     }
 
-    public static function getReceivedSignalClasses()
+    public function getReceivedSignalClasses()
     {
         return ['eZ\Publish\Core\SignalSlot\Signal\TrashService\TrashSignal'];
     }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/UnassignUserFromUserGroupSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/UnassignUserFromUserGroupSlotTest.php
@@ -10,11 +10,16 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\UserService\UnAssignUserFromUserGroupSignal;
 
-class UnassignUserFromUserGroupSlotTest extends AbstractPurgeAllSlotTest implements SlotTest
+class UnassignUserFromUserGroupSlotTest extends AbstractContentSlotTest
 {
-    public static function createSignal()
+    public function createSignal()
     {
-        return new UnAssignUserFromUserGroupSignal();
+        return new UnAssignUserFromUserGroupSignal(['userId' => $this->contentId, 'userGroupId' => 99]);
+    }
+
+    public function generateTags()
+    {
+        return ['content-' . $this->contentId, 'content-99'];
     }
 
     public function getSlotClass()
@@ -22,7 +27,7 @@ class UnassignUserFromUserGroupSlotTest extends AbstractPurgeAllSlotTest impleme
         return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UnassignUserFromUserGroupSlot';
     }
 
-    public static function getReceivedSignalClasses()
+    public function getReceivedSignalClasses()
     {
         return ['eZ\Publish\Core\SignalSlot\Signal\UserService\UnAssignUserFromUserGroupSignal'];
     }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/UnhideLocationSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/UnhideLocationSlotTest.php
@@ -10,11 +10,26 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\LocationService\UnhideLocationSignal;
 
-class UnhideLocationSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
+class UnhideLocationSlotTest extends AbstractContentSlotTest
 {
-    public static function createSignal()
+    protected $locationId = 99;
+
+    public function createSignal()
     {
-        return new UnhideLocationSignal(['contentId' => self::getContentId()]);
+        return new UnhideLocationSignal(
+            [
+                'contentId' => $this->contentId,
+                'locationId' => $this->locationId,
+            ]
+        );
+    }
+
+    public function generateTags()
+    {
+        $tags = parent::generateTags();
+        $tags[] = 'path-' . $this->locationId;
+
+        return $tags;
     }
 
     public function getSlotClass()
@@ -22,7 +37,7 @@ class UnhideLocationSlotTest extends AbstractPurgeForContentSlotTest implements 
         return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UnhideLocationSlot';
     }
 
-    public static function getReceivedSignalClasses()
+    public function getReceivedSignalClasses()
     {
         return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\UnhideLocationSignal'];
     }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/UpdateLocationSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/UpdateLocationSlotTest.php
@@ -10,11 +10,11 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\LocationService\UpdateLocationSignal;
 
-class UpdateLocationSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
+class UpdateLocationSlotTest extends AbstractContentSlotTest
 {
-    public static function createSignal()
+    public function createSignal()
     {
-        return new UpdateLocationSignal(['contentId' => self::getContentId()]);
+        return new UpdateLocationSignal(['contentId' => $this->contentId]);
     }
 
     public function getSlotClass()
@@ -22,7 +22,7 @@ class UpdateLocationSlotTest extends AbstractPurgeForContentSlotTest implements 
         return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UpdateLocationSlot';
     }
 
-    public static function getReceivedSignalClasses()
+    public function getReceivedSignalClasses()
     {
         return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\UpdateLocationSignal'];
     }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/UpdateUserSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/UpdateUserSlotTest.php
@@ -10,11 +10,16 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\UserService\UpdateUserSignal;
 
-class UpdateUserSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
+class UpdateUserSlotTest extends AbstractContentSlotTest
 {
-    public static function createSignal()
+    public function createSignal()
     {
-        return new UpdateUserSignal(['userId' => self::getContentId()]);
+        return new UpdateUserSignal(['userId' => $this->contentId]);
+    }
+
+    public function generateTags()
+    {
+        return ['content-' . $this->contentId];
     }
 
     public function getSlotClass()
@@ -22,7 +27,7 @@ class UpdateUserSlotTest extends AbstractPurgeForContentSlotTest implements Slot
         return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UpdateUserSlot';
     }
 
-    public static function getReceivedSignalClasses()
+    public function getReceivedSignalClasses()
     {
         return ['eZ\Publish\Core\SignalSlot\Signal\UserService\UpdateUserSignal'];
     }


### PR DESCRIPTION
> Extracted from #1772
> Part of [EZP-22401](https://jira.ez.no/browse/EZP-22401)

Adds tagging support to HttpCache Signal Slots. Each signal will send a purge request with the list of tags matching the operation it is registered for.

The main difference with #1772 is the removal of `purgeByTags()` in favor of `purge()`.

### TODO
- [x] Squash once reviewed
- [x] change of ownership 