### PR TITLE
Fix EZP-26949: SiteAccess reverse match doesn't work with default SiteAccess

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Router.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Router.php
@@ -222,6 +222,7 @@ class Router implements SiteAccessRouterInterface, SiteAccessAware
             $request->setPathinfo($this->siteAccess->matcher->analyseURI($request->pathinfo));
         }
 
+        $siteAccessClass = $this->siteAccessClass;
         foreach ($this->siteAccessesConfiguration as $matchingClass => $matchingConfiguration) {
             $matcher = $this->matcherBuilder->buildMatcher($matchingClass, $matchingConfiguration, $request);
             if (!$matcher instanceof VersatileMatcher) {
@@ -237,7 +238,6 @@ class Router implements SiteAccessRouterInterface, SiteAccessAware
                 continue;
             }
 
-            $siteAccessClass = $this->siteAccessClass;
             /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess $siteAccess */
             $siteAccess = new $siteAccessClass();
             $siteAccess->name = $siteAccessName;
@@ -248,9 +248,9 @@ class Router implements SiteAccessRouterInterface, SiteAccessAware
         }
 
         // No VersatileMatcher configured for $siteAccessName.
-        $this->logger->notice("Siteaccess '$siteAccessName' could not be reverse-matched against configuration. No VersatileMatcher found.");
+        $this->logger->notice("Siteaccess '$siteAccessName' could not be reverse-matched against configuration. No VersatileMatcher found. Returning default SiteAccess.");
 
-        return null;
+        return new $siteAccessClass($this->defaultSiteAccess, 'default');
     }
 
     /**

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterTest.php
@@ -265,14 +265,13 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $matcherBuilder = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilderInterface');
         $logger = $this->getMock('Psr\Log\LoggerInterface');
         $matcherClass = 'Map\Host';
-        $matchedSiteAccess = 'foo';
+        $defaultSiteAccess = 'default_sa';
         $matcherConfig = array(
-            'phoenix-rises.fm' => $matchedSiteAccess,
-            'ez.no' => 'default_sa',
+            'phoenix-rises.fm' => 'foo',
         );
         $config = array($matcherClass => $matcherConfig);
 
-        $router = new Router($matcherBuilder, $logger, 'default_sa', $config, array($matchedSiteAccess, 'default_sa'));
+        $router = new Router($matcherBuilder, $logger, $defaultSiteAccess, $config, array($defaultSiteAccess, 'foo'));
         $router->setSiteAccess(new SiteAccess('test', 'test'));
         $request = $router->getRequest();
         $matcherBuilder
@@ -284,6 +283,6 @@ class RouterTest extends PHPUnit_Framework_TestCase
         $logger
             ->expects($this->once())
             ->method('notice');
-        $this->assertNull($router->matchByName($matchedSiteAccess));
+        $this->assertEquals(new SiteAccess($defaultSiteAccess, 'default'), $router->matchByName($defaultSiteAccess));
     }
 }


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-26949

`SiteAccess\Router::matchByName()` should return default SiteAccess when
no SiteAccess could be matched, instead of `null`.
Otherwise this is not aligned to what `match()` does.

Yes, I know, I'm the one who introduced this bug :blush: :octocat: