### PR TITLE
Fix EZP-27151: Added version number to REST imageId

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
@@ -213,13 +213,14 @@ ezpublish_rest_createDraftFromCurrentVersion:
 # Binary content
 
 ezpublish_rest_binaryContent_getImageVariation:
-    path: /content/binary/images/{imageId}/variations/{variationIdentifier}
+    path: /content/binary/images/{imageId}/variations/{variationIdentifier}/{contentVersion}
     defaults:
         _controller: ezpublish_rest.controller.binary_content:getImageVariation
+        contentVersion: 0
     methods: [GET]
     requirements:
-        imageId: \d+-\d+
-
+        imageId: \d+-\d+(-\d+)?
+        contentVersion: \d
 
 # Views
 

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
@@ -219,7 +219,6 @@ ezpublish_rest_binaryContent_getImageVariation:
     methods: [GET]
     requirements:
         imageId: \d+-\d+(-\d+)?
-        contentVersion: \d
 
 # Views
 

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
@@ -213,10 +213,9 @@ ezpublish_rest_createDraftFromCurrentVersion:
 # Binary content
 
 ezpublish_rest_binaryContent_getImageVariation:
-    path: /content/binary/images/{imageId}/variations/{variationIdentifier}/{contentVersion}
+    path: /content/binary/images/{imageId}/variations/{variationIdentifier}
     defaults:
         _controller: ezpublish_rest.controller.binary_content:getImageVariation
-        contentVersion: 0
     methods: [GET]
     requirements:
         imageId: \d+-\d+(-\d+)?

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -94,7 +94,7 @@ class ImageStorage extends GatewayBasedStorage
                 );
             }
 
-            $field->value->externalData['imageId'] = $versionInfo->contentInfo->id . '-' . $field->id;
+            $field->value->externalData['imageId'] = $versionInfo->contentInfo->id . '-' . $field->id . $versionInfo->versionNo;
             $field->value->externalData['uri'] = $binaryFile->uri;
             $field->value->externalData['id'] = $binaryFile->id;
             $field->value->externalData['mime'] = $this->IOService->getMimeType($binaryFile->id);
