### PR TITLE
WIP: Http cache multi-tagging: MVC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ before_script:
 
 # execute phpunit or behat as the script command
 script:
-  - if [ "$TEST_CONFIG" != "" ] ; then php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1 vendor/bin/phpunit -c $TEST_CONFIG ; fi
+  - if [ "$TEST_CONFIG" != "" ] ; then php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1 vendor/bin/phpunit -c $TEST_CONFIG && php vendor/bin/phpspec run --format=pretty; fi
   - if [ "$BEHAT_OPTS" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/behat $BEHAT_OPTS" ; fi
   - if [ "$REST_TEST_CONFIG" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1 bin/phpunit -v vendor/ezsystems/ezpublish-kernel/eZ/Bundle/EzPublishRestBundle/Tests/Functional"  ; fi
 

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,9 @@
         "matthiasnoback/symfony-dependency-injection-test": "0.*",
         "mockery/mockery": "~0.9.4",
         "symfony/assetic-bundle": "~2.3",
-        "ezsystems/behatbundle": "^6.1"
+        "ezsystems/behatbundle": "^6.1",
+        "phpspec/phpspec": "^3.2",
+        "memio/spec-gen": "^0.6"
     },
     "replace": {
         "ezsystems/ezpublish": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,40 +4,40 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f73fe1017d49d4dc3d3749648202f48c",
-    "content-hash": "99b2470e946a130390079505b94dd059",
+    "hash": "b95e1d57be37a09d97875d50a9663fcd",
+    "content-hash": "465cdae68cd83e63e38f00bfdd781454",
     "packages": [
         {
             "name": "doctrine/annotations",
-            "version": "v1.2.7",
+            "version": "v1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "f25c8aab83e0c3e976fd7d19875f198ccf2f7535"
+                "reference": "bd4461328621bde0ae6b1b2675fbc6aca4ceb558"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/f25c8aab83e0c3e976fd7d19875f198ccf2f7535",
-                "reference": "f25c8aab83e0c3e976fd7d19875f198ccf2f7535",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/bd4461328621bde0ae6b1b2675fbc6aca4ceb558",
+                "reference": "bd4461328621bde0ae6b1b2675fbc6aca4ceb558",
                 "shasum": ""
             },
             "require": {
                 "doctrine/lexer": "1.*",
-                "php": ">=5.3.2"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
                 "doctrine/cache": "1.*",
-                "phpunit/phpunit": "4.*"
+                "phpunit/phpunit": "^5.6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "1.4.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Common\\Annotations\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -73,20 +73,20 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2015-08-31 12:32:49"
+            "time": "2016-12-30 15:59:45"
         },
         {
             "name": "doctrine/cache",
-            "version": "v1.6.0",
+            "version": "v1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6"
+                "reference": "b6f544a20f4807e81f7044d31e679ccbb1866dc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/f8af318d14bdb0eff0336795b428b547bd39ccb6",
-                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/b6f544a20f4807e81f7044d31e679ccbb1866dc3",
+                "reference": "b6f544a20f4807e81f7044d31e679ccbb1866dc3",
                 "shasum": ""
             },
             "require": {
@@ -143,32 +143,33 @@
                 "cache",
                 "caching"
             ],
-            "time": "2015-12-31 16:37:02"
+            "time": "2016-10-29 11:16:17"
         },
         {
             "name": "doctrine/collections",
-            "version": "v1.3.0",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/collections.git",
-                "reference": "6c1e4eef75f310ea1b3e30945e9f06e652128b8a"
+                "reference": "1a4fb7e902202c33cce8c55989b945612943c2ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/collections/zipball/6c1e4eef75f310ea1b3e30945e9f06e652128b8a",
-                "reference": "6c1e4eef75f310ea1b3e30945e9f06e652128b8a",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/1a4fb7e902202c33cce8c55989b945612943c2ba",
+                "reference": "1a4fb7e902202c33cce8c55989b945612943c2ba",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "doctrine/coding-standard": "~0.1@dev",
+                "phpunit/phpunit": "^5.7"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.3.x-dev"
                 }
             },
             "autoload": {
@@ -209,20 +210,20 @@
                 "collections",
                 "iterator"
             ],
-            "time": "2015-04-14 22:21:58"
+            "time": "2017-01-03 10:49:41"
         },
         {
             "name": "doctrine/common",
-            "version": "v2.6.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/common.git",
-                "reference": "a579557bc689580c19fee4e27487a67fe60defc0"
+                "reference": "930297026c8009a567ac051fd545bf6124150347"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/common/zipball/a579557bc689580c19fee4e27487a67fe60defc0",
-                "reference": "a579557bc689580c19fee4e27487a67fe60defc0",
+                "url": "https://api.github.com/repos/doctrine/common/zipball/930297026c8009a567ac051fd545bf6124150347",
+                "reference": "930297026c8009a567ac051fd545bf6124150347",
                 "shasum": ""
             },
             "require": {
@@ -231,10 +232,10 @@
                 "doctrine/collections": "1.*",
                 "doctrine/inflector": "1.*",
                 "doctrine/lexer": "1.*",
-                "php": "~5.5|~7.0"
+                "php": "~5.6|~7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.8|~5.0"
+                "phpunit/phpunit": "^5.4.6"
             },
             "type": "library",
             "extra": {
@@ -282,29 +283,29 @@
                 "persistence",
                 "spl"
             ],
-            "time": "2015-12-25 13:18:31"
+            "time": "2017-01-13 14:02:13"
         },
         {
             "name": "doctrine/dbal",
-            "version": "v2.5.4",
+            "version": "v2.5.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "abbdfd1cff43a7b99d027af3be709bc8fc7d4769"
+                "reference": "fc376f7a61498e18520cd6fa083752a4ca08072b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/abbdfd1cff43a7b99d027af3be709bc8fc7d4769",
-                "reference": "abbdfd1cff43a7b99d027af3be709bc8fc7d4769",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/fc376f7a61498e18520cd6fa083752a4ca08072b",
+                "reference": "fc376f7a61498e18520cd6fa083752a4ca08072b",
                 "shasum": ""
             },
             "require": {
-                "doctrine/common": ">=2.4,<2.7-dev",
+                "doctrine/common": ">=2.4,<2.8-dev",
                 "php": ">=5.3.2"
             },
             "require-dev": {
                 "phpunit/phpunit": "4.*",
-                "symfony/console": "2.*"
+                "symfony/console": "2.*||^3.0"
             },
             "suggest": {
                 "symfony/console": "For helpful console commands such as SQL execution and import of files."
@@ -353,41 +354,41 @@
                 "persistence",
                 "queryobject"
             ],
-            "time": "2016-01-05 22:11:12"
+            "time": "2017-01-23 23:17:10"
         },
         {
             "name": "doctrine/doctrine-bundle",
-            "version": "1.6.4",
+            "version": "1.6.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/DoctrineBundle.git",
-                "reference": "dd40b0a7fb16658cda9def9786992b8df8a49be7"
+                "reference": "a01d99bc6c9a6c8a8ace0012690099dd957ce9b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/dd40b0a7fb16658cda9def9786992b8df8a49be7",
-                "reference": "dd40b0a7fb16658cda9def9786992b8df8a49be7",
+                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/a01d99bc6c9a6c8a8ace0012690099dd957ce9b9",
+                "reference": "a01d99bc6c9a6c8a8ace0012690099dd957ce9b9",
                 "shasum": ""
             },
             "require": {
                 "doctrine/dbal": "~2.3",
                 "doctrine/doctrine-cache-bundle": "~1.0",
                 "jdorn/sql-formatter": "~1.1",
-                "php": ">=5.3.2",
-                "symfony/console": "~2.3|~3.0",
-                "symfony/dependency-injection": "~2.3|~3.0",
-                "symfony/doctrine-bridge": "~2.2|~3.0",
-                "symfony/framework-bundle": "~2.3|~3.0"
+                "php": ">=5.5.9",
+                "symfony/console": "~2.7|~3.0",
+                "symfony/dependency-injection": "~2.7|~3.0",
+                "symfony/doctrine-bridge": "~2.7|~3.0",
+                "symfony/framework-bundle": "~2.7|~3.0"
             },
             "require-dev": {
                 "doctrine/orm": "~2.3",
                 "phpunit/phpunit": "~4",
-                "satooshi/php-coveralls": "~0.6.1",
+                "satooshi/php-coveralls": "^1.0",
                 "symfony/phpunit-bridge": "~2.7|~3.0",
                 "symfony/property-info": "~2.8|~3.0",
-                "symfony/validator": "~2.2|~3.0",
-                "symfony/yaml": "~2.2|~3.0",
-                "twig/twig": "~1.10"
+                "symfony/validator": "~2.7|~3.0",
+                "symfony/yaml": "~2.7|~3.0",
+                "twig/twig": "~1.10|~2.0"
             },
             "suggest": {
                 "doctrine/orm": "The Doctrine ORM integration is optional in the bundle.",
@@ -434,7 +435,7 @@
                 "orm",
                 "persistence"
             ],
-            "time": "2016-08-10 15:35:22"
+            "time": "2017-01-16 12:01:26"
         },
         {
             "name": "doctrine/doctrine-cache-bundle",
@@ -719,16 +720,16 @@
         },
         {
             "name": "friendsofsymfony/http-cache-bundle",
-            "version": "1.3.9",
+            "version": "1.3.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfSymfony/FOSHttpCacheBundle.git",
-                "reference": "04247810151f8721740069f2376bf933ed9a7971"
+                "reference": "d5ccceeb0c6ce806b0b1f7fcc4f7a752fc85cf87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSHttpCacheBundle/zipball/04247810151f8721740069f2376bf933ed9a7971",
-                "reference": "04247810151f8721740069f2376bf933ed9a7971",
+                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSHttpCacheBundle/zipball/d5ccceeb0c6ce806b0b1f7fcc4f7a752fc85cf87",
+                "reference": "d5ccceeb0c6ce806b0b1f7fcc4f7a752fc85cf87",
                 "shasum": ""
             },
             "require": {
@@ -795,7 +796,7 @@
                 "purge",
                 "varnish"
             ],
