### PR TITLE
EZP-25946: Procedure to migrate existing images/binaries to another IO adapter

### DIFF
--- a/doc/specifications/io/io_migration_script.md
+++ b/doc/specifications/io/io_migration_script.md
@@ -1,0 +1,75 @@
+# IO migration
+
+> Added in 6.10
+
+**NB: This feature is experimental, for the time being. Use with caution!**
+
+### Context
+This document describes a command script that can migrate binary files
+from an IO repository to another.
+
+A common use-case is to migrate local files, stored with the default IO
+configuration, to a new IO configuration.
+
+We will consider the following IO configuration for this document:
+
+```yaml
+ez_io:
+    binarydata_handlers:
+        # native binarydata handler, filesystem
+        default:
+        nfs:
+            flysystem:
+                adapter: nfs_adapter
+        aws_s3:
+    metadata_handlers:
+        # native metadata handler, filesystem
+        default:
+        dfs:
+            legacy_dfs_cluster:
+                connection: doctrine.dbal.dfs_connection
+        aws_s3:
+
+ezpublish:
+    system:
+        default:
+            io:
+                metadata_handler: dfs
+                binarydata_handler: nfs
+```
+
+### Console script
+Migrating is done by running the `ezplatform:io:migrate-files` console script
+from one set of io handlers to another:
+```
+php app/console ezplatform:io:migrate-files
+--from=<from_metadata_handler>,<from_binarydata_handler>
+--to=<to_metadata_handler>,<to_binarydata_handler>
+```
+
+Migration expects that IO handlers specified in the `from` and `to` 
+arguments are configured in the `ez_io` section.
+
+Without any argument, the command migrates files from the `default`
+io handlers, which use the filesystem for storage, to the first defined
+non-default io handlers. With the configuration above, executing the script
+without any argument would be like running:
+
+`php app/console ezplatform:io:migrate-files --from=default,default --to=nfs,dfs`
+
+In most cases, once io has been configured, existing files can be migrated
+by running the command without any argument.
+
+By using different arguments, any kind of migration is possible. This would
+migrate files from DFS to AWS/S3.
+`php app/console ezplatform:io:migrate-files --from=nfs,dfs --to=aws_s3,aws_s3`
+
+Other script options are:
+```
+--list-io-handlers         List available IO handlers
+--bulk-count=BULK-COUNT    Number of files processed at once [default: 100]
+--dry-run                  Execute a dry run
+```
+
+Script logging follows common settings, i.e. by default the migration will be
+logged if you use `--env=dev`.

