### PR TITLE
EZP-26921: Name encoding issue when title exceeds max name length

### DIFF
--- a/eZ/Publish/Core/Repository/Helper/NameSchemaService.php
+++ b/eZ/Publish/Core/Repository/Helper/NameSchemaService.php
@@ -202,7 +202,7 @@ class NameSchemaService
 
             // Make sure length is not longer then $limit unless it's 0
             if ($this->settings['limit'] && strlen($name) > $this->settings['limit']) {
-                $name = rtrim(substr($name, 0, $this->settings['limit'] - strlen($this->settings['sequence']))) . $this->settings['sequence'];
+                $name = rtrim(mb_substr($name, 0, $this->settings['limit'] - strlen($this->settings['sequence']))) . $this->settings['sequence'];
             }
 
             $names[$languageCode] = $name;

--- a/eZ/Publish/Core/Repository/Helper/NameSchemaService.php
+++ b/eZ/Publish/Core/Repository/Helper/NameSchemaService.php
@@ -201,7 +201,7 @@ class NameSchemaService
             }
 
             // Make sure length is not longer then $limit unless it's 0
-            if ($this->settings['limit'] && strlen($name) > $this->settings['limit']) {
+            if ($this->settings['limit'] && mb_strlen($name) > $this->settings['limit']) {
                 $name = rtrim(mb_substr($name, 0, $this->settings['limit'] - strlen($this->settings['sequence']))) . $this->settings['sequence'];
             }
 


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-26921

change substr to multi-byte substr (mb_substr). It fix problems with long cyrillic names

Closes #1899