### PR TITLE
Some improvements on API PHPDoc to use more specific types

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/Content.php
+++ b/eZ/Publish/API/Repository/Values/Content/Content.php
@@ -16,7 +16,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo convenience getter for getVersionInfo()->getContentInfo()
  * @property-read mixed $id convenience getter for retrieving the contentId: $versionInfo->contentInfo->id
  * @property-read \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo calls getVersionInfo()
- * @property-read array $fields access fields, calls getFields()
+ * @property-read \eZ\Publish\API\Repository\Values\Content\Field[] $fields access fields, calls getFields()
  */
 abstract class Content extends ValueObject
 {
@@ -37,7 +37,7 @@ abstract class Content extends ValueObject
      * @param string $fieldDefIdentifier
      * @param string $languageCode
      *
-     * @return mixed a primitive type or a field type Value object depending on the field type.
+     * @return \eZ\Publish\SPI\FieldType\Value|null a primitive type or a field type Value object depending on the field type.
      */
     abstract public function getFieldValue($fieldDefIdentifier, $languageCode = null);
 

--- a/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
@@ -25,7 +25,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read bool $alwaysAvailable Indicates if the Content object is shown in the mainlanguage if its not present in an other requested language
  * @property-read string $remoteId a global unique id of the Content object
  * @property-read string $mainLanguageCode The main language code of the Content object. If the available flag is set to true the Content is shown in this language if the requested language does not exist.
- * @property-read mixed $mainLocationId Identifier of the main location.
+ * @property-read mixed|null $mainLocationId Identifier of the main location.
  */
 class ContentInfo extends ValueObject
 {
@@ -122,7 +122,7 @@ class ContentInfo extends ValueObject
      * If the Content object has multiple locations,
      * $mainLocationId will point to the main one.
      *
-     * @var mixed
+     * @var mixed|null
      */
     protected $mainLocationId;
 }

--- a/eZ/Publish/API/Repository/Values/Content/Location.php
+++ b/eZ/Publish/API/Repository/Values/Content/Location.php
@@ -133,7 +133,7 @@ abstract class Location extends ValueObject
      *
      * A universally unique identifier.
      *
-     * @var mixed
+     * @var string
      */
     protected $remoteId;
 
@@ -180,7 +180,7 @@ abstract class Location extends ValueObject
      *
      * Valid values are found at {@link Location::SORT_FIELD_*}
      *
-     * @var mixed
+     * @var int
      */
     protected $sortField;
 
@@ -189,7 +189,7 @@ abstract class Location extends ValueObject
      *
      * Valid values are {@link Location::SORT_ORDER_*}
      *
-     * @var mixed
+     * @var int
      */
     protected $sortOrder;
 

--- a/eZ/Publish/API/Repository/Values/Content/VersionInfo.php
+++ b/eZ/Publish/API/Repository/Values/Content/VersionInfo.php
@@ -22,7 +22,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read mixed $creatorId the user id of the user which created this version
  * @property-read int $status the status of this version. One of VersionInfo::STATUS_DRAFT, VersionInfo::STATUS_PUBLISHED, VersionInfo::STATUS_ARCHIVED
  * @property-read string $initialLanguageCode the language code of the version. This value is used to flag a version as a translation to specific language
- * @property-read array $languageCodes a collection of all languages which exist in this version.
+ * @property-read string[] $languageCodes a collection of all languages which exist in this version.
  */
 abstract class VersionInfo extends ValueObject
 {

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentType.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentType.php
@@ -198,7 +198,7 @@ abstract class ContentType extends ValueObject
      *
      * Valid values are found at {@link Location::SORT_FIELD_*}
      *
-     * @var mixed
+     * @var int
      */
     protected $defaultSortField;
 
@@ -207,7 +207,7 @@ abstract class ContentType extends ValueObject
      *
      * Valid values are {@link Location::SORT_ORDER_*}
      *
-     * @var mixed
+     * @var int
      */
     protected $defaultSortOrder;
 

--- a/eZ/Publish/Core/Repository/Values/Content/Content.php
+++ b/eZ/Publish/Core/Repository/Values/Content/Content.php
@@ -59,16 +59,7 @@ class Content extends APIContent
     }
 
     /**
-     * Returns a field value for the given value
-     * $version->fields[$fieldDefId][$languageCode] is an equivalent call
-     * if no language is given on a translatable field this method returns
-     * the value of the initial language of the version if present, otherwise null.
-     * On non translatable fields this method ignores the languageCode parameter.
-     *
-     * @param string $fieldDefIdentifier
-     * @param string $languageCode
-     *
-     * @return mixed a primitive type or a field type Value object depending on the field type.
+     * {@inheritdoc}
      */
     public function getFieldValue($fieldDefIdentifier, $languageCode = null)
     {

--- a/eZ/Publish/Core/Repository/Values/Content/VersionInfo.php
+++ b/eZ/Publish/Core/Repository/Values/Content/VersionInfo.php
@@ -14,7 +14,7 @@ use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
  * This class holds version information data. It also contains the corresponding {@link Content} to
  * which the version belongs to.
  *
- * @property-read array $names returns an array with language code keys and name values
+ * @property-read string[] $names returns an array with language code keys and name values
  * @property-read \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo calls getContentInfo()
  * @property-read int $id the internal id of the version
  * @property-read int $versionNo the version number of this version (which only increments in scope of a single Content object)
@@ -23,14 +23,14 @@ use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
  * @property-read int $creatorId the user id of the user which created this version
  * @property-read int $status the status of this version. One of VersionInfo::STATUS_DRAFT, VersionInfo::STATUS_PUBLISHED, VersionInfo::STATUS_ARCHIVED
  * @property-read string $initialLanguageCode the language code of the version. This value is used to flag a version as a translation to specific language
- * @property-read array $languageCodes a collection of all languages which exist in this version.
+ * @property-read string[] $languageCodes a collection of all languages which exist in this version.
  *
  * @internal Meant for internal use by Repository, type hint against API object instead.
  */
 class VersionInfo extends APIVersionInfo
 {
     /**
-     * @var array
+     * @var string[]
      */
     protected $names;
 


### PR DESCRIPTION
Second try to update PHPDoc
(first: https://github.com/ezsystems/ezpublish-kernel/pull/1981)
Like as title PHPDoc was outdated, it disturbed fast programming.
It's not all updates of PHPDoc. If this part will come out correct i will create next PR.
Now should be fine with this PR, 

@andrerom 
https://github.com/ezsystems/ezpublish-kernel/pull/1981#issuecomment-300290399
I really do not want to omit 'mixed -> string|int' but i did that.
In API VersionInfo class ids are marked as "int".

