### PR TITLE
Fix EZP-27237: fixed wrong content loading logic in ContentViewBuilder

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -106,7 +106,7 @@ class ContentViewBuilder implements ViewBuilder
                 throw new InvalidArgumentException('Content', 'No content could be loaded from parameters');
             }
 
-            $content = $view->isEmbed() ? $this->loadContent($contentId) : $this->loadEmbeddedContent($contentId, $location);
+            $content = $view->isEmbed() ? $this->loadEmbeddedContent($contentId, $location) : $this->loadContent($contentId);
         }
 
         $view->setContent($content);


### PR DESCRIPTION
> [EZP-27237](https://jira.ez.no/browse/EZP-27237)

The `ContentViewBuilder` will load the Content differently depending if the View is an embed one or not. That logic was reversed, and `loadEmbedContent()` was used to load content for regular views, and `loadContent()` for embed views.

Tested manually.