### PR TITLE
[WiP] Simplified REST structures

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -97,6 +97,16 @@ However in this specification only the standard schemas and media types are defi
 If there is only one media type defined for xml or json, it is also possible to specify
 application/xml or application/json.
 
+Simplified JSON Media Types
+---------------------------
+
+While the standard media types allow you to perform arbitrary actions on the
+content repository, they are sometimes not as easy to use for standard actions.
+For this reason, there are alternative media types available to interact with
+certain ressources. The structure of these follows the general rules defined
+for JSON media types above, but there is no equivalent in XML. See the
+dedicated entity operation for support of a simplified type.
+
 URIs
 ----
 
@@ -475,6 +485,7 @@ Creating Content
          :application/vnd.ez.api.ContentInfo+xml:  if set all informations for the content object (excluding the current version) are returned in xml format (see Content_)
          :application/vnd.ez.api.ContentInfo+json:  if set all informations for the content object (excluding the current version) are returned in json format (see Content_)
     :Content-Type:
+         :application/vnd.ez.api.simplified.ContentCreate+json: the SimplifiedContentCreate_ schema encoded in json
          :application/vnd.ez.api.ContentCreate+json: the ContentCreate_ schema encoded in json
          :application/vnd.ez.api.ContentCreate+xml: the ContentCreate_ schema encoded in xml
 :Response:
@@ -7075,6 +7086,37 @@ ContentCreate XML Schema
       </xsd:complexType>
       <xsd:element name="ContentCreate" type="contentCreateType"></xsd:element>
     </xsd:schema>
+
+
+.. _SimplifiedContentCreate:
+
+Simplified ContentCreate Example
+--------------------------------
+
+.. code:: json
+
+    {
+        "ContentCreate": {
+            "ContentType": "/content/types/_by_identified/article",
+            "LocationCreate": {
+                "_parentUrlAliasPath": "/content/urlaliases/_by_path/places-tastes/tastes/"
+            },
+            "ContentSection": "/content/section/_by_identifier/places",
+            "Owner": "/user/users/_by_login/jessica",
+            "alwaysAvailable": "false",
+            "modificationDate": "2017-03-02T12:00:00",
+            "remoteId": "remote123456",
+            "fields": {
+                "en-US": {
+                    "title": "This is a title",
+                    "intro": {
+                        "xhtml5edit": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<section xmlns=\"http://ez.no/namespaces/ezpublish5/xhtml5/edit\"><p>Article intro.</p></section>\n",
+                        "xml": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<section xmlns=\"http://docbook.org/ns/docbook\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" xmlns:ezxhtml=\"http://ez.no/xmlns/ezpublish/docbook/xhtml\" xmlns:ezcustom=\"http://ez.no/xmlns/ezpublish/docbook/custom\" version=\"5.0-variant ezpublish-1.0\"><para>Article intro.</para></section>\n"
+                    },
+                }
+            }
+        }
+    }
 
 .. _ContentUpdate:
 

--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -136,18 +136,23 @@ support GET/HEAD operations and will return a redirect to the cannonical entity
 URL. However, when using them as a reference in a POST/PUT/PATCH request, the
 server will accept them and automatically reference the correct entity.
 
+Alias URLs are built using the collection resource of an entity + a filter
+query parameter which identifies the entity in question uniquely (e.g.
+``remoteId`` or ``identifier``).
+
 A request/response cycle for an alias URI is supposed to be executed as follows:
 
-:Resource: /content/types/_by_identifier/article
+:Resource: /content/types/?identifier=article
 :Method: GET
 :Response:
 
 .. code:: http
 
-        HTTP/1.1 308 Permanent Redirect
+        HTTP/1.1 307 Temporary Redirect
         Location: /content/types/23
 
-Therefore, referencing the content type with ID 23 is valid using the URI ``/content/types/_by_identifier/article``.
+Therefore, referencing the content type with ID 23 is valid using the URI
+``/content/types/?identifier=article``.
 
 OPTIONS requests
 ----------------

--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -121,7 +121,33 @@ In this document, for the sake of readability, no prefix is used in the URIs. In
 prefixes all REST hrefs.
 
 Remember that URIs to REST resources should never be generated manually, but obtained from earlier REST
- calls.
+calls.
+
+Alias URIs
+----------
+
+By default entity URIs are constructed using a (server local) URL template and
+the database ID of the referenced entity. While this mechanism might be subject
+to change (e.g. to support multi-server/-domain setups with interlinking)
+users are requesting more intuitive ways to identify entities to reference
+entities while creating/updating related entities. Alias URIs help to achieve
+this by providing more human readable resource identifiers. These URIs only
+support GET/HEAD operations and will return a redirect to the cannonical entity
+URL. However, when using them as a reference in a POST/PUT/PATCH request, the
+server will accept them and automatically reference the correct entity.
+
+A request/response cycle for an alias URI is supposed to be executed as follows:
+
+:Resource: /content/types/_by_identifier/article
+:Method: GET
+:Response:
+
+.. code:: http
+
+        HTTP/1.1 308 Permanent Redirect
+        Location: /content/types/23
+
+Therefore, referencing the content type with ID 23 is valid using the URI ``/content/types/_by_identifier/article``.
 
 OPTIONS requests
 ----------------
@@ -274,6 +300,14 @@ Resource                                                          POST          
 /content/urlwildcards/<ID>                                        .                   get url wildcard        .                            delete url wc.
 ================================================================= =================== ======================= ============================ ================ ==============
 
+the following alias URIs are supported:
+
+=============================================================== ===============================
+Alias URI                                                       Target
+--------------------------------------------------------------- -------------------------------
+/content/objects/_by_remote_id/<remote-ID>                      /content/objects/<ID>
+/content/objectstategroups/_by_identifier/<identifier>          /content/objectstategroups/<ID>
+=============================================================== ===============================
 
 Specification
 -------------
@@ -3293,6 +3327,15 @@ Resource                                           POST                GET      
 /content/types/<ID>/draft/fieldDefinitions/<ID>    .                   load field def.     update field definition delete field definition
 ================================================== =================== =================== ======================= =======================
 
+the following alias URIs are supported:
+
+=============================================================== ===============================
+Alias URI                                                       Target
+--------------------------------------------------------------- -------------------------------
+/content/typegroups/_by_identifier/<identifier>                 /content/typegroups/<ID>
+/content/types/_by_identifier/<identifier>                      /content/types/<ID>
+=============================================================== ===============================
+
 Specification
 -------------
 
