### PR TITLE
Fix EZP-26900: Maximum file size is not retained for 'ezimage' field …

### DIFF
--- a/eZ/Publish/Core/FieldType/Image/Type.php
+++ b/eZ/Publish/Core/FieldType/Image/Type.php
@@ -171,8 +171,7 @@ class Type extends FieldType
                         break;
                     }
 
-                    // Database stores maxFileSize in MB
-                    if (($parameters['maxFileSize'] * 1024 * 1024) < $fieldValue->fileSize) {
+                    if (($parameters['maxFileSize']) < $fieldValue->fileSize) {
                         $errors[] = new ValidationError(
                             'The file size cannot exceed %size% byte.',
                             'The file size cannot exceed %size% bytes.',

--- a/eZ/Publish/Core/FieldType/Tests/ImageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageTest.php
@@ -524,7 +524,7 @@ class ImageTest extends FieldTypeTest
                 array(
                     'validatorConfiguration' => array(
                         'FileSizeValidator' => array(
-                            'maxFileSize' => 1,
+                            'maxFileSize' => 1048576,
                         ),
                     ),
                 ),
@@ -613,7 +613,7 @@ class ImageTest extends FieldTypeTest
                 array(
                     'validatorConfiguration' => array(
                         'FileSizeValidator' => array(
-                            'maxFileSize' => 0.01,
+                            'maxFileSize' => 51200,
                         ),
                     ),
                 ),
@@ -631,7 +631,7 @@ class ImageTest extends FieldTypeTest
                         'The file size cannot exceed %size% byte.',
                         'The file size cannot exceed %size% bytes.',
                         array(
-                            '%size%' => 0.01,
+                            '%size%' => 51200,
                         ),
                         'fileSize'
                     ),
@@ -643,7 +643,7 @@ class ImageTest extends FieldTypeTest
                 array(
                     'validatorConfiguration' => array(
                         'FileSizeValidator' => array(
-                            'maxFileSize' => 1,
+                            'maxFileSize' => 1048576,
                         ),
                     ),
                 ),
@@ -666,7 +666,7 @@ class ImageTest extends FieldTypeTest
                 array(
                     'validatorConfiguration' => array(
                         'FileSizeValidator' => array(
-                            'maxFileSize' => 0.01,
+                            'maxFileSize' => 1,
                         ),
                     ),
                 ),
@@ -685,7 +685,7 @@ class ImageTest extends FieldTypeTest
                         'The file size cannot exceed %size% byte.',
                         'The file size cannot exceed %size% bytes.',
                         array(
-                            '%size%' => 0.01,
+                            '%size%' => 1,
                         ),
                         'fileSize'
                     ),
@@ -697,7 +697,7 @@ class ImageTest extends FieldTypeTest
                 array(
                     'validatorConfiguration' => array(
                         'FileSizeValidator' => array(
-                            'maxFileSize' => 1,
+                            'maxFileSize' => 1048576,
                         ),
                     ),
                 ),
@@ -722,7 +722,7 @@ class ImageTest extends FieldTypeTest
                 array(
                     'validatorConfiguration' => array(
                         'FileSizeValidator' => array(
-                            'maxFileSize' => 1,
+                            'maxFileSize' => 1048576,
                         ),
                     ),
                 ),

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
@@ -222,9 +222,12 @@ EOT;
      */
     public function toStorageFieldDefinition(FieldDefinition $fieldDef, StorageFieldDefinition $storageDef)
     {
-        $storageDef->dataInt1 = (isset($fieldDef->fieldTypeConstraints->validators['FileSizeValidator']['maxFileSize'])
-            ? round($fieldDef->fieldTypeConstraints->validators['FileSizeValidator']['maxFileSize'] / 1024 / 1024)
+        $maxFileSize = (isset($fieldDef->fieldTypeConstraints->validators['FileSizeValidator']['maxFileSize'])
+            ? $fieldDef->fieldTypeConstraints->validators['FileSizeValidator']['maxFileSize']
             : 0);
+
+        $storageDef->dataInt1 = floor($maxFileSize / (1024 * 1024));
+        $storageDef->dataInt2 = $maxFileSize % (1024 * 1024);
     }
 
     /**
@@ -235,13 +238,13 @@ EOT;
      */
     public function toFieldDefinition(StorageFieldDefinition $storageDef, FieldDefinition $fieldDef)
     {
+        $maxFileSize = (int)$storageDef->dataInt1 * (1024 * 1024) + (int)$storageDef->dataInt2;
+
         $fieldDef->fieldTypeConstraints = new FieldTypeConstraints(
             array(
                 'validators' => array(
                     'FileSizeValidator' => array(
-                        'maxFileSize' => ($storageDef->dataInt1 != 0
-                            ? (int)$storageDef->dataInt1 * 1024 * 1024
-                            : null),
+                        'maxFileSize' => ($maxFileSize != 0 ? $maxFileSize : null),
                     ),
                 ),
             )


### PR DESCRIPTION
> JIRA issue: https://jira.ez.no/browse/EZP-26900

This PR is alternative approach to fix EZP-26900 issue in relation to #1952, but it doesn't fix EZP-26901 issue (inconsistency in entering values for Maximum file size).

# Problem description

Currently eZ Platform rounded off "Maximum file size" (MFS) value to 1MB in `ezimage` field type, when field definition is converted between `eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition` and `eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition`: 

| toStorageFieldDefinition          | toFieldDefinition          |
|:---------------------------------:|:--------------------------:|
| `data_int1 = round(MFS / (1024^2))` | `MFS = data_int1 * (1024^2)` |

This behaviour causes that user is unable to set MSF to values like 400KB, 2.5MB etc., because we losing fractional part of megabyte.

# Changes description 

This patch modify way how "Maximum file size" is stored as follows:

* `data_int1` stores integer part of MSF rounded up to 1MB (as before)
* `data_int2` stores fractional part of MSF

Conversion between `eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition` and `eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition` after changes: 

| toStorageFieldDefinition          | toFieldDefinition                        |
|:---------------------------------:|:----------------------------------------:|
| `data_int1 = floor(MFS / (1024^2))` | `MFS = data_int1 * (1024^2) + data_int2`   |
| `data_int2 = MFS % (1024^2)`        |                                          |

Internal representation of example values:

| MFS (MB) | data_int1 | data_int2 |
|---------:|----------:|----------:|
| 0        | 0         | 0         |
| 1        | 1         | 0         |
| 0.5      | 0         | 524288    |
| 1.5      | 1         | 524288    |  
| 203.75   | 203       | 786432    | 

# Backward compatibility

I'm not sure that this kind of change is acceptable from BC perspective. 
