### PR TITLE
Fix EZP-27331: Cannot override view parameters

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/View/BaseView.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/BaseView.php
@@ -71,7 +71,7 @@ abstract class BaseView implements View
      */
     public function addParameters(array $parameters)
     {
-        $this->parameters += $parameters;
+        $this->parameters = array_replace($this->parameters, $parameters);
     }
 
     /**


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-27331

When using the view system, it is now possible to add arbitrary parameters. 
However it is currently possible to *replace* an existing one as `BaseView::addParameters()` uses `+= ` assignment and does not expose a setter.

Thus, if a key in `$parameters` already exists in `$this->parameters`, it is ignored.
Issue reference for EzCoreExtraBundle: https://github.com/lolautruche/EzCoreExtraBundle/issues/23

This patch replaces `+=` by `array_replace()`, like in Symfony `ParameterBag`.