@@ -4304,6 +4347,15 @@ Resource                                      POST                  GET         
 /user/sessions                                create session        .                       .                     .                             .             .
 /user/sessions/<sessionID>                    .                     .                       .                     delete session                .             .
 ============================================= ===================== ======================= ===================== ============================= ============= =====================
+
+the following alias URIs are supported:
+
+=============================================================== ===============================
+Alias URI                                                       Target
+--------------------------------------------------------------- -------------------------------
+/user/users/_by_login/<login>                                   /user/users/<ID>
+/user/users/_by_email/<email>                                   /user/users/<ID>
+=============================================================== ===============================
 
 
 Managing Users and Groups

--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -368,13 +368,14 @@ XML Example
         <contentByRemoteId href="/api/ezp/v2/content/objects{?remoteId}" media-type="" />
         <contentTypes href="/api/ezp/v2/content/types" media-type="application/vnd.ez.api.ContentTypeInfoList+xml" />
         <contentTypeByIdentifier href="/api/ezp/v2/content/types{?identifier}" media-type="" />
+        <contentTypeByRemoteId href="/api/ezp/v2/content/types{?remoteId}" media-type="" />
         <contentTypeGroups href="/api/ezp/v2/content/typegroups" media-type="application/vnd.ez.api.ContentTypeGroupList+xml" />
         <contentTypeGroupByIdentifier href="/api/ezp/v2/content/typegroups{?identifier}" media-type="" />
         <users href="/api/ezp/v2/user/users" media-type="application/vnd.ez.api.UserRefList+xml" />
         <usersByRoleId href="/api/ezp/v2/user/users{?roleId}" media-type="application/vnd.ez.api.UserRefList+xml" />
-        <usersByRemoteId href="/api/ezp/v2/user/users{?remoteId}" media-type="application/vnd.ez.api.UserRefList+xml" />
+        <usersByRemoteId href="/api/ezp/v2/user/users{?remoteId}" media-type="" />
         <usersByEmail href="/api/ezp/v2/user/users{?email}" media-type="application/vnd.ez.api.UserRefList+xml" />
-        <usersByLogin href="/api/ezp/v2/user/users{?login}" media-type="application/vnd.ez.api.UserRefList+xml" />
+        <usersByLogin href="/api/ezp/v2/user/users{?login}" media-type="" />
         <roles href="/api/ezp/v2/user/roles" media-type="application/vnd.ez.api.RoleList+xml" />
         <rootLocation href="/api/ezp/v2/content/locations/1/2" media-type="application/vnd.ez.api.Location+xml" />
         <rootUserGroup href="/api/ezp/v2/user/groups/1/5" media-type="application/vnd.ez.api.UserGroup+xml" />

--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -7165,7 +7165,7 @@ Simplified ContentCreate Example
             },
             "ContentSection": "/content/section/?identifier=places",
             "Owner": "/user/users/?login=jessica",
