### PR TITLE
[Doc] Improve DocBook Schematron README

### DIFF
--- a/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/Readme.rst
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/Readme.rst
@@ -39,3 +39,11 @@ ISO Schematron is handled through XSLT transformation, so XSLT stylesheet
 generated from ISO Schematron is also provided:
 
  - docbook.iso.sch.xsl
+
+To generate XSLT stylesheet from a Schematron file, `xsltproc` - command line XSLT processor, needs
+to be installed on the system. XSLT stylesheet can be generated issuing the following command:
+
+.. code:: bash
+
+   # Usage: sch2xsl.sh source_file target_file
+   ../../stylesheets/schematron/sch2xsl.sh docbook.iso.sch docbook.iso.sch.xsl

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/schematron/sch2xsl.sh
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/schematron/sch2xsl.sh
@@ -6,4 +6,8 @@ if [ "$#" -ne 2 ]; then
     exit 1
 fi
 
-xsltproc iso_dsdl_include.xsl $1 | xsltproc iso_abstract_expand.xsl - | xsltproc --output $2 iso_svrl_for_xslt1.xsl -
+# get script directory
+SCRIPT=$(readlink -f "$0") # take into account symlinks
+SCRIPTPATH=$(dirname "$SCRIPT")
+
+xsltproc "${SCRIPTPATH}/iso_dsdl_include.xsl" $1 | xsltproc "${SCRIPTPATH}/iso_abstract_expand.xsl" - | xsltproc --output $2 "${SCRIPTPATH}/iso_svrl_for_xslt1.xsl" -


### PR DESCRIPTION
It seems that `Readme.rst` on generating XSLT stylesheet from the Schematron schema files needs to be improved.

- [x] Improve `sch2xsl.sh` script to work when executed from any place in the system, so its usage is more user-friendly
- [x] Improve DocBook Schematron `Readme.rst` to show how to generate a XSLT stylescheet (`.xsl`) from a Schematron (`.sch`) file.