### PR TITLE
EZP-24852: Add UserReference support in Authentication/User providers

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Security/ReferenceUserInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/ReferenceUserInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * File containing the ReferenceUserInterface class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Security;
+
+/**
+ * Interface for Repository based users, where we only serialize user id / Reference in session values.
+ *
+ * Use of user reference allows us to strip api user on serialization to avoid it being sent to session storage,
+ * as UserProvider calls {@link UserInterface::setAPIUser()} during refresh stage.
+ *
+ * This method and logic implied above will be added to UserInterface in 7.0, where this interface will be deprecated,
+ * so for forward compatibility make sure to also implement the method, even if you don't implement this interface.
+ */
+interface ReferenceUserInterface extends UserInterface
+{
+    /**
+     * @return \eZ\Publish\API\Repository\Values\User\UserReference
+     */
+    public function getAPIUserReference();
+
+    /**
+     * @throws \LogicException If api user has not been refreshed yet by UserProvider after being
+     *         unserialized from session.
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\User
+     */
+    public function getAPIUser();
+}

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RepositoryAuthenticationProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RepositoryAuthenticationProviderTest.php
@@ -72,8 +72,13 @@ class RepositoryAuthenticationProviderTest extends PHPUnit_Framework_TestCase
     public function testCheckAuthenticationCredentialsChanged()
     {
         $apiUser = $this->getMockBuilder('eZ\Publish\API\Repository\Values\User\User')
-            ->setConstructorArgs(array(array('passwordHash' => 'some_encoded_password')))
+            ->setConstructorArgs([['passwordHash' => 'some_encoded_password']])
+            ->setMethods(['getUserId'])
             ->getMockForAbstractClass();
+        $apiUser
+            ->expects($this->once())
+            ->method('getUserId')
+            ->will($this->returnValue(456));
         $tokenUser = new User($apiUser);
         $token = new UsernamePasswordToken($tokenUser, 'foo', 'bar');
 
@@ -98,6 +103,7 @@ class RepositoryAuthenticationProviderTest extends PHPUnit_Framework_TestCase
 
         $apiUser = $this->getMockBuilder('eZ\Publish\API\Repository\Values\User\User')
             ->setConstructorArgs(array(array('passwordHash' => $password)))
+            ->setMethods(['getUserId'])
             ->getMockForAbstractClass();
         $tokenUser = new User($apiUser);
         $token = new UsernamePasswordToken($tokenUser, 'foo', 'bar');

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests;
 
+use eZ\Publish\Core\Repository\Values\User\UserReference;
 use PHPUnit_Framework_TestCase;
 use eZ\Publish\Core\MVC\Symfony\Security\User;
 
@@ -28,8 +29,14 @@ class UserTest extends PHPUnit_Framework_TestCase
                     ),
                 )
             )
+            ->setMethods(['getUserId'])
             ->getMockForAbstractClass();
+
         $roles = array('ROLE_USER');
+        $apiUser
+            ->expects($this->once())
+            ->method('getUserId')
+            ->will($this->returnValue(42));
 
         $user = new User($apiUser, $roles);
         $this->assertSame($apiUser, $user->getAPIUser());
@@ -48,9 +55,8 @@ class UserTest extends PHPUnit_Framework_TestCase
         $userId = 123;
         $apiUser = $this->getMock('eZ\Publish\API\Repository\Values\User\User');
         $apiUser
-            ->expects($this->any())
-            ->method('__get')
-            ->with('id')
+            ->expects($this->once())
+            ->method('getUserId')
             ->will($this->returnValue($userId));
         $roles = array('ROLE_USER');
 
@@ -58,9 +64,8 @@ class UserTest extends PHPUnit_Framework_TestCase
 
         $apiUser2 = $this->getMock('eZ\Publish\API\Repository\Values\User\User');
         $apiUser2
