### PR TITLE
EZP-25679: Document decoupling BC break

### DIFF
--- a/doc/bc/changes-6.9.md
+++ b/doc/bc/changes-6.9.md
@@ -3,15 +3,8 @@
 Changes affecting version compatibility with former or future versions.
 
 ## Changes
+- EZP-25679: `ezpublish.api.service.*` now correctly point to the outermost api: SignalSlot
 
+  What changed: All `ezpublish.api.service.*` services are now aliases, not reusing `ezpublish.api.reposiotry` alias to better decouple the repository and correct the services returned.
 
-## Deprecations
-
-
-## Removed features
-
-* All `ezpublish.api.service.*` services are now aliases, not reusing `ezpublish.api.reposiotry` alias.
-
-  As part of `EZP-25679: Decouple SignalSlot services` all API services are now individual aliases,
-  meaning they won't automatically take advantage of `ezpublish.api.reposiotry` to pick implementation.
-  This is done to not have to load the whole repository and all it's services, just to load one.
+  How it might affect your code: Make sure you always type hint against the interfaces for our `API` and never `Core` implementation classes to avoid this causing issues.

--- a/doc/bc/changes-6.9.md
+++ b/doc/bc/changes-6.9.md
@@ -10,3 +10,5 @@ Changes affecting version compatibility with former or future versions.
   How it might affect your code: Make sure you always type hint against the interfaces for our `API` and never `Core` implementation classes to avoid this causing issues.
 
 ## Deprecations
+
+## Removed features

--- a/doc/bc/changes-6.9.md
+++ b/doc/bc/changes-6.9.md
@@ -8,3 +8,5 @@ Changes affecting version compatibility with former or future versions.
   What changed: All `ezpublish.api.service.*` services are now aliases, not reusing `ezpublish.api.reposiotry` alias to better decouple the repository and correct the services returned.
 
   How it might affect your code: Make sure you always type hint against the interfaces for our `API` and never `Core` implementation classes to avoid this causing issues.
+
+## Deprecations


### PR DESCRIPTION
> Context:
> - Fix is to make sure type hint is on API and not Core: https://github.com/ezsystems/date-based-publisher/pull/18/files
> - Caused by: https://github.com/ezsystems/ezpublish-kernel/pull/1884
> - Affected service id’s:  @ezpublish.api.service.*

Changes documentation now brings more detail about what's done and how it may affect current installation.