### PR TITLE
EZP-26608 fixing default fields group list

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
@@ -117,11 +117,7 @@ class Configuration extends SiteAccessConfiguration
                                     }
 
                                     if (!isset($v['fields_groups']['list'])) {
-                                        $v['fields_groups']['list'] = ['content'];
-                                    }
-
-                                    if (!isset($v['fields_groups']['default'])) {
-                                        $v['fields_groups']['default'] = 'content';
+                                        $v['fields_groups']['list'] = [];
                                     }
 
                                     if (!isset($v['options'])) {
@@ -171,7 +167,7 @@ class Configuration extends SiteAccessConfiguration
                                 ->info('Definitions of fields groups.')
                                 ->children()
                                     ->arrayNode('list')->prototype('scalar')->end()->end()
-                                    ->scalarNode('default')->defaultValue('content')->end()
+                                    ->scalarNode('default')->defaultValue('%ezsettings.default.content.field_groups.default%')->end()
                                 ->end()
                             ->end()
                             ->arrayNode('options')

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -187,6 +187,12 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
             $config['repositories'] = array();
         }
 
+        foreach ($config['repositories'] as $name => &$repository) {
+            if (empty($repository['fields_groups']['list'])) {
+                $repository['fields_groups']['list'] = $container->getParameter('ezsettings.default.content.field_groups.list');
+            }
+        }
+
         $container->setParameter('ezpublish.repositories', $config['repositories']);
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
@@ -351,6 +351,144 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
         $this->assertSame($repositories, $this->container->getParameter('ezpublish.repositories'));
     }
 
