### PR TITLE
Http cache tag aware store

### DIFF
--- a/doc/specifications/cache/multi_tagging.md
+++ b/doc/specifications/cache/multi_tagging.md
@@ -1,0 +1,40 @@
+# Multi-tagging
+
+Cache tagging, aka cache labeling is a concepts being introduced in both:
+- HttpCache using both the builtin enhanced PHP based Symfony Proxy, and Varnish *(with plain BAN and with xkey vmod)*
+- Repository Cache *(coming, to replace current persistence cache)*
+
+This document concentrates on defining out of the box tags, and attempts to give guidelines for how to
+use them both in responses and how to best handle invalidation.
+
+## Recommendations
+
+### Avoiding Cache Stamping effect
+
+_Cache stamped (dog-piling): That several requests are requesting a cache item at the same time, worst case being a high
+traffic page like front page being expired and all traffic is in parallel trying to regenerate the cache overloading the
+system._
+
+Two ways to avoid:
+
+
+### Staleness / Soft purge vs instant UI updates
+
+For HttpCache, to be able to archive stable performance of your setup our recommendation involves using Varnish with
+xkey vmod, and soft purge of http cache. This means the given cache item will be re-generated on next request, and until
+cache has been refreshed all other parallel requests are served stale cache item *(the old version)*.
+
+This is great for avoiding cache stamped effect, however for things like the Platform UI you'll need to take this into
+account. There are two ways of solving this:
+- Make UI code aware that operations won't update the response immediately, like in distributed systems with eventually consistency.
+- Setup UI on separate admin/backend domain where cache is shared with main domain, but where grace time is always 0.
+
+### Cache stamped protection
+
+Normally archived by having a percentage of randomness in expiry before the actual expiry time, so not several requests
+end up trying to re generate a given cache, or several caches in parallel typically at the same time.
+
+### Avoiding to eager tag invalidation
+
+
+

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/cache.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/cache.yml
@@ -2,7 +2,7 @@ parameters:
     ezpublish.cache_pool.factory.class: eZ\Bundle\EzPublishCoreBundle\ApiLoader\CacheFactory
     ezpublish.http_cache.purger.instant.class: eZ\Bundle\EzPublishCoreBundle\Cache\Http\InstantCachePurger
     ezpublish.http_cache.purge_client.local.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\LocalPurgeClient
