### PR TITLE
EZP-26608 - fixing default fields group list by adding 'metadata'

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
@@ -117,7 +117,7 @@ class Configuration extends SiteAccessConfiguration
                                     }
 
                                     if (!isset($v['fields_groups']['list'])) {
-                                        $v['fields_groups']['list'] = ['content'];
+                                        $v['fields_groups']['list'] = ['content', 'metadata'];
                                     }
 
                                     if (!isset($v['fields_groups']['default'])) {


### PR DESCRIPTION
It fixes https://jira.ez.no/browse/EZP-26608

# Description
**A bug**: Configuration is set that if there's no config related to list of fields groups coming from user it creates default list containing only `content`. 
**Solution:** Changing contents of default list by adding `metadata` to the list

## Note:
This PR should be followed by updating translation file for field groups https://github.com/ezsystems/repository-forms/blob/master/bundle/Resources/translations/ezplatform_fields_groups.en.xlf