### PR TITLE
Allow extensions to customize the siteaccess configuration

### DIFF
--- a/doc/specifications/siteaccess/siteaccess_aware_configuration.md
+++ b/doc/specifications/siteaccess/siteaccess_aware_configuration.md
@@ -274,3 +274,44 @@ A few limitation exist with this scope hash merge:
 * Semantic setting name and internal name will be the same (like `foo_setting` in the examples above).
 * Applicable to 1st level semantic parameter only (i.e. settings right under the SiteAccess name).
 * Merge is not recursive. Only 2nd level merge is possible by using `ContextualizerInterface::MERGE_FROM_SECOND_LEVEL` option.
+
+## SiteAccess configuration filtering
+Since kernel v6.9, the SiteAccess configuration can be customized by 3rd party bundles before
+it gets processed. It can be used to declare custom siteaccesses, prevent some names from being used...
+
+To do so, you need to:
+- define a `SiteAccessConfigurationFilter` that implements `eZ\Bundle\EzPublishCoreBundle\SiteAccess\SiteAccessConfigurationFilter`,
+- add this filter to the CoreBundle's extension.
+
+Example of a SiteAccessConfigurationFilter:
+```php
+namespace AppBundle\Platform;
+
+use eZ\Bundle\EzPublishCoreBundle\SiteAccess\SiteAccessConfigurationFilter;
+
+class MySiteAccessConfigurationFilter implements SiteAccessConfigurationFilter
+{
+    function filter(array $configuration)
+    {
+        $configuration['list'][] = 'foo';
+
+        return $configuration;
+    }
+}
+```
+
+Registering the filter:
+```
+namespace AppBundle;
+
+use AppBundle\Platform\MySiteAccessConfigurationFilter;
+
+class AppBundle
+{
+    public function build(ContainerBuilder $container)
+    {
+        $eZExtension = $container->getExtension('ezpublish');
+        $eZExtension->addSiteAccessConfigurationFilter(new MySiteAccessConfigurationFilter());
+    }
+}
+```

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
@@ -25,11 +25,20 @@ class Configuration extends SiteAccessConfiguration
      * @var Configuration\Suggestion\Collector\SuggestionCollectorInterface
      */
     private $suggestionCollector;
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\SiteAccess\SiteAccessConfigurationFilter[]
+     */
+    private $siteAccessConfigurationFilters;
 
     public function __construct(ParserInterface $mainConfigParser, SuggestionCollectorInterface $suggestionCollector)
     {
         $this->suggestionCollector = $suggestionCollector;
         $this->mainConfigParser = $mainConfigParser;
+    }
+
+    public function setSiteAccessConfigurationFilters(array $filters)
+    {
+        $this->siteAccessConfigurationFilters = $filters;
     }
 
     /**
@@ -267,6 +276,17 @@ class Configuration extends SiteAccessConfiguration
                                 ->prototype('variable')->end()
                             ->end()
                         ->end()
+                    ->end()
+                    ->beforeNormalization()
+                        ->always()->then(function ($v) {
+                            if (isset($this->siteAccessConfigurationFilters)) {
+                                foreach ($this->siteAccessConfigurationFilters as $filter) {
+                                    $v = $filter->filter($v);
+                                }
+                            }
+
+                            return $v;
+                        })
                     ->end()
                 ->end()
                 ->arrayNode('locale_conversion')

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -15,6 +15,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Suggestion\C
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Suggestion\Formatter\YamlSuggestionFormatter;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider\PoliciesConfigBuilder;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider\PolicyProviderInterface;
+use eZ\Bundle\EzPublishCoreBundle\SiteAccess\SiteAccessConfigurationFilter;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -56,6 +57,11 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
      * @var array
      */
     private $defaultSettingsCollection = [];
+
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\SiteAccess\SiteAccessConfigurationFilter[]
+     */
+    private $siteaccessConfigurationFilters = [];
 
     public function __construct(array $configParsers = array())
     {
@@ -142,7 +148,10 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
      */
     public function getConfiguration(array $config, ContainerBuilder $container)
     {
-        return new Configuration($this->getMainConfigParser(), $this->suggestionCollector);
+        $configuration = new Configuration($this->getMainConfigParser(), $this->suggestionCollector);
+        $configuration->setSiteAccessConfigurationFilters($this->siteaccessConfigurationFilters);
+
+        return $configuration;
     }
 
     /**
@@ -541,5 +550,10 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
     public function addDefaultSettings($fileLocation, array $files)
     {
         $this->defaultSettingsCollection[$fileLocation] = $files;
+    }
+
+    public function addSiteAccessConfigurationFilter(SiteAccessConfigurationFilter $filter)
+    {
+        $this->siteaccessConfigurationFilters[] = $filter;
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/SiteAccess/SiteAccessConfigurationFilter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/SiteAccess/SiteAccessConfigurationFilter.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\SiteAccess;
+
+/**
+ * Allows to filter SiteAccess configuration before it gets processed.
+ */
+interface SiteAccessConfigurationFilter
+{
+    /**
+     * Receives the siteaccess configuration array and returns it.
+     *
+     * @param array $siteAccessConfiguration
+     *        The SiteAccess configuration array before it gets normalized and processed.
+     *        Keys: groups, list, default_siteaccess.
+     *        Example:
+     *        ```
+     *        [
+     *            'list' => ['site'],
+     *            'groups' => ['site_group' => ['site']],
+     *            'default_siteaccess' => 'site',
+     *            'match' => ['URIElement' => 1]
+     *        ]
+     *        ```
+     *
+     * @return array The modified siteaccess configuration array
+     */
+    public function filter(array $siteAccessConfiguration);
+}


### PR DESCRIPTION
> [EZP-27115](http://jira.ez.no/browse/EZP-27115)

Allows bundles to add a `SiteAccessConfigurationFilter`, that gets to filter the siteaccess configuration array before it is applied:

```php
// MyBundle.php
$extension = $container->getExtension('ezpublish');
$extension->addSiteAccessConfigurationFilter(new MyFilter());

// MyFilter.php
function filter($configuration)
{
  $configuration['list'][] = 'foo';
  $configuration['groups']['site_group'][] = 'foo';

  return $configuration;
}
```

### Use-cases
Dynamically create admin siteaccess(es) for the Hybrid UI.

### Architecture
The `SiteAccessConfigurationFilter`, added by 3rd party bundles to the `ezpublish` extension, are provided to the CoreBundle's `Configuration`. They are iterated on in the `beforeNormalization()` method of the `siteaccess` configuration node.

### Tasks
- [x] JIRA Story with description of user (developer) benefit
- [ ] Unit test additions to `EzPublishCoreExtension`.
- [x] Add PhpDoc to the CoreExtension public method and to the Filter interface.
- [x] Document the feature (`doc/specifications/siteaccess/siteaccess_aware_configuration.md`)