### PR TITLE
EZP-27296: Ignore facetBuilders in LegacySE, don't throw

### DIFF
--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/FacetContentType.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/FacetContentType.php
@@ -1,0 +1,40 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(array(
+   'facets' => 
+  array (
+  ),
+   'searchHits' => 
+  array (
+    0 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 57,
+        'title' => 'Home',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => 'eng-GB',
+       'highlight' => NULL,
+    )),
+    1 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 58,
+        'title' => 'Contact Us',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => 'eng-GB',
+       'highlight' => NULL,
+    )),
+  ),
+   'spellSuggestion' => NULL,
+   'time' => 1,
+   'timedOut' => NULL,
+   'maxScore' => NULL,
+   'totalCount' => 2,
+));
+

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/FacetContentTypeMinCount.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/FacetContentTypeMinCount.php
@@ -1,0 +1,40 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(array(
+   'facets' => 
+  array (
+  ),
+   'searchHits' => 
+  array (
+    0 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 57,
+        'title' => 'Home',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => 'eng-GB',
+       'highlight' => NULL,
+    )),
+    1 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 58,
+        'title' => 'Contact Us',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => 'eng-GB',
+       'highlight' => NULL,
+    )),
+  ),
+   'spellSuggestion' => NULL,
+   'time' => 1,
+   'timedOut' => NULL,
+   'maxScore' => NULL,
+   'totalCount' => 2,
+));
+

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/FacetContentTypeMinLimit.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/FacetContentTypeMinLimit.php
@@ -1,0 +1,40 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(array(
+   'facets' => 
+  array (
+  ),
+   'searchHits' => 
+  array (
+    0 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 57,
+        'title' => 'Home',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => 'eng-GB',
+       'highlight' => NULL,
+    )),
+    1 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 58,
+        'title' => 'Contact Us',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => 'eng-GB',
+       'highlight' => NULL,
+    )),
+  ),
+   'spellSuggestion' => NULL,
+   'time' => 1,
+   'timedOut' => NULL,
+   'maxScore' => NULL,
+   'totalCount' => 2,
+));
+

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/FacetFieldRegexp.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/FacetFieldRegexp.php
@@ -1,0 +1,40 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(array(
+   'facets' => 
+  array (
+  ),
+   'searchHits' => 
+  array (
+    0 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 57,
+        'title' => 'Home',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => 'eng-GB',
+       'highlight' => NULL,
+    )),
+    1 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 58,
+        'title' => 'Contact Us',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => 'eng-GB',
+       'highlight' => NULL,
+    )),
+  ),
+   'spellSuggestion' => NULL,
+   'time' => 1,
+   'timedOut' => NULL,
+   'maxScore' => NULL,
+   'totalCount' => 2,
+));
+

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/FacetFieldRegexpSortCount.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/FacetFieldRegexpSortCount.php
@@ -1,0 +1,40 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(array(
+   'facets' => 
+  array (
+  ),
+   'searchHits' => 
+  array (
+    0 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 57,
+        'title' => 'Home',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => 'eng-GB',
+       'highlight' => NULL,
+    )),
+    1 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 58,
+        'title' => 'Contact Us',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => 'eng-GB',
+       'highlight' => NULL,
+    )),
+  ),
+   'spellSuggestion' => NULL,
+   'time' => 1,
+   'timedOut' => NULL,
+   'maxScore' => NULL,
+   'totalCount' => 2,
+));
+

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/FacetFieldRegexpSortTerm.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/FacetFieldRegexpSortTerm.php
@@ -1,0 +1,40 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(array(
+   'facets' => 
+  array (
+  ),
+   'searchHits' => 
+  array (
+    0 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 57,
+        'title' => 'Home',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => 'eng-GB',
+       'highlight' => NULL,
+    )),
+    1 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 58,
+        'title' => 'Contact Us',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => 'eng-GB',
+       'highlight' => NULL,
+    )),
+  ),
+   'spellSuggestion' => NULL,
+   'time' => 1,
+   'timedOut' => NULL,
+   'maxScore' => NULL,
+   'totalCount' => 2,
+));
+

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/FacetFieldSimple.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/FacetFieldSimple.php
@@ -1,0 +1,40 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(array(
+   'facets' => 
+  array (
+  ),
+   'searchHits' => 
+  array (
+    0 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 57,
+        'title' => 'Home',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => 'eng-GB',
+       'highlight' => NULL,
+    )),
+    1 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 58,
+        'title' => 'Contact Us',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => 'eng-GB',
+       'highlight' => NULL,
+    )),
+  ),
+   'spellSuggestion' => NULL,
+   'time' => 1,
+   'timedOut' => NULL,
+   'maxScore' => NULL,
+   'totalCount' => 2,
+));
+

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/FacetSection.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/FacetSection.php
@@ -1,0 +1,40 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(array(
+   'facets' => 
+  array (
+  ),
+   'searchHits' => 
+  array (
+    0 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 57,
+        'title' => 'Home',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => 'eng-GB',
+       'highlight' => NULL,
+    )),
+    1 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 58,
+        'title' => 'Contact Us',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => 'eng-GB',
+       'highlight' => NULL,
+    )),
+  ),
+   'spellSuggestion' => NULL,
+   'time' => 1,
+   'timedOut' => NULL,
+   'maxScore' => NULL,
+   'totalCount' => 2,
+));
+

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/FacetTerm.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/FacetTerm.php
@@ -1,0 +1,40 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(array(
+   'facets' => 
+  array (
+  ),
+   'searchHits' => 
+  array (
+    0 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 57,
+        'title' => 'Home',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => 'eng-GB',
+       'highlight' => NULL,
+    )),
+    1 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 58,
+        'title' => 'Contact Us',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => 'eng-GB',
+       'highlight' => NULL,
+    )),
+  ),
+   'spellSuggestion' => NULL,
+   'time' => 1,
+   'timedOut' => NULL,
+   'maxScore' => NULL,
+   'totalCount' => 2,
+));
+