-            "time": "2016-09-06 11:30:45"
+            "time": "2017-01-06 14:39:18"
         },
         {
             "name": "guzzle/guzzle",
@@ -1105,6 +1106,76 @@
             "time": "2014-01-12 16:20:24"
         },
         {
+            "name": "jms/translation-bundle",
+            "version": "1.3.1",
+            "target-dir": "JMS/TranslationBundle",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/JMSTranslationBundle.git",
+                "reference": "e79fe1cd77e7749223c870bdae0bd400c21a102d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/JMSTranslationBundle/zipball/e79fe1cd77e7749223c870bdae0bd400c21a102d",
+                "reference": "e79fe1cd77e7749223c870bdae0bd400c21a102d",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^1.4 || ^2.0",
+                "php": "^5.3.3 || ^7.0",
+                "symfony/console": "^2.3 || ^3.0",
+                "symfony/framework-bundle": "^2.3 || ^3.0"
+            },
+            "conflict": {
+                "twig/twig": "<1.12"
+            },
+            "require-dev": {
+                "jms/di-extra-bundle": "^1.1",
+                "matthiasnoback/symfony-dependency-injection-test": "^0.7.6",
+                "nyholm/nsa": "^1.0.1",
+                "phpunit/phpunit": "4.8.27",
+                "psr/log": "^1.0",
+                "sensio/framework-extra-bundle": "^2.3 || ^3.0",
+                "symfony/expression-language": "^2.6 || ^3.0",
+                "symfony/symfony": "^2.3 || ^3.0",
+                "twig/twig": "^1.12"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "JMS\\TranslationBundle": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache2"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Puts the Symfony Translation Component on steroids",
+            "homepage": "http://jmsyst.com/bundles/JMSTranslationBundle",
+            "keywords": [
+                "extract",
+                "extraction",
+                "i18n",
+                "interface",
+                "multilanguage",
+                "translation",
+                "ui",
+                "webinterface"
+            ],
+            "time": "2016-08-13 23:17:44"
+        },
+        {
             "name": "kriswallsmith/buzz",
             "version": "v0.15",
             "source": {
@@ -1154,20 +1225,20 @@
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.27",
+            "version": "1.0.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "50e2045ed70a7e75a5e30bc3662904f3b67af8a9"
+                "reference": "5c7f98498b12d47f9de90ec9186a90000125777c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/50e2045ed70a7e75a5e30bc3662904f3b67af8a9",
-                "reference": "50e2045ed70a7e75a5e30bc3662904f3b67af8a9",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/5c7f98498b12d47f9de90ec9186a90000125777c",
+                "reference": "5c7f98498b12d47f9de90ec9186a90000125777c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": ">=5.5.9"
             },
             "conflict": {
                 "league/flysystem-sftp": "<1.0.6"
@@ -1233,30 +1304,33 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2016-08-10 08:55:11"
+            "time": "2017-01-23 10:32:09"
         },
         {
             "name": "liip/imagine-bundle",
-            "version": "1.6.0",
+            "version": "1.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liip/LiipImagineBundle.git",
-                "reference": "cc881beb2daea75068ad75329e6d71963fa95028"
+                "reference": "d653f4d22b33c2c2870cb87df8a32508186a799a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liip/LiipImagineBundle/zipball/cc881beb2daea75068ad75329e6d71963fa95028",
-                "reference": "cc881beb2daea75068ad75329e6d71963fa95028",
+                "url": "https://api.github.com/repos/liip/LiipImagineBundle/zipball/d653f4d22b33c2c2870cb87df8a32508186a799a",
+                "reference": "d653f4d22b33c2c2870cb87df8a32508186a799a",
                 "shasum": ""
             },
             "require": {
                 "imagine/imagine": "^0.6.3,<0.7",
                 "php": "^5.3.9|^7.0",
+                "symfony/asset": "~2.3|~3.0",
                 "symfony/filesystem": "~2.3|~3.0",
                 "symfony/finder": "~2.3|~3.0",
                 "symfony/framework-bundle": "~2.3|~3.0",
                 "symfony/options-resolver": "~2.3|~3.0",
-                "symfony/process": "~2.3|~3.0"
+                "symfony/process": "~2.3|~3.0",
+                "symfony/templating": "~2.3|~3.0",
+                "symfony/translation": "~2.3|~3.0"
             },
             "require-dev": {
                 "amazonwebservices/aws-sdk-for-php": "~1.0",
@@ -1264,8 +1338,11 @@
                 "doctrine/cache": "~1.1",
                 "doctrine/orm": "~2.3",
                 "ext-gd": "*",
+                "friendsofphp/php-cs-fixer": "~2.0",
                 "phpunit/phpunit": "~4.3",
                 "psr/log": "~1.0",
+                "satooshi/php-coveralls": "~1.0",
+                "sllh/php-cs-fixer-styleci-bridge": "~2.1",
                 "symfony/browser-kit": "~2.3|~3.0",
                 "symfony/console": "~2.3|~3.0",
                 "symfony/dependency-injection": "~2.3|~3.0",
@@ -1275,16 +1352,17 @@
                 "twig/twig": "~1.12"
             },
             "suggest": {
-                "amazonwebservices/aws-sdk-for-php": "Add it if you'd like to use aws v1 resolver",
-                "aws/aws-sdk-php": "Add it if you'd like to use aws v2 or v3 resolver",
-                "league/flysystem": "If you'd want to use Flysystem binary loader",
-                "monolog/monolog": "If you'd want to write logs",
-                "twig/twig": "If you'd want to use some handy twig filters, version 1.12 or greater required"
+                "amazonwebservices/aws-sdk-for-php": "Required to use AWS version 1 cache resolver.",
+                "aws/aws-sdk-php": "Required to use AWS version 2/3 cache resolver.",
+                "ext-exif": "Required to read metadata from Exif information",
+                "league/flysystem": "Required to use FlySystem data loader or cache resolver.",
+                "monolog/monolog": "A psr/log compatible logger is required to enable logging.",
+                "twig/twig": "Required to use the provided Twig extension. Version 1.12 or greater needed."
             },
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.6.x-dev"
+                    "dev-master": "1.7.x-dev"
                 }
             },
             "autoload": {
@@ -1308,24 +1386,24 @@
                 "image",
                 "imagine"
             ],
-            "time": "2016-07-22 14:52:30"
+            "time": "2017-01-20 01:55:04"
         },
         {
             "name": "nelmio/cors-bundle",
-            "version": "1.4.1",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nelmio/NelmioCorsBundle.git",
-                "reference": "fa14a81737c605bf4766054cdcb72a16a433d537"
+                "reference": "cc9a26517b65769e6e3cea10099d4a40ce11ca29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nelmio/NelmioCorsBundle/zipball/fa14a81737c605bf4766054cdcb72a16a433d537",
-                "reference": "fa14a81737c605bf4766054cdcb72a16a433d537",
+                "url": "https://api.github.com/repos/nelmio/NelmioCorsBundle/zipball/cc9a26517b65769e6e3cea10099d4a40ce11ca29",
+                "reference": "cc9a26517b65769e6e3cea10099d4a40ce11ca29",
                 "shasum": ""
             },
             "require": {
-                "symfony/framework-bundle": "^2.2 || ^3.0"
+                "symfony/framework-bundle": "^2.7 || ^3.0"
             },
             "require-dev": {
                 "matthiasnoback/symfony-dependency-injection-test": "^0.7.6",
@@ -1334,7 +1412,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "1.5.x-dev"
                 }
             },
             "autoload": {
@@ -1365,42 +1443,142 @@
                 "cors",
                 "crossdomain"
             ],
-            "time": "2015-12-09 17:26:34"
+            "time": "2017-01-22 21:34:09"
         },
         {
-            "name": "ocramius/proxy-manager",
-            "version": "1.0.2",
+            "name": "nikic/php-parser",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Ocramius/ProxyManager.git",
-                "reference": "57e9272ec0e8deccf09421596e0e2252df440e11"
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "4dd659edadffdc2143e4753df655d866dbfeedf0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/57e9272ec0e8deccf09421596e0e2252df440e11",
-                "reference": "57e9272ec0e8deccf09421596e0e2252df440e11",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4dd659edadffdc2143e4753df655d866dbfeedf0",
+                "reference": "4dd659edadffdc2143e4753df655d866dbfeedf0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "zendframework/zend-code": ">2.2.5,<3.0"
+                "ext-tokenizer": "*",
+                "php": ">=5.4"
             },
             "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "time": "2016-09-16 12:04:44"
+        },
+        {
+            "name": "ocramius/package-versions",
+            "version": "1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/PackageVersions.git",
+                "reference": "51e867c70f0799790b3e82276875414ce13daaca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/PackageVersions/zipball/51e867c70f0799790b3e82276875414ce13daaca",
+                "reference": "51e867c70f0799790b3e82276875414ce13daaca",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": "~7.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.3",
+                "ext-zip": "*",
+                "phpunit/phpunit": "^5.4.7"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PackageVersions\\Installer",
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PackageVersions\\": "src/PackageVersions"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "time": "2016-12-30 09:49:15"
+        },
+        {
+            "name": "ocramius/proxy-manager",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Ocramius/ProxyManager.git",
+                "reference": "6c89b7bd6039d8047b1473e2074cb56baa4bc15d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Ocramius/ProxyManager/zipball/6c89b7bd6039d8047b1473e2074cb56baa4bc15d",
+                "reference": "6c89b7bd6039d8047b1473e2074cb56baa4bc15d",
+                "shasum": ""
+            },
+            "require": {
+                "ocramius/package-versions": "^1.0",
+                "php": "~7.0",
+                "zendframework/zend-code": "~3.0"
+            },
+            "require-dev": {
+                "couscous/couscous": "^1.4.0",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "1.5.*"
+                "phpunit/phpunit": "^5.1.3",
+                "squizlabs/php_codesniffer": "^2.5.1"
             },
             "suggest": {
                 "ocramius/generated-hydrator": "To have very fast object to array to object conversion for ghost objects",
                 "zendframework/zend-json": "To have the JsonRpc adapter (Remote Object feature)",
                 "zendframework/zend-soap": "To have the Soap adapter (Remote Object feature)",
-                "zendframework/zend-stdlib": "To use the hydrator proxy",
                 "zendframework/zend-xmlrpc": "To have the XmlRpc adapter (Remote Object feature)"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1416,7 +1594,7 @@
                 {
                     "name": "Marco Pivetta",
                     "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
+                    "homepage": "http://ocramius.github.io/"
                 }
             ],
             "description": "A library providing utilities to generate, instantiate and generally operate with Object Proxies",
@@ -1428,20 +1606,20 @@
                 "proxy pattern",
                 "service proxies"
             ],
-            "time": "2015-08-09 04:28:19"
+            "time": "2016-02-08 13:50:05"
         },
         {
             "name": "oneup/flysystem-bundle",
-            "version": "1.4.1",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/1up-lab/OneupFlysystemBundle.git",
-                "reference": "2459169ed38e38bff1471ce0b25d4b341d0a938f"
+                "reference": "66f3e11ee6bbf793202be7c1413e95bbac50e335"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/1up-lab/OneupFlysystemBundle/zipball/2459169ed38e38bff1471ce0b25d4b341d0a938f",
-                "reference": "2459169ed38e38bff1471ce0b25d4b341d0a938f",
+                "url": "https://api.github.com/repos/1up-lab/OneupFlysystemBundle/zipball/66f3e11ee6bbf793202be7c1413e95bbac50e335",
+                "reference": "66f3e11ee6bbf793202be7c1413e95bbac50e335",
                 "shasum": ""
             },
             "require": {
@@ -1450,22 +1628,28 @@
                 "symfony/framework-bundle": "~2.0|~3.0"
             },
             "require-dev": {
+                "jenko/flysystem-gaufrette": "^1.0",
                 "league/flysystem-aws-s3-v2": "~1.0",
                 "league/flysystem-cached-adapter": "~1.0",
                 "league/flysystem-copy": "~1.0",
                 "league/flysystem-dropbox": "~1.0",
                 "league/flysystem-gridfs": "~1.0",
+                "league/flysystem-memory": "~1.0",
                 "league/flysystem-rackspace": "~1.0",
                 "league/flysystem-sftp": "~1.0",
                 "league/flysystem-webdav": "~1.0",
                 "league/flysystem-ziparchive": "~1.0",
+                "litipk/flysystem-fallback-adapter": "~0.1",
                 "phpunit/phpunit": "4.4.*",
                 "symfony/browser-kit": "~2.0|~3.0",
-                "symfony/finder": "~2.0|~3.0"
+                "symfony/finder": "~2.0|~3.0",
+                "twistor/flysystem-stream-wrapper": "~1.0"
             },
             "suggest": {
                 "ext-fileinfo": "Required for MimeType",
+                "jenko/flysystem-gaufrette": "Allows you to use gaufrette adapter",
                 "league/flysystem-aws-s3-v2": "Use S3 storage with AWS SDK v2",
+                "league/flysystem-aws-s3-v3": "Use S3 storage with AWS SDK v3",
                 "league/flysystem-cached-adapter": "Flysystem adapter decorator for metadata caching",
                 "league/flysystem-copy": "Allows you to use Copy.com storage",
                 "league/flysystem-dropbox": "Use Dropbox storage",
@@ -1473,7 +1657,9 @@
                 "league/flysystem-rackspace": "Allows you to use Rackspace Cloud Files",
                 "league/flysystem-sftp": "Allows SFTP server storage via phpseclib",
                 "league/flysystem-webdav": "Allows you to use WebDAV storage",
-                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter"
+                "league/flysystem-ziparchive": "Allows you to use ZipArchive adapter",
+                "litipk/flysystem-fallback-adapter": "Allows you to use a fallback filesystem",
+                "twistor/flysystem-stream-wrapper": "Allows you to use stream wrapper"
             },
             "type": "symfony-bundle",
             "autoload": {
@@ -1501,20 +1687,20 @@
                 "abstraction",
                 "filesystem"
             ],
-            "time": "2016-05-31 11:05:39"
+            "time": "2017-01-27 09:39:48"
         },
         {
             "name": "pagerfanta/pagerfanta",
-            "version": "v1.0.3",
+            "version": "v1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/whiteoctober/Pagerfanta.git",
-                "reference": "a874d3612d954dcbbb49e5ffe178890918fb76fb"
+                "reference": "f846c5e06bb66df659a688ea4734aab49de589d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/whiteoctober/Pagerfanta/zipball/a874d3612d954dcbbb49e5ffe178890918fb76fb",
-                "reference": "a874d3612d954dcbbb49e5ffe178890918fb76fb",
+                "url": "https://api.github.com/repos/whiteoctober/Pagerfanta/zipball/f846c5e06bb66df659a688ea4734aab49de589d6",
+                "reference": "f846c5e06bb66df659a688ea4734aab49de589d6",
                 "shasum": ""
             },
             "require": {
@@ -1527,7 +1713,7 @@
                 "jmikola/geojson": "~1.0",
                 "mandango/mandango": "~1.0@dev",
                 "mandango/mondator": "~1.0@dev",
-                "phpunit/phpunit": "~4",
+                "phpunit/phpunit": "~4 | ~5",
                 "propel/propel1": "~1.6",
                 "ruflin/elastica": "~1.3",
                 "solarium/solarium": "~3.1"
@@ -1568,20 +1754,20 @@
                 "paginator",
                 "paging"
             ],
