### PR TITLE
EZP-27297: Wrong Path Format in PreviewLocationProvider

### DIFF
--- a/eZ/Publish/Core/Helper/PreviewLocationProvider.php
+++ b/eZ/Publish/Core/Helper/PreviewLocationProvider.php
@@ -76,7 +76,7 @@ class PreviewLocationProvider
                     'status' => Location::STATUS_DRAFT,
                     'parentLocationId' => $parentLocations[0]->id,
                     'depth' => $parentLocations[0]->depth + 1,
-                    'pathString' => $parentLocations[0]->pathString . '/x',
+                    'pathString' => $parentLocations[0]->pathString . 'x/',
                 )
             );
         }


### PR DESCRIPTION
Ticket: https://jira.ez.no/browse/EZP-27297
The function **loadMainLocation** in **PreviewLocationProvider** returns a wrong path format:
- returns **"/1/2//x"** instead of **"/1/2/x/"**

