### PR TITLE
EZP-27368: Add test for an exception in ez_render_field function

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/field_rendering_functions/ez_render_field_exception.test
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/field_rendering_functions/ez_render_field_exception.test
@@ -1,0 +1,23 @@
+--TEST--
+Exception for "ez_render_field" function
+--TEMPLATE--
+{% extends 'templates/base.html.twig' %}
+{% block content %}
+{{ ez_render_field( notexisting, 'testfield' ) }}
+{% endblock %}
+--DATA--
+return array(
+    'notexisting' => $this->getContent(
+        'notexisting',
+        array(
+            'notexisting' => array(
+                'id' => 2,
+                'fieldDefIdentifier' => 'testfield',
+                'value' => 'foo2',
+                'languageCode' => 'fre-FR'
+            ),
+        )
+    )
+)
+--EXCEPTION--
+Twig_Error_Runtime: An exception has been thrown during the rendering of a template ("Cannot find 'notexisting_field' template block.") in "index.twig" at line 4.


### PR DESCRIPTION
> [EZP-27368](https://jira.ez.no/browse/EZP-27368)
# 
It's testing an exception thrown here:  https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/MVC/Symfony/Templating/Twig/FieldBlockRenderer.php#L318.