-            "time": "2014-10-06 10:57:25"
+            "time": "2016-11-28 09:17:04"
         },
         {
             "name": "paragonie/random_compat",
-            "version": "v2.0.2",
+            "version": "v2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/random_compat.git",
-                "reference": "088c04e2f261c33bed6ca5245491cfca69195ccf"
+                "reference": "a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/088c04e2f261c33bed6ca5245491cfca69195ccf",
-                "reference": "088c04e2f261c33bed6ca5245491cfca69195ccf",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e",
+                "reference": "a9b97968bcde1c4de2a5ec6cbd06a0f6c919b46e",
                 "shasum": ""
             },
             "require": {
@@ -1616,7 +1802,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2016-04-03 06:00:07"
+            "time": "2016-11-07 23:38:38"
         },
         {
             "name": "psr/cache",
@@ -1666,22 +1852,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.0.0",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.3.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
             "autoload": {
-                "psr-0": {
-                    "Psr\\Log\\": ""
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1695,12 +1889,13 @@
                 }
             ],
             "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
             "keywords": [
                 "log",
                 "psr",
                 "psr-3"
             ],
-            "time": "2012-12-21 11:40:51"
+            "time": "2016-10-10 12:19:37"
         },
         {
             "name": "qafoo/rmf",
@@ -1728,21 +1923,21 @@
         },
         {
             "name": "sensio/distribution-bundle",
-            "version": "v5.0.9",
+            "version": "v5.0.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/SensioDistributionBundle.git",
-                "reference": "e5e0d8d06b07864b2752bd865537b0817edf4c5a"
+                "reference": "17846680901003d26d823c2e3ac9228702837916"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioDistributionBundle/zipball/e5e0d8d06b07864b2752bd865537b0817edf4c5a",
-                "reference": "e5e0d8d06b07864b2752bd865537b0817edf4c5a",
+                "url": "https://api.github.com/repos/sensiolabs/SensioDistributionBundle/zipball/17846680901003d26d823c2e3ac9228702837916",
+                "reference": "17846680901003d26d823c2e3ac9228702837916",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.9",
-                "sensiolabs/security-checker": "~3.0",
+                "sensiolabs/security-checker": "~3.0|~4.0",
                 "symfony/class-loader": "~2.3|~3.0",
                 "symfony/config": "~2.3|~3.0",
                 "symfony/dependency-injection": "~2.3|~3.0",
@@ -1776,20 +1971,20 @@
                 "configuration",
                 "distribution"
             ],
-            "time": "2016-09-06 01:05:01"
+            "time": "2017-01-10 14:58:45"
         },
         {
             "name": "sensio/framework-extra-bundle",
-            "version": "v3.0.16",
+            "version": "v3.0.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/SensioFrameworkExtraBundle.git",
-                "reference": "507a15f56fa7699f6cc8c2c7de4080b19ce22546"
+                "reference": "d57c2f297d17ee82baf8cae0b16dae34a9378784"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/507a15f56fa7699f6cc8c2c7de4080b19ce22546",
-                "reference": "507a15f56fa7699f6cc8c2c7de4080b19ce22546",
+                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/d57c2f297d17ee82baf8cae0b16dae34a9378784",
+                "reference": "d57c2f297d17ee82baf8cae0b16dae34a9378784",
                 "shasum": ""
             },
             "require": {
@@ -1798,14 +1993,20 @@
                 "symfony/framework-bundle": "~2.3|~3.0"
             },
             "require-dev": {
+                "symfony/asset": "~2.7|~3.0",
                 "symfony/browser-kit": "~2.3|~3.0",
                 "symfony/dom-crawler": "~2.3|~3.0",
                 "symfony/expression-language": "~2.4|~3.0",
                 "symfony/finder": "~2.3|~3.0",
-                "symfony/phpunit-bridge": "~2.7|~3.0",
+                "symfony/phpunit-bridge": "~3.2",
+                "symfony/psr-http-message-bridge": "^0.3",
                 "symfony/security-bundle": "~2.4|~3.0",
+                "symfony/templating": "~2.3|~3.0",
+                "symfony/translation": "~2.3|~3.0",
                 "symfony/twig-bundle": "~2.3|~3.0",
-                "twig/twig": "~1.11|~2.0"
+                "symfony/yaml": "~2.3|~3.0",
+                "twig/twig": "~1.11|~2.0",
+                "zendframework/zend-diactoros": "^1.3"
             },
             "suggest": {
                 "symfony/expression-language": "",
@@ -1838,24 +2039,24 @@
                 "annotations",
                 "controllers"
             ],
-            "time": "2016-03-25 17:08:27"
+            "time": "2017-01-10 19:42:56"
         },
         {
             "name": "sensiolabs/security-checker",
-            "version": "v3.0.2",
+            "version": "v4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/security-checker.git",
-                "reference": "21696b0daa731064c23cfb694c60a2584a7b6e93"
+                "reference": "116027b57b568ed61b7b1c80eeb4f6ee9e8c599c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/21696b0daa731064c23cfb694c60a2584a7b6e93",
-                "reference": "21696b0daa731064c23cfb694c60a2584a7b6e93",
+                "url": "https://api.github.com/repos/sensiolabs/security-checker/zipball/116027b57b568ed61b7b1c80eeb4f6ee9e8c599c",
+                "reference": "116027b57b568ed61b7b1c80eeb4f6ee9e8c599c",
                 "shasum": ""
             },
             "require": {
-                "symfony/console": "~2.0|~3.0"
+                "symfony/console": "~2.7|~3.0"
             },
             "bin": [
                 "security-checker"
@@ -1863,7 +2064,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1882,7 +2083,7 @@
                 }
             ],
             "description": "A security checker for your composer.lock",
-            "time": "2015-11-07 08:07:40"
+            "time": "2016-09-23 18:09:57"
         },
         {
             "name": "symfony-cmf/routing",
@@ -1945,16 +2146,16 @@
         },
         {
             "name": "symfony/polyfill-intl-icu",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-icu.git",
-                "reference": "0f8dc2c45f69f8672379e9210bca4a115cd5146f"
+                "reference": "2d6e2b20d457603eefb6e614286c22efca30fdb4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/0f8dc2c45f69f8672379e9210bca4a115cd5146f",
-                "reference": "0f8dc2c45f69f8672379e9210bca4a115cd5146f",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/2d6e2b20d457603eefb6e614286c22efca30fdb4",
+                "reference": "2d6e2b20d457603eefb6e614286c22efca30fdb4",
                 "shasum": ""
             },
             "require": {
@@ -1967,7 +2168,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -1999,20 +2200,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594"
+                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dff51f72b0706335131b00a7f49606168c582594",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/e79d363049d1c2128f133a2667e4f4190904f7f4",
+                "reference": "e79d363049d1c2128f133a2667e4f4190904f7f4",
                 "shasum": ""
             },
             "require": {
@@ -2024,7 +2225,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -2058,20 +2259,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/polyfill-php56",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php56.git",
-                "reference": "3edf57a8fbf9a927533344cef65ad7e1cf31030a"
+                "reference": "1dd42b9b89556f18092f3d1ada22cb05ac85383c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/3edf57a8fbf9a927533344cef65ad7e1cf31030a",
-                "reference": "3edf57a8fbf9a927533344cef65ad7e1cf31030a",
+                "url": "https://api.github.com/repos/symfony/polyfill-php56/zipball/1dd42b9b89556f18092f3d1ada22cb05ac85383c",
+                "reference": "1dd42b9b89556f18092f3d1ada22cb05ac85383c",
                 "shasum": ""
             },
             "require": {
@@ -2081,7 +2282,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -2114,20 +2315,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/polyfill-php70",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php70.git",
-                "reference": "a42f4b6b05ed458910f8af4c4e1121b0101b2d85"
+                "reference": "13ce343935f0f91ca89605a2f6ca6f5c2f3faac2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/a42f4b6b05ed458910f8af4c4e1121b0101b2d85",
-                "reference": "a42f4b6b05ed458910f8af4c4e1121b0101b2d85",
+                "url": "https://api.github.com/repos/symfony/polyfill-php70/zipball/13ce343935f0f91ca89605a2f6ca6f5c2f3faac2",
+                "reference": "13ce343935f0f91ca89605a2f6ca6f5c2f3faac2",
                 "shasum": ""
             },
             "require": {
@@ -2137,7 +2338,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -2173,20 +2374,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/polyfill-util",
-            "version": "v1.2.0",
+            "version": "v1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-util.git",
-                "reference": "ef830ce3d218e622b221d6bfad42c751d974bf99"
+                "reference": "746bce0fca664ac0a575e465f65c6643faddf7fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/ef830ce3d218e622b221d6bfad42c751d974bf99",
-                "reference": "ef830ce3d218e622b221d6bfad42c751d974bf99",
+                "url": "https://api.github.com/repos/symfony/polyfill-util/zipball/746bce0fca664ac0a575e465f65c6643faddf7fb",
+                "reference": "746bce0fca664ac0a575e465f65c6643faddf7fb",
                 "shasum": ""
             },
             "require": {
@@ -2195,7 +2396,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -2225,20 +2426,20 @@
                 "polyfill",
                 "shim"
             ],
-            "time": "2016-05-18 14:26:46"
+            "time": "2016-11-14 01:06:16"
         },
         {
             "name": "symfony/symfony",
-            "version": "v3.1.4",
+            "version": "v3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/symfony.git",
-                "reference": "65ca9e4fbdb34f6d463ef77898ca583b101a4162"
+                "reference": "358c59fd21f9db7fdb465d1e07fba822d9e18e9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/symfony/zipball/65ca9e4fbdb34f6d463ef77898ca583b101a4162",
-                "reference": "65ca9e4fbdb34f6d463ef77898ca583b101a4162",
+                "url": "https://api.github.com/repos/symfony/symfony/zipball/358c59fd21f9db7fdb465d1e07fba822d9e18e9e",
+                "reference": "358c59fd21f9db7fdb465d1e07fba822d9e18e9e",
                 "shasum": ""
             },
             "require": {
@@ -2251,7 +2452,7 @@
                 "symfony/polyfill-php56": "~1.0",
                 "symfony/polyfill-php70": "~1.0",
                 "symfony/polyfill-util": "~1.0",
-                "twig/twig": "~1.23|~2.0"
+                "twig/twig": "~1.28|~2.0"
             },
             "conflict": {
                 "phpdocumentor/reflection-docblock": "<3.0",
@@ -2306,6 +2507,7 @@
                 "symfony/validator": "self.version",
                 "symfony/var-dumper": "self.version",
                 "symfony/web-profiler-bundle": "self.version",
+                "symfony/workflow": "self.version",
                 "symfony/yaml": "self.version"
             },
             "require-dev": {
@@ -2315,18 +2517,19 @@
                 "doctrine/dbal": "~2.4",
                 "doctrine/doctrine-bundle": "~1.4",
                 "doctrine/orm": "~2.4,>=2.4.5",
-                "egulias/email-validator": "~1.2,>=1.2.1",
+                "egulias/email-validator": "~1.2,>=1.2.8|~2.0",
                 "monolog/monolog": "~1.11",
                 "ocramius/proxy-manager": "~0.4|~1.0|~2.0",
                 "phpdocumentor/reflection-docblock": "^3.0",
                 "predis/predis": "~1.0",
+                "symfony/phpunit-bridge": "~3.2",
                 "symfony/polyfill-apcu": "~1.1",
                 "symfony/security-acl": "~2.8|~3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2365,7 +2568,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2016-09-03 15:28:43"
+            "time": "2017-01-12 21:36:55"
         },
         {
             "name": "tedivm/stash",
@@ -2490,16 +2693,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.24.2",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "33093f6e310e6976baeac7b14f3a6ec02f2d79b7"
+                "reference": "ddc9e3e20ee9c0b6908f401ac8353635b750eca7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/33093f6e310e6976baeac7b14f3a6ec02f2d79b7",
-                "reference": "33093f6e310e6976baeac7b14f3a6ec02f2d79b7",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/ddc9e3e20ee9c0b6908f401ac8353635b750eca7",
+                "reference": "ddc9e3e20ee9c0b6908f401ac8353635b750eca7",
                 "shasum": ""
             },
             "require": {
@@ -2507,12 +2710,12 @@
             },
             "require-dev": {
                 "symfony/debug": "~2.7",
-                "symfony/phpunit-bridge": "~2.7"
+                "symfony/phpunit-bridge": "~3.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.24-dev"
+                    "dev-master": "1.31-dev"
                 }
             },
             "autoload": {
@@ -2547,30 +2750,31 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2016-09-01 17:50:53"
+            "time": "2017-01-11 19:36:15"
         },
         {
             "name": "zendframework/zend-code",
-            "version": "2.6.3",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-code.git",
-                "reference": "95033f061b083e16cdee60530ec260d7d628b887"
+                "reference": "2899c17f83a7207f2d7f53ec2f421204d3beea27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/95033f061b083e16cdee60530ec260d7d628b887",
-                "reference": "95033f061b083e16cdee60530ec260d7d628b887",
+                "url": "https://api.github.com/repos/zendframework/zend-code/zipball/2899c17f83a7207f2d7f53ec2f421204d3beea27",
+                "reference": "2899c17f83a7207f2d7f53ec2f421204d3beea27",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || 7.0.0 - 7.0.4 || ^7.0.6",
+                "php": "^5.6 || 7.0.0 - 7.0.4 || ^7.0.6",
                 "zendframework/zend-eventmanager": "^2.6 || ^3.0"
             },
             "require-dev": {
                 "doctrine/annotations": "~1.0",
-                "fabpot/php-cs-fixer": "1.7.*",
+                "ext-phar": "*",
                 "phpunit/phpunit": "^4.8.21",
+                "squizlabs/php_codesniffer": "^2.5",
                 "zendframework/zend-stdlib": "^2.7 || ^3.0"
             },
             "suggest": {
@@ -2580,8 +2784,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev",
-                    "dev-develop": "2.7-dev"
+                    "dev-master": "3.1-dev",
+                    "dev-develop": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2599,30 +2803,30 @@
                 "code",
                 "zf2"
             ],
