### PR TITLE
EZP-27290: Remove abstract on DebugTemplate to fix dumping logs in profiler

### DIFF
--- a/eZ/Bundle/EzPublishDebugBundle/Twig/DebugTemplate.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Twig/DebugTemplate.php
@@ -16,7 +16,7 @@ use Twig_Template;
  * Wraps the display method to:
  * - Inject debug info into template to be able to see in the markup which one is used
  */
-abstract class DebugTemplate extends Twig_Template
+class DebugTemplate extends Twig_Template
 {
     public function display(array $context, array $blocks = array())
     {
@@ -59,5 +59,37 @@ abstract class DebugTemplate extends Twig_Template
         } else {
             echo $templateResult;
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTemplateName()
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSource()
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doDisplay(array $context, array $blocks = array())
+    {
+        return '';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDebugInfo()
+    {
+        return array();
     }
 }


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-27290

Starting with https://github.com/symfony/symfony/commit/eddecbd112c13eadac6533b39287205b90430a21 and in combination with legacy eZ templates, when an exception happens (even a silenced deprecation notice, which is converted to an exception) while rendering the template, one gets a message `Cannot instantiate abstract class eZ\Bundle\EzPublishDebugBundle\Twig\DebugTemplate` in the log, which ultimately breaks the profiler.

The issue comes from https://github.com/symfony/symfony/blob/master/src/Symfony/Component/VarDumper/Caster/ExceptionCaster.php#L201-L202, which presumes that every subclass of `Twig_Template` is instantiable.

Haven't found other way to solve this other than this. The fix is also compatible with Twig 2.0 (for when we enable it again in the repo).