### PR TITLE
EZP-27014: 'ezkeyword' data not saved properly

### DIFF
--- a/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway/LegacyStorage.php
@@ -225,6 +225,10 @@ class LegacyStorage extends Gateway
         $existingKeywordMap = array();
 
         foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $row) {
+            // filter out keywords that aren't the exact match (e.g. differ by case)
+            if (!in_array($row['keyword'], $keywordList)) {
+                continue;
+            }
             $existingKeywordMap[$row['keyword']] = $row['id'];
         }
 


### PR DESCRIPTION
> Fixes [EZP-27014](https://jira.ez.no/browse/EZP-27014)
> Status: **Work in progress**

Creating Content Object with `ezkeyword` field filled with keyword differing only by case, results in all keywords being appended, e.g. "Foo, foo".

**TODO**:
- [x] Create unit test that uncovers reported bug.
- [x] Fix the bug.