-            "time": "2016-04-20 17:26:42"
+            "time": "2016-10-24 13:23:32"
         },
         {
             "name": "zendframework/zend-eventmanager",
-            "version": "3.0.1",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-eventmanager.git",
-                "reference": "5c80bdee0e952be112dcec0968bad770082c3a6e"
+                "reference": "c3bce7b7d47c54040b9ae51bc55491c72513b75d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-eventmanager/zipball/5c80bdee0e952be112dcec0968bad770082c3a6e",
-                "reference": "5c80bdee0e952be112dcec0968bad770082c3a6e",
+                "url": "https://api.github.com/repos/zendframework/zend-eventmanager/zipball/c3bce7b7d47c54040b9ae51bc55491c72513b75d",
+                "reference": "c3bce7b7d47c54040b9ae51bc55491c72513b75d",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5 || ^7.0"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
                 "athletic/athletic": "^0.1",
                 "container-interop/container-interop": "^1.1.0",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "^2.0",
+                "phpunit/phpunit": "^5.6",
+                "zendframework/zend-coding-standard": "~1.0.0",
                 "zendframework/zend-stdlib": "^2.7.3 || ^3.0"
             },
             "suggest": {
@@ -2632,8 +2836,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev",
-                    "dev-develop": "3.1-dev"
+                    "dev-master": "3.1-dev",
+                    "dev-develop": "3.2-dev"
                 }
             },
             "autoload": {
@@ -2653,7 +2857,7 @@
                 "events",
                 "zf2"
             ],
-            "time": "2016-02-18 20:53:00"
+            "time": "2016-12-19 21:47:12"
         },
         {
             "name": "zetacomponents/base",
@@ -2894,6 +3098,71 @@
             "time": "2016-04-26 07:54:33"
         },
         {
+            "name": "gnugat/redaktilo",
+            "version": "v1.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/gnugat/redaktilo.git",
+                "reference": "6ec2da8bc31c0a723ac14670cf193324b773b05e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/gnugat/redaktilo/zipball/6ec2da8bc31c0a723ac14670cf193324b773b05e",
+                "reference": "6ec2da8bc31c0a723ac14670cf193324b773b05e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3|^7.0",
+                "symfony/filesystem": "^2.4.3|^3.0"
+            },
+            "require-dev": {
+                "bossa/phpspec2-expect": "^1.0",
+                "phpspec/phpspec": "^2.4",
+                "phpunit/phpunit": "^4.5|^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Gnugat\\Redaktilo\\": "src/Gnugat/Redaktilo"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Loïck Piera",
+                    "email": "pyrech@gmail.com",
+                    "homepage": "http://loickpiera.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Loïc Faugeron",
+                    "email": "faugeron.loic@gmail.com",
+                    "homepage": "http://gnugat.github.io",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Find, insert, replace and remove lines with an Editor-like object",
+            "keywords": [
+                "edit",
+                "editor",
+                "file",
+                "find",
+                "insert",
+                "lines",
+                "remove",
+                "replace"
+            ],
+            "time": "2015-12-01 17:44:21"
+        },
+        {
             "name": "hamcrest/hamcrest-php",
             "version": "v1.2.2",
             "source": {
@@ -2940,16 +3209,16 @@
         },
         {
             "name": "kriswallsmith/assetic",
-            "version": "v1.3.2",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kriswallsmith/assetic.git",
-                "reference": "9928f7c4ad98b234e3559d1049abd13387f86db5"
+                "reference": "e911c437dbdf006a8f62c2f59b15b2d69a5e0aa1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kriswallsmith/assetic/zipball/9928f7c4ad98b234e3559d1049abd13387f86db5",
-                "reference": "9928f7c4ad98b234e3559d1049abd13387f86db5",
+                "url": "https://api.github.com/repos/kriswallsmith/assetic/zipball/e911c437dbdf006a8f62c2f59b15b2d69a5e0aa1",
+                "reference": "e911c437dbdf006a8f62c2f59b15b2d69a5e0aa1",
                 "shasum": ""
             },
             "require": {
@@ -2957,21 +3226,21 @@
                 "symfony/process": "~2.1|~3.0"
             },
             "conflict": {
-                "twig/twig": "<1.23"
+                "twig/twig": "<1.27"
             },
             "require-dev": {
-                "cssmin/cssmin": "3.0.1",
-                "joliclic/javascript-packer": "1.1",
-                "kamicane/packager": "1.0",
                 "leafo/lessphp": "^0.3.7",
                 "leafo/scssphp": "~0.1",
-                "mrclay/minify": "~2.2",
+                "meenie/javascript-packer": "^1.1",
+                "mrclay/minify": "<2.3",
+                "natxet/cssmin": "3.0.4",
                 "patchwork/jsqueeze": "~1.0|~2.0",
-                "phpunit/phpunit": "~4.8",
+                "phpunit/phpunit": "~4.8 || ^5.6",
                 "psr/log": "~1.0",
                 "ptachoire/cssembed": "~1.0",
                 "symfony/phpunit-bridge": "~2.7|~3.0",
-                "twig/twig": "~1.8|~2.0"
+                "twig/twig": "~1.23|~2.0",
+                "yfix/packager": "dev-master"
             },
             "suggest": {
                 "leafo/lessphp": "Assetic provides the integration with the lessphp LESS compiler",
@@ -3013,7 +3282,7 @@
                 "compression",
                 "minification"
             ],
-            "time": "2015-11-12 13:51:40"
+            "time": "2016-11-11 18:43:20"
         },
         {
             "name": "matthiasnoback/symfony-config-test",
@@ -3113,6 +3382,364 @@
             "time": "2015-11-12 15:32:36"
         },
         {
+            "name": "memio/linter",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/memio/linter.git",
+                "reference": "76286a4ea75c457946a2b5b68d793d6362d870b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/memio/linter/zipball/76286a4ea75c457946a2b5b68d793d6362d870b4",
+                "reference": "76286a4ea75c457946a2b5b68d793d6362d870b4",
+                "shasum": ""
+            },
+            "require": {
+                "memio/model": "^1.0",
+                "memio/validator": "^1.0",
+                "php": "^5.3|^7.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "^1.6",
+                "phpspec/phpspec": "^2.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Memio\\Linter\\": "src/Memio/Linter"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Loïc Faugeron",
+                    "email": "faugeron.loic@gmail.com",
+                    "homepage": "http://gnugat.github.io",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Memio's linter, a set of constraint that check models for syntax errors",
+            "homepage": "http://memio.github.io/memio",
+            "keywords": [
+                "code",
+                "generator",
+                "php"
+            ],
+            "time": "2015-12-01 16:44:02"
+        },
+        {
+            "name": "memio/memio",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/memio/memio.git",
+                "reference": "370d1fc0568a8eb4bc4bf25f7114a590b2717cb9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/memio/memio/zipball/370d1fc0568a8eb4bc4bf25f7114a590b2717cb9",
+                "reference": "370d1fc0568a8eb4bc4bf25f7114a590b2717cb9",
+                "shasum": ""
+            },
+            "require": {
+                "memio/linter": "^1.0",
+                "memio/model": "^1.3",
+                "memio/pretty-printer": "^1.0",
+                "memio/twig-template-engine": "^1.2",
+                "memio/validator": "^1.0",
+                "php": "^5.3|^7.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "^1.6",
+                "phpunit/phpunit": "^4.6|^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Memio\\Memio\\": "src/Memio/Memio",
+                    "Memio\\Memio\\Config\\": "config"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Loïc Faugeron",
+                    "email": "faugeron.loic@gmail.com",
+                    "homepage": "http://gnugat.github.io",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A highly opinionated PHP code generator library",
+            "homepage": "http://memio.github.io/memio",
+            "keywords": [
+                "code",
+                "generator",
+                "php"
+            ],
+            "time": "2015-12-01 17:28:21"
+        },
+        {
+            "name": "memio/model",
+            "version": "v1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/memio/model.git",
+                "reference": "fbf1a4e4f610424b0600ec0d58e8ab9b55ba53e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/memio/model/zipball/fbf1a4e4f610424b0600ec0d58e8ab9b55ba53e7",
+                "reference": "fbf1a4e4f610424b0600ec0d58e8ab9b55ba53e7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3|^7.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "^1.6",
+                "phpspec/phpspec": "^2.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Memio\\Model\\": "src/Memio/Model"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Loïc Faugeron",
+                    "email": "faugeron.loic@gmail.com",
+                    "homepage": "http://gnugat.github.io",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Memio's models, used to describe the code to generate",
+            "homepage": "http://memio.github.io/memio",
+            "keywords": [
+                "code",
+                "generator",
+                "php"
+            ],
+            "time": "2015-12-01 17:21:08"
+        },
+        {
+            "name": "memio/pretty-printer",
+            "version": "v1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/memio/pretty-printer.git",
+                "reference": "d0365eb3afbd1fd417698b89002e31afa9ce3174"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/memio/pretty-printer/zipball/d0365eb3afbd1fd417698b89002e31afa9ce3174",
+                "reference": "d0365eb3afbd1fd417698b89002e31afa9ce3174",
+                "shasum": ""
+            },
+            "require": {
+                "memio/model": "^1.0",
+                "php": "^5.3|^7.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "^1.6",
+                "phpspec/phpspec": "^2.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Memio\\PrettyPrinter\\": "src/Memio/PrettyPrinter"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Loïc Faugeron",
+                    "email": "faugeron.loic@gmail.com",
+                    "homepage": "http://gnugat.github.io",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Memio's PrettyPrinter, used to generate PHP code from given Model",
+            "homepage": "http://memio.github.io/memio",
+            "keywords": [
+                "code",
+                "generator",
+                "php"
+            ],
+            "time": "2015-12-01 11:11:18"
+        },
+        {
+            "name": "memio/spec-gen",
+            "version": "v0.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/memio/spec-gen.git",
+                "reference": "18704292ea613c3739e5afb4731062a0ee32ecb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/memio/spec-gen/zipball/18704292ea613c3739e5afb4731062a0ee32ecb0",
+                "reference": "18704292ea613c3739e5afb4731062a0ee32ecb0",
+                "shasum": ""
+            },
+            "require": {
+                "gnugat/redaktilo": "^1.7",
+                "memio/memio": "^1.1",
+                "php": "^5.6 || ^7.0",
+                "phpspec/phpspec": "^3.0@beta",
+                "symfony/event-dispatcher": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^1.6",
+                "phpunit/phpunit": "^4.6 || ^5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Memio\\SpecGen\\": "src/Memio/SpecGen"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Loïc Faugeron",
+                    "email": "faugeron.loic@gmail.com",
+                    "homepage": "http://gnugat.github.io",
+                    "role": "Developer"
+                }
+            ],
+            "description": "phpspec extension for better code generation",
+            "homepage": "http://memio.github.io/spec-gen",
+            "keywords": [
+                "code",
+                "extension",
+                "generator",
+                "php",
+                "phpspec"
+            ],
+            "time": "2016-09-17 16:37:05"
+        },
+        {
+            "name": "memio/twig-template-engine",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/memio/twig-template-engine.git",
+                "reference": "661b1e560c68963dbe84727710bdfb0f5004965e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/memio/twig-template-engine/zipball/661b1e560c68963dbe84727710bdfb0f5004965e",
+                "reference": "661b1e560c68963dbe84727710bdfb0f5004965e",
+                "shasum": ""
+            },
+            "require": {
+                "memio/model": "^1.3",
+                "memio/pretty-printer": "^1.0",
+                "php": "^5.3 || ^7.0",
+                "twig/twig": "^1.18 || ^2.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^1.6",
+                "phpspec/phpspec": "^2.4 || ^3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Memio\\TwigTemplateEngine\\": "src/Memio/TwigTemplateEngine",
+                    "Memio\\TwigTemplateEngine\\Config\\": "config"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Loïc Faugeron",
+                    "email": "faugeron.loic@gmail.com",
+                    "homepage": "http://gnugat.github.io",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Memio's Twig templates, used to generate PHP code from given Model",
+            "homepage": "http://memio.github.io/memio",
+            "keywords": [
+                "code",
+                "generator",
+                "php",
+                "templates",
+                "twig"
+            ],
+            "time": "2017-01-12 12:01:49"
+        },
+        {
+            "name": "memio/validator",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/memio/validator.git",
+                "reference": "5424fd8b43c833bfa634551fc5cb46962124900d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/memio/validator/zipball/5424fd8b43c833bfa634551fc5cb46962124900d",
+                "reference": "5424fd8b43c833bfa634551fc5cb46962124900d",
+                "shasum": ""
+            },
+            "require": {
+                "memio/model": "^1.0",
+                "php": "^5.3|^7.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "^1.6",
+                "phpspec/phpspec": "^2.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Memio\\Validator\\": "src/Memio/Validator"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Loïc Faugeron",
+                    "email": "faugeron.loic@gmail.com",
+                    "homepage": "http://gnugat.github.io",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Memio's validator, used to check built models again a pre-defined set of rules",
+            "homepage": "http://memio.github.io/memio",
+            "keywords": [
+                "code",
+                "generator",
+                "php"
+            ],
+            "time": "2015-12-01 16:49:43"
+        },
+        {
             "name": "mikey179/vfsStream",
             "version": "v1.1.0",
             "source": {
@@ -3144,16 +3771,16 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "0.9.5",
+            "version": "0.9.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/padraic/mockery.git",
-                "reference": "4db079511a283e5aba1b3c2fb19037c645e70fc2"
+                "reference": "4de7969f4664da3cef1ccd83866c9f59378c3371"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/padraic/mockery/zipball/4db079511a283e5aba1b3c2fb19037c645e70fc2",
-                "reference": "4db079511a283e5aba1b3c2fb19037c645e70fc2",
+                "url": "https://api.github.com/repos/padraic/mockery/zipball/4de7969f4664da3cef1ccd83866c9f59378c3371",
+                "reference": "4de7969f4664da3cef1ccd83866c9f59378c3371",
                 "shasum": ""
             },
             "require": {
@@ -3205,7 +3832,7 @@
                 "test double",
                 "testing"
             ],
-            "time": "2016-05-22 21:52:33"
+            "time": "2016-12-19 14:50:55"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3263,16 +3890,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.1.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd"
+                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/9270140b940ff02e58ec577c237274e92cd40cdd",
-                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
                 "shasum": ""
             },
             "require": {
@@ -3304,20 +3931,20 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-06-10 09:48:41"
+            "time": "2016-09-30 07:12:33"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "0.2",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
-                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
                 "shasum": ""
             },
             "require": {
@@ -3351,20 +3978,140 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-06-10 07:14:17"
+            "time": "2016-11-25 06:54:22"
         },
         {
-            "name": "phpspec/prophecy",
-            "version": "v1.6.1",
+            "name": "phpspec/php-diff",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0"
+                "url": "https://github.com/phpspec/php-diff.git",
+                "reference": "0464787bfa7cd13576c5a1e318709768798bec6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/58a8137754bc24b25740d4281399a4a3596058e0",
-                "reference": "58a8137754bc24b25740d4281399a4a3596058e0",
+                "url": "https://api.github.com/repos/phpspec/php-diff/zipball/0464787bfa7cd13576c5a1e318709768798bec6a",
+                "reference": "0464787bfa7cd13576c5a1e318709768798bec6a",
+                "shasum": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Diff": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Boulton",
+                    "homepage": "http://github.com/chrisboulton"
+                }
+            ],
+            "description": "A comprehensive library for generating differences between two hashable objects (strings or arrays).",
+            "time": "2016-04-07 12:29:16"
+        },
+        {
+            "name": "phpspec/phpspec",
+            "version": "3.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/phpspec.git",
+                "reference": "019a113b657aed90a4aa8f5e39696800779b8b2c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/phpspec/zipball/019a113b657aed90a4aa8f5e39696800779b8b2c",
+                "reference": "019a113b657aed90a4aa8f5e39696800779b8b2c",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.1",
+                "ext-tokenizer": "*",
+                "php": "^5.6 || ^7.0",
+                "phpspec/php-diff": "^1.0.0",
+                "phpspec/prophecy": "^1.5",
+                "sebastian/exporter": "^1.0 || ^2.0",
+                "symfony/console": "^2.7 || ^3.0",
+                "symfony/event-dispatcher": "^2.7 || ^3.0",
+                "symfony/finder": "^2.7 || ^3.0",
+                "symfony/process": "^2.7 || ^3.0",
+                "symfony/yaml": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "behat/behat": "^3.1",
+                "ciaranmcnulty/versionbasedtestskipper": "^0.2.1",
+                "phpunit/phpunit": "^5.4",
+                "symfony/filesystem": "^3.0"
+            },
+            "suggest": {
+                "phpspec/nyan-formatters": "Adds Nyan formatters"
+            },
+            "bin": [
+                "bin/phpspec"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "PhpSpec": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "homepage": "http://marcelloduarte.net/"
+                },
+                {
+                    "name": "Ciaran McNulty",
+                    "homepage": "https://ciaranmcnulty.com/"
+                }
+            ],
+            "description": "Specification-oriented BDD framework for PHP 5.6+",
+            "homepage": "http://phpspec.net/",
+            "keywords": [
+                "BDD",
+                "SpecBDD",
+                "TDD",
+                "spec",
+                "specification",
+                "testing",
+                "tests"
+            ],
+            "time": "2016-12-05 13:46:47"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/6c52c2722f8460122f96f86346600e1077ce22cb",
+                "reference": "6c52c2722f8460122f96f86346600e1077ce22cb",
                 "shasum": ""
             },
             "require": {
@@ -3372,10 +4119,11 @@
                 "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
                 "sebastian/comparator": "^1.1",
-                "sebastian/recursion-context": "^1.0"
+                "sebastian/recursion-context": "^1.0|^2.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.0"
+                "phpspec/phpspec": "^2.0",
+                "phpunit/phpunit": "^4.8 || ^5.6.5"
             },
             "type": "library",
             "extra": {
@@ -3413,7 +4161,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-06-07 08:13:47"
+            "time": "2016-11-21 14:58:47"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3479,16 +4227,16 @@
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -3522,7 +4270,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2016-10-03 07:40:28"
         },
         {
             "name": "phpunit/php-text-template",
@@ -3611,16 +4359,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.8",
+            "version": "1.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3b402f65a4cc90abf6e1104e388b896ce209631b",
+                "reference": "3b402f65a4cc90abf6e1104e388b896ce209631b",
                 "shasum": ""
             },
             "require": {
@@ -3656,20 +4404,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2016-11-15 14:06:22"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.27",
+            "version": "4.8.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90"
+                "reference": "7eb45205d27edd94bd2b3614085ea158bd1e2bca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c062dddcb68e44b563f66ee319ddae2b5a322a90",
-                "reference": "c062dddcb68e44b563f66ee319ddae2b5a322a90",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7eb45205d27edd94bd2b3614085ea158bd1e2bca",
+                "reference": "7eb45205d27edd94bd2b3614085ea158bd1e2bca",
                 "shasum": ""
             },
             "require": {
@@ -3685,7 +4433,7 @@
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-timer": "^1.0.6",
                 "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.1",
+                "sebastian/comparator": "~1.2.2",
                 "sebastian/diff": "~1.2",
                 "sebastian/environment": "~1.3",
                 "sebastian/exporter": "~1.2",
@@ -3728,7 +4476,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-07-21 06:48:14"
+            "time": "2017-01-26 16:15:36"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -3788,22 +4536,22 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "1.2.0",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
+                "reference": "6a1ed12e8b2409076ab22e3897126211ff8b1f7f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "sebastian/exporter": "~1.2 || ~2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "~4.4"
@@ -3848,7 +4596,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2016-11-19 09:18:40"
         },
         {
             "name": "sebastian/diff",
@@ -4160,20 +4908,20 @@
         },
         {
             "name": "symfony/assetic-bundle",
-            "version": "v2.8.0",
+            "version": "v2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/assetic-bundle.git",
-                "reference": "aa5b4f8b712f38745928fa845ddb73300bb2af6d"
+                "reference": "0241b135ff64c6031048c6425cd833a8300da46b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/assetic-bundle/zipball/aa5b4f8b712f38745928fa845ddb73300bb2af6d",
-                "reference": "aa5b4f8b712f38745928fa845ddb73300bb2af6d",
+                "url": "https://api.github.com/repos/symfony/assetic-bundle/zipball/0241b135ff64c6031048c6425cd833a8300da46b",
+                "reference": "0241b135ff64c6031048c6425cd833a8300da46b",
                 "shasum": ""
             },
             "require": {
-                "kriswallsmith/assetic": "~1.3",
+                "kriswallsmith/assetic": "~1.4",
                 "php": ">=5.3.0",
                 "symfony/console": "~2.3|~3.0",
                 "symfony/dependency-injection": "~2.3|~3.0",
@@ -4182,7 +4930,7 @@
             },
             "conflict": {
                 "kriswallsmith/spork": "<=0.2",
-                "twig/twig": "<1.20"
+                "twig/twig": "<1.27"
             },
             "require-dev": {
                 "kriswallsmith/spork": "~0.3",
@@ -4200,7 +4948,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
@@ -4226,24 +4974,24 @@
                 "compression",
                 "minification"
             ],
