### PR TITLE
EZP-26885: As a Developer I want to future proof my Field Types by using Doctrine [in external storage]

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
@@ -40,6 +40,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider\Re
 use eZ\Publish\Core\Base\Container\Compiler\FieldTypeCollectionPass;
 use eZ\Publish\Core\Base\Container\Compiler\FieldTypeNameableCollectionPass;
 use eZ\Publish\Core\Base\Container\Compiler\RegisterLimitationTypePass;
+use eZ\Publish\Core\Base\Container\Compiler\Storage\ExternalStorageHandlerRegistryPass;
 use eZ\Publish\Core\Base\Container\Compiler\Storage\ExternalStorageRegistryPass;
 use eZ\Publish\Core\Base\Container\Compiler\Storage\Legacy\FieldValueConverterRegistryPass;
 use eZ\Publish\Core\Base\Container\Compiler\Storage\Legacy\RoleLimitationConverterPass;
@@ -93,6 +94,7 @@ class EzPublishCoreBundle extends Bundle
         $container->addCompilerPass(new ViewProvidersPass());
 
         // Storage passes
+        $container->addCompilerPass(new ExternalStorageHandlerRegistryPass());
         $container->addCompilerPass(new ExternalStorageRegistryPass());
         // Legacy Storage passes
         $container->addCompilerPass(new FieldValueConverterRegistryPass());

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage_engines.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage_engines.yml
@@ -1,7 +1,7 @@
 parameters:
     ezpublish.persistence.connection.factory.class: eZ\Bundle\EzPublishCoreBundle\ApiLoader\StorageConnectionFactory
     ezpublish.api.repository_configuration_provider.class: eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider
-    ezpublish.persistence.connection.class: Doctrine\DBAL\Connection
+    ezpublish.persistence.connection.class: eZ\Publish\Core\Persistence\Doctrine\DoctrineConnection
 
 services:
     ezpublish.api.repository_configuration_provider:

--- a/eZ/Publish/Core/Base/Container/ApiLoader/Storage/ExternalStorageRegistryFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/Storage/ExternalStorageRegistryFactory.php
@@ -52,7 +52,7 @@ class ExternalStorageRegistryFactory implements ContainerAwareInterface
      *
      * @param string $externalStorageRegistryClass
      *
