### PR TITLE
EZP-24617: Fixing toFieldDefinition method for ISBNConverter

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ISBNConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ISBNConverter.php
@@ -82,7 +82,7 @@ class ISBNConverter implements Converter
     {
         $fieldDef->fieldTypeConstraints->fieldSettings = new FieldSettings(
             array(
-                'isISBN13' => !empty($storageDef->dataInt1) ? (bool)$storageDef->dataInt1 : false,
+                'isISBN13' => !empty($storageDef->dataInt1),
             )
         );
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ISBNConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ISBNConverter.php
@@ -24,7 +24,7 @@ class ISBNConverter implements Converter
      *
      * Note: Class should instead be configured as service if it gains dependencies.
      *
-     * @return ISBN
+     * @return ISBNConverter
      */
     public static function create()
     {
@@ -82,7 +82,7 @@ class ISBNConverter implements Converter
     {
         $fieldDef->fieldTypeConstraints->fieldSettings = new FieldSettings(
             array(
-                'isISBN13' => !empty($storageDef->dataInt1),
+                'isISBN13' => !empty($storageDef->dataInt1) ? (bool)$storageDef->dataInt1 : false,
             )
         );
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ISBNConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ISBNConverter.php
@@ -82,7 +82,7 @@ class ISBNConverter implements Converter
     {
         $fieldDef->fieldTypeConstraints->fieldSettings = new FieldSettings(
             array(
-                'isISBN13' => !empty($storageDef->dataInt1) ? (bool)$storageDef->dataInt1 : true,
+                'isISBN13' => !empty($storageDef->dataInt1) ? (bool)$storageDef->dataInt1 : false,
             )
         );
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/ISBNTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/ISBNTest.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * File containing the ISBNTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;
+
+use eZ\Publish\Core\FieldType\FieldSettings;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\ISBNConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition as PersistenceFieldDefinition;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Test for ISBNConverter in Legacy Storage.
+ */
+class ISBNTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\ISBNConverter
+     */
+    protected $converter;
+
+    protected function setUp()
+    {
+        $this->converter = new ISBNConverter();
+    }
+
+    /**
+     * @dataProvider data_toFieldDefinition
+     *
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\ISBNConverter::toFieldDefinition
+     */
+    public function testToFieldDefinition($dataInt, $excpectedIsbn13Value)
+    {
+        $fieldDef = new PersistenceFieldDefinition();
+        $storageDefinition = new StorageFieldDefinition([
+            'dataInt1' => $dataInt,
+        ]);
+
+        $this->converter->toFieldDefinition($storageDefinition, $fieldDef);
+
+        /** @var FieldSettings $fieldSettings */
+        $fieldSettings = $fieldDef->fieldTypeConstraints->fieldSettings;
+        self::assertSame($excpectedIsbn13Value, $fieldSettings['isISBN13']);
+    }
+
+    public function data_toFieldDefinition()
+    {
+        return [
+            [1, true],
+            [0, false],
+            [null, false],
+        ];
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/ISBNTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/ISBNTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * File containing the ISBNTest class.
  *

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/ISBNTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/ISBNTest.php
@@ -30,7 +30,7 @@ class ISBNTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider data_toFieldDefinition
+     * @dataProvider providerForTestToFieldDefinition
      *
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\ISBNConverter::toFieldDefinition
      */
@@ -48,7 +48,7 @@ class ISBNTest extends PHPUnit_Framework_TestCase
         self::assertSame($excpectedIsbn13Value, $fieldSettings['isISBN13']);
     }
 
-    public function data_toFieldDefinition()
+    public function providerForTestToFieldDefinition()
     {
         return [
             [1, true],


### PR DESCRIPTION
# Description

It fixes https://jira.ez.no/browse/EZP-24617

### More details:
Method resulted with true in both dataInt values: 1 and 0