### PR TITLE
EZP-26885: Refactor Field Types external storages to inject gateways and connection handler via DI

### DIFF
--- a/doc/bc/changes-6.11.md
+++ b/doc/bc/changes-6.11.md
@@ -1,0 +1,16 @@
+# Backwards compatibility changes
+
+Changes affecting version compatibility with former or future versions.
+
+## Changes
+
+## Deprecations
+
+- EZP-26885: Field Type external storage
+  - Abstract base class `eZ\Publish\Core\FieldType\StorageGateway` for the gateway of a Field Type
+   external storage is deprecated.
+  - The `eZ\Publish\Core\FieldType\StorageGateway::setConnection` method is deprecated.
+
+  See [6.11 Upgrade Notes](../upgrade/6.11.md) for the details.
+
+## Removed features

--- a/doc/bc/changes-6.11.md
+++ b/doc/bc/changes-6.11.md
@@ -8,8 +8,9 @@ Changes affecting version compatibility with former or future versions.
 
 - EZP-26885: Field Type external storage
   - Abstract base class `eZ\Publish\Core\FieldType\StorageGateway` for the gateway of a Field Type
-   external storage is deprecated.
-  - The `eZ\Publish\Core\FieldType\StorageGateway::setConnection` method is deprecated.
+    external storage and specifically its method `setConnection` are deprecated.
+  - Abstract base class `eZ\Publish\Core\FieldType\GatewayBasedStorage` for Field Type external storage
+    which uses gateway and specifically its method `getGateway` are deprecated.
 
   See [6.11 Upgrade Notes](../upgrade/6.11.md) for the details.
 

--- a/doc/upgrade/6.11.md
+++ b/doc/upgrade/6.11.md
@@ -1,0 +1,168 @@
+# Upgrade steps from 6.10 to 6.11
+
+## Field Type external storage
+
+### External storage gateways
+
+Abstract base class `eZ\Publish\Core\FieldType\StorageGateway` for the gateway of a Field Type
+external storage and the `eZ\Publish\Core\FieldType\StorageGateway::setConnection` method are deprecated.
+
+To prepare your FieldType for future storage engines and avoid using the deprecated abstract,
+extend the`eZ\Publish\SPI\FieldType\StorageGateway` class and inject Database Handler directly
+into the gateway instead.
+
+Before:
+```yml
+app.field_type.custom_field_type.storage_gateway:
+    class: CustomFieldTypeStorageGateway
+    tags:
+        - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: customfield, identifier: LegacyStorage}
+```
+
+```php
+use eZ\Publish\Core\FieldType\StorageGateway;
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+
+class CustomFieldTypeStorageGateway extends StorageGateway
+{
+    /**
+     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
+     */
+    protected $dbHandler;
+
+    public function setConnection(DatabaseHandler $dbHandler)
+    {
+        $this->dbHandler = $dbHandler;
+    }
+
+
+    // ...
+}
+```
+
+After:
+```yml
+app.field_type.custom_field_type.storage_gateway:
+    class: CustomFieldTypeStorageGateway
+    arguments:
+        - "@ezpublish.api.storage_engine.legacy.dbhandler"
+```
+
+```php
+use eZ\Publish\SPI\FieldType\StorageGateway;
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+
+class CustomFieldTypeStorageGateway extends StorageGateway
+{
+    /**
+     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
+     */
+    protected $dbHandler;
+
+    public function __construct(DatabaseHandler $dbHandler)
+    {
+        $this->dbHandler = $dbHandler;
+    }
+
+    // ...
+}
+```
+### External storage handlers
+
+Abstract base class `eZ\Publish\Core\FieldType\GatewayBasedStorage` for Field Type external storage
+which uses gateway is deprecated.
+
+To prepare your FieldType for future storage engines and avoid using the deprecated abstract,
+use `eZ\Publish\SPI\FieldType\GatewayBasedStorage` instead and inject external
+storage gateway using Dependency Injection.
+
+Before:
+```yml
+app.field_type.custom_field_type.external_storage:
+    class: CustomFieldTypeStorage
+    tags:
+        - {name: ezpublish.fieldType.externalStorageHandler, alias: customfield}
+```
+
+```php
+use eZ\Publish\Core\FieldType\GatewayBasedStorage;
+
+class CustomFieldTypeStorage extends GatewayBasedStorage
+{
+    public function __construct(array $gateways = [])
+    {
+        // ...
+    }
+
+    public function storeFieldData(VersionInfo $versionInfo, Field $field, array $context)
+    {
+        $this->getGateway($context)->storeFieldData($versionInfo, $field);
+
+        // ..
+    }
+
+    public function getFieldData(VersionInfo $versionInfo, Field $field, array $context)
+    {
+        $this->getGateway($context)->getFieldData($versionInfo, $field);
+
+        // ..
+    }
+
+    public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds, array $context)
+    {
+        $this->getGateway($context)->deleteFieldData($versionInfo, $field);
+
+        // ..
+    }
+
+    // ...
+}
+```
+
+After:
+```yml
+app.field_type.custom_field_type.external_storage:
+    class: CustomFieldTypeStorage
+    arguments:
+        - "@app.field_type.custom_field_type.storage_gateway"
+    tags:
+        - {name: ezpublish.fieldType.externalStorageHandler, alias: customfield}
+```
+
+```php
+use eZ\Publish\SPI\FieldType\GatewayBasedStorage;
+use eZ\Publish\SPI\FieldType\StorageGateway;
+
+class CustomFieldTypeStorage extends GatewayBasedStorage
+{
+    public function __construct(StorageGateway gateway)
+    {
+        parent::__construct($gateway);
+
+        // ...
+    }
+
+    public function storeFieldData(VersionInfo $versionInfo, Field $field, array $context)
+    {
+        $this->gateway->storeFieldData($versionInfo, $field);
+
+        // ..
+    }
+
+    public function getFieldData(VersionInfo $versionInfo, Field $field, array $context)
+    {
+        $this->gateway->getFieldData($versionInfo, $field);
+
+        // ..
+    }
+
+    public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds, array $context)
+    {
+        $this->gateway->deleteFieldData($versionInfo, $field);
+
+        // ..
+    }
+
+    // ...
+}
+```