-            "alwaysAvailable": "false",
+            "alwaysAvailable": false,
             "modificationDate": "2017-03-02T12:00:00",
             "remoteId": "remote123456",
             "fields": {

--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -364,28 +364,32 @@ XML Example
 
     <?xml version="1.0" encoding="UTF-8"?>
     <Root media-type="application/vnd.ez.api.Root+xml">
-        <content media-type="" href="/api/ezp/v2/content/objects"/>
-        <contentByRemoteId media-type="" href="/api/ezp/v2/content/objects{?remoteId}"/>
-        <contentTypes media-type="application/vnd.ez.api.ContentTypeInfoList+xml" href="/api/ezp/v2/content/types"/>
-        <contentTypeByIdentifier media-type="" href="/api/ezp/v2/content/types{?identifier}"/>
-        <contentTypeGroups media-type="application/vnd.ez.api.ContentTypeGroupList+xml" href="/api/ezp/v2/content/typegroups"/>
-        <contentTypeGroupByIdentifier media-type="" href="/api/ezp/v2/content/typegroups{?identifier}"/>
-        <users media-type="application/vnd.ez.api.UserRefList+xml" href="/api/ezp/v2/user/users"/>
-        <roles media-type="application/vnd.ez.api.RoleList+xml" href="/api/ezp/v2/user/roles"/>
-        <rootLocation media-type="application/vnd.ez.api.Location+xml" href="/api/ezp/v2/content/locations/1/2"/>
-        <rootUserGroup media-type="application/vnd.ez.api.UserGroup+xml" href="/api/ezp/v2/user/groups/1/5"/>
-        <rootMediaFolder media-type="application/vnd.ez.api.Location+xml" href="/api/ezp/v2/content/locations/1/43"/>
-        <locationByRemoteId media-type="" href="/api/ezp/v2/content/locations{?remoteId}"/>
-        <locationByPath media-type="" href="/api/ezp/v2/content/locations{?locationPath}"/>
-        <trash media-type="application/vnd.ez.api.Trash+xml" href="/api/ezp/v2/content/trash"/>
-        <sections media-type="application/vnd.ez.api.SectionList+xml" href="/api/ezp/v2/content/sections"/>
-        <views media-type="application/vnd.ez.api.RefList+xml" href="/api/ezp/v2/views"/>
-        <objectStateGroups media-type="application/vnd.ez.api.ObjectStateGroupList+xml" href="/api/ezp/v2/content/objectstategroups"/>
-        <objectStates media-type="application/vnd.ez.api.ObjectStateList+xml" href="/api/ezp/v2/content/objectstategroups/{objectStateGroupId}/objectstates"/>
-        <globalUrlAliases media-type="application/vnd.ez.api.UrlAliasRefList+xml" href="/api/ezp/v2/content/urlaliases"/>
-        <urlWildcards media-type="application/vnd.ez.api.UrlWildcardList+xml" href="/api/ezp/v2/content/urlwildcards"/>
-        <createSession media-type="application/vnd.ez.api.UserSession+xml" href="/api/ezp/v2/user/sessions"/>
-        <refreshSession media-type="application/vnd.ez.api.UserSession+xml" href="/api/ezp/v2/user/sessions/{sessionId}/refresh"/>
+        <content href="/api/ezp/v2/content/objects" media-type="" />
+        <contentByRemoteId href="/api/ezp/v2/content/objects{?remoteId}" media-type="" />
+        <contentTypes href="/api/ezp/v2/content/types" media-type="application/vnd.ez.api.ContentTypeInfoList+xml" />
+        <contentTypeByIdentifier href="/api/ezp/v2/content/types{?identifier}" media-type="" />
+        <contentTypeGroups href="/api/ezp/v2/content/typegroups" media-type="application/vnd.ez.api.ContentTypeGroupList+xml" />
+        <contentTypeGroupByIdentifier href="/api/ezp/v2/content/typegroups{?identifier}" media-type="" />
+        <users href="/api/ezp/v2/user/users" media-type="application/vnd.ez.api.UserRefList+xml" />
+        <usersByRoleId href="/api/ezp/v2/user/users{?roleId}" media-type="application/vnd.ez.api.UserRefList+xml" />
+        <usersByRemoteId href="/api/ezp/v2/user/users{?remoteId}" media-type="application/vnd.ez.api.UserRefList+xml" />
+        <usersByEmail href="/api/ezp/v2/user/users{?email}" media-type="application/vnd.ez.api.UserRefList+xml" />
+        <usersByLogin href="/api/ezp/v2/user/users{?login}" media-type="application/vnd.ez.api.UserRefList+xml" />
+        <roles href="/api/ezp/v2/user/roles" media-type="application/vnd.ez.api.RoleList+xml" />
+        <rootLocation href="/api/ezp/v2/content/locations/1/2" media-type="application/vnd.ez.api.Location+xml" />
+        <rootUserGroup href="/api/ezp/v2/user/groups/1/5" media-type="application/vnd.ez.api.UserGroup+xml" />
+        <rootMediaFolder href="/api/ezp/v2/content/locations/1/43" media-type="application/vnd.ez.api.Location+xml" />
+        <locationByRemoteId href="/api/ezp/v2/content/locations{?remoteId}" media-type="" />
+        <locationByPath href="/api/ezp/v2/content/locations{?locationPath}" media-type="" />
+        <trash href="/api/ezp/v2/content/trash" media-type="application/vnd.ez.api.Trash+xml" />
+        <sections href="/api/ezp/v2/content/sections" media-type="application/vnd.ez.api.SectionList+xml" />
+        <views href="/api/ezp/v2/views" media-type="application/vnd.ez.api.RefList+xml" />
+        <objectStateGroups href="/api/ezp/v2/content/objectstategroups" media-type="application/vnd.ez.api.ObjectStateGroupList+xml" />
+        <objectStates href="/api/ezp/v2/content/objectstategroups/{objectStateGroupId}/objectstates" media-type="application/vnd.ez.api.ObjectStateList+xml" />
+        <globalUrlAliases href="/api/ezp/v2/content/urlaliases" media-type="application/vnd.ez.api.UrlAliasRefList+xml" />
+        <urlWildcards href="/api/ezp/v2/content/urlwildcards" media-type="application/vnd.ez.api.UrlWildcardList+xml" />
+        <createSession href="/api/ezp/v2/user/sessions" media-type="application/vnd.ez.api.UserSession+xml" />
+        <refreshSession href="/api/ezp/v2/user/sessions/{sessionId}/refresh" media-type="application/vnd.ez.api.UserSession+xml" />
     </Root>
 
 JSON Example

--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -7159,12 +7159,12 @@ Simplified ContentCreate Example
 
     {
         "ContentCreate": {
-            "ContentType": "/content/types/_by_identified/article",
+            "ContentType": "/content/types/?identifier=article",
             "LocationCreate": {
-                "_parentUrlAliasPath": "/content/urlaliases/_by_path/places-tastes/tastes/"
+                "_parentUrlAliasPath": "/content/urlaliases/?path=/places-tastes/tastes/"
             },
-            "ContentSection": "/content/section/_by_identifier/places",
-            "Owner": "/user/users/_by_login/jessica",
+            "ContentSection": "/content/section/?identifier=places",
+            "Owner": "/user/users/?login=jessica",
             "alwaysAvailable": "false",
             "modificationDate": "2017-03-02T12:00:00",
             "remoteId": "remote123456",

--- a/eZ/Bundle/EzPublishRestBundle/RequestParser/Router.php
+++ b/eZ/Bundle/EzPublishRestBundle/RequestParser/Router.php
@@ -44,6 +44,7 @@ class Router implements RequestParser
     public function parseType($url)
     {
         $matchResult = $this->matchUrl($url);
+
         return $matchResult['_route'];
     }
 
@@ -74,6 +75,7 @@ class Router implements RequestParser
         }
 
         $this->router->setContext($originalContext);
+
         return $matchResult;
     }
 

--- a/eZ/Bundle/EzPublishRestBundle/RequestParser/Router.php
+++ b/eZ/Bundle/EzPublishRestBundle/RequestParser/Router.php
@@ -34,6 +34,25 @@ class Router implements RequestParser
      */
     public function parse($url)
     {
+        return $this->matchUrl($url);
+    }
+
+    /**
+     * @param string $url
+     * @return string
+     */
+    public function parseType($url)
+    {
+        $matchResult = $this->matchUrl($url);
+        return $matchResult['_route'];
+    }
+
+    /**
+     * @param string $url
+     * @return array
+     */
+    private function matchUrl($url)
+    {
         // we create a request with a new context in order to match $url to a route and get its properties
         $request = Request::create($url, 'GET');
         $originalContext = $this->router->getContext();
@@ -55,7 +74,6 @@ class Router implements RequestParser
         }
 
         $this->router->setContext($originalContext);
-
         return $matchResult;
     }
 

--- a/eZ/Bundle/EzPublishRestBundle/ResourceResolverFactory.php
+++ b/eZ/Bundle/EzPublishRestBundle/ResourceResolverFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace eZ\Publish\Core\REST\Server;
+namespace eZ\Bundle\EzPublishRestBundle;
 
 use eZ\Publish\Core\REST\Common\RequestParser;
 

--- a/eZ/Bundle/EzPublishRestBundle/ResourceResolverFactory.php
+++ b/eZ/Bundle/EzPublishRestBundle/ResourceResolverFactory.php
@@ -3,7 +3,6 @@
 namespace eZ\Bundle\EzPublishRestBundle;
 
 use eZ\Publish\Core\REST\Common\RequestParser;
