### PR TITLE
[PHPDoc] Fix PHPDoc on BaseIntegrationTest::getHandler()

### DIFF
--- a/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
@@ -601,7 +601,7 @@ abstract class BaseIntegrationTest extends TestCase
      * Returns the Handler.
      *
      * @param string $identifier
-     * @param \eZ\Publish\SPI\Persistence\FieldType $fieldType
+     * @param \eZ\Publish\SPI\FieldType\FieldType $fieldType
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter $fieldValueConverter
      * @param \eZ\Publish\SPI\FieldType\FieldStorage $externalStorage
      *


### PR DESCRIPTION
Based on usage of function BaseIntegrationTest::getHandler(), for example here:
https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/SPI/Tests/FieldType/AuthorIntegrationTest.php#L59
The first parameter should be instance of \eZ\Publish\SPI\FieldType\FieldType instead of \eZ\Publish\SPI\Persistence\FieldType.