### PR TITLE
Fix EZP-26902: Binary files max file size in content type view has wrong unit

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
@@ -294,7 +294,7 @@
         <div class="ez-fielddefinition-setting-value">
         {% if fielddefinition.validatorConfiguration.FileSizeValidator.maxFileSize %}
             {# TODO l10n / unit #}
-            {{ fielddefinition.validatorConfiguration.FileSizeValidator.maxFileSize }} bytes
+            {{ fielddefinition.validatorConfiguration.FileSizeValidator.maxFileSize }} MB
         {% else %}
             <em>No defined maximum size</em>
         {% endif %}


### PR DESCRIPTION
> [EZP-26902](https://jira.ez.no/browse/EZP-26902)

The size is entered and stored in megabytes, but the fielddefinition settings template presents it as bytes.

<img width="272" alt="capture d ecran 2017-01-31 a 10 06 04" src="https://cloud.githubusercontent.com/assets/235928/22458620/9455e20c-e79d-11e6-89a1-8210e1e653fb.png">
