### PR TITLE
[REST] Made routes non-siteaccess-aware

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/DependencyInjection/EzPublishRestExtension.php
+++ b/eZ/Bundle/EzPublishRestBundle/DependencyInjection/EzPublishRestExtension.php
@@ -50,5 +50,13 @@ class EzPublishRestExtension extends Extension implements PrependExtensionInterf
             $container->prependExtensionConfig('nelmio_cors', $config);
             $container->addResource(new FileResource($file));
         }
+
+        $this->prependRouterConfiguration($container);
+    }
+
+    private function prependRouterConfiguration(ContainerBuilder $container)
+    {
+        $config = ['router' => ['default_router' => ['non_siteaccess_aware_routes' => ['ezpublish_rest_']]]];
+        $container->prependExtensionConfig('ezpublish', $config);
     }
 }


### PR DESCRIPTION
> JIRA: [EZP-27349](https://jira.ez.no/browse/EZP-27349)
> Required by ezsystems/hybrid-platform-ui#2

**Must be merged to master, not 7.0**

Marks REST routes as non-siteaccess aware so that they aren't prefixed with the siteaccess when generating a link using the UrlGenerator.

Can be tested by generating any REST URL using the UrlGenerator (from a twig template for instance):

```
{{ path( 'ezpublish_rest_loadLocation', {'locationPath': location.pathString|trim('/')} ) }}
```

Without this patch, the current siteaccess will be prefixed before the REST URL, and it won't work as expected.