-            ->expects($this->any())
-            ->method('__get')
-            ->with('id')
+            ->expects($this->once())
+            ->method('getUserId')
             ->will($this->returnValue($userId));
         $user2 = new User($apiUser2, array());
 
@@ -71,9 +76,8 @@ class UserTest extends PHPUnit_Framework_TestCase
     {
         $apiUser = $this->getMock('eZ\Publish\API\Repository\Values\User\User');
         $apiUser
-            ->expects($this->any())
-            ->method('__get')
-            ->with('id')
+            ->expects($this->once())
+            ->method('getUserId')
             ->will($this->returnValue(123));
         $roles = array('ROLE_USER');
 
@@ -81,9 +85,8 @@ class UserTest extends PHPUnit_Framework_TestCase
 
         $apiUser2 = $this->getMock('eZ\Publish\API\Repository\Values\User\User');
         $apiUser2
-            ->expects($this->any())
-            ->method('__get')
-            ->with('id')
+            ->expects($this->once())
+            ->method('getUserId')
             ->will($this->returnValue(456));
         $user2 = new User($apiUser2, array());
 
@@ -93,7 +96,11 @@ class UserTest extends PHPUnit_Framework_TestCase
     public function testIsEqualToNotSameUserType()
     {
         $user = new User();
-        $user2 = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $user2 = $this->getMock('eZ\Publish\Core\MVC\Symfony\Security\ReferenceUserInterface');
+        $user2
+            ->expects($this->once())
+            ->method('getAPIUserReference')
+            ->willReturn(new UserReference(456));
         $this->assertFalse($user->isEqualTo($user2));
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests;
 
+use eZ\Publish\Core\MVC\Symfony\Security\ReferenceUserInterface;
 use eZ\Publish\Core\Repository\Values\User\UserReference;
 use PHPUnit_Framework_TestCase;
 use eZ\Publish\Core\MVC\Symfony\Security\User;
@@ -96,7 +97,7 @@ class UserTest extends PHPUnit_Framework_TestCase
     public function testIsEqualToNotSameUserType()
     {
         $user = new User();
-        $user2 = $this->getMock('eZ\Publish\Core\MVC\Symfony\Security\ReferenceUserInterface');
+        $user2 = $this->getMock(ReferenceUserInterface::class);
         $user2
             ->expects($this->once())
             ->method('getAPIUserReference')

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserWrappedTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserWrappedTest.php
@@ -8,8 +8,10 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests;
 
+use eZ\Publish\Core\MVC\Symfony\Security\UserInterface;
 use eZ\Publish\Core\MVC\Symfony\Security\UserWrapped;
 use PHPUnit_Framework_TestCase;
+use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\User;
 
 class UserWrappedTest extends PHPUnit_Framework_TestCase
@@ -127,7 +129,7 @@ class UserWrappedTest extends PHPUnit_Framework_TestCase
 
     public function testIsEqualTo()
     {
-        $originalUser = $this->getMock('eZ\Publish\Core\MVC\Symfony\Security\User');
+        $originalUser = $this->getMock('eZ\Publish\Core\MVC\Symfony\Security\Tests\UserEquatableInterface');
         $user = new UserWrapped($originalUser, $this->apiUser);
         $otherUser = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
         $originalUser
@@ -137,4 +139,11 @@ class UserWrappedTest extends PHPUnit_Framework_TestCase
             ->will($this->returnValue(false));
         $this->assertFalse($user->isEqualTo($otherUser));
     }
+}
+
+/**
+ * @internal For use with tests only
+ */
+interface UserEquatableInterface extends UserInterface, EquatableInterface
+{
 }

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserWrappedTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserWrappedTest.php
@@ -129,7 +129,7 @@ class UserWrappedTest extends PHPUnit_Framework_TestCase
 
     public function testIsEqualTo()
     {
-        $originalUser = $this->getMock('eZ\Publish\Core\MVC\Symfony\Security\Tests\UserEquatableInterface');
+        $originalUser = $this->getMock(UserEquatableInterface::class);
         $user = new UserWrapped($originalUser, $this->apiUser);
         $otherUser = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
         $originalUser

--- a/eZ/Publish/Core/MVC/Symfony/Security/User/Provider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/User/Provider.php
@@ -12,6 +12,7 @@ use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\Core\MVC\Symfony\Security\User;
 use eZ\Publish\Core\MVC\Symfony\Security\UserInterface;
+use eZ\Publish\Core\MVC\Symfony\Security\ReferenceUserInterface;
 use eZ\Publish\API\Repository\Values\User\User as APIUser;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\User\UserInterface as CoreUserInterface;
@@ -80,7 +81,11 @@ class Provider implements APIUserProviderInterface
         }
 
         try {
-            $refreshedAPIUser = $this->repository->getUserService()->loadUser($user->getAPIUser()->id);
+            $refreshedAPIUser = $this->repository->getUserService()->loadUser(
+                $user instanceof ReferenceUserInterface ?
+                $user->getAPIUserReference()->getUserId() :
+                $user->getAPIUser()->id
+            );
             $user->setAPIUser($refreshedAPIUser);
             $this->repository->setCurrentUser($refreshedAPIUser);
 

--- a/eZ/Publish/Core/MVC/Symfony/Security/UserInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserInterface.php
@@ -22,7 +22,7 @@ interface UserInterface extends AdvancedUserInterface
     public function getAPIUser();
 
     /**
-     * @deprecated Will be replaced {@link ReferenceUserInterface::getAPIUser()} in 7.0.
+     * @deprecated Will be replaced by {@link ReferenceUserInterface::getAPIUser()}, adding LogicException to signature.
      *
      * @param \eZ\Publish\API\Repository\Values\User\User $apiUser
      */

--- a/eZ/Publish/Core/MVC/Symfony/Security/UserInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserInterface.php
@@ -22,6 +22,8 @@ interface UserInterface extends AdvancedUserInterface
     public function getAPIUser();
 
     /**
+     * @deprecated Will be replaced {@link ReferenceUserInterface::getAPIUser()} in 7.0.
+     *
      * @param \eZ\Publish\API\Repository\Values\User\User $apiUser
      */
     public function setAPIUser(APIUser $apiUser);

--- a/eZ/Publish/Core/REST/Server/Security/RestAuthenticator.php
+++ b/eZ/Publish/Core/REST/Server/Security/RestAuthenticator.php
@@ -193,7 +193,7 @@ class RestAuthenticator implements ListenerInterface, AuthenticatorInterface
             return false;
         }
 
-        $wasAnonymous = $previousUser->getAPIUser()->id == $this->configResolver->getParameter('anonymous_user_id');
+        $wasAnonymous = $previousUser->getAPIUser()->getUserId() == $this->configResolver->getParameter('anonymous_user_id');
         // TODO: isEqualTo is not on the interface
         return !$wasAnonymous && !$user->isEqualTo($previousUser);
     }

--- a/eZ/Publish/Core/REST/Server/Tests/Security/RestSessionBasedAuthenticatorTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Security/RestSessionBasedAuthenticatorTest.php
@@ -210,8 +210,7 @@ class RestSessionBasedAuthenticatorTest extends PHPUnit_Framework_TestCase
         $apiUser = $this->getMock('eZ\Publish\API\Repository\Values\User\User');
         $apiUser
             ->expects($this->any())
-            ->method('__get')
-            ->with('id')
+            ->method('getUserId')
             ->will($this->returnValue($userId));
 
         return new EzUser($apiUser);


### PR DESCRIPTION
> JIRA:  https://jira.ez.no/browse/EZP-24852

As we anyway always refresh APIUser on load, this changes our symfony User to not serialize APIUser to session anymore to reduce size of session being serialized back and forth.

On top of that make sure WrappedUser does not get self or User injected to avoid possibility of wrong use and bloated session value.