-            "time": "2015-12-28 13:12:39"
+            "time": "2016-11-22 11:42:57"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
-                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3|^7.0"
+                "php": "^5.3.3 || ^7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -4252,7 +5000,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
@@ -4276,7 +5024,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-08-09 15:02:57"
+            "time": "2016-11-23 20:04:58"
         }
     ],
     "aliases": [],
@@ -4285,7 +5033,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~5.5|~7.0",
+        "php": "~5.6|~7.0",
         "ext-ctype": "*",
         "ext-fileinfo": "*",
         "ext-intl": "*",

--- a/doc/specifications/cache/response_taggers.md
+++ b/doc/specifications/cache/response_taggers.md
@@ -1,0 +1,34 @@
+# Response taggers API
+
+> added in ezpublish-kernel 6.8
+
+ResponseTaggers will take a `Response`, a `ResponseConfigurator` and any value object, and will add tags to the Response
+based on the value.
+
+## Example
+This will add the 'content-<contentId>`, 'location-<mainLocationId>` and `content-type-<contentTypeId>` tags to the
+Response:
+
+```php
+$contentInfoResponseTagger->tag($response, $configurator, $contentInfo);
+```
+
+## The ResponseConfigurator
+A `ResponseCacheConfigurator` configures an HTTP Response object: make the response public, add tags, set the shared max
+age... It is provided to `ResponseTaggers` who use it to add the tags to the Response.
+
+The `ConfigurableResponseCacheConfigurator` (`ezplatform.view_cache.response_configurator`) will follow the `view_cache`
+configuration, and only enable cache if it is enabled in the configuration.
+
+## Delegator and Value Taggers
+Even though they share the same API, ResponseTaggers are of two types, reflected by their namespace: Delegator and Value.
+
+Delegator Taggers will extract another value, or several, from the given value, and pass it on to another tagger. For
+instance, a `ContentView` is covered by both the `ContentValueViewTagger` and the `LocationValueViewTagger`. The first will
+extract the `Content` from the `ContentView`, and pass it to the `ContentInfoTagger`. The second will extract the `Location`,
+and pass it to the `LocationViewTagger`.
+
+## The Dispatcher Tagger
+While it is more efficient to use a known tagger directly, sometimes you don't know what object you want to tag with.
+The Dispatcher ResponseTagger will accept any value, and will pass it to every tagger registered with the service tag
+`ezplatform.http_response_tagger`.

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ResponseTaggersPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ResponseTaggersPass.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Processes services tagged as ezplatform.cache_response_tagger, and registers them with the dispatcher.
+ */
+class ResponseTaggersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('ezplatform.view_cache.response_tagger.dispatcher')) {
+            return;
+        }
+
+        $taggers = [];
+
+        $taggedServiceIds = $container->findTaggedServiceIds('ezplatform.cache_response_tagger');
+        foreach ($taggedServiceIds as $taggedServiceId => $tags) {
+            $taggers[] = new Reference($taggedServiceId);
+        }
+
+        $dispatcher = $container->getDefinition('ezplatform.view_cache.response_tagger.dispatcher');
+        $dispatcher->replaceArgument(0, $taggers);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -115,6 +115,7 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
         $this->handleLocale($config, $container, $loader);
         $this->handleHelpers($config, $container, $loader);
         $this->handleImage($config, $container, $loader);
+        $this->handleViewCache($config, $container, $loader);
 
         // Map settings
         $processor = new ConfigurationProcessor($container, 'ezsettings');
@@ -404,6 +405,11 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
     private function handleHelpers(array $config, ContainerBuilder $container, FileLoader $loader)
     {
         $loader->load('helpers.yml');
+    }
+
+    private function handleViewCache(array $config, ContainerBuilder $container, FileLoader $loader)
+    {
+        $loader->load('view_cache.yml');
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/EventSubscriber/HttpCacheResponseSubscriber.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventSubscriber/HttpCacheResponseSubscriber.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\EventSubscriber;
+
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ResponseCacheConfigurator;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\ResponseTagger;
+use eZ\Publish\Core\MVC\Symfony\View\CachableView;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Configures the Response HTTP cache properties.
+ */
+class HttpCacheResponseSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\ResponseTagger
+     */
+    private $dispatcherTagger;
+
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ResponseCacheConfigurator
+     */
+    private $responseConfigurator;
+
+    public function __construct(ResponseCacheConfigurator $responseConfigurator, ResponseTagger $dispatcherTagger)
+    {
+        $this->responseConfigurator = $responseConfigurator;
+        $this->dispatcherTagger = $dispatcherTagger;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [KernelEvents::RESPONSE => 'configureCache'];
+    }
+
+    public function configureCache(FilterResponseEvent $event)
+    {
+        $view = $event->getRequest()->attributes->get('view');
+        if (!$view instanceof CachableView || !$view->isCacheEnabled()) {
+            return;
+        }
+
+        $response = $event->getResponse();
+        $this->responseConfigurator->enableCache($response);
+        $this->responseConfigurator->setSharedMaxAge($response);
+        $this->dispatcherTagger->tag($this->responseConfigurator, $response, $view);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
@@ -27,6 +27,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\LocalePass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\ContentViewPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\LocationViewPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\BlockViewPass;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\ResponseTaggersPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\SecurityPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\SignalSlotPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\TranslationCollectorPass;
@@ -100,6 +101,7 @@ class EzPublishCoreBundle extends Bundle
         $securityExtension = $container->getExtension('security');
         $securityExtension->addSecurityListenerFactory(new HttpBasicFactory());
         $container->addCompilerPass(new TranslationCollectorPass());
+        $container->addCompilerPass(new ResponseTaggersPass());
     }
 
     public function getContainerExtension()

--- a/eZ/Bundle/EzPublishCoreBundle/Features/ViewCache/view_cache_tags.feature
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/ViewCache/view_cache_tags.feature
@@ -1,0 +1,21 @@
+Feature: HTTP cache tagging of views
+Background:
+    Given that view cache is enabled
+
+Scenario: Viewing a content item tags the Response
+  Given a Content item
+   When I view this Content item
+   Then the response is tagged with "content-<contentId>"
+    And the response is tagged with "location-<locationId>"
+    And the response is tagged with "content-type-<contentTypeId>"
+
+Scenario: Viewing a particular location of a content tags the Response with that location's ID
+  Given a Content item with a secondary Location
+   When I view the Content item from that location
+   Then the response is tagged with "location-<secondaryLocationId>"
+
+Scenario: Viewing a content item with a relation with the default field template tags the Response
+  Given a Content item with a filled relation field
+    And the default template is used to render relation fields
+   When I view this content item
+   Then the response is tagged with "relation-<relatedContentId>"

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -296,12 +296,11 @@ services:
 
     ezpublish.view.cache_response_listener:
         class: "%ezpublish.view.cache_response_listener.class%"
+        deprecated: 'The "%service_id%" service is deprecated. Use "ezplatform.view_cache.response_subscriber" instead'
         arguments:
             - $content.view_cache$
             - $content.ttl_cache$
             - $content.default_ttl$
-        tags:
-            - { name: kernel.event_subscriber }
 
     ezpublish.view.block_cache_response_listener:
         class: "%ezpublish.view.block_cache_response_listener.class%"

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/view_cache.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/view_cache.yml
@@ -1,4 +1,12 @@
 services:
+    ezplatform.view_cache.response_subscriber:
+        class: 'eZ\Bundle\EzPublishCoreBundle\EventSubscriber\HttpCacheResponseSubscriber'
+        arguments:
+            - '@ezplatform.view_cache.response_configurator'
+            - '@ezplatform.view_cache.response_tagger.dispatcher'
+        tags:
+            - { name: kernel.event_subscriber }
+
     ezplatform.view_cache.response_configurator:
         class: 'eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ConfigurableResponseCacheConfigurator'
         arguments:

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/view_cache.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/view_cache.yml
@@ -1,0 +1,35 @@
+services:
+    ezplatform.view_cache.response_configurator:
+        class: 'eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ConfigurableResponseCacheConfigurator'
+        arguments:
+            - '$content.view_cache$'
+            - '$content.ttl_cache$'
+            - '$content.default_ttl$'
+
+    ezplatform.view_cache.response_tagger.dispatcher:
+        class: 'eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Delegator\DispatcherTagger'
+        # Taggers are added by a compiler pass
+        arguments:
+            - []
+
+    ezplatform.view_cache.response_tagger.content_value_view:
+        class: 'eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Delegator\ContentValueViewTagger'
+        arguments: ['@ezplatform.view_cache.response_tagger.content_info']
+        tags:
+            - {name: ezplatform.cache_response_tagger}
+
+    ezplatform.view_cache.response_tagger.location_value_view:
+        class: 'eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Delegator\LocationValueViewTagger'
+        arguments: ['@ezplatform.view_cache.response_tagger.location']
+        tags:
+            - {name: ezplatform.cache_response_tagger}
+
+    ezplatform.view_cache.response_tagger.content_info:
+        class: 'eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Value\ContentInfoTagger'
+        tags:
+            - {name: ezplatform.cache_response_tagger}
+
+    ezplatform.view_cache.response_tagger.location:
+        class: 'eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Value\LocationTagger'
+        tags:
+            - {name: ezplatform.cache_response_tagger}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -264,6 +264,7 @@
     {% if not ez_is_field_empty( content, field ) %}
     <ul {{ block( 'field_attributes' ) }}>
         {% for contentId in field.value.destinationContentIds %}
+        {{ fos_httpcache_tag('relation-' ~ contentId) }}
         <li>
             {{ render( controller( "ez_content:viewAction", {'contentId': contentId, 'viewType': 'embed', 'noLayout': 1} ) ) }}
         </li>
@@ -415,6 +416,7 @@
 {% block ezobjectrelation_field %}
 {% spaceless %}
 {% if not ez_is_field_empty( content, field ) %}
+    {{ fos_httpcache_tag('relation-' ~ field.value.destinationContentId) }}
     <div {{ block( 'field_attributes' ) }}>
         {{ render( controller( "ez_content:viewAction", {'contentId': field.value.destinationContentId, 'viewType': 'text_linked', 'noLayout': 1} ) ) }}
     </div>

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseConfigurator/ConfigurableResponseCacheConfigurator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseConfigurator/ConfigurableResponseCacheConfigurator.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * A ResponseCacheConfigurator configurable by constructor arguments.
+ */
+class ConfigurableResponseCacheConfigurator implements ResponseCacheConfigurator
+{
+    /**
+     * True if view cache is enabled, false if it is not.
+     *
+     * @var bool
+     */
+    private $enableViewCache;
+
+    /**
+     * True if TTL cache is enabled, false if it is not.
+     * @var bool
+     */
+    private $enableTtlCache;
+
+    /**
+     * Default ttl for ttl cache.
+     *
+     * @var int
+     */
+    private $defaultTtl;
+
+    public function __construct($enableViewCache, $enableTtlCache, $defaultTtl)
+    {
+        $this->enableViewCache = $enableViewCache;
+        $this->enableTtlCache = $enableTtlCache;
+        $this->defaultTtl = $defaultTtl;
+    }
+
+    public function enableCache(Response $response)
+    {
+        if ($this->enableViewCache) {
+            $response->setPublic();
+        }
+
+        return $this;
+    }
+
+    public function setSharedMaxAge(Response $response)
+    {
+        if ($this->enableViewCache && $this->enableTtlCache && !$response->headers->hasCacheControlDirective('s-maxage')) {
+            $response->setSharedMaxAge($this->defaultTtl);
+        }
+
+        return $this;
+    }
+
+    public function addTags(Response $response, $tags)
+    {
+        if ($this->enableViewCache) {
+            $response->headers->set('xkey', $tags, false);
+        }
+
+        return $this;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseConfigurator/ResponseCacheConfigurator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseConfigurator/ResponseCacheConfigurator.php
@@ -3,11 +3,9 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator;
 
 use Symfony\Component\HttpFoundation\Response;
-
 
 /**
  * Configures caching options of an HTTP Response.

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseConfigurator/ResponseCacheConfigurator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseConfigurator/ResponseCacheConfigurator.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator;
+
+use Symfony\Component\HttpFoundation\Response;
+
+
+/**
+ * Configures caching options of an HTTP Response.
+ */
+interface ResponseCacheConfigurator
+{
+    /**
+     * Enables cache on a Response.
+     *
+     * @param \Symfony\Component\HttpFoundation\Response $response
+     *
+     * @return ResponseCacheConfigurator
+     */
+    public function enableCache(Response $response);
+
+    /**
+     * Sets the shared-max-age property of a Response if it is not already set.
+     *
+     * @param \Symfony\Component\HttpFoundation\Response $response
+     *
+     * @return ResponseCacheConfigurator
+     */
+    public function setSharedMaxAge(Response $response);
+
+    /**
+     * Adds $tags to the response's cache tags header.
+     *
+     * @param \Symfony\Component\HttpFoundation\Response $response
+     * @param string|array $tags Single tag, or array of tags
+     *
+     * @return ResponseCacheConfigurator
+     */
+    public function addTags(Response $response, $tags);
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Delegator/ContentValueViewTagger.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Delegator/ContentValueViewTagger.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Delegator;
+
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ResponseCacheConfigurator;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\ResponseTagger;
+use eZ\Publish\Core\MVC\Symfony\View\ContentValueView;
+use Symfony\Component\HttpFoundation\Response;
+
+class ContentValueViewTagger implements ResponseTagger
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\ResponseTagger
+     */
+    private $contentInfoTagger;
+
+    public function __construct(ResponseTagger $contentInfoTagger)
+    {
+        $this->contentInfoTagger = $contentInfoTagger;
+    }
+
+    public function tag(ResponseCacheConfigurator $configurator, Response $response, $view)
+    {
+        if (!$view instanceof ContentValueView || !($content = $view->getContent()) instanceof Content) {
+            return $this;
+        }
+
+        $contentInfo = $content->getVersionInfo()->getContentInfo();
+        $this->contentInfoTagger->tag($configurator, $response, $contentInfo);
+
+        return $this;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Delegator/DispatcherTagger.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Delegator/DispatcherTagger.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Delegator;
+
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ResponseCacheConfigurator;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\ResponseTagger;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Dispatches a value to all registered ResponseTaggers.
+ */
+class DispatcherTagger implements ResponseTagger
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\ResponseTagger
+     */
+    private $taggers = [];
+
+    public function __construct(array $taggers = [])
+    {
+        $this->taggers = $taggers;
+    }
+
+    public function tag(ResponseCacheConfigurator $configurator, Response $response, $value)
+    {
+        foreach ($this->taggers as $tagger) {
+            $tagger->tag($configurator, $response, $value);
+        }
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Delegator/LocationValueViewTagger.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Delegator/LocationValueViewTagger.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Delegator;
+
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ResponseCacheConfigurator;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\ResponseTagger;
+use eZ\Publish\Core\MVC\Symfony\View\LocationValueView;
+use Symfony\Component\HttpFoundation\Response;
+
+class LocationValueViewTagger implements ResponseTagger
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\ResponseTagger
+     */
+    private $locationTagger;
+
+    public function __construct(ResponseTagger $locationTagger)
+    {
+        $this->locationTagger = $locationTagger;
+    }
+
+    public function tag(ResponseCacheConfigurator $configurator, Response $response, $view)
+    {
+        if (!$view instanceof LocationValueView || !($location = $view->getLocation()) instanceof Location) {
+            return $this;
+        }
+
+        $this->locationTagger->tag($configurator, $response, $location);
+
+        return $this;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/ResponseTagger.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/ResponseTagger.php
@@ -5,7 +5,6 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger;
 
-use eZ\Publish\Core\MVC\Symfony\Cache\Http\ConfigurableResponseCacheConfigurator;
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ResponseCacheConfigurator;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/ResponseTagger.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/ResponseTagger.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger;
+
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ConfigurableResponseCacheConfigurator;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ResponseCacheConfigurator;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Tags a Response based on data from a value.
+ */
+interface ResponseTagger
+{
+    /**
+     * Extracts tags from a value, and adds them using the Configurator.
+     *
+     * @param ResponseCacheConfigurator $configurator
+     * @param \Symfony\Component\HttpFoundation\Response $response
+     * @param mixed $value
+     *
+     * @return \eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\ResponseTagger
+     */
+    public function tag(ResponseCacheConfigurator $configurator, Response $response, $value);
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Value/ContentInfoTagger.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Value/ContentInfoTagger.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Value;
+
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ConfigurableResponseCacheConfigurator;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ResponseCacheConfigurator;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\ResponseTagger;
+use Symfony\Component\HttpFoundation\Response;
+
+class ContentInfoTagger implements ResponseTagger
+{
+    public function tag(ResponseCacheConfigurator $configurator, Response $response, $value)
+    {
+        if (!$value instanceof ContentInfo) {
+            return $this;
+        }
+
+        $configurator->addTags(
+            $response,
+            ['content-' . $value->id, 'content-type-' . $value->contentTypeId]
+        );
+
+        if ($value->mainLocationId) {
+            $configurator->addTags($response, ['location-' . $value->mainLocationId]);
+        }
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Value/ContentInfoTagger.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Value/ContentInfoTagger.php
@@ -3,7 +3,6 @@
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Value;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
-use eZ\Publish\Core\MVC\Symfony\Cache\Http\ConfigurableResponseCacheConfigurator;
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ResponseCacheConfigurator;
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\ResponseTagger;
 use Symfony\Component\HttpFoundation\Response;

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Value/LocationTagger.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Value/LocationTagger.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Value;
+
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ResponseCacheConfigurator;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\ResponseTagger;
+use Symfony\Component\HttpFoundation\Response;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+
+class LocationTagger implements ResponseTagger
+{
+    public function tag(ResponseCacheConfigurator $configurator, Response $response, $value)
+    {
+        if (!$value instanceof Location) {
+            return $this;
+        }
+
+        if ($value->id !== $value->contentInfo->mainLocationId) {
+            $configurator->addTags($response, ['location-' . $value->id]);
+        }
+
+        $configurator->addTags($response, ['parent-' . $value->parentLocationId]);
+        $configurator->addTags(
+            $response,
+            array_map(
+                function ($pathItem) {
+                    return 'path-' . $pathItem;
+                },
+                $value->path
+            )
+        );
+
+        return $this;
+    }
+}

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,0 +1,8 @@
+extensions:
+    Memio\SpecGen\MemioSpecGenExtension: ~
+
+suites:
+    kernel:
+        namespace: eZ
+        src_path: %paths.config%
+

--- a/spec/eZ/Bundle/EzPublishCoreBundle/EventSubscriber/HttpCacheResponseSubscriberSpec.php
+++ b/spec/eZ/Bundle/EzPublishCoreBundle/EventSubscriber/HttpCacheResponseSubscriberSpec.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace spec\eZ\Bundle\EzPublishCoreBundle\EventSubscriber;
+
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ResponseCacheConfigurator;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\ResponseTagger;
+use eZ\Publish\Core\MVC\Symfony\View\CachableView;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+
+class HttpCacheResponseSubscriberSpec extends ObjectBehavior
+{
+    public function let(
+        FilterResponseEvent $event,
+        Request $request,
+        Response $response,
+        ParameterBag $requestAttributes,
+        ResponseCacheConfigurator $configurator,
+        ResponseTagger $dispatcherTagger
+    ) {
+        $request->attributes = $requestAttributes;
+        $event->getRequest()->willReturn($request);
+        $event->getResponse()->willReturn($response);
+
+        $this->beConstructedWith($configurator, $dispatcherTagger);
+    }
+
+    public function it_does_not_enable_cache_if_the_view_is_not_a_cachableview(
+        FilterResponseEvent $event,
+        ResponseCacheConfigurator $configurator,
+        ParameterBag $requestAttributes,
+        View $nonCachableView
+    ) {
+        $requestAttributes->get('view')->willReturn($nonCachableView);
+        $configurator->enableCache()->shouldNotBecalled();
+
+        $this->configureCache($event);
+    }
+
+    public function it_does_not_enable_cache_if_it_is_disabled_in_the_view(
+        FilterResponseEvent $event,
+        ResponseCacheConfigurator $configurator,
+        CachableView $view,
+        ParameterBag $requestAttributes
+    ) {
+        $requestAttributes->get('view')->willReturn($view);
+        $view->isCacheEnabled()->willReturn(false);
+        $configurator->enableCache()->shouldNotBecalled();
+
+        $this->configureCache($event);
+    }
+
+    public function it_enables_cache(
+        FilterResponseEvent $event,
+        ResponseCacheConfigurator $configurator,
+        CachableView $view,
+        ParameterBag $requestAttributes,
+        ResponseTagger $dispatcherTagger
+    ) {
+        $requestAttributes->get('view')->willReturn($view);
+        $view->isCacheEnabled()->willReturn(true);
+
+        $this->configureCache($event);
+
+        $configurator->enableCache(Argument::type(Response::class))->shouldHaveBeenCalled();
+        $configurator->setSharedMaxAge(Argument::type(Response::class))->shouldHaveBeenCalled();
+        $dispatcherTagger->tag($configurator, Argument::type(Response::class), $view)->shouldHaveBeenCalled();
+    }
+}

--- a/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseConfigurator/ConfigurableResponseCacheConfiguratorSpec.php
+++ b/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseConfigurator/ConfigurableResponseCacheConfiguratorSpec.php
@@ -4,25 +4,23 @@ namespace spec\eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator;
 
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ConfigurableResponseCacheConfigurator;
 use PhpSpec\ObjectBehavior;
-use Prophecy\Argument;
-use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class ConfigurableResponseCacheConfiguratorSpec extends ObjectBehavior
 {
-    function let(Response $response, ResponseHeaderBag $headers)
+    public function let(Response $response, ResponseHeaderBag $headers)
     {
         $response->headers = $headers;
         $this->beConstructedWith(true, true, 30);
     }
 
-    function it_is_initializable()
+    public function it_is_initializable()
     {
         $this->shouldHaveType(ConfigurableResponseCacheConfigurator::class);
     }
 
-    function it_sets_cache_control_to_public_if_viewcache_is_enabled(Response $response)
+    public function it_sets_cache_control_to_public_if_viewcache_is_enabled(Response $response)
     {
         $this->beConstructedWith(true, false, 0);
         $this->enableCache($response);
@@ -30,7 +28,7 @@ class ConfigurableResponseCacheConfiguratorSpec extends ObjectBehavior
         $response->setPublic()->shouldHaveBeenCalled();
     }
 
-    function it_does_not_set_cache_control_if_viewcache_is_disabled(Response $response)
+    public function it_does_not_set_cache_control_if_viewcache_is_disabled(Response $response)
     {
         $this->beConstructedWith(false, false, 0);
         $this->enableCache($response);
@@ -38,7 +36,7 @@ class ConfigurableResponseCacheConfiguratorSpec extends ObjectBehavior
         $response->setPublic()->shouldNotHaveBeenCalled();
     }
 
-    function it_does_not_set_shared_maxage_if_ttl_cache_is_disabled(Response $response)
+    public function it_does_not_set_shared_maxage_if_ttl_cache_is_disabled(Response $response)
     {
         $this->beConstructedWith(true, false, 30);
         $this->setSharedMaxAge($response);
@@ -46,7 +44,7 @@ class ConfigurableResponseCacheConfiguratorSpec extends ObjectBehavior
         $response->setSharedMaxAge(30)->shouldNotHaveBeenCalled();
     }
 
-    function it_does_not_set_shared_maxage_if_it_is_already_set_in_the_response(Response $response, ResponseHeaderBag $headers)
+    public function it_does_not_set_shared_maxage_if_it_is_already_set_in_the_response(Response $response, ResponseHeaderBag $headers)
     {
         $this->beConstructedWith(true, true, 30);
         $headers->hasCacheControlDirective('s-maxage')->willReturn(true);
@@ -56,7 +54,7 @@ class ConfigurableResponseCacheConfiguratorSpec extends ObjectBehavior
         $response->setSharedMaxAge($response, 30)->shouldNotHaveBeenCalled();
     }
 
-    function it_sets_shared_maxage(Response $response, ResponseHeaderBag $headers)
+    public function it_sets_shared_maxage(Response $response, ResponseHeaderBag $headers)
     {
         $this->beConstructedWith(true, true, 30);
         $headers->hasCacheControlDirective('s-maxage')->willReturn(false);
@@ -66,7 +64,7 @@ class ConfigurableResponseCacheConfiguratorSpec extends ObjectBehavior
         $response->setSharedMaxAge(30)->shouldHaveBeenCalled();
     }
 
-    function it_does_not_add_tags_if_viewcache_is_disabled(Response $response, ResponseHeaderBag $headers)
+    public function it_does_not_add_tags_if_viewcache_is_disabled(Response $response, ResponseHeaderBag $headers)
     {
         $this->beConstructedWith(false, false, 0);
         $this->addTags($response, ['foo-1', 'bar-2']);
@@ -74,7 +72,7 @@ class ConfigurableResponseCacheConfiguratorSpec extends ObjectBehavior
         $headers->set('xkey', ['foo-1', 'bar-2'])->shouldNotHaveBeenCalled();
     }
 
-    function it_adds_tags_to_the_xkey_header(Response $response, ResponseHeaderBag $headers)
+    public function it_adds_tags_to_the_xkey_header(Response $response, ResponseHeaderBag $headers)
     {
         $this->beConstructedWith(false, false, 0);
         $this->addTags($response, ['foo-1', 'bar-2']);

--- a/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseConfigurator/ConfigurableResponseCacheConfiguratorSpec.php
+++ b/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseConfigurator/ConfigurableResponseCacheConfiguratorSpec.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace spec\eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator;
+
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ConfigurableResponseCacheConfigurator;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+
+class ConfigurableResponseCacheConfiguratorSpec extends ObjectBehavior
+{
+    function let(Response $response, ResponseHeaderBag $headers)
+    {
+        $response->headers = $headers;
+        $this->beConstructedWith(true, true, 30);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(ConfigurableResponseCacheConfigurator::class);
+    }
+
+    function it_sets_cache_control_to_public_if_viewcache_is_enabled(Response $response)
+    {
+        $this->beConstructedWith(true, false, 0);
+        $this->enableCache($response);
+
+        $response->setPublic()->shouldHaveBeenCalled();
+    }
+
+    function it_does_not_set_cache_control_if_viewcache_is_disabled(Response $response)
+    {
+        $this->beConstructedWith(false, false, 0);
+        $this->enableCache($response);
+
+        $response->setPublic()->shouldNotHaveBeenCalled();
+    }
+
+    function it_does_not_set_shared_maxage_if_ttl_cache_is_disabled(Response $response)
+    {
+        $this->beConstructedWith(true, false, 30);
+        $this->setSharedMaxAge($response);
+
+        $response->setSharedMaxAge(30)->shouldNotHaveBeenCalled();
+    }
+
+    function it_does_not_set_shared_maxage_if_it_is_already_set_in_the_response(Response $response, ResponseHeaderBag $headers)
+    {
+        $this->beConstructedWith(true, true, 30);
+        $headers->hasCacheControlDirective('s-maxage')->willReturn(true);
+
+        $this->setSharedMaxAge($response);
+
+        $response->setSharedMaxAge($response, 30)->shouldNotHaveBeenCalled();
+    }
+
+    function it_sets_shared_maxage(Response $response, ResponseHeaderBag $headers)
+    {
+        $this->beConstructedWith(true, true, 30);
+        $headers->hasCacheControlDirective('s-maxage')->willReturn(false);
+
+        $this->setSharedMaxAge($response);
+
+        $response->setSharedMaxAge(30)->shouldHaveBeenCalled();
+    }
+
+    function it_does_not_add_tags_if_viewcache_is_disabled(Response $response, ResponseHeaderBag $headers)
+    {
+        $this->beConstructedWith(false, false, 0);
+        $this->addTags($response, ['foo-1', 'bar-2']);
+
+        $headers->set('xkey', ['foo-1', 'bar-2'])->shouldNotHaveBeenCalled();
+    }
+
+    function it_adds_tags_to_the_xkey_header(Response $response, ResponseHeaderBag $headers)
+    {
+        $this->beConstructedWith(false, false, 0);
+        $this->addTags($response, ['foo-1', 'bar-2']);
+
+        $headers->set('xkey', ['foo-1', 'bar-2'])->shouldNotHaveBeenCalled();
+    }
+}

--- a/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Delegator/ContentValueViewTaggerSpec.php
+++ b/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Delegator/ContentValueViewTaggerSpec.php
@@ -3,7 +3,6 @@
 namespace spec\eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Delegator;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
-use eZ\Publish\Core\MVC\Symfony\Cache\Http\ConfigurableResponseCacheConfigurator;
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ResponseCacheConfigurator;
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Delegator\ContentValueViewTagger;
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\ResponseTagger;

--- a/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Delegator/ContentValueViewTaggerSpec.php
+++ b/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Delegator/ContentValueViewTaggerSpec.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace spec\eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Delegator;
+
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ConfigurableResponseCacheConfigurator;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ResponseCacheConfigurator;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Delegator\ContentValueViewTagger;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\ResponseTagger;
+use eZ\Publish\Core\MVC\Symfony\View\ContentValueView;
+use eZ\Publish\Core\Repository\Values\Content\Content;
+use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\Response;
+
+class ContentValueViewTaggerSpec extends ObjectBehavior
+{
+    public function let(ResponseTagger $contentInfoTagger)
+    {
+        $this->beConstructedWith($contentInfoTagger);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(ContentValueViewTagger::class);
+    }
+
+    public function it_delegates_tagging_of_the_content_info(
+        ResponseTagger $contentInfoTagger,
+        ResponseCacheConfigurator $configurator,
+        Response $response,
+        ContentValueView $view
+    ) {
+        $contentInfo = new ContentInfo();
+        $content = new Content(['versionInfo' => new VersionInfo(['contentInfo' => $contentInfo])]);
+        $view->getContent()->willReturn($content);
+
+        $this->tag($configurator, $response, $view);
+
+        $contentInfoTagger->tag($configurator, $response, $contentInfo)->shouldHaveBeenCalled();
+    }
+}

--- a/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Delegator/DispatcherTaggerSpec.php
+++ b/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Delegator/DispatcherTaggerSpec.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace spec\eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Delegator;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ConfigurableResponseCacheConfigurator;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ResponseCacheConfigurator;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Delegator\DispatcherTagger;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\ResponseTagger;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\Response;
+
+class DispatcherTaggerSpec extends ObjectBehavior
+{
+    public function let(ResponseTagger $taggerOne, ResponseTagger $taggerTwo)
+    {
+        $this->beConstructedWith([$taggerOne, $taggerTwo]);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(DispatcherTagger::class);
+    }
+
+    public function it_calls_tag_on_every_tagger(
+        ResponseTagger $taggerOne,
+        ResponseTagger $taggerTwo,
+        ResponseCacheConfigurator $configurator,
+        Response $response,
+        ValueObject $value
+    ) {
+        $this->tag($configurator, $response, $value);
+
+        $taggerOne->tag($configurator, $response, $value)->shouldHaveBeenCalled();
+        $taggerTwo->tag($configurator, $response, $value)->shouldHaveBeenCalled();
+    }
+}

--- a/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Delegator/DispatcherTaggerSpec.php
+++ b/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Delegator/DispatcherTaggerSpec.php
@@ -3,7 +3,6 @@
 namespace spec\eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Delegator;
 
 use eZ\Publish\API\Repository\Values\ValueObject;
-use eZ\Publish\Core\MVC\Symfony\Cache\Http\ConfigurableResponseCacheConfigurator;
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ResponseCacheConfigurator;
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Delegator\DispatcherTagger;
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\ResponseTagger;

--- a/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Delegator/LocationValueViewTaggerSpec.php
+++ b/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Delegator/LocationValueViewTaggerSpec.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace spec\eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Delegator;
+
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ResponseCacheConfigurator;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Delegator\LocationValueViewTagger;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\ResponseTagger;
+use eZ\Publish\Core\MVC\Symfony\View\LocationValueView;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\Response;
+
+class LocationValueViewTaggerSpec extends ObjectBehavior
+{
+    public function let(ResponseTagger $locationTagger)
+    {
+        $this->beConstructedWith($locationTagger);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(LocationValueViewTagger::class);
+    }
+
+    public function it_delegates_tagging_of_the_location(
+        ResponseTagger $locationTagger,
+        ResponseCacheConfigurator $configurator,
+        Response $response,
+        LocationValueView $view
+    ) {
+        $location = new Location();
+        $view->getLocation()->willReturn($location);
+        $this->tag($configurator, $response, $view);
+
+        $locationTagger->tag($configurator, $response, $location)->shouldHaveBeenCalled();
+    }
+}

--- a/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Value/ContentInfoTaggerSpec.php
+++ b/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Value/ContentInfoTaggerSpec.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace spec\eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Value;
+
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ConfigurableResponseCacheConfigurator;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ResponseCacheConfigurator;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Value\ContentInfoTagger;
+use PhpSpec\ObjectBehavior;
+use Symfony\Component\HttpFoundation\Response;
+
+class ContentInfoTaggerSpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(ContentInfoTagger::class);
+    }
+
+    public function it_ignores_non_content_info(
+        ResponseCacheConfigurator $configurator,
+        Response $response)
+    {
+        $this->tag($configurator, $response, null);
+
+        $configurator->addTags()->shouldNotHaveBeenCalled();
+    }
+
+    public function it_tags_with_content_and_content_type_id(
+        ResponseCacheConfigurator $configurator,
+        Response $response)
+    {
+        $value = new ContentInfo(['id' => 123, 'contentTypeId' => 987]);
+
+        $this->tag($configurator, $response, $value);
+
+        $configurator->addTags($response, ['content-123', 'content-type-987'])->shouldHaveBeenCalled();
+    }
+
+    public function it_tags_with_location_id_if_one_is_set(
+        ResponseCacheConfigurator $configurator,
+        Response $response)
+    {
+        $value = new ContentInfo(['mainLocationId' => 456]);
+
+        $this->tag($configurator, $response, $value);
+
+        $configurator->addTags($response, ['location-456'])->shouldHaveBeenCalled();
+    }
+}

--- a/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Value/ContentInfoTaggerSpec.php
+++ b/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Value/ContentInfoTaggerSpec.php
@@ -3,7 +3,6 @@
 namespace spec\eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Value;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
-use eZ\Publish\Core\MVC\Symfony\Cache\Http\ConfigurableResponseCacheConfigurator;
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ResponseCacheConfigurator;
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Value\ContentInfoTagger;
 use PhpSpec\ObjectBehavior;

--- a/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Value/LocationTaggerSpec.php
+++ b/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Value/LocationTaggerSpec.php
@@ -3,9 +3,7 @@
 namespace spec\eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Value;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
-use eZ\Publish\Core\MVC\Symfony\Cache\Http\ConfigurableResponseCacheConfigurator;
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ResponseCacheConfigurator;
-use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\ResponseTagger;
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Value\LocationTagger;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use PhpSpec\ObjectBehavior;

--- a/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Value/LocationTaggerSpec.php
+++ b/spec/eZ/Publish/Core/MVC/Symfony/Cache/Http/ResponseTagger/Value/LocationTaggerSpec.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace spec\eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Value;
+
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ConfigurableResponseCacheConfigurator;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseConfigurator\ResponseCacheConfigurator;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\ResponseTagger;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ResponseTagger\Value\LocationTagger;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Symfony\Component\HttpFoundation\Response;
+
+class LocationTaggerSpec extends ObjectBehavior
+{
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(LocationTagger::class);
+    }
+
+    public function it_ignores_non_location(
+        ResponseCacheConfigurator $configurator,
+        Response $response)
+    {
+        $this->tag($configurator, $response, null);
+
+        $configurator->addTags($response, Argument::any())->shouldNotHaveBeenCalled();
+    }
+
+    public function it_tags_with_location_id_if_not_main_location(
+        ResponseCacheConfigurator $configurator,
+        Response $response
+    ) {
+        $value = new Location(['id' => 123, 'contentInfo' => new ContentInfo(['mainLocationId' => 321])]);
+        $this->tag($configurator, $response, $value);
+
+        $configurator->addTags($response, ['location-123'])->shouldHaveBeenCalled();
+    }
+
+    public function it_tags_with_parent_location_id(
+        ResponseCacheConfigurator $configurator,
+        Response $response)
+    {
+        $value = new Location(['parentLocationId' => 123, 'contentInfo' => new ContentInfo()]);
+
+        $this->tag($configurator, $response, $value);
+
+        $configurator->addTags($response, ['parent-123'])->shouldHaveBeenCalled();
+    }
+
+    public function it_tags_with_path_items(
+        ResponseCacheConfigurator $configurator,
+        Response $response)
+    {
+        $value = new Location(['pathString' => '/1/2/123', 'contentInfo' => new ContentInfo()]);
+
+        $this->tag($configurator, $response, $value);
+
+        $configurator->addTags($response, ['path-1', 'path-2', 'path-123'])->shouldHaveBeenCalled();
+    }
+}


### PR DESCRIPTION
> MVC part of [EZP-22401](http://jira.ez.no/browse/EZP-22401)

The objective is to add to Responses from the MVC layer a `xkey` header with the tags matching the value objects they contain. For a typical content view, it would be like `xkey: content-1, location-2, content-type-1`.

_As this value <=> cache tag mapping also applies to REST embedding, the logic must be re-usable by the REST API._

## Architecture

It articulates around `ResponseTaggers`. Those will, for a given value object type, add tags to a `Response`. While some may add tags directly (`ContentInfoTagger`, `RelationTagger`), others will extract one or more value objects from the one they were given, and delegate its tagging to others Taggers (`ContentValueViewTagger`, `RestContentTagger`).

```
$tagger->tag($configurator, $response, $content);
```

To do the actual tagging, the Taggers are given a `ResponseCacheConfigurator`. This configurator centralizes the cache configuration of the response, included but not limited to the `xkey` header name. It can also make the response public, and set the shared max age:

```
$configurator->makePublic($response);
$configurator->setSharedMaxAge($response);
$configurator->addTags($response, ['content-1']);
```

The actual tagging is done by the `HttpCacheResponseSubscriber`, that replaces (and deprecates) `CacheViewResponseListener`. It uses a `Configurator` and a `ResponseTagger`. The `ResponseTagger` is a special one, the `DispatcherTagger`. It has all the tagger services tagged with `ezplatform.cache_response_tagger`.

The listener will tell the dispatcher `ResponseTagger` to tag the `Response` with the View object it gets from the request attributes.

### Tagging example
Taking ContentView as an example, the call chain is as follows:
```
- CacheViewEventListener, $dispatcherTagger->tag($contentView)
  - ContentValueViewTagger # Extracts the ContentInfo using the ContentValueView interface
      - ContentInfoTagger # adds tags for the content info
    - LocationValueViewTagger # Extracts the ContentInfo using the LocationValueView interface
      - LocationTagger # adds tags for the location