-
 use eZ\Publish\API\Repository\Repository;
 
 class ResourceResolverFactory

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
@@ -27,7 +27,7 @@ parameters:
     ezpublish_rest.factory.class: eZ\Bundle\EzPublishRestBundle\ApiLoader\Factory
     ezpublish_rest.request_parser.class: eZ\Bundle\EzPublishRestBundle\RequestParser\Router
     ezpublish_rest.resource_resolver.class: eZ\Publish\Core\REST\Server\ResourceResolver
-    ezpublish_rest.resource_resolver.factory.class: eZ\Publish\Core\REST\Server\ResourceResolverFactory
+    ezpublish_rest.resource_resolver.factory.class: eZ\Bundle\EzPublishRestBundle\ResourceResolverFactory
     ezpublish_rest.parser_tools.class: eZ\Publish\Core\REST\Common\Input\ParserTools
     ezpublish_rest.field_type_parser.class: eZ\Publish\Core\REST\Common\Input\FieldTypeParser
     ezpublish_rest.field_type_serializer.class: eZ\Publish\Core\REST\Common\Output\FieldTypeSerializer

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
@@ -26,6 +26,8 @@ parameters:
 
     ezpublish_rest.factory.class: eZ\Bundle\EzPublishRestBundle\ApiLoader\Factory
     ezpublish_rest.request_parser.class: eZ\Bundle\EzPublishRestBundle\RequestParser\Router
+    ezpublish_rest.resource_resolver.class: eZ\Publish\Core\REST\Server\ResourceResolver
+    ezpublish_rest.resource_resolver.factory.class: eZ\Publish\Core\REST\Server\ResourceResolverFactory
     ezpublish_rest.parser_tools.class: eZ\Publish\Core\REST\Common\Input\ParserTools
     ezpublish_rest.field_type_parser.class: eZ\Publish\Core\REST\Common\Input\FieldTypeParser
     ezpublish_rest.field_type_serializer.class: eZ\Publish\Core\REST\Common\Output\FieldTypeSerializer
@@ -126,6 +128,14 @@ services:
          class: "%ezpublish_rest.root_resource_builder.class%"
          arguments: ["@router", "@ezpublish_rest.templated_router", "$rest_root_resources$"]
 
+    ezpublish_rest.resource_resolver:
+        class: "%ezpublish_rest.resource_resolver.class%"
+        factory: [ "@ezpublish_rest.resource_resolver.factory", "createResolver"]
+
+    ezpublish_rest.resource_resolver.factory:
+        class: "%ezpublish_rest.resource_resolver.factory.class%"
+        arguments: ["@ezpublish_rest.request_parser", "@ezpublish.api.repository"]
+
     ezpublish_rest.controller.base:
         class: "%ezpublish_rest.controller.base.class%"
         calls:
@@ -134,6 +144,7 @@ services:
             - [ setRouter, ["@router"] ]
             - [ setRequestParser, ["@ezpublish_rest.request_parser"] ]
             - [ setRepository, ["@ezpublish.api.repository"] ]
+            - [ setResourceResolver, ["@ezpublish_rest.resource_resolver"] ]
 
     ezpublish_rest.controller.root:
         class: "%ezpublish_rest.controller.root.class%"

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ContentTypeTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ContentTypeTest.php
@@ -160,7 +160,6 @@ XML;
         $response = $this->sendHttpRequest(
             $this->createHttpRequest('GET', '/api/ezp/v2/content/typegroups?identifier=testUpdateContentTypeGroup')
         );
-        // @todo Check if list filtered by identifier is supposed to send a 307
         self::assertHttpResponseCodeEquals($response, 307);
     }
 

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ContentTypeTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ContentTypeTest.php
@@ -236,28 +236,28 @@ XML;
      * @depends testCreateContentType
      * Covers GET /content/types?identifier=<contentTypeIdentifier>
      */
-    public function testListContentTypesByIdentifier()
+    public function testListContentTypesByIdentifier($contentTypeHref)
     {
         $response = $this->sendHttpRequest(
             $this->createHttpRequest('GET', '/api/ezp/v2/content/types?identifier=tCreate')
         );
 
-        // @todo This isn't consistent with the behaviour of /content/typegroups?identifier=
-        self::assertHttpResponseCodeEquals($response, 200);
+        self::assertHttpResponseCodeEquals($response, 307);
+        self::assertEquals($response->getHeader('Location'), $contentTypeHref);
     }
 
     /**
      * @depends testCreateContentType
-     * Covers GET /content/types?remoteid=<contentTypeRemoteId>
+     * Covers GET /content/types?remoteId=<contentTypeRemoteId>
      */
-    public function testListContentTypesByRemoteId()
+    public function testListContentTypesByRemoteId($contentTypeHref)
     {
         $response = $this->sendHttpRequest(
             $this->createHttpRequest('GET', '/api/ezp/v2/content/types?remoteId=testCreateContentType')
         );
 
-        // @todo This isn't consistent with the behaviour of /content/typegroups?identifier=
-        self::assertHttpResponseCodeEquals($response, 200);
+        self::assertHttpResponseCodeEquals($response, 307);
+        self::assertEquals($response->getHeader('Location'), $contentTypeHref);
     }
 
     /**

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/UserTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/UserTest.php
@@ -226,11 +226,41 @@ XML;
      * @depends testCreateUser
      * Covers GET /user/users?remoteId={userRemoteId}
      */