@@ -131,7 +131,7 @@ class ImageStorage extends GatewayBasedStorage
     public function getFieldData(VersionInfo $versionInfo, Field $field, array $context)
     {
         if ($field->value->data !== null) {
-            $field->value->data['imageId'] = $versionInfo->contentInfo->id . '-' . $field->id;
+            $field->value->data['imageId'] = $versionInfo->contentInfo->id . '-' . $field->id . '-' . $versionInfo->versionNo;
             $binaryFile = $this->IOService->loadBinaryFile($field->value->data['id']);
             $field->value->data['id'] = $binaryFile->id;
             $field->value->data['fileSize'] = $binaryFile->size;

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -183,7 +183,7 @@ class ImageStorage extends GatewayBasedStorage
      *
      * @return string
      */
-    private function buildImageId(VersionInfo $versionInfo, Field $field): string
+    private function buildImageId(VersionInfo $versionInfo, Field $field)
     {
         return sprintf(
             '%s-%s-%s',

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -94,7 +94,7 @@ class ImageStorage extends GatewayBasedStorage
                 );
             }
 
-            $field->value->externalData['imageId'] = $versionInfo->contentInfo->id . '-' . $field->id . $versionInfo->versionNo;
+            $field->value->externalData['imageId'] = $this->buildImageId($versionInfo, $field);
             $field->value->externalData['uri'] = $binaryFile->uri;
             $field->value->externalData['id'] = $binaryFile->id;
             $field->value->externalData['mime'] = $this->IOService->getMimeType($binaryFile->id);
@@ -131,7 +131,7 @@ class ImageStorage extends GatewayBasedStorage
     public function getFieldData(VersionInfo $versionInfo, Field $field, array $context)
     {
         if ($field->value->data !== null) {
-            $field->value->data['imageId'] = $versionInfo->contentInfo->id . '-' . $field->id . '-' . $versionInfo->versionNo;
+            $field->value->data['imageId'] = $this->buildImageId($versionInfo, $field);
             $binaryFile = $this->IOService->loadBinaryFile($field->value->data['id']);
             $field->value->data['id'] = $binaryFile->id;
             $field->value->data['fileSize'] = $binaryFile->size;
@@ -175,5 +175,19 @@ class ImageStorage extends GatewayBasedStorage
     {
         // @todo: Correct?
         return null;
+    }
+
+    /**
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     *
+     * @return string
+     */
+    private function buildImageId(VersionInfo $versionInfo, Field $field): string
+    {
+        return sprintf(
+            '%s-%s-%s',
+            $versionInfo->contentInfo->id, $field->id, $versionInfo->versionNo
+        );
     }
 }

--- a/eZ/Publish/Core/REST/Server/Controller/BinaryContent.php
+++ b/eZ/Publish/Core/REST/Server/Controller/BinaryContent.php
@@ -20,6 +20,11 @@ use eZ\Publish\API\Repository\Exceptions\InvalidVariationException;
 class BinaryContent extends RestController
 {
     /**
+     * @var \eZ\Publish\SPI\Variation\VariationHandler
+     */
+    protected $imageVariationHandler;
+
+    /**
      * Construct controller.
      *
      * @param \eZ\Publish\SPI\Variation\VariationHandler $imageVariationHandler
@@ -33,7 +38,10 @@ class BinaryContent extends RestController
      * Returns data about the image variation $variationIdentifier of image field $fieldId.
      * Will generate the alias if it hasn't been generated yet.
      *
-     * @param mixed  $imageId
+     * @param mixed  $imageId A custom ID that identifies the image field.
+     *                        Until v6.9, the format is {contentId}-{fieldId}.
+     *                        since v6.9, the format is {contentId}-{fieldId}-{versionNumber}.
+     *                        If the version number isn't specified, the default one is used.
      * @param string $variationIdentifier
      *
      * @throws \eZ\Publish\Core\REST\Common\Exceptions\NotFoundException
@@ -42,16 +50,7 @@ class BinaryContent extends RestController
      */
     public function getImageVariation($imageId, $variationIdentifier)
     {
-        $idArray = explode('-', $imageId);
-        $versionNumber = null;
-        if (count($idArray) == 2) {
-            list($contentId, $fieldId) = $idArray;
-        } elseif (count($idArray) == 3) {
-            list($contentId, $fieldId, $versionNumber) = $idArray;
-        } else {
-            throw new Exceptions\NotFoundException("Invalid image ID {$imageId}");
-        }
-
+        list($contentId, $fieldId, $versionNumber) = $this->parseImageId($imageId);
         $content = $this->repository->getContentService()->loadContent($contentId, null, $versionNumber);
 
         $fieldFound = false;
@@ -72,26 +71,42 @@ class BinaryContent extends RestController
             throw new Exceptions\NotFoundException("Image file {$field->value->id} doesn't exist");
         }
 
-        $versionInfo = $this->repository->getContentService()->loadVersionInfo($content->contentInfo, $versionNumber);
-
         try {
-            $variation = $this->imageVariationHandler->getVariation($field, $versionInfo, $variationIdentifier);
+            $variation = $this->imageVariationHandler->getVariation($field, $content->getVersionInfo(), $variationIdentifier);
 
-            if ($content->contentInfo->mainLocationId === null) {
+            if ($content->contentInfo->mainLocationId === null || $versionNumber !== $content->contentInfo->currentVersionNo) {
                 return $variation;
-            } else {
-                return new CachedValue(
-                    $variation,
-                    array('locationId' => $content->contentInfo->mainLocationId)
-                );
             }
+
+            return new CachedValue(
+                $variation,
+                array('locationId' => $content->contentInfo->mainLocationId)
+            );
         } catch (InvalidVariationException $e) {
             throw new Exceptions\NotFoundException("Invalid image variation $variationIdentifier");
         }
     }
 
     /**
-     * @var \eZ\Publish\SPI\Variation\VariationHandler
+     * Parses an imageId string into contentId, fieldId and versionNumber.
+     *
+     * @param string $imageId Either {contentId}-{fieldId} or {contentId}-{fieldId}-{versionNumber}
+     *
+     * @return array An array with 3 keys: contentId, fieldId and versionNumber.
+     *               If the versionNumber wasn't set, it is returned as null.
+     *
+     * @throws \eZ\Publish\Core\REST\Common\Exceptions\NotFoundException If the imageId format is invalid
      */
-    protected $imageVariationHandler;
+    private function parseImageId($imageId)
+    {
+        $idArray = explode('-', $imageId);
+
+        if (count($idArray) == 2) {
+            return array_merge($idArray, [null]);
+        } elseif (count($idArray) == 3) {
+            return $idArray;
+        }
+
+        throw new Exceptions\NotFoundException("Invalid image ID {$imageId}");
+    }
 }

--- a/eZ/Publish/Core/REST/Server/Controller/BinaryContent.php
+++ b/eZ/Publish/Core/REST/Server/Controller/BinaryContent.php
@@ -43,12 +43,16 @@ class BinaryContent extends RestController
     public function getImageVariation($imageId, $variationIdentifier)
     {
         $idArray = explode('-', $imageId);
-        if (count($idArray) != 2) {
+        $versionNumber = null;
+        if (count($idArray) == 2) {
+            list($contentId, $fieldId) = $idArray;
+        } elseif (count($idArray) == 3) {
+            list($contentId, $fieldId, $versionNumber) = $idArray;
+        } else {
             throw new Exceptions\NotFoundException("Invalid image ID {$imageId}");
         }
-        list($contentId, $fieldId) = $idArray;
 
-        $content = $this->repository->getContentService()->loadContent($contentId);
+        $content = $this->repository->getContentService()->loadContent($contentId, null, $versionNumber);
 
         $fieldFound = false;
         /** @var $field \eZ\Publish\API\Repository\Values\Content\Field */
@@ -68,7 +72,7 @@ class BinaryContent extends RestController
             throw new Exceptions\NotFoundException("Image file {$field->value->id} doesn't exist");
         }
 
-        $versionInfo = $this->repository->getContentService()->loadVersionInfo($content->contentInfo);
+        $versionInfo = $this->repository->getContentService()->loadVersionInfo($content->contentInfo, $versionNumber);
 
         try {
             $variation = $this->imageVariationHandler->getVariation($field, $versionInfo, $variationIdentifier);


### PR DESCRIPTION
> Fixes [EZP-27151](https://jira.ez.no/browse/EZP-27151)

Adds the content version number to the `imageId` argument: `<contentId>-<fieldId>-<versionNumber>`. If none is provided, the route will still be valid, and will pick the currently published version (same behaviour as previous versions).

This part of the REST API clearly deserves a refactoring, but this bugfix isn't the right time for it :)

Tested manually...