### PR TITLE
Fix ezp 27266 image files not deleted upon content draft removal

### DIFF
--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/LegacyStorage.php
@@ -272,7 +272,7 @@ class LegacyStorage extends Gateway
         $selectQuery = $connection->createSelectQuery();
         $selectQuery->select(
             $selectQuery->expr->count(
-                $connection->quoteColumn('id', 'ezcontentobject_attribute')
+                'DISTINCT' . $connection->quoteColumn('id', 'ezcontentobject_attribute')
             )
         )->from(
             $connection->quoteTable('ezcontentobject_attribute')
@@ -302,7 +302,7 @@ class LegacyStorage extends Gateway
         $statement = $selectQuery->prepare();
         $statement->execute();
 
-        return (int)$statement->fetchColumn() === 0;
+        return (int)$statement->fetchColumn() <= 1;
     }
 
     public function extractFilesFromXml($xml)

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/LegacyStorage.php
@@ -272,7 +272,7 @@ class LegacyStorage extends Gateway
         $selectQuery = $connection->createSelectQuery();
         $selectQuery->select(
             $selectQuery->expr->count(
-                'DISTINCT' . $connection->quoteColumn('id', 'ezcontentobject_attribute')
+                'DISTINCT ' . $connection->quoteColumn('id', 'ezcontentobject_attribute')
             )
         )->from(
             $connection->quoteTable('ezcontentobject_attribute')


### PR DESCRIPTION
**Jira issue**: [https://jira.ez.no/browse/EZP-27266](https://jira.ez.no/browse/EZP-27266)

## **Description**:
Query in `eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway\LegacyStorage::canRemoveImageReference` in insufficient to get proper information about number of rows, because `ezimagefile` and `ezcontentobject_attribute` are related via `ezcontentobject_attribute.id` which **is duplicated** although is auto_incremented. Due to this `COUNT` returns too large quantity and method always returns `false`. 

This PR is a workaround to avoid this behavior and I'm aware that it can be solved in more elegant way. 