### PR TITLE
EZP-27250: Fulltext search not working on "User" content

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -376,6 +376,40 @@ abstract class BaseTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Create a user using given data.
+     *
+     * @param string $login
+     * @param string $firstName
+     * @param string $lastName
+     * @return \eZ\Publish\API\Repository\Values\User\User
+     */
+    protected function createUser($login, $firstName, $lastName)
+    {
+        $repository = $this->getRepository();
+
+        $userService = $repository->getUserService();
+        $userGroup = $userService->loadUserGroup(13);
+
+        // Instantiate a create struct with mandatory properties
+        $userCreate = $userService->newUserCreateStruct(
+            $login,
+            "{$login}@example.com",
+            'secret',
+            'eng-US'
+        );
+        $userCreate->enabled = true;
+
+        // Set some fields required by the user ContentType
+        $userCreate->setField('first_name', $firstName);
+        $userCreate->setField('last_name', $lastName);
+
+        // Create a new user instance.
+        $user = $userService->createUser($userCreate, array($userGroup));
+
+        return $user;
+    }
+
+    /**
      * Only for internal use.
      *
      * Creates a \DateTime object for $timestamp in the current time zone

--- a/eZ/Publish/Core/settings/search_engines/legacy/slots.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/slots.yml
@@ -9,6 +9,10 @@ parameters:
     ezpublish.search.legacy.slot.recover.class: eZ\Publish\Core\Search\Common\Slot\Recover
     ezpublish.search.legacy.slot.update_content_metadata.class: eZ\Publish\Core\Search\Common\Slot\UpdateContentMetadata
     ezpublish.search.legacy.slot.assign_section.class: eZ\Publish\Core\Search\Common\Slot\AssignSection
+    ezpublish.search.legacy.slot.create_user.class: eZ\Publish\Core\Search\Common\Slot\CreateUser
+    ezpublish.search.legacy.slot.delete_user.class: eZ\Publish\Core\Search\Common\Slot\DeleteUser
+    ezpublish.search.legacy.slot.create_user_group.class: eZ\Publish\Core\Search\Common\Slot\CreateUserGroup
+    ezpublish.search.legacy.slot.delete_user_group.class: eZ\Publish\Core\Search\Common\Slot\DeleteUserGroup
 
 services:
     ezpublish.search.legacy.slot:
@@ -72,3 +76,27 @@ services:
         class: "%ezpublish.search.legacy.slot.assign_section.class%"
         tags:
             - {name: ezpublish.search.legacy.slot, signal: SectionService\AssignSectionSignal}
+
+    ezpublish.search.legacy.slot.create_user:
+        parent: ezpublish.search.legacy.slot
+        class: "%ezpublish.search.legacy.slot.create_user.class%"
+        tags:
+            - {name: ezpublish.search.legacy.slot, signal: UserService\CreateUserSignal}
+
+    ezpublish.search.legacy.slot.delete_user:
+        parent: ezpublish.search.legacy.slot
+        class: "%ezpublish.search.legacy.slot.delete_user.class%"
+        tags:
+            - {name: ezpublish.search.legacy.slot, signal: UserService\DeleteUserSignal}
+
+    ezpublish.search.legacy.slot.create_user_group:
+        parent: ezpublish.search.legacy.slot
+        class: "%ezpublish.search.legacy.slot.create_user_group.class%"
+        tags:
+            - {name: ezpublish.search.legacy.slot, signal: UserService\CreateUserGroupSignal}
+
+    ezpublish.search.legacy.slot.delete_user_group:
+        parent: ezpublish.search.legacy.slot
+        class: "%ezpublish.search.legacy.slot.delete_user_group.class%"
+        tags:
+            - {name: ezpublish.search.legacy.slot, signal: UserService\DeleteUserGroupSignal}


### PR DESCRIPTION
> Fixes [EZP-27250](https://jira.ez.no/browse/EZP-27250)
> Branch: **6.7**

Legacy/SQL Search engine is missing Search Slots related to User Field Type (`ezuser`), so when user is added, reindexing is required to be able to search for that user. This PR fixes this issue.

Please note that search applies only to Content Fields (First name, Last name), not login.

**TODO**:
- [x] Create integration test.
- [x] Add missing slots.