### PR TITLE
EZP-26838: Change representation of custom tags in xhtml5edit format

### DIFF
--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -528,29 +528,51 @@
     </xsl:element>
   </xsl:template>
 
-  <xsl:template match="docbook:eztemplate | docbook:eztemplateinline">
-    <xsl:element name="{local-name()}" namespace="{$outputNamespace}">
-      <xsl:if test="@name">
-        <xsl:attribute name="data-ezname">
-          <xsl:value-of select="@name"/>
-        </xsl:attribute>
-      </xsl:if>
-      <xsl:if test="@ezxhtml:class">
-        <xsl:attribute name="class">
-          <xsl:value-of select="@ezxhtml:class"/>
-        </xsl:attribute>
-      </xsl:if>
-      <xsl:if test="@ezxhtml:align">
-        <xsl:attribute name="data-ezalign">
-          <xsl:value-of select="@ezxhtml:align"/>
-        </xsl:attribute>
-      </xsl:if>
+  <!-- Custom template tag code -->
+  <xsl:template match="docbook:eztemplate">
+    <xsl:element name="div" namespace="{$outputNamespace}">
+      <xsl:attribute name="data-ezelement">eztemplate</xsl:attribute>
+      <xsl:call-template name="addCommonTemplateAttributes"/>
       <xsl:apply-templates/>
     </xsl:element>
   </xsl:template>
 
-  <xsl:template match="docbook:eztemplate/docbook:ezcontent | docbook:eztemplateinline/docbook:ezcontent">
-    <xsl:element name="{local-name()}" namespace="{$outputNamespace}">
+  <xsl:template match="docbook:eztemplateinline">
+    <xsl:element name="span" namespace="{$outputNamespace}">
+      <xsl:attribute name="data-ezelement">eztemplateinline</xsl:attribute>
+      <xsl:call-template name="addCommonTemplateAttributes"/>
+      <xsl:apply-templates/>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template name="addCommonTemplateAttributes">
+    <xsl:if test="@name">
+      <xsl:attribute name="data-ezname">
+        <xsl:value-of select="@name"/>
+      </xsl:attribute>
+    </xsl:if>
+    <xsl:if test="@ezxhtml:class">
+      <xsl:attribute name="class">
+        <xsl:value-of select="@ezxhtml:class"/>
+      </xsl:attribute>
+    </xsl:if>
+    <xsl:if test="@ezxhtml:align">
+      <xsl:attribute name="data-ezalign">
+        <xsl:value-of select="@ezxhtml:align"/>
+      </xsl:attribute>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="docbook:eztemplate/docbook:ezcontent">
+    <xsl:element name="div" namespace="{$outputNamespace}">
+      <xsl:attribute name="data-ezelement">ezcontent</xsl:attribute>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:element>
+  </xsl:template>
+
+  <xsl:template match="docbook:eztemplateinline/docbook:ezcontent">
+    <xsl:element name="span" namespace="{$outputNamespace}">
+      <xsl:attribute name="data-ezelement">ezcontent</xsl:attribute>
       <xsl:apply-templates select="node()|@*"/>
     </xsl:element>
   </xsl:template>

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -532,8 +532,8 @@
     </xsl:element>
   </xsl:template>
 
-  <xsl:template match="ezxhtml5:eztemplate | ezxhtml5:eztemplateinline">
-    <xsl:element name="{local-name()}" namespace="http://docbook.org/ns/docbook">
+  <xsl:template match="ezxhtml5:div[@data-ezelement='eztemplate'] | ezxhtml5:span[@data-ezelement='eztemplateinline']">
+    <xsl:element name="{@data-ezelement}" namespace="http://docbook.org/ns/docbook">
       <xsl:if test="@data-ezname">
         <xsl:attribute name="name">
           <xsl:value-of select="@data-ezname"/>
@@ -553,9 +553,9 @@
     </xsl:element>
   </xsl:template>
 
-  <xsl:template match="ezxhtml5:eztemplate/ezxhtml5:ezcontent | ezxhtml5:eztemplateinline/ezxhtml5:ezcontent">
-    <xsl:element name="{local-name()}" namespace="http://docbook.org/ns/docbook">
-      <xsl:apply-templates select="node()|@*"/>
+  <xsl:template match="ezxhtml5:div[@data-ezelement='eztemplate']/ezxhtml5:div[@data-ezelement='ezcontent'] | ezxhtml5:span[@data-ezelement='eztemplateinline']/ezxhtml5:span[@data-ezelement='ezcontent']">
+    <xsl:element name="ezcontent" namespace="http://docbook.org/ns/docbook">
+      <xsl:apply-templates/>
     </xsl:element>
   </xsl:template>
 

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/024-template.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/024-template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
-  <eztemplate data-ezname="factbox" class="templateClass" data-ezalign="left">
-    <ezcontent>
+  <div data-ezelement="eztemplate" data-ezname="factbox" class="templateClass" data-ezalign="left">
+    <div data-ezelement="ezcontent">
       <table title="tableTitle">
         <caption>About factoids</caption>
         <tr>
@@ -20,12 +20,12 @@
           </td>
         </tr>
       </table>
-    </ezcontent>
+    </div>
     <span data-ezelement="ezconfig">
       <span data-ezelement="ezvalue" data-ezvalue-key="title">Factoids</span>
     </span>