+    /**
+     * @dataProvider repositoriesConfigurationFieldGroupsProvider
+     */
+    public function testRepositoriesConfigurationFieldGroups($repositories, $expectedRepositories)
+    {
+        $this->load(['repositories' => $repositories]);
+        $this->assertTrue($this->container->hasParameter('ezpublish.repositories'));
+
+        $repositoriesPar = $this->container->getParameter('ezpublish.repositories');
+        $this->assertEquals(count($repositories), count($repositoriesPar));
+
+        foreach ($repositoriesPar as $key => $repo) {
+            $this->assertArrayHasKey($key, $expectedRepositories);
+            $this->assertArrayHasKey('fields_groups', $repo);
+            $this->assertEquals($expectedRepositories[$key]['fields_groups'], $repo['fields_groups'], 'Invalid fields groups element', 0.0, 10, true);
+        }
+    }
+
+    public function repositoriesConfigurationFieldGroupsProvider()
+    {
+        return [
+            //empty config
+            [
+                ['main' => null],
+                ['main' => [
+                        'fields_groups' => [
+                            'list' => ['content', 'metadata'],
+                            'default' => '%ezsettings.default.content.field_groups.default%',
+                        ],
+                    ],
+                ],
+            ],
+            //single item with custom fields
+            [
+                ['foo' => [
+                        'fields_groups' => [
+                            'list' => ['bar', 'baz', 'john'],
+                            'default' => 'bar',
+                        ],
+                    ],
+                ],
+                ['foo' => [
+                        'fields_groups' => [
+                            'list' => ['bar', 'baz', 'john'],
+                            'default' => 'bar',
+                        ],
+                    ],
+                ],
+            ],
+            //mixed item with custom config and empty item
+            [
+                [
+                    'foo' => [
+                        'fields_groups' => [
+                            'list' => ['bar', 'baz', 'john', 'doe'],
+                            'default' => 'bar',
+                        ],
+                    ],
+                    'anotherone' => null,
+                ],
+                [
+                    'foo' => [
+                        'fields_groups' => [
+                            'list' => ['bar', 'baz', 'john', 'doe'],
+                            'default' => 'bar',
+                        ],
+                    ],
+                    'anotherone' => [
+                        'fields_groups' => [
+                            'list' => ['content', 'metadata'],
+                            'default' => '%ezsettings.default.content.field_groups.default%',
+                        ],
+                    ],
+                ],
+            ],
+            //items with only one field configured
+            [
+                [
+                    'foo' => [
+                        'fields_groups' => [
+                            'list' => ['bar', 'baz', 'john'],
+                        ],
+                    ],
+                    'bar' => [
+                        'fields_groups' => [
+                            'default' => 'metadata',
+                        ],
+                    ],
+                ],
+                [
+                    'foo' => [
+                        'fields_groups' => [
+                            'list' => ['bar', 'baz', 'john'],
+                            'default' => '%ezsettings.default.content.field_groups.default%',
+                        ],
+                    ],
+                    'bar' => [
+                        'fields_groups' => [
+                            'list' => ['content', 'metadata'],
+                            'default' => 'metadata',
+                        ],
+                    ],
+                ],
+            ],
+            //two different repositories
+            [
+                [
+                    'foo' => [
+                        'fields_groups' => [
+                            'list' => ['bar', 'baz', 'john', 'doe'],
+                            'default' => 'bar',
+                        ],
+                    ],
+                    'bar' => [
+                        'fields_groups' => [
+                            'list' => ['lorem', 'ipsum'],
+                            'default' => 'lorem',
+                        ],
+                    ],
+                ],
+                [
+                    'foo' => [
+                        'fields_groups' => [
+                            'list' => ['bar', 'baz', 'john', 'doe'],
+                            'default' => 'bar',
+                        ],
+                    ],
+                    'bar' => [
+                        'fields_groups' => [
+                            'list' => ['lorem', 'ipsum'],
+                            'default' => 'lorem',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
     public function testRepositoriesConfigurationEmpty()
     {
         $repositories = array(

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
@@ -316,8 +316,8 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'connection' => 'blabla',
                 ),
                 'fields_groups' => array(
-                    'list' => ['content'],
-                    'default' => 'content',
+                    'list' => ['content', 'metadata'],
+                    'default' => '%ezsettings.default.content.field_groups.default%',
                 ),
                 'options' => [
                     'default_version_archive_limit' => 5,
@@ -333,8 +333,8 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'connection' => 'lalala',
                 ),
                 'fields_groups' => array(
-                    'list' => ['content'],
-                    'default' => 'content',
+                    'list' => ['content', 'metadata'],
+                    'default' => '%ezsettings.default.content.field_groups.default%',
                 ),
                 'options' => [
                     'default_version_archive_limit' => 5,
@@ -369,8 +369,8 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'config' => array(),
                 ),
                 'fields_groups' => array(
-                    'list' => ['content'],
-                    'default' => 'content',
+                    'list' => ['content', 'metadata'],
+                    'default' => '%ezsettings.default.content.field_groups.default%',
                 ),
                 'options' => [
                     'default_version_archive_limit' => 5,
@@ -409,8 +409,8 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'config' => array(),
                 ),
                 'fields_groups' => array(
-                    'list' => ['content'],
-                    'default' => 'content',
+                    'list' => ['content', 'metadata'],
+                    'default' => '%ezsettings.default.content.field_groups.default%',
                 ),
                 'options' => [
                     'default_version_archive_limit' => 5,
@@ -449,8 +449,8 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'config' => array(),
                 ),
                 'fields_groups' => array(
-                    'list' => ['content'],
-                    'default' => 'content',
+                    'list' => ['content', 'metadata'],
+                    'default' => '%ezsettings.default.content.field_groups.default%',
                 ),
                 'options' => [
                     'default_version_archive_limit' => 5,
@@ -499,8 +499,8 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'config' => array(),
                 ),
                 'fields_groups' => array(
-                    'list' => ['content'],
-                    'default' => 'content',
+                    'list' => ['content', 'metadata'],
+                    'default' => '%ezsettings.default.content.field_groups.default%',
                 ),
                 'options' => [
                     'default_version_archive_limit' => 5,
@@ -518,8 +518,8 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'config' => array(),
                 ),
                 'fields_groups' => array(
-                    'list' => ['content'],
-                    'default' => 'content',
+                    'list' => ['content', 'metadata'],
+                    'default' => '%ezsettings.default.content.field_groups.default%',
                 ),
                 'options' => [
                     'default_version_archive_limit' => 5,
@@ -556,8 +556,8 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                     'config' => array(),
                 ),
                 'fields_groups' => array(
-                    'list' => ['content'],
-                    'default' => 'content',
+                    'list' => ['content', 'metadata'],
+                    'default' => '%ezsettings.default.content.field_groups.default%',
                 ),
                 'options' => [
                     'default_version_archive_limit' => 5,


### PR DESCRIPTION
This is alternative version of #1988 I'm not sure which one is better so I'm opening two PR for reviewers to decide which one we should continue with.

It fixes https://jira.ez.no/browse/EZP-26608

# Description

**A bug**: Configuration is set that if there's no config related to list of fields groups coming from user it creates default list containing only content.
**Solution**: Changing contents of default list by adding reading value from parameter ezsettings.default.content.field_groups.list