### PR TITLE
EZP-27344: Make declaration of twig "settings" block optional for custom Field Types

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/field_rendering_functions/ez_render_fielddefinition_settings.test
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/field_rendering_functions/ez_render_fielddefinition_settings.test
@@ -5,6 +5,7 @@
 {{ ez_render_fielddefinition_settings( overrides ) }}
 {{ ez_render_fielddefinition_settings( notdefault ) }}
 {{ ez_render_fielddefinition_settings( withdata ) }}
+{{ ez_render_fielddefinition_settings( notexisting ) }}
 --DATA--
 return array(
     'nooverride' => $this->getFieldDefinition( 'eznooverride' ),
@@ -13,10 +14,12 @@ return array(
     'withdata' => $this->getFieldDefinition(
         'ezwithdata', 42,
         array( 'frameworks' => array( 'YUI3', 'jQuery' ) )
-    )
+    ),
+    'notexisting' => $this->getFieldDefinition( 'eznotexisting' )
 )
 --EXPECT--
 default (no override)
 override2
 not default
 42 ezwithdata YUI3, jQuery
+

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/FieldBlockRenderer.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/FieldBlockRenderer.php
@@ -199,8 +199,6 @@ class FieldBlockRenderer implements FieldBlockRendererInterface
      * @param array $params
      * @param int $type Either self::VIEW or self::EDIT
      *
-     * @throws MissingFieldBlockException If no template block can be found for $field
-     *
      * @return string
      */
     private function renderFieldDefinition(FieldDefinition $fieldDefinition, array $params, $type)
@@ -218,7 +216,7 @@ class FieldBlockRenderer implements FieldBlockRendererInterface
         $blocks = $this->getBlocksByFieldDefinition($fieldDefinition, $type);
 
         if (!$this->baseTemplate->hasBlock($blockName, $context, $blocks)) {
-            throw new MissingFieldBlockException("Cannot find '$blockName' template block.");
+            return '';
         }
 
         return $this->baseTemplate->renderBlock($blockName, $context, $blocks);


### PR DESCRIPTION
> [EZP-27344](https://jira.ez.no/browse/EZP-27344)
#
Excerpt from the ticket above:
"Currently creating custom Field Type requires creating Twig file with settings block like this one from the tutorial: https://github.com/ezsystems/TweetFieldTypeBundle/blob/master/Resources/views/platformui/content_type/view/eztweet.html.twig. It is required regardless of whether developer wants to implement some custom settings or not. 
In my opinion, it shouldn't be required if there are no settings because it unnecessarily complicates the creation of simple Field Types. Also, it should be consistent with field_definition_edit Twig block and currently this block is not required if the developer doesn't want to implement something more advanced, like a validator."
I decided to go for catching an Exception in the function responsible for rendering settings. 