-  </eztemplate>
-  <eztemplate data-ezname="externalimage" class="templateClass2" data-ezalign="right">
+  </div>
+  <div data-ezelement="eztemplate" data-ezname="externalimage" class="templateClass2" data-ezalign="right">
     <span data-ezelement="ezconfig">
       <span data-ezelement="ezvalue" data-ezvalue-key="src">http://upload.wikimedia.org/wikipedia/commons/c/c6/R-S_mk2.gif</span>
       <span data-ezelement="ezvalue" data-ezvalue-key="height">365</span>
@@ -33,9 +33,9 @@
       <span data-ezelement="ezvalue" data-ezvalue-key="alt">flip-flop</span>
       <span data-ezelement="ezvalue" data-ezvalue-key="caption">bistable multivibrator</span>
     </span>
-  </eztemplate>
-  <eztemplate data-ezname="factoidbox" class="templateClass3" data-ezalign="center">
-    <ezcontent>It is widely known that the bistable multivibrator hums z's in the middle octave key of E.</ezcontent>
-  </eztemplate>
-  <eztemplate data-ezname="factoidbox" class="templateClass4" data-ezalign="center"/>
+  </div>
+  <div data-ezelement="eztemplate" data-ezname="factoidbox" class="templateClass3" data-ezalign="center">
+    <div data-ezelement="ezcontent">It is widely known that the bistable multivibrator hums z's in the middle octave key of E.</div>
+  </div>
+  <div data-ezelement="eztemplate" data-ezname="factoidbox" class="templateClass4" data-ezalign="center"/>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/025-templateInline.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/025-templateInline.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
-  <p>Some <eztemplateinline data-ezname="emojicake"/> for the otherwise unremarkable paragraph.</p>
-  <p>This paragraph is just showing off its <eztemplateinline data-ezname="emojicrocodile">
+  <p>Some <span data-ezelement="eztemplateinline" data-ezname="emojicake"/> for the otherwise unremarkable paragraph.</p>
+  <p>This paragraph is just showing off its <span data-ezelement="eztemplateinline" data-ezname="emojicrocodile">
     <span data-ezelement="ezconfig">
       <span data-ezelement="ezvalue" data-ezvalue-key="size">large</span>
     </span>
-  </eztemplateinline>.</p>
-  <p>The equation <eztemplateinline data-ezname="tex" class="templateClass">
-    <ezcontent>e^{\pi i}+1=0</ezcontent>
+  </span>.</p>
+  <p>The equation <span data-ezelement="eztemplateinline" data-ezname="tex" class="templateClass">
+    <span data-ezelement="ezcontent">e^{\pi i}+1=0</span>
     <span data-ezelement="ezconfig">
       <span data-ezelement="ezvalue" data-ezvalue-key="color">red</span>
     </span>
-  </eztemplateinline> ties together five of the most important mathematical constants.</p>
-  <p>This paragraph contains some <eztemplateinline data-ezname="bold">
-    <ezcontent>styled <eztemplateinline data-ezname="strikedthrough">
-      <ezcontent>text</ezcontent>
-    </eztemplateinline></ezcontent>
-  </eztemplateinline>.</p>
+  </span> ties together five of the most important mathematical constants.</p>
+  <p>This paragraph contains some <span data-ezelement="eztemplateinline" data-ezname="bold">
+    <span data-ezelement="ezcontent">styled <span data-ezelement="eztemplateinline" data-ezname="strikedthrough">
+      <span data-ezelement="ezcontent">text</span>
+    </span></span>
+  </span>.</p>
 </section>


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-26838


Changes custom tag representation in xhtml5edit _(our custom xhtml5 format used by editor)_ from:
```xml
<eztemplate data-ezname="factoidbox" class="templateClass3" data-ezalign="center">
    <ezcontent>It is widely known that the bistable multivibrator hums z's in the middle octave key of E.</ezcontent>
</eztemplate>

<eztemplateinline data-ezname="strikedthrough">
    <ezcontent>text</ezcontent>
</eztemplateinline>
```

To:
```xml
<div data-ezelement="eztemplate" data-ezname="factoidbox" class="templateClass3" data-ezalign="center">
    <div data-ezelement="ezcontent">It is widely known that the bistable multivibrator hums z's in the middle octave key of E.</div>
</div>

<span data-ezelement="eztemplateinline" data-ezname="strikedthrough">
    <span data-ezelement="ezcontent">text</span>
</span>
```

To unblock editor from starting to use these tags. Internal docbook format as introduced in eZ Platform 1.0 and used by 5.4 upgrade script does not change.

This is almost the same as proposed in the issue with two notable changes:
- For consistency uses `data-ezelement="ezcontent"` over new `data-ezcustomtagcontent` attribute
- For same consistency refer to custom tags by the docbook tag name in `data-ezelement= eztemplate[inline]` given format is already in use\*.

\* However I suggest we cleanup our vocabulary to refer to custom tags in the following two flavors:
- **Custom template tag**: Aka legacy custom tag, a inline or block general custom tag
- **Custom docbook tag**: *New* in RichText, allows you to define custom docbook tags with full semantical meaning _(by defining that in xsd/rng + xsl files)_

Second option involves a lot more work for integrator, but can in some use cases make sense for customers that want more advance features / semantic on tags, _and where no existing docbook tag can be (re)used._