### PR TITLE
EZP-26885: As a Developer I want to future proof my Field Types by using Doctrine [in external storage]

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage_engines.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage_engines.yml
@@ -1,7 +1,7 @@
 parameters:
     ezpublish.persistence.connection.factory.class: eZ\Bundle\EzPublishCoreBundle\ApiLoader\StorageConnectionFactory
     ezpublish.api.repository_configuration_provider.class: eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider
-    ezpublish.persistence.connection.class: Doctrine\DBAL\Connection
+    ezpublish.persistence.connection.class: eZ\Publish\Core\Persistence\Doctrine\DoctrineConnection
 
 services:
     ezpublish.api.repository_configuration_provider:

--- a/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
@@ -261,6 +261,7 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
 
     /**
      * @dep_ends eZ\Publish\API\Repository\Tests\ContentTypeServiceTest::testCreateContentType
+     * @group fieldTypeIntegration
      */
     public function testCreateContentType()
     {
@@ -396,6 +397,7 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
     /**
      * @dep_ends eZ\Publish\API\Repository\Tests\ContentTypeServiceTest::testLoadContentType
      * @depends testCreateContentType
+     * @group fieldTypeIntegration
      */
     public function testLoadContentTypeField()
     {
@@ -493,6 +495,7 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
     /**
      * @dep_ends eZ\Publish\API\Repository\Tests\ContentServiceTest::testCreateContent;
      * @depends testLoadContentTypeField
+     * @group fieldTypeIntegration
      */
     public function testCreateContent()
     {
@@ -588,6 +591,9 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
     /**
      * @dep_ends eZ\Publish\API\Repository\Tests\ContentServiceTest::testLoadContent
      * @depends testCreateContent
+     * @group fieldTypeIntegration
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content
      */
     public function testLoadField()
     {
@@ -601,6 +607,7 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
 
     /**
      * @depends testLoadField
+     * @group fieldTypeIntegration
      */
     public function testLoadFieldType()
     {
@@ -697,6 +704,7 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
     /**
      * @dep_ends eZ\Publish\API\Repository\Tests\ContentServiceTest::testUpdateContent
      * @depends testLoadFieldType
+     * @group fieldTypeIntegration
      */
     public function testUpdateField()
     {
@@ -733,6 +741,7 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
 
     /**
      * @depends testUpdateField
+     * @group fieldTypeIntegration
      */
     public function testUpdateTypeFieldStillAvailable($content)
     {
@@ -747,6 +756,7 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
 
     /**
      * @depends testUpdateTypeFieldStillAvailable
+     * @group fieldTypeIntegration
      */
     public function testUpdatedDataCorrect(Field $field)
     {

--- a/eZ/Publish/API/Repository/Tests/FieldType/UrlIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/UrlIntegrationTest.php
@@ -176,7 +176,7 @@ class UrlIntegrationTest extends SearchBaseIntegrationTest
     /**
      * Get update field externals data.
      *
-     * @return array
+     * @return \eZ\Publish\Core\FieldType\Url\Value::__construct
      */
     public function getValidUpdateFieldData()
     {

--- a/eZ/Publish/Core/Base/Container/ApiLoader/Storage/ExternalStorageRegistryFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/Storage/ExternalStorageRegistryFactory.php
@@ -52,7 +52,7 @@ class ExternalStorageRegistryFactory implements ContainerAwareInterface
      *
      * @param string $externalStorageRegistryClass
      *
-     * @return \eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry
+     * @return \eZ\Publish\Core\Persistence\Content\StorageRegistry
      */
     public function buildExternalStorageRegistry($externalStorageRegistryClass)
     {

--- a/eZ/Publish/Core/FieldType/GatewayBasedStorage.php
+++ b/eZ/Publish/Core/FieldType/GatewayBasedStorage.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\FieldType;
 
+use eZ\Publish\Core\Persistence\Content\StorageHandler;
 use eZ\Publish\SPI\FieldType\FieldStorage;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
@@ -33,6 +34,11 @@ abstract class GatewayBasedStorage implements FieldStorage
     protected $gateways;
 
     /**
+     * @var \eZ\Publish\Core\Persistence\Content\StorageHandler
+     */
+    protected $storageHandler = null;
+
+    /**
      * Construct from gateways.
      *
      * @param \eZ\Publish\Core\FieldType\StorageGateway[] $gateways
@@ -42,6 +48,17 @@ abstract class GatewayBasedStorage implements FieldStorage
         foreach ($gateways as $identifier => $gateway) {
             $this->addGateway($identifier, $gateway);
         }
+    }
+
+    /**
+     * Set explicitly StorageHandler for specific FieldType Storage.
+     * If set will be used to override context and get proper Gateway.
+     *
+     * @param \eZ\Publish\Core\Persistence\Content\StorageHandler $storageHandler
+     */
+    public function setExternalStorageHandler(StorageHandler $storageHandler)
+    {
+        $this->storageHandler = $storageHandler;
     }
 
     /**
@@ -64,6 +81,10 @@ abstract class GatewayBasedStorage implements FieldStorage
      */
     protected function getGateway(array $context)
     {
+        if ($this->storageHandler !== null) {
+            $context = $this->storageHandler->getContext();
+        }
+
         if (!isset($this->gateways[$context['identifier']])) {
             throw new \OutOfBoundsException("No gateway for ${context['identifier']} available.");
         }

--- a/eZ/Publish/Core/FieldType/RichText/RichTextStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/RichText/RichTextStorage/Gateway/DoctrineStorage.php
@@ -8,14 +8,14 @@
  */
 namespace eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway;
 
-use eZ\Publish\Core\Persistence\Doctrine\Connection;
+use eZ\Publish\Core\Persistence\Doctrine\DoctrineConnection;
 use eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway;
 use RuntimeException;
 
 class DoctrineStorage extends Gateway
 {
     /**
-     * @var \eZ\Publish\Core\Persistence\Doctrine\Connection
+     * @var \eZ\Publish\Core\Persistence\Doctrine\DoctrineConnection
      */
     protected $connection;
 
@@ -24,12 +24,12 @@ class DoctrineStorage extends Gateway
      */
     public function setConnection($connection)
     {
-        if (!$connection instanceof Connection) {
+        if (!$connection instanceof DoctrineConnection) {
             throw new RuntimeException(
                 sprintf(
                     '%s::setConnection expects an instance of %s, but %s given',
                     self::class,
-                    Connection::class,
+                    DoctrineConnection::class,
                     get_class($connection)
                 )
             );
@@ -58,7 +58,7 @@ class DoctrineStorage extends Gateway
                 ->select('id', 'remote_id')
                 ->from('ezcontentobject')
                 ->where($query->expr()->in('remote_id', ':remoteIds'))
-                ->setParameter(':remoteIds', $remoteIds, Connection::PARAM_STR_ARRAY)
+                ->setParameter(':remoteIds', $remoteIds, DoctrineConnection::PARAM_STR_ARRAY)
             ;
 
             $statement = $query->execute();

--- a/eZ/Publish/Core/FieldType/RichText/RichTextStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/RichText/RichTextStorage/Gateway/DoctrineStorage.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway;
+
+use eZ\Publish\Core\Persistence\Doctrine\Connection;
+use eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway;
+use RuntimeException;
+
+class DoctrineStorage extends Gateway
+{
+    /**
+     * @var \eZ\Publish\Core\Persistence\Doctrine\Connection
+     */
+    protected $connection;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setConnection($connection)
+    {
+        if (!$connection instanceof Connection) {
+            throw new RuntimeException(
+                sprintf(
+                    '%s::setConnection expects an instance of %s, but %s given',
+                    self::class,
+                    Connection::class,
+                    get_class($connection)
+                )
+            );
+        }
+
+        $this->urlGateway->setConnection($connection);
+        $this->connection = $connection;
+    }
+
+    /**
+     * Returns a list of Content ids for a list of remote ids.
+     *
+     * Non-existent ids are ignored.
+     *
+     * @param string[] $remoteIds An array of Content remote ids
+     *
+     * @return array An array of Content ids, with remote ids as keys
+     */
+    public function getContentIds(array $remoteIds)
+    {
+        $objectRemoteIdMap = [];
+
+        if (!empty($remoteIds)) {
+            $query = $this->connection->createQueryBuilder();
+            $query
+                ->select('id', 'remote_id')
+                ->from('ezcontentobject')
+                ->where($query->expr()->in('remote_id', ':remoteIds'))
+                ->setParameter(':remoteIds', $remoteIds, Connection::PARAM_STR_ARRAY)
+            ;
+
+            $statement = $query->execute();
+            foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $row) {
+                $objectRemoteIdMap[$row['remote_id']] = $row['id'];
+            }
+        }
+
+        return $objectRemoteIdMap;
+    }
+}

--- a/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway/DoctrineStorage.php
@@ -1,0 +1,227 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway;
+
+use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway;
+use eZ\Publish\Core\Persistence\Doctrine\Connection;
+use PDO;
+use RuntimeException;
+
+class DoctrineStorage extends Gateway
+{
+    const URL_TABLE = 'ezurl';
+    const URL_LINK_TABLE = 'ezurl_object_link';
+
+    /**
+     * @var \eZ\Publish\Core\Persistence\Doctrine\Connection
+     */
+    protected $connection;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setConnection($connection)
+    {
+        if (!$connection instanceof Connection) {
+            throw new RuntimeException(
+                sprintf(
+                    '%s::setConnection expects an instance of %s, but %s given',
+                    self::class,
+                    Connection::class,
+                    get_class($connection)
+                )
+            );
+        }
+
+        $this->connection = $connection;
+    }
+
+    /**
+     * Returns a list of URLs for a list of URL ids.
+     *
+     * Non-existent ids are ignored.
+     *
+     * @param int[]|string[] $ids An array of URL ids
+     *
+     * @return array An array of URLs, with ids as keys
+     */
+    public function getIdUrlMap(array $ids)
+    {
+        $map = [];
+
+        if (!empty($ids)) {
+            $query = $this->connection->createQueryBuilder();
+            $query
+                ->select('id', 'url')
+                ->from(self::URL_TABLE)
+                ->where('id IN (:ids)')
+                ->setParameter(':ids', $ids, Connection::PARAM_STR_ARRAY);
+
+            $statement = $query->execute();
+            foreach ($statement->fetchAll(PDO::FETCH_ASSOC) as $row) {
+                $map[$row['id']] = $row['url'];
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Returns a list of URL ids for a list of URLs.
+     *
+     * Non-existent URLs are ignored.
+     *
+     * @param string[] $urls An array of URLs
+     *
+     * @return array An array of URL ids, with URLs as keys
+     */
+    public function getUrlIdMap(array $urls)
+    {
+        $map = [];
+
+        if (!empty($urls)) {
+            $query = $this->connection->createQueryBuilder();
+            $query
+                ->select('id', 'url')
+                ->from(self::URL_TABLE)
+                ->where(
+                    $query->expr()->in('url', ':urls')
+                )
+                ->setParameter(':urls', $urls, Connection::PARAM_STR_ARRAY);
+
+            $statement = $query->execute();
+            foreach ($statement->fetchAll(PDO::FETCH_ASSOC) as $row) {
+                $map[$row['url']] = $row['id'];
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Inserts a new $url and returns its id.
+     *
+     * @param string $url The URL to insert in the database
+     *
+     * @return int|string
+     */
+    public function insertUrl($url)
+    {
+        $time = time();
+
+        $query = $this->connection->createQueryBuilder();
+
+        $query->insert(
+            $this->connection->quoteIdentifier(self::URL_TABLE)
+        )->values([
+            'created' => ':created',
+            'modified' => ':modified',
+            'original_url_md5' => ':original_url_md5',
+            'url' => ':url',
+        ])
+            ->setParameter(':created', $time, PDO::PARAM_INT)
+            ->setParameter(':modified', $time, PDO::PARAM_INT)
+            ->setParameter(':original_url_md5', md5($url))
+            ->setParameter(':url', $url)
+        ;
+
+        $query->execute();
+
+        return $this->connection->lastInsertId(
+            $this->connection->getSequenceName(self::URL_TABLE, 'id')
+        );
+    }
+
+    /**
+     * Creates link to URL with $urlId for field with $fieldId in $versionNo.
+     *
+     * @param int|string $urlId
+     * @param int|string $fieldId
+     * @param int $versionNo
+     */
+    public function linkUrl($urlId, $fieldId, $versionNo)
+    {
+        $query = $this->connection->createQueryBuilder();
+
+        $query->insert(
+            $this->connection->quoteIdentifier(self::URL_LINK_TABLE)
+        )->values([
+            'contentobject_attribute_id' => ':contentobject_attribute_id',
+            'contentobject_attribute_version' => ':contentobject_attribute_version',
+            'url_id' => ':url_id',
+        ])
+            ->setParameter(':contentobject_attribute_id', $fieldId, PDO::PARAM_INT)
+            ->setParameter(':contentobject_attribute_version', $versionNo, PDO::PARAM_INT)
+            ->setParameter(':url_id', $urlId, PDO::PARAM_INT)
+        ;
+
+        $query->execute();
+    }
+    /**
+     * Removes link to URL for $fieldId in $versionNo and cleans up possibly orphaned URLs.
+     *
+     * @param int|string $fieldId
+     * @param int $versionNo
+     */
+    public function unlinkUrl($fieldId, $versionNo)
+    {
+        $deleteQuery = $this->connection->createQueryBuilder();
+
+        $deleteQuery->delete(
+            $this->connection->quoteIdentifier(self::URL_LINK_TABLE)
+        )->where(
+            $deleteQuery->expr()->andX(
+                $deleteQuery->expr()->in('contentobject_attribute_id', ':contentobject_attribute_id'),
+                $deleteQuery->expr()->in('contentobject_attribute_version', ':contentobject_attribute_version')
+            )
+        )
+            ->setParameter(':contentobject_attribute_id', $fieldId, PDO::PARAM_INT)
+            ->setParameter(':contentobject_attribute_version', $versionNo, PDO::PARAM_INT)
+        ;
+
+        $deleteQuery->execute();
+
+        $this->deleteOrphanedUrls();
+    }
+
+    /**
+     * Deletes all orphaned URLs.
+     *
+     * @todo using two queries because zeta Database does not support joins in delete query.
+     * That could be avoided if the feature is implemented there.
+     *
+     * URL is orphaned if it is not linked to a content attribute through ezurl_object_link table.
+     */
+    private function deleteOrphanedUrls()
+    {
+        $query = $this->connection->createQueryBuilder();
+
+        $query
+            ->select('url.id')
+            ->from($this->connection->quoteIdentifier(self::URL_TABLE), 'url')
+            ->leftJoin('url', $this->connection->quoteIdentifier(self::URL_LINK_TABLE), 'link', 'url.id = link.url_id')
+            ->where($query->expr()->isNull('link.url_id'))
+        ;
+        $statement = $query->execute();
+        $ids = $statement->fetchAll(PDO::FETCH_COLUMN);
+        if (empty($ids)) {
+            return;
+        }
+
+        $deleteQuery = $this->connection->createQueryBuilder();
+
+        $deleteQuery
+            ->delete($this->connection->quoteIdentifier(self::URL_TABLE))
+            ->where($deleteQuery->expr()->in('id', ':ids'))
+            ->setParameter(':ids', $ids, Connection::PARAM_STR_ARRAY)
+        ;
+
+        $deleteQuery->execute();
+    }
+}

--- a/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway/DoctrineStorage.php
@@ -9,7 +9,7 @@
 namespace eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway;
 
 use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway;
-use eZ\Publish\Core\Persistence\Doctrine\Connection;
+use eZ\Publish\Core\Persistence\Doctrine\DoctrineConnection;
 use PDO;
 use RuntimeException;
 
@@ -19,7 +19,7 @@ class DoctrineStorage extends Gateway
     const URL_LINK_TABLE = 'ezurl_object_link';
 
     /**
-     * @var \eZ\Publish\Core\Persistence\Doctrine\Connection
+     * @var \eZ\Publish\Core\Persistence\Doctrine\DoctrineConnection
      */
     protected $connection;
 
@@ -28,12 +28,12 @@ class DoctrineStorage extends Gateway
      */
     public function setConnection($connection)
     {
-        if (!$connection instanceof Connection) {
+        if (!$connection instanceof DoctrineConnection) {
             throw new RuntimeException(
                 sprintf(
                     '%s::setConnection expects an instance of %s, but %s given',
                     self::class,
-                    Connection::class,
+                    DoctrineConnection::class,
                     get_class($connection)
                 )
             );
@@ -61,7 +61,7 @@ class DoctrineStorage extends Gateway
                 ->select('id', 'url')
                 ->from(self::URL_TABLE)
                 ->where('id IN (:ids)')
-                ->setParameter(':ids', $ids, Connection::PARAM_STR_ARRAY);
+                ->setParameter(':ids', $ids, DoctrineConnection::PARAM_STR_ARRAY);
 
             $statement = $query->execute();
             foreach ($statement->fetchAll(PDO::FETCH_ASSOC) as $row) {
@@ -93,7 +93,7 @@ class DoctrineStorage extends Gateway
                 ->where(
                     $query->expr()->in('url', ':urls')
                 )
-                ->setParameter(':urls', $urls, Connection::PARAM_STR_ARRAY);
+                ->setParameter(':urls', $urls, DoctrineConnection::PARAM_STR_ARRAY);
 
             $statement = $query->execute();
             foreach ($statement->fetchAll(PDO::FETCH_ASSOC) as $row) {
@@ -219,7 +219,7 @@ class DoctrineStorage extends Gateway
         $deleteQuery
             ->delete($this->connection->quoteIdentifier(self::URL_TABLE))
             ->where($deleteQuery->expr()->in('id', ':ids'))
-            ->setParameter(':ids', $ids, Connection::PARAM_STR_ARRAY)
+            ->setParameter(':ids', $ids, DoctrineConnection::PARAM_STR_ARRAY)
         ;
 
         $deleteQuery->execute();

--- a/eZ/Publish/Core/Persistence/Content/StorageHandler.php
+++ b/eZ/Publish/Core/Persistence/Content/StorageHandler.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Persistence\Content;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+
+/**
+ * Handler for external storages.
+ */
+class StorageHandler
+{
+    /**
+     * Storage registry.
+     *
+     * @var \eZ\Publish\Core\Persistence\Content\StorageRegistry
+     */
+    protected $storageRegistry;
+
+    /**
+     * Array with database context.
+     *
+     * @var array
+     */
+    protected $context;
+
+    /**
+     * Creates a new storage handler.
+     *
+     * @param \eZ\Publish\Core\Persistence\Content\StorageRegistry $storageRegistry
+     * @param array $context
+     */
+    public function __construct(StorageRegistry $storageRegistry, array $context)
+    {
+        $this->storageRegistry = $storageRegistry;
+        $this->context = $context;
+    }
+
+    /**
+     * Stores data from $field in its corresponding external storage.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @return mixed
+     */
+    public function storeFieldData(VersionInfo $versionInfo, Field $field)
+    {
+        return $this->storageRegistry->getStorage($field->type)->storeFieldData(
+            $versionInfo,
+            $field,
+            $this->context
+        );
+    }
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $originalField
+     * @return mixed
+     */
+    public function copyFieldData(VersionInfo $versionInfo, Field $field, Field $originalField)
+    {
+        return $this->storageRegistry->getStorage($field->type)->storeFieldData(
+            $versionInfo,
+            $field,
+            $this->context
+        );
+    }
+
+    /**
+     * Fetches external data for $field from its corresponding external storage.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param Field $field
+     */
+    public function getFieldData(VersionInfo $versionInfo, Field $field)
+    {
+        $storage = $this->storageRegistry->getStorage($field->type);
+        if ($storage->hasFieldData()) {
+            $storage->getFieldData($versionInfo, $field, $this->context);
+        }
+    }
+
+    /**
+     * Deletes data for field $ids from external storage of $fieldType.
+     *
+     * @param string $fieldType
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param mixed[] $ids
+     */
+    public function deleteFieldData($fieldType, VersionInfo $versionInfo, array $ids)
+    {
+        $this->storageRegistry->getStorage($fieldType)
+            ->deleteFieldData($versionInfo, $ids, $this->context);
+    }
+
+    /**
+     * Get StorageHandler context data.
+     *
+     * @return array
+     */
+    public function getContext()
+    {
+        return $this->context;
+    }
+}

--- a/eZ/Publish/Core/Persistence/Content/StorageRegistry.php
+++ b/eZ/Publish/Core/Persistence/Content/StorageRegistry.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Persistence\Content;
+
+use eZ\Publish\SPI\FieldType\FieldStorage;
+use eZ\Publish\Core\FieldType\NullStorage;
+
+/**
+ * Registry for external storages.
+ */
+class StorageRegistry
+{
+    /**
+     * Map of storages.
+     *
+     * @var array
+     */
+    protected $storageMap = [];
+
+    /**
+     * Create field storage registry with converter map.
+     *
+     * In $storageMap a mapping of field type names to object / callable is
+     * expected, in case of callable factory it should return the storage object.
+     * The object is used to store/restore/delete/… data in external storage
+     * (e.g.another database or a web service). The storage object must comply to
+     * the {@link \eZ\Publish\SPI\FieldType\FieldStorage} interface.
+     *
+     * @param array $storageMap A map where key is field type name, and value is
+     *              a callable factory to get FieldStorage OR FieldStorage object
+     */
+    public function __construct(array $storageMap)
+    {
+        foreach ($storageMap as $typeName => $storage) {
+            $this->register($typeName, $storage);
+        }
+    }
+
+    /**
+     * Register $storage for $typeName.
+     *
+     * @param string $typeName
+     * @param mixed $storage Callable or FieldStorage
+     */
+    public function register($typeName, $storage)
+    {
+        $this->storageMap[$typeName] = $storage;
+    }
+
+    /**
+     * Returns the storage for $typeName.
+     *
+     * @param string $typeName
+     *
+     * @throws \RuntimeException When type is neither FieldStorage instance or callable factory
+     *
+     * @return \eZ\Publish\SPI\FieldType\FieldStorage
+     */
+    public function getStorage($typeName)
+    {
+        if (!isset($this->storageMap[$typeName])) {
+            $this->storageMap[$typeName] = new NullStorage();
+        } elseif (!$this->storageMap[$typeName] instanceof FieldStorage) {
+            if (!is_callable($this->storageMap[$typeName])) {
+                throw new \RuntimeException("FieldStorage '$typeName' is neither callable or instance");
+            }
+
+            $factory = $this->storageMap[$typeName];
+            $this->storageMap[$typeName] = call_user_func($factory);
+        }
+
+        return $this->storageMap[$typeName];
+    }
+}

--- a/eZ/Publish/Core/Persistence/Doctrine/Connection.php
+++ b/eZ/Publish/Core/Persistence/Doctrine/Connection.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Persistence\Doctrine;
+
+use Doctrine\DBAL\Connection as DoctrineConnection;
+
+class Connection extends DoctrineConnection
+{
+    /**
+     * Get sequence name bound to database table and column.
+     *
+     * @param string $table
+     * @param string $column
+     * @return string
+     */
+    public function getSequenceName($table, $column)
+    {
+        // @todo: change to <table>_<column>_seq when merged into 7.0
+        return sprintf('%s_s', $table);
+    }
+}

--- a/eZ/Publish/Core/Persistence/Doctrine/ConnectionHandler.php
+++ b/eZ/Publish/Core/Persistence/Doctrine/ConnectionHandler.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\Persistence\Doctrine;
 
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\Core\Persistence\Database\QueryException;
+use eZ\Publish\Core\Persistence\Doctrine\Connection as DoctrineConnectionWrapper;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\DBALException;
@@ -33,6 +34,8 @@ class ConnectionHandler implements DatabaseHandler
         } else {
             $parsed = $dsn;
         }
+        // use custom wrapper extending \Doctrine\DBAL\Connection
+        $parsed['wrapperClass'] = DoctrineConnectionWrapper::class;
 
         return DriverManager::getConnection($parsed);
     }

--- a/eZ/Publish/Core/Persistence/Doctrine/ConnectionHandler.php
+++ b/eZ/Publish/Core/Persistence/Doctrine/ConnectionHandler.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\Core\Persistence\Doctrine;
 
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\Core\Persistence\Database\QueryException;
-use eZ\Publish\Core\Persistence\Doctrine\Connection as DoctrineConnectionWrapper;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\DBALException;
@@ -35,7 +34,7 @@ class ConnectionHandler implements DatabaseHandler
             $parsed = $dsn;
         }
         // use custom wrapper extending \Doctrine\DBAL\Connection
-        $parsed['wrapperClass'] = DoctrineConnectionWrapper::class;
+        $parsed['wrapperClass'] = DoctrineConnection::class;
 
         return DriverManager::getConnection($parsed);
     }

--- a/eZ/Publish/Core/Persistence/Doctrine/DoctrineConnection.php
+++ b/eZ/Publish/Core/Persistence/Doctrine/DoctrineConnection.php
@@ -8,12 +8,20 @@
  */
 namespace eZ\Publish\Core\Persistence\Doctrine;
 
-use Doctrine\DBAL\Connection as DoctrineConnection;
+use Doctrine\DBAL\Connection;
 
-class Connection extends DoctrineConnection
+/**
+ * Wrapper class adding extra features to \Doctrine\DBAL\Connection.
+ *
+ * Note: DoctrineConnection is used instead of Connection to avoid names collision.
+ */
+class DoctrineConnection extends Connection
 {
     /**
      * Get sequence name bound to database table and column.
+     *
+     * Note: must be compatible with:
+     * @see \eZ\Publish\Core\Persistence\Doctrine\ConnectionHandler\PostgresConnectionHandler::quoteIdentifier
      *
      * @param string $table
      * @param string $column

--- a/eZ/Publish/Core/Persistence/Legacy/Content/StorageHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/StorageHandler.php
@@ -8,59 +8,20 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content;
 
+use eZ\Publish\Core\Persistence\Content\StorageHandler as ContentStorageHandler;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 
 /**
  * Handler for external storages.
  */
-class StorageHandler
+class StorageHandler extends ContentStorageHandler
 {
-    /**
-     * Storage registry.
-     *
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry
-     */
-    protected $storageRegistry;
-
-    /**
-     * Array with database context.
-     *
-     * @var array
-     */
-    protected $context;
-
-    /**
-     * Creates a new storage handler.
-     *
-     * @param StorageRegistry $storageRegistry
-     * @param array $context
-     */
-    public function __construct(StorageRegistry $storageRegistry, array $context)
-    {
-        $this->storageRegistry = $storageRegistry;
-        $this->context = $context;
-    }
-
-    /**
-     * Stores data from $field in its corresponding external storage.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
-     * @param Field $field
-     */
-    public function storeFieldData(VersionInfo $versionInfo, Field $field)
-    {
-        return $this->storageRegistry->getStorage($field->type)->storeFieldData(
-            $versionInfo,
-            $field,
-            $this->context
-        );
-    }
-
     /**
      * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
      * @param \eZ\Publish\SPI\Persistence\Content\Field $field
      * @param \eZ\Publish\SPI\Persistence\Content\Field $originalField
+     * @return mixed
      */
     public function copyFieldData(VersionInfo $versionInfo, Field $field, Field $originalField)
     {
@@ -70,32 +31,5 @@ class StorageHandler
             $originalField,
             $this->context
         );
-    }
-
-    /**
-     * Fetches external data for $field from its corresponding external storage.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
-     * @param Field $field
-     */
-    public function getFieldData(VersionInfo $versionInfo, Field $field)
-    {
-        $storage = $this->storageRegistry->getStorage($field->type);
-        if ($storage->hasFieldData()) {
-            $storage->getFieldData($versionInfo, $field, $this->context);
-        }
-    }
-
-    /**
-     * Deletes data for field $ids from external storage of $fieldType.
-     *
-     * @param string $fieldType
-     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
-     * @param mixed[] $ids
-     */
-    public function deleteFieldData($fieldType, VersionInfo $versionInfo, array $ids)
-    {
-        $this->storageRegistry->getStorage($fieldType)
-            ->deleteFieldData($versionInfo, $ids, $this->context);
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/StorageRegistry.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/StorageRegistry.php
@@ -8,73 +8,14 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content;
 
-use eZ\Publish\SPI\FieldType\FieldStorage;
-use eZ\Publish\Core\FieldType\NullStorage;
+use eZ\Publish\Core\Persistence\Content\StorageRegistry as ContentStorageRegistry;
 
 /**
  * Registry for external storages.
+ *
+ * @deprecated Use \eZ\Publish\Core\Persistence\Content\StorageRegistry
+ * @see \eZ\Publish\Core\Persistence\Content\StorageRegistry
  */
-class StorageRegistry
+class StorageRegistry extends ContentStorageRegistry
 {
-    /**
-     * Map of storages.
-     *
-     * @var array
-     */
-    protected $storageMap = array();
-
-    /**
-     * Create field storage registry with converter map.
-     *
-     * In $storageMap a mapping of field type names to object / callable is
-     * expected, in case of callable factory it should return the storage object.
-     * The object is used to store/restore/delete/… data in external storage
-     * (e.g.another database or a web service). The storage object must comply to
-     * the {@link \eZ\Publish\SPI\FieldType\FieldStorage} interface.
-     *
-     * @param array $storageMap A map where key is field type name, and value is
-     *              a callable factory to get FieldStorage OR FieldStorage object
-     */
-    public function __construct(array $storageMap)
-    {
-        foreach ($storageMap as $typeName => $storage) {
-            $this->register($typeName, $storage);
-        }
-    }
-
-    /**
-     * Register $storage for $typeName.
-     *
-     * @param string $typeName
-     * @param mixed $storage Callable or FieldStorage
-     */
-    public function register($typeName, $storage)
-    {
-        $this->storageMap[$typeName] = $storage;
-    }
-
-    /**
-     * Returns the storage for $typeName.
-     *
-     * @param string $typeName
-     *
-     * @throws \RuntimeException When type is neither FieldStorage instance or callable factory
-     *
-     * @return \eZ\Publish\SPI\FieldType\FieldStorage
-     */
-    public function getStorage($typeName)
-    {
-        if (!isset($this->storageMap[$typeName])) {
-            $this->storageMap[$typeName] = new NullStorage();
-        } elseif (!$this->storageMap[$typeName] instanceof FieldStorage) {
-            if (!is_callable($this->storageMap[$typeName])) {
-                throw new \RuntimeException("FieldStorage '$typeName' is neither callable or instance");
-            }
-
-            $factory = $this->storageMap[$typeName];
-            $this->storageMap[$typeName] = call_user_func($factory);
-        }
-
-        return $this->storageMap[$typeName];
-    }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/StorageHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/StorageHandlerTest.php
@@ -22,7 +22,7 @@ class StorageHandlerTest extends TestCase
     /**
      * StorageRegistry mock.
      *
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry
+     * @var \eZ\Publish\Core\Persistence\Content\StorageRegistry
      */
     protected $storageRegistryMock;
 
@@ -190,7 +190,7 @@ class StorageHandlerTest extends TestCase
     /**
      * Returns a StorageRegistry mock.
      *
-     * @return \eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry
+     * @return \eZ\Publish\Core\Persistence\Content\StorageRegistry
      */
     protected function getStorageRegistryMock()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/StorageRegistryTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/StorageRegistryTest.php
@@ -9,7 +9,7 @@
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
-use eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry;
+use eZ\Publish\Core\Persistence\Content\StorageRegistry;
 
 /**
  * Test case for StorageRegistry.
@@ -17,7 +17,7 @@ use eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry;
 class StorageRegistryTest extends TestCase
 {
     /**
-     * @covers eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry::register
+     * @covers \eZ\Publish\Core\Persistence\Content\StorageRegistry::register
      */
     public function testRegister()
     {
@@ -34,7 +34,7 @@ class StorageRegistryTest extends TestCase
     }
 
     /**
-     * @covers eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry::getStorage
+     * @covers \eZ\Publish\Core\Persistence\Content\StorageRegistry::getStorage
      */
     public function testGetStorage()
     {
@@ -50,8 +50,8 @@ class StorageRegistryTest extends TestCase
     }
 
     /**
-     * @covers eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry::getStorage
-     * @covers eZ\Publish\Core\Persistence\Legacy\Exception\StorageNotFound
+     * @covers \eZ\Publish\Core\Persistence\Content\StorageRegistry::getStorage
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Exception\StorageNotFound
      */
     public function testGetNotFound()
     {

--- a/eZ/Publish/Core/settings/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/fieldtype_external_storages.yml
@@ -58,6 +58,8 @@ services:
 
     ezpublish.fieldType.ezrichtext.externalStorage:
         class: "%ezpublish.fieldType.ezrichtext.externalStorage.class%"
+        calls:
+            - [setExternalStorageHandler, ['@ezpublish.persistence.doctrine.external_storage_handler']]
         tags:
             - {name: ezpublish.fieldType.externalStorageHandler, alias: ezrichtext}
 

--- a/eZ/Publish/Core/settings/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/fieldtype_external_storages.yml
@@ -51,6 +51,8 @@ services:
         arguments:
             - []
             - "@?logger"
+        calls:
+            - [setExternalStorageHandler, ['@ezpublish.persistence.doctrine.external_storage_handler']]
         tags:
             - {name: ezpublish.fieldType.externalStorageHandler, alias: ezurl}
 

--- a/eZ/Publish/Core/settings/storage_engines/common.yml
+++ b/eZ/Publish/Core/settings/storage_engines/common.yml
@@ -2,7 +2,7 @@ parameters:
     ezpublish.persistence.field_type_registry.factory.class: eZ\Publish\Core\Base\Container\ApiLoader\Storage\FieldTypeRegistryFactory
     ezpublish.persistence.field_type_registry.class: eZ\Publish\Core\Persistence\FieldTypeRegistry
     ezpublish.persistence.external_storage_registry.factory.class: eZ\Publish\Core\Base\Container\ApiLoader\Storage\ExternalStorageRegistryFactory
-    ezpublish.persistence.external_storage_registry.class: eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry
+    ezpublish.persistence.external_storage_registry.class: eZ\Publish\Core\Persistence\Content\StorageRegistry
     ezpublish.persistence.slug_converter.class: eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\SlugConverter
 
     # Transformation parser/compiler for search purpose

--- a/eZ/Publish/Core/settings/storage_engines/legacy.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy.yml
@@ -16,7 +16,7 @@ parameters:
     ezpublish.spi.search.legacy.class: eZ\Publish\Core\Persistence\Legacy\Content\Search\MainHandler
     ezpublish.spi.persistence.legacy.class: eZ\Publish\Core\Persistence\Legacy\Handler
     ezpublish.api.storage_engine.legacy.dbhandler.class: eZ\Publish\Core\Persistence\Doctrine\ConnectionHandler
-    ezpublish.persistence.connection.class: Doctrine\DBAL\Connection
+    ezpublish.persistence.connection.class: eZ\Publish\Core\Persistence\Doctrine\Connection
     ezpublish.spi.persistence.legacy.transactionhandler.class: eZ\Publish\Core\Persistence\Legacy\TransactionHandler
 
 services:
@@ -51,6 +51,9 @@ services:
         factory: "%ezpublish.api.storage_engine.legacy.dbhandler.class%::createConnectionFromDSN"
         arguments:
             - "%legacy_dsn%"
+
+    ezpublish.api.storage_engine.doctrine.connection:
+        alias: ezpublish.api.storage_engine.legacy.connection
 
     ezpublish.spi.persistence.legacy.transactionhandler:
         class: "%ezpublish.spi.persistence.legacy.transactionhandler.class%"

--- a/eZ/Publish/Core/settings/storage_engines/legacy.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy.yml
@@ -16,7 +16,7 @@ parameters:
     ezpublish.spi.search.legacy.class: eZ\Publish\Core\Persistence\Legacy\Content\Search\MainHandler
     ezpublish.spi.persistence.legacy.class: eZ\Publish\Core\Persistence\Legacy\Handler
     ezpublish.api.storage_engine.legacy.dbhandler.class: eZ\Publish\Core\Persistence\Doctrine\ConnectionHandler
-    ezpublish.persistence.connection.class: eZ\Publish\Core\Persistence\Doctrine\Connection
+    ezpublish.persistence.connection.class: eZ\Publish\Core\Persistence\Doctrine\DoctrineConnection
     ezpublish.spi.persistence.legacy.transactionhandler.class: eZ\Publish\Core\Persistence\Legacy\TransactionHandler
 
 services:

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -1,5 +1,6 @@
 parameters:
     ezpublish.persistence.legacy.external_storage_handler.class: eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler
+    ezpublish.persistence.doctrine.external_storage_handler.class: eZ\Publish\Core\Persistence\Content\StorageHandler
 
     ezpublish.fieldType.ezbinaryfile.storage_gateway.class: eZ\Publish\Core\FieldType\BinaryFile\BinaryFileStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezgmaplocation.storage_gateway.class: eZ\Publish\Core\FieldType\MapLocation\MapLocationStorage\Gateway\LegacyStorage
@@ -19,6 +20,14 @@ services:
             -
                 identifier: "LegacyStorage"
                 connection: "@ezpublish.api.storage_engine.legacy.dbhandler"
+
+    ezpublish.persistence.doctrine.external_storage_handler:
+        class: "%ezpublish.persistence.doctrine.external_storage_handler.class%"
+        arguments:
+            - "@ezpublish.persistence.external_storage_registry"
+            -
+                identifier: "DoctrineStorage"
+                connection: "@ezpublish.api.storage_engine.doctrine.connection"
 
     ezpublish.fieldType.ezbinaryfile.storage_gateway:
         class: "%ezpublish.fieldType.ezbinaryfile.storage_gateway.class%"

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -8,7 +8,7 @@ parameters:
     ezpublish.fieldType.ezkeyword.storage_gateway.class: eZ\Publish\Core\FieldType\Keyword\KeywordStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezmedia.storage_gateway.class: eZ\Publish\Core\FieldType\Media\MediaStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezrichtext.storage_gateway.class: eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\LegacyStorage
-    ezpublish.fieldType.ezurl.storage_gateway.class: eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\LegacyStorage
+    ezpublish.fieldType.ezurl.storage_gateway.class: eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezuser.storage_gateway.class: eZ\Publish\Core\FieldType\User\UserStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezpage.storage_gateway.class: eZ\Publish\Core\FieldType\Page\PageStorage\Gateway\LegacyStorage
 
@@ -53,7 +53,7 @@ services:
     ezpublish.fieldType.ezurl.storage_gateway:
         class: "%ezpublish.fieldType.ezurl.storage_gateway.class%"
         tags:
-            - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezurl, identifier: LegacyStorage}
+            - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezurl, identifier: DoctrineStorage}
 
     ezpublish.fieldType.ezpage.storage_gateway:
         class: "%ezpublish.fieldType.ezpage.storage_gateway.class%"

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -7,7 +7,7 @@ parameters:
     ezpublish.fieldType.ezimage.storage_gateway.class: eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezkeyword.storage_gateway.class: eZ\Publish\Core\FieldType\Keyword\KeywordStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezmedia.storage_gateway.class: eZ\Publish\Core\FieldType\Media\MediaStorage\Gateway\LegacyStorage
-    ezpublish.fieldType.ezrichtext.storage_gateway.class: eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\LegacyStorage
+    ezpublish.fieldType.ezrichtext.storage_gateway.class: eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezurl.storage_gateway.class: eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezuser.storage_gateway.class: eZ\Publish\Core\FieldType\User\UserStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezpage.storage_gateway.class: eZ\Publish\Core\FieldType\Page\PageStorage\Gateway\LegacyStorage
@@ -48,7 +48,7 @@ services:
         class: "%ezpublish.fieldType.ezrichtext.storage_gateway.class%"
         arguments: ["@ezpublish.fieldType.ezurl.storage_gateway"]
         tags:
-            - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezrichtext, identifier: LegacyStorage}
+            - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezrichtext, identifier: DoctrineStorage}
 
     ezpublish.fieldType.ezurl.storage_gateway:
         class: "%ezpublish.fieldType.ezurl.storage_gateway.class%"

--- a/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
@@ -611,7 +611,7 @@ abstract class BaseIntegrationTest extends TestCase
         $fieldTypeRegistry = self::$container->get('ezpublish.persistence.field_type_registry');
         /** @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry $converterRegistry */
         $converterRegistry = self::$container->get('ezpublish.persistence.legacy.field_value_converter.registry');
-        /** @var \eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry $storageRegistry */
+        /** @var \eZ\Publish\Core\Persistence\Content\StorageRegistry $storageRegistry */
         $storageRegistry = self::$container->get('ezpublish.persistence.external_storage_registry');
 
         $textLineFieldType = new \eZ\Publish\Core\FieldType\TextLine\Type();


### PR DESCRIPTION
> Implements [EZP-26885](https://jira.ez.no/browse/EZP-26885)
> Status: **Ready for a review**

We want to be able to use `\Doctrine\DBAL\Connection` for FieldTypes external storage directly.

To achieve this, FieldType external storage needs to be injected with `DoctrineStorage` gateway which uses Doctrine instead of Legacy Connection Handler.
PR also consists of TMP commits presenting sample implementations, for `Url` and `RichText` FieldTypes.

The main architecture issue related to this implementation is the fact that `\eZ\Publish\Core\Persistence\Legacy\Content\FieldHandler` uses, common for all FieldTypes, Legacy StorageHandler. This means that it's not enough to just register Doctrine gateway for a given FieldType but also `FieldHandler` must use proper `StorageHandler`.

To workaround this issue Doctrine `StorageHandler` is [injected directly into `DoctrineStorage` (`GatewayBasedStorage`) implementation for a specific field](https://github.com/alongosz/ezpublish-kernel/blob/75dbd4f1157c88ee6f1c16e80ed0fa54e9caa1ef/eZ/Publish/Core/settings/fieldtype_external_storages.yml#L55). If `GatewayBasedStorage` got explicitly injected with `StorageHandler`, then this one is used instead of the one passed by `FieldHandler` to get a proper gateway.

However, sometimes [gateway is injected directly](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/FieldType/RichText/RichTextStorage/Gateway/LegacyStorage.php#L40) setting incorrect Connection. 
To avoid this, `DoctrineStorage` Gateway for a FieldType gets [injected directly with proper Connection](https://github.com/alongosz/ezpublish-kernel/blob/75dbd4f1157c88ee6f1c16e80ed0fa54e9caa1ef/eZ/Publish/Core/settings/storage_engines/doctrine/external_storage_gateways.yml#L16) and `setConnection` is ignored.

This solution is far from perfect (hence the "workaround" keyword appears), so let's discuss improvements.

**TODO**:
- [x] Create Doctrine StorageHandler for FieldTypes.
- [x] Refactor `\eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry` to `\eZ\Publish\Core\Persistence\Content\StorageRegistry` to reflect this is common for storage engines.
- [x] Refactor `\eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler` to `\eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler` to extract common part for all storage engines.
- [x] Override `\Doctrine\DBAL\Connection` with custom wrapper extending it.
- [ ] Discuss solution.
- [ ] Move TMP commit to other PR if/when this one is accepted.