### PR TITLE
Fix EZP-26164: error saving a binary field copied translation

### DIFF
--- a/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage.php
@@ -83,6 +83,11 @@ class BinaryBaseStorage extends GatewayBasedStorage
                 $binaryFile->uri;
         }
 
+        // copy from another field
+        if (!isset($field->value->externalData['mimeType']) && isset($field->value->externalData['id'])) {
+            $field->value->externalData['mimeType'] = $this->IOService->getMimeType($field->value->externalData['id']);
+        }
+
         $this->removeOldFile($field->id, $versionInfo->versionNo, $context);
 
         $this->getGateway($context)->storeFileReference($versionInfo, $field);


### PR DESCRIPTION
> Fixes [EZP-26164](https://jira.ez.no/browse/EZP-26164)

When a Binary Field is saved with external data, but doesn't have a mimeType defined, gets it from the IOService using the stored file. Covers the case where a Field Value is copied from another translation and left untouched.