### PR TITLE
EZP-26764: Fix ContentType FieldDefinition settings views

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
@@ -82,12 +82,12 @@
     {% else %}
         {% set interval = settings.dateInterval %}
         {% set defaultValue = 'Current datetime adjusted by ' %}
-        {% set defaultValue = interval.y ? defaultValue ~ interval.y ~ ' year(s)' : defaultValue %}
-        {% set defaultValue = interval.m ? defaultValue ~ interval.m ~ ' month(s)' : defaultValue %}
-        {% set defaultValue = interval.d ? defaultValue ~ interval.d ~ ' day(s)' : defaultValue %}
-        {% set defaultValue = interval.h ? defaultValue ~ interval.h ~ ' hour(s)' : defaultValue %}
-        {% set defaultValue = interval.i ? defaultValue ~ interval.i ~ ' minute(s)' : defaultValue %}
-        {% set defaultValue = interval.s and settings.useSeconds ? defaultValue ~ interval.s ~ ' second(s)' : defaultValue %}
+        {% set defaultValue = interval.y ? defaultValue ~ ' ' ~ interval.y ~ ' year(s)' : defaultValue %}
+        {% set defaultValue = interval.m ? defaultValue ~ ' ' ~  interval.m ~ ' month(s)' : defaultValue %}
+        {% set defaultValue = interval.d ? defaultValue ~ ' ' ~ interval.d ~ ' day(s)' : defaultValue %}
+        {% set defaultValue = interval.h ? defaultValue ~ ' ' ~ interval.h ~ ' hour(s)' : defaultValue %}
+        {% set defaultValue = interval.i ? defaultValue ~ ' ' ~ interval.i ~ ' minute(s)' : defaultValue %}
+        {% set defaultValue = interval.s and settings.useSeconds ? defaultValue ~ ' ' ~ interval.s ~ ' second(s)' : defaultValue %}
     {% endif %}
     {{ block( 'settings_defaultvalue' ) }}
     <li class="ez-fielddefinition-setting use-seconds">

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
@@ -9,6 +9,16 @@
 <ul class="ez-fielddefinition-settings ez-fielddefinition-{{ fielddefinition.fieldTypeIdentifier }}-settings">
     {% set defaultValue = fielddefinition.defaultValue.text %}
     {{ block( 'settings_defaultvalue' ) }}
+    <li class="ez-fielddefinition-setting min-length">
+        <div class="ez-fielddefinition-setting-name">Min string length:</div>
+        <div class="ez-fielddefinition-setting-value">
+        {% if fielddefinition.validatorConfiguration.StringLengthValidator.minStringLength %}
+            {{ fielddefinition.validatorConfiguration.StringLengthValidator.minStringLength }} characters
+        {% else %}
+            <em>No defined minimum string length</em>
+        {% endif %}
+        </div>
+    </li>
     <li class="ez-fielddefinition-setting max-length">
         <div class="ez-fielddefinition-setting-name">Max string length:</div>
         <div class="ez-fielddefinition-setting-value">


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-26764

# Description

min length Text line settings was missing. Also, fixed the string generated the adjusted datetime on DateAndTime settings.

# Tests

manual tests