### PR TITLE
EZP-27280: Search field type TextField should be multivalued

### DIFF
--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleStringMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleStringMapper.php
@@ -27,6 +27,7 @@ class MultipleStringMapper extends StringMapper
     {
         return
             $field->type instanceof FieldType\MultipleStringField ||
+            $field->type instanceof FieldType\TextField ||
             $field->type instanceof FieldType\FullTextField;
     }
 

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/StringMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/StringMapper.php
@@ -27,8 +27,7 @@ class StringMapper extends FieldValueMapper
     public function canMap(Field $field)
     {
         return
-            $field->type instanceof FieldType\StringField ||
-            $field->type instanceof FieldType\TextField;
+            $field->type instanceof FieldType\StringField;
     }
 
     /**


### PR DESCRIPTION
### JIRA issue: https://jira.ez.no/browse/EZP-27280

Required by https://github.com/ezsystems/ezplatform-solr-search-engine/pull/90

Makes `TextField` search field type valued mapped as multivalued string.

Multivalued field is stored same as a single value, but with extra "spacing" between the single values/tokens. This prevents spurious phrase matches across single values, so it's actually desirable for the language analyzed field that `TextField` represents. See [doc about `positionIncrementGap`](https://cwiki.apache.org/confluence/display/solr/Field+Type+Definitions+and+Properties#FieldTypeDefinitionsandProperties-GeneralProperties).

Previously the multiple text values had to be concatenated and passed to the search `Field` as a single value. This enables passing an array of values. There should be no functional difference for the existing code as the value will be [casted to array before being mapped](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleStringMapper.php#L44).