### PR TITLE
DateAndTimeTest::testFromHash fails occasionally on Travis

### DIFF
--- a/eZ/Publish/Core/FieldType/Tests/DateAndTimeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/DateAndTimeTest.php
@@ -237,8 +237,8 @@ class DateAndTimeTest extends FieldTypeTest
         );
         if ($expectedResult->value !== null) {
             $this->assertLessThan(
-                $expectedResult->value->getTimestamp() + 20,
-                $actualResult->value->getTimestamp(),
+                $expectedResult->value->add(new DateInterval('PT20S')),
+                $actualResult->value,
                 'fromHash() method did not create expected result.'
             );
         }

--- a/eZ/Publish/Core/FieldType/Tests/DateAndTimeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/DateAndTimeTest.php
@@ -282,6 +282,8 @@ class DateAndTimeTest extends FieldTypeTest
     public function provideInputForFromHash()
     {
         $date = new \DateTime('Tue, 28 Aug 2012 12:20:00 +0200');
+        $dateNowPlus42S = new \DateTime();
+        $dateNowPlus42S->add(new DateInterval('PT42S'));
 
         return array(
             array(
@@ -305,13 +307,13 @@ class DateAndTimeTest extends FieldTypeTest
                 array(
                     'timestring' => 'now',
                 ),
-                DateAndTimeValue::fromTimestamp(time()),
+                new DateAndTimeValue(new \DateTime()),
             ),
             array(
                 array(
                     'timestring' => '+42 seconds',
                 ),
-                DateAndTimeValue::fromTimestamp(time() + 42),
+                new DateAndTimeValue($dateNowPlus42S),
             ),
         );
     }


### PR DESCRIPTION
Ref: https://travis-ci.com/ezsystems/ezpublish-kernel-ee/jobs/66407749
Still works locally, but fails on Travis. Testing an approach that doesn't use timestamps, similar to https://github.com/ezsystems/ezpublish-kernel/pull/1916