-    ezpublish.http_cache.store.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\LocationAwareStore
+    ezpublish.http_cache.store.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\Proxy\TagAwareStore
     ezpublish.http_cache.store.root: "%kernel.cache_dir%/http_cache"
     ezpublish.http_cache.cache_manager.class: FOS\HttpCacheBundle\CacheManager
     ezpublish.http_cache.proxy_client.varnish.factory.class: eZ\Bundle\EzPublishCoreBundle\Cache\Http\VarnishProxyClientFactory

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/ContentPurger.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/ContentPurger.php
@@ -10,8 +10,8 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Http;
 
 /**
  * Interface allowing for HttpCache stores to purge specific content.
- * When purging content by locationId, purgeByRequest() would receive a Request object with X-Location-Id or X-Group-Location-Id headers
- * indicating which locations to purge.
+ * When purging content by tags, purgeByRequest() would receive a Request object with xkey headers
+ * indicating which objects to purge.
  */
 interface ContentPurger extends RequestAwarePurger
 {

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/ContentPurger.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/ContentPurger.php
@@ -18,6 +18,8 @@ interface ContentPurger extends RequestAwarePurger
     /**
      * Purges all cached content.
      *
+     * @deprecated Use cache:clear, with multi tagging theoretically there shouldn't be need to delete all anymore from core.
+     *
      * @return bool
      */
     public function purgeAllContent();

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/LocationAwareStore.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/LocationAwareStore.php
@@ -16,6 +16,8 @@ use Symfony\Component\Filesystem\Exception\IOException;
 
 /**
  * LocationAwareStore implements all the logic for storing cache metadata regarding locations.
+ *
+ * @deprecated This class is deprecated since v6.8.0. Use TagAwareStore instead.
  */
 class LocationAwareStore extends Store implements ContentPurger
 {

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/Proxy/TagAwareStore.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/Proxy/TagAwareStore.php
@@ -1,0 +1,232 @@
+<?php
+
+/**
+ * File containing the TagAwareStore class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\Proxy;
+
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ContentPurger;
+use Symfony\Component\HttpKernel\HttpCache\Store;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * TagAwareStore implements all the logic for storing cache metadata regarding tags (locations, content type, ..).
+ */
+class TagAwareStore extends Store implements ContentPurger
+{
+    const TAG_CACHE_DIR = 'ez';
+
+    /**
+     * @var \Symfony\Component\Filesystem\Filesystem
+     */
+    private $fs;
+
+    /**
+     * Injects a Filesystem instance
+     * For unit tests only.
+     *
+     * @internal
+     *
+     * @param \Symfony\Component\Filesystem\Filesystem $fs
+     */
+    public function setFilesystem(Filesystem $fs)
+    {
+        $this->fs = $fs;
+    }
+
+    /**
+     * @return \Symfony\Component\Filesystem\Filesystem
+     */
+    private function getFilesystem()
+    {
+        if (!isset($this->fs)) {
+            $this->fs = new Filesystem();
+        }
+
+        return $this->fs;
+    }
+
+    /**
+     * Writes a cache entry to the store for the given Request and Response.
+     *
+     * Existing entries are read and any that match the response are removed. This
+     * method calls write with the new list of cache entries.
+     *
+     * @param Request  $request  A Request instance
+     * @param Response $response A Response instance
+     *
+     * @return string The key under which the response is stored
+     *
+     * @throws \RuntimeException
+     */
+    public function write(Request $request, Response $response)
+    {
+        $key = parent::write($request, $response);
+
+        // Now save tags
+        $digest = $response->headers->get('X-Content-Digest');
+        $tags = $response->headers->get('xkey', null, false);
+
+        if ($response->headers->has('X-Location-Id')) {
+            $tags[] = 'location-' . $response->headers->get('X-Location-Id');
+        }
+
+        foreach (array_unique($tags) as $tag) {
+            if (false === $this->saveTag($tag, $digest)) {
+                throw new \RuntimeException('Unable to store the cache tag meta information.');
+            }
+        }
+
+        return $key;
+    }
+
+    /**
+     * Save digest for the given tag.
+     *
+     * @param string $tag    The tag key
+     * @param string $digest The digest hash to store representing the cache item.
+     *
+     * @return bool
+     */
+    private function saveTag($tag, $digest)
+    {
+        $path = $this->getTagPath($tag) . DIRECTORY_SEPARATOR . $digest;
+        if (!is_dir(dirname($path)) && false === @mkdir(dirname($path), 0777, true) && !is_dir(dirname($path))) {
+            return false;
+        }
+
+        $tmpFile = tempnam(dirname($path), basename($path));
+        if (false === $fp = @fopen($tmpFile, 'wb')) {
+            return false;
+        }
+        @fwrite($fp, $digest);
+        @fclose($fp);
+
+        if ($digest != file_get_contents($tmpFile)) {
+            return false;
+        }
+
+        if (false === @rename($tmpFile, $path)) {
+            return false;
+        }
+
+        @chmod($path, 0666 & ~umask());
+
+        return true;
+    }
+
+    /**
+     * Purges data from $request.
+     * If xkey or X-Location-Id (deprecated) header is present, the store will purge cache for given locationId or group of locationIds.
+     * If not, regular purge by URI will occur.
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *
+     * @return bool True if purge was successful. False otherwise
+     */
+    public function purgeByRequest(Request $request)
+    {
+        if (!$request->headers->has('X-Location-Id') && !$request->headers->has('xkey')) {
+            return $this->purge($request->getUri());
+        }
+
+        // For BC with older purge code covering most use cases.
+        $locationId = $request->headers->get('X-Location-Id');
+        if ($locationId === '*' || $locationId === '.*') {
+            return $this->purgeAllContent();
+        }
+
+        if ($request->headers->has('xkey')) {
+            $tags = explode(' ', $request->headers->get('xkey'));
+        } elseif ($locationId[0] === '(' && substr($locationId, -1) === ')') {
+            // Deprecated: (123|456|789) => Purge for #123, #456 and #789 location IDs.
+            $tags = array_map(
+                function ($id) {return 'location-' . $id;},
+                explode('|', substr($locationId, 1, -1))
+            );
+        } else {
+            $tags = array('location-' . $locationId);
+        }
+
+        if (empty($tags)) {
+            return false;
+        }
+
+        foreach ($tags as $tag) {
+            $this->purgeByCacheTag($tag);
+        }
+
+        return true;
+    }
+
+    /**
+     * Purges all cached content.
+     *
+     * @deprecated Use cache:clear, with multi tagging theoretically there shouldn't be need to delete all anymore from core.
+     *
+     * @internal @param Filesystem $fs Internal argument for unit tests to be able to mock Filesystem class.
+     * @return bool
+     */
+    public function purgeAllContent()
+    {
+        $fs = $this->getFilesystem();
+        $fs->remove($this->getTagPath());
+        $fs->remove($this->root);
+
+        return true;
+    }
+
+    /**
+     * Purges cache for tag.
+     *
+     * @param string $tag
+     */
+    private function purgeByCacheTag($tag)
+    {
+        $cacheTagsCacheDir = $this->getTagPath($tag);
+        if (!file_exists($cacheTagsCacheDir) || !is_dir($cacheTagsCacheDir)) {
+            return;
+        }
+
+        $files = (new Finder())->files()->in($cacheTagsCacheDir);
+        foreach ($files as $file) {
+            // @todo Change to be able to reuse parent::invalidate() or parent::purge() ?
+            if ($digest = file_get_contents($file->getRealPath())) {
+                @unlink($this->getPath($digest));
+            }
+            @unlink($file);
+        }
+        // We let folder stay in case another process have just written new cache tags.
+    }
+
+    /**
+     * Returns cache dir for $tag.
+     *
+     * This method is public only for unit tests.
+     * Use it only if you know what you are doing.
+     *
+     * @internal
+     *
+     * @param int $tag
+     *
+     * @return string
+     */
+    public function getTagPath($tag = null)
+    {
+        $path = $this->root . DIRECTORY_SEPARATOR . static::TAG_CACHE_DIR;
+        if ($tag) {
+            // Flip the tag so we put id first so it gets sliced into folders.
+            // (otherwise we would easily reach inode limits on file system)
+            $tag = strrev($tag);
+            $path .= DIRECTORY_SEPARATOR . substr($tag, 0, 2) . DIRECTORY_SEPARATOR . substr($tag, 2, 2) . DIRECTORY_SEPARATOR . substr($tag, 4);
+        }
+
+        return $path;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/Proxy/TagAwareStore.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/Proxy/TagAwareStore.php
@@ -170,7 +170,6 @@ class TagAwareStore extends Store implements ContentPurger
      *
      * @deprecated Use cache:clear, with multi tagging theoretically there shouldn't be need to delete all anymore from core.
      *
-     * @internal @param Filesystem $fs Internal argument for unit tests to be able to mock Filesystem class.
      * @return bool
      */
     public function purgeAllContent()

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/TagAwareStoreTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/TagAwareStoreTest.php
@@ -1,0 +1,207 @@
+<?php
+
+/**
+ * File containing the TagAwareStoreTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\CacheTests\Http;
+
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\Proxy\TagAwareStore;
+use Symfony\Component\HttpFoundation\Request;
+use PHPUnit_Framework_TestCase;
+
+class TagAwareStoreTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\Cache\Http\Proxy\TagAwareStore
+     */
+    private $store;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->store = new TagAwareStore(__DIR__);
+    }
+
+    protected function tearDown()
+    {
+        array_map('unlink', glob(__DIR__ . '/*.purging'));
+        parent::tearDown();
+    }
+
+    public function testGetPath()
+    {
+        $path = $this->store->getTagPath('location-123') . DIRECTORY_SEPARATOR . 'en' . sha1('someContent');
+        $this->assertStringStartsWith(__DIR__ . DIRECTORY_SEPARATOR . 'ez' . DIRECTORY_SEPARATOR . '32' . DIRECTORY_SEPARATOR . '1-' . DIRECTORY_SEPARATOR . 'noitacol', $path);
+    }
+
+    public function testGetStalePath()
+    {
+        $this->markTestIncomplete('@todo Stale handling removed, needs adjustments once it is re added in new form');
+        // Generate the lock file to force using the stale cache dir
+        $locationId = 123;
+        $prefix = TagAwareStore::TAG_CACHE_DIR . DIRECTORY_SEPARATOR . $locationId;
+        $prefixStale = TagAwareStore::TAG_CACHE_DIR . DIRECTORY_SEPARATOR . $locationId;
+        $lockFile = $this->store->getLocationCacheLockName($locationId);
+        file_put_contents($lockFile, getmypid());
+
+        $path = $this->store->getPath($prefix . DIRECTORY_SEPARATOR . 'en' . sha1('someContent'));
+        $this->assertStringStartsWith(__DIR__ . DIRECTORY_SEPARATOR . $prefixStale, $path);
+        @unlink($lockFile);
+    }
+
+    public function testGetPathDeadProcess()
+    {
+        $this->markTestIncomplete('@todo Stale handling removed, needs adjustments once it is re added in new form');
+        if (!function_exists('posix_kill')) {
+            self::markTestSkipped('posix_kill() function is needed for this test');
+        }
+
+        $locationId = 123;
+        $prefix = TagAwareStore::TAG_CACHE_DIR . "/$locationId";
+        $lockFile = $this->store->getLocationCacheLockName($locationId);
+        file_put_contents($lockFile, '99999999999999999');
+
+        $path = $this->store->getPath("$prefix/en" . sha1('someContent'));
+        $this->assertStringStartsWith(__DIR__ . "/$prefix", $path);
+        $this->assertFalse(file_exists($lockFile));
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getFilesystemMock()
+    {
+        return $this->getMock('Symfony\\Component\\Filesystem\\Filesystem');
+    }
+
+    public function testPurgeByRequestSingleLocation()
+    {
+        $this->markTestIncomplete('@todo needs adjustments for new impl on top of tags');
+        $fs = $this->getFilesystemMock();
+        $this->store->setFilesystem($fs);
+        $locationId = 123;
+        $locationCacheDir = $this->store->getTagPath('location-' . $locationId);
+        $staleCacheDir = str_replace(TagAwareStore::TAG_CACHE_DIR, TagAwareStore::TAG_CACHE_DIR, $locationCacheDir);
+
+        $fs
+            ->expects($this->any())
+            ->method('exists')
+            ->with($locationCacheDir)
+            ->will($this->returnValue(true));
+        $fs
+            ->expects($this->once())
+            ->method('mkdir')
+            ->with($staleCacheDir);
+        $fs
+            ->expects($this->once())
+            ->method('mirror')
+            ->with($locationCacheDir, $staleCacheDir);
+        $fs
+            ->expects($this->once())
+            ->method('remove')
+            ->with($locationCacheDir);
+
+        $request = Request::create('/', 'PURGE');
+        $request->headers->set('X-Location-Id', "$locationId");
+        $this->store->purgeByRequest($request);
+    }
+
+    public function testPurgeByRequestMultipleLocations()
+    {
+        $this->markTestIncomplete('@todo needs adjustments for new impl on top of tags');
+        $fs = $this->getFilesystemMock();
+        $this->store->setFilesystem($fs);
+        $locationIds = array(123, 456, 789);
+        $i = 0;
+        foreach ($locationIds as $locationId) {
+            $locationCacheDir = $this->store->getTagPath('location-' . $locationId);
+            $staleCacheDir = str_replace(TagAwareStore::TAG_CACHE_DIR, TagAwareStore::TAG_CACHE_DIR, $locationCacheDir);
+
+            $fs
+                ->expects($this->at($i++))
+                ->method('exists')
+                ->with($locationCacheDir)
+                ->will($this->returnValue(true));
+            $fs
+                ->expects($this->at($i++))
+                ->method('mkdir')
+                ->with($staleCacheDir);
+            $fs
+                ->expects($this->at($i++))
+                ->method('mirror')
+                ->with($locationCacheDir, $staleCacheDir);
+            $fs
+                ->expects($this->at($i++))
+                ->method('remove')
+                ->with($locationCacheDir);
+        }
+
+        $request = Request::create('/', 'BAN');
+        $request->headers->set('X-Location-Id', '(' . implode('|', $locationIds) . ')');
+        $this->store->purgeByRequest($request);
+    }
+
+    public function testPurgeAllContent()
+    {
+        $fs = $this->getFilesystemMock();
+        $this->store->setFilesystem($fs);
+        $locationCacheDir = $this->store->getTagPath();
+
+        $fs
+            ->expects($this->at(0))
+            ->method('remove')
+            ->with($locationCacheDir);
+
+        $fs
+            ->expects($this->at(1))
+            ->method('remove')
+            ->with(__DIR__);
+
+        $this->store->purgeAllContent();
+    }
+
+    public function testPurgeAllContentByRequest()
+    {
+        $fs = $this->getFilesystemMock();
+        $this->store->setFilesystem($fs);
+        $locationCacheDir = $this->store->getTagPath();
+
+        $fs
+            ->expects($this->at(0))
+            ->method('remove')
+            ->with($locationCacheDir);
+
+        $fs
+            ->expects($this->at(1))
+            ->method('remove')
+            ->with(__DIR__);
+
+        $request = Request::create('/', 'BAN');
+        $request->headers->set('X-Location-Id', '.*');
+        $this->store->purgeByRequest($request);
+    }
+
+    public function testPurgeAllContentByRequestBC()
+    {
+        $fs = $this->getFilesystemMock();
+        $this->store->setFilesystem($fs);
+        $locationCacheDir = $this->store->getTagPath();
+
+        $fs
+            ->expects($this->at(0))
+            ->method('remove')
+            ->with($locationCacheDir);
+
+        $fs
+            ->expects($this->at(1))
+            ->method('remove')
+            ->with(__DIR__);
+
+        $request = Request::create('/', 'PURGE');
+        $request->headers->set('X-Location-Id', '*');
+        $this->store->purgeByRequest($request);
+    }
+}


### PR DESCRIPTION
> Tag aware storage part of [EZP-22401](http://jira.ez.no/browse/EZP-22401)

Implements storage of tagged HTTP cache for the Symfony reverse proxy.

### TODO
- [ ] Rebase & fix ownership of commits
- [ ] Describe
- [ ] Finalize `doc/specifications/cache/multi_tagging.md`