--- a/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage/Gateway.php
@@ -10,7 +10,7 @@ namespace eZ\Publish\Core\FieldType\BinaryBase\BinaryBaseStorage;
 
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
-use eZ\Publish\Core\FieldType\StorageGateway;
+use eZ\Publish\SPI\FieldType\StorageGateway;
 
 abstract class Gateway extends StorageGateway
 {

--- a/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage/Gateway/LegacyStorage.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\FieldType\BinaryBase\BinaryBaseStorage\Gateway;
 
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\Core\FieldType\BinaryBase\BinaryBaseStorage\Gateway;
@@ -17,11 +18,14 @@ use eZ\Publish\Core\Persistence\Database\InsertQuery;
 abstract class LegacyStorage extends Gateway
 {
     /**
-     * Connection.
-     *
-     * @var mixed
+     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
      */
     protected $dbHandler;
+
+    public function __construct(DatabaseHandler $dbHandler)
+    {
+        $this->dbHandler = $dbHandler;
+    }
 
     /**
      * Returns the table name to store data in.
@@ -111,47 +115,21 @@ abstract class LegacyStorage extends Gateway
     }
 
     /**
-     * Set database handler for this gateway.
-     *
-     * @param mixed $dbHandler
-     *
-     * @throws \RuntimeException if $dbHandler is not an instance of
-     *         {@link \eZ\Publish\Core\Persistence\Database\DatabaseHandler}
-     */
-    public function setConnection($dbHandler)
-    {
-        // This obviously violates the Liskov substitution Principle, but with
-        // the given class design there is no sane other option. Actually the
-        // dbHandler *should* be passed to the constructor, and there should
-        // not be the need to post-inject it.
-        if (!$dbHandler instanceof \eZ\Publish\Core\Persistence\Database\DatabaseHandler) {
-            throw new \RuntimeException('Invalid dbHandler passed');
-        }
-
-        $this->dbHandler = $dbHandler;
-    }
-
-    /**
      * Returns the active connection.
-     *
-     * @throws \RuntimeException if no connection has been set, yet.
      *
      * @return \eZ\Publish\Core\Persistence\Database\DatabaseHandler
      */
     protected function getConnection()
     {
-        if ($this->dbHandler === null) {
-            throw new \RuntimeException('Missing database connection.');
-        }
-
         return $this->dbHandler;
     }
 
     /**
      * Stores the file reference in $field for $versionNo.
      *
-     * @param VersionInfo $versionInfo
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @return bool
      */
     public function storeFileReference(VersionInfo $versionInfo, Field $field)
     {

--- a/eZ/Publish/Core/FieldType/GatewayBasedStorage.php
+++ b/eZ/Publish/Core/FieldType/GatewayBasedStorage.php
@@ -11,9 +11,12 @@ namespace eZ\Publish\Core\FieldType;
 use eZ\Publish\SPI\FieldType\FieldStorage;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+use eZ\Publish\SPI\FieldType\GatewayBasedStorage as SPIGatewayBasedStorage;
 
 /**
  * Storage gateway base class to be used by FieldType storages.
+ *
+ * @deprecated Since 6.11. Use {@link \eZ\Publish\SPI\FieldType\GatewayBasedStorage}
  *
  * This class gives a common basis to realized gateway based storage
  * dispatching. It is intended to deal as a base class for FieldType storages,
@@ -39,6 +42,16 @@ abstract class GatewayBasedStorage implements FieldStorage
      */
     public function __construct(array $gateways = array())
     {
+        @trigger_error(
+            sprintf(
+                '%s extends deprecated %s. Extend %s instead',
+                static::class,
+                self::class,
+                SPIGatewayBasedStorage::class
+            ),
+            E_USER_DEPRECATED
+        );
+
         foreach ($gateways as $identifier => $gateway) {
             $this->addGateway($identifier, $gateway);
         }
@@ -58,12 +71,23 @@ abstract class GatewayBasedStorage implements FieldStorage
     /**
      * Retrieve the fitting gateway, base on the identifier in $context.
      *
+     * @deprecated Since 6.11. Retrieving gateway based on $context is deprecated
+     *             and will be removed in 7.0. Inject gateway directly into FieldStorage
+     *
      * @param array $context
      *
      * @return \eZ\Publish\Core\FieldType\StorageGateway
      */
     protected function getGateway(array $context)
     {
+        @trigger_error(
+            sprintf(
+                '%s: Retrieving gateway based on $context is deprecated and will be removed in 7.0. Inject gateway directly into FieldStorage',
+                get_class($this)
+            ),
+            E_USER_DEPRECATED
+        );
+
         if (!isset($this->gateways[$context['identifier']])) {
             throw new \OutOfBoundsException("No gateway for ${context['identifier']} available.");
         }

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway.php
@@ -9,8 +9,11 @@
 namespace eZ\Publish\Core\FieldType\Image\ImageStorage;
 
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
-use eZ\Publish\Core\FieldType\StorageGateway;
+use eZ\Publish\SPI\FieldType\StorageGateway;
 
+/**
+ * Image Field Type external storage gateway.
+ */
 abstract class Gateway extends StorageGateway
 {
     /**

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/LegacyStorage.php
@@ -9,15 +9,14 @@
 namespace eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway;
 
 use eZ\Publish\Core\IO\UrlRedecorator;
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway;
 
 class LegacyStorage extends Gateway
 {
     /**
-     * Connection.
-     *
-     * @var mixed
+     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
      */
     protected $dbHandler;
 
@@ -26,58 +25,32 @@ class LegacyStorage extends Gateway
      *
      * @var array
      */
-    protected $fieldNameMap = array(
+    protected $fieldNameMap = [
         'id' => 'fieldId',
         'version' => 'versionNo',
         'language_code' => 'languageCode',
         'path_identification_string' => 'nodePathString',
         'data_string' => 'xml',
-    );
+    ];
 
     /**
-     * @var UrlRedecorator
+     * @var \eZ\Publish\Core\IO\UrlRedecorator
      */
     private $redecorator;
 
-    public function __construct(UrlRedecorator $redecorator)
+    public function __construct(UrlRedecorator $redecorator, DatabaseHandler $dbHandler)
     {
         $this->redecorator = $redecorator;
-    }
-
-    /**
-     * Set database handler for this gateway.
-     *
-     * @param mixed $dbHandler
-     *
-     * @throws \RuntimeException if $dbHandler is not an instance of
-     *         {@link \eZ\Publish\Core\Persistence\Database\DatabaseHandler}
-     */
-    public function setConnection($dbHandler)
-    {
-        // This obviously violates the Liskov substitution Principle, but with
-        // the given class design there is no sane other option. Actually the
-        // dbHandler *should* be passed to the constructor, and there should
-        // not be the need to post-inject it.
-        if (!$dbHandler instanceof \eZ\Publish\Core\Persistence\Database\DatabaseHandler) {
-            throw new \RuntimeException('Invalid dbHandler passed');
-        }
-
         $this->dbHandler = $dbHandler;
     }
 
     /**
      * Returns the active connection.
      *
-     * @throws \RuntimeException if no connection has been set, yet.
-     *
      * @return \eZ\Publish\Core\Persistence\Database\DatabaseHandler
      */
     protected function getConnection()
     {
-        if ($this->dbHandler === null) {
-            throw new \RuntimeException('Missing database connection.');
-        }
-
         return $this->dbHandler;
     }
 

--- a/eZ/Publish/Core/FieldType/Keyword/KeywordStorage.php
+++ b/eZ/Publish/Core/FieldType/Keyword/KeywordStorage.php
@@ -8,7 +8,7 @@
  */
 namespace eZ\Publish\Core\FieldType\Keyword;
 
-use eZ\Publish\Core\FieldType\GatewayBasedStorage;
+use eZ\Publish\SPI\FieldType\GatewayBasedStorage;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
 
@@ -22,15 +22,22 @@ use eZ\Publish\SPI\Persistence\Content\Field;
 class KeywordStorage extends GatewayBasedStorage
 {
     /**
+     * @var \eZ\Publish\Core\FieldType\Keyword\KeywordStorage\Gateway
+     */
+    protected $gateway;
+
+    /**
      * @see \eZ\Publish\SPI\FieldType\FieldStorage
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param array $context
+     * @return mixed
      */
     public function storeFieldData(VersionInfo $versionInfo, Field $field, array $context)
     {
-        $gateway = $this->getGateway($context);
+        $contentTypeId = $this->gateway->getContentTypeId($field);
 
-        $contentTypeId = $gateway->getContentTypeId($field);
-
-        return $gateway->storeFieldData($field, $contentTypeId);
+        return $this->gateway->storeFieldData($field, $contentTypeId);
     }
 
     /**
@@ -44,9 +51,8 @@ class KeywordStorage extends GatewayBasedStorage
      */
     public function getFieldData(VersionInfo $versionInfo, Field $field, array $context)
     {
-        $gateway = $this->getGateway($context);
         // @todo: This should already retrieve the ContentType ID
-        return $gateway->getFieldData($field);
+        return $this->gateway->getFieldData($field);
     }
 
     /**
@@ -66,9 +72,8 @@ class KeywordStorage extends GatewayBasedStorage
             return false;
         }
 
-        $gateway = $this->getGateway($context);
         foreach ($fieldIds as $fieldId) {
-            $gateway->deleteFieldData($fieldId);
+            $this->gateway->deleteFieldData($fieldId);
         }
 
         return true;
@@ -85,8 +90,10 @@ class KeywordStorage extends GatewayBasedStorage
     }
 
     /**
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
      * @param \eZ\Publish\SPI\Persistence\Content\Field $field
      * @param array $context
+     * @return \eZ\Publish\SPI\Search\Field[]|null
      */
     public function getIndexData(VersionInfo $versionInfo, Field $field, array $context)
     {

--- a/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway.php
@@ -9,8 +9,11 @@
 namespace eZ\Publish\Core\FieldType\Keyword\KeywordStorage;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
-use eZ\Publish\Core\FieldType\StorageGateway;
+use eZ\Publish\SPI\FieldType\StorageGateway;
 
+/**
+ * Keyword Field Type external storage gateway.
+ */
 abstract class Gateway extends StorageGateway
 {
     /**

--- a/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway/LegacyStorage.php
@@ -9,46 +9,22 @@ use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 class LegacyStorage extends Gateway
 {
     /**
-     * Connection.
-     *
-     * @var mixed
+     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
      */
     protected $dbHandler;
 
-    /**
-     * Set database handler for this gateway.
-     *
-     * @param mixed $dbHandler
-     *
-     * @throws \RuntimeException if $dbHandler is not an instance of
-     *         {@link \eZ\Publish\Core\Persistence\Database\DatabaseHandler}
-     */
-    public function setConnection($dbHandler)
+    public function __construct(DatabaseHandler $dbHandler)
     {
-        // This obviously violates the Liskov substitution Principle, but with
-        // the given class design there is no sane other option. Actually the
-        // dbHandler *should* be passed to the constructor, and there should
-        // not be the need to post-inject it.
-        if (!$dbHandler instanceof DatabaseHandler) {
-            throw new \RuntimeException('Invalid dbHandler passed');
-        }
-
         $this->dbHandler = $dbHandler;
     }
 
     /**
      * Returns the active connection.
      *
-     * @throws \RuntimeException if no connection has been set, yet.
-     *
      * @return \eZ\Publish\Core\Persistence\Database\DatabaseHandler
      */
     protected function getConnection()
     {
-        if ($this->dbHandler === null) {
-            throw new \RuntimeException('Missing database connection.');
-        }
-
         return $this->dbHandler;
     }
 

--- a/eZ/Publish/Core/FieldType/MapLocation/MapLocationStorage.php
+++ b/eZ/Publish/Core/FieldType/MapLocation/MapLocationStorage.php
@@ -8,7 +8,7 @@
  */
 namespace eZ\Publish\Core\FieldType\MapLocation;
 
-use eZ\Publish\Core\FieldType\GatewayBasedStorage;
+use eZ\Publish\SPI\FieldType\GatewayBasedStorage;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
 
@@ -18,13 +18,20 @@ use eZ\Publish\SPI\Persistence\Content\Field;
 class MapLocationStorage extends GatewayBasedStorage
 {
     /**
+     * @var \eZ\Publish\Core\FieldType\MapLocation\MapLocationStorage\Gateway
+     */
+    protected $gateway;
+
+    /**
      * @see \eZ\Publish\SPI\FieldType\FieldStorage
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param array $context
+     * @return mixed
      */
     public function storeFieldData(VersionInfo $versionInfo, Field $field, array $context)
     {
-        $gateway = $this->getGateway($context);
-
-        return $gateway->storeFieldData($versionInfo, $field);
+        return $this->gateway->storeFieldData($versionInfo, $field);
     }
 
     /**
@@ -38,20 +45,19 @@ class MapLocationStorage extends GatewayBasedStorage
      */
     public function getFieldData(VersionInfo $versionInfo, Field $field, array $context)
     {
-        $gateway = $this->getGateway($context);
-        $gateway->getFieldData($versionInfo, $field);
+        $this->gateway->getFieldData($versionInfo, $field);
     }
 
     /**
-     * @param VersionInfo $versionInfo
-     * @param array $fieldId
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param array $fieldIds
      * @param array $context
      *
      * @return bool
      */
     public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds, array $context)
     {
-        $this->getGateway($context)->deleteFieldData($versionInfo, $fieldIds);
+        $this->gateway->deleteFieldData($versionInfo, $fieldIds);
     }
 
     /**
@@ -65,8 +71,10 @@ class MapLocationStorage extends GatewayBasedStorage
     }
 
     /**
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
      * @param \eZ\Publish\SPI\Persistence\Content\Field $field
      * @param array $context
+     * @return \eZ\Publish\SPI\Search\Field[]|null
      */
     public function getIndexData(VersionInfo $versionInfo, Field $field, array $context)
     {

--- a/eZ/Publish/Core/FieldType/MapLocation/MapLocationStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/MapLocation/MapLocationStorage/Gateway.php
@@ -10,8 +10,11 @@ namespace eZ\Publish\Core\FieldType\MapLocation\MapLocationStorage;
 
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
-use eZ\Publish\Core\FieldType\StorageGateway;
+use eZ\Publish\SPI\FieldType\StorageGateway;
 
+/**
+ * MapLocation Field Type external storage gateway.
+ */
 abstract class Gateway extends StorageGateway
 {
     /**

--- a/eZ/Publish/Core/FieldType/MapLocation/MapLocationStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/MapLocation/MapLocationStorage/Gateway/LegacyStorage.php
@@ -9,52 +9,29 @@
 namespace eZ\Publish\Core\FieldType\MapLocation\MapLocationStorage\Gateway;
 
 use eZ\Publish\Core\FieldType\MapLocation\MapLocationStorage\Gateway;
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 
 class LegacyStorage extends Gateway
 {
     /**
-     * Connection.
-     *
-     * @var mixed
+     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
      */
     protected $dbHandler;
 
-    /**
-     * Set database handler for this gateway.
-     *
-     * @param mixed $dbHandler
-     *
-     * @throws \RuntimeException if $dbHandler is not an instance of
-     *         {@link \eZ\Publish\Core\Persistence\Database\DatabaseHandler}
-     */
-    public function setConnection($dbHandler)
+    public function __construct(DatabaseHandler $dbHandler)
     {
-        // This obviously violates the Liskov substitution Principle, but with
-        // the given class design there is no sane other option. Actually the
-        // dbHandler *should* be passed to the constructor, and there should
-        // not be the need to post-inject it.
-        if (!$dbHandler instanceof \eZ\Publish\Core\Persistence\Database\DatabaseHandler) {
-            throw new \RuntimeException('Invalid dbHandler passed');
-        }
-
         $this->dbHandler = $dbHandler;
     }
 
     /**
      * Returns the active connection.
      *
-     * @throws \RuntimeException if no connection has been set, yet.
-     *
      * @return \eZ\Publish\Core\Persistence\Database\DatabaseHandler
      */
     protected function getConnection()
     {
-        if ($this->dbHandler === null) {
-            throw new \RuntimeException('Missing database connection.');
-        }
-
         return $this->dbHandler;
     }
 
@@ -64,8 +41,8 @@ class LegacyStorage extends Gateway
      * Potentially rewrites data in $field and returns true, if the $field
      * needs to be updated in the database.
      *
-     * @param VersionInfo $versionInfo
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
      *
      * @return bool If restoring of the internal field data is required
      */
@@ -79,7 +56,7 @@ class LegacyStorage extends Gateway
                 'hasData' => false,
             );
 
-            return;
+            return false;
         }
 
         if ($this->hasFieldData($field->id, $versionInfo->versionNo)) {
@@ -99,8 +76,8 @@ class LegacyStorage extends Gateway
     /**
      * Performs an update on the field data.
      *
-     * @param VersionInfo $versionInfo
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
      *
      * @return bool
      */
@@ -138,8 +115,8 @@ class LegacyStorage extends Gateway
     /**
      * Stores new field data.
      *
-     * @param VersionInfo $versionInfo
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
      */
     protected function storeNewFieldData(VersionInfo $versionInfo, Field $field)
     {
@@ -170,8 +147,8 @@ class LegacyStorage extends Gateway
     /**
      * Sets the loaded field data into $field->externalData.
      *
-     * @param VersionInfo $versionInfo
-     * @param Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
      *
      * @return array
      */
@@ -245,7 +222,7 @@ class LegacyStorage extends Gateway
     /**
      * Deletes the data for all given $fieldIds.
      *
-     * @param VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
      * @param array $fieldIds
      */
     public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds)

--- a/eZ/Publish/Core/FieldType/Page/PageStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/Page/PageStorage/Gateway.php
@@ -8,7 +8,7 @@
  */
 namespace eZ\Publish\Core\FieldType\Page\PageStorage;
 
-use eZ\Publish\Core\FieldType\StorageGateway;
+use eZ\Publish\SPI\FieldType\StorageGateway;
 use eZ\Publish\Core\FieldType\Page\Parts\Block;
 
 /**

--- a/eZ/Publish/Core/FieldType/Page/PageStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Page/PageStorage/Gateway/LegacyStorage.php
@@ -14,7 +14,6 @@ use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\Core\FieldType\Page\Parts\Block;
 use eZ\Publish\Core\FieldType\Page\Parts\Item;
 use PDO;
-use RuntimeException;
 use DateTime;
 use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
@@ -25,40 +24,18 @@ class LegacyStorage extends Gateway
      */
     protected $dbHandler;
 
-    /**
-     * Set database handler for this gateway.
-     *
-     * @param mixed $dbHandler
-     *
-     * @throws \RuntimeException if $dbHandler is not an instance of
-     *         {@link \eZ\Publish\Core\Persistence\Database\DatabaseHandler}
-     */
-    public function setConnection($dbHandler)
+    public function __construct(DatabaseHandler $dbHandler)
     {
-        // This obviously violates the Liskov substitution Principle, but with
-        // the given class design there is no sane other option. Actually the
-        // dbHandler *should* be passed to the constructor, and there should
-        // not be the need to post-inject it.
-        if (!$dbHandler instanceof DatabaseHandler) {
-            throw new RuntimeException('Invalid dbHandler passed');
-        }
-
         $this->dbHandler = $dbHandler;
     }
 
     /**
      * Returns the active connection.
      *
-     * @throws \RuntimeException if no connection has been set, yet.
-     *
      * @return \eZ\Publish\Core\Persistence\Database\DatabaseHandler
      */
     protected function getConnection()
     {
-        if ($this->dbHandler === null) {
-            throw new RuntimeException('Missing database connection.');
-        }
-
         return $this->dbHandler;
     }
 

--- a/eZ/Publish/Core/FieldType/RichText/RichTextStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/RichText/RichTextStorage/Gateway.php
@@ -8,7 +8,7 @@
  */
 namespace eZ\Publish\Core\FieldType\RichText\RichTextStorage;
 
-use eZ\Publish\Core\FieldType\StorageGateway;
+use eZ\Publish\SPI\FieldType\StorageGateway;
 use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway as UrlGateway;
 
 /**

--- a/eZ/Publish/Core/FieldType/RichText/RichTextStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/RichText/RichTextStorage/Gateway/LegacyStorage.php
@@ -9,8 +9,8 @@
 namespace eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway;
 
 use eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway;
+use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway as UrlGateway;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
-use RuntimeException;
 
 class LegacyStorage extends Gateway
 {
@@ -19,41 +19,19 @@ class LegacyStorage extends Gateway
      */
     protected $dbHandler;
 
-    /**
-     * Set database handler for this gateway.
-     *
-     * @param mixed $dbHandler
-     *
-     * @throws \RuntimeException if $dbHandler is not an instance of
-     *         {@link \eZ\Publish\Core\Persistence\Database\DatabaseHandler}
-     */
-    public function setConnection($dbHandler)
+    public function __construct(UrlGateway $urlGateway, DatabaseHandler $dbHandler)
     {
-        // This obviously violates the Liskov substitution Principle, but with
-        // the given class design there is no sane other option. Actually the
-        // dbHandler *should* be passed to the constructor, and there should
-        // not be the need to post-inject it.
-        if (!$dbHandler instanceof DatabaseHandler) {
-            throw new RuntimeException('Invalid dbHandler passed');
-        }
-
-        $this->urlGateway->setConnection($dbHandler);
+        parent::__construct($urlGateway);
         $this->dbHandler = $dbHandler;
     }
 
     /**
      * Returns the active connection.
      *
-     * @throws \RuntimeException if no connection has been set, yet.
-     *
      * @return \eZ\Publish\Core\Persistence\Database\DatabaseHandler
      */
     protected function getConnection()
     {
-        if ($this->dbHandler === null) {
-            throw new \RuntimeException('Missing database connection.');
-        }
-
         return $this->dbHandler;
     }
 

--- a/eZ/Publish/Core/FieldType/StorageGateway.php
+++ b/eZ/Publish/Core/FieldType/StorageGateway.php
@@ -8,20 +8,19 @@
  */
 namespace eZ\Publish\Core\FieldType;
 
+use eZ\Publish\SPI\FieldType\StorageGateway as SPIStorageGateway;
+
 /**
  * Abstract base class for storage gateways.
  *
- * This base class must be extended by storage gateways to be used with a
- * {@link eZ\Publish\Core\FieldType\GatewayBasedStorage} based storage
- * implementation.
- *
- * The {@link setConnection()} method is called by the GatewayBasedStorage to
- * set the connection from the current persistence context.
+ * @deprecated Since 6.11. Extend {@link \eZ\Publish\SPI\FieldType\StorageGateway} class instead.
  */
-abstract class StorageGateway
+abstract class StorageGateway extends SPIStorageGateway
 {
     /**
      * Sets the data storage connection to use.
+     *
+     * @deprecated Since 6.11. Set gateway connection using Dependency Injection.
      *
      * Allows injection of the data storage connection to be used from external
      * source. This can be a database connection resource or something else to

--- a/eZ/Publish/Core/FieldType/Tests/Page/PageServiceTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Page/PageServiceTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\FieldType\Tests\Page;
 
 use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\FieldType\Page\PageStorage;
 use eZ\Publish\Core\FieldType\Page\Parts\Block;
 use eZ\Publish\Core\FieldType\Page\Parts\Item;
 use eZ\Publish\Core\FieldType\Page\Parts\Page;
@@ -55,7 +56,10 @@ class PageServiceTest extends PHPUnit_Framework_TestCase
         $this->zoneDefinition = $this->getZoneDefinition();
         $this->blockDefinition = $this->getBlockDefinition();
 
-        $this->storageGateway = $this->getMockForAbstractClass('eZ\\Publish\\Core\\FieldType\\Page\\PageStorage\\Gateway');
+        $this->storageGateway = $this
+            ->getMockBuilder(PageStorage\Gateway::class)
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->contentService = $this->getMock('eZ\\Publish\\API\\Repository\\ContentService');
         $pageServiceClass = static::PAGESERVICE_CLASS;
         $this->pageService = new $pageServiceClass(

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Gateway/LegacyStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Gateway/LegacyStorageTest.php
@@ -52,8 +52,7 @@ class LegacyStorageTest extends TestCase
     {
         if (!isset($this->storageGateway)) {
             $dbHandler = $this->getDatabaseHandler();
-            $urlGateway = new UrlStorageLegacyGateway();
-            $urlGateway->setConnection($dbHandler);
+            $urlGateway = new UrlStorageLegacyGateway($dbHandler);
             $this->storageGateway = new LegacyStorage($urlGateway, $dbHandler);
         }
 

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Gateway/LegacyStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Gateway/LegacyStorageTest.php
@@ -9,7 +9,7 @@
 namespace eZ\Publish\Core\FieldType\Tests\RichText\Gateway;
 
 use eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\LegacyStorage;
-use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\LegacyStorage as UrlStorage;
+use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\LegacyStorage as UrlStorageLegacyGateway;
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 
 /**
@@ -17,23 +17,6 @@ use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
  */
 class LegacyStorageTest extends TestCase
 {
-    public function testSetConnection()
-    {
-        $gateway = $this->getStorageGateway();
-
-        $gateway->setConnection($this->getMock('eZ\\Publish\\Core\\Persistence\\Database\\DatabaseHandler'));
-    }
-
-    /**
-     * @expectedException \RuntimeException
-     */
-    public function testSetConnectionThrowsRuntimeException()
-    {
-        $gateway = $this->getStorageGateway();
-
-        $gateway->setConnection(new \DateTime());
-    }
-
     public function testGetContentIds()
     {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/contentobjects.php');
@@ -68,10 +51,10 @@ class LegacyStorageTest extends TestCase
     protected function getStorageGateway()
     {
         if (!isset($this->storageGateway)) {
-            $this->storageGateway = new LegacyStorage(
-                new UrlStorage()
-            );
-            $this->storageGateway->setConnection($this->getDatabaseHandler());
+            $dbHandler = $this->getDatabaseHandler();
+            $urlGateway = new UrlStorageLegacyGateway();
+            $urlGateway->setConnection($dbHandler);
+            $this->storageGateway = new LegacyStorage($urlGateway, $dbHandler);
         }
 
         return $this->storageGateway;

--- a/eZ/Publish/Core/FieldType/Tests/RichText/RichTextStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/RichTextStorageTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\Core\FieldType\Tests\RichText;
 
+use eZ\Publish\Core\FieldType\RichText\RichTextStorage;
+use eZ\Publish\SPI\FieldType\StorageGateway;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
@@ -93,12 +95,7 @@ class RichTextStorageTest extends PHPUnit_Framework_TestCase
         $value = new FieldValue(array('data' => $xmlString));
         $field = new Field(array('value' => $value));
 
-        $storage = $this->getPartlyMockedStorage(array('getGateway'));
-        $storage
-            ->expects($this->once())
-            ->method('getGateway')
-            ->with($this->getContext())
-            ->will($this->returnValue($gateway));
+        $storage = $this->getPartlyMockedStorage($gateway);
         $storage->getFieldData(
             $versionInfo,
             $field,
@@ -231,12 +228,7 @@ class RichTextStorageTest extends PHPUnit_Framework_TestCase
                 ->with($id, 42, 24);
         }
 
-        $storage = $this->getPartlyMockedStorage(array('getGateway'));
-        $storage
-            ->expects($this->once())
-            ->method('getGateway')
-            ->with($this->getContext())
-            ->will($this->returnValue($gateway));
+        $storage = $this->getPartlyMockedStorage($gateway);
         $result = $storage->storeFieldData(
             $versionInfo,
             $field,
@@ -313,13 +305,7 @@ class RichTextStorageTest extends PHPUnit_Framework_TestCase
         $value = new FieldValue(array('data' => $xmlString));
         $field = new Field(array('value' => $value));
 
-        $storage = $this->getPartlyMockedStorage(array('getGateway'));
-        $storage
-            ->expects($this->once())
-            ->method('getGateway')
-            ->with($this->getContext())
-            ->will($this->returnValue($gateway));
-
+        $storage = $this->getPartlyMockedStorage($gateway);
         $storage->storeFieldData(
             $versionInfo,
             $field,
@@ -332,13 +318,7 @@ class RichTextStorageTest extends PHPUnit_Framework_TestCase
         $versionInfo = new VersionInfo(array('versionNo' => 42));
         $fieldIds = array(12, 23);
         $gateway = $this->getGatewayMock();
-        $storage = $this->getPartlyMockedStorage(array('getGateway'));
-        $storage
-            ->expects($this->once())
-            ->method('getGateway')
-            ->with($this->getContext())
-            ->will($this->returnValue($gateway));
-
+        $storage = $this->getPartlyMockedStorage($gateway);
         $gateway
             ->expects($this->at(0))
             ->method('unlinkUrl')
@@ -357,19 +337,18 @@ class RichTextStorageTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @param array $methods
-     *
+     * @param \eZ\Publish\SPI\FieldType\StorageGateway $gateway
      * @return \eZ\Publish\Core\FieldType\RichText\RichTextStorage|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected function getPartlyMockedStorage(array $methods)
+    protected function getPartlyMockedStorage(StorageGateway $gateway)
     {
         return $this->getMock(
-            'eZ\\Publish\\Core\\FieldType\\RichText\\RichTextStorage',
-            $methods,
-            array(
-                array(),
+            RichTextStorage::class,
+            null,
+            [
+                $gateway,
                 $this->getLoggerMock(),
-            )
+            ]
         );
     }
 
@@ -412,7 +391,7 @@ class RichTextStorageTest extends PHPUnit_Framework_TestCase
     {
         if (!isset($this->gatewayMock)) {
             $this->gatewayMock = $this
-                ->getMockBuilder('eZ\\Publish\\Core\\FieldType\\RichText\\RichTextStorage\\Gateway')
+                ->getMockBuilder(RichTextStorage\Gateway::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         }

--- a/eZ/Publish/Core/FieldType/Tests/Url/Gateway/LegacyStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Url/Gateway/LegacyStorageTest.php
@@ -16,23 +16,6 @@ use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
  */
 class LegacyStorageTest extends TestCase
 {
-    public function testSetConnection()
-    {
-        $gateway = $this->getStorageGateway();
-
-        $gateway->setConnection($this->getMock('eZ\\Publish\\Core\\Persistence\\Database\\DatabaseHandler'));
-    }
-
-    /**
-     * @expectedException \RuntimeException
-     */
-    public function testSetConnectionThrowsRuntimeException()
-    {
-        $gateway = $this->getStorageGateway();
-
-        $gateway->setConnection(new \DateTime());
-    }
-
     public function testGetIdUrlMap()
     {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/urls.php');
@@ -212,8 +195,7 @@ class LegacyStorageTest extends TestCase
     protected function getStorageGateway()
     {
         if (!isset($this->storageGateway)) {
-            $this->storageGateway = new LegacyStorage();
-            $this->storageGateway->setConnection($this->getDatabaseHandler());
+            $this->storageGateway = new LegacyStorage($this->getDatabaseHandler());
         }
 
         return $this->storageGateway;

--- a/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway.php
@@ -8,7 +8,7 @@
  */
 namespace eZ\Publish\Core\FieldType\Url\UrlStorage;
 
-use eZ\Publish\Core\FieldType\StorageGateway;
+use eZ\Publish\SPI\FieldType\StorageGateway;
 
 /**
  * Abstract gateway class for Url field type.

--- a/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway/LegacyStorage.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway;
 
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway;
-use RuntimeException;
 use PDO;
 
 /**
@@ -22,46 +21,22 @@ class LegacyStorage extends Gateway
     const URL_LINK_TABLE = 'ezurl_object_link';
 
     /**
-     * Connection.
-     *
-     * @var mixed
+     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
      */
     protected $dbHandler;
 
-    /**
-     * Set database handler for this gateway.
-     *
-     * @param mixed $dbHandler
-     *
-     * @throws \RuntimeException if $dbHandler is not an instance of
-     *         {@link \eZ\Publish\Core\Persistence\Database\DatabaseHandler}
-     */
-    public function setConnection($dbHandler)
+    public function __construct(DatabaseHandler $dbHandler)
     {
-        // This obviously violates the Liskov substitution Principle, but with
-        // the given class design there is no sane other option. Actually the
-        // dbHandler *should* be passed to the constructor, and there should
-        // not be the need to post-inject it.
-        if (!($dbHandler instanceof DatabaseHandler)) {
-            throw new RuntimeException('Invalid dbHandler passed');
-        }
-
         $this->dbHandler = $dbHandler;
     }
 
     /**
      * Returns the active connection.
      *
-     * @throws \RuntimeException if no connection has been set, yet.
-     *
      * @return \eZ\Publish\Core\Persistence\Database\DatabaseHandler
      */
     protected function getConnection()
     {
-        if ($this->dbHandler === null) {
-            throw new RuntimeException('Missing database connection.');
-        }
-
         return $this->dbHandler;
     }
 

--- a/eZ/Publish/Core/FieldType/User/UserStorage.php
+++ b/eZ/Publish/Core/FieldType/User/UserStorage.php
@@ -8,7 +8,7 @@
  */
 namespace eZ\Publish\Core\FieldType\User;
 
-use eZ\Publish\Core\FieldType\GatewayBasedStorage;
+use eZ\Publish\SPI\FieldType\GatewayBasedStorage;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
 
@@ -16,17 +16,7 @@ use eZ\Publish\SPI\Persistence\Content\Field;
  * Description of UserStorage.
  *
  * Methods in this interface are called by storage engine.
- *
- * $context array passed to most methods provides some context for the field handler about the
- * currently used storage engine.
- * The array should at least define 2 keys :
- *   - identifier (connection identifier)
- *   - connection (the connection handler)
- * For example, using Legacy storage engine, $context will be:
- *   - identifier = 'LegacyStorage'
- *   - connection = {@link \eZ\Publish\Core\Persistence\Database\DatabaseHandler} object handler (for DB connection),
- *                  to be used accordingly to
- *                  {@link http://incubator.apache.org/zetacomponents/documentation/trunk/Database/tutorial.html ezcDatabase} usage
+ * Proper Gateway and its Connection is injected via Dependency Injection.
  *
  * The User storage handles the following attributes, following the user field
  * type in eZ Publish 4:
@@ -40,6 +30,13 @@ use eZ\Publish\SPI\Persistence\Content\Field;
 class UserStorage extends GatewayBasedStorage
 {
     /**
+     * Field Type External Storage Gateway.
+     *
+     * @var \eZ\Publish\Core\FieldType\User\UserStorage\Gateway
+     */
+    protected $gateway;
+
+    /**
      * Allows custom field types to store data in an external source (e.g. another DB table).
      *
      * Stores value for $field in an external data source.
@@ -52,32 +49,14 @@ class UserStorage extends GatewayBasedStorage
      * database back end on create, before the external data source may be
      * called from storing).
      *
-     * The context array provides some context for the field handler about the
-     * currently used storage engine.
-     * The array should at least define 2 keys :
-     *   - identifier (connection identifier)
-     *   - connection (the connection handler)
-     * For example, using Legacy storage engine, $context will be:
-     *   - identifier = 'LegacyStorage'
-     *   - connection = {@link \eZ\Publish\Core\Persistence\Database\DatabaseHandler} object handler (for DB connection),
-     *                  to be used accordingly to
-     * The context array provides some context for the field handler about the
-     * currently used storage engine.
-     * The array should at least define 2 keys :
-     *   - identifier (connection identifier)
-     *   - connection (the connection handler)
-     * For example, using Legacy storage engine, $context will be:
-     *   - identifier = 'LegacyStorage'
-     *   - connection = {@link \eZ\Publish\Core\Persistence\Database\DatabaseHandler} object handler (for DB connection),
-     *                  to be used accordingly to
-     *                  {@link http://incubator.apache.org/zetacomponents/documentation/trunk/Database/tutorial.html ezcDatabase} usage
+     * Database connection handler is injected into the Gateway via Dependency Injection.
      *
      * This method might return true if $field needs to be updated after storage done here (to store a PK for instance).
      * In any other case, this method must not return anything (null).
      *
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
      * @param \eZ\Publish\SPI\Persistence\Content\Field $field
      * @param array $context
-     *
      * @return null|true
      */
     public function storeFieldData(VersionInfo $versionInfo, Field $field, array $context)
@@ -91,13 +70,13 @@ class UserStorage extends GatewayBasedStorage
      * This value holds the data as a {@link eZ\Publish\Core\FieldType\Value} based object,
      * according to the field type (e.g. for TextLine, it will be a {@link eZ\Publish\Core\FieldType\TextLine\Value} object).
      *
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
      * @param \eZ\Publish\SPI\Persistence\Content\Field $field
      * @param array $context
      */
     public function getFieldData(VersionInfo $versionInfo, Field $field, array $context)
     {
-        $gateway = $this->getGateway($context);
-        $field->value->externalData = $gateway->getFieldData($field->id);
+        $field->value->externalData = $this->gateway->getFieldData($field->id);
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/User/UserStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/User/UserStorage/Gateway.php
@@ -8,7 +8,7 @@
  */
 namespace eZ\Publish\Core\FieldType\User\UserStorage;
 
-use eZ\Publish\Core\FieldType\StorageGateway;
+use eZ\Publish\SPI\FieldType\StorageGateway;
 
 abstract class Gateway extends StorageGateway
 {

--- a/eZ/Publish/Core/FieldType/User/UserStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/User/UserStorage/Gateway/LegacyStorage.php
@@ -9,15 +9,21 @@
 namespace eZ\Publish\Core\FieldType\User\UserStorage\Gateway;
 
 use eZ\Publish\Core\FieldType\User\UserStorage\Gateway;
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 
 class LegacyStorage extends Gateway
 {
     /**
      * Connection.
      *
-     * @var mixed
+     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
      */
     protected $dbHandler;
+
+    public function __construct(DatabaseHandler $dbHandler)
+    {
+        $this->dbHandler = $dbHandler;
+    }
 
     /**
      * Default values for user fields.
@@ -39,6 +45,7 @@ class LegacyStorage extends Gateway
      * Maps legacy database column names to property names.
      *
      * @var array
+     * @return array
      */
     protected function getPropertyMap()
     {
@@ -80,24 +87,6 @@ class LegacyStorage extends Gateway
                 'cast' => 'intval',
             ),
         );
-    }
-
-    /**
-     * Set dbHandler for gateway.
-     *
-     * @param mixed $dbHandler
-     */
-    public function setConnection($dbHandler)
-    {
-        // This obviously violates the Liskov substitution Principle, but with
-        // the given class design there is no sane other option. Actually the
-        // dbHandler *should* be passed to the constructor, and there should
-        // not be the need to post-inject it.
-        if (!$dbHandler instanceof \eZ\Publish\Core\Persistence\Database\DatabaseHandler) {
-            throw new \RuntimeException('Invalid dbHandler passed');
-        }
-
-        $this->dbHandler = $dbHandler;
     }
 
     /**

--- a/eZ/Publish/Core/settings/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/fieldtype_external_storages.yml
@@ -33,6 +33,7 @@ services:
 
     ezpublish.fieldType.ezkeyword.externalStorage:
         class: "%ezpublish.fieldType.ezkeyword.externalStorage.class%"
+        arguments: ["@ezpublish.fieldType.ezkeyword.storage_gateway"]
         tags:
             - {name: ezpublish.fieldType.externalStorageHandler, alias: ezkeyword}
 

--- a/eZ/Publish/Core/settings/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/fieldtype_external_storages.yml
@@ -50,7 +50,7 @@ services:
     ezpublish.fieldType.ezurl.externalStorage:
         class: "%ezpublish.fieldType.ezurl.externalStorage.class%"
         arguments:
-            - []
+            - "@ezpublish.fieldType.ezurl.storage_gateway"
             - "@?logger"
         tags:
             - {name: ezpublish.fieldType.externalStorageHandler, alias: ezurl}

--- a/eZ/Publish/Core/settings/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/fieldtype_external_storages.yml
@@ -22,7 +22,7 @@ services:
     ezpublish.fieldType.ezimage.externalStorage:
         class: "%ezpublish.fieldType.ezimage.externalStorage.class%"
         arguments:
-            - []
+            - "@ezpublish.fieldType.ezimage.storage_gateway"
             - "@ezpublish.fieldType.ezimage.io_service"
             - "@ezpublish.fieldType.ezimage.pathGenerator"
             - "@ezpublish.fieldType.metadataHandler.imagesize"

--- a/eZ/Publish/Core/settings/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/fieldtype_external_storages.yml
@@ -62,6 +62,7 @@ services:
 
     ezpublish.fieldType.ezgmaplocation.externalStorage:
         class: "%ezpublish.fieldType.ezgmaplocation.externalStorage.class%"
+        arguments: ["@ezpublish.fieldType.externalStorageHandler.ezgmaplocation.gateway"]
         tags:
             - {name: ezpublish.fieldType.externalStorageHandler, alias: ezgmaplocation}
 

--- a/eZ/Publish/Core/settings/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/fieldtype_external_storages.yml
@@ -68,6 +68,7 @@ services:
 
     ezpublish.fieldType.ezuser.externalStorage:
         class: "%ezpublish.fieldType.ezuser.externalStorage.class%"
+        arguments: ["@ezpublish.fieldType.ezuser.storage_gateway"]
         tags:
             - {name: ezpublish.fieldType.externalStorageHandler, alias: ezuser}
 

--- a/eZ/Publish/Core/settings/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/fieldtype_external_storages.yml
@@ -12,7 +12,7 @@ services:
     ezpublish.fieldType.ezbinaryfile.externalStorage:
         class: "%ezpublish.fieldType.ezbinaryfile.externalStorage.class%"
         arguments:
-            - []
+            - "@ezpublish.fieldType.ezbinaryfile.storage_gateway"
             - "@ezpublish.fieldType.ezbinaryfile.io_service"
             - "@ezpublish.fieldType.ezbinaryfile.pathGenerator"
             - "@ezpublish.core.io.mimeTypeDetector"
@@ -40,7 +40,7 @@ services:
     ezpublish.fieldType.ezmedia.externalStorage:
         class: "%ezpublish.fieldType.ezmedia.externalStorage.class%"
         arguments:
-            - []
+            - "@ezpublish.fieldType.ezmedia.storage_gateway"
             - "@ezpublish.fieldType.ezbinaryfile.io_service"
             - "@ezpublish.fieldType.ezbinaryfile.pathGenerator"
             - "@ezpublish.core.io.mimeTypeDetector"

--- a/eZ/Publish/Core/settings/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/fieldtype_external_storages.yml
@@ -57,6 +57,7 @@ services:
 
     ezpublish.fieldType.ezrichtext.externalStorage:
         class: "%ezpublish.fieldType.ezrichtext.externalStorage.class%"
+        arguments: ["@ezpublish.fieldType.ezrichtext.storage_gateway"]
         tags:
             - {name: ezpublish.fieldType.externalStorageHandler, alias: ezrichtext}
 

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -34,9 +34,9 @@ services:
 
     ezpublish.fieldType.ezrichtext.storage_gateway:
         class: "%ezpublish.fieldType.ezrichtext.storage_gateway.class%"
-        arguments: ["@ezpublish.fieldType.ezurl.storage_gateway"]
-        tags:
-            - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezrichtext, identifier: LegacyStorage}
+        arguments:
+            - "@ezpublish.fieldType.ezurl.storage_gateway"
+            - "@ezpublish.api.storage_engine.legacy.dbhandler"
 
     ezpublish.fieldType.ezurl.storage_gateway:
         class: "%ezpublish.fieldType.ezurl.storage_gateway.class%"

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -45,8 +45,7 @@ services:
 
     ezpublish.fieldType.ezpage.storage_gateway:
         class: "%ezpublish.fieldType.ezpage.storage_gateway.class%"
-        calls:
-            - [setConnection, ["@ezpublish.api.storage_engine.legacy.dbhandler"]]
+        arguments: ["@ezpublish.api.storage_engine.legacy.dbhandler"]
 
     ezpublish.fieldType.ezimage.storage_gateway:
         class: "%ezpublish.fieldType.ezimage.storage_gateway.class%"

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -22,8 +22,7 @@ services:
 
     ezpublish.fieldType.ezbinaryfile.storage_gateway:
         class: "%ezpublish.fieldType.ezbinaryfile.storage_gateway.class%"
-        tags:
-            - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezbinaryfile, identifier: LegacyStorage}
+        arguments: ["@ezpublish.api.storage_engine.legacy.dbhandler"]
 
     ezpublish.fieldType.ezkeyword.storage_gateway:
         class: "%ezpublish.fieldType.ezkeyword.storage_gateway.class%"
@@ -31,8 +30,7 @@ services:
 
     ezpublish.fieldType.ezmedia.storage_gateway:
         class: "%ezpublish.fieldType.ezmedia.storage_gateway.class%"
-        tags:
-            - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezmedia, identifier: LegacyStorage}
+        arguments: ["@ezpublish.api.storage_engine.legacy.dbhandler"]
 
     ezpublish.fieldType.ezrichtext.storage_gateway:
         class: "%ezpublish.fieldType.ezrichtext.storage_gateway.class%"

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -60,5 +60,4 @@ services:
 
     ezpublish.fieldType.ezuser.storage_gateway:
         class: "%ezpublish.fieldType.ezuser.storage_gateway.class%"
-        tags:
-            - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezuser, identifier: LegacyStorage}
+        arguments: ["@ezpublish.api.storage_engine.legacy.dbhandler"]

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -56,8 +56,7 @@ services:
 
     ezpublish.fieldType.externalStorageHandler.ezgmaplocation.gateway:
         class: "%ezpublish.fieldType.ezgmaplocation.storage_gateway.class%"
-        tags:
-            - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezgmaplocation, identifier: LegacyStorage}
+        arguments: ["@ezpublish.api.storage_engine.legacy.dbhandler"]
 
     ezpublish.fieldType.ezuser.storage_gateway:
         class: "%ezpublish.fieldType.ezuser.storage_gateway.class%"

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -40,8 +40,7 @@ services:
 
     ezpublish.fieldType.ezurl.storage_gateway:
         class: "%ezpublish.fieldType.ezurl.storage_gateway.class%"
-        tags:
-            - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezurl, identifier: LegacyStorage}
+        arguments: ["@ezpublish.api.storage_engine.legacy.dbhandler"]
 
     ezpublish.fieldType.ezpage.storage_gateway:
         class: "%ezpublish.fieldType.ezpage.storage_gateway.class%"

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -52,8 +52,7 @@ services:
         class: "%ezpublish.fieldType.ezimage.storage_gateway.class%"
         arguments:
             - "@ezpublish.core.io.image_fieldtype.legacy_url_redecorator"
-        tags:
-            - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezimage, identifier: LegacyStorage}
+            - "@ezpublish.api.storage_engine.legacy.dbhandler"
 
     ezpublish.fieldType.externalStorageHandler.ezgmaplocation.gateway:
         class: "%ezpublish.fieldType.ezgmaplocation.storage_gateway.class%"

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -27,8 +27,7 @@ services:
 
     ezpublish.fieldType.ezkeyword.storage_gateway:
         class: "%ezpublish.fieldType.ezkeyword.storage_gateway.class%"
-        tags:
-            - {name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezkeyword, identifier: LegacyStorage}
+        arguments: ["@ezpublish.api.storage_engine.legacy.dbhandler"]
 
     ezpublish.fieldType.ezmedia.storage_gateway:
         class: "%ezpublish.fieldType.ezmedia.storage_gateway.class%"

--- a/eZ/Publish/SPI/FieldType/GatewayBasedStorage.php
+++ b/eZ/Publish/SPI/FieldType/GatewayBasedStorage.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\SPI\FieldType;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+
+/**
+ * Field Type External Storage gateway base class.
+ */
+abstract class GatewayBasedStorage implements FieldStorage
+{
+    /**
+     * Field Type External Storage Gateway.
+     *
+     * @var \eZ\Publish\SPI\FieldType\StorageGateway
+     */
+    protected $gateway;
+
+    /**
+     * @param \eZ\Publish\SPI\FieldType\StorageGateway $gateway
+     */
+    public function __construct(StorageGateway $gateway)
+    {
+        $this->gateway = $gateway;
+    }
+
+    /**
+     * This method is used exclusively by Legacy Storage to copy external data of existing field in main language to
+     * the untranslatable field not passed in create or update struct, but created implicitly in storage layer.
+     *
+     * By default the method falls back to the {@link \eZ\Publish\SPI\FieldType\FieldStorage::storeFieldData()}.
+     * External storages implement this method as needed.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $originalField
+     * @param array $context
+     *
+     * @return null|bool Same as {@link \eZ\Publish\SPI\FieldType\FieldStorage::storeFieldData()}.
+     */
+    public function copyLegacyField(VersionInfo $versionInfo, Field $field, Field $originalField, array $context)
+    {
+        return $this->storeFieldData($versionInfo, $field, $context);
+    }
+}

--- a/eZ/Publish/SPI/FieldType/StorageGateway.php
+++ b/eZ/Publish/SPI/FieldType/StorageGateway.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\SPI\FieldType;
+
+/**
+ * Base class for FieldType external storage gateways.
+ */
+abstract class StorageGateway
+{
+    /**
+     * Get sequence name bound to database table and column.
+     *
+     * Note: must be compatible with:
+     * @see \eZ\Publish\Core\Persistence\Doctrine\ConnectionHandler\PostgresConnectionHandler::quoteIdentifier
+     *
+     * @param string $table
+     * @param string $column
+     * @return string
+     */
+    protected function getSequenceName($table, $column)
+    {
+        // @todo: change to <table>_<column>_seq when merged into 7.0
+        return sprintf('%s_s', $table);
+    }
+}

--- a/eZ/Publish/SPI/Tests/FieldType/BinaryFileIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BinaryFileIntegrationTest.php
@@ -63,7 +63,7 @@ class BinaryFileIntegrationTest extends FileBaseIntegrationTest
     /**
      * Get handler with required custom field types registered.
      *
-     * @return Handler
+     * @return \eZ\Publish\SPI\Persistence\Handler
      */
     public function getCustomHandler()
     {
@@ -77,9 +77,7 @@ class BinaryFileIntegrationTest extends FileBaseIntegrationTest
             $fieldType,
             new Legacy\Content\FieldValue\Converter\BinaryFileConverter(),
             new FieldType\BinaryFile\BinaryFileStorage(
-                array(
-                    'LegacyStorage' => new FieldType\BinaryFile\BinaryFileStorage\Gateway\LegacyStorage(),
-                ),
+                new FieldType\BinaryFile\BinaryFileStorage\Gateway\LegacyStorage($this->getDatabaseHandler()),
                 $this->ioService,
                 new FieldType\BinaryBase\PathGenerator\LegacyPathGenerator(),
                 new FileInfo()

--- a/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
@@ -85,8 +85,9 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
             $fieldType,
             new Legacy\Content\FieldValue\Converter\ImageConverter($this->ioService, $urlRedecorator),
             new FieldType\Image\ImageStorage(
-                array(
-                    'LegacyStorage' => new FieldType\Image\ImageStorage\Gateway\LegacyStorage($urlRedecorator),
+                new FieldType\Image\ImageStorage\Gateway\LegacyStorage(
+                    $urlRedecorator,
+                    $this->getDatabaseHandler()
                 ),
                 $this->ioService,
                 new FieldType\Image\PathGenerator\LegacyPathGenerator(),

--- a/eZ/Publish/SPI/Tests/FieldType/KeywordIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/KeywordIntegrationTest.php
@@ -60,9 +60,7 @@ class KeywordIntegrationTest extends BaseIntegrationTest
             $fieldType,
             new Legacy\Content\FieldValue\Converter\KeywordConverter(),
             new FieldType\Keyword\KeywordStorage(
-                array(
-                    'LegacyStorage' => new FieldType\Keyword\KeywordStorage\Gateway\LegacyStorage(),
-                )
+                new FieldType\Keyword\KeywordStorage\Gateway\LegacyStorage($this->getDatabaseHandler())
             )
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/MapLocationIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/MapLocationIntegrationTest.php
@@ -48,7 +48,7 @@ class MapLocationIntegrationTest extends BaseIntegrationTest
     /**
      * Get handler with required custom field types registered.
      *
-     * @return Handler
+     * @return \eZ\Publish\SPI\Persistence\Handler
      */
     public function getCustomHandler()
     {
@@ -60,8 +60,8 @@ class MapLocationIntegrationTest extends BaseIntegrationTest
             $fieldType,
             new Legacy\Content\FieldValue\Converter\MapLocationConverter(),
             new FieldType\MapLocation\MapLocationStorage(
-                array(
-                    'LegacyStorage' => new FieldType\MapLocation\MapLocationStorage\Gateway\LegacyStorage(),
+                new FieldType\MapLocation\MapLocationStorage\Gateway\LegacyStorage(
+                    $this->getDatabaseHandler()
                 )
             )
         );

--- a/eZ/Publish/SPI/Tests/FieldType/MediaIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/MediaIntegrationTest.php
@@ -63,7 +63,7 @@ class MediaIntegrationTest extends FileBaseIntegrationTest
     /**
      * Get handler with required custom field types registered.
      *
-     * @return Handler
+     * @return \eZ\Publish\SPI\Persistence\Handler
      */
     public function getCustomHandler()
     {
@@ -75,9 +75,7 @@ class MediaIntegrationTest extends FileBaseIntegrationTest
             $fieldType,
             new Legacy\Content\FieldValue\Converter\MediaConverter(),
             new FieldType\Media\MediaStorage(
-                array(
-                    'LegacyStorage' => new FieldType\Media\MediaStorage\Gateway\LegacyStorage(),
-                ),
+                new FieldType\Media\MediaStorage\Gateway\LegacyStorage($this->getDatabaseHandler()),
                 $this->ioService = self::$container->get('ezpublish.fieldType.ezbinaryfile.io_service'),
                 $legacyPathGenerator = new FieldType\BinaryBase\PathGenerator\LegacyPathGenerator(),
                 new FileInfo()

--- a/eZ/Publish/SPI/Tests/FieldType/RichTextIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/RichTextIntegrationTest.php
@@ -67,8 +67,7 @@ class RichTextIntegrationTest extends BaseIntegrationTest
         );
         $fieldType->setTransformationProcessor($this->getTransformationProcessor());
 
-        $urlGateway = new UrlGateway();
-        $urlGateway->setConnection($this->getDatabaseHandler());
+        $urlGateway = new UrlGateway($this->getDatabaseHandler());
 
         return $this->getHandler(
             'ezrichtext',

--- a/eZ/Publish/SPI/Tests/FieldType/RichTextIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/RichTextIntegrationTest.php
@@ -50,7 +50,7 @@ class RichTextIntegrationTest extends BaseIntegrationTest
     /**
      * Get handler with required custom field types registered.
      *
-     * @return Handler
+     * @return \eZ\Publish\SPI\Persistence\Handler
      */
     public function getCustomHandler()
     {
@@ -67,13 +67,17 @@ class RichTextIntegrationTest extends BaseIntegrationTest
         );
         $fieldType->setTransformationProcessor($this->getTransformationProcessor());
 
+        $urlGateway = new UrlGateway();
+        $urlGateway->setConnection($this->getDatabaseHandler());
+
         return $this->getHandler(
             'ezrichtext',
             $fieldType,
             new RichTextConverter(),
             new FieldType\RichText\RichTextStorage(
-                array(
-                    'LegacyStorage' => new LegacyStorage(new UrlGateway()),
+                new LegacyStorage(
+                    $urlGateway,
+                    $this->getDatabaseHandler()
                 )
             )
         );

--- a/eZ/Publish/SPI/Tests/FieldType/UrlIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/UrlIntegrationTest.php
@@ -48,7 +48,7 @@ class UrlIntegrationTest extends BaseIntegrationTest
     /**
      * Get handler with required custom field types registered.
      *
-     * @return Handler
+     * @return \eZ\Publish\SPI\Persistence\Handler
      */
     public function getCustomHandler()
     {
@@ -60,9 +60,7 @@ class UrlIntegrationTest extends BaseIntegrationTest
             $fieldType,
             new Legacy\Content\FieldValue\Converter\UrlConverter(),
             new FieldType\Url\UrlStorage(
-                array(
-                    'LegacyStorage' => new FieldType\Url\UrlStorage\Gateway\LegacyStorage(),
-                )
+                new FieldType\Url\UrlStorage\Gateway\LegacyStorage($this->getDatabaseHandler())
             )
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/UserIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/UserIntegrationTest.php
@@ -50,7 +50,7 @@ class UserIntegrationTest extends BaseIntegrationTest
     /**
      * Get handler with required custom field types registered.
      *
-     * @return Handler
+     * @return \eZ\Publish\SPI\Persistence\Handler
      */
     public function getCustomHandler()
     {
@@ -62,9 +62,7 @@ class UserIntegrationTest extends BaseIntegrationTest
             $fieldType,
             new Legacy\Content\FieldValue\Converter\NullConverter(),
             new FieldType\User\UserStorage(
-                array(
-                    'LegacyStorage' => new FieldType\User\UserStorage\Gateway\LegacyStorage(),
-                )
+                new FieldType\User\UserStorage\Gateway\LegacyStorage($this->getDatabaseHandler())
             )
         );
     }


### PR DESCRIPTION
Part 1 of [EZP-26885](https://jira.ez.no/browse/EZP-26885) implementation.
------------

> We want to be able to use `\Doctrine\DBAL\Connection` for FieldTypes external storage directly.
> To achieve this, FieldType external storage needs to be injected with `DoctrineStorage` gateway which uses Doctrine instead of Legacy Connection Handler.

This PR is the first step towards solving [EZP-26885](https://jira.ez.no/browse/EZP-26885). To be able easily inject Doctrine instead of Legacy DatabaseHandler we need to make the latter fully injectable. Up to now, external storage gateway was chosen by context passed by `\eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler`.

This PR refactors Field Type-specific external storages so they get injected with proper, FT-specific gateways. 
Each gateway gets injected with `\eZ\Publish\Core\Persistence\Doctrine\ConnectionHandler`.
In the future Legacy gateway injected into FT-specific external storage can be replaced with Doctrine gateway which would use `\Doctrine\DBAL\Connection`.

**TODO**:
- [x] Introduce to SPI layer `GatewayBasedStorage` which refactored FT storages should extend.
- [x] Introduce to SPI layer `StorageGateway` to be extended by refactored FT ext. storages gateways.
- [x] Deprecate `\eZ\Publish\Core\FieldType\GatewayBasedStorage` which sets and gets gateways from context.
- [x] Deprecate `\eZ\Publish\Core\FieldType\StorageGateway` which allows setting connection manually, without DI.
- [x] Refactor `Keyword` FT external storage.
- [x] Refactor `BinaryFile` and `Media` FT external storage.
- [x] Refactor `Image` FT external storage.
- [x] Refactor `MapLocation` FT external storage.
- [x] Refactor `User` FT external storage.
- [x] Refactor `Page` FT external storage.
- [x] Refactor `RichText` FT external storage.
- [x] Refactor `Url` FT external storage.
- [x] Perform manual tests with web app.
- [x] Make upgrade doc.