### PR TITLE
EZP-27022: "Current date adjusted" fails on DST

### DIFF
--- a/eZ/Publish/Core/FieldType/Tests/DateAndTimeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/DateAndTimeTest.php
@@ -229,7 +229,7 @@ class DateAndTimeTest extends FieldTypeTest
 
         $actualResult = $fieldType->fromHash($inputHash);
 
-        // Tests may run slowly. Allow 20 seconds margin of error.
+        // Tests may run slowly. Allow 60 seconds margin of error.
         $this->assertGreaterThanOrEqual(
             $expectedResult,
             $actualResult,
@@ -237,7 +237,7 @@ class DateAndTimeTest extends FieldTypeTest
         );
         if ($expectedResult->value !== null) {
             $this->assertLessThan(
-                $expectedResult->value->getTimestamp() + 20,
+                $expectedResult->value->getTimestamp() + 60,
                 $actualResult->value->getTimestamp(),
                 'fromHash() method did not create expected result.'
             );

--- a/eZ/Publish/Core/FieldType/Tests/DateAndTimeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/DateAndTimeTest.php
@@ -229,7 +229,7 @@ class DateAndTimeTest extends FieldTypeTest
 
         $actualResult = $fieldType->fromHash($inputHash);
 
-        // Tests may run slowly. Allow 60 seconds margin of error.
+        // Tests may run slowly. Allow 20 seconds margin of error.
         $this->assertGreaterThanOrEqual(
             $expectedResult,
             $actualResult,
@@ -237,7 +237,7 @@ class DateAndTimeTest extends FieldTypeTest
         );
         if ($expectedResult->value !== null) {
             $this->assertLessThan(
-                $expectedResult->value->getTimestamp() + 60,
+                $expectedResult->value->getTimestamp() + 20,
                 $actualResult->value->getTimestamp(),
                 'fromHash() method did not create expected result.'
             );

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
@@ -123,7 +123,7 @@ class DateAndTimeConverter implements Converter
                 $data = array(
                     'rfc850' => null,
                     'timestamp' => $date->getTimestamp(), // @deprecated timestamp is no longer used and will be removed in a future version.
-                    'timestring' => sprintf('%+d seconds', $date->getTimestamp() - time()),
+                    'timestring' => $dateInterval->format('%y years, %m months, %d days, %h hours, %i minutes, %s seconds'),
                 );
                 break;
 


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-27022
> Ready for review

https://jira.ez.no/browse/EZP-26791 introduced a timestring (like "now", or "1 day, 2 hours") as the way to delay the initialisation of the datetime value until when you're creating it, rather than when the content type cache was last cleared (which was the bug).

This fails for DEFAULT_CURRENT_DATE_ADJUSTED because the adjustment is calculated by taking current time, adding the DateInterval, and comparing the resulting time with the original as timestamps, before making a timestring out of it. But timestamps do not care about DST (daylight savings time), so this will in some cases lead to off-by-one-hour bugs.

The fix is to instead format the timestring as containing all the properties of the DateInterval (years, months, days, hours, minutes, seconds, whether they are zero or not). By not translating to timestamps we avoid the bug.