-    public function testLoadUserByRemoteId()
+    public function testLoadUserByRemoteId($userHref)
     {
         $remoteId = $this->addTestSuffix('testCreateUser');
         $response = $this->sendHttpRequest(
             $this->createHttpRequest('GET', "/api/ezp/v2/user/users?remoteId=$remoteId")
+        );
+
+        self::assertHttpResponseCodeEquals($response, 307);
+        self::assertEquals($response->getHeader('Location'), $userHref);
+    }
+
+    /**
+     * @depends testCreateUser
+     * Covers GET /user/users?login={userLogin}
+     */
+    public function testLoadUserByLogin($userHref)
+    {
+        $login = $this->addTestSuffix('testCreateUser');
+        $response = $this->sendHttpRequest(
+            $this->createHttpRequest('GET', "/api/ezp/v2/user/users?login=$login")
+        );
+
+        self::assertHttpResponseCodeEquals($response, 307);
+        self::assertEquals($response->getHeader('Location'), $userHref);
+    }
+
+    /**
+     * @depends testCreateUser
+     * Covers GET /user/users?email={userEmail}
+     */
+    public function testLoadUserByEmail()
+    {
+        $email = $this->addTestSuffix('testCreateUser') . '@example.net';
+        $response = $this->sendHttpRequest(
+            $this->createHttpRequest('GET', "/api/ezp/v2/user/users?email=$email")
         );
 
         self::assertHttpResponseCodeEquals($response, 200);

--- a/eZ/Publish/Core/REST/Common/RequestParser.php
+++ b/eZ/Publish/Core/REST/Common/RequestParser.php
@@ -23,6 +23,14 @@ interface RequestParser
     public function parse($url);
 
     /**
+     * Returns the type name associated with $url.
+     *
+     * @param string $url
+     * @return string
+     */
+    public function parseType($url);
+
+    /**
      * Generate a URL of the given type from the specified values.
      *
      * @param string $type

--- a/eZ/Publish/Core/REST/Common/RequestParser/EzPublish.php
+++ b/eZ/Publish/Core/REST/Common/RequestParser/EzPublish.php
@@ -70,6 +70,7 @@ class EzPublish extends Pattern
         'urlWildcard' => '/content/urlwildcards/{urlwildcard}',
         'urlAliases' => '/content/urlaliases',
         'urlAlias' => '/content/urlaliases/{urlalias}',
+        'urlAliasByUrl' => '/content/urlaliases?url={urlalias}',
         'views' => '/content/views',
         'view' => '/content/views/{view}',
         'viewResults' => '/content/views/{view}/results',

--- a/eZ/Publish/Core/REST/Common/RequestParser/EzPublish.php
+++ b/eZ/Publish/Core/REST/Common/RequestParser/EzPublish.php
@@ -88,6 +88,8 @@ class EzPublish extends Pattern
         'policy' => '/user/roles/{role}/policies/{policy}',
         'users' => '/user/users',
         'user' => '/user/users/{user}',
+        'userByRemoteId' => '/user/users?remoteId={user}',
+        'userByLogin' => '/user/users?login={user}',
         'userDrafts' => '/user/users/{user}/drafts',
         'userGroups' => '/user/users/{user}/groups',
         'userGroupAssign' => '/user/users/{user}/groups?group={&group}',

--- a/eZ/Publish/Core/REST/Common/RequestParser/Pattern.php
+++ b/eZ/Publish/Core/REST/Common/RequestParser/Pattern.php
@@ -78,10 +78,22 @@ class Pattern implements RequestParser
      * @param string $url
      *
      * @return array
+     *
+     * @todo Refactor usages of parse() to accept Request struct.
      */
     public function parse($url)
     {
-        foreach ($this->map as $pattern) {
+        $request = $this->parseRequest($url);
+        return $request->variables;
+    }
+
+    /**
+     * @param string $url
+     * @return Request
+     */
+    private function parseRequest($url)
+    {
+        foreach ($this->map as $type => $pattern) {
             $pattern = $this->compile($pattern);
             if (preg_match($pattern, $url, $match)) {
                 // remove numeric keys
@@ -91,11 +103,26 @@ class Pattern implements RequestParser
                     }
                 }
 
-                return $match;
+                return new Request($type, $match);
             }
         }
 
         throw new Exceptions\InvalidArgumentException("URL '$url' did not match any route.");
+    }
+
+    /**
+     * Returns the type name associated with $url.
+     *
+     * @param string $url
+     * @return string
+     *
+     * @todo Refactor usages of parse() to accept Request struct and remove
+     *       this method.
+     */
+    public function parseType($url)
+    {
+        $request = $this->parseRequest($url);
+        return $request->type;
     }
 
     /**

--- a/eZ/Publish/Core/REST/Common/RequestParser/Pattern.php
+++ b/eZ/Publish/Core/REST/Common/RequestParser/Pattern.php
@@ -84,6 +84,7 @@ class Pattern implements RequestParser
     public function parse($url)
     {
         $request = $this->parseRequest($url);
+
         return $request->variables;
     }
 
@@ -122,6 +123,7 @@ class Pattern implements RequestParser
     public function parseType($url)
     {
         $request = $this->parseRequest($url);
+
         return $request->type;
     }
 

--- a/eZ/Publish/Core/REST/Common/RequestParser/Request.php
+++ b/eZ/Publish/Core/REST/Common/RequestParser/Request.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace eZ\Publish\Core\REST\Common\RequestParser;
+
+class Request
+{
+    /**
+     * @var mixed[string]
+     */
+    public $variables;
+
+    /**
+     * @var string
+     */
+    public $type;
+
+    /**
+     * @param string $type
+     * @param mixed[string] $variables
+     */
+    public function __construct($type, array $variables)
+    {
+        $this->type = $type;
+        $this->variables = $variables;
+    }
+}

--- a/eZ/Publish/Core/REST/Common/Tests/RequestParser/PatternTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/RequestParser/PatternTest.php
@@ -132,6 +132,21 @@ class PatternTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test parsing type for URL.
+     *
+     * @dataProvider getParseValues
+     */
+    public function testParseType($type, $url, $values)
+    {
+        $urlHandler = $this->getWorkingUrlHandler();
+
+        $this->assertSame(
+            $type,
+            $urlHandler->parseType($url)
+        );
+    }
+
+    /**
      * Test generating unknown URL type.
      *
      * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException

--- a/eZ/Publish/Core/REST/Common/Tests/RequestParser/PatternTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/RequestParser/PatternTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\REST\Common\Tests\UrlHandler;
+namespace eZ\Publish\Core\REST\Common\Tests\RequestParser;
 
 use eZ\Publish\Core\REST\Common;
 use PHPUnit_Framework_TestCase;

--- a/eZ/Publish/Core/REST/Server/Controller.php
+++ b/eZ/Publish/Core/REST/Server/Controller.php
@@ -15,7 +15,6 @@ use Symfony\Component\Routing\RouterInterface;
 use eZ\Publish\Core\REST\Common\Input\Dispatcher as InputDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use eZ\Publish\Core\REST\Common\RequestParser as RequestParser;
-use eZ\Publish\Core\REST\Server\ResourceResolver;
 
 abstract class Controller implements ContainerAwareInterface
 {

--- a/eZ/Publish/Core/REST/Server/Controller.php
+++ b/eZ/Publish/Core/REST/Server/Controller.php
@@ -15,6 +15,7 @@ use Symfony\Component\Routing\RouterInterface;
 use eZ\Publish\Core\REST\Common\Input\Dispatcher as InputDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use eZ\Publish\Core\REST\Common\RequestParser as RequestParser;
+use eZ\Publish\Core\REST\Server\ResourceResolver;
 
 abstract class Controller implements ContainerAwareInterface
 {
@@ -42,6 +43,11 @@ abstract class Controller implements ContainerAwareInterface
      */
     protected $repository;
 
