### PR TITLE
EZP-27308: Remove deprecated usage of Symfony services

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
@@ -41,7 +41,7 @@ services:
         abstract: true
         calls:
             - [setRequestContext, ["@router.request_context"]]
-            - [setSiteAccess, ["@?ezpublish.siteaccess="]]
+            - [setSiteAccess, ["@?ezpublish.siteaccess"]]
             - [setSiteAccessRouter, ["@ezpublish.siteaccess_router"]]
             - [setLogger, ["@?logger"]]
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -188,7 +188,7 @@ services:
 
     ezpublish.twig.extension.image:
         class: "%ezpublish.twig.extension.image.class%"
-        arguments: ["@ezpublish.fieldtype.ezimage.variation_service"]
+        arguments: ["@ezpublish.fieldType.ezimage.variation_service"]
         tags:
             - { name: twig.extension }
 

--- a/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
+++ b/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
@@ -79,7 +79,7 @@ services:
     ezpublish.core.io.stream_file_listener:
         class: "%ezpublish.core.io.stream_file_listener.class%"
         arguments:
-            - "@ezpublish.fieldtype.ezimage.io_service"
+            - "@ezpublish.fieldType.ezimage.io_service"
             - "@ezpublish.config.resolver"
         tags:
             - { name: kernel.event_subscriber }

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
@@ -678,7 +678,7 @@ services:
         arguments:
             - "@ezpublish_rest.parser_tools"
             - "@ezpublish.api.service.content"
-            - "@ezpublish_rest.input.parser.versioninfo"
+            - "@ezpublish_rest.input.parser.VersionInfo"
             - "@ezpublish_rest.field_type_parser"
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.Content }


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-27308

Non strict service references are not used any more, and service names will become case sensitive in later Symfony versions.