--- a/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/FacetUser.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/FacetUser.php
@@ -1,0 +1,40 @@
+<?php
+
+return eZ\Publish\API\Repository\Values\Content\Search\SearchResult::__set_state(array(
+   'facets' => 
+  array (
+  ),
+   'searchHits' => 
+  array (
+    0 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 57,
+        'title' => 'Home',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => 'eng-GB',
+       'highlight' => NULL,
+    )),
+    1 => 
+    eZ\Publish\API\Repository\Values\Content\Search\SearchHit::__set_state(array(
+       'valueObject' => 
+      array (
+        'id' => 58,
+        'title' => 'Contact Us',
+      ),
+       'score' => NULL,
+       'index' => NULL,
+       'matchedTranslation' => 'eng-GB',
+       'highlight' => NULL,
+    )),
+  ),
+   'spellSuggestion' => NULL,
+   'time' => 1,
+   'timedOut' => NULL,
+   'maxScore' => NULL,
+   'totalCount' => 2,
+));
+

--- a/eZ/Publish/API/Repository/Values/Content/Query.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query.php
@@ -60,6 +60,9 @@ class Query extends ValueObject
     /**
      * An array of facet builders.
      *
+     * Search engines may ignore any, or given facet builders they don't support and will just return search result
+     * facets supported by the engine. API consumer should dynamically iterate over returned facets for further use.
+     *
      * @var \eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder[]
      */
     public $facetBuilders = array();

--- a/eZ/Publish/Core/Search/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Handler.php
@@ -154,10 +154,6 @@ class Handler implements SearchHandlerInterface
         $query->filter = $query->filter ?: new Criterion\MatchAll();
         $query->query = $query->query ?: new Criterion\MatchAll();
 
-        if (count($query->facetBuilders)) {
-            throw new NotImplementedException('Facets are not supported by the legacy search engine.');
-        }
-
         // The legacy search does not know about scores, so that we just
         // combine the query with the filter
         $filter = new Criterion\LogicalAnd(array($query->query, $query->filter));
@@ -271,10 +267,6 @@ class Handler implements SearchHandlerInterface
         $start = microtime(true);
         $query->filter = $query->filter ?: new Criterion\MatchAll();
         $query->query = $query->query ?: new Criterion\MatchAll();
-
-        if (count($query->facetBuilders)) {
-            throw new NotImplementedException('Facets are not supported by the legacy search engine.');
-        }
 
         // The legacy search does not know about scores, so we just
         // combine the query with the filter


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-27296

Adapt Legach Search engine and clarify API doc.
This is done to avoid consumer code having to check what searc henigne is in use and conditionally
apply facet builders.


Integration tests before this change:
```
Tests: 6157, Assertions: 10137, Skipped: 4927, Incomplete: 6.
```

After change 20 of the skipped became incomplete, and by generating fixtures for the expected behaviour we now have:
```

Tests: 6157, Assertions: 10157, Skipped: 4907, Incomplete: 6.
```