+    /**
+     * @var \eZ\Publish\Core\REST\Server\ResourceResolver
+     */
+    protected $resourceResolver;
+
     public function setInputDispatcher(InputDispatcher $inputDispatcher)
     {
         $this->inputDispatcher = $inputDispatcher;
@@ -60,6 +66,11 @@ abstract class Controller implements ContainerAwareInterface
     public function setRequestParser(RequestParser $requestParser)
     {
         $this->requestParser = $requestParser;
+    }
+
+    public function setResourceResolver(ResourceResolver $resourceResolver)
+    {
+        $this->resourceResolver = $resourceResolver;
     }
 
     /**

--- a/eZ/Publish/Core/REST/Server/Controller/Content.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Content.php
@@ -275,8 +275,7 @@ class Content extends RestController
     private function parseContentCreate(Request $request)
     {
         if ($request->headers->has('content-type')
-            && $request->headers->get('content-type') === 'application/vnd.ez.api.simplified.ContentCreate+json')
-        {
+            && $request->headers->get('content-type') === 'application/vnd.ez.api.simplified.ContentCreate+json') {
             return $this->parseSimplifiedContentCreate($request);
         }
 

--- a/eZ/Publish/Core/REST/Server/Controller/ContentType.php
+++ b/eZ/Publish/Core/REST/Server/Controller/ContentType.php
@@ -211,11 +211,13 @@ class ContentType extends RestController
     {
         if ($request->query->has('identifier')) {
             $contentType = $this->loadContentTypeByIdentifier($request);
+
             return $this->createContentTypeRedirect($contentType->id);
         }
 
         if ($request->query->has('remoteId')) {
             $contentType = $this->loadContentTypeByRemoteId($request);
+
             return $this->createContentTypeRedirect($contentType->id);
         }
 

--- a/eZ/Publish/Core/REST/Server/Controller/ContentType.php
+++ b/eZ/Publish/Core/REST/Server/Controller/ContentType.php
@@ -209,24 +209,20 @@ class ContentType extends RestController
      */
     public function listContentTypes(Request $request)
     {
+        if ($request->query->has('identifier')) {
+            $contentType = $this->loadContentTypeByIdentifier($request);
+            return $this->createContentTypeRedirect($contentType->id);
+        }
+
+        if ($request->query->has('remoteId')) {
+            $contentType = $this->loadContentTypeByRemoteId($request);
+            return $this->createContentTypeRedirect($contentType->id);
+        }
+
         if ($this->getMediaType($request) === 'application/vnd.ez.api.contenttypelist') {
             $return = new Values\ContentTypeList(array(), $request->getPathInfo());
         } else {
             $return = new Values\ContentTypeInfoList(array(), $request->getPathInfo());
-        }
-
-        if ($request->query->has('identifier')) {
-            $return->contentTypes = array($this->loadContentTypeByIdentifier($request));
-
-            return $return;
-        }
-
-        if ($request->query->has('remoteId')) {
-            $return->contentTypes = array(
-                $this->loadContentTypeByRemoteId($request),
-            );
-
-            return $return;
         }
 
         $limit = null;
@@ -246,6 +242,22 @@ class ContentType extends RestController
         $return->contentTypes = array_slice($contentTypes, $offset, $limit);
 
         return $return;
+    }
+
+    /**
+     * @param mixed $contentTypeId
+     * @return Values\TemporaryRedirect
+     */
+    private function createContentTypeRedirect($contentTypeId)
+    {
+        return new Values\TemporaryRedirect(
+            $this->router->generate(
+                'ezpublish_rest_loadContentType',
+                array(
+                    'contentTypeId' => $contentTypeId,
+                )
+            )
+        );
     }
 
     /**

--- a/eZ/Publish/Core/REST/Server/Controller/User.php
+++ b/eZ/Publish/Core/REST/Server/Controller/User.php
@@ -468,11 +468,13 @@ class User extends RestController
                 $user = $this->userService->loadUser(
                     $this->contentService->loadContentInfoByRemoteId($request->query->get('remoteId'))->id
                 );
+
                 return $this->redirectToUser($user->id);
             }
 
             if ($request->query->has('login')) {
                 $user = $this->userService->loadUserByLogin($request->query->get('login'));
+
                 return $this->redirectToUser($user->id);
             }
 

--- a/eZ/Publish/Core/REST/Server/ResourceResolver.php
+++ b/eZ/Publish/Core/REST/Server/ResourceResolver.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace eZ\Publish\Core\REST\Server;
+
+use eZ\Publish\Core\REST\Common\RequestParser;
+use eZ\Publish\Core\REST\Common\Exceptions;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+
+class ResourceResolver
+{
+    /**
+     * @var RequestParser
+     */
+    private $requestParser;
+
+    /**
+     * @var \eZ\Publish\API\Repository\ContentTypeService
+     */
+    protected $contentTypeService;
+
+    /**
+     * @param RequestParser $requestParser
+     * @param ContentTypeService $contentTypeService
+     */
+    public function __construct(RequestParser $requestParser, ContentTypeService $contentTypeService)
+    {
+        $this->requestParser = $requestParser;
+        $this->contentTypeService = $contentTypeService;
+    }
+
+    /**
+     * @param string $uri
+     */
+    public function resolveContentType($uri)
+    {
+        $contentTypeVariables = $this->requestParser->parse($uri);
+        $uriType = $this->requestParser->parseType($uri);
+
+        switch ($uriType) {
+            case 'typeByIdentifier':
+                return $this->contentTypeService->loadContentTypeByIdentifier(
+                    $contentTypeVariables['type']
+                );
+
+            case 'typeByRemoteId':
+                return $this->contentTypeService->loadContentTypeByRemoteId(
+                    $contentTypeVariables['type']
+                );
+
+            case 'type':
+                return $this->contentTypeService->loadContentType(
+                    $contentTypeVariables['type']
+                );
+        }
+
+        throw new Exceptions\InvalidArgumentException("Could not retrieve ContenType for '$uri'.");
+    }
+}

--- a/eZ/Publish/Core/REST/Server/ResourceResolver.php
+++ b/eZ/Publish/Core/REST/Server/ResourceResolver.php
@@ -5,8 +5,6 @@ namespace eZ\Publish\Core\REST\Server;
 use eZ\Publish\Core\REST\Common\RequestParser;
 use eZ\Publish\Core\REST\Common\Exceptions;
 
-use eZ\Publish\API\Repository\ContentTypeService;
-
 class ResourceResolver
 {
     /**

--- a/eZ/Publish/Core/REST/Server/ResourceResolverFactory.php
+++ b/eZ/Publish/Core/REST/Server/ResourceResolverFactory.php
@@ -14,6 +14,8 @@ class ResourceResolverFactory
 
     private $contentTypeService;
 
+    private $urlAliasService;
+
     private $sectionService;
 
     private $userService;
@@ -21,18 +23,21 @@ class ResourceResolverFactory
     /**
      * @param \eZ\Publish\Core\REST\Common\RequestParser $requestParser
      * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
+     * @param \eZ\Publish\API\Repository\UrlAliasService $urlAliasService
      * @param \eZ\Publish\API\Repository\SectionService $sectionService
      * @param \eZ\Publish\API\Repository\UserService $userService
      */
     public function __construct(
         RequestParser $requestParser,
         ContentTypeService $contentTypeService,
+        UrlAliasService $urlAliasService,
         SectionService $sectionService,
         UserService $userService
     ) {
         $this->requestParser = $requestParser;
 
         $this->contentTypeService = $contentTypeService;
+        $this->urlAliasService = $urlAliasService;
         $this->sectionService = $sectionService;
         $this->userService = $userService;
     }
@@ -43,6 +48,7 @@ class ResourceResolverFactory
     public function createResolver()
     {
         $contentTypeService = $this->contentTypeService;
+        $urlAliasService = $this->urlAliasService;
         $sectionService = $this->sectionService;
         $userService = $this->userService;
 
@@ -59,7 +65,12 @@ class ResourceResolverFactory
                     return $contentTypeService->loadContentTypeByRemoteId($uriParameters['type']);
                 },
 
-                // TODO: URLAliases still need an alias URI (SIC ;))
+                'urlAlias' => function ($uriParameters) use ($urlAliasService) {
+                    return $urlAliasService->load($uriParameters['urlAlias']);
+                },
+                'urlAliasByUrl' => function ($uriParameters) use ($urlAliasService) {
+                    return $urlAliasService->lookup($uriParameters['urlAlias']);
+                },
 
                 'section' => function ($uriParameters) use ($sectionService) {
                     return $sectionService->loadSection($uriParameters['section']);

--- a/eZ/Publish/Core/REST/Server/ResourceResolverFactory.php
+++ b/eZ/Publish/Core/REST/Server/ResourceResolverFactory.php
@@ -35,10 +35,10 @@ class ResourceResolverFactory
      */
     public function createResolver()
     {
-        $contentTypeService = $this->getContentTypeService();
-        $urlAliasService = $this->getUrlAliasService();
-        $sectionService = $this->getSectionService();
-        $userService = $this->getUserService();
+        $contentTypeService = $this->repository->getContentTypeService();
+        $urlAliasService = $this->repository->getUrlAliasService();
+        $sectionService = $this->repository->getSectionService();
+        $userService = $this->repository->getUserService();
 
         return new ResourceResolver(
             $this->requestParser,

--- a/eZ/Publish/Core/REST/Server/ResourceResolverFactory.php
+++ b/eZ/Publish/Core/REST/Server/ResourceResolverFactory.php
@@ -71,7 +71,10 @@ class ResourceResolverFactory
                 'user' => function ($uriParameters) use ($userService) {
                     return $userService->loadUser($uriParameters['user']);
                 },
-                // TODO: User by Login missing in URL mapping
+                // TODO: User by Remote ID
+                'userByLogin' => function ($uriParameters) use ($userService) {
+                    return $userService->loadUserByLogin($uriParameters['user']);
+                },
             ]
         );
     }

--- a/eZ/Publish/Core/REST/Server/ResourceResolverFactory.php
+++ b/eZ/Publish/Core/REST/Server/ResourceResolverFactory.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace eZ\Publish\Core\REST\Server;
+
+use eZ\Publish\Core\REST\Common\RequestParser;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\SectionService;
+use eZ\Publish\API\Repository\UserService;
+
+class ResourceResolverFactory
+{
+    private $requestParser;
+
+    private $contentTypeService;
+
+    private $sectionService;
+
+    private $userService;
+
+    /**
+     * @param \eZ\Publish\Core\REST\Common\RequestParser $requestParser
+     * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
+     * @param \eZ\Publish\API\Repository\SectionService $sectionService
+     * @param \eZ\Publish\API\Repository\UserService $userService
+     */
+    public function __construct(
+        RequestParser $requestParser,
+        ContentTypeService $contentTypeService,
+        SectionService $sectionService,
+        UserService $userService
+    ) {
+        $this->requestParser = $requestParser;
+
+        $this->contentTypeService = $contentTypeService;
+        $this->sectionService = $sectionService;
+        $this->userService = $userService;
+    }
+
+    /**
+     * @return \eZ\Publish\Core\REST\Server\ResourceResolver
+     */
+    public function createResolver()
+    {
+        $contentTypeService = $this->contentTypeService;
+        $sectionService = $this->sectionService;
+        $userService = $this->userService;
+
+        return new ResourceResolver(
+            $this->requestParser,
+            [
+                'type' => function ($uriParameters) use ($contentTypeService) {
+                    return $contentTypeService->loadContentType($uriParameters['type']);
+                },
+                'typeByIdentifier' => function ($uriParameters) use ($contentTypeService) {
+                    return $contentTypeService->loadContentTypeByIdentifier($uriParameters['type']);
+                },
+                'typeByRemoteId' => function ($uriParameters) use ($contentTypeService) {
+                    return $contentTypeService->loadContentTypeByRemoteId($uriParameters['type']);
+                },
+
+                // TODO: URLAliases still need an alias URI (SIC ;))
+
+                'section' => function ($uriParameters) use ($sectionService) {
+                    return $sectionService->loadSection($uriParameters['section']);
+                },
+                'sectionByIdentifier' => function ($uriParameters) use ($sectionService) {
+                    return $sectionService->loadSectionByIdentifier($uriParameters['section']);
+                },
+
+                'user' => function ($uriParameters) use ($userService) {
+                    return $userService->loadUser($uriParameters['user']);
+                },
+                // TODO: User by Login missing in URL mapping
+            ]
+        );
+    }
+}

--- a/eZ/Publish/Core/REST/Server/ResourceResolverFactory.php
+++ b/eZ/Publish/Core/REST/Server/ResourceResolverFactory.php
@@ -4,42 +4,30 @@ namespace eZ\Publish\Core\REST\Server;
 
 use eZ\Publish\Core\REST\Common\RequestParser;
 
-use eZ\Publish\API\Repository\ContentTypeService;
-use eZ\Publish\API\Repository\SectionService;
-use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\API\Repository\Repository;
 
 class ResourceResolverFactory
 {
+    /**
+     * @var \eZ\Publish\Core\REST\Common\RequestParser
+     */
     private $requestParser;
 
-    private $contentTypeService;
-
-    private $urlAliasService;
-
-    private $sectionService;
-
-    private $userService;
+    /**
+     * @var \eZ\Publish\API\Repository\Repository
+     */
+    private $repository;
 
     /**
      * @param \eZ\Publish\Core\REST\Common\RequestParser $requestParser
-     * @param \eZ\Publish\API\Repository\ContentTypeService $contentTypeService
-     * @param \eZ\Publish\API\Repository\UrlAliasService $urlAliasService
-     * @param \eZ\Publish\API\Repository\SectionService $sectionService
-     * @param \eZ\Publish\API\Repository\UserService $userService
+     * @param \eZ\Publish\API\Repository\Repository $repository
      */
     public function __construct(
         RequestParser $requestParser,
-        ContentTypeService $contentTypeService,
-        UrlAliasService $urlAliasService,
-        SectionService $sectionService,
-        UserService $userService
+        Repository $repository
     ) {
         $this->requestParser = $requestParser;
-
-        $this->contentTypeService = $contentTypeService;
-        $this->urlAliasService = $urlAliasService;
-        $this->sectionService = $sectionService;
-        $this->userService = $userService;
+        $this->repository = $repository;
     }
 
     /**
@@ -47,10 +35,10 @@ class ResourceResolverFactory
      */
     public function createResolver()
     {
-        $contentTypeService = $this->contentTypeService;
-        $urlAliasService = $this->urlAliasService;
-        $sectionService = $this->sectionService;
-        $userService = $this->userService;
+        $contentTypeService = $this->getContentTypeService();
+        $urlAliasService = $this->getUrlAliasService();
+        $sectionService = $this->getSectionService();
+        $userService = $this->getUserService();
 
         return new ResourceResolver(
             $this->requestParser,

--- a/eZ/Publish/Core/REST/Server/Tests/ResourceResolverTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/ResourceResolverTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace eZ\Publish\Core\REST\Server\Tests;
+
+use eZ\Publish\Core\REST\Server\ResourceResolver;
+use eZ\Publish\Core\REST\Common\RequestParser;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+
+class ResourceResolverTest extends \PHPUnit_Framework_TestCase
+{
+
+    private $resourceResolver;
+
+    private $contentTypeServiceMock;
+
+    public function setup()
+    {
+        $this->contentTypeServiceMock = $this->getMockBuilder(
+            ContentTypeService::class            
+        )->getMock();
+
+        $this->resourceResolver = new ResourceResolver(
+            new RequestParser\EzPublish(),
+            $this->contentTypeServiceMock
+        );
+    }
+
+    public function provideResolveMapping()
+    {
+        return [
+            [
+                '/content/types?identifier=article',
+                'loadContentTypeByIdentifier',
+                'article',
+            ],
+            [
+                '/content/types?remoteId=ABC-123',
+                'loadContentTypeByRemoteId',
+                'ABC-123',
+            ],
+            [
+                '/content/types/23',
+                'loadContentType',
+                '23',
+            ],
+        ];
+    }
+
+    /**
+     * @param string $uri
+     * @param string $expectedMethod
+     * @param string $expectedParameter
+     *
+     * @dataProvider provideResolveMapping
+     */
+    public function testResolveMapping($uri, $expectedMethod, $expectedParameter)
+    {
+        $expectedReturnValue = new \stdClass();
+
+        $this->contentTypeServiceMock->expects($this->once())
+            ->method($expectedMethod)
+            ->with($expectedParameter)
+            ->will($this->returnValue($expectedReturnValue));
+
+        $this->assertSame(
+            $expectedReturnValue,
+            $this->resourceResolver->resolveContentType($uri)
+        );
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Tests/ResourceResolverTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/ResourceResolverTest.php
@@ -6,11 +6,8 @@ use eZ\Publish\Core\REST\Server\ResourceResolver;
 use eZ\Publish\Core\REST\Common\RequestParser;
 use eZ\Publish\Core\REST\Common\Exceptions;
 
-use eZ\Publish\API\Repository\ContentTypeService;
-
 class ResourceResolverTest extends \PHPUnit_Framework_TestCase
 {
-
     private $resourceResolver;
 
     private $resolverCallableMock;
@@ -18,7 +15,7 @@ class ResourceResolverTest extends \PHPUnit_Framework_TestCase
     public function setup()
     {
         $this->resolverCallableMock = $this->getMockBuilder(
-            \stdClass::class            
+            \stdClass::class
         )->setMethods(['__invoke'])
         ->getMock();
 


### PR DESCRIPTION
This PR deals to discuss simplified REST structures, based on the initial approach presented [here](https://github.com/kamilmusial/EzSystemsRestv3BundlePrototype/blob/46b8bef69e077d76dc7deaf589400dd491f8cfc0/doc/specifications/drafts/rest_content_managemet.md).

The basic idea is to ease usage of the REST API, especially for JSON based clients.

* [x] Specify initial draft for discussion
* [x] Discuss and evolve approaches
* [x] Add specification for linking alias URIs in types (if accepted)
* [ ] Provide prototype implementation
  * [x] Implement mechanism to resolve resources from alias URLs
  * [x] Implement custom parsing approach for simplified content create
  * [ ] Adjust resource resolver approach to work on URL parameters since symfony request matching is not how Core implementation works
  * [ ] Implement functional test for simplified content create
  * [ ] Re-check specs for re-worked alias URI updates

Further TODOs:

* [ ] Introduce tests for all alias URIs with non existent identifiers (should return 404)