### PR TITLE
EZP-23912: Impossible to empty a Keyword field

### DIFF
--- a/eZ/Publish/Core/FieldType/Keyword/KeywordStorage.php
+++ b/eZ/Publish/Core/FieldType/Keyword/KeywordStorage.php
@@ -26,10 +26,6 @@ class KeywordStorage extends GatewayBasedStorage
      */
     public function storeFieldData(VersionInfo $versionInfo, Field $field, array $context)
     {
-        if (empty($field->value->externalData) && !is_array($field->value->externalData)) {
-            return;
-        }
-
         $gateway = $this->getGateway($context);
 
         $contentTypeId = $gateway->getContentTypeId($field);

--- a/eZ/Publish/Core/FieldType/Keyword/KeywordStorage.php
+++ b/eZ/Publish/Core/FieldType/Keyword/KeywordStorage.php
@@ -26,7 +26,7 @@ class KeywordStorage extends GatewayBasedStorage
      */
     public function storeFieldData(VersionInfo $versionInfo, Field $field, array $context)
     {
-        if (empty($field->value->externalData)) {
+        if (empty($field->value->externalData) && !is_array($field->value->externalData)) {
             return;
         }
 

--- a/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway/LegacyStorage.php
@@ -60,6 +60,12 @@ class LegacyStorage extends Gateway
      */
     public function storeFieldData(Field $field, $contentTypeId)
     {
+        if (empty($field->value->externalData) && !empty($field->id)) {
+            $this->deleteFieldData($field->id);
+
+            return;
+        }
+
         $existingKeywordMap = $this->getExistingKeywords($field->value->externalData, $contentTypeId);
 
         $this->deleteOldKeywordAssignments($field->id);


### PR DESCRIPTION
> Fixes: [EZP-23912](https://jira.ez.no/browse/EZP-23912)
> Backport: **6.7**

This PR fixes the bug which occurs when updating `ezkeyword` field with an empty keyword list (keyword list is not affected).

**TODO**:
- [x] Fix the bug (c723fc2).
- [x] Showcase bug via integration test (ccc20db).
*Note: as a separate task this test should be moved to `BaseIntegrationTest` parent class with proper fixes for `ezuser` field (out of scope of this PR)*.