### PR TITLE
Fix EZP-27254: Command to clean up relations causing "Unknown relation type 0." exception

### DIFF
--- a/eZ/Bundle/EzPublishMigrationBundle/Command/LegacyStorage/CleanUpRelationTypeEqZeroCommand.php
+++ b/eZ/Bundle/EzPublishMigrationBundle/Command/LegacyStorage/CleanUpRelationTypeEqZeroCommand.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishMigrationBundle\Command\LegacyStorage;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use RuntimeException;
+
+class CleanUpRelationTypeEqZeroCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('ezpublish:update:legacy_storage_clean_up_relation_type_eq_zero')
+            ->setDescription('Clean up invalid relation type in Legacy Storage database')
+            ->addArgument('action', InputArgument::REQUIRED, 'Action: ' . implode(', ', $this->getAvailableActions()))
+            ->setHelp(
+                <<<EOT
+The command <info>%command.name%</info> cleans up corrupted relations in Legacy Storage database. See: https://jira.ez.no/browse/EZP-27254
+
+<warning>During the script execution the database should not be modified.
+
+To avoid surprises you are advised to create a backup or execute a dry run:
+ 
+    %command.name% dry-run
+    
+before proceeding with actual update.</warning>
+
+Since this script can potentially run for a very long time, to avoid memory
+exhaustion run it in production environment using the <info>--env=prod</info> switch.
+EOT
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $action = $input->getArgument('action');
+
+        if (!$this->isValidAction($action)) {
+            throw new RuntimeException(
+                "Action '{$action}' is not supported, use one of: " .
+                implode(', ', $this->getAvailableActions())
+            );
+        }
+
+        $totalCount = $this->getTotalCount();
+        $output->writeln('Found total relations to delete: ' . $totalCount);
+        if ($totalCount == 0) {
+            $output->writeln('Nothing to process, exiting.');
+
+            return;
+        }
+
+        if ($this->confirmExecution($input, $output)) {
+            switch ($action) {
+                case 'fix':
+                    $this->executeFix();
+                    break;
+                case 'list':
+                case 'dry-run':
+                    $this->executeList($output, $totalCount);
+                    break;
+            }
+        }
+
+        $output->writeln('');
+    }
+
+    protected function confirmExecution(InputInterface $input, OutputInterface $output)
+    {
+        $question = new ConfirmationQuestion('<question>Are you sure you want to proceed?</question> ', false);
+
+        return $this
+            ->getHelper('question')
+            ->ask($input, $output, $question);
+    }
+
+    protected function executeFix()
+    {
+        /** @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler $conn */
+        $conn = $this->getContainer()->get('ezpublish.connection');
+        $conn->exec('DELETE FROM ezcontentobject_link WHERE relation_type = 0');
+    }
+
+    protected function executeList(OutputInterface $output, $totalCount)
+    {
+        $output->writeln('The following relations will be removed: ');
+        $output->writeln("ID\tFCO_ID\tFCO_V\tTCO_ID\tRT");
+
+        $passSize = 1000;
+        $passCount = ceil($totalCount / $passSize);
+        for ($pass = 0; $pass <= $passCount; ++$pass) {
+            $relations = $this->getCorruptedRelations($pass * $passSize, $passSize);
+            foreach ($relations as $relation) {
+                $output->writeln(vsprintf("%s\t%s\t%s\t%s\t%s", $relation));
+            }
+            $relations = null;
+        }
+    }
+
+    protected function getCorruptedRelations($offset, $limit)
+    {
+        /** @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler $connection */
+        $connection = $this->getContainer()->get('ezpublish.connection');
+
+        $query = $connection->createSelectQuery();
+        $query
+            ->select(
+                $connection->quoteColumn('id'),
+                $connection->quoteColumn('from_contentobject_id'),
+                $connection->quoteColumn('from_contentobject_version'),
+                $connection->quoteColumn('to_contentobject_id'),
+                $connection->quoteColumn('relation_type')
+            )
+            ->from('ezcontentobject_link')
+            ->where(
+                $query->expr->eq(
+                    $connection->quoteColumn('relation_type'),
+                    $query->bindValue('0')
+                )
+            )
+            ->orderBy('id', 'ASC')
+            ->limit($limit, $offset);
+
+        $stmt = $query->prepare();
+        $stmt->execute();
+
+        return $stmt->fetchAll(\PDO::FETCH_NUM);
+    }
+
+    protected function getTotalCount()
+    {
+        /** @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler $conn */
+        $conn = $this->getContainer()->get('ezpublish.connection');
+
+        $stmt = $conn->prepare('SELECT COUNT(id) FROM ezcontentobject_link WHERE relation_type = 0');
+        $stmt->execute();
+
+        return (int)$stmt->fetchColumn();
+    }
+
+    protected function getAvailableActions()
+    {
+        return ['fix', 'list', 'dry-run'];
+    }
+
+    protected function isValidAction($action)
+    {
+        return in_array($action, $this->getAvailableActions());
+    }
+}

