### PR TITLE
EZP-26914: Improve exception message from liip:imagine:resolve

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/BinaryLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/BinaryLoaderTest.php
@@ -10,8 +10,10 @@ namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine;
 
 use eZ\Bundle\EzPublishCoreBundle\Imagine\BinaryLoader;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\IO\Exception\InvalidBinaryFileIdException;
 use eZ\Publish\Core\IO\Values\BinaryFile;
 use eZ\Publish\Core\IO\Values\MissingBinaryFile;
+use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
 use Liip\ImagineBundle\Model\Binary;
 use PHPUnit_Framework_TestCase;
 
@@ -68,6 +70,25 @@ class BinaryLoaderTest extends PHPUnit_Framework_TestCase
             ->will($this->returnValue(new MissingBinaryFile()));
 
         $this->binaryLoader->find($path);
+    }
+
+    public function testFindBadPathRoot()
+    {
+        $path = 'var/site/storage/images/1/2/3/123-name/name.png';
+        $this->ioService
+            ->expects($this->once())
+            ->method('loadBinaryFile')
+            ->with($path)
+            ->will($this->throwException(new InvalidBinaryFileIdException($path)));
+
+        try {
+            $this->binaryLoader->find($path);
+        } catch (NotLoadableException $e) {
+            $this->assertContains(
+                "Suggested value: '1/2/3/123-name/name.png'",
+                $e->getMessage()
+            );
+        }
     }
 
     public function testFind()


### PR DESCRIPTION
> [EZP-26914](http://jira.ez.no/browse/EZP-26914)

The command expects a path relative to the `storage/images` directory, but it is not documented anywhere, and the current message does not help:

```
php app/console liip:imagine:cache:resolve var/site/storage/images/7/4/2/0/247-1-eng-GB/test.jpg

[eZ\Publish\Core\IO\Exception\InvalidBinaryFileIdException]                        
Argument 'BinaryFile::id' is invalid: 'NULL' is wrong value in class 'BinaryFile'
```

This adds  a catch on the exception that indicates an invalid prefix, and a message that reminds this expectation:

```
php app/console liip:imagine:cache:resolve var/site/storage/images/7/4/2/0/247-1-eng-GB/test.jpg

[Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException]                                                                               
Source image not found in var/site/storage/images/7/4/2/0/247-1-eng-GB/test.jpg.
Repository images path are expected to be relative to the var/<site>/storage/images directory.                                                                               
Suggested value: '7/4/2/0/247-1-eng-GB/test.jpg'              
```

#### Testing
The exception handling and suggestion are unit tested.