-     * @return \eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry
+     * @return \eZ\Publish\Core\Persistence\Content\StorageRegistry
      */
     public function buildExternalStorageRegistry($externalStorageRegistryClass)
     {

--- a/eZ/Publish/Core/Base/Container/ApiLoader/Storage/FieldTypeRegistryFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/Storage/FieldTypeRegistryFactory.php
@@ -9,6 +9,8 @@
 namespace eZ\Publish\Core\Base\Container\ApiLoader\Storage;
 
 use eZ\Publish\Core\Base\Container\ApiLoader\FieldTypeCollectionFactory;
+use eZ\Publish\SPI\Persistence\Content\StorageHandler;
+use eZ\Publish\SPI\Persistence\Content\StorageHandlerRegistry;
 
 class FieldTypeRegistryFactory
 {
@@ -17,13 +19,21 @@ class FieldTypeRegistryFactory
      *
      * @param string $fieldTypeRegistryClass
      * @param \eZ\Publish\Core\Base\Container\ApiLoader\FieldTypeCollectionFactory $fieldTypeCollectionFactory
+     * @param \eZ\Publish\SPI\Persistence\Content\StorageHandlerRegistry $storageHandlerRegistry
+     * @param \eZ\Publish\SPI\Persistence\Content\StorageHandler $defaultStorageHandler
      *
      * @return \eZ\Publish\Core\Persistence\FieldTypeRegistry
      */
-    public function buildFieldTypeRegistry($fieldTypeRegistryClass, FieldTypeCollectionFactory $fieldTypeCollectionFactory)
-    {
+    public function buildFieldTypeRegistry(
+        $fieldTypeRegistryClass,
+        FieldTypeCollectionFactory $fieldTypeCollectionFactory,
+        StorageHandlerRegistry $storageHandlerRegistry,
+        StorageHandler $defaultStorageHandler
+    ) {
         return new $fieldTypeRegistryClass(
-            $fieldTypeCollectionFactory->getFieldTypes()
+            $fieldTypeCollectionFactory->getFieldTypes(),
+            $storageHandlerRegistry,
+            $defaultStorageHandler
         );
     }
 }

--- a/eZ/Publish/Core/Base/Container/Compiler/Storage/ExternalStorageHandlerRegistryPass.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/Storage/ExternalStorageHandlerRegistryPass.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Base\Container\Compiler\Storage;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use LogicException;
+
+/**
+ * This compiler pass will register external storage persistence handlers.
+ */
+class ExternalStorageHandlerRegistryPass implements CompilerPassInterface
+{
+    /**
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     *
+     * @throws \LogicException
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $storageHandlerRegistryServiceId = 'ezpublish.persistence.external_storage_handler.registry';
+        $storageHandlerRegistryServiceTagName = 'ezpublish.persistence.externalStorageHandler';
+        if (!$container->hasDefinition($storageHandlerRegistryServiceId)) {
+            return;
+        }
+
+        // Register Persistence Layer-specific External Storage Handlers (for Doctrine, Legacy, etc.)
+        $storageHandlerRegistry = $container->getDefinition($storageHandlerRegistryServiceId);
+        foreach ($container->findTaggedServiceIds($storageHandlerRegistryServiceTagName) as $id => $attributes) {
+            foreach ($attributes as $attribute) {
+                if (!isset($attribute['identifier'])) {
+                    throw new LogicException("$storageHandlerRegistryServiceTagName service tag needs an 'identifier' attribute to identify the Storage. None given.");
+                }
+
+                $storageHandlerRegistry->addMethodCall(
+                    'register',
+                    [
+                        $attribute['identifier'],
+                        new Reference($id),
+                    ]
+                );
+            }
+        }
+    }
+}

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/Storage/ExternalStorageHandlerRegistryPassTest.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/Storage/ExternalStorageHandlerRegistryPassTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Base\Tests\Container\Compiler\Storage;
+
+use eZ\Publish\Core\Base\Container\Compiler\Storage\ExternalStorageHandlerRegistryPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class ExternalStorageHandlerRegistryPassTest extends AbstractCompilerPassTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->setDefinition('ezpublish.persistence.external_storage_handler.registry', new Definition());
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new ExternalStorageHandlerRegistryPass());
+    }
+
+    public function testRegisterExternalStoragePersistenceHandler()
+    {
+        $def = new Definition();
+        $storageIdentifier = 'StorageIdentifier';
+        $def->addTag('ezpublish.persistence.externalStorageHandler', ['identifier' => $storageIdentifier]
+        );
+        $serviceId = 'some_service_id';
+        $this->setDefinition($serviceId, $def);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'ezpublish.persistence.external_storage_handler.registry',
+            'register',
+            array($storageIdentifier, new Reference($serviceId))
+        );
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testRegisterExternalStoragePersistenceHandlerNoIdentifier()
+    {
+        $def = new Definition();
+        $storageIdentifier = 'StorageIdentifier';
+        $def->addTag('ezpublish.persistence.externalStorageHandler');
+        $serviceId = 'some_service_id';
+        $this->setDefinition($serviceId, $def);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'ezpublish.persistence.external_storage_handler.registry',
+            'register',
+            array($storageIdentifier, new Reference($serviceId))
+        );
+    }
+}

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/Storage/ExternalStorageRegistryPassTest.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/Storage/ExternalStorageRegistryPassTest.php
@@ -20,6 +20,7 @@ class ExternalStorageRegistryPassTest extends AbstractCompilerPassTestCase
     {
         parent::setUp();
         $this->setDefinition('ezpublish.persistence.external_storage_registry.factory', new Definition());
+        $this->setDefinition('ezpublish.persistence.field_type_registry', new Definition());
     }
 
     protected function registerCompilerPass(ContainerBuilder $container)

--- a/eZ/Publish/Core/FieldType/RichText/RichTextStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/RichText/RichTextStorage/Gateway/DoctrineStorage.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway;
+
+use eZ\Publish\Core\Persistence\Doctrine\DoctrineConnection;
+use eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway;
+use RuntimeException;
+
+class DoctrineStorage extends Gateway
+{
+    /**
+     * @var \eZ\Publish\Core\Persistence\Doctrine\DoctrineConnection
+     */
+    protected $connection;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setConnection($connection)
+    {
+        if (!$connection instanceof DoctrineConnection) {
+            throw new RuntimeException(
+                sprintf(
+                    '%s::setConnection expects an instance of %s, but %s given',
+                    self::class,
+                    DoctrineConnection::class,
+                    get_class($connection)
+                )
+            );
+        }
+
+        $this->urlGateway->setConnection($connection);
+        $this->connection = $connection;
+    }
+
+    /**
+     * Returns a list of Content ids for a list of remote ids.
+     *
+     * Non-existent ids are ignored.
+     *
+     * @param string[] $remoteIds An array of Content remote ids
+     *
+     * @return array An array of Content ids, with remote ids as keys
+     */
+    public function getContentIds(array $remoteIds)
+    {
+        $objectRemoteIdMap = [];
+
+        if (!empty($remoteIds)) {
+            $query = $this->connection->createQueryBuilder();
+            $query
+                ->select('id', 'remote_id')
+                ->from('ezcontentobject')
+                ->where($query->expr()->in('remote_id', ':remoteIds'))
+                ->setParameter(':remoteIds', $remoteIds, DoctrineConnection::PARAM_STR_ARRAY)
+            ;
+
+            $statement = $query->execute();
+            foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $row) {
+                $objectRemoteIdMap[$row['remote_id']] = $row['id'];
+            }
+        }
+
+        return $objectRemoteIdMap;
+    }
+}

--- a/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway/DoctrineStorage.php
@@ -1,0 +1,227 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway;
+
+use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway;
+use eZ\Publish\Core\Persistence\Doctrine\DoctrineConnection;
+use PDO;
+use RuntimeException;
+
+class DoctrineStorage extends Gateway
+{
+    const URL_TABLE = 'ezurl';
+    const URL_LINK_TABLE = 'ezurl_object_link';
+
+    /**
+     * @var \eZ\Publish\Core\Persistence\Doctrine\DoctrineConnection
+     */
+    protected $connection;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setConnection($connection)
+    {
+        if (!$connection instanceof DoctrineConnection) {
+            throw new RuntimeException(
+                sprintf(
+                    '%s::setConnection expects an instance of %s, but %s given',
+                    self::class,
+                    DoctrineConnection::class,
+                    get_class($connection)
+                )
+            );
+        }
+
+        $this->connection = $connection;
+    }
+
+    /**
+     * Returns a list of URLs for a list of URL ids.
+     *
+     * Non-existent ids are ignored.
+     *
+     * @param int[]|string[] $ids An array of URL ids
+     *
+     * @return array An array of URLs, with ids as keys
+     */
+    public function getIdUrlMap(array $ids)
+    {
+        $map = [];
+
+        if (!empty($ids)) {
+            $query = $this->connection->createQueryBuilder();
+            $query
+                ->select('id', 'url')
+                ->from(self::URL_TABLE)
+                ->where('id IN (:ids)')
+                ->setParameter(':ids', $ids, DoctrineConnection::PARAM_STR_ARRAY);
+
+            $statement = $query->execute();
+            foreach ($statement->fetchAll(PDO::FETCH_ASSOC) as $row) {
+                $map[$row['id']] = $row['url'];
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Returns a list of URL ids for a list of URLs.
+     *
+     * Non-existent URLs are ignored.
+     *
+     * @param string[] $urls An array of URLs
+     *
+     * @return array An array of URL ids, with URLs as keys
+     */
+    public function getUrlIdMap(array $urls)
+    {
+        $map = [];
+
+        if (!empty($urls)) {
+            $query = $this->connection->createQueryBuilder();
+            $query
+                ->select('id', 'url')
+                ->from(self::URL_TABLE)
+                ->where(
+                    $query->expr()->in('url', ':urls')
+                )
+                ->setParameter(':urls', $urls, DoctrineConnection::PARAM_STR_ARRAY);
+
+            $statement = $query->execute();
+            foreach ($statement->fetchAll(PDO::FETCH_ASSOC) as $row) {
+                $map[$row['url']] = $row['id'];
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Inserts a new $url and returns its id.
+     *
+     * @param string $url The URL to insert in the database
+     *
+     * @return int|string
+     */
+    public function insertUrl($url)
+    {
+        $time = time();
+
+        $query = $this->connection->createQueryBuilder();
+
+        $query->insert(
+            $this->connection->quoteIdentifier(self::URL_TABLE)
+        )->values([
+            'created' => ':created',
+            'modified' => ':modified',
+            'original_url_md5' => ':original_url_md5',
+            'url' => ':url',
+        ])
+            ->setParameter(':created', $time, PDO::PARAM_INT)
+            ->setParameter(':modified', $time, PDO::PARAM_INT)
+            ->setParameter(':original_url_md5', md5($url))
+            ->setParameter(':url', $url)
+        ;
+
+        $query->execute();
+
+        return $this->connection->lastInsertId(
+            $this->connection->getSequenceName(self::URL_TABLE, 'id')
+        );
+    }
+
+    /**
+     * Creates link to URL with $urlId for field with $fieldId in $versionNo.
+     *
+     * @param int|string $urlId
+     * @param int|string $fieldId
+     * @param int $versionNo
+     */
+    public function linkUrl($urlId, $fieldId, $versionNo)
+    {
+        $query = $this->connection->createQueryBuilder();
+
+        $query->insert(
+            $this->connection->quoteIdentifier(self::URL_LINK_TABLE)
+        )->values([
+            'contentobject_attribute_id' => ':contentobject_attribute_id',
+            'contentobject_attribute_version' => ':contentobject_attribute_version',
+            'url_id' => ':url_id',
+        ])
+            ->setParameter(':contentobject_attribute_id', $fieldId, PDO::PARAM_INT)
+            ->setParameter(':contentobject_attribute_version', $versionNo, PDO::PARAM_INT)
+            ->setParameter(':url_id', $urlId, PDO::PARAM_INT)
+        ;
+
+        $query->execute();
+    }
+    /**
+     * Removes link to URL for $fieldId in $versionNo and cleans up possibly orphaned URLs.
+     *
+     * @param int|string $fieldId
+     * @param int $versionNo
+     */
+    public function unlinkUrl($fieldId, $versionNo)
+    {
+        $deleteQuery = $this->connection->createQueryBuilder();
+
+        $deleteQuery->delete(
+            $this->connection->quoteIdentifier(self::URL_LINK_TABLE)
+        )->where(
+            $deleteQuery->expr()->andX(
+                $deleteQuery->expr()->in('contentobject_attribute_id', ':contentobject_attribute_id'),
+                $deleteQuery->expr()->in('contentobject_attribute_version', ':contentobject_attribute_version')
+            )
+        )
+            ->setParameter(':contentobject_attribute_id', $fieldId, PDO::PARAM_INT)
+            ->setParameter(':contentobject_attribute_version', $versionNo, PDO::PARAM_INT)
+        ;
+
+        $deleteQuery->execute();
+
+        $this->deleteOrphanedUrls();
+    }
+
+    /**
+     * Deletes all orphaned URLs.
+     *
+     * @todo using two queries because zeta Database does not support joins in delete query.
+     * That could be avoided if the feature is implemented there.
+     *
+     * URL is orphaned if it is not linked to a content attribute through ezurl_object_link table.
+     */
+    private function deleteOrphanedUrls()
+    {
+        $query = $this->connection->createQueryBuilder();
+
+        $query
+            ->select('url.id')
+            ->from($this->connection->quoteIdentifier(self::URL_TABLE), 'url')
+            ->leftJoin('url', $this->connection->quoteIdentifier(self::URL_LINK_TABLE), 'link', 'url.id = link.url_id')
+            ->where($query->expr()->isNull('link.url_id'))
+        ;
+        $statement = $query->execute();
+        $ids = $statement->fetchAll(PDO::FETCH_COLUMN);
+        if (empty($ids)) {
+            return;
+        }
+
+        $deleteQuery = $this->connection->createQueryBuilder();
+
+        $deleteQuery
+            ->delete($this->connection->quoteIdentifier(self::URL_TABLE))
+            ->where($deleteQuery->expr()->in('id', ':ids'))
+            ->setParameter(':ids', $ids, DoctrineConnection::PARAM_STR_ARRAY)
+        ;
+
+        $deleteQuery->execute();
+    }
+}

--- a/eZ/Publish/Core/Persistence/Content/StorageRegistry.php
+++ b/eZ/Publish/Core/Persistence/Content/StorageRegistry.php
@@ -1,12 +1,12 @@
 <?php
 
 /**
- * File containing the StorageRegistry class.
+ * This file is part of the eZ Publish Kernel package.
  *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\Persistence\Legacy\Content;
+namespace eZ\Publish\Core\Persistence\Content;
 
 use eZ\Publish\SPI\FieldType\FieldStorage;
 use eZ\Publish\Core\FieldType\NullStorage;
@@ -21,7 +21,7 @@ class StorageRegistry
      *
      * @var array
      */
-    protected $storageMap = array();
+    protected $storageMap = [];
 
     /**
      * Create field storage registry with converter map.

--- a/eZ/Publish/Core/Persistence/Doctrine/ConnectionHandler.php
+++ b/eZ/Publish/Core/Persistence/Doctrine/ConnectionHandler.php
@@ -33,6 +33,8 @@ class ConnectionHandler implements DatabaseHandler
         } else {
             $parsed = $dsn;
         }
+        // use custom wrapper extending \Doctrine\DBAL\Connection
+        $parsed['wrapperClass'] = DoctrineConnection::class;
 
         return DriverManager::getConnection($parsed);
     }

--- a/eZ/Publish/Core/Persistence/Doctrine/Content/StorageHandler.php
+++ b/eZ/Publish/Core/Persistence/Doctrine/Content/StorageHandler.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Persistence\Doctrine\Content;
+
+use eZ\Publish\Core\Persistence\Content\StorageRegistry;
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\StorageHandler as SPIStorageHandler;
+use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+
+class StorageHandler implements SPIStorageHandler
+{
+    /**
+     * Storage registry.
+     *
+     * @var \eZ\Publish\Core\Persistence\Content\StorageRegistry
+     */
+    protected $storageRegistry;
+
+    /**
+     * Array with database context.
+     *
+     * @var array
+     */
+    protected $context;
+
+    /**
+     * Creates a new storage handler.
+     *
+     * @param \eZ\Publish\Core\Persistence\Content\StorageRegistry $storageRegistry
+     * @param array $context
+     */
+    public function __construct(StorageRegistry $storageRegistry, array $context)
+    {
+        $this->storageRegistry = $storageRegistry;
+        $this->context = $context;
+    }
+
+    /**
+     * Stores data from $field in its corresponding external storage.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @return mixed
+     */
+    public function storeFieldData(VersionInfo $versionInfo, Field $field)
+    {
+        return $this->storageRegistry->getStorage($field->type)->storeFieldData(
+            $versionInfo,
+            $field,
+            $this->context
+        );
+    }
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $originalField
+     * @return mixed
+     */
+    public function copyFieldData(VersionInfo $versionInfo, Field $field, Field $originalField)
+    {
+        return $this->storageRegistry->getStorage($field->type)->storeFieldData(
+            $versionInfo,
+            $field,
+            $this->context
+        );
+    }
+
+    /**
+     * Fetches external data for $field from its corresponding external storage.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param Field $field
+     */
+    public function getFieldData(VersionInfo $versionInfo, Field $field)
+    {
+        $storage = $this->storageRegistry->getStorage($field->type);
+        if ($storage->hasFieldData()) {
+            $storage->getFieldData($versionInfo, $field, $this->context);
+        }
+    }
+
+    /**
+     * Deletes data for field $ids from external storage of $fieldType.
+     *
+     * @param string $fieldType
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param mixed[] $ids
+     */
+    public function deleteFieldData($fieldType, VersionInfo $versionInfo, array $ids)
+    {
+        $this->storageRegistry->getStorage($fieldType)
+            ->deleteFieldData($versionInfo, $ids, $this->context);
+    }
+}

--- a/eZ/Publish/Core/Persistence/Doctrine/DoctrineConnection.php
+++ b/eZ/Publish/Core/Persistence/Doctrine/DoctrineConnection.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Persistence\Doctrine;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Wrapper class adding extra features to \Doctrine\DBAL\Connection.
+ *
+ * Note: DoctrineConnection is used instead of Connection to avoid names collision.
+ */
+class DoctrineConnection extends Connection
+{
+    /**
+     * Get sequence name bound to database table and column.
+     *
+     * Note: must be compatible with:
+     * @see \eZ\Publish\Core\Persistence\Doctrine\ConnectionHandler\PostgresConnectionHandler::quoteIdentifier
+     *
+     * @param string $table
+     * @param string $column
+     * @return string
+     */
+    public function getSequenceName($table, $column)
+    {
+        // @todo: change to <table>_<column>_seq when merged into 7.0
+        return sprintf('%s_s', $table);
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldHandler.php
@@ -42,13 +42,6 @@ class FieldHandler
     protected $mapper;
 
     /**
-     * Storage Handler.
-     *
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler
-     */
-    protected $storageHandler;
-
-    /**
      * FieldType registry.
      *
      * @var \eZ\Publish\Core\Persistence\FieldTypeRegistry
@@ -67,20 +60,17 @@ class FieldHandler
      *
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\Gateway $contentGateway
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\Mapper $mapper
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler $storageHandler
      * @param \eZ\Publish\SPI\Persistence\Content\Language\Handler $languageHandler
      * @param \eZ\Publish\Core\Persistence\FieldTypeRegistry $fieldTypeRegistry
      */
     public function __construct(
         Gateway $contentGateway,
         Mapper $mapper,
-        StorageHandler $storageHandler,
         LanguageHandler $languageHandler,
         FieldTypeRegistry $fieldTypeRegistry
     ) {
         $this->contentGateway = $contentGateway;
         $this->mapper = $mapper;
-        $this->storageHandler = $storageHandler;
         $this->languageHandler = $languageHandler;
         $this->fieldTypeRegistry = $fieldTypeRegistry;
     }
@@ -177,10 +167,11 @@ class FieldHandler
             $this->mapper->convertToStorageValue($field)
         );
 
+        $storageHandler = $this->fieldTypeRegistry->getStorageHandler($field->type);
         // If the storage handler returns true, it means that $field value has been modified
         // So we need to update it in order to store those modifications
         // Field converter is called once again via the Mapper
-        if ($this->storageHandler->storeFieldData($content->versionInfo, $field) === true) {
+        if ($storageHandler->storeFieldData($content->versionInfo, $field) === true) {
             $this->contentGateway->updateField(
                 $field,
                 $this->mapper->convertToStorageValue($field)
@@ -222,10 +213,11 @@ class FieldHandler
             $this->mapper->convertToStorageValue($field)
         );
 
+        $storageHandler = $this->fieldTypeRegistry->getStorageHandler($field->type);
         // If the storage handler returns true, it means that $field value has been modified
         // So we need to update it in order to store those modifications
         // Field converter is called once again via the Mapper
-        if ($this->storageHandler->copyFieldData($content->versionInfo, $field, $originalField) === true) {
+        if ($storageHandler->copyFieldData($content->versionInfo, $field, $originalField) === true) {
             $this->contentGateway->updateField(
                 $field,
                 $this->mapper->convertToStorageValue($field)
@@ -250,10 +242,11 @@ class FieldHandler
             $this->mapper->convertToStorageValue($field)
         );
 
+        $storageHandler = $this->fieldTypeRegistry->getStorageHandler($field->type);
         // If the storage handler returns true, it means that $field value has been modified
         // So we need to update it in order to store those modifications
         // Field converter is called once again via the Mapper
-        if ($this->storageHandler->storeFieldData($content->versionInfo, $field) === true) {
+        if ($storageHandler->storeFieldData($content->versionInfo, $field) === true) {
             $this->contentGateway->updateField(
                 $field,
                 $this->mapper->convertToStorageValue($field)
@@ -285,10 +278,11 @@ class FieldHandler
             $this->mapper->convertToStorageValue($field)
         );
 
+        $storageHandler = $this->fieldTypeRegistry->getStorageHandler($field->type);
         // If the storage handler returns true, it means that $field value has been modified
         // So we need to update it in order to store those modifications
         // Field converter is called once again via the Mapper
-        if ($this->storageHandler->copyFieldData($content->versionInfo, $field, $originalField) === true) {
+        if ($storageHandler->copyFieldData($content->versionInfo, $field, $originalField) === true) {
             $this->contentGateway->updateField(
                 $field,
                 $this->mapper->convertToStorageValue($field)
@@ -304,7 +298,8 @@ class FieldHandler
     public function loadExternalFieldData(Content $content)
     {
         foreach ($content->fields as $field) {
-            $this->storageHandler->getFieldData($content->versionInfo, $field);
+            $storageHandler = $this->fieldTypeRegistry->getStorageHandler($field->type);
+            $storageHandler->getFieldData($content->versionInfo, $field);
         }
     }
 
@@ -400,10 +395,11 @@ class FieldHandler
             $this->mapper->convertToStorageValue($field)
         );
 
+        $storageHandler = $this->fieldTypeRegistry->getStorageHandler($field->type);
         // If the storage handler returns true, it means that $field value has been modified
         // So we need to update it in order to store those modifications
         // Field converter is called once again via the Mapper
-        if ($this->storageHandler->copyFieldData($content->versionInfo, $field, $originalField) === true) {
+        if ($storageHandler->copyFieldData($content->versionInfo, $field, $originalField) === true) {
             $this->contentGateway->updateField(
                 $field,
                 $this->mapper->convertToStorageValue($field)
@@ -458,7 +454,8 @@ class FieldHandler
     public function deleteFields($contentId, VersionInfo $versionInfo)
     {
         foreach ($this->contentGateway->getFieldIdsByType($contentId, $versionInfo->versionNo) as $fieldType => $ids) {
-            $this->storageHandler->deleteFieldData($fieldType, $versionInfo, $ids);
+            $storageHandler = $this->fieldTypeRegistry->getStorageHandler($fieldType);
+            $storageHandler->deleteFieldData($fieldType, $versionInfo, $ids);
         }
         $this->contentGateway->deleteFields($contentId, $versionInfo->versionNo);
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/StorageHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/StorageHandler.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content;
 
+use eZ\Publish\Core\Persistence\Content\StorageRegistry;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\StorageHandler as SPIStorageHandler;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
@@ -47,7 +48,8 @@ class StorageHandler implements SPIStorageHandler
      * Stores data from $field in its corresponding external storage.
      *
      * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @return mixed
      */
     public function storeFieldData(VersionInfo $versionInfo, Field $field)
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/StorageHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/StorageHandler.php
@@ -9,12 +9,13 @@
 namespace eZ\Publish\Core\Persistence\Legacy\Content;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\StorageHandler as SPIStorageHandler;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 
 /**
  * Handler for external storages.
  */
-class StorageHandler
+class StorageHandler implements SPIStorageHandler
 {
     /**
      * Storage registry.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater.php
@@ -8,8 +8,8 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Type;
 
+use eZ\Publish\Core\Persistence\FieldTypeRegistry;
 use eZ\Publish\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
-use eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry as Registry;
 use eZ\Publish\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
 use eZ\Publish\SPI\Persistence\Content\Type;
@@ -35,11 +35,11 @@ class ContentUpdater
     protected $converterRegistry;
 
     /**
-     * Storage handler.
+     * Field Type Registry.
      *
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler
+     * @var \eZ\Publish\Core\Persistence\FieldTypeRegistry
      */
-    protected $storageHandler;
+    protected $fieldTypeRegistry;
 
     /**
      * @var \eZ\Publish\Core\Persistence\Legacy\Content\Mapper
@@ -51,20 +51,19 @@ class ContentUpdater
      *
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\Gateway $contentGateway
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry $converterRegistry
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler $storageHandler
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\Mapper $contentMapper
+     * @param \eZ\Publish\Core\Persistence\FieldTypeRegistry $fieldTypeRegistry
      */
     public function __construct(
         ContentGateway $contentGateway,
         Registry $converterRegistry,
-        StorageHandler $storageHandler,
-        ContentMapper $contentMapper
+        ContentMapper $contentMapper,
+        FieldTypeRegistry $fieldTypeRegistry
     ) {
         $this->contentGateway = $contentGateway;
         $this->converterRegistry = $converterRegistry;
-        $this->storageHandler = $storageHandler;
-        $this->storageHandler = $storageHandler;
         $this->contentMapper = $contentMapper;
+        $this->fieldTypeRegistry = $fieldTypeRegistry;
     }
 
     /**
@@ -83,7 +82,7 @@ class ContentUpdater
                 $actions[] = new ContentUpdater\Action\RemoveField(
                     $this->contentGateway,
                     $fieldDef,
-                    $this->storageHandler,
+                    $this->fieldTypeRegistry->getStorageHandler($fieldDef->fieldType),
                     $this->contentMapper
                 );
             }
@@ -96,7 +95,7 @@ class ContentUpdater
                     $this->converterRegistry->getConverter(
                         $fieldDef->fieldType
                     ),
-                    $this->storageHandler,
+                    $this->fieldTypeRegistry->getStorageHandler($fieldDef->fieldType),
                     $this->contentMapper
                 );
             }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action/AddField.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action/AddField.php
@@ -14,8 +14,8 @@ use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\Gateway;
-use eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
+use eZ\Publish\SPI\Persistence\Content\StorageHandler;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 
 /**
@@ -55,7 +55,7 @@ class AddField extends Action
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\Gateway $contentGateway
      * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDef
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter $converter
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler $storageHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\StorageHandler $storageHandler
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\Mapper $contentMapper
      */
     public function __construct(

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action/RemoveField.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action/RemoveField.php
@@ -10,8 +10,8 @@ namespace eZ\Publish\Core\Persistence\Legacy\Content\Type\ContentUpdater\Action;
 
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\ContentUpdater\Action;
 use eZ\Publish\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
-use eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
+use eZ\Publish\SPI\Persistence\Content\StorageHandler;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 
 /**
@@ -43,7 +43,7 @@ class RemoveField extends Action
      *
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\Gateway $contentGateway
      * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDef
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler $storageHandler
+     * @param \eZ\Publish\SPI\Persistence\Content\StorageHandler $storageHandler
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\Mapper $contentMapper
      */
     public function __construct(

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldHandlerTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;
 
+use eZ\Publish\Core\Persistence\FieldTypeRegistry;
 use eZ\Publish\SPI\Persistence\Content\Type;
 use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo;
@@ -978,7 +979,6 @@ class FieldHandlerTest extends LanguageAwareTestCase
         $mock = new FieldHandler(
             $this->getContentGatewayMock(),
             $this->getMapperMock(),
-            $this->getStorageHandlerMock(),
             $this->getLanguageHandler(),
             $this->getFieldTypeRegistryMock()
         );
@@ -1049,7 +1049,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
     {
         if (!isset($this->fieldTypeRegistryMock)) {
             $this->fieldTypeRegistryMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\FieldTypeRegistry',
+                FieldTypeRegistry::class,
                 array(),
                 array(),
                 '',
@@ -1064,6 +1064,16 @@ class FieldHandlerTest extends LanguageAwareTestCase
                 $this->isType('string')
             )->will(
                 $this->returnValue($this->getFieldTypeMock())
+            );
+
+            $this->fieldTypeRegistryMock->expects(
+                $this->any()
+            )->method(
+                'getStorageHandler'
+            )->with(
+                $this->isType('string')
+            )->will(
+                $this->returnValue($this->getStorageHandlerMock())
             );
         }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/StorageHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/StorageHandlerTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;
 
+use eZ\Publish\Core\Persistence\Content\StorageRegistry;
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
@@ -22,7 +23,7 @@ class StorageHandlerTest extends TestCase
     /**
      * StorageRegistry mock.
      *
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry
+     * @var \eZ\Publish\Core\Persistence\Content\StorageRegistry
      */
     protected $storageRegistryMock;
 
@@ -190,13 +191,13 @@ class StorageHandlerTest extends TestCase
     /**
      * Returns a StorageRegistry mock.
      *
-     * @return \eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry
+     * @return \eZ\Publish\Core\Persistence\Content\StorageRegistry
      */
     protected function getStorageRegistryMock()
     {
         if (!isset($this->storageRegistryMock)) {
             $this->storageRegistryMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageRegistry',
+                StorageRegistry::class,
                 array(),
                 array(array())
             );

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/StorageRegistryTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/StorageRegistryTest.php
@@ -9,7 +9,7 @@
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
-use eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry;
+use eZ\Publish\Core\Persistence\Content\StorageRegistry;
 
 /**
  * Test case for StorageRegistry.
@@ -17,7 +17,7 @@ use eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry;
 class StorageRegistryTest extends TestCase
 {
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry::register
+     * @covers \eZ\Publish\Core\Persistence\Content\StorageRegistry::register
      */
     public function testRegister()
     {
@@ -34,7 +34,7 @@ class StorageRegistryTest extends TestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry::getStorage
+     * @covers \eZ\Publish\Core\Persistence\Content\StorageRegistry::getStorage
      */
     public function testGetStorage()
     {
@@ -50,7 +50,7 @@ class StorageRegistryTest extends TestCase
     }
 
     /**
-     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry::getStorage
+     * @covers \eZ\Publish\Core\Persistence\Content\StorageRegistry::getStorage
      * @covers \eZ\Publish\Core\Persistence\Legacy\Exception\StorageNotFound
      */
     public function testGetNotFound()

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdaterTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdaterTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Type;
 
+use eZ\Publish\Core\Persistence\FieldTypeRegistry;
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\ContentUpdater;
 use eZ\Publish\SPI\Persistence\Content\Type;
 use PHPUnit_Framework_TestCase;
@@ -44,6 +46,13 @@ class ContentUpdaterTest extends PHPUnit_Framework_TestCase
      * @var \eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler
      */
     protected $contentStorageHandlerMock;
+
+    /**
+     * FieldTypeRegistry mock.
+     *
+     * @var \eZ\Publish\Core\Persistence\FieldTypeRegistry
+     */
+    protected $fieldTypeRegistryMock;
 
     /**
      * Content Updater to test.
@@ -250,7 +259,7 @@ class ContentUpdaterTest extends PHPUnit_Framework_TestCase
     {
         if (!isset($this->contentStorageHandlerMock)) {
             $this->contentStorageHandlerMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageHandler',
+                StorageHandler::class,
                 array(),
                 array(),
                 '',
@@ -259,6 +268,30 @@ class ContentUpdaterTest extends PHPUnit_Framework_TestCase
         }
 
         return $this->contentStorageHandlerMock;
+    }
+
+    /**
+     * Return FieldTypeRegistry mock.
+     *
+     * @return \eZ\Publish\Core\Persistence\FieldTypeRegistry|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getFieldTypeRegistryMock()
+    {
+        if (!isset($this->fieldTypeRegistryMock)) {
+            $this->fieldTypeRegistryMock = $this->getMockBuilder(FieldTypeRegistry::class)
+                ->disableOriginalConstructor()
+                ->getMock()
+            ;
+
+            $this->fieldTypeRegistryMock
+                ->method('getStorageHandler')
+                ->with($this->isType('string'))
+                ->will(
+                    $this->returnValue($this->getContentStorageHandlerMock())
+                );
+        }
+
+        return $this->fieldTypeRegistryMock;
     }
 
     /**
@@ -292,8 +325,8 @@ class ContentUpdaterTest extends PHPUnit_Framework_TestCase
             $this->contentUpdater = new ContentUpdater(
                 $this->getContentGatewayMock(),
                 $this->getConverterRegistryMock(),
-                $this->getContentStorageHandlerMock(),
-                $this->getContentMapperMock()
+                $this->getContentMapperMock(),
+                $this->getFieldTypeRegistryMock()
             );
         }
 

--- a/eZ/Publish/Core/Persistence/Tests/FieldTypeRegistryTest.php
+++ b/eZ/Publish/Core/Persistence/Tests/FieldTypeRegistryTest.php
@@ -10,6 +10,10 @@ namespace eZ\Publish\Core\Persistence\Tests;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\Core\Persistence\FieldTypeRegistry;
+use eZ\Publish\SPI\Persistence\Content\StorageHandler;
+use eZ\Publish\SPI\Persistence\Content\StorageHandlerRegistry;
+use eZ\Publish\SPI\Persistence\FieldType;
+use eZ\Publish\SPI\FieldType\FieldType as SPIFieldType;
 
 /**
  * Test case for FieldTypeRegistry.
@@ -22,12 +26,16 @@ class FieldTypeRegistryTest extends TestCase
     public function testConstructor()
     {
         $fieldType = $this->getFieldTypeMock();
-        $registry = new FieldTypeRegistry(array('some-type' => $fieldType));
+        $registry = new FieldTypeRegistry(
+            ['some-type' => $fieldType],
+            $this->getStorageHandlerRegistryMock(),
+            $this->getStorageHandlerMock()
+        );
 
         $this->assertAttributeSame(
-            array(
+            [
                 'some-type' => $fieldType,
-            ),
+            ],
             'coreFieldTypeMap',
             $registry
         );
@@ -39,11 +47,15 @@ class FieldTypeRegistryTest extends TestCase
     public function testGetFieldTypeInstance()
     {
         $instance = $this->getFieldTypeMock();
-        $registry = new FieldTypeRegistry(array('some-type' => $instance));
+        $registry = new FieldTypeRegistry(
+            ['some-type' => $instance],
+            $this->getStorageHandlerRegistryMock(),
+            $this->getStorageHandlerMock()
+        );
 
         $result = $registry->getFieldType('some-type');
 
-        $this->assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\FieldType', $result);
+        $this->assertInstanceOf(FieldType::class, $result);
         $this->assertAttributeSame(
             $instance,
             'internalFieldType',
@@ -60,11 +72,15 @@ class FieldTypeRegistryTest extends TestCase
         $closure = function () use ($instance) {
             return $instance;
         };
-        $registry = new FieldTypeRegistry(array('some-type' => $closure));
+        $registry = new FieldTypeRegistry(
+            ['some-type' => $closure],
+            $this->getStorageHandlerRegistryMock(),
+            $this->getStorageHandlerMock()
+        );
 
         $result = $registry->getFieldType('some-type');
 
-        $this->assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\FieldType', $result);
+        $this->assertInstanceOf(FieldType::class, $result);
         $this->assertAttributeSame(
             $instance,
             'internalFieldType',
@@ -80,7 +96,11 @@ class FieldTypeRegistryTest extends TestCase
      */
     public function testGetNotFound()
     {
-        $registry = new FieldTypeRegistry(array());
+        $registry = new FieldTypeRegistry(
+            [],
+            $this->getStorageHandlerRegistryMock(),
+            $this->getStorageHandlerMock()
+        );
         $registry->getFieldType('not-found');
     }
 
@@ -92,7 +112,11 @@ class FieldTypeRegistryTest extends TestCase
      */
     public function testGetNotFoundBCException()
     {
-        $registry = new FieldTypeRegistry(array());
+        $registry = new FieldTypeRegistry(
+            [],
+            $this->getStorageHandlerRegistryMock(),
+            $this->getStorageHandlerMock()
+        );
         $registry->getFieldType('not-found');
     }
 
@@ -103,7 +127,11 @@ class FieldTypeRegistryTest extends TestCase
      */
     public function testGetNotCallableOrInstance()
     {
-        $registry = new FieldTypeRegistry(array('some-type' => new \DateTime()));
+        $registry = new FieldTypeRegistry(
+            ['some-type' => new \DateTime()],
+            $this->getStorageHandlerRegistryMock(),
+            $this->getStorageHandlerMock()
+        );
         $registry->getFieldType('some-type');
     }
 
@@ -113,7 +141,11 @@ class FieldTypeRegistryTest extends TestCase
     public function testRegister()
     {
         $fieldType = $this->getFieldTypeMock();
-        $registry = new FieldTypeRegistry(array());
+        $registry = new FieldTypeRegistry(
+            [],
+            $this->getStorageHandlerRegistryMock(),
+            $this->getStorageHandlerMock()
+        );
         $registry->register('some-type', $fieldType);
 
         $this->assertAttributeSame(
@@ -128,12 +160,32 @@ class FieldTypeRegistryTest extends TestCase
     /**
      * Returns a mock for persistence field type.
      *
-     * @return \eZ\Publish\SPI\Persistence\FieldType
+     * @return \eZ\Publish\SPI\Persistence\FieldType|\PHPUnit_Framework_MockObject_MockObject
      */
     protected function getFieldTypeMock()
     {
         return $this->getMock(
-            'eZ\\Publish\\SPI\\FieldType\\FieldType'
+            SPIFieldType::class
         );
+    }
+
+    /**
+     * Returns a mock for persistence storage handler registry.
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content\StorageHandlerRegistry|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getStorageHandlerRegistryMock()
+    {
+        return $this->getMock(StorageHandlerRegistry::class);
+    }
+
+    /**
+     * Returns a mock for persistence storage handler.
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content\StorageHandler|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getStorageHandlerMock()
+    {
+        return $this->getMock(StorageHandler::class);
     }
 }

--- a/eZ/Publish/Core/settings/containerBuilder.php
+++ b/eZ/Publish/Core/settings/containerBuilder.php
@@ -57,6 +57,7 @@ $containerBuilder->addCompilerPass(new Compiler\FieldTypeCollectionPass());
 $containerBuilder->addCompilerPass(new Compiler\FieldTypeNameableCollectionPass());
 $containerBuilder->addCompilerPass(new Compiler\RegisterLimitationTypePass());
 
+$containerBuilder->addCompilerPass(new Compiler\Storage\ExternalStorageHandlerRegistryPass());
 $containerBuilder->addCompilerPass(new Compiler\Storage\ExternalStorageRegistryPass());
 $containerBuilder->addCompilerPass(new Compiler\Storage\Legacy\FieldValueConverterRegistryPass());
 $containerBuilder->addCompilerPass(new Compiler\Storage\Legacy\RoleLimitationConverterPass());

--- a/eZ/Publish/Core/settings/storage_engines/common.yml
+++ b/eZ/Publish/Core/settings/storage_engines/common.yml
@@ -50,6 +50,8 @@ services:
         arguments:
             - "%ezpublish.persistence.field_type_registry.class%"
             - "@ezpublish.field_type_collection.factory"
+            - "@ezpublish.persistence.external_storage_handler.registry"
+            - "@ezpublish.persistence.legacy.external_storage_handler"
 
     ezpublish.persistence.external_storage_registry.factory:
         class: "%ezpublish.persistence.external_storage_registry.factory.class%"

--- a/eZ/Publish/Core/settings/storage_engines/common.yml
+++ b/eZ/Publish/Core/settings/storage_engines/common.yml
@@ -3,7 +3,7 @@ parameters:
     ezpublish.persistence.field_type_registry.class: eZ\Publish\Core\Persistence\FieldTypeRegistry
     ezpublish.persistence.external_storage_handler.registry.class: eZ\Publish\SPI\Persistence\Content\StorageHandlerRegistry
     ezpublish.persistence.external_storage_registry.factory.class: eZ\Publish\Core\Base\Container\ApiLoader\Storage\ExternalStorageRegistryFactory
-    ezpublish.persistence.external_storage_registry.class: eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry
+    ezpublish.persistence.external_storage_registry.class: eZ\Publish\Core\Persistence\Content\StorageRegistry
     ezpublish.persistence.slug_converter.class: eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\SlugConverter
 
     # Transformation parser/compiler for search purpose

--- a/eZ/Publish/Core/settings/storage_engines/common.yml
+++ b/eZ/Publish/Core/settings/storage_engines/common.yml
@@ -1,6 +1,7 @@
 parameters:
     ezpublish.persistence.field_type_registry.factory.class: eZ\Publish\Core\Base\Container\ApiLoader\Storage\FieldTypeRegistryFactory
     ezpublish.persistence.field_type_registry.class: eZ\Publish\Core\Persistence\FieldTypeRegistry
+    ezpublish.persistence.external_storage_handler.registry.class: eZ\Publish\SPI\Persistence\Content\StorageHandlerRegistry
     ezpublish.persistence.external_storage_registry.factory.class: eZ\Publish\Core\Base\Container\ApiLoader\Storage\ExternalStorageRegistryFactory
     ezpublish.persistence.external_storage_registry.class: eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry
     ezpublish.persistence.slug_converter.class: eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\SlugConverter
@@ -38,6 +39,10 @@ parameters:
 services:
     ezpublish.persistence.field_type_registry.factory:
         class: "%ezpublish.persistence.field_type_registry.factory.class%"
+
+    # register persistence storage handlers to this service by tagging them as ezpublish.persistence.externalStorageHandler
+    ezpublish.persistence.external_storage_handler.registry:
+        class: "%ezpublish.persistence.external_storage_handler.registry.class%"
 
     ezpublish.persistence.field_type_registry:
         class: "%ezpublish.persistence.field_type_registry.class%"

--- a/eZ/Publish/Core/settings/storage_engines/legacy.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy.yml
@@ -52,6 +52,9 @@ services:
         arguments:
             - "%legacy_dsn%"
 
+    ezpublish.api.storage_engine.doctrine.connection:
+        alias: ezpublish.api.storage_engine.legacy.connection
+
     ezpublish.spi.persistence.legacy.transactionhandler:
         class: "%ezpublish.spi.persistence.legacy.transactionhandler.class%"
         arguments:

--- a/eZ/Publish/Core/settings/storage_engines/legacy.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy.yml
@@ -16,7 +16,7 @@ parameters:
     ezpublish.spi.search.legacy.class: eZ\Publish\Core\Persistence\Legacy\Content\Search\MainHandler
     ezpublish.spi.persistence.legacy.class: eZ\Publish\Core\Persistence\Legacy\Handler
     ezpublish.api.storage_engine.legacy.dbhandler.class: eZ\Publish\Core\Persistence\Doctrine\ConnectionHandler
-    ezpublish.persistence.connection.class: Doctrine\DBAL\Connection
+    ezpublish.persistence.connection.class: eZ\Publish\Core\Persistence\Doctrine\DoctrineConnection
     ezpublish.spi.persistence.legacy.transactionhandler.class: eZ\Publish\Core\Persistence\Legacy\TransactionHandler
 
 services:

--- a/eZ/Publish/Core/settings/storage_engines/legacy/content.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/content.yml
@@ -43,7 +43,6 @@ services:
         arguments:
             - "@ezpublish.persistence.legacy.content.gateway"
             - "@ezpublish.persistence.legacy.content.mapper"
-            - "@ezpublish.persistence.legacy.external_storage_handler"
             - "@ezpublish.spi.persistence.legacy.language.handler"
             - "@ezpublish.persistence.field_type_registry"
         lazy: true

--- a/eZ/Publish/Core/settings/storage_engines/legacy/content_type.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/content_type.yml
@@ -37,8 +37,8 @@ services:
         arguments:
             - "@ezpublish.persistence.legacy.content.gateway"
             - "@ezpublish.persistence.legacy.field_value_converter.registry"
-            - "@ezpublish.persistence.legacy.external_storage_handler"
             - "@ezpublish.persistence.legacy.content.mapper"
+            - "@ezpublish.persistence.field_type_registry"
 
     ezpublish.persistence.legacy.content_type.update_handler.base:
         abstract: true

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -7,7 +7,7 @@ parameters:
     ezpublish.fieldType.ezimage.storage_gateway.class: eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezkeyword.storage_gateway.class: eZ\Publish\Core\FieldType\Keyword\KeywordStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezmedia.storage_gateway.class: eZ\Publish\Core\FieldType\Media\MediaStorage\Gateway\LegacyStorage
-    ezpublish.fieldType.ezrichtext.storage_gateway.class: eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\LegacyStorage
+    ezpublish.fieldType.ezrichtext.storage_gateway.class: eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezurl.storage_gateway.class: eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezuser.storage_gateway.class: eZ\Publish\Core\FieldType\User\UserStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezpage.storage_gateway.class: eZ\Publish\Core\FieldType\Page\PageStorage\Gateway\LegacyStorage
@@ -52,7 +52,7 @@ services:
         class: "%ezpublish.fieldType.ezrichtext.storage_gateway.class%"
         arguments: ["@ezpublish.fieldType.ezurl.storage_gateway"]
         tags:
-            - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezrichtext, identifier: LegacyStorage}
+            - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezrichtext, identifier: DoctrineStorage}
 
     ezpublish.fieldType.ezurl.storage_gateway:
         class: "%ezpublish.fieldType.ezurl.storage_gateway.class%"

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -1,5 +1,6 @@
 parameters:
     ezpublish.persistence.legacy.external_storage_handler.class: eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler
+    ezpublish.persistence.doctrine.external_storage_handler.class: eZ\Publish\Core\Persistence\Doctrine\Content\StorageHandler
 
     ezpublish.fieldType.ezbinaryfile.storage_gateway.class: eZ\Publish\Core\FieldType\BinaryFile\BinaryFileStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezgmaplocation.storage_gateway.class: eZ\Publish\Core\FieldType\MapLocation\MapLocationStorage\Gateway\LegacyStorage
@@ -21,6 +22,16 @@ services:
                 connection: "@ezpublish.api.storage_engine.legacy.dbhandler"
         tags:
             - {name: ezpublish.persistence.externalStorageHandler, identifier: LegacyStorage}
+
+    ezpublish.persistence.doctrine.external_storage_handler:
+        class: "%ezpublish.persistence.doctrine.external_storage_handler.class%"
+        arguments:
+            - "@ezpublish.persistence.external_storage_registry"
+            -
+                identifier: "DoctrineStorage"
+                connection: "@ezpublish.api.storage_engine.doctrine.connection"
+        tags:
+            - {name: ezpublish.persistence.externalStorageHandler, identifier: DoctrineStorage}
 
     ezpublish.fieldType.ezbinaryfile.storage_gateway:
         class: "%ezpublish.fieldType.ezbinaryfile.storage_gateway.class%"

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -8,7 +8,7 @@ parameters:
     ezpublish.fieldType.ezkeyword.storage_gateway.class: eZ\Publish\Core\FieldType\Keyword\KeywordStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezmedia.storage_gateway.class: eZ\Publish\Core\FieldType\Media\MediaStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezrichtext.storage_gateway.class: eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\LegacyStorage
-    ezpublish.fieldType.ezurl.storage_gateway.class: eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\LegacyStorage
+    ezpublish.fieldType.ezurl.storage_gateway.class: eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezuser.storage_gateway.class: eZ\Publish\Core\FieldType\User\UserStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezpage.storage_gateway.class: eZ\Publish\Core\FieldType\Page\PageStorage\Gateway\LegacyStorage
 
@@ -57,7 +57,7 @@ services:
     ezpublish.fieldType.ezurl.storage_gateway:
         class: "%ezpublish.fieldType.ezurl.storage_gateway.class%"
         tags:
-            - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezurl, identifier: LegacyStorage}
+            - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezurl, identifier: DoctrineStorage}
 
     ezpublish.fieldType.ezpage.storage_gateway:
         class: "%ezpublish.fieldType.ezpage.storage_gateway.class%"

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -19,6 +19,8 @@ services:
             -
                 identifier: "LegacyStorage"
                 connection: "@ezpublish.api.storage_engine.legacy.dbhandler"
+        tags:
+            - {name: ezpublish.persistence.externalStorageHandler, identifier: LegacyStorage}
 
     ezpublish.fieldType.ezbinaryfile.storage_gateway:
         class: "%ezpublish.fieldType.ezbinaryfile.storage_gateway.class%"

--- a/eZ/Publish/SPI/Persistence/Content/StorageHandler.php
+++ b/eZ/Publish/SPI/Persistence/Content/StorageHandler.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\SPI\Persistence\Content;
+
+/**
+ * Handler for Field external storages for.
+ */
+interface StorageHandler
+{
+    /**
+     * Write external data for field into external storage.
+     *
+     * @param VersionInfo $versionInfo
+     * @param Field $field
+     * @return mixed
+     */
+    public function storeFieldData(VersionInfo $versionInfo, Field $field);
+
+    /**
+     * Copy external data from $originalField into $field.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $originalField
+     */
+    public function copyFieldData(VersionInfo $versionInfo, Field $field, Field $originalField);
+
+    /**
+     * Fetch external data for $field from its corresponding external storage.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     */
+    public function getFieldData(VersionInfo $versionInfo, Field $field);
+
+    /**
+     * Delete data for field $ids from external storage of $fieldType.
+     *
+     * @param string $fieldType
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param mixed[] $ids
+     */
+    public function deleteFieldData($fieldType, VersionInfo $versionInfo, array $ids);
+}

--- a/eZ/Publish/SPI/Persistence/Content/StorageHandlerRegistry.php
+++ b/eZ/Publish/SPI/Persistence/Content/StorageHandlerRegistry.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\SPI\Persistence\Content;
+
+use RuntimeException;
+
+/**
+ * Registry of External Storage Handlers (Persistence Layer).
+ */
+class StorageHandlerRegistry
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\StorageHandler[]
+     */
+    private $map;
+
+    /**
+     * Register Storage Handler.
+     *
+     * @param string $identifier Storage Handler identifier
+     * @param \eZ\Publish\SPI\Persistence\Content\StorageHandler $storageHandler
+     */
+    public function register($identifier, StorageHandler $storageHandler)
+    {
+        $this->map[$identifier] = $storageHandler;
+    }
+
+    /**
+     * Get registered Storage Handler.
+     *
+     * @param $identifier
+     * @return \eZ\Publish\SPI\Persistence\Content\StorageHandler
+     */
+    public function get($identifier)
+    {
+        if (!isset($this->map[$identifier])) {
+            throw new RuntimeException("StorageHandler '$identifier' does not exist");
+        }
+
+        return $this->map[$identifier];
+    }
+}

--- a/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
@@ -620,7 +620,7 @@ abstract class BaseIntegrationTest extends TestCase
         $fieldTypeRegistry = self::$container->get('ezpublish.persistence.field_type_registry');
         /** @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry $converterRegistry */
         $converterRegistry = self::$container->get('ezpublish.persistence.legacy.field_value_converter.registry');
-        /** @var \eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry $storageRegistry */
+        /** @var \eZ\Publish\Core\Persistence\Content\StorageRegistry $storageRegistry */
         $storageRegistry = self::$container->get('ezpublish.persistence.external_storage_registry');
 
         $textLineFieldType = new \eZ\Publish\Core\FieldType\TextLine\Type();

--- a/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
@@ -609,6 +609,13 @@ abstract class BaseIntegrationTest extends TestCase
      */
     protected function getHandler($identifier, $fieldType, $fieldValueConverter, $externalStorage)
     {
+        // Register default storage handler before accessing dependent services
+        /** @var \eZ\Publish\SPI\Persistence\Content\StorageHandlerRegistry $storageHandlerRegistry */
+        $storageHandlerRegistry = self::$container->get('ezpublish.persistence.external_storage_handler.registry');
+        /** @var \eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler $legacyStorageHandler */
+        $legacyStorageHandler = self::$container->get('ezpublish.persistence.legacy.external_storage_handler');
+        $storageHandlerRegistry->register('LegacyStorage', $legacyStorageHandler);
+
         /** @var \eZ\Publish\Core\Persistence\FieldTypeRegistry $fieldTypeRegistry */
         $fieldTypeRegistry = self::$container->get('ezpublish.persistence.field_type_registry');
         /** @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry $converterRegistry */


### PR DESCRIPTION
> Alternative approach to #1908
> Implements [EZP-26885](https://jira.ez.no/browse/EZP-26885)
> ------------

> We want to be able to use `\Doctrine\DBAL\Connection` for FieldTypes external storage directly.
> To achieve this, FieldType external storage needs to be injected with `DoctrineStorage` gateway which uses Doctrine instead of Legacy Connection Handler.

Note: we actually use `eZ\Publish\Core\Persistence\Doctrine\DoctrineConnection` which extends `Doctrine\DBAL\Connection`.

This approach makes `FieldHandler` and `ContentUpdater` determine proper persistence Storage Handler for the specific FieldType from the `FieldTypeRegistry`. Relevant changes are presented in 12ab214.

The difference between this PR and #1908 is that injecting proper persistence Storage Handler into `GatewayBasedStorage` for each FieldType is no longer required. Sample implementation for `ezurl` is shown in c176270.

To avoid adding too much responsibility to objects, `StorageHandlerRegistry` is introduced (along with proper compiler pass) to store actual persistence  Storage Handlers (objects implementing `\eZ\Publish\SPI\Persistence\Content\StorageHandler`). 
`FieldTypeRegistry` gets them "asking" `StorageHandlerRegistry` for e.g. `LegacyStorage` or `DoctrineStorage`.

Note: "Storage handler" refers both to e.g `eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler` and also to implementations which are obtained by it (like `eZ\Publish\Core\FieldType\Url\UrlStorage`). In this description I added "persistence" keyword to distinguish the first one.

**TODO**:
- [x] Replace usages of `Doctrine\DBAL\Connection` with `eZ\Publish\Core\Persistence\Doctrine\DoctrineConnection` to be able to reuse getting Db sequence name if needed and supported by DBMS.
- [x] Add `StorageHandlerRegistry` which can register persistence Storage Handlers (and register `LegacyStorage` to it).
- [x] Refactor `FieldHandler` and `ContentUpdater` to get `StorageHandler` from `FieldTypeRegistry`.
- [x] Move `StorageRegistry` to `eZ\Publish\Core\Persistence\Content\StorageRegistry` namespace to reflect it's more common.
- [x] Add Doctrine persistence StorageHandler (registered to `StorageHandlerRegistry`).
- [ ] Move TMP commits with sample implementations/usages to other PR if/when this one is accepted.