### PR TITLE
[Sf 3.x] Fix Symfony console script path

### DIFF
--- a/bin/extract-translations.sh
+++ b/bin/extract-translations.sh
@@ -3,7 +3,7 @@ echo 'Translation extraction';
 cd ../../..;
 # Extract string for default locale
 echo '# Extract Kernel : EzPublishCoreBundle';
-./app/console translation:extract en -v \
+./bin/console translation:extract en -v \
   --dir=./vendor/ezsystems/ezpublish-kernel/eZ \
   --exclude-dir=Bundle/PlatformBehatBundle \
   --exclude-dir=Tests \

--- a/doc/specifications/image/variation_purging.md
+++ b/doc/specifications/image/variation_purging.md
@@ -8,7 +8,7 @@ Makes it possible to clear all variations generated for an alias. Uses the liip:
 Example (the `-v` option will log removals to the console), removing variations for the `large` and `gallery` aliases :
 
 ```shell
-php app/console liip:imagine:cache:remove --filters=large --filters=gallery -v
+php bin/console liip:imagine:cache:remove --filters=large --filters=gallery -v
 ```
 
 ## Internal changes

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/ConsoleContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/ConsoleContext.php
@@ -116,7 +116,7 @@ class ConsoleContext extends EzContext implements Context, SnippetAcceptingConte
         }
         $php = escapeshellarg($phpPath);
         $phpArgs = implode(' ', array_map('escapeshellarg', $arguments));
-        $console = escapeshellarg('app/console');
+        $console = escapeshellarg('bin/console');
         $cmd = escapeshellarg($command);
 
         $console .= ' --env=' . escapeshellarg('behat');

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/QueryControllerContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/QueryControllerContext.php
@@ -127,7 +127,7 @@ class QueryControllerContext extends RawMinkContext implements Context
         $fs = new Filesystem();
         $fs->mkdir(dirname($phpFilePath));
         $fs->dumpFile($phpFilePath, $phpFileContents);
-        shell_exec('php app/console --env=behat cache:clear');
+        shell_exec('php bin/console --env=behat cache:clear');
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/YamlConfigurationContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/YamlConfigurationContext.php
@@ -30,7 +30,7 @@ class YamlConfigurationContext implements Context
 
         $this->addImportToPlatformYaml($destinationFileName);
 
-        shell_exec('php app/console --env=behat cache:clear');
+        shell_exec('php bin/console --env=behat cache:clear');
     }
 
     private function addImportToPlatformYaml($importedFileName)

--- a/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
@@ -239,7 +239,7 @@ class InstallPlatformCommand extends Command
         $php = escapeshellarg($phpPath) . ($phpArgs ? ' ' . $phpArgs : '');
 
         // Make sure to pass along relevant global Symfony options to console command
-        $console = escapeshellarg('app/console');
+        $console = escapeshellarg('bin/console');
         if ($output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL) {
             $console .= ' -' . str_repeat('v', $output->getVerbosity() - 1);
         }


### PR DESCRIPTION
> **Target branch**: `7.0`

This PR fixes for `v2` and `Kernel 7.0` hardcoded Symfony console script path to `bin/console`.
Suggestions how to parametrize this instead of hardcoding are welcomed, but for now I decided it would be an overkill.

Main reason behind this is that reindexing called by `ezplatform:install` crashes each time I try to test it :)