### PR TITLE
Fix EZP-25276: Different timezones on server/local env changes the inserted date

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/DateIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/DateIntegrationTest.php
@@ -109,7 +109,9 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
      */
     public function getValidCreationFieldData()
     {
-        return DateValue::fromString('Wed, 21 Jul 2013 16:59:50');
+        // We may only create times from timestamps here, since storing will
+        // loose information about the timezone.
+        return DateValue::fromTimestamp(86400);
     }
 
     /**
@@ -119,7 +121,7 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
      */
     public function getFieldName()
     {
-        return 'Wednesday 24 July 2013';
+        return 'Friday 02 January 1970';
     }
 
     /**
@@ -137,11 +139,10 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
             $field->value
         );
 
-        $dateTime = new DateTime('Wed, 21 Jul 2013 16:59:50');
-        $dateTime->setTime(0, 0, 0);
         $expectedData = array(
-            'date' => $dateTime,
+            'date' => new DateTime('@86400'),
         );
+
         $this->assertPropertiesCorrect(
             $expectedData,
             $field->value
@@ -186,11 +187,11 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
      */
     public function getValidUpdateFieldData()
     {
-        return DateValue::fromString('Wed, 21 Jul 2013 17:59:50');
+        return DateValue::fromTimestamp(86400);
     }
 
     /**
-     * Asserts the the field data was loaded correctly.
+     * Asserts the field data was loaded correctly.
      *
      * Asserts that the data provided by {@link getValidUpdateFieldData()}
      * was stored and loaded correctly.
@@ -204,10 +205,8 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
             $field->value
         );
 
-        $dateTime = new DateTime('Wed, 21 Jul 2013 17:59:50');
-        $dateTime->setTime(0, 0, 0);
         $expectedData = array(
-            'date' => $dateTime,
+            'date' => new DateTime('@86400'),
         );
         $this->assertPropertiesCorrect(
             $expectedData,
@@ -276,13 +275,14 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
      */
     public function provideToHashData()
     {
-        $dateTime = new DateTime();
+        $timestamp = 186401;
+        $dateTime = new DateTime("@{$timestamp}");
 
         return array(
             array(
-                DateValue::fromTimestamp($timestamp = 186401),
+                DateValue::fromTimestamp($timestamp),
                 array(
-                    'timestamp' => $dateTime->setTimestamp($timestamp)->setTime(0, 0, 0)->getTimestamp(),
+                    'timestamp' => $dateTime->setTime(0, 0, 0)->getTimestamp(),
                     'rfc850' => $dateTime->format(DateTime::RFC850),
                 ),
             ),
@@ -311,19 +311,22 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
      */
     public function provideFromHashData()
     {
+        $timestamp = 123456;
+
         $dateTime = new DateTime();
+        $dateTime->setTimestamp($timestamp)->setTime(0, 0, 0);
 
         return array(
             array(
                 array(
-                    'timestamp' => $dateTime->setTimestamp(123456)->setTime(0, 0, 0)->getTimestamp(),
+                    'timestamp' => $timestamp,
                     'rfc850' => ($rfc850 = $dateTime->format(DateTime::RFC850)),
                 ),
                 DateValue::fromString($rfc850),
             ),
             array(
                 array(
-                    'timestamp' => $dateTime->setTimestamp($timestamp = 123456)->setTime(0, 0, 0)->getTimestamp(),
+                    'timestamp' => $timestamp,
                     'rfc850' => null,
                 ),
                 DateValue::fromTimestamp($timestamp),
@@ -349,16 +352,12 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
 
     protected function getValidSearchValueOne()
     {
-        $date = new DateTime('1970-01-02');
-
-        return $date->getTimestamp();
+        return 86400;
     }
 
     protected function getValidSearchValueTwo()
     {
-        $date = new DateTime('1970-01-03');
-
-        return $date->getTimestamp();
+        return 172800;
     }
 
     protected function getSearchTargetValueOne()

--- a/eZ/Publish/Core/FieldType/Date/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Date/SearchField.php
@@ -29,11 +29,7 @@ class SearchField implements Indexable
      */
     public function getIndexData(Field $field, FieldDefinition $fieldDefinition)
     {
-        // The field type stores date value as a timestamp of the start of the day in the
-        // environment's timezone.
-        // We format this as Y-m-d and add Z to signify UTC (zero offset).
-        $dateTime = new DateTime();
-        $dateTime->setTimestamp($field->value->data['timestamp']);
+        $dateTime = new DateTime("@{$field->value->data['timestamp']}");
 
         return array(
             new Search\Field(

--- a/eZ/Publish/Core/FieldType/Date/Value.php
+++ b/eZ/Publish/Core/FieldType/Date/Value.php
@@ -76,10 +76,7 @@ class Value extends BaseValue
     public static function fromTimestamp($timestamp)
     {
         try {
-            $dateTime = new DateTime();
-            $dateTime->setTimestamp($timestamp);
-
-            return new static($dateTime);
+            return new static(new DateTime("@{$timestamp}"));
         } catch (Exception $e) {
             throw new InvalidArgumentValue('$timestamp', $timestamp, __CLASS__, $e);
         }

--- a/eZ/Publish/Core/FieldType/Tests/DateTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/DateTest.php
@@ -135,8 +135,6 @@ class DateTest extends FieldTypeTest
      */
     public function provideValidInputForAcceptValue()
     {
-        $dateTime = new DateTime();
-
         return array(
             array(
                 null,
@@ -149,12 +147,12 @@ class DateTest extends FieldTypeTest
             array(
                 ($timestamp = 1346149200),
                 new DateValue(
-                    clone $dateTime->setTimestamp($timestamp)
+                    new DateTime("@{$timestamp}")
                 ),
             ),
             array(
-                DateValue::fromTimestamp(1372895999),
-                new DateValue($dateTime->setTimestamp(1372895999)->setTime(0, 0, 0)),
+                DateValue::fromTimestamp($timestamp = 1372895999),
+                new DateValue(new DateTime("@{$timestamp}")),
             ),
             array(
                 ($dateTime = new DateTime()),
@@ -263,7 +261,7 @@ class DateTest extends FieldTypeTest
                 array(
                     'timestamp' => ($timestamp = 1362614400),
                 ),
-                new DateValue(clone $dateTime->setTimestamp($timestamp)),
+                new DateValue(new DateTime("@{$timestamp}")),
             ),
             array(
                 array(


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-25276

## Description
When the server's timezone is not UTC, the date won't be retrieved properly.
Timestamps are stored in UTC timezone, if you are in a timezone starting with  `-`, the date retrieved will be the day before. 

For example: 03/27/2017
- Stored as `03/27/2017 00:00:00` (as a timestamp)
- Was retrieved in a server configured to use New York's time as `03/27/2017 00:00:00` minus 6 hours so the day before: `03/26/2017 18:00:00` (as a timestamp)

This patch makes sure date are retrieved as UTC. It is based on the DateAndTime behavior: https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/FieldType/DateAndTime/Value.php#L71

## Tests
Manual test on platformUI and update of unit test.

## TODO
- [x] Update integration test
- [x] Rebase