### PR TITLE
EZP-26901: Inconsistency in entering values for Maximum file size 

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
@@ -223,7 +223,7 @@ EOT;
     public function toStorageFieldDefinition(FieldDefinition $fieldDef, StorageFieldDefinition $storageDef)
     {
         $storageDef->dataInt1 = (isset($fieldDef->fieldTypeConstraints->validators['FileSizeValidator']['maxFileSize'])
-            ? round($fieldDef->fieldTypeConstraints->validators['FileSizeValidator']['maxFileSize'] / 1024 / 1024)
+            ? $fieldDef->fieldTypeConstraints->validators['FileSizeValidator']['maxFileSize']
             : 0);
     }
 
@@ -240,7 +240,7 @@ EOT;
                 'validators' => array(
                     'FileSizeValidator' => array(
                         'maxFileSize' => ($storageDef->dataInt1 != 0
-                            ? (int)$storageDef->dataInt1 * 1024 * 1024
+                            ? $storageDef->dataInt1
                             : null),
                     ),
                 ),


### PR DESCRIPTION
Link: https://jira.ez.no/browse/EZP-26901 

# Description 

This PR change the input unit "Maximum file size" value, from byte to megabyte, in 'ezimage' field type (in similar to 'ezbinaryfile' and 'ezmedia'). This PR will also resolves https://jira.ez.no/browse/EZP-26900 issue. 

It require a related PR in platform-ui repository (I will paste URL here when it will be ready). 

# TODO

- [ ] Link related PR in platform-ui 
- [ ] Update tests if needed
