### PR TITLE
EZP-26976: Add RichText xhtml5 support for thead & tfoot

### DIFF
--- a/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/ezpublish.rng
@@ -48,6 +48,35 @@
         </oneOrMore>
       </element>
     </define>
+    <define name="db.html.informaltable.model">
+      <optional>
+        <ref name="db.html.informaltable.info"/>
+      </optional>
+      <choice>
+        <zeroOrMore>
+          <ref name="db.html.col"/>
+        </zeroOrMore>
+        <zeroOrMore>
+          <ref name="db.html.colgroup"/>
+        </zeroOrMore>
+      </choice>
+      <optional>
+        <ref name="db.html.thead"/>
+      </optional>
+      <interleave>
+        <optional>
+          <ref name="db.html.tfoot"/>
+        </optional>
+        <choice>
+          <oneOrMore>
+            <ref name="db.html.tbody"/>
+          </oneOrMore>
+          <oneOrMore>
+            <ref name="db.html.tr"/>
+          </oneOrMore>
+        </choice>
+      </interleave>
+    </define>
     <define name="db.abbrev"><notAllowed/></define>
     <define name="db.abstract"><notAllowed/></define>
     <define name="db.accel"><notAllowed/></define>

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -303,9 +303,25 @@
           <xsl:value-of select="./docbook:caption"/>
         </xsl:element>
       </xsl:if>
-      <xsl:for-each select="./docbook:tr | ./docbook:tbody/docbook:tr">
-        <xsl:apply-templates select="current()"/>
-      </xsl:for-each>
+      <xsl:if test="./docbook:thead">
+        <xsl:element name="thead" namespace="{$outputNamespace}">
+          <xsl:for-each select="./docbook:thead/docbook:tr">
+            <xsl:apply-templates select="current()"/>
+          </xsl:for-each>
+        </xsl:element>
+      </xsl:if>
+      <xsl:element name="tbody" namespace="{$outputNamespace}">
+        <xsl:for-each select="./docbook:tr | ./docbook:tbody/docbook:tr">
+          <xsl:apply-templates select="current()"/>
+        </xsl:for-each>
+      </xsl:element>
+      <xsl:if test="./docbook:tfoot">
+        <xsl:element name="tfoot" namespace="{$outputNamespace}">
+          <xsl:for-each select="./docbook:tfoot/docbook:tr">
+            <xsl:apply-templates select="current()"/>
+          </xsl:for-each>
+        </xsl:element>
+      </xsl:if>
     </xsl:element>
   </xsl:template>
 

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
@@ -303,9 +303,25 @@
           <xsl:value-of select="./docbook:caption"/>
         </xsl:element>
       </xsl:if>
-      <xsl:for-each select="./docbook:tr | ./docbook:tbody/docbook:tr">
-        <xsl:apply-templates select="current()"/>
-      </xsl:for-each>
+      <xsl:if test="./docbook:thead">
+        <xsl:element name="thead" namespace="{$outputNamespace}">
+          <xsl:for-each select="./docbook:thead/docbook:tr">
+            <xsl:apply-templates select="current()"/>
+          </xsl:for-each>
+        </xsl:element>
+      </xsl:if>
+      <xsl:element name="tbody" namespace="{$outputNamespace}">
+        <xsl:for-each select="./docbook:tr | ./docbook:tbody/docbook:tr">
+          <xsl:apply-templates select="current()"/>
+        </xsl:for-each>
+      </xsl:element>
+      <xsl:if test="./docbook:tfoot">
+        <xsl:element name="tfoot" namespace="{$outputNamespace}">
+          <xsl:for-each select="./docbook:tfoot/docbook:tr">
+            <xsl:apply-templates select="current()"/>
+          </xsl:for-each>
+        </xsl:element>
+      </xsl:if>
     </xsl:element>
   </xsl:template>
 

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -305,11 +305,25 @@
           <xsl:value-of select="./ezxhtml5:caption"/>
         </caption>
       </xsl:if>
+      <xsl:if test="./ezxhtml5:thead">
+        <thead>
+          <xsl:for-each select="./ezxhtml5:thead/ezxhtml5:tr">
+            <xsl:apply-templates select="current()"/>
+          </xsl:for-each>
+        </thead>
+      </xsl:if>
       <tbody>
         <xsl:for-each select="./ezxhtml5:tr | ./ezxhtml5:tbody/ezxhtml5:tr">
           <xsl:apply-templates select="current()"/>
         </xsl:for-each>
       </tbody>
+      <xsl:if test="./ezxhtml5:tfoot">
+        <tfoot>
+          <xsl:for-each select="./ezxhtml5:tfoot/ezxhtml5:tr">
+            <xsl:apply-templates select="current()"/>
+          </xsl:for-each>
+        </tfoot>
+      </xsl:if>
     </xsl:element>
   </xsl:template>
 

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/docbook/026-tableTitles.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/docbook/026-tableTitles.xml
@@ -16,6 +16,13 @@
           <title ezxhtml:level="3">Heading 3</title>
           <title ezxhtml:level="3">Heading 3</title>
           <informaltable border="1" class="class2" style="border-width:1px;" title="summary2" width="100%">
+            <thead>
+              <tr>
+                <td>
+                  <para>head</para>
+                </td>
+              </tr>
+            </thead>
             <tbody>
               <tr>
                 <td>
@@ -24,6 +31,13 @@
                 </td>
               </tr>
             </tbody>
+            <tfoot>
+              <tr>
+                <td>
+                  <para>foot</para>
+                </td>
+              </tr>
+            </tfoot>
           </informaltable>
         </td>
       </tr>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/010-htmlInformaltable.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/010-htmlInformaltable.xml
@@ -1,26 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
   <table class="tableClass" border="1" title="tableTitle" style="width:24px;border-width:42px;">
-    <tr class="rowClass1">
-      <th class="headingClass1" colspan="1" rowspan="5" abbr="XSLT" scope="col" style="width:102px;vertical-align:top;">
-        <p>11</p>
-      </th>
-      <th class="headingClass2" colspan="2" rowspan="6" abbr="XSD" scope="row" style="width:37%;vertical-align:middle;">
-        <p>12.1</p>
-        <p>12.2</p>
-      </th>
-    </tr>
-    <tr class="rowClass2">
-      <td class="cellClass1" colspan="3" rowspan="7" style="width:74%;vertical-align:bottom;">
-        <p>21</p>
-        <ul class="itemizedListClass">
-          <li class="listItemClass">This is a list item.</li>
-        </ul>
-      </td>
-      <td class="cellClass2" colspan="4" rowspan="8" style="width:38px;vertical-align:baseline;">
-        <p>22</p>
-        <p>This is a paragraph<br/>with some<br/>extra <em>CHEESE!</em><br/>and line breaks.</p>
-      </td>
-    </tr>
+    <tbody>
+      <tr class="rowClass1">
+        <th class="headingClass1" colspan="1" rowspan="5" abbr="XSLT" scope="col" style="width:102px;vertical-align:top;">
+          <p>11</p>
+        </th>
+        <th class="headingClass2" colspan="2" rowspan="6" abbr="XSD" scope="row" style="width:37%;vertical-align:middle;">
+          <p>12.1</p>
+          <p>12.2</p>
+        </th>
+      </tr>
+      <tr class="rowClass2">
+        <td class="cellClass1" colspan="3" rowspan="7" style="width:74%;vertical-align:bottom;">
+          <p>21</p>
+          <ul class="itemizedListClass">
+            <li class="listItemClass">This is a list item.</li>
+          </ul>
+        </td>
+        <td class="cellClass2" colspan="4" rowspan="8" style="width:38px;vertical-align:baseline;">
+          <p>22</p>
+          <p>This is a paragraph<br/>with some<br/>extra <em>CHEESE!</em><br/>and line breaks.</p>
+        </td>
+      </tr>
+    </tbody>
   </table>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/011-htmlTable.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/011-htmlTable.xml
@@ -2,21 +2,23 @@
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
   <table class="tableClass" title="tableTitle" style="width:24%;">
     <caption>Table caption.</caption>