```

## Usage in REST
In the current REST embedding implementation, an extra REST controller layer is added so that tags can be added to a `CachedValue` decorator. The controllers implementation contains the tagging logic.

The idea is to remove this controller layer, and use the tagger from the `CachedValue` and `ResourceLink` visitors to tag the HTTP responses.

Additional Taggers will be needed to extract actual repository value objects from the REST aggregate value objects (example: RestContent).

### PhpSpec
The classes from this feature have been specificed using [phpspec](http://www.phpspec.net/en/stable/), "A php toolset to drive emergent
design by specification.". Please have a look at the [execution result from travis](https://travis-ci.org/ezsystems/ezpublish-kernel/jobs/196446788#L603), they should explain the architecture above quite well.

The commit adds phpspec, as well as spec-gen, a library that generates code based on specifications.

### Testing done
- phpspec
- http request with cache enabled on the home page, checked that the xkey tags were sent

### Behat
The pull-request includes [three behat scenarios](https://github.com/ezsystems/ezpublish-kernel/blob/http_cache_mvc/eZ/Bundle/EzPublishCoreBundle/Features/ViewCache/view_cache_tags.feature) that cover the main lines of content view cache tagging. The sentences are not implemented.

### TODO
- [x] Fix unit tests
- [x] Make sure phpunit _and_ phpspec must both pass for travis to pass
- [x] Write down description above to [spec document](https://github.com/ezsystems/ezpublish-kernel/blob/http_cache_mvc/doc/specifications/cache/response_taggers.md)
- [ ] Consider merging `ResponseCacheConfigurator::makePublic()` and `::setSharedMaxAge()` to one `::configure()` call. The settings can be used to set both `cache-control` and `s-maxage`.
- [ ] **Make sure that fos-httpcache-bundle is configured to send the `xkey` header for cache tags**
- [ ] Update BC doc
