### PR TITLE
EZP-25007: "Number of text rows in the editor" should be removed from RichText fieldtype

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
@@ -31,12 +31,7 @@
 </ul>
 {% endblock %}
 
-{% block ezrichtext_settings %}
-    <ul class="ez-fielddefinition-settings ez-fielddefinition-{{ fielddefinition.fieldTypeIdentifier }}-settings">
-        {% set rows = settings.numRows %}
-        {{ block( 'settings_preferredrows' ) }}
-    </ul>
-{% endblock %}
+{% block ezrichtext_settings %}{% endblock %}
 
 {% block ezcountry_settings %}
 <ul class="ez-fielddefinition-settings ez-fielddefinition-{{ fielddefinition.fieldTypeIdentifier }}-settings">

--- a/eZ/Publish/API/Repository/Tests/FieldType/RichTextIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/RichTextIntegrationTest.php
@@ -153,12 +153,7 @@ EOT
      */
     public function getSettingsSchema()
     {
-        return array(
-            'numRows' => array(
-                'type' => 'int',
-                'default' => 10,
-            ),
-        );
+        return [];
     }
 
     /**
@@ -168,9 +163,7 @@ EOT
      */
     public function getValidFieldSettings()
     {
-        return array(
-            'numRows' => 0,
-        );
+        return [];
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/RichText/Type.php
+++ b/eZ/Publish/Core/FieldType/RichText/Type.php
@@ -26,20 +26,6 @@ use RuntimeException;
 class Type extends FieldType
 {
     /**
-     * List of settings available for this FieldType.
-     *
-     * The key is the setting name, and the value is the default value for this setting
-     *
-     * @var array
-     */
-    protected $settingsSchema = array(
-        'numRows' => array(
-            'type' => 'int',
-            'default' => 10,
-        ),
-    );
-
-    /**
      * @var \eZ\Publish\Core\FieldType\RichText\ValidatorDispatcher
      */
     protected $internalFormatValidator;
@@ -350,48 +336,6 @@ class Type extends FieldType
     public function isSearchable()
     {
         return true;
-    }
-
-    /**
-     * Validates the fieldSettings of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct.
-     *
-     * @param mixed $fieldSettings
-     *
-     * @return \eZ\Publish\SPI\FieldType\ValidationError[]
-     */
-    public function validateFieldSettings($fieldSettings)
-    {
-        $validationErrors = array();
-
-        foreach ($fieldSettings as $name => $value) {
-            if (isset($this->settingsSchema[$name])) {
-                switch ($name) {
-                    case 'numRows':
-                        if (!is_integer($value)) {
-                            $validationErrors[] = new ValidationError(
-                                "Setting '%setting%' value must be of integer type",
-                                null,
-                                array(
-                                    '%setting%' => $name,
-                                ),
-                                "[$name]"
-                            );
-                        }
-                        break;
-                }
-            } else {
-                $validationErrors[] = new ValidationError(
-                    "Setting '%setting%' is unknown",
-                    null,
-                    array(
-                        '%setting%' => $name,
-                    ),
-                    "[$name]"
-                );
-            }
-        }
-
-        return $validationErrors;
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/Tests/RichTextTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichTextTest.php
@@ -82,12 +82,7 @@ class RichTextTest extends PHPUnit_Framework_TestCase
     {
         $fieldType = $this->getFieldType();
         self::assertSame(
-            array(
-                'numRows' => array(
-                    'type' => 'int',
-                    'default' => 10,
-                ),
-            ),
+            [],
             $fieldType->getSettingsSchema(),
             'The settings schema does not match what is expected.'
         );

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RichTextConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RichTextConverter.php
@@ -13,7 +13,6 @@ use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
-use eZ\Publish\Core\FieldType\FieldSettings;
 use eZ\Publish\Core\FieldType\RichText\Value;
 
 class RichTextConverter implements Converter
@@ -62,7 +61,7 @@ class RichTextConverter implements Converter
      */
     public function toStorageFieldDefinition(FieldDefinition $fieldDefinition, StorageFieldDefinition $storageDefinition)
     {
-        $storageDefinition->dataInt1 = $fieldDefinition->fieldTypeConstraints->fieldSettings['numRows'];
+        // Nothing to store
     }
 
     /**
@@ -73,12 +72,6 @@ class RichTextConverter implements Converter
      */
     public function toFieldDefinition(StorageFieldDefinition $storageDefinition, FieldDefinition $fieldDefinition)
     {
-        $fieldDefinition->fieldTypeConstraints->fieldSettings = new FieldSettings(
-            array(
-                'numRows' => $storageDefinition->dataInt1,
-            )
-        );
-
         $fieldDefinition->defaultValue->data = Value::EMPTY_VALUE;
     }
 

--- a/eZ/Publish/SPI/Tests/FieldType/RichTextIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/RichTextIntegrationTest.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\SPI\Tests\FieldType;
 
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichTextConverter;
 use eZ\Publish\Core\FieldType;
-use eZ\Publish\Core\FieldType\FieldSettings;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\SPI\Persistence\Content\FieldTypeConstraints;
 use eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\LegacyStorage;
@@ -106,15 +105,7 @@ class RichTextIntegrationTest extends BaseIntegrationTest
             array('fieldType', 'ezrichtext'),
             array(
                 'fieldTypeConstraints',
-                new FieldTypeConstraints(
-                    array(
-                        'fieldSettings' => new FieldSettings(
-                            array(
-                                'numRows' => 0,
-                            )
-                        ),
-                    )
-                ),
+                new FieldTypeConstraints(),
             ),
         );
     }


### PR DESCRIPTION
> Fixes [EZP-25007](https://jira.ez.no/browse/EZP-25007)

This PR removes `numRows` setting from the `RichText` Field Type and is required for changes in 
[repository-forms#112](https://github.com/ezsystems/repository-forms/pull/112) to work.

**TODO**:
- [x] Remove all references of `numRows` setting related to RichText FieldType
- [x] ~Solve cross-dependency with repository-forms to make tests passing.~ ([comment](https://github.com/ezsystems/ezpublish-kernel/pull/1915#issuecomment-281324961))