--- a/eZ/Bundle/EzPublishMigrationBundle/Command/LegacyStorage/CleanUpRelationTypeEqZeroCommand.php
+++ b/eZ/Bundle/EzPublishMigrationBundle/Command/LegacyStorage/CleanUpRelationTypeEqZeroCommand.php
@@ -14,6 +14,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use eZ\Publish\Core\Persistence\Legacy\Handler as LegacyStorageEngine;
 use RuntimeException;
 
 class CleanUpRelationTypeEqZeroCommand extends ContainerAwareCommand
@@ -53,6 +54,8 @@ EOT
             );
         }
 
+        $this->checkStorage();
+
         $totalCount = $this->getTotalCount();
         $output->writeln('Found total relations to delete: ' . $totalCount);
         if ($totalCount == 0) {
@@ -74,6 +77,20 @@ EOT
         }
 
         $output->writeln('');
+    }
+
+    /**
+     * Checks that configured storage engine is Legacy Storage Engine.
+     */
+    protected function checkStorage()
+    {
+        $storageEngine = $this->getContainer()->get('ezpublish.api.storage_engine');
+
+        if (!$storageEngine instanceof LegacyStorageEngine) {
+            throw new RuntimeException(
+                'Expected to find Legacy Storage Engine but found something else.'
+            );
+        }
     }
 
     protected function confirmExecution(InputInterface $input, OutputInterface $output)


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27254

# Description

This PR adds a console command to `EzPublishMigrationBundle` that clean up relations with invalid relation type (equal zero). Those relations are created by bug in legacy in specific conditions and cause "Unknown relation type 0." exception when the content object is accessed via REST API. More details: https://github.com/ezsystems/ezpublish-legacy/pull/1295. 

# Usage

The command can be executed in two modes:

* `fix` - Executes clean up 
*  `list` / `dry-run`  - Prints table with all corrupted relations that will be deleted:

```
| ID  | FROM_CONTENTOBEJCT_ID | FROM_CONTENTOBJECT_VERSION | TO_CONTENTOBJECT_ID | RELATION_TYPE |
+-----+-----------------------+----------------------------+---------------------+---------------+
| 101 | 2803                  | 9                          | 1323                | 0             |
| 102 | 1702                  | 3                          | 5817                | 0             |
| 103 | 1662                  | 7                          | 1559                | 0             |
| 104 | 6939                  | 8                          | 2809                | 0             |
| 105 | 4169                  | 6                          | 7171                | 0             |
| 106 | 2448                  | 3                          | 8902                | 0             |
...
| 196 | 6039                  | 4                          | 7064                | 0             |
| 197 | 2513                  | 9                          | 3517                | 0             |
| 198 | 1161                  | 1                          | 6599                | 0             |
| 199 | 6887                  | 2                          | 6012                | 0             |
| 200 | 4734                  | 10                         | 1826                | 0             |
+-----+-----------------------+----------------------------+---------------------+---------------+
```

# Clean Up

Internally invalid relations as deleted by the following SQL statement: 

```
DELETE FROM ezcontentobject_link WHERE relation_type = 0
``` 