--- a/eZ/Bundle/EzPublishIOBundle/Command/MigrateFilesCommand.php
+++ b/eZ/Bundle/EzPublishIOBundle/Command/MigrateFilesCommand.php
@@ -1,0 +1,314 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\Command;
+
+use eZ\Bundle\EzPublishIOBundle\Migration\FileListerRegistry;
+use eZ\Bundle\EzPublishIOBundle\Migration\FileMigratorInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+final class MigrateFilesCommand extends Command
+{
+    /** @var mixed Configuration for metadata handlers */
+    private $configuredMetadataHandlers;
+
+    /** @var mixed Configuration for binary data handlers */
+    private $configuredBinarydataHandlers;
+
+    /** @var \eZ\Bundle\EzPublishIOBundle\Migration\FileListerRegistry */
+    private $fileListerRegistry;
+
+    /** @var \eZ\Bundle\EzPublishIOBundle\Migration\FileListerInterface[] */
+    private $fileListers;
+
+    /** @var \eZ\Bundle\EzPublishIOBundle\Migration\FileMigratorInterface */
+    private $fileMigrator;
+
+    public function __construct(
+        array $configuredMetadataHandlers,
+        array $configuredBinarydataHandlers,
+        FileListerRegistry $fileListerRegistry,
+        FileMigratorInterface $fileMigrator
+    ) {
+        $this->configuredMetadataHandlers = $configuredMetadataHandlers;
+        $this->configuredBinarydataHandlers = $configuredBinarydataHandlers;
+        if (!array_key_exists('default', $this->configuredMetadataHandlers)) {
+            $this->configuredMetadataHandlers['default'] = [];
+        }
+        if (!array_key_exists('default', $this->configuredBinarydataHandlers)) {
+            $this->configuredBinarydataHandlers['default'] = [];
+        }
+
+        $this->fileListerRegistry = $fileListerRegistry;
+        $this->fileMigrator = $fileMigrator;
+
+        foreach ($this->fileListerRegistry->getIdentifiers() as $fileListerIdentifier) {
+            $this->fileListers[] = $this->fileListerRegistry->getItem($fileListerIdentifier);
+        }
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('ezplatform:io:migrate-files')
+            ->setDescription('Migrates files from one IO repository to another')
+            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Migrate from <from_metadata_handler>,<from_binarydata_handler>')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'Migrate to <to_metadata_handler>,<to_binarydata_handler>')
+            ->addOption('list-io-handlers', null, InputOption::VALUE_NONE, 'List available IO handlers')
+            ->addOption('bulk-count', null, InputOption::VALUE_REQUIRED, 'Number of files processed at once', 100)
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Execute a dry run')
+            ->setHelp(
+                <<<EOT
+The command <info>%command.name%</info> migrates files from one IO repository
+to another. It can for example be used to migrate local files from the default
+IO configuration to a new IO configuration, like a clustered setup.
+
+<fg=red>NB: This command is experimental. Use with caution!</>
+
+The <info>--from</info> and <info>--to</info> values must be specified as <info><metadata_handler>,<binarydata_handler></info>.
+If <info>--from</info> is omitted, the default IO configuration will be used.
+If <info>--to</info> is omitted, the first non-default IO configuration will be used.
+
+<fg=red>During the script execution the files should not be modified. To avoid
+surprises you are advised to create a backup and/or execute a dry run before
+proceeding with actual update.</>
+
+Since this script can potentially run for a very long time, to avoid memory
+exhaustion run it in production environment using <info>--env=prod</info> switch.
+
+EOT
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ($input->getOption('list-io-handlers')) {
+            $this->outputConfiguredHandlers($output);
+
+            return;
+        }
+
+        $bulkCount = (int)$input->getOption('bulk-count');
+        if ($bulkCount < 1) {
+            $output->writeln('The value for --bulk-count must be a positive integer.');
+
+            return;
+        }
+
+        $output->writeln($this->getProcessedHelp());
+
+        $fromHandlers = $input->getOption('from') ? explode(',', $input->getOption('from')) : null;
+        $toHandlers = $input->getOption('to') ? explode(',', $input->getOption('to')) : null;
+
+        if (!$fromHandlers) {
+            $fromHandlers = ['default', 'default'];
+        }
+        if (!$toHandlers) {
+            $toHandlers = [
+                array_keys($this->configuredMetadataHandlers)[0],
+                array_keys($this->configuredBinarydataHandlers)[0],
+            ];
+        }
+
+        if (!$this->validateHandlerOptions($fromHandlers, $toHandlers, $output)) {
+            return;
+        }
+
+        $output->writeln([
+            "Migrating from '$fromHandlers[0],$fromHandlers[1]' to '$toHandlers[0],$toHandlers[1]'",
+            '',
+        ]);
+
+        $totalCount = 0;
+        foreach ($this->fileListers as $fileLister) {
+            $fileLister->setIODataHandlersByIdentifiers(
+                $fromHandlers[0],
+                $fromHandlers[1],
+                $toHandlers[0],
+                $toHandlers[1]
+            );
+
+            $totalCount += $fileLister->countFiles();
+        }
+        $this->fileMigrator->setIODataHandlersByIdentifiers(
+            $fromHandlers[0],
+            $fromHandlers[1],
+            $toHandlers[0],
+            $toHandlers[1]
+        );
+
+        $output->writeln([
+            'Total number of files to migrate: ' . ($totalCount === null ? 'unknown' : $totalCount),
+            'This number does not include image aliases, but they will also be migrated.',
+            '',
+        ]);
+
+        if ($totalCount === 0) {
+            $output->writeln('Nothing to process.');
+
+            return;
+        }
+
+        $helper = $this->getHelper('question');
+        $question = new ConfirmationQuestion(
+            '<question>Are you sure you want to proceed?</question> ',
+            false
+        );
+
+        if (!$helper->ask($input, $output, $question)) {
+            $output->writeln('Aborting.');
+
+            return;
+        }
+
+        $this->migrateFiles(
+            $totalCount,
+            $bulkCount,
+            $input->getOption('dry-run'),
+            $output
+        );
+    }
+
+    /**
+     * Output the configured meta/binary data handlers.
+     *
+     * @param OutputInterface $output
+     */
+    protected function outputConfiguredHandlers(OutputInterface $output)
+    {
+        $output->writeln(
+            'Configured meta data handlers: ' . implode(', ', array_keys($this->configuredMetadataHandlers))
+        );
+        $output->writeln(
+            'Configured binary data handlers: ' . implode(', ', array_keys($this->configuredBinarydataHandlers))
+        );
+    }
+
+    /**
+     * Verify that the handler options have been set to meaningful values.
+     *
+     * @param mixed $fromHandlers
+     * @param mixed $toHandlers
+     * @param OutputInterface $output
+     * @return bool
+     */
+    protected function validateHandlerOptions(
+        $fromHandlers,
+        $toHandlers,
+        OutputInterface $output
+    ) {
+        foreach (['From' => $fromHandlers, 'To' => $toHandlers] as $direction => $handlers) {
+            $lowerDirection = strtolower($direction);
+            if (count($handlers) !== 2) {
+                $output->writeln(
+                    "Enter two comma separated values for the --$lowerDirection option: " .
+                    "<{$lowerDirection}_metadata_handler>,<{$lowerDirection}_binarydata_handler>"
+                );
+
+                return false;
+            }
+
+            foreach (['meta' => $handlers[0], 'binary' => $handlers[1]] as $fileDataType => $handler) {
+                if (!in_array($handler, array_keys(
+                    $fileDataType === 'meta' ? $this->configuredMetadataHandlers : $this->configuredBinarydataHandlers
+                ))) {
+                    $output->writeln("$direction $fileDataType data handler '$handler' is not configured.");
+                    $this->outputConfiguredHandlers($output);
+
+                    return false;
+                }
+            }
+        }
+
+        if ($fromHandlers === $toHandlers) {
+            $output->writeln('From and to handlers are the same. Nothing to do.');
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Migrate files.
+     *
+     * @param int|null $totalFileCount Total count of files, null if unknown
+     * @param int $bulkCount Number of files to process in each batch
+     * @param bool $dryRun
+     * @param OutputInterface $output
+     */
+    protected function migrateFiles(
+        $totalFileCount = null,
+        $bulkCount,
+        $dryRun,
+        OutputInterface $output
+    ) {
+        $progress = new ProgressBar($output, $totalFileCount);
+        if ($totalFileCount) {
+            $progress->setFormat("%message%\n %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s%");
+        } else {
+            $progress->setFormat("%message%\n %current% [%bar%] %elapsed:6s% %memory:6s%");
+        }
+
+        $output->writeln('');
+        $progress->setMessage('Starting migration...');
+        $progress->start();
+
+        $elapsedFileCount = 0;
+        $timestamp = microtime(true);
+        $updateFrequency = 1;
+
+        foreach ($this->fileListers as $fileLister) {
+            $pass = 0;
+            do {
+                $metadataList = $fileLister->loadMetadataList($bulkCount, $pass * $bulkCount);
+
+                foreach ($metadataList as $metadata) {
+                    if (!$dryRun) {
+                        $this->fileMigrator->migrateFile($metadata);
+                    }
+
+                    $progress->setMessage('Updated file ' . $metadata->id);
+                    $progress->advance();
+                    ++$elapsedFileCount;
+
+                    // Magic that ensures the progressbar is updated ca. once per second
+                    if (($elapsedFileCount % $updateFrequency) === 0) {
+                        $newTimestamp = microtime(true);
+                        if ($newTimestamp - $timestamp > 0.5 && $updateFrequency > 1) {
+                            $updateFrequency = (int)($updateFrequency / 2);
+                            $progress->setRedrawFrequency($updateFrequency);
+                        } elseif ($newTimestamp - $timestamp < 0.1 && $updateFrequency < 10000) {
+                            $updateFrequency = $updateFrequency * 2;
+                            $progress->setRedrawFrequency($updateFrequency);
+                        }
+                        $timestamp = $newTimestamp;
+                    }
+                }
+
+                ++$pass;
+            } while (count($metadataList) > 0);
+        }
+
+        $progress->setMessage('');
+        $progress->finish();
+
+        $output->writeln("\n\nFinished processing $elapsedFileCount files.");
+        if ($totalFileCount && $totalFileCount > $elapsedFileCount) {
+            $output->writeln([
+                'Files that could not be migrated: ' . ($totalFileCount - $elapsedFileCount),
+                '',
+            ]);
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishIOBundle/DependencyInjection/Compiler/MigrationFileListerPass.php
+++ b/eZ/Bundle/EzPublishIOBundle/DependencyInjection/Compiler/MigrationFileListerPass.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class MigrationFileListerPass implements CompilerPassInterface
+{
+    /**
+     * Registers the FileListerInterface into the file lister registry.
+     *
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('ezpublish.core.io.migration.file_lister_registry')) {
+            return;
+        }
+
+        $fileListersTagged = $container->findTaggedServiceIds('ezpublish.core.io.migration.file_lister');
+
+        $fileListers = [];
+        foreach ($fileListersTagged as $id => $tags) {
+            foreach ($tags as $attributes) {
+                $fileListers[$attributes['identifier']] = new Reference($id);
+            }
+        }
+
+        $fileListerRegistryDef = $container->findDefinition('ezpublish.core.io.migration.file_lister_registry');
+        $fileListerRegistryDef->setArguments([$fileListers]);
+    }
+}

--- a/eZ/Bundle/EzPublishIOBundle/EzPublishIOBundle.php
+++ b/eZ/Bundle/EzPublishIOBundle/EzPublishIOBundle.php
@@ -28,6 +28,7 @@ class EzPublishIOBundle extends Bundle
                 $extension->getBinarydataHandlerFactories()
             )
         );
+        $container->addCompilerPass(new Compiler\MigrationFileListerPass());
         parent::build($container);
     }
 

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/BinaryFileLister.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/BinaryFileLister.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\Migration\FileLister;
+
+use eZ\Bundle\EzPublishIOBundle\ApiLoader\HandlerFactory;
+use eZ\Bundle\EzPublishIOBundle\Migration\FileListerInterface;
+use eZ\Bundle\EzPublishIOBundle\Migration\MigrationHandler;
+use eZ\Publish\Core\IO\Exception\BinaryFileNotFoundException;
+use Iterator;
+use LimitIterator;
+use Psr\Log\LoggerInterface;
+
+final class BinaryFileLister extends MigrationHandler implements FileListerInterface
+{
+    /** @var \eZ\Bundle\EzPublishIOBundle\Migration\FileLister\FileIteratorInterface */
+    private $fileList;
+
+    /** @var string Directory where files are stored, within the storage dir. Example: 'original' */
+    private $filesDir;
+
+    /**
+     * @param \eZ\Bundle\EzPublishIOBundle\ApiLoader\HandlerFactory $metadataHandlerFactory
+     * @param \eZ\Bundle\EzPublishIOBundle\ApiLoader\HandlerFactory $binarydataHandlerFactory
+     * @param \Psr\Log\LoggerInterface $logger
+     * @param \Iterator $fileList
+     * @param string $filesDir Directory where files are stored, within the storage dir. Example: 'original'
+     */
+    public function __construct(
+        HandlerFactory $metadataHandlerFactory,
+        HandlerFactory $binarydataHandlerFactory,
+        LoggerInterface $logger = null,
+        Iterator $fileList,
+        $filesDir
+    ) {
+        $this->fileList = $fileList;
+        $this->filesDir = $filesDir;
+
+        $this->fileList->rewind();
+
+        parent::__construct($metadataHandlerFactory, $binarydataHandlerFactory, $logger);
+    }
+
+    public function countFiles()
+    {
+        return count($this->fileList);
+    }
+
+    public function loadMetadataList($limit = null, $offset = null)
+    {
+        $metadataList = [];
+        $fileLimitList = new LimitIterator($this->fileList, $offset, $limit);
+
+        foreach ($fileLimitList as $fileId) {
+            try {
+                $metadataList[] = $this->fromMetadataHandler->load($this->filesDir . '/' . $fileId);
+            } catch (BinaryFileNotFoundException $e) {
+                $this->logMissingFile($fileId);
+
+                continue;
+            }
+        }
+
+        return $metadataList;
+    }
+}

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/BinaryFileLister.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/BinaryFileLister.php
@@ -14,7 +14,7 @@ use Iterator;
 use LimitIterator;
 use Psr\Log\LoggerInterface;
 
-final class BinaryFileLister extends MigrationHandler implements FileListerInterface
+class BinaryFileLister extends MigrationHandler implements FileListerInterface
 {
     /** @var \eZ\Bundle\EzPublishIOBundle\Migration\FileLister\FileIteratorInterface */
     private $fileList;

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileIterator/LegacyStorageFileIterator.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileIterator/LegacyStorageFileIterator.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\Migration\FileLister\FileIterator;
+
+use eZ\Bundle\EzPublishIOBundle\Migration\FileLister\FileRowReaderInterface;
+use eZ\Bundle\EzPublishIOBundle\Migration\FileLister\FileIteratorInterface;
+
+/**
+ * Iterator for entries in legacy's file tables.
+ *
+ * The returned items are filename of binary/media files (video/87c2bfd00.wmv).
+ */
+final class LegacyStorageFileIterator implements FileIteratorInterface
+{
+    /** @var mixed Last fetched item. */
+    private $item;
+
+    /** @var int Iteration cursor on $statement. */
+    private $cursor;
+
+    /** @var \eZ\Bundle\EzPublishIOBundle\Migration\FileLister\FileRowReaderInterface Used to get file rows. */
+    private $rowReader;
+
+    /**
+     * @param \eZ\Bundle\EzPublishIOBundle\Migration\FileLister\FileRowReaderInterface $rowReader
+     */
+    public function __construct(FileRowReaderInterface $rowReader)
+    {
+        $this->rowReader = $rowReader;
+    }
+
+    public function current()
+    {
+        return $this->item;
+    }
+
+    public function next()
+    {
+        $this->fetchRow();
+    }
+
+    public function key()
+    {
+        return $this->cursor;
+    }
+
+    public function valid()
+    {
+        return $this->cursor < $this->count();
+    }
+
+    public function rewind()
+    {
+        $this->cursor = -1;
+        $this->rowReader->init();
+        $this->fetchRow();
+    }
+
+    public function count()
+    {
+        return $this->rowReader->getCount();
+    }
+
+    /**
+     * Fetches the next item from the resultset and moves the cursor forward.
+     */
+    private function fetchRow()
+    {
+        ++$this->cursor;
+        $fileId = $this->rowReader->getRow();
+
+        $this->item = $fileId;
+    }
+}

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileIteratorInterface.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileIteratorInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * File containing the FileIteratorInterface interface.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\Migration\FileLister;
+
+use Iterator;
+use Countable;
+
+/**
+ * Iterates over BinaryFile id entries.
+ */
+interface FileIteratorInterface extends Countable, Iterator
+{
+}

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileRowReader/LegacyStorageBinaryFileRowReader.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileRowReader/LegacyStorageBinaryFileRowReader.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\Migration\FileLister\FileRowReader;
+
+final class LegacyStorageBinaryFileRowReader extends LegacyStorageFileRowReader
+{
+    /**
+     * Returns the table name to store data in.
+     *
+     * @return string
+     */
+    protected function getStorageTable()
+    {
+        return 'ezbinaryfile';
+    }
+}

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileRowReader/LegacyStorageFileRowReader.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileRowReader/LegacyStorageFileRowReader.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\Migration\FileLister\FileRowReader;
+
+use eZ\Bundle\EzPublishIOBundle\Migration\FileLister\FileRowReaderInterface;
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+
+abstract class LegacyStorageFileRowReader implements FileRowReaderInterface
+{
+    /** @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler */
+    private $dbHandler;
+
+    /** @var \PDOStatement */
+    private $statement;
+
+    /**
+     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler Database handler
+     */
+    public function __construct(DatabaseHandler $dbHandler)
+    {
+        $this->dbHandler = $dbHandler;
+    }
+
+    final public function init()
+    {
+        $selectQuery = $this->dbHandler->createSelectQuery();
+        $selectQuery->select('filename, mime_type')->from($this->dbHandler->quoteTable($this->getStorageTable()));
+        $this->statement = $selectQuery->prepare();
+        $this->statement->execute();
+    }
+
+    /**
+     * Returns the table name to store data in.
+     *
+     * @return string
+     */
+    abstract protected function getStorageTable();
+
+    final public function getRow()
+    {
+        $row = $this->statement->fetch();
+
+        return $this->prependMimeToPath($row['filename'], $row['mime_type']);
+    }
+
+    final public function getCount()
+    {
+        return $this->statement->rowCount();
+    }
+
+    /**
+     * Prepends $path with the first part of the given $mimeType.
+     *
+     * @param string $path
+     * @param string $mimeType
+     *
+     * @return string
+     */
+    private function prependMimeToPath($path, $mimeType)
+    {
+        return substr($mimeType, 0, strpos($mimeType, '/')) . '/' . $path;
+    }
+}

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileRowReader/LegacyStorageMediaFileRowReader.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileRowReader/LegacyStorageMediaFileRowReader.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\Migration\FileLister\FileRowReader;
+
+final class LegacyStorageMediaFileRowReader extends LegacyStorageFileRowReader
+{
+    /**
+     * Returns the table name to store data in.
+     *
+     * @return string
+     */
+    protected function getStorageTable()
+    {
+        return 'ezmedia';
+    }
+}

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileRowReaderInterface.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileRowReaderInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * File containing the FileRowReaderInterface interface.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\Migration\FileLister;
+
+/**
+ * Reads files from a data source.
+ */
+interface FileRowReaderInterface
+{
+    /**
+     * Initializes the reader.
+     *
+     * Can for instance be used to create and execute a database query.
+     */
+    public function init();
+
+    /**
+     * Returns the next row from the data source.
+     *
+     * @return mixed|null The row's value, or null if none.
+     */
+    public function getRow();
+
+    /**
+     * Returns the total row count.
+     *
+     * @return int
+     */
+    public function getCount();
+}

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/ImageFileLister.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/ImageFileLister.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\Migration\FileLister;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator;
+use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\ImageFileList;
+use eZ\Bundle\EzPublishIOBundle\ApiLoader\HandlerFactory;
+use eZ\Bundle\EzPublishIOBundle\Migration\FileListerInterface;
+use eZ\Bundle\EzPublishIOBundle\Migration\MigrationHandler;
+use eZ\Publish\Core\IO\Exception\BinaryFileNotFoundException;
+use Iterator;
+use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
+use LimitIterator;
+use Psr\Log\LoggerInterface;
+
+final class ImageFileLister extends MigrationHandler implements FileListerInterface
+{
+    /** @var ImageFileList */
+    private $imageFileList;
+
+    /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator */
+    private $variationPathGenerator;
+
+    /** @var \Liip\ImagineBundle\Imagine\Filter\FilterConfiguration */
+    private $filterConfiguration;
+
+    /** @var string Directory where images are stored, within the storage dir. Example: 'images' */
+    private $imagesDir;
+
+    /**
+     * @param \eZ\Bundle\EzPublishIOBundle\ApiLoader\HandlerFactory $metadataHandlerFactory
+     * @param \eZ\Bundle\EzPublishIOBundle\ApiLoader\HandlerFactory $binarydataHandlerFactory
+     * @param \Psr\Log\LoggerInterface $logger
+     * @param \Iterator $imageFileList
+     * @param \eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator
+     * @param \Liip\ImagineBundle\Imagine\Filter\FilterConfiguration
+     * @param string $imagesDir Directory where images are stored, within the storage dir. Example: 'images'
+     */
+    public function __construct(
+        HandlerFactory $metadataHandlerFactory,
+        HandlerFactory $binarydataHandlerFactory,
+        LoggerInterface $logger = null,
+        Iterator $imageFileList,
+        VariationPathGenerator $variationPathGenerator,
+        FilterConfiguration $filterConfiguration,
+        $imagesDir
+    ) {
+        $this->imageFileList = $imageFileList;
+        $this->variationPathGenerator = $variationPathGenerator;
+        $this->filterConfiguration = $filterConfiguration;
+        $this->imagesDir = $imagesDir;
+
+        $this->imageFileList->rewind();
+
+        parent::__construct($metadataHandlerFactory, $binarydataHandlerFactory, $logger);
+    }
+
+    public function countFiles()
+    {
+        return count($this->imageFileList);
+    }
+
+    public function loadMetadataList($limit = null, $offset = null)
+    {
+        $metadataList = [];
+        $imageLimitList = new LimitIterator($this->imageFileList, $offset, $limit);
+        $aliasNames = array_keys($this->filterConfiguration->all());
+
+        foreach ($imageLimitList as $originalImageId) {
+            try {
+                $metadataList[] = $this->fromMetadataHandler->load($this->imagesDir . '/' . $originalImageId);
+            } catch (BinaryFileNotFoundException $e) {
+                $this->logMissingFile($originalImageId);
+
+                continue;
+            }
+
+            foreach ($aliasNames as $aliasName) {
+                $variationImageId = $this->variationPathGenerator->getVariationPath($originalImageId, $aliasName);
+
+                try {
+                    $metadataList[] = $this->fromMetadataHandler->load($this->imagesDir . '/' . $variationImageId);
+                } catch (BinaryFileNotFoundException $e) {
+                    $this->logMissingFile($variationImageId);
+                }
+            }
+        }
+
+        return $metadataList;
+    }
+}

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/ImageFileLister.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/ImageFileLister.php
@@ -17,7 +17,7 @@ use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
 use LimitIterator;
 use Psr\Log\LoggerInterface;
 
-final class ImageFileLister extends MigrationHandler implements FileListerInterface
+class ImageFileLister extends MigrationHandler implements FileListerInterface
 {
     /** @var ImageFileList */
     private $imageFileList;

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileListerInterface.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileListerInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * File containing the FileListerInterface interface.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\Migration;
+
+use eZ\Publish\SPI\IO\BinaryFile;
+
+interface FileListerInterface extends MigrationHandlerInterface
+{
+    /**
+     * Count the number of existing files.
+     *
+     * @return int|null Number of files, or null if they cannot be counted
+     */
+    public function countFiles();
+
+    /**
+     * Loads and returns metadata for files, optionally limited by $limit and $offset.
+     *
+     * @param int|null $limit The number of files to load data for, or null
+     * @param int|null $offset The offset used when loading in batches, or null
+     *
+     * @return BinaryFile[]
+     */
+    public function loadMetadataList($limit = null, $offset = null);
+}

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileListerRegistry.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileListerRegistry.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * File containing the FileListerRegistry interface.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\Migration;
+
+/**
+ * A registry of FileListerInterfaces.
+ */
+interface FileListerRegistry
+{
+    /**
+     * Returns the FileListerInterface matching the argument.
+     *
+     * @param string $identifier An identifier string.
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\NotFoundException If no FileListerInterface exists with this identifier
+     *
+     * @return \eZ\Bundle\EzPublishIOBundle\Migration\FileListerInterface The FileListerInterface given by the identifier.
+     */
+    public function getItem($identifier);
+
+    /**
+     * Returns the identifiers of all registered FileListerInterfaces.
+     *
+     * @return string[] Array of identifier strings.
+     */
+    public function getIdentifiers();
+}

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileListerRegistry/ConfigurableRegistry.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileListerRegistry/ConfigurableRegistry.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\Migration\FileListerRegistry;
+
+use eZ\Bundle\EzPublishIOBundle\Migration\FileListerRegistry;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+
+/**
+ * A registry of FileListerInterfaces which is configurable via the array passed to its constructor.
+ */
+final class ConfigurableRegistry implements FileListerRegistry
+{
+    /** @var \eZ\Bundle\EzPublishIOBundle\Migration\FileListerInterface[] */
+    private $registry = [];
+
+    /**
+     * @param \eZ\Bundle\EzPublishIOBundle\Migration\FileListerInterface[] $items Hash of FileListerInterfaces, with identifier string as key.
+     */
+    public function __construct(array $items = [])
+    {
+        $this->registry = $items;
+    }
+
+    /**
+     * Returns the FileListerInterface matching the argument.
+     *
+     * @param string $identifier An identifier string.
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\NotFoundException If no FileListerInterface exists with this identifier
+     *
+     * @return \eZ\Bundle\EzPublishIOBundle\Migration\FileListerInterface The FileListerInterface given by the identifier.
+     */
+    public function getItem($identifier)
+    {
+        if (isset($this->registry[$identifier])) {
+            return $this->registry[$identifier];
+        }
+
+        throw new NotFoundException('Migration file lister', $identifier);
+    }
+
+    /**
+     * Returns the identifiers of all registered FileListerInterfaces.
+     *
+     * @return string[] Array of identifier strings.
+     */
+    public function getIdentifiers()
+    {
+        return array_keys($this->registry);
+    }
+}

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileMigrator/FileMigrator.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileMigrator/FileMigrator.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\Migration\FileMigrator;
+
+use eZ\Bundle\EzPublishIOBundle\Migration\FileMigratorInterface;
+use eZ\Bundle\EzPublishIOBundle\Migration\MigrationHandler;
+use eZ\Publish\Core\IO\Exception\BinaryFileNotFoundException;
+use eZ\Publish\SPI\IO\BinaryFile;
+use eZ\Publish\SPI\IO\BinaryFileCreateStruct;
+
+final class FileMigrator extends MigrationHandler implements FileMigratorInterface
+{
+    public function migrateFile(BinaryFile $binaryFile)
+    {
+        try {
+            $binaryFileResource = $this->fromBinarydataHandler->getResource($binaryFile->id);
+        } catch (BinaryFileNotFoundException $e) {
+            $this->logError("Cannot load binary data for: '{$binaryFile->id}'. Error: " . $e->getMessage());
+
+            return false;
+        }
+
+        $binaryFileCreateStruct = new BinaryFileCreateStruct();
+        $binaryFileCreateStruct->id = $binaryFile->id;
+        $binaryFileCreateStruct->setInputStream($binaryFileResource);
+
+        try {
+            $this->toBinarydataHandler->create($binaryFileCreateStruct);
+        } catch (\RuntimeException $e) {
+            $this->logError("Cannot migrate binary data for: '{$binaryFile->id}'. Error: " . $e->getMessage());
+
+            return false;
+        }
+
+        $metadataCreateStruct = new BinaryFileCreateStruct();
+        $metadataCreateStruct->id = $binaryFile->id;
+        $metadataCreateStruct->size = $binaryFile->size;
+        $metadataCreateStruct->mtime = $binaryFile->mtime;
+        $metadataCreateStruct->mimeType = $this->fromMetadataHandler->getMimeType($binaryFile->id);
+
+        try {
+            $this->toMetadataHandler->create($metadataCreateStruct);
+        } catch (\RuntimeException $e) {
+            $this->logError("Cannot migrate metadata for: '{$binaryFile->id}'. Error: " . $e->getMessage() . $e->getPrevious()->getMessage());
+
+            return false;
+        }
+
+        $this->logInfo("Successfully migrated: '{$binaryFile->id}'");
+
+        return true;
+    }
+}

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileMigratorInterface.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileMigratorInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * File containing the FileMigratorInterface interface.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\Migration;
+
+use eZ\Publish\SPI\IO\BinaryFile;
+
+/**
+ * Interface for file migrators, mandates the migrateFile method.
+ */
+interface FileMigratorInterface extends MigrationHandlerInterface
+{
+    /**
+     * Migrate a file.
+     *
+     * @param BinaryFile $binaryFile Information about the file
+     *
+     * @return bool Success or failure
+     */
+    public function migrateFile(BinaryFile $binaryFile);
+}

--- a/eZ/Bundle/EzPublishIOBundle/Migration/MigrationHandler.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/MigrationHandler.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\Migration;
+
+use eZ\Bundle\EzPublishIOBundle\ApiLoader\HandlerFactory;
+use Psr\Log\LoggerInterface;
+
+/**
+ * The migration handler sets up from/to IO data handlers, and provides logging, for file migrators and listers.
+ */
+abstract class MigrationHandler implements MigrationHandlerInterface
+{
+    /** @var \eZ\Bundle\EzPublishIOBundle\ApiLoader\HandlerFactory */
+    private $metadataHandlerFactory;
+
+    /** @var \eZ\Bundle\EzPublishIOBundle\ApiLoader\HandlerFactory */
+    private $binarydataHandlerFactory;
+
+    /** @var \Psr\Log\LoggerInterface */
+    private $logger;
+
+    /** @var \eZ\Publish\Core\IO\IOMetadataHandler */
+    protected $fromMetadataHandler;
+
+    /** @var \eZ\Publish\Core\IO\IOBinarydataHandler */
+    protected $fromBinarydataHandler;
+
+    /** @var \eZ\Publish\Core\IO\IOMetadataHandler */
+    protected $toMetadataHandler;
+
+    /** @var \eZ\Publish\Core\IO\IOBinarydataHandler */
+    protected $toBinarydataHandler;
+
+    public function __construct(
+        HandlerFactory $metadataHandlerFactory,
+        HandlerFactory $binarydataHandlerFactory,
+        LoggerInterface $logger = null
+    ) {
+        $this->metadataHandlerFactory = $metadataHandlerFactory;
+        $this->binarydataHandlerFactory = $binarydataHandlerFactory;
+        $this->logger = $logger;
+    }
+
+    final public function setIODataHandlersByIdentifiers(
+        $fromMetadataHandlerIdentifier,
+        $fromBinarydataHandlerIdentifier,
+        $toMetadataHandlerIdentifier,
+        $toBinarydataHandlerIdentifier
+    ) {
+        $this->fromMetadataHandler = $this->metadataHandlerFactory->getConfiguredHandler($fromMetadataHandlerIdentifier);
+        $this->fromBinarydataHandler = $this->binarydataHandlerFactory->getConfiguredHandler($fromBinarydataHandlerIdentifier);
+        $this->toMetadataHandler = $this->metadataHandlerFactory->getConfiguredHandler($toMetadataHandlerIdentifier);
+        $this->toBinarydataHandler = $this->binarydataHandlerFactory->getConfiguredHandler($toBinarydataHandlerIdentifier);
+
+        return $this;
+    }
+
+    final protected function logError($message)
+    {
+        if (isset($this->logger)) {
+            $this->logger->error($message);
+        }
+    }
+
+    final protected function logInfo($message)
+    {
+        if (isset($this->logger)) {
+            $this->logger->info($message);
+        }
+    }
+
+    final protected function logMissingFile($id)
+    {
+        $this->logInfo("File with id $id not found");
+    }
+}

--- a/eZ/Bundle/EzPublishIOBundle/Migration/MigrationHandlerInterface.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/MigrationHandlerInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * File containing the MigrationHandlerInterface interface.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\Migration;
+
+interface MigrationHandlerInterface
+{
+    /**
+     * Set the from/to handlers based on identifiers.
+     * Returns the MigrationHandler.
+     *
+     * @param string $fromMetadataHandlerIdentifier
+     * @param string $fromBinarydataHandlerIdentifier
+     * @param string $toMetadataHandlerIdentifier
+     * @param string $toBinarydataHandlerIdentifier
+     *
+     * @return MigrationHandlerInterface
+     */
+    public function setIODataHandlersByIdentifiers(
+        $fromMetadataHandlerIdentifier,
+        $fromBinarydataHandlerIdentifier,
+        $toMetadataHandlerIdentifier,
+        $toBinarydataHandlerIdentifier
+    );
+}

--- a/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
+++ b/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
@@ -1,8 +1,92 @@
 parameters:
+    ezpublish.core.io.command.migrate_files.class: eZ\Bundle\EzPublishIOBundle\Command\MigrateFilesCommand
+    ezpublish.core.io.migration.file_lister_registry.class: eZ\Bundle\EzPublishIOBundle\Migration\FileListerRegistry\ConfigurableRegistry
+    ezpublish.core.io.migration.file_lister.binary_file_lister.class: eZ\Bundle\EzPublishIOBundle\Migration\FileLister\BinaryFileLister
+    ezpublish.core.io.migration.file_lister.image_file_lister.class: eZ\Bundle\EzPublishIOBundle\Migration\FileLister\ImageFileLister
+    ezpublish.core.io.migration.file_lister.media_file_lister.class: eZ\Bundle\EzPublishIOBundle\Migration\FileLister\BinaryFileLister
+    ezpublish.core.io.migration.file_lister.file_iterator.binary_file_iterator.class: eZ\Bundle\EzPublishIOBundle\Migration\FileLister\FileIterator\LegacyStorageFileIterator
+    ezpublish.core.io.migration.file_lister.file_iterator.media_file_iterator.class: eZ\Bundle\EzPublishIOBundle\Migration\FileLister\FileIterator\LegacyStorageFileIterator
+    ezpublish.core.io.migration.file_lister.file_row_reader.binary_file_row_reader.class: eZ\Bundle\EzPublishIOBundle\Migration\FileLister\FileRowReader\LegacyStorageBinaryFileRowReader
+    ezpublish.core.io.migration.file_lister.file_row_reader.media_file_row_reader.class: eZ\Bundle\EzPublishIOBundle\Migration\FileLister\FileRowReader\LegacyStorageMediaFileRowReader
+    ezpublish.core.io.migration.file_migrator.class: eZ\Bundle\EzPublishIOBundle\Migration\FileMigrator\FileMigrator
+    ezpublish.core.io.migration.migration_handler.class: eZ\Bundle\EzPublishIOBundle\Migration\MigrationHandler
     ezpublish.core.io.stream_file_listener.class: eZ\Bundle\EzPublishIOBundle\EventListener\StreamFileListener
     ezpublish.core.io.flysystem.default_adapter.class: League\Flysystem\Adapter\Local
 
 services:
+    ezpublish.core.io.command.migrate_files:
+        class: "%ezpublish.core.io.command.migrate_files.class%"
+        arguments:
+            - "%ez_io.metadata_handlers%"
+            - "%ez_io.binarydata_handlers%"
+            - "@ezpublish.core.io.migration.file_lister_registry"
+            - "@ezpublish.core.io.migration.file_migrator"
+        tags:
+            - { name: console.command }
+
+    ezpublish.core.io.migration.file_lister_registry:
+        class: "%ezpublish.core.io.migration.file_lister_registry.class%"
+
+    ezpublish.core.io.migration.migration_handler:
+        class: "%ezpublish.core.io.migration.migration_handler.class%"
+        arguments:
+            - "@ezpublish.core.io.metadata_handler.factory"
+            - "@ezpublish.core.io.binarydata_handler.factory"
+            - "@logger"
+
+    ezpublish.core.io.migration.file_lister.binary_file_lister:
+        class: "%ezpublish.core.io.migration.file_lister.binary_file_lister.class%"
+        parent: ezpublish.core.io.migration.migration_handler
+        arguments:
+            - "@ezpublish.core.io.migration.file_lister.file_iterator.binary_file_iterator"
+            - "%ezsettings.default.binary_dir%"
+        tags:
+            - { name: "ezpublish.core.io.migration.file_lister", identifier: "binary_file" }
+
+    ezpublish.core.io.migration.file_lister.media_file_lister:
+        class: "%ezpublish.core.io.migration.file_lister.media_file_lister.class%"
+        parent: ezpublish.core.io.migration.migration_handler
+        arguments:
+            - "@ezpublish.core.io.migration.file_lister.file_iterator.media_file_iterator"
+            - "%ezsettings.default.binary_dir%"
+        tags:
+            - { name: "ezpublish.core.io.migration.file_lister", identifier: "media_file" }
+
+    ezpublish.core.io.migration.file_lister.image_file_lister:
+        class: "%ezpublish.core.io.migration.file_lister.image_file_lister.class%"
+        parent: ezpublish.core.io.migration.migration_handler
+        arguments:
+            - "@ezpublish.image_alias.variation_purger.legacy_storage_image_file.image_file_list"
+            - "@ezpublish.image_alias.variation_path_generator"
+            - "@liip_imagine.filter.configuration"
+            - "%ezsettings.default.image.published_images_dir%"
+        tags:
+            - { name: "ezpublish.core.io.migration.file_lister", identifier: "image_file" }
+
+    ezpublish.core.io.migration.file_lister.file_iterator.binary_file_iterator:
+        class: "%ezpublish.core.io.migration.file_lister.file_iterator.binary_file_iterator.class%"
+        arguments:
+            - "@ezpublish.core.io.migration.file_lister.file_row_reader.binary_file_row_reader"
+
+    ezpublish.core.io.migration.file_lister.file_iterator.media_file_iterator:
+        class: "%ezpublish.core.io.migration.file_lister.file_iterator.media_file_iterator.class%"
+        arguments:
+            - "@ezpublish.core.io.migration.file_lister.file_row_reader.media_file_row_reader"
+
+    ezpublish.core.io.migration.file_lister.file_row_reader.binary_file_row_reader:
+        class: "%ezpublish.core.io.migration.file_lister.file_row_reader.binary_file_row_reader.class%"
+        arguments:
+            - "@ezpublish.api.storage_engine.legacy.dbhandler"
+
+    ezpublish.core.io.migration.file_lister.file_row_reader.media_file_row_reader:
+        class: "%ezpublish.core.io.migration.file_lister.file_row_reader.media_file_row_reader.class%"
+        arguments:
+            - "@ezpublish.api.storage_engine.legacy.dbhandler"
+
+    ezpublish.core.io.migration.file_migrator:
+        class: "%ezpublish.core.io.migration.file_migrator.class%"
+        parent: ezpublish.core.io.migration.migration_handler
+
     # Builds the binarydata and metadata handler based on the siteaccess config
     ezpublish.core.io.metadata_handler:
         class: eZ\Publish\Core\IO\IOMetadataHandler

--- a/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
+++ b/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
@@ -42,6 +42,7 @@ services:
             - "%ezsettings.default.binary_dir%"
         tags:
             - { name: "ezpublish.core.io.migration.file_lister", identifier: "binary_file" }
+        lazy: true
 
     ezpublish.core.io.migration.file_lister.media_file_lister:
         class: "%ezpublish.core.io.migration.file_lister.media_file_lister.class%"
@@ -51,6 +52,7 @@ services:
             - "%ezsettings.default.binary_dir%"
         tags:
             - { name: "ezpublish.core.io.migration.file_lister", identifier: "media_file" }
+        lazy: true
 
     ezpublish.core.io.migration.file_lister.image_file_lister:
         class: "%ezpublish.core.io.migration.file_lister.image_file_lister.class%"
@@ -62,6 +64,7 @@ services:
             - "%ezsettings.default.image.published_images_dir%"
         tags:
             - { name: "ezpublish.core.io.migration.file_lister", identifier: "image_file" }
+        lazy: true
 
     ezpublish.core.io.migration.file_lister.file_iterator.binary_file_iterator:
         class: "%ezpublish.core.io.migration.file_lister.file_iterator.binary_file_iterator.class%"


### PR DESCRIPTION
> Implements https://jira.ez.no/browse/EZP-25946
> Ready for review

Migrates files from local storage to NFS/DFS cluster, and vice versa. (Theoretically, any Flysystem adapter should work.)

Adds a Command which validates from/to input and runs the migration in batches. Input options partially based on [legacy clusterize.php](https://github.com/ezsystems/ezpublish-legacy/blob/d76ce9824dabaceeefa77530c8c611e447d1b109/bin/php/clusterize.php) but made more generic. Meaning it's not just for clusterize/unclusterize, but also for migrating between e.g. NFS and AWS/S3.

`$ php app/console ezplatform:io:migrate-files --dry-run --from=default,default --to=dfs,nfs`

Same as https://github.com/ezsystems/ezpublish-kernel/pull/1825 but for 6.7, ensuring all tests pass.

Had to un-`final`-ise file lister classes in order to make the services lazy and thus escape siteaccess hell which caused Travis to fail. Problem? :trollface: