### PR TITLE
EZP-27367: Update FileSystemTwigIntegrationTestCase::doIntegrationTest for Twig 2.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
         "oneup/flysystem-bundle": "^1.0",
         "friendsofsymfony/http-cache-bundle": "~1.2|^1.3.8",
         "sensio/framework-extra-bundle": "~3.0",
-        "jms/translation-bundle": "^1.0"
+        "jms/translation-bundle": "^1.0",
+        "twig/twig": "~1.27|~2.0"
     },
     "require-dev": {
         "mikey179/vfsStream": "1.1.0",

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FileSystemTwigIntegrationTestCase.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FileSystemTwigIntegrationTestCase.php
@@ -124,9 +124,9 @@ abstract class FileSystemTwigIntegrationTestCase extends Twig_Test_IntegrationTe
 
                 foreach (array_keys($templates) as $name) {
                     echo "Template: $name\n";
-                    $source = $loader->getSource($name);
+                    $source = $loader->getSourceContext($name);
                     echo $twig->compile(
-                        $twig->parse($twig->tokenize($source, $name))
+                        $twig->parse($twig->tokenize($source))
                     );
                 }
             }


### PR DESCRIPTION
>[EZP-27367](https://jira.ez.no/browse/EZP-27367)
# 
Currently on failed test the function FileSystemTwigIntegrationTestCase::doIntegrationTest breaks with an error: 
> Error: Call to undefined method Twig_Loader_Chain::getSource()

It comes from the fact that function Twig_Loader_Chain::getSource() was deprecated in Twig version 1.27 and removed in version 2.0 in favor of Twig_Loader_Chain::getSourceContext(), which was introduced in version 1.27. I decided to go for a compability with version <1.27, so in this PR I am handling both cases.