### PR TITLE
Fix EZP-27152: show REST exceptions in Symfony profiler

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/EventListener/ResponseListener.php
+++ b/eZ/Bundle/EzPublishRestBundle/EventListener/ResponseListener.php
@@ -42,7 +42,7 @@ class ResponseListener implements EventSubscriberInterface
         return array(
             KernelEvents::VIEW => 'onKernelResultView',
             // Must happen BEFORE the Core ExceptionListener.
-            KernelEvents::EXCEPTION => ['onKernelExceptionView', 20],
+            KernelEvents::EXCEPTION => ['onKernelExceptionView', -5],
         );
     }
 
@@ -81,6 +81,5 @@ class ResponseListener implements EventSubscriberInterface
                 $event->getException()
             )
         );
-        $event->stopPropagation();
     }
 }

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/value_object_visitors.yml
@@ -174,6 +174,7 @@ services:
         arguments: [ "%kernel.debug%", "@translator" ]
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Exceptions\NotFoundException }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Symfony\Component\HttpKernel\Exception\NotFoundHttpException }
 
     ezpublish_rest.output.value_object_visitor.UnauthorizedException:
         parent: ezpublish_rest.output.value_object_visitor.base
@@ -181,6 +182,7 @@ services:
         arguments: [ "%kernel.debug%", "@translator" ]
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Exceptions\UnauthorizedException }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Symfony\Component\Security\Core\Exception\AccessDeniedException }
 
     ezpublish_rest.output.value_object_visitor.BadStateException:
         parent: ezpublish_rest.output.value_object_visitor.base
@@ -188,6 +190,7 @@ services:
         arguments: [ "%kernel.debug%", "@translator" ]
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Exceptions\BadStateException }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Symfony\Component\HttpKernel\Exception\BadRequestHttpException }
 
     ezpublish_rest.output.value_object_visitor.BadRequestException:
         parent: ezpublish_rest.output.value_object_visitor.base
@@ -196,6 +199,7 @@ services:
         tags:
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Server\Exceptions\BadRequestException }
             - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\REST\Common\Exceptions\Parser }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Symfony\Component\HttpKernel\Exception\BadRequestHttpException }
 
     ezpublish_rest.output.value_object_visitor.ContentFieldValidationException:
         parent: ezpublish_rest.output.value_object_visitor.BadRequestException


### PR DESCRIPTION
> Fixes [EZP-27152](https://jira.ez.no/browse/EZP-27152)

The REST exception handler had a priority higher than the Symfony Profiler's, and stops event propagation.

![Sf profiler exceptions](https://cloud.githubusercontent.com/assets/235928/25377511/1338593c-29a8-11e7-9512-d7731214521e.png)

The fix moves the REST exception listener further down the listeners list. Since it sets a Response on the event, and doing that stops propagation, it needs to happen _after_ the profiler listener.

Furthermore, since the Core Exception listener will wrap REST exceptions into Symfony ones, those it maps to have been added to the REST value object visitors for exceptions to that the HTTP code is correct.

### TODO
- [ ] Cover travis failures (likely case of unmapped exceptions)