### PR TITLE
[CI] Force Sf 3.x requirement to test with latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
       env: SOLR_VERSION="6.4.1" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml"
 # 7.1
     - php: 7.1
-      env: TEST_CONFIG="phpunit.xml"
+      env: TEST_CONFIG="phpunit.xml" SYMFONY_VERSION="^3.2.0"
     - php: 7.1
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb"
 # hhvm - disabled, no need to enable before travis has newer versions avaiable

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,7 +40,7 @@ install:
     - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
     - IF %PHP%==1 appveyor DownloadFile https://getcomposer.org/composer.phar
     - cd c:\projects\ezpublish-kernel
-    - composer update --no-progress --ansi
+    - composer install --no-suggest --no-progress --ansi
 
 test_script:
     - cd c:\projects\ezpublish-kernel

--- a/eZ/Bundle/EzPublishIOBundle/Tests/EventListener/StreamFileListenerTest.php
+++ b/eZ/Bundle/EzPublishIOBundle/Tests/EventListener/StreamFileListenerTest.php
@@ -88,9 +88,14 @@ class StreamFileListenerTest extends PHPUnit_Framework_TestCase
         $this->eventListener->onKernelRequest($event);
 
         self::assertTrue($event->hasResponse());
+        $expectedResponse = new BinaryStreamResponse($binaryFile, $this->ioServiceMock);
+        $response = $event->getResponse();
+        // since symfony/symfony v3.2.7 Response sets Date header if not explicitly set
+        // @see https://github.com/symfony/symfony/commit/e3d90db74773406fb8fdf07f36cb8ced4d187f62
+        $expectedResponse->setDate($response->getDate());
         self::assertEquals(
-            new BinaryStreamResponse($binaryFile, $this->ioServiceMock),
-            $event->getResponse()
+            $expectedResponse,
+            $response
         );
     }
 
@@ -115,9 +120,14 @@ class StreamFileListenerTest extends PHPUnit_Framework_TestCase
         $this->eventListener->onKernelRequest($event);
 
         self::assertTrue($event->hasResponse());
+        $expectedResponse = new BinaryStreamResponse($binaryFile, $this->ioServiceMock);
+        $response = $event->getResponse();
+        // since symfony/symfony v3.2.7 Response sets Date header if not explicitly set
+        // @see https://github.com/symfony/symfony/commit/e3d90db74773406fb8fdf07f36cb8ced4d187f62
+        $expectedResponse->setDate($response->getDate());
         self::assertEquals(
-            new BinaryStreamResponse($binaryFile, $this->ioServiceMock),
-            $event->getResponse()
+            $expectedResponse,
+            $response
         );
     }
 


### PR DESCRIPTION
This PR:
- [x] [Travis] Forces Symfony version (`^3.2.0`) for basic unit tests (`phpunit.xml`) run on PHP `7.1`. It allows us to test against the latest release of Sf.
- [x] [AppVeyor] Respects packages in `composer.lock` by running composer install instead of composer update (so we uncover regressions only on Travis).
- [x] Fix bug in tests run by Travis (uncovered in #1954).