### PR TITLE
Fix EZP-26961: No X-Location-Id header in redirections

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/RequestEventListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/RequestEventListener.php
@@ -124,10 +124,15 @@ class RequestEventListener implements EventSubscriberInterface
                     $semanticPathinfo = $siteaccess->matcher->analyseLink($semanticPathinfo);
                 }
 
+                $headers = [];
+                if ($request->attributes->has('locationId')) {
+                    $headers[ 'X-Location-Id'] = $request->attributes->get('locationId');
+                }
                 $event->setResponse(
                     new RedirectResponse(
                         $semanticPathinfo . ($queryString ? "?$queryString" : ''),
-                        301
+                        301,
+                        $headers
                     )
                 );
                 $event->stopPropagation();

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Routing/UrlAliasRouterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Routing/UrlAliasRouterTest.php
@@ -196,6 +196,7 @@ class UrlAliasRouterTest extends BaseUrlAliasRouterTest
         $this->assertSame($locationId, $request->attributes->get('locationId'));
         $this->assertTrue($request->attributes->get('needsRedirect'));
         $this->assertSame($path, $request->attributes->get('semanticPathinfo'));
+        $this->assertSame($locationId, $request->attributes->get('locationId'));
     }
 
     public function testMatchRequestLocationCaseRedirectWithRootRootLocation()

--- a/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
@@ -156,6 +156,9 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
                         // Specify not to prepend siteaccess while redirecting when applicable since it would be already present (see UrlAliasGenerator::doGenerate())
                         $request->attributes->set('prependSiteaccessOnRedirect', false);
                     } elseif ($this->needsCaseRedirect($urlAlias, $requestedPath, $pathPrefix)) {
+                        if ($urlAlias->destination instanceof Location) {
+                            $request->attributes->set('locationId', $urlAlias->destination->id);
+                        }
                         $request->attributes->set('semanticPathinfo', $this->removePathPrefix($urlAlias->path, $pathPrefix));
                         $request->attributes->set('needsRedirect', true);
                     }


### PR DESCRIPTION
> Fixes [EZP-26961](https://jira.ez.no/browse/EZP-26961)

|Q|A|
|---|---|
|Target branch|6.7|
|Unit tests|yes|
|Backward compatible|yes|

When a content has been renamed, the redirection emitted by the UrlAliasRouter must contain the X-Location-Id header. This adds the location id as a request attribute when the redirect URLAlias is found, and adds the header to the Response in the RequestListener.

