### PR TITLE
EZP-27279: Remove Twig 1.x version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,8 +32,7 @@
         "oneup/flysystem-bundle": "^1.0",
         "friendsofsymfony/http-cache-bundle": "~1.2|^1.3.8",
         "sensio/framework-extra-bundle": "~3.0",
-        "jms/translation-bundle": "^1.0",
-        "twig/twig": "^1.0"
+        "jms/translation-bundle": "^1.0"
     },
     "require-dev": {
         "mikey179/vfsStream": "1.1.0",


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-27279

JMS Translation Bundle as of v1.3.2 supports Twig 2.0 (https://github.com/schmittjoh/JMSTranslationBundle/pull/439).

Made against `6.7`, since original PR that limited Twig to 1.x (#1877) was also against this branch.