-    <tr class="rowClass1">
-      <th class="headingClass1" colspan="1" rowspan="5" abbr="XSLT" scope="col" style="width:102px;vertical-align:top;">
-        <p>11</p>
-      </th>
-      <th class="headingClass2" colspan="2" rowspan="6" abbr="XSD" scope="row" style="width:37%;vertical-align:middle;">
-        <p>12</p>
-      </th>
-    </tr>
-    <tr class="rowClass2">
-      <td class="cellClass1" colspan="3" rowspan="7" style="width:74%;vertical-align:bottom;">
-        <p>21</p>
-      </td>
-      <td class="cellClass2" colspan="4" rowspan="8" style="width:38px;vertical-align:baseline;">
-        <p>22</p>
-      </td>
-    </tr>
+    <tbody>
+      <tr class="rowClass1">
+        <th class="headingClass1" colspan="1" rowspan="5" abbr="XSLT" scope="col" style="width:102px;vertical-align:top;">
+          <p>11</p>
+        </th>
+        <th class="headingClass2" colspan="2" rowspan="6" abbr="XSD" scope="row" style="width:37%;vertical-align:middle;">
+          <p>12</p>
+        </th>
+      </tr>
+      <tr class="rowClass2">
+        <td class="cellClass1" colspan="3" rowspan="7" style="width:74%;vertical-align:bottom;">
+          <p>21</p>
+        </td>
+        <td class="cellClass2" colspan="4" rowspan="8" style="width:38px;vertical-align:baseline;">
+          <p>22</p>
+        </td>
+      </tr>
+    </tbody>
   </table>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/018-htmlTable.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/018-htmlTable.xml
@@ -2,13 +2,15 @@
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
   <table class="tableClass" title="tableTitle" style="width:24%;">
     <caption>Table caption.</caption>
-    <tr class="rowClass1">
-      <th class="headingClass1" colspan="1" rowspan="5" abbr="XSLT" scope="col" style="width:102px;vertical-align:top;">11</th>
-      <th class="headingClass2" colspan="2" rowspan="6" abbr="XSD" scope="row" style="width:37%;vertical-align:middle;">12</th>
-    </tr>
-    <tr class="rowClass2">
-      <td class="cellClass1" colspan="3" rowspan="7" style="width:74%;vertical-align:bottom;">21</td>
-      <td class="cellClass2" colspan="4" rowspan="8" style="width:38px;vertical-align:baseline;">22</td>
-    </tr>
+    <tbody>
+      <tr class="rowClass1">
+        <th class="headingClass1" colspan="1" rowspan="5" abbr="XSLT" scope="col" style="width:102px;vertical-align:top;">11</th>
+        <th class="headingClass2" colspan="2" rowspan="6" abbr="XSD" scope="row" style="width:37%;vertical-align:middle;">12</th>
+      </tr>
+      <tr class="rowClass2">
+        <td class="cellClass1" colspan="3" rowspan="7" style="width:74%;vertical-align:bottom;">21</td>
+        <td class="cellClass2" colspan="4" rowspan="8" style="width:38px;vertical-align:baseline;">22</td>
+      </tr>
+    </tbody>
   </table>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/024-template.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/024-template.xml
@@ -4,21 +4,23 @@
     <div data-ezelement="ezcontent">
       <table title="tableTitle">
         <caption>About factoids</caption>
-        <tr>
-          <th>
-            <h3 style="text-align:center;">Some facts about factoids</h3>
-          </th>
-        </tr>
-        <tr>
-          <td>
-            <p>A factoid is a questionable or spurious (unverified, false, or fabricated) statement presented as a fact, but without supporting evidence.</p>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <p>Factoids may give rise to, or arise from, common misconceptions and urban legends.</p>
-          </td>
-        </tr>
+        <tbody>
+          <tr>
+            <th>
+              <h3 style="text-align:center;">Some facts about factoids</h3>
+            </th>
+          </tr>
+          <tr>
+            <td>
+              <p>A factoid is a questionable or spurious (unverified, false, or fabricated) statement presented as a fact, but without supporting evidence.</p>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <p>Factoids may give rise to, or arise from, common misconceptions and urban legends.</p>
+            </td>
+          </tr>
+        </tbody>
       </table>
     </div>
     <span data-ezelement="ezconfig">

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/026-tableTitles.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/026-tableTitles.xml
@@ -4,21 +4,39 @@
   <h2>Heading 2</h2>
   <h3>Heading 3</h3>
   <table border="1" class="class1" style="width:100%;border-width:1px;" title="summary1">
-    <tr>
-      <td>
-        <h2>Heading 2</h2>
-        <h2>Heading 2</h2>
-        <h3>Heading 3</h3>
-        <h3>Heading 3</h3>
-        <table border="1" class="class2" style="width:100%;border-width:1px;" title="summary2">
-          <tr>
-            <td>
-              <h2>Heading 2</h2>
-              <h3>Heading 3</h3>
-            </td>
-          </tr>
-        </table>
-      </td>
-    </tr>
+    <tbody>
+      <tr>
+        <td>
+          <h2>Heading 2</h2>
+          <h2>Heading 2</h2>
+          <h3>Heading 3</h3>
+          <h3>Heading 3</h3>
+          <table border="1" class="class2" style="width:100%;border-width:1px;" title="summary2">
+            <thead>
+              <tr>
+                <td>
+                  <p>head</p>
+                </td>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <h2>Heading 2</h2>
+                  <h3>Heading 3</h3>
+                </td>
+              </tr>
+            </tbody>
+            <tfoot>
+              <tr>
+                <td>
+                  <p>foot</p>
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+        </td>
+      </tr>
+    </tbody>
   </table>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/output/010-htmlInformaltable.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/output/010-htmlInformaltable.xml
@@ -1,26 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
   <table class="tableClass" border="1" title="tableTitle" style="width:24px;border-width:42px;">
-    <tr class="rowClass1">
-      <th class="headingClass1" colspan="1" rowspan="5" abbr="XSLT" scope="col" style="width:102px;vertical-align:top;">
-        <p>11</p>
-      </th>
-      <th class="headingClass2" colspan="2" rowspan="6" abbr="XSD" scope="row" style="width:37%;vertical-align:middle;">
-        <p>12.1</p>
-        <p>12.2</p>
-      </th>
-    </tr>
-    <tr class="rowClass2">
-      <td class="cellClass1" colspan="3" rowspan="7" style="width:74%;vertical-align:bottom;">
-        <p>21</p>
-        <ul class="itemizedListClass">
-          <li class="listItemClass">This is a list item.</li>
-        </ul>
-      </td>
-      <td class="cellClass2" colspan="4" rowspan="8" style="width:38px;vertical-align:baseline;">
-        <p>22</p>
-        <p>This is a paragraph<br/>with some<br/>extra <em>CHEESE!</em><br/>and line breaks.</p>
-      </td>
-    </tr>
+    <tbody>
+      <tr class="rowClass1">
+        <th class="headingClass1" colspan="1" rowspan="5" abbr="XSLT" scope="col" style="width:102px;vertical-align:top;">
+          <p>11</p>
+        </th>
+        <th class="headingClass2" colspan="2" rowspan="6" abbr="XSD" scope="row" style="width:37%;vertical-align:middle;">
+          <p>12.1</p>
+          <p>12.2</p>
+        </th>
+      </tr>
+      <tr class="rowClass2">
+        <td class="cellClass1" colspan="3" rowspan="7" style="width:74%;vertical-align:bottom;">
+          <p>21</p>
+          <ul class="itemizedListClass">
+            <li class="listItemClass">This is a list item.</li>
+          </ul>
+        </td>
+        <td class="cellClass2" colspan="4" rowspan="8" style="width:38px;vertical-align:baseline;">
+          <p>22</p>
+          <p>This is a paragraph<br/>with some<br/>extra <em>CHEESE!</em><br/>and line breaks.</p>
+        </td>
+      </tr>
+    </tbody>
   </table>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/output/011-htmlTable.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/output/011-htmlTable.xml
@@ -2,21 +2,23 @@
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
   <table class="tableClass" title="tableTitle" style="width:24%;">
     <caption>Table caption.</caption>
-    <tr class="rowClass1">
-      <th class="headingClass1" colspan="1" rowspan="5" abbr="XSLT" scope="col" style="width:102px;vertical-align:top;">
-        <p>11</p>
-      </th>
-      <th class="headingClass2" colspan="2" rowspan="6" abbr="XSD" scope="row" style="width:37%;vertical-align:middle;">
-        <p>12</p>
-      </th>
-    </tr>
-    <tr class="rowClass2">
-      <td class="cellClass1" colspan="3" rowspan="7" style="width:74%;vertical-align:bottom;">
-        <p>21</p>
-      </td>
-      <td class="cellClass2" colspan="4" rowspan="8" style="width:38px;vertical-align:baseline;">
-        <p>22</p>
-      </td>
-    </tr>
+    <tbody>
+      <tr class="rowClass1">
+        <th class="headingClass1" colspan="1" rowspan="5" abbr="XSLT" scope="col" style="width:102px;vertical-align:top;">
+          <p>11</p>
+        </th>
+        <th class="headingClass2" colspan="2" rowspan="6" abbr="XSD" scope="row" style="width:37%;vertical-align:middle;">
+          <p>12</p>
+        </th>
+      </tr>
+      <tr class="rowClass2">
+        <td class="cellClass1" colspan="3" rowspan="7" style="width:74%;vertical-align:bottom;">
+          <p>21</p>
+        </td>
+        <td class="cellClass2" colspan="4" rowspan="8" style="width:38px;vertical-align:baseline;">
+          <p>22</p>
+        </td>
+      </tr>
+    </tbody>
   </table>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/output/018-htmlTable.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/output/018-htmlTable.xml
@@ -2,13 +2,15 @@
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
   <table class="tableClass" title="tableTitle" style="width:24%;">
     <caption>Table caption.</caption>
-    <tr class="rowClass1">
-      <th class="headingClass1" colspan="1" rowspan="5" abbr="XSLT" scope="col" style="width:102px;vertical-align:top;">11</th>
-      <th class="headingClass2" colspan="2" rowspan="6" abbr="XSD" scope="row" style="width:37%;vertical-align:middle;">12</th>
-    </tr>
-    <tr class="rowClass2">
-      <td class="cellClass1" colspan="3" rowspan="7" style="width:74%;vertical-align:bottom;">21</td>
-      <td class="cellClass2" colspan="4" rowspan="8" style="width:38px;vertical-align:baseline;">22</td>
-    </tr>
+    <tbody>
+      <tr class="rowClass1">
+        <th class="headingClass1" colspan="1" rowspan="5" abbr="XSLT" scope="col" style="width:102px;vertical-align:top;">11</th>
+        <th class="headingClass2" colspan="2" rowspan="6" abbr="XSD" scope="row" style="width:37%;vertical-align:middle;">12</th>
+      </tr>
+      <tr class="rowClass2">
+        <td class="cellClass1" colspan="3" rowspan="7" style="width:74%;vertical-align:bottom;">21</td>
+        <td class="cellClass2" colspan="4" rowspan="8" style="width:38px;vertical-align:baseline;">22</td>
+      </tr>
+    </tbody>
   </table>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/output/026-tableTitles.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/output/026-tableTitles.xml
@@ -4,21 +4,39 @@
   <h2>Heading 2</h2>
   <h3>Heading 3</h3>
   <table border="1" class="class1" style="width:100%;border-width:1px;" title="summary1">
-    <tr>
-      <td>
-        <h2>Heading 2</h2>
-        <h2>Heading 2</h2>
-        <h3>Heading 3</h3>
-        <h3>Heading 3</h3>
-        <table border="1" class="class2" style="width:100%;border-width:1px;" title="summary2">
-          <tr>
-            <td>
-              <h2>Heading 2</h2>
-              <h3>Heading 3</h3>
-            </td>
-          </tr>
-        </table>
-      </td>
-    </tr>
+    <tbody>
+      <tr>
+        <td>
+          <h2>Heading 2</h2>
+          <h2>Heading 2</h2>
+          <h3>Heading 3</h3>
+          <h3>Heading 3</h3>
+          <table border="1" class="class2" style="width:100%;border-width:1px;" title="summary2">
+            <thead>
+              <tr>
+                <td>
+                  <p>head</p>
+                </td>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <h2>Heading 2</h2>
+                  <h3>Heading 3</h3>
+                </td>
+              </tr>
+            </tbody>
+            <tfoot>
+              <tr>
+                <td>
+                  <p>foot</p>
+                </td>
+              </tr>
+            </tfoot>
+          </table>
+        </td>
+      </tr>
+    </tbody>
   </table>
 </section>


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-26976

Related to PlatformUI fix: https://github.com/ezsystems/PlatformUIBundle/pull/817

"BC":
- This changes xhtml5 edit & ouput formats to _always_ return tbody in tables, and optionally also thead/tfoot if present.

Todo:
- [x] Could need some help to figure out how to fix docbook ezpublish.rng validation for thead / tfoot _(error is cryptic, refers to completely other tags, but it only shows up when those two are added in the docbook document)_