### PR TITLE
EZP-26885: As a Developer I want to future proof my Field Types by using Doctrine [in external storage]

### DIFF
--- a/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage/Gateway/DoctrineStorage.php
@@ -1,0 +1,414 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\BinaryBase\BinaryBaseStorage\Gateway;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\Core\FieldType\BinaryBase\BinaryBaseStorage\Gateway;
+use PDO;
+
+/**
+ * Base class for binary files external storage DoctrineStorage gateways.
+ */
+abstract class DoctrineStorage extends Gateway
+{
+    /**
+     * @var \Doctrine\DBAL\Connection
+     */
+    protected $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * Return the table name to store data in.
+     *
+     * @return string
+     */
+    abstract protected function getStorageTable();
+
+    /**
+     * Return a column to property mapping for the storage table.
+     *
+     * @return array
+     */
+    protected function getPropertyMapping()
+    {
+        return [
+            'filename' => [
+                'name' => 'id',
+                'cast' => 'strval',
+            ],
+            'mime_type' => [
+                'name' => 'mimeType',
+                'cast' => 'strval',
+            ],
+            'original_filename' => [
+                'name' => 'fileName',
+                'cast' => 'strval',
+            ],
+        ];
+    }
+
+    /**
+     * Set columns to be fetched from the database.
+     *
+     * This method is intended to be overwritten by derived classes in order to
+     * add additional columns to be fetched from the database. Please do not
+     * forget to call the parent when overwriting this method.
+     *
+     * @param \Doctrine\DBAL\Query\QueryBuilder $queryBuilder
+     * @param int $fieldId
+     * @param int $versionNo
+     */
+    protected function setFetchColumns(QueryBuilder $queryBuilder, $fieldId, $versionNo)
+    {
+        $queryBuilder->select(
+            $this->connection->quoteIdentifier('filename'),
+            $this->connection->quoteIdentifier('mime_type'),
+            $this->connection->quoteIdentifier('original_filename')
+        );
+    }
+
+    /**
+     * Set the required insert columns to insert query builder.
+     *
+     * This method is intended to be overwritten by derived classes in order to
+     * add additional columns to be set in the database. Please do not forget
+     * to call the parent when overwriting this method.
+     *
+     * @param \Doctrine\DBAL\Query\QueryBuilder $queryBuilder
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     */
+    protected function setInsertColumns(QueryBuilder $queryBuilder, VersionInfo $versionInfo, Field $field)
+    {
+        $queryBuilder
+            ->setValue('contentobject_attribute_id', ':fieldId')
+            ->setValue('filename', ':filename')
+            ->setValue('mime_type', ':mimeType')
+            ->setValue('original_filename', ':originalFilename')
+            ->setValue('version', ':versionNo')
+            ->setParameter(':fieldId', $field->id, PDO::PARAM_INT)
+            ->setParameter(':filename', $this->removeMimeFromPath($field->value->externalData['id']))
+            ->setParameter(':mimeType', $field->value->externalData['mimeType'])
+            ->setParameter(':originalFilename', $field->value->externalData['fileName'])
+            ->setParameter(':versionNo', $versionInfo->versionNo, PDO::PARAM_INT)
+        ;
+    }
+
+    /**
+     * Store the file reference in $field for $versionNo.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     * @return bool
+     */
+    public function storeFileReference(VersionInfo $versionInfo, Field $field)
+    {
+        $insertQuery = $this->connection->createQueryBuilder();
+        $insertQuery->insert(
+            $this->connection->quoteIdentifier($this->getStorageTable())
+        );
+
+        $this->setInsertColumns($insertQuery, $versionInfo, $field);
+
+        $insertQuery->execute();
+
+        return false;
+    }
+
+    /**
+     * Remove the prepended mime-type directory from $path for legacy storage.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    public function removeMimeFromPath($path)
+    {
+        $res = substr($path, strpos($path, '/') + 1);
+
+        return $res;
+    }
+
+    /**
+     * Return the file reference data for the given $fieldId in $versionNo.
+     *
+     * @param int $fieldId
+     * @param int $versionNo
+     *
+     * @return array|null
+     */
+    public function getFileReferenceData($fieldId, $versionNo)
+    {
+        $selectQuery = $this->connection->createQueryBuilder();
+
+        $this->setFetchColumns($selectQuery, $fieldId, $versionNo);
+
+        $selectQuery
+            ->from($this->connection->quoteIdentifier($this->getStorageTable()))
+            ->where(
+                $selectQuery->expr()->andX(
+                    $selectQuery->expr()->eq(
+                        $this->connection->quoteIdentifier('contentobject_attribute_id'),
+                        ':fieldId'
+                    ),
+                    $selectQuery->expr()->eq(
+                        $this->connection->quoteIdentifier('version'),
+                        ':versionNo'
+                    )
+                )
+            )
+            ->setParameter(':fieldId', $fieldId, PDO::PARAM_INT)
+            ->setParameter(':versionNo', $versionNo, PDO::PARAM_INT)
+        ;
+
+        $statement = $selectQuery->execute();
+
+        $result = $statement->fetchAll(PDO::FETCH_ASSOC);
+
+        if (count($result) < 1) {
+            return null;
+        }
+
+        $convertedResult = [];
+        foreach (reset($result) as $column => $value) {
+            $convertedResult[$this->toPropertyName($column)] = $this->castToPropertyValue($value, $column);
+        }
+        $convertedResult['id'] = $this->prependMimeToPath(
+            $convertedResult['id'],
+            $convertedResult['mimeType']
+        );
+
+        return $convertedResult;
+    }
+
+    /**
+     * Return the property name for the given $columnName.
+     *
+     * @param string $columnName
+     *
+     * @return string
+     */
+    protected function toPropertyName($columnName)
+    {
+        $propertyMap = $this->getPropertyMapping();
+
+        return $propertyMap[$columnName]['name'];
+    }
+
+    /**
+     * Return $value casted as specified by {@link getPropertyMapping()}.
+     *
+     * @param mixed $value
+     * @param string $columnName
+     *
+     * @return mixed
+     */
+    protected function castToPropertyValue($value, $columnName)
+    {
+        $propertyMap = $this->getPropertyMapping();
+        $castFunction = $propertyMap[$columnName]['cast'];
+
+        return $castFunction($value);
+    }
+
+    /**
+     * Prepend $path with the first part of the given $mimeType.
+     *
+     * @param string $path
+     * @param string $mimeType
+     *
+     * @return string
+     */
+    public function prependMimeToPath($path, $mimeType)
+    {
+        $res = substr($mimeType, 0, strpos($mimeType, '/')) . '/' . $path;
+
+        return $res;
+    }
+
+    /**
+     * Remove all file references for the given $fieldIds.
+     *
+     * @param array $fieldIds
+     * @param int $versionNo
+     */
+    public function removeFileReferences(array $fieldIds, $versionNo)
+    {
+        if (empty($fieldIds)) {
+            return;
+        }
+
+        $deleteQuery = $this->connection->createQueryBuilder();
+        $deleteQuery
+            ->delete($this->connection->quoteIdentifier($this->getStorageTable()))
+            ->where(
+                $deleteQuery->expr()->andX(
+                    $deleteQuery->expr()->in(
+                        $this->connection->quoteIdentifier('contentobject_attribute_id'),
+                        ':fieldIds'
+                    ),
+                    $deleteQuery->expr()->eq(
+                        $this->connection->quoteIdentifier('version'),
+                        ':versionNo'
+                    )
+                )
+            )
+            ->setParameter(':fieldIds', $fieldIds, Connection::PARAM_INT_ARRAY)
+            ->setParameter(':versionNo', $versionNo, PDO::PARAM_INT)
+        ;
+
+        $deleteQuery->execute();
+    }
+
+    /**
+     * Remove a specific file reference for $fieldId and $versionId.
+     *
+     * @param int $fieldId
+     * @param int $versionNo
+     */
+    public function removeFileReference($fieldId, $versionNo)
+    {
+        $deleteQuery = $this->connection->createQueryBuilder();
+        $deleteQuery
+            ->delete($this->connection->quoteIdentifier($this->getStorageTable()))
+            ->where(
+                $deleteQuery->expr()->andX(
+                    $deleteQuery->expr()->eq(
+                        $this->connection->quoteIdentifier('contentobject_attribute_id'),
+                        ':fieldId'
+                    ),
+                    $deleteQuery->expr()->eq(
+                        $this->connection->quoteIdentifier('version'),
+                        ':versionNo'
+                    )
+                )
+            )
+            ->setParameter(':fieldId', $fieldId, PDO::PARAM_INT)
+            ->setParameter(':versionNo', $versionNo, PDO::PARAM_INT)
+        ;
+
+        $deleteQuery->execute();
+    }
+
+    /**
+     * Return a set o file references, referenced by the given $fieldIds.
+     *
+     * @param array $fieldIds
+     *
+     * @return array
+     */
+    public function getReferencedFiles(array $fieldIds, $versionNo)
+    {
+        if (empty($fieldIds)) {
+            return [];
+        }
+
+        $selectQuery = $this->connection->createQueryBuilder();
+        $selectQuery
+            ->select(
+                $this->connection->quoteIdentifier('filename'),
+                $this->connection->quoteIdentifier('mime_type')
+            )
+            ->from($this->connection->quoteIdentifier($this->getStorageTable()))
+            ->where(
+                $selectQuery->expr()->andX(
+                    $selectQuery->expr()->in(
+                        $this->connection->quoteIdentifier('contentobject_attribute_id'),
+                        ':fieldIds'
+                    ),
+                    $selectQuery->expr()->eq(
+                        $this->connection->quoteIdentifier('version'),
+                        ':versionNo'
+                    )
+                )
+            )
+            ->setParameter(':fieldIds', $fieldIds, Connection::PARAM_INT_ARRAY)
+            ->setParameter(':versionNo', $versionNo, PDO::PARAM_INT)
+        ;
+
+        $statement = $selectQuery->execute();
+
+        return array_map(
+            function ($row) {
+                return $this->prependMimeToPath($row['filename'], $row['mime_type']);
+            },
+            $statement->fetchAll(PDO::FETCH_ASSOC)
+        );
+    }
+
+    /**
+     * Return a map with the number of references each file from $files has.
+     *
+     * @param array $files
+     *
+     * @return array
+     */
+    public function countFileReferences(array $files)
+    {
+        if (empty($files)) {
+            return [];
+        }
+
+        $selectQuery = $this->connection->createQueryBuilder();
+        $selectQuery
+            ->select(
+                $this->connection->quoteIdentifier('filename'),
+                $this->connection->quoteIdentifier('mime_type'),
+                sprintf(
+                    'COUNT(%s) AS count',
+                    $this->connection->quoteIdentifier('contentobject_attribute_id')
+                )
+            )
+            ->from($this->connection->quoteIdentifier($this->getStorageTable()))
+            ->where(
+                $selectQuery->expr()->in(
+                    $this->connection->quoteIdentifier('filename'),
+                    ':filenames'
+                )
+            )
+            ->groupBy(
+                $this->connection->quoteIdentifier('filename'),
+                $this->connection->quoteIdentifier('mime_type')
+            )
+            ->setParameter(
+                ':filenames',
+                array_map(
+                    [$this, 'removeMimeFromPath'],
+                    $files
+                ),
+                Connection::PARAM_STR_ARRAY
+            )
+        ;
+
+        $statement = $selectQuery->execute();
+
+        $countMap = [];
+        foreach ($statement->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $path = $this->prependMimeToPath($row['filename'], $row['mime_type']);
+            $countMap[$path] = (int)$row['count'];
+        }
+
+        // Complete counts
+        foreach ($files as $path) {
+            // This is already the correct path
+            if (!isset($countMap[$path])) {
+                $countMap[$path] = 0;
+            }
+        }
+
+        return $countMap;
+    }
+}

--- a/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage/Gateway/LegacyStorage.php
@@ -15,6 +15,9 @@ use eZ\Publish\Core\FieldType\BinaryBase\BinaryBaseStorage\Gateway;
 use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use eZ\Publish\Core\Persistence\Database\InsertQuery;
 
+/**
+ * @deprecated since 6.11. Use {@see \eZ\Publish\Core\FieldType\BinaryBase\BinaryBaseStorage\Gateway\DoctrineStorage} instead.
+ */
 abstract class LegacyStorage extends Gateway
 {
     /**
@@ -24,6 +27,10 @@ abstract class LegacyStorage extends Gateway
 
     public function __construct(DatabaseHandler $dbHandler)
     {
+        @trigger_error(
+            sprintf('%s is deprecated, use %s instead', self::class, DoctrineStorage::class),
+            E_USER_DEPRECATED
+        );
         $this->dbHandler = $dbHandler;
     }
 

--- a/eZ/Publish/Core/FieldType/BinaryFile/BinaryFileStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/BinaryFile/BinaryFileStorage/Gateway/DoctrineStorage.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\BinaryFile\BinaryFileStorage\Gateway;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\Core\FieldType\BinaryBase\BinaryBaseStorage\Gateway\DoctrineStorage as BaseDoctrineStorage;
+use PDO;
+
+/**
+ * Binary File Field Type external storage DoctrineStorage gateway.
+ */
+class DoctrineStorage extends BaseDoctrineStorage
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getStorageTable()
+    {
+        return 'ezbinaryfile';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getPropertyMapping()
+    {
+        $propertyMap = parent::getPropertyMapping();
+        $propertyMap['download_count'] = [
+            'name' => 'downloadCount',
+            'cast' => 'intval',
+        ];
+
+        return $propertyMap;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setFetchColumns(QueryBuilder $queryBuilder, $fieldId, $versionNo)
+    {
+        parent::setFetchColumns($queryBuilder, $fieldId, $versionNo);
+
+        $queryBuilder->addSelect(
+            $this->connection->quoteIdentifier('download_count')
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setInsertColumns(QueryBuilder $queryBuilder, VersionInfo $versionInfo, Field $field)
+    {
+        parent::setInsertColumns($queryBuilder, $versionInfo, $field);
+
+        $queryBuilder
+            ->setValue('download_count', ':downloadCount')
+            ->setParameter(
+                ':downloadCount',
+                $field->value->externalData['downloadCount'],
+                PDO::PARAM_INT
+            )
+        ;
+    }
+}

--- a/eZ/Publish/Core/FieldType/BinaryFile/BinaryFileStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/BinaryFile/BinaryFileStorage/Gateway/LegacyStorage.php
@@ -14,6 +14,9 @@ use eZ\Publish\Core\FieldType\BinaryBase\BinaryBaseStorage\Gateway\LegacyStorage
 use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use eZ\Publish\Core\Persistence\Database\InsertQuery;
 
+/**
+ * @deprecated since 6.11. Use {@see \eZ\Publish\Core\FieldType\BinaryFile\BinaryFileStorage\Gateway\DoctrineStorage} instead.
+ */
 class LegacyStorage extends BaseLegacyStorage
 {
     /**

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
@@ -1,0 +1,318 @@
+<?php
+
+/**
+ * File containing the ImageStorage Gateway.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway;
+
+use Doctrine\DBAL\Connection;
+use DOMDocument;
+use eZ\Publish\Core\IO\UrlRedecorator;
+use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+use eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway;
+use PDO;
+
+/**
+ * Image Field Type external storage DoctrineStorage gateway.
+ */
+class DoctrineStorage extends Gateway
+{
+    const IMAGE_FILE_TABLE = 'ezimagefile';
+
+    /**
+     * @var \Doctrine\DBAL\Connection
+     */
+    protected $connection;
+
+    /**
+     * Maps database field names to property names.
+     *
+     * @var array
+     */
+    protected $fieldNameMap = [
+        'id' => 'fieldId',
+        'version' => 'versionNo',
+        'language_code' => 'languageCode',
+        'path_identification_string' => 'nodePathString',
+        'data_string' => 'xml',
+    ];
+
+    /**
+     * @var \eZ\Publish\Core\IO\UrlRedecorator
+     */
+    private $redecorator;
+
+    public function __construct(UrlRedecorator $redecorator, Connection $connection)
+    {
+        $this->redecorator = $redecorator;
+        $this->connection = $connection;
+    }
+
+    /**
+     * Return the node path string of $versionInfo.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     *
+     * @return string
+     */
+    public function getNodePathString(VersionInfo $versionInfo)
+    {
+        $selectQuery = $this->connection->createQueryBuilder();
+        $selectQuery
+            ->select($this->connection->quoteIdentifier('path_identification_string'))
+            ->from($this->connection->quoteIdentifier('ezcontentobject_tree'))
+            ->where(
+                $selectQuery->expr()->andX(
+                    $selectQuery->expr()->eq(
+                        $this->connection->quoteIdentifier('contentobject_id'),
+                        ':contentObjectId'
+                    ),
+                    $selectQuery->expr()->eq(
+                        $this->connection->quoteIdentifier('contentobject_version'),
+                        ':versionNo'
+                    ),
+                    $selectQuery->expr()->eq(
+                        $this->connection->quoteIdentifier('node_id'),
+                        $this->connection->quoteIdentifier('main_node_id')
+                    )
+                )
+            )
+            ->setParameter(':contentObjectId', $versionInfo->contentInfo->id, PDO::PARAM_INT)
+            ->setParameter(':versionNo', $versionInfo->versionNo, PDO::PARAM_INT)
+        ;
+
+        $statement = $selectQuery->execute();
+
+        return $statement->fetchColumn();
+    }
+
+    /**
+     * Store a reference to the image in $path for $fieldId.
+     *
+     * @param string $uri File IO uri (not legacy)
+     * @param int $fieldId
+     */
+    public function storeImageReference($uri, $fieldId)
+    {
+        // legacy stores the path to the image without a leading /
+        $path = $this->redecorator->redecorateFromSource($uri);
+
+        $insertQuery = $this->connection->createQueryBuilder();
+        $insertQuery
+            ->insert($this->connection->quoteIdentifier(self::IMAGE_FILE_TABLE))
+            ->values(
+                [
+                    $this->connection->quoteIdentifier('contentobject_attribute_id') => ':fieldId',
+                    $this->connection->quoteIdentifier('filepath') => ':path',
+                ]
+            )
+            ->setParameter(':fieldId', $fieldId, PDO::PARAM_INT)
+            ->setParameter(':path', $path)
+        ;
+
+        $insertQuery->execute();
+    }
+
+    /**
+     * Return an XML content stored for the given $fieldIds.
+     *
+     * @param int $versionNo
+     * @param array $fieldIds
+     *
+     * @return array
+     */
+    public function getXmlForImages($versionNo, array $fieldIds)
+    {
+        $selectQuery = $this->connection->createQueryBuilder();
+        $selectQuery
+            ->select(
+                $this->connection->quoteIdentifier('attr.id'),
+                $this->connection->quoteIdentifier('attr.data_text')
+            )
+            ->from($this->connection->quoteIdentifier('ezcontentobject_attribute'), 'attr')
+            ->where(
+                $selectQuery->expr()->andX(
+                    $selectQuery->expr()->eq(
+                        $this->connection->quoteIdentifier('attr.version'),
+                        ':versionNo'
+                    ),
+                    $selectQuery->expr()->in(
+                        $this->connection->quoteIdentifier('attr.id'),
+                        ':fieldIds'
+                    )
+                )
+            )
+            ->setParameter(':versionNo', $versionNo, PDO::PARAM_INT)
+            ->setParameter(':fieldIds', $fieldIds, Connection::PARAM_INT_ARRAY)
+        ;
+
+        $statement = $selectQuery->execute();
+
+        $fieldLookup = [];
+        foreach ($statement->fetchAll(PDO::FETCH_ASSOC) as $row) {
+            $fieldLookup[$row['id']] = $row['data_text'];
+        }
+
+        return $fieldLookup;
+    }
+
+    /**
+     * Remove all references from $fieldId to a path that starts with $path.
+     *
+     * @param string $uri File IO uri (not legacy)
+     * @param int $versionNo
+     * @param int $fieldId
+     */
+    public function removeImageReferences($uri, $versionNo, $fieldId)
+    {
+        $path = $this->redecorator->redecorateFromSource($uri);
+
+        if (!$this->canRemoveImageReference($path, $versionNo, $fieldId)) {
+            return;
+        }
+
+        $deleteQuery = $this->connection->createQueryBuilder();
+        $deleteQuery
+            ->delete($this->connection->quoteIdentifier(self::IMAGE_FILE_TABLE))
+            ->where(
+                $deleteQuery->expr()->andX(
+                    $deleteQuery->expr()->eq(
+                        $this->connection->quoteIdentifier('contentobject_attribute_id'),
+                        ':fieldId'
+                    ),
+                    $deleteQuery->expr()->like(
+                        $this->connection->quoteIdentifier('filepath'),
+                        ':likePath'
+                    )
+                )
+            )
+            ->setParameter(':fieldId', $fieldId, PDO::PARAM_INT)
+            ->setParameter(':likePath', $path . '%')
+        ;
+
+        $deleteQuery->execute();
+    }
+
+    /**
+     * Return the number of recorded references to the given $path.
+     *
+     * @param string $uri File IO uri (not legacy)
+     *
+     * @return int
+     */
+    public function countImageReferences($uri)
+    {
+        $path = $this->redecorator->redecorateFromSource($uri);
+
+        $selectQuery = $this->connection->createQueryBuilder();
+        $selectQuery
+            ->select('COUNT(' . $this->connection->quoteIdentifier('id') . ')')
+            ->from($this->connection->quoteIdentifier(self::IMAGE_FILE_TABLE))
+            ->where(
+                $selectQuery->expr()->like(
+                    $this->connection->quoteIdentifier('filepath'),
+                    ':likePath'
+                )
+            )
+            ->setParameter(':likePath', $path . '%')
+        ;
+
+        $statement = $selectQuery->execute();
+
+        return intval($statement->fetchColumn());
+    }
+
+    /**
+     * Check if image $path can be removed when deleting $versionNo and $fieldId.
+     *
+     * @param string $path legacy image path (var/storage/images...)
+     * @param int $versionNo
+     * @param int $fieldId
+     *
+     * @return bool
+     */
+    protected function canRemoveImageReference($path, $versionNo, $fieldId)
+    {
+        $selectQuery = $this->connection->createQueryBuilder();
+        $selectQuery
+            ->select('COUNT(' . $this->connection->quoteIdentifier('attr.id') . ')')
+            ->from($this->connection->quoteIdentifier('ezcontentobject_attribute'), 'attr')
+            ->innerJoin(
+                'attr',
+                $this->connection->quoteIdentifier(self::IMAGE_FILE_TABLE),
+                'img',
+                $selectQuery->expr()->eq(
+                    $this->connection->quoteIdentifier('img.contentobject_attribute_id'),
+                    $this->connection->quoteIdentifier('attr.id')
+                )
+            )
+            ->where(
+                $selectQuery->expr()->andX(
+                    $selectQuery->expr()->eq(
+                        $this->connection->quoteIdentifier('contentobject_attribute_id'),
+                        ':fieldId'
+                    ),
+                    $selectQuery->expr()->neq(
+                        $this->connection->quoteIdentifier('version'),
+                        ':versionNo'
+                    ),
+                    $selectQuery->expr()->like(
+                        $this->connection->quoteIdentifier('filepath'),
+                        ':likePath'
+                    )
+                )
+            )
+            ->setParameter(':fieldId', $fieldId, PDO::PARAM_INT)
+            ->setParameter(':versionNo', $versionNo, PDO::PARAM_INT)
+            ->setParameter(':likePath', $path . '%')
+        ;
+
+        $statement = $selectQuery->execute();
+
+        return intval($statement->fetchColumn()) === 0;
+    }
+
+    /**
+     * Extract, stored in DocBook XML, file paths.
+     *
+     * @param string $xml
+     * @return array|null
+     */
+    public function extractFilesFromXml($xml)
+    {
+        if (empty($xml)) {
+            // Empty image value
+            return null;
+        }
+
+        $files = [];
+
+        $dom = new DOMDocument();
+        $dom->loadXml($xml);
+        if ($dom->documentElement->hasAttribute('dirpath')) {
+            $url = $dom->documentElement->getAttribute('url');
+            if (empty($url)) {
+                return null;
+            }
+
+            $files['original'] = $this->redecorator->redecorateFromTarget($url);
+            foreach ($dom->documentElement->childNodes as $childNode) {
+                /** @var \DOMElement $childNode */
+                if ($childNode->nodeName !== 'alias') {
+                    continue;
+                }
+
+                $files[$childNode->getAttribute('name')] = $this->redecorator->redecorateFromTarget(
+                    $childNode->getAttribute('url')
+                );
+            }
+
+            return $files;
+        }
+
+        return null;
+    }
+}

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/LegacyStorage.php
@@ -13,6 +13,9 @@ use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway;
 
+/**
+ * @deprecated since 6.11. Use {@see \eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway\DoctrineStorage} instead.
+ */
 class LegacyStorage extends Gateway
 {
     /**
@@ -40,6 +43,10 @@ class LegacyStorage extends Gateway
 
     public function __construct(UrlRedecorator $redecorator, DatabaseHandler $dbHandler)
     {
+        @trigger_error(
+            sprintf('%s is deprecated, use %s instead', self::class, DoctrineStorage::class),
+            E_USER_DEPRECATED
+        );
         $this->redecorator = $redecorator;
         $this->dbHandler = $dbHandler;
     }

--- a/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway/DoctrineStorage.php
@@ -1,0 +1,360 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\Keyword\KeywordStorage\Gateway;
+
+use Doctrine\DBAL\Connection;
+use eZ\Publish\Core\FieldType\Keyword\KeywordStorage\Gateway;
+use eZ\Publish\SPI\Persistence\Content\Field;
+use RuntimeException;
+
+class DoctrineStorage extends Gateway
+{
+    const KEYWORD_TABLE = 'ezkeyword';
+    const KEYWORD_ATTRIBUTE_LINK_TABLE = 'ezkeyword_attribute_link';
+
+    /**
+     * @var \Doctrine\DBAL\Connection
+     */
+    protected $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * Stores the keyword list from $field->value->externalData.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Field
+     * @param int $contentTypeId
+     */
+    public function storeFieldData(Field $field, $contentTypeId)
+    {
+        if (empty($field->value->externalData) && !empty($field->id)) {
+            $this->deleteFieldData($field->id);
+
+            return;
+        }
+
+        $existingKeywordMap = $this->getExistingKeywords(
+            $field->value->externalData,
+            $contentTypeId
+        );
+
+        $this->deleteOldKeywordAssignments($field->id);
+
+        $this->assignKeywords(
+            $field->id,
+            $this->insertKeywords(
+                array_diff_key(
+                    array_fill_keys($field->value->externalData, true),
+                    $existingKeywordMap
+                ),
+                $contentTypeId
+            ) + $existingKeywordMap
+        );
+
+        $this->deleteOrphanedKeywords();
+    }
+
+    /**
+     * Sets the list of assigned keywords into $field->value->externalData.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     */
+    public function getFieldData(Field $field)
+    {
+        $field->value->externalData = $this->getAssignedKeywords($field->id);
+    }
+
+    /**
+     * Retrieve the ContentType ID for the given $field.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     *
+     * @return int
+     */
+    public function getContentTypeId(Field $field)
+    {
+        return $this->loadContentTypeId($field->fieldDefinitionId);
+    }
+
+    /**
+     * Deletes keyword data for the given $fieldId.
+     *
+     * @param int $fieldId
+     */
+    public function deleteFieldData($fieldId)
+    {
+        $this->deleteOldKeywordAssignments($fieldId);
+        $this->deleteOrphanedKeywords();
+    }
+
+    /**
+     * Returns a list of keywords assigned to $fieldId.
+     *
+     * @param int $fieldId
+     *
+     * @return string[]
+     */
+    protected function getAssignedKeywords($fieldId)
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->select($this->connection->quoteIdentifier('keyword'))
+            ->from($this->connection->quoteIdentifier(self::KEYWORD_TABLE), 'kwd')
+            ->innerJoin(
+                'kwd',
+                $this->connection->quoteIdentifier(self::KEYWORD_ATTRIBUTE_LINK_TABLE),
+                'attr',
+                $query->expr()->eq(
+                    $this->connection->quoteIdentifier('kwd.id'),
+                    $this->connection->quoteIdentifier('attr.keyword_id')
+                )
+            )
+            ->where(
+                $query->expr()->eq(
+                    $this->connection->quoteIdentifier('attr.objectattribute_id'),
+                    ':fieldId'
+                )
+            )
+            ->setParameter(':fieldId', $fieldId)
+        ;
+
+        $statement = $query->execute();
+
+        return $statement->fetchAll(\PDO::FETCH_COLUMN);
+    }
+
+    /**
+     * Retrieves the content type ID for the given $fieldDefinitionId.
+     *
+     * @param int $fieldDefinitionId
+     *
+     * @return int
+     */
+    protected function loadContentTypeId($fieldDefinitionId)
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->select($this->connection->quoteIdentifier('contentclass_id'))
+            ->from($this->connection->quoteIdentifier('ezcontentclass_attribute'))
+            ->where(
+                $query->expr()->eq('id', ':fieldDefinitionId')
+            )
+            ->setParameter(':fieldDefinitionId', $fieldDefinitionId);
+
+        $statement = $query->execute();
+
+        $row = $statement->fetch(\PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            throw new RuntimeException(
+                sprintf(
+                    'Content Type ID cannot be retrieved based on the field definition ID "%s"',
+                    $fieldDefinitionId
+                )
+            );
+        }
+
+        return intval($row['contentclass_id']);
+    }
+
+    /**
+     * Returns already existing keywords from $keywordList as a map.
+     *
+     * The map has the following format:
+     * <code>
+     *  array(
+     *      '<keyword>' => <id>,
+     *      // ...
+     *  );
+     * </code>
+     *
+     * @param string[] $keywordList
+     * @param int $contentTypeId
+     *
+     * @return int[]
+     */
+    protected function getExistingKeywords($keywordList, $contentTypeId)
+    {
+        // Retrieving potentially existing keywords
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->select(
+                $this->connection->quoteIdentifier('id'),
+                $this->connection->quoteIdentifier('keyword')
+            )
+            ->from($this->connection->quoteIdentifier(self::KEYWORD_TABLE))
+            ->where(
+                $query->expr()->andX(
+                    $query->expr()->in(
+                        $this->connection->quoteIdentifier('keyword'),
+                        ':keywordList'
+                    ),
+                    $query->expr()->eq(
+                        $this->connection->quoteIdentifier('class_id'),
+                        ':contentTypeId'
+                    )
+                )
+            )
+            ->setParameter(':keywordList', $keywordList, Connection::PARAM_STR_ARRAY)
+            ->setParameter(':contentTypeId', $contentTypeId);
+
+        $statement = $query->execute();
+
+        $existingKeywordMap = [];
+        foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $row) {
+            // filter out keywords that aren't the exact match (e.g. differ by case)
+            if (!in_array($row['keyword'], $keywordList)) {
+                continue;
+            }
+            $existingKeywordMap[$row['keyword']] = $row['id'];
+        }
+
+        return $existingKeywordMap;
+    }
+
+    /**
+     * Inserts $keywordsToInsert for $fieldDefinitionId and returns a map of
+     * these keywords to their ID.
+     *
+     * The returned array has the following format:
+     * <code>
+     *  array(
+     *      '<keyword>' => <id>,
+     *      // ...
+     *  );
+     * </code>
+     *
+     * @param string[] $keywordsToInsert
+     * @param int $contentTypeId
+     *
+     * @return int[]
+     */
+    protected function insertKeywords(array $keywordsToInsert, $contentTypeId)
+    {
+        $keywordIdMap = [];
+        // Inserting keywords not yet registered
+        if (!empty($keywordsToInsert)) {
+            $insertQuery = $this->connection->createQueryBuilder();
+            $insertQuery
+                ->insert($this->connection->quoteIdentifier(self::KEYWORD_TABLE))
+                ->values(
+                    [
+                        $this->connection->quoteIdentifier('class_id') => ':contentTypeId',
+                        $this->connection->quoteIdentifier('keyword') => ':keyword',
+                    ]
+                )
+                ->setParameter(':contentTypeId', $contentTypeId, \PDO::PARAM_INT);
+
+            foreach (array_keys($keywordsToInsert) as $keyword) {
+                $insertQuery->setParameter(':keyword', $keyword);
+                $insertQuery->execute();
+                $keywordIdMap[$keyword] = $this->connection->lastInsertId(
+                    $this->getSequenceName(self::KEYWORD_TABLE, 'id')
+                );
+            }
+        }
+
+        return $keywordIdMap;
+    }
+
+    protected function deleteOldKeywordAssignments($fieldId)
+    {
+        $deleteQuery = $this->connection->createQueryBuilder();
+        $deleteQuery
+            ->delete($this->connection->quoteIdentifier(self::KEYWORD_ATTRIBUTE_LINK_TABLE))
+            ->where(
+                $deleteQuery->expr()->eq(
+                    $this->connection->quoteIdentifier('objectattribute_id'),
+                    ':fieldId'
+                )
+            )
+            ->setParameter(':fieldId', $fieldId, \PDO::PARAM_INT);
+
+        $deleteQuery->execute();
+    }
+
+    /**
+     * Assigns keywords from $keywordMap to the field with $fieldId.
+     *
+     * $keywordMap has the format:
+     * <code>
+     *  array(
+     *      '<keyword>' => <id>,
+     *      // ...
+     *  );
+     * </code>
+     *
+     * @param int $fieldId
+     * @param int[] $keywordMap
+     */
+    protected function assignKeywords($fieldId, array $keywordMap)
+    {
+        $insertQuery = $this->connection->createQueryBuilder();
+        $insertQuery
+            ->insert($this->connection->quoteIdentifier(self::KEYWORD_ATTRIBUTE_LINK_TABLE))
+            ->values(
+                [
+                    $this->connection->quoteIdentifier('keyword_id') => ':keywordId',
+                    $this->connection->quoteIdentifier('objectattribute_id') => ':fieldId',
+                ]
+            )
+        ;
+
+        foreach ($keywordMap as $keyword => $keywordId) {
+            $insertQuery
+                ->setParameter(':keywordId', $keywordId, \PDO::PARAM_INT)
+                ->setParameter(':fieldId', $fieldId, \PDO::PARAM_INT);
+            $insertQuery->execute();
+        }
+    }
+
+    /**
+     * Deletes all orphaned keywords.
+     *
+     * Keyword is orphaned if it is not linked to a content attribute through
+     * ezkeyword_attribute_link table.
+     */
+    protected function deleteOrphanedKeywords()
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->select($this->connection->quoteIdentifier('kwd.id'))
+            ->from($this->connection->quoteIdentifier(self::KEYWORD_TABLE), 'kwd')
+            ->leftJoin(
+                'kwd',
+                $this->connection->quoteIdentifier(self::KEYWORD_ATTRIBUTE_LINK_TABLE),
+                'attr',
+                $query->expr()->eq(
+                    $this->connection->quoteIdentifier('attr.keyword_id'),
+                    $this->connection->quoteIdentifier('kwd.id')
+                )
+            )
+            ->where($query->expr()->isNull('attr.id'));
+
+        $statement = $query->execute();
+        $ids = $statement->fetchAll(\PDO::FETCH_COLUMN);
+
+        if (empty($ids)) {
+            return;
+        }
+
+        $deleteQuery = $this->connection->createQueryBuilder();
+        $deleteQuery
+            ->delete($this->connection->quoteIdentifier(self::KEYWORD_TABLE))
+            ->where(
+                $deleteQuery->expr()->in($this->connection->quoteIdentifier('id'), ':ids')
+            )
+            ->setParameter(':ids', $ids, Connection::PARAM_INT_ARRAY);
+
+        $deleteQuery->execute();
+    }
+}

--- a/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway/LegacyStorage.php
@@ -6,6 +6,9 @@ use eZ\Publish\Core\FieldType\Keyword\KeywordStorage\Gateway;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 
+/**
+ * @deprecated since 6.11. Use {@see \eZ\Publish\Core\FieldType\Keyword\KeywordStorage\Gateway\DoctrineStorage} instead.
+ */
 class LegacyStorage extends Gateway
 {
     /**
@@ -15,6 +18,10 @@ class LegacyStorage extends Gateway
 
     public function __construct(DatabaseHandler $dbHandler)
     {
+        @trigger_error(
+            sprintf('%s is deprecated, use %s instead', self::class, DoctrineStorage::class),
+            E_USER_DEPRECATED
+        );
         $this->dbHandler = $dbHandler;
     }
 

--- a/eZ/Publish/Core/FieldType/MapLocation/MapLocationStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/MapLocation/MapLocationStorage/Gateway/DoctrineStorage.php
@@ -1,0 +1,244 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\MapLocation\MapLocationStorage\Gateway;
+
+use Doctrine\DBAL\Connection;
+use eZ\Publish\Core\FieldType\MapLocation\MapLocationStorage\Gateway;
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+use PDO;
+
+class DoctrineStorage extends Gateway
+{
+    const MAP_LOCATION_TABLE = 'ezgmaplocation';
+
+    /**
+     * @var \Doctrine\DBAL\Connection
+     */
+    protected $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * Store the data stored in the given $field.
+     *
+     * Potentially rewrites data in $field and returns true, if the $field
+     * needs to be updated in the database.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     *
+     * @return bool If restoring of the internal field data is required
+     */
+    public function storeFieldData(VersionInfo $versionInfo, Field $field)
+    {
+        if ($field->value->externalData === null) {
+            // Store empty value and return
+            $this->deleteFieldData($versionInfo, [$field->id]);
+            $field->value->data = [
+                'sortKey' => null,
+                'hasData' => false,
+            ];
+
+            return false;
+        }
+
+        if ($this->hasFieldData($field->id, $versionInfo->versionNo)) {
+            $this->updateFieldData($versionInfo, $field);
+        } else {
+            $this->storeNewFieldData($versionInfo, $field);
+        }
+
+        $field->value->data = [
+            'sortKey' => $field->value->externalData['address'],
+            'hasData' => true,
+        ];
+
+        return true;
+    }
+
+    /**
+     * Perform an update on the field data.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     *
+     * @return bool
+     */
+    protected function updateFieldData(VersionInfo $versionInfo, Field $field)
+    {
+        $updateQuery = $this->connection->createQueryBuilder();
+        $updateQuery->update($this->connection->quoteIdentifier(self::MAP_LOCATION_TABLE))
+            ->set($this->connection->quoteIdentifier('latitude'), ':latitude')
+            ->set($this->connection->quoteIdentifier('longitude'), ':longitude')
+            ->set($this->connection->quoteIdentifier('address'), ':address')
+            ->where(
+                $updateQuery->expr()->andX(
+                    $updateQuery->expr()->eq(
+                        $this->connection->quoteIdentifier('contentobject_attribute_id'),
+                        ':fieldId'
+                    ),
+                    $updateQuery->expr()->eq(
+                        $this->connection->quoteIdentifier('contentobject_version'),
+                        ':versionNo'
+                    )
+                )
+            )
+            ->setParameter(':latitude', $field->value->externalData['latitude'])
+            ->setParameter(':longitude', $field->value->externalData['longitude'])
+            ->setParameter(':address', $field->value->externalData['address'])
+            ->setParameter(':fieldId', $field->id, PDO::PARAM_INT)
+            ->setParameter(':versionNo', $versionInfo->versionNo, PDO::PARAM_INT)
+        ;
+
+        $updateQuery->execute();
+    }
+
+    /**
+     * Store new field data.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     */
+    protected function storeNewFieldData(VersionInfo $versionInfo, Field $field)
+    {
+        $insertQuery = $this->connection->createQueryBuilder();
+        $insertQuery
+            ->insert($this->connection->quoteIdentifier(self::MAP_LOCATION_TABLE))
+            ->values([
+                'latitude' => ':latitude',
+                'longitude' => ':longitude',
+                'address' => ':address',
+                'contentobject_attribute_id' => ':fieldId',
+                'contentobject_version' => ':versionNo',
+            ])
+            ->setParameter(':latitude', $field->value->externalData['latitude'])
+            ->setParameter(':longitude', $field->value->externalData['longitude'])
+            ->setParameter(':address', $field->value->externalData['address'])
+            ->setParameter(':fieldId', $field->id)
+            ->setParameter(':versionNo', $versionInfo->versionNo)
+        ;
+
+        $insertQuery->execute();
+    }
+
+    /**
+     * Set the loaded field data into $field->externalData.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param \eZ\Publish\SPI\Persistence\Content\Field $field
+     *
+     * @return array
+     */
+    public function getFieldData(VersionInfo $versionInfo, Field $field)
+    {
+        $field->value->externalData = $this->loadFieldData($field->id, $versionInfo->versionNo);
+    }
+
+    /**
+     * Return the data for the given $fieldId.
+     *
+     * If no data is found, null is returned.
+     *
+     * @param int $fieldId
+     * @param int $versionNo
+     *
+     * @return array|null
+     */
+    protected function loadFieldData($fieldId, $versionNo)
+    {
+        $selectQuery = $this->connection->createQueryBuilder();
+        $selectQuery
+            ->select(
+                $this->connection->quoteIdentifier('latitude'),
+                $this->connection->quoteIdentifier('longitude'),
+                $this->connection->quoteIdentifier('address')
+            )
+            ->from($this->connection->quoteIdentifier('ezgmaplocation'))
+            ->where(
+                $selectQuery->expr()->andX(
+                    $selectQuery->expr()->eq(
+                        $this->connection->quoteIdentifier('contentobject_attribute_id'),
+                        ':fieldId'
+                    ),
+                    $selectQuery->expr()->eq(
+                        $this->connection->quoteIdentifier('contentobject_version'),
+                        ':versionNo'
+                    )
+                )
+            )
+            ->setParameter(':fieldId', $fieldId, PDO::PARAM_INT)
+            ->setParameter(':versionNo', $versionNo, PDO::PARAM_INT)
+        ;
+
+        $statement = $selectQuery->execute();
+
+        $rows = $statement->fetchAll(PDO::FETCH_ASSOC);
+        if (!isset($rows[0])) {
+            return null;
+        }
+
+        // Cast coordinates as the DB can return them as strings
+        $rows[0]['latitude'] = (float)$rows[0]['latitude'];
+        $rows[0]['longitude'] = (float)$rows[0]['longitude'];
+
+        return $rows[0];
+    }
+
+    /**
+     * Return if field data exists for $fieldId.
+     *
+     * @param int $fieldId
+     * @param int $versionNo
+     *
+     * @return bool
+     */
+    protected function hasFieldData($fieldId, $versionNo)
+    {
+        return $this->loadFieldData($fieldId, $versionNo) !== null;
+    }
+
+    /**
+     * Delete the data for all given $fieldIds.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param int[] $fieldIds
+     */
+    public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds)
+    {
+        if (empty($fieldIds)) {
+            // Nothing to do
+            return;
+        }
+
+        $deleteQuery = $this->connection->createQueryBuilder();
+        $deleteQuery
+            ->delete($this->connection->quoteIdentifier(self::MAP_LOCATION_TABLE))
+            ->where(
+                $deleteQuery->expr()->andX(
+                    $deleteQuery->expr()->in(
+                        $this->connection->quoteIdentifier('contentobject_attribute_id'),
+                        ':fieldIds'
+                    ),
+                    $deleteQuery->expr()->eq(
+                        $this->connection->quoteIdentifier('contentobject_version'),
+                        ':versionNo'
+                    )
+                )
+            )
+            ->setParameter(':fieldIds', $fieldIds, Connection::PARAM_INT_ARRAY)
+            ->setParameter(':versionNo', $versionInfo->versionNo, PDO::PARAM_INT)
+        ;
+
+        $deleteQuery->execute();
+    }
+}

--- a/eZ/Publish/Core/FieldType/MapLocation/MapLocationStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/MapLocation/MapLocationStorage/Gateway/LegacyStorage.php
@@ -13,6 +13,9 @@ use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 
+/**
+ * @deprecated since 6.11. Use {@see \eZ\Publish\Core\FieldType\MapLocation\MapLocationStorage\Gateway\DoctrineStorage} instead.
+ */
 class LegacyStorage extends Gateway
 {
     /**
@@ -22,6 +25,10 @@ class LegacyStorage extends Gateway
 
     public function __construct(DatabaseHandler $dbHandler)
     {
+        @trigger_error(
+            sprintf('%s is deprecated, use %s instead', self::class, DoctrineStorage::class),
+            E_USER_DEPRECATED
+        );
         $this->dbHandler = $dbHandler;
     }
 

--- a/eZ/Publish/Core/FieldType/Media/MediaStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Media/MediaStorage/Gateway/DoctrineStorage.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\Media\MediaStorage\Gateway;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\Core\FieldType\BinaryBase\BinaryBaseStorage\Gateway\DoctrineStorage as BaseDoctrineStorage;
+use PDO;
+
+/**
+ * Media Field Type external storage DoctrineStorage gateway.
+ */
+class DoctrineStorage extends BaseDoctrineStorage
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function getStorageTable()
+    {
+        return 'ezmedia';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getPropertyMapping()
+    {
+        $propertyMap = parent::getPropertyMapping();
+        $propertyMap['has_controller'] = [
+            'name' => 'hasController',
+            'cast' => function ($val) {
+                return (bool)$val;
+            },
+        ];
+        $propertyMap['is_autoplay'] = [
+            'name' => 'autoplay',
+            'cast' => function ($val) {
+                return (bool)$val;
+            },
+        ];
+        $propertyMap['is_loop'] = [
+            'name' => 'loop',
+            'cast' => function ($val) {
+                return (bool)$val;
+            },
+        ];
+        $propertyMap['width'] = [
+            'name' => 'width',
+            'cast' => 'intval',
+        ];
+        $propertyMap['height'] = [
+            'name' => 'height',
+            'cast' => 'intval',
+        ];
+
+        return $propertyMap;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setFetchColumns(QueryBuilder $queryBuilder, $fieldId, $versionNo)
+    {
+        parent::setFetchColumns($queryBuilder, $fieldId, $versionNo);
+
+        $queryBuilder->addSelect(
+            [
+                $this->connection->quoteIdentifier('has_controller'),
+                $this->connection->quoteIdentifier('is_autoplay'),
+                $this->connection->quoteIdentifier('is_loop'),
+                $this->connection->quoteIdentifier('width'),
+                $this->connection->quoteIdentifier('height'),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setInsertColumns(QueryBuilder $queryBuilder, VersionInfo $versionInfo, Field $field)
+    {
+        parent::setInsertColumns($queryBuilder, $versionInfo, $field);
+
+        $queryBuilder
+            ->setValue('controls', ':controls')
+            ->setValue('has_controller', ':hasController')
+            ->setValue('height', ':height')
+            ->setValue('is_autoplay', ':isAutoplay')
+            ->setValue('is_loop', ':isLoop')
+            ->setValue('pluginspage', ':pluginsPage')
+            ->setValue('quality', ':quality')
+            ->setValue('width', ':width')
+            ->setParameter(':controls', '')
+            ->setParameter(
+                ':hasController',
+                $field->value->externalData['hasController'],
+                PDO::PARAM_INT
+            )
+            ->setParameter(':height', $field->value->externalData['height'], PDO::PARAM_INT)
+            ->setParameter(':isAutoplay', $field->value->externalData['autoplay'], PDO::PARAM_INT)
+            ->setParameter(':isLoop', $field->value->externalData['loop'], PDO::PARAM_INT)
+            ->setParameter(':pluginsPage', '')
+            ->setParameter(':quality', 'high')
+            ->setParameter(':width', $field->value->externalData['width'], PDO::PARAM_INT)
+        ;
+    }
+}

--- a/eZ/Publish/Core/FieldType/Media/MediaStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Media/MediaStorage/Gateway/LegacyStorage.php
@@ -14,6 +14,9 @@ use eZ\Publish\Core\FieldType\BinaryBase\BinaryBaseStorage\Gateway\LegacyStorage
 use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use eZ\Publish\Core\Persistence\Database\InsertQuery;
 
+/**
+ * @deprecated since 6.11. Use {@see \eZ\Publish\Core\FieldType\Media\MediaStorage\Gateway\DoctrineStorage} instead.
+ */
 class LegacyStorage extends BaseLegacyStorage
 {
     /**

--- a/eZ/Publish/Core/FieldType/Page/PageStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Page/PageStorage/Gateway/DoctrineStorage.php
@@ -1,0 +1,304 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\Page\PageStorage\Gateway;
+
+use DateTime;
+use Doctrine\DBAL\Connection;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\FieldType\Page\PageStorage\Gateway;
+use eZ\Publish\Core\FieldType\Page\Parts\Block;
+use eZ\Publish\Core\FieldType\Page\Parts\Item;
+use PDO;
+
+class DoctrineStorage extends Gateway
+{
+    const EZM_POOL_TABLE = 'ezm_pool';
+    const EZM_BLOCK_TABLE = 'ezm_block';
+
+    /**
+     * @var \Doctrine\DBAL\Connection
+     */
+    protected $connection = self::EZM_POOL_TABLE;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * Return valid items (that are to be displayed), for a given block.
+     *
+     * @param \eZ\Publish\Core\FieldType\Page\Parts\Block
+     *
+     * @return \eZ\Publish\Core\FieldType\Page\Parts\Item[]
+     */
+    public function getValidBlockItems(Block $block)
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->select(
+                $this->connection->quoteIdentifier('p.object_id'),
+                $this->connection->quoteIdentifier('p.node_id'),
+                $this->connection->quoteIdentifier('p.priority'),
+                $this->connection->quoteIdentifier('p.ts_publication'),
+                $this->connection->quoteIdentifier('p.ts_visible'),
+                $this->connection->quoteIdentifier('p.ts_hidden'),
+                $this->connection->quoteIdentifier('p.rotation_until'),
+                $this->connection->quoteIdentifier('p.moved_to')
+            )
+            ->from($this->connection->quoteIdentifier(self::EZM_POOL_TABLE), 'p')
+            ->innerJoin(
+                't',
+                $this->connection->quoteIdentifier('ezcontentobject_tree'),
+                $query->expr()->eq(
+                    $this->connection->quoteIdentifier('t.node_id'),
+                    $this->connection->quoteIdentifier('p.node_id')
+                )
+            )
+            ->where(
+                $query->expr()->eq('p.block_id', ':blockId'),
+                $query->expr()->gt('p.ts_visible', ':tsVisible'),
+                $query->expr()->eq('p.ts_hidden', 'tsHidden')
+            )
+            ->setParameter(':blockId', $block->id)
+            ->setParameter(':tsVisible', 0, PDO::PARAM_INT)
+            ->setParameter(':tsHidden', 0, PDO::PARAM_INT)
+            ->orderBy('p.priority', 'DESC')
+        ;
+
+        $statement = $query->execute();
+
+        $rows = $statement->fetchAll(PDO::FETCH_ASSOC);
+        $items = [];
+        foreach ($rows as $row) {
+            $items[] = $this->buildBlockItem(
+                $row + [
+                    'block_id' => $block->id,
+                    'ts_hidden' => 0,
+                ]
+            );
+        }
+
+        return $items;
+    }
+
+    /**
+     * Return the block item having a highest visible date, for given block.
+     * Return null if no block item is registered for block.
+     *
+     * @param \eZ\Publish\Core\FieldType\Page\Parts\Block $block
+     *
+     * @return \eZ\Publish\Core\FieldType\Page\Parts\Item|null
+     */
+    public function getLastValidBlockItem(Block $block)
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->select(
+                $this->connection->quoteIdentifier('p.object_id'),
+                $this->connection->quoteIdentifier('p.node_id'),
+                $this->connection->quoteIdentifier('p.priority'),
+                $this->connection->quoteIdentifier('p.ts_publication'),
+                $this->connection->quoteIdentifier('p.ts_visible'),
+                $this->connection->quoteIdentifier('p.ts_hidden'),
+                $this->connection->quoteIdentifier('p.rotation_until'),
+                $this->connection->quoteIdentifier('p.moved_to')
+            )
+            ->from($this->connection->quoteIdentifier(self::EZM_POOL_TABLE), 'p')
+            ->where(
+                $query->expr()->eq('p.block_id', ':blockId'),
+                $query->expr()->gt('p.ts_visible', ':tsVisible'),
+                $query->expr()->eq('p.ts_hidden', 'tsHidden')
+            )
+            ->setParameter(':blockId', $block->id)
+            ->setParameter(':tsVisible', 0, PDO::PARAM_INT)
+            ->setParameter(':tsHidden', 0, PDO::PARAM_INT)
+            ->orderBy('p.ts_visible', 'DESC')
+            ->setMaxResults(1)
+        ;
+
+        $statement = $query->execute();
+
+        $rows = $statement->fetchAll(PDO::FETCH_ASSOC);
+        if (empty($rows)) {
+            return null;
+        }
+
+        return $this->buildBlockItem(
+            $rows[0] + array(
+                'block_id' => $block->id,
+                'ts_hidden' => 0,
+            )
+        );
+    }
+
+    /**
+     * Return queued items (the next to be displayed), for a given block.
+     *
+     * @param \eZ\Publish\Core\FieldType\Page\Parts\Block
+     *
+     * @return \eZ\Publish\Core\FieldType\Page\Parts\Item[]
+     */
+    public function getWaitingBlockItems(Block $block)
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->select(
+                $this->connection->quoteIdentifier('p.object_id'),
+                $this->connection->quoteIdentifier('p.node_id'),
+                $this->connection->quoteIdentifier('p.priority'),
+                $this->connection->quoteIdentifier('p.ts_publication'),
+                $this->connection->quoteIdentifier('p.ts_hidden'),
+                $this->connection->quoteIdentifier('p.ts_visible'),
+                $this->connection->quoteIdentifier('p.rotation_until'),
+                $this->connection->quoteIdentifier('p.moved_to')
+            )
+            ->from($this->connection->quoteIdentifier(self::EZM_POOL_TABLE), 'p')
+            ->where(
+                $query->expr()->eq('p.block_id', ':blockId'),
+                $query->expr()->eq('p.ts_visible', ':tsVisible'),
+                $query->expr()->eq('p.ts_hidden', 'tsHidden')
+            )
+            ->setParameter(':blockId', $block->id)
+            ->setParameter(':tsVisible', 0, PDO::PARAM_INT)
+            ->setParameter(':tsHidden', 0, PDO::PARAM_INT)
+            ->orderBy('p.ts_publication')
+            ->orderBy('p.priority')
+        ;
+
+        $statement = $query->execute();
+
+        $rows = $statement->fetchAll(PDO::FETCH_ASSOC);
+        $items = [];
+        foreach ($rows as $row) {
+            $items[] = $this->buildBlockItem(
+                $row + array(
+                    'block_id' => $block->id,
+                    'ts_visible' => 0,
+                    'ts_hidden' => 0,
+                )
+            );
+        }
+
+        return $items;
+    }
+
+    /**
+     * Return archived items (that were previously displayed), for a given block.
+     *
+     * @param \eZ\Publish\Core\FieldType\Page\Parts\Block
+     *
+     * @return \eZ\Publish\Core\FieldType\Page\Parts\Item[]
+     */
+    public function getArchivedBlockItems(Block $block)
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->select(
+                $this->connection->quoteIdentifier('p.object_id'),
+                $this->connection->quoteIdentifier('p.node_id'),
+                $this->connection->quoteIdentifier('p.priority'),
+                $this->connection->quoteIdentifier('p.ts_publication'),
+                $this->connection->quoteIdentifier('p.ts_visible'),
+                $this->connection->quoteIdentifier('p.ts_hidden'),
+                $this->connection->quoteIdentifier('p.rotation_until'),
+                $this->connection->quoteIdentifier('p.moved_to')
+            )
+            ->from($this->connection->quoteIdentifier(self::EZM_POOL_TABLE), 'p')
+            ->where(
+                $query->expr()->eq('p.block_id', ':blockId'),
+                $query->expr()->gt('p.ts_hidden', ':tsHidden')
+            )
+            ->setParameter(':blockId', $block->id)
+            ->setParameter(':tsHidden', 0, PDO::PARAM_INT)
+            ->orderBy('p.ts_hidden')
+        ;
+
+        $statement = $query->execute();
+
+        $rows = $statement->fetchAll(PDO::FETCH_ASSOC);
+        $items = [];
+        foreach ($rows as $row) {
+            $items[] = $this->buildBlockItem(
+                $row + [
+                    'block_id' => $block->id,
+                ]
+            );
+        }
+
+        return $items;
+    }
+
+    /**
+     * Return Content id for the given Block $id or false if Block could not be found.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If block could not be found.
+     *
+     * @param string $id
+     *
+     * @return int
+     */
+    public function getContentIdByBlockId($id)
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->select($this->connection->quoteIdentifier('contentobject_id'))
+            ->from($this->connection->quoteIdentifier('ezcontentobject_tree'), 't')
+            ->innerJoin(
+                'b',
+                $this->connection->quoteIdentifier(self::EZM_BLOCK_TABLE),
+                $query->expr()->eq(
+                    $this->connection->quoteIdentifier('b.node_id'),
+                    $this->connection->quoteIdentifier('t.node_id')
+                )
+            )
+            ->where(
+                $query->expr()->eq($this->connection->quoteIdentifier('b.id'), ':id')
+            )
+            ->setParameter($id, null, PDO::PARAM_STR)
+        ;
+
+        $statement = $query->execute();
+
+        $contentId = $statement->fetchColumn();
+        if ($contentId === false) {
+            throw new NotFoundException('Block', $id);
+        }
+
+        return $contentId;
+    }
+
+    /**
+     * Build a Page\Parts\Item object from a row returned from ezm_pool table.
+     *
+     * @param array $row Hash representing a block item as stored in ezm_pool table.
+     *
+     * @return \eZ\Publish\Core\FieldType\Page\Parts\Item
+     */
+    protected function buildBlockItem(array $row)
+    {
+        return new Item(
+            [
+                'blockId' => $row['block_id'],
+                'contentId' => (int)$row['object_id'],
+                'locationId' => (int)$row['node_id'],
+                'priority' => (int)$row['priority'],
+                'publicationDate' => new DateTime("@{$row['ts_publication']}"),
+                'visibilityDate' => $row['ts_visible'] ? new DateTime(
+                    "@{$row['ts_visible']}"
+                ) : null,
+                'hiddenDate' => $row['ts_hidden'] ? new DateTime("@{$row['ts_hidden']}") : null,
+                'rotationUntilDate' => $row['rotation_until'] ? new DateTime(
+                    "@{$row['rotation_until']}"
+                ) : null,
+                'movedTo' => $row['moved_to'],
+            ]
+        );
+    }
+}

--- a/eZ/Publish/Core/FieldType/Page/PageStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Page/PageStorage/Gateway/LegacyStorage.php
@@ -17,6 +17,9 @@ use PDO;
 use DateTime;
 use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
+/**
+ * @deprecated since 6.11. Use {@see \eZ\Publish\Core\FieldType\Page\PageStorage\Gateway\DoctrineStorage} instead.
+ */
 class LegacyStorage extends Gateway
 {
     /**
@@ -26,6 +29,10 @@ class LegacyStorage extends Gateway
 
     public function __construct(DatabaseHandler $dbHandler)
     {
+        @trigger_error(
+            sprintf('%s is deprecated, use %s instead', self::class, DoctrineStorage::class),
+            E_USER_DEPRECATED
+        );
         $this->dbHandler = $dbHandler;
     }
 

--- a/eZ/Publish/Core/FieldType/RichText/RichTextStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/RichText/RichTextStorage/Gateway/DoctrineStorage.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway;
+
+use Doctrine\DBAL\Connection;
+use eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway;
+use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway as UrlGateway;
+
+class DoctrineStorage extends Gateway
+{
+    /**
+     * @var \Doctrine\DBAL\Connection
+     */
+    protected $connection;
+
+    public function __construct(UrlGateway $urlGateway, Connection $connection)
+    {
+        parent::__construct($urlGateway);
+        $this->connection = $connection;
+    }
+
+    /**
+     * Return a list of Content ids for a list of remote ids.
+     *
+     * Non-existent ids are ignored.
+     *
+     * @param string[] $remoteIds An array of Content remote ids
+     *
+     * @return int[] An array of Content ids, with remote ids as keys
+     */
+    public function getContentIds(array $remoteIds)
+    {
+        $objectRemoteIdMap = [];
+
+        if (!empty($remoteIds)) {
+            $query = $this->connection->createQueryBuilder();
+            $query
+                ->select(
+                    $this->connection->quoteIdentifier('id'),
+                    $this->connection->quoteIdentifier('remote_id')
+                )
+                ->from('ezcontentobject')
+                ->where($query->expr()->in('remote_id', ':remoteIds'))
+                ->setParameter(':remoteIds', $remoteIds, Connection::PARAM_STR_ARRAY)
+            ;
+
+            $statement = $query->execute();
+            foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $row) {
+                $objectRemoteIdMap[$row['remote_id']] = $row['id'];
+            }
+        }
+
+        return $objectRemoteIdMap;
+    }
+}

--- a/eZ/Publish/Core/FieldType/RichText/RichTextStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/RichText/RichTextStorage/Gateway/LegacyStorage.php
@@ -12,6 +12,9 @@ use eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway;
 use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway as UrlGateway;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 
+/**
+ * @deprecated since 6.11. Use {@see \eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\DoctrineStorage} instead.
+ */
 class LegacyStorage extends Gateway
 {
     /**
@@ -21,6 +24,10 @@ class LegacyStorage extends Gateway
 
     public function __construct(UrlGateway $urlGateway, DatabaseHandler $dbHandler)
     {
+        @trigger_error(
+            sprintf('%s is deprecated, use %s instead', self::class, DoctrineStorage::class),
+            E_USER_DEPRECATED
+        );
         parent::__construct($urlGateway);
         $this->dbHandler = $dbHandler;
     }

--- a/eZ/Publish/Core/FieldType/Tests/Integration/BaseCoreFieldTypeIntegrationTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Integration/BaseCoreFieldTypeIntegrationTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\Tests\Integration;
+
+use eZ\Publish\API\Repository\Tests\BaseTest as APIBaseTest;
+
+/**
+ * Base class for non-API Field Type integration tests (like Gateway w/ DBMS integration).
+ */
+abstract class BaseCoreFieldTypeIntegrationTest extends APIBaseTest
+{
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        if (!isset($_ENV['setupFactory'])) {
+            self::markTestSkipped(
+                static::class . ' is an integration test and requires setupFactory env setting. '
+                . 'Use phpunit-integration-legacy.xml configuration to run it'
+            );
+        }
+    }
+
+    /**
+     * Return the database handler from the service container.
+     *
+     * @return \eZ\Publish\Core\Persistence\Doctrine\ConnectionHandler|object
+     */
+    protected function getDatabaseHandler()
+    {
+        return $this->getSetupFactory()->getServiceContainer()->get(
+            'ezpublish.api.storage_engine.legacy.dbhandler'
+        );
+    }
+
+    /**
+     * Return the database connection from the service container.
+     *
+     * @return \Doctrine\DBAL\Connection|object
+     */
+    protected function getDatabaseConnection()
+    {
+        return $this->getSetupFactory()->getServiceContainer()->get(
+            'ezpublish.api.storage_engine.legacy.connection'
+        );
+    }
+}

--- a/eZ/Publish/Core/FieldType/Tests/Integration/User/UserStorage/Gateway/DoctrineStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Integration/User/UserStorage/Gateway/DoctrineStorageTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\Tests\Integration\User\UserStorage\Gateway;
+
+use eZ\Publish\Core\FieldType\Tests\Integration\User\UserStorage\UserStorageGatewayTest;
+use eZ\Publish\Core\FieldType\User\UserStorage\Gateway\DoctrineStorage;
+
+class DoctrineStorageTest extends UserStorageGatewayTest
+{
+    /**
+     * @return \eZ\Publish\Core\FieldType\User\UserStorage\Gateway
+     */
+    protected function getGateway()
+    {
+        $dbHandler = $this->getDatabaseHandler();
+
+        return new DoctrineStorage($dbHandler->getConnection());
+    }
+}

--- a/eZ/Publish/Core/FieldType/Tests/Integration/User/UserStorage/Gateway/LegacyStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Integration/User/UserStorage/Gateway/LegacyStorageTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\Tests\Integration\User\UserStorage\Gateway;
+
+use eZ\Publish\Core\FieldType\Tests\Integration\User\UserStorage\UserStorageGatewayTest;
+use eZ\Publish\Core\FieldType\User\UserStorage\Gateway\LegacyStorage;
+
+class LegacyStorageTest extends UserStorageGatewayTest
+{
+    /**
+     * @return \eZ\Publish\Core\FieldType\User\UserStorage\Gateway
+     */
+    protected function getGateway()
+    {
+        $dbHandler = $this->getDatabaseHandler();
+
+        return new LegacyStorage($dbHandler);
+    }
+}

--- a/eZ/Publish/Core/FieldType/Tests/Integration/User/UserStorage/UserStorageGatewayTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Integration/User/UserStorage/UserStorageGatewayTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\Tests\Integration\User\UserStorage;
+
+use eZ\Publish\Core\FieldType\Tests\Integration\BaseCoreFieldTypeIntegrationTest;
+
+/**
+ * User Field Type external storage gateway tests.
+ */
+abstract class UserStorageGatewayTest extends BaseCoreFieldTypeIntegrationTest
+{
+    /**
+     * @return \eZ\Publish\Core\FieldType\User\UserStorage\Gateway
+     */
+    abstract protected function getGateway();
+
+    /**
+     * @return array
+     */
+    public function providerForGetFieldData()
+    {
+        $expectedUserData = [
+            10 => [
+                'hasStoredLogin' => true,
+                'contentId' => 10,
+                'login' => 'anonymous',
+                'email' => 'nospam@ez.no',
+                'passwordHash' => '4e6f6184135228ccd45f8233d72a0363',
+                'passwordHashType' => '2',
+                'enabled' => true,
+                'maxLogin' => 1000,
+            ],
+            14 => [
+                'hasStoredLogin' => true,
+                'contentId' => 14,
+                'login' => 'admin',
+                'email' => 'spam@ez.no',
+                'passwordHash' => 'c78e3b0f3d9244ed8c6d1c29464bdff9',
+                'passwordHashType' => '2',
+                'enabled' => true,
+                'maxLogin' => 10,
+            ],
+        ];
+
+        return [
+            [null, 10, $expectedUserData[10]],
+            [21, null, $expectedUserData[10]],
+            [null, 14, $expectedUserData[14]],
+            [28, null, $expectedUserData[14]],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForGetFieldData
+     * @param int|null $fieldId
+     * @param int $userId
+     * @param array $expectedUserData
+     */
+    public function testGetFieldData($fieldId, $userId, array $expectedUserData)
+    {
+        $data = $this->getGateway()->getFieldData($fieldId, $userId);
+        $this->assertEquals($expectedUserData, $data);
+    }
+}

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Gateway/DoctrineStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Gateway/DoctrineStorageTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\Tests\RichText\Gateway;
+
+use eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\DoctrineStorage;
+use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage as UrlStorageDoctrineGateway;
+use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
+
+/**
+ * Tests the RichText DoctrineStorage.
+ */
+class DoctrineStorageTest extends TestCase
+{
+    /**
+     * @var \eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\DoctrineStorage
+     */
+    protected $storageGateway;
+
+    public function testGetContentIds()
+    {
+        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/contentobjects.php');
+
+        $gateway = $this->getStorageGateway();
+
+        $this->assertEquals(
+            array(
+                'f5c88a2209584891056f987fd965b0ba' => 4,
+                'faaeb9be3bd98ed09f606fc16d144eca' => 10,
+            ),
+            $gateway->getContentIds(
+                array(
+                    'f5c88a2209584891056f987fd965b0ba',
+                    'faaeb9be3bd98ed09f606fc16d144eca',
+                    'fake',
+                )
+            )
+        );
+    }
+
+    /**
+     * Return a ready to test DoctrineStorage gateway.
+     *
+     * @return \eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\DoctrineStorage
+     */
+    protected function getStorageGateway()
+    {
+        if (!isset($this->storageGateway)) {
+            $connection = $this->getDatabaseHandler()->getConnection();
+            $urlGateway = new UrlStorageDoctrineGateway($connection);
+            $this->storageGateway = new DoctrineStorage($urlGateway, $connection);
+        }
+
+        return $this->storageGateway;
+    }
+}

--- a/eZ/Publish/Core/FieldType/Tests/Url/Gateway/DoctrineStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Url/Gateway/DoctrineStorageTest.php
@@ -1,0 +1,193 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\Tests\Url\Gateway;
+
+use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage;
+use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
+
+/**
+ * Url DoctrineStorage gateway tests.
+ */
+class DoctrineStorageTest extends TestCase
+{
+    public function testGetIdUrlMap()
+    {
+        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/urls.php');
+
+        $gateway = $this->getStorageGateway();
+
+        $this->assertEquals(
+            array(
+                23 => '/content/view/sitemap/2',
+                24 => '/content/view/tagcloud/2',
+            ),
+            $gateway->getIdUrlMap(
+                array(23, 24, 'fake')
+            )
+        );
+    }
+
+    public function testGetUrlIdMap()
+    {
+        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/urls.php');
+
+        $gateway = $this->getStorageGateway();
+
+        $this->assertEquals(
+            array(
+                '/content/view/sitemap/2' => 23,
+                '/content/view/tagcloud/2' => 24,
+            ),
+            $gateway->getUrlIdMap(
+                array(
+                    '/content/view/sitemap/2',
+                    '/content/view/tagcloud/2',
+                    'fake',
+                )
+            )
+        );
+    }
+
+    public function testInsertUrl()
+    {
+        $gateway = $this->getStorageGateway();
+
+        $url = 'one/two/three';
+        $time = time();
+        $id = $gateway->insertUrl($url);
+
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->select('*')
+            ->from(DoctrineStorage::URL_TABLE)
+            ->where(
+                $query->expr()->eq(
+                    $this->connection->quoteIdentifier('id'),
+                    ':id'
+                )
+            )
+            ->setParameter('id', $id, \PDO::PARAM_INT)
+        ;
+
+        $statement = $query->execute();
+        $result = $statement->fetchAll(\PDO::FETCH_ASSOC);
+
+        $expected = [
+            [
+                'id' => $id,
+                'is_valid' => '1',
+                'last_checked' => '0',
+                'original_url_md5' => md5($url),
+                'url' => $url,
+            ],
+        ];
+
+        $this->assertGreaterThanOrEqual($time, $result[0]['created']);
+        $this->assertGreaterThanOrEqual($time, $result[0]['modified']);
+
+        unset($result[0]['created']);
+        unset($result[0]['modified']);
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testLinkUrl()
+    {
+        $gateway = $this->getStorageGateway();
+
+        $urlId = 12;
+        $fieldId = 10;
+        $versionNo = 1;
+        $gateway->linkUrl($urlId, $fieldId, $versionNo);
+
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->select('*')
+            ->from(DoctrineStorage::URL_LINK_TABLE)
+            ->where(
+                $query->expr()->eq($this->connection->quoteIdentifier('url_id'), ':urlId')
+            )
+            ->setParameter(':urlId', $urlId, \PDO::PARAM_INT)
+        ;
+
+        $statement = $query->execute();
+
+        $result = $statement->fetchAll(\PDO::FETCH_ASSOC);
+
+        $expected = [
+            [
+                'contentobject_attribute_id' => $fieldId,
+                'contentobject_attribute_version' => $versionNo,
+                'url_id' => $urlId,
+            ],
+        ];
+
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testUnlinkUrl()
+    {
+        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/urls.php');
+
+        $gateway = $this->getStorageGateway();
+
+        $fieldId = 42;
+        $versionNo = 5;
+        $gateway->unlinkUrl($fieldId, $versionNo);
+
+        $query = $this->connection->createQueryBuilder();
+        $query->select('*')->from(DoctrineStorage::URL_LINK_TABLE);
+
+        $statement = $query->execute();
+        $result = $statement->fetchAll(\PDO::FETCH_ASSOC);
+
+        $expected = [
+            [
+                'contentobject_attribute_id' => 43,
+                'contentobject_attribute_version' => 6,
+                'url_id' => 24,
+            ],
+        ];
+
+        $this->assertEquals($expected, $result);
+
+        // Check that orphaned URLs are correctly removed
+        $query = $this->connection->createQueryBuilder();
+        $query->select('*')->from(DoctrineStorage::URL_TABLE);
+
+        $statement = $query->execute();
+
+        $result = $statement->fetchAll(\PDO::FETCH_ASSOC);
+
+        $expected = [
+            [
+                'created' => '1343140541',
+                'id' => '24',
+                'is_valid' => '1',
+                'last_checked' => '0',
+                'modified' => '1343140541',
+                'original_url_md5' => 'c86bcb109d8e70f9db65c803baafd550',
+                'url' => '/content/view/tagcloud/2',
+            ],
+        ];
+
+        $this->assertEquals($expected, $result);
+    }
+
+    protected function getStorageGateway()
+    {
+        if (!isset($this->storageGateway)) {
+            $this->storageGateway = new DoctrineStorage(
+                $this->getDatabaseHandler()->getConnection()
+            );
+        }
+
+        return $this->storageGateway;
+    }
+}

--- a/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway/DoctrineStorage.php
@@ -1,0 +1,233 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway;
+
+use Doctrine\DBAL\Connection;
+use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway;
+use PDO;
+
+class DoctrineStorage extends Gateway
+{
+    const URL_TABLE = 'ezurl';
+    const URL_LINK_TABLE = 'ezurl_object_link';
+
+    /**
+     * @var \Doctrine\DBAL\Connection
+     */
+    protected $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * Return a list of URLs for a list of URL ids.
+     *
+     * Non-existent ids are ignored.
+     *
+     * @param int[] $ids An array of URL ids
+     *
+     * @return array An array of URLs, with ids as keys
+     */
+    public function getIdUrlMap(array $ids)
+    {
+        $map = [];
+
+        if (!empty($ids)) {
+            $query = $this->connection->createQueryBuilder();
+            $query
+                ->select(
+                    $this->connection->quoteIdentifier('id'),
+                    $this->connection->quoteIdentifier('url')
+                )
+                ->from(self::URL_TABLE)
+                ->where('id IN (:ids)')
+                ->setParameter(':ids', $ids, Connection::PARAM_INT_ARRAY);
+
+            $statement = $query->execute();
+            foreach ($statement->fetchAll(PDO::FETCH_ASSOC) as $row) {
+                $map[$row['id']] = $row['url'];
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Return a list of URL ids for a list of URLs.
+     *
+     * Non-existent URLs are ignored.
+     *
+     * @param string[] $urls An array of URLs
+     *
+     * @return array An array of URL ids, with URLs as keys
+     */
+    public function getUrlIdMap(array $urls)
+    {
+        $map = [];
+
+        if (!empty($urls)) {
+            $query = $this->connection->createQueryBuilder();
+            $query
+                ->select(
+                    $this->connection->quoteIdentifier('id'),
+                    $this->connection->quoteIdentifier('url')
+                )
+                ->from(self::URL_TABLE)
+                ->where(
+                    $query->expr()->in('url', ':urls')
+                )
+                ->setParameter(':urls', $urls, Connection::PARAM_STR_ARRAY);
+
+            $statement = $query->execute();
+            foreach ($statement->fetchAll(PDO::FETCH_ASSOC) as $row) {
+                $map[$row['url']] = $row['id'];
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Insert a new $url and returns its id.
+     *
+     * @param string $url The URL to insert in the database
+     *
+     * @return string
+     */
+    public function insertUrl($url)
+    {
+        $time = time();
+
+        $query = $this->connection->createQueryBuilder();
+
+        $query
+            ->insert($this->connection->quoteIdentifier(self::URL_TABLE))
+            ->values(
+                [
+                    'created' => ':created',
+                    'modified' => ':modified',
+                    'original_url_md5' => ':original_url_md5',
+                    'url' => ':url',
+                ]
+            )
+            ->setParameter(':created', $time, PDO::PARAM_INT)
+            ->setParameter(':modified', $time, PDO::PARAM_INT)
+            ->setParameter(':original_url_md5', md5($url))
+            ->setParameter(':url', $url)
+        ;
+
+        $query->execute();
+
+        return $this->connection->lastInsertId(
+            $this->getSequenceName(self::URL_TABLE, 'id')
+        );
+    }
+
+    /**
+     * Create link to URL with $urlId for field with $fieldId in $versionNo.
+     *
+     * @param int $urlId
+     * @param int $fieldId
+     * @param int $versionNo
+     */
+    public function linkUrl($urlId, $fieldId, $versionNo)
+    {
+        $query = $this->connection->createQueryBuilder();
+
+        $query
+            ->insert($this->connection->quoteIdentifier(self::URL_LINK_TABLE))
+            ->values(
+                [
+                    'contentobject_attribute_id' => ':contentobject_attribute_id',
+                    'contentobject_attribute_version' => ':contentobject_attribute_version',
+                    'url_id' => ':url_id',
+                ]
+            )
+            ->setParameter(':contentobject_attribute_id', $fieldId, PDO::PARAM_INT)
+            ->setParameter(':contentobject_attribute_version', $versionNo, PDO::PARAM_INT)
+            ->setParameter(':url_id', $urlId, PDO::PARAM_INT)
+        ;
+
+        $query->execute();
+    }
+
+    /**
+     * Remove link to URL for $fieldId in $versionNo and cleans up possibly orphaned URLs.
+     *
+     * @param int $fieldId
+     * @param int $versionNo
+     */
+    public function unlinkUrl($fieldId, $versionNo)
+    {
+        $deleteQuery = $this->connection->createQueryBuilder();
+
+        $deleteQuery
+            ->delete($this->connection->quoteIdentifier(self::URL_LINK_TABLE))
+            ->where(
+                $deleteQuery->expr()->andX(
+                    $deleteQuery->expr()->in(
+                        'contentobject_attribute_id',
+                        ':contentobject_attribute_id'
+                    ),
+                    $deleteQuery->expr()->in(
+                        'contentobject_attribute_version',
+                        ':contentobject_attribute_version'
+                    )
+                )
+            )
+            ->setParameter(':contentobject_attribute_id', $fieldId, PDO::PARAM_INT)
+            ->setParameter(':contentobject_attribute_version', $versionNo, PDO::PARAM_INT)
+        ;
+
+        $deleteQuery->execute();
+
+        $this->deleteOrphanedUrls();
+    }
+
+    /**
+     * Delete all orphaned URLs.
+     *
+     * That could be avoided if the feature is implemented there.
+     *
+     * URL is orphaned if it is not linked to a content attribute through ezurl_object_link table.
+     */
+    private function deleteOrphanedUrls()
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->select($this->connection->quoteIdentifier('url.id'))
+            ->from($this->connection->quoteIdentifier(self::URL_TABLE), 'url')
+            ->leftJoin(
+                'url',
+                $this->connection->quoteIdentifier(self::URL_LINK_TABLE),
+                'link',
+                'url.id = link.url_id'
+            )
+            ->where($query->expr()->isNull('link.url_id'))
+        ;
+
+        $statement = $query->execute();
+
+        $ids = $statement->fetchAll(PDO::FETCH_COLUMN);
+        if (empty($ids)) {
+            return;
+        }
+
+        $deleteQuery = $this->connection->createQueryBuilder();
+        $deleteQuery
+            ->delete($this->connection->quoteIdentifier(self::URL_TABLE))
+            ->where($deleteQuery->expr()->in('id', ':ids'))
+            ->setParameter(':ids', $ids, Connection::PARAM_STR_ARRAY)
+        ;
+
+        $deleteQuery->execute();
+    }
+}

--- a/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway/LegacyStorage.php
@@ -14,6 +14,8 @@ use PDO;
 
 /**
  * Url field type external storage gateway implementation using Zeta Database Component.
+ *
+ * @deprecated since 6.11. Use {@see \eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage} instead.
  */
 class LegacyStorage extends Gateway
 {
@@ -27,6 +29,10 @@ class LegacyStorage extends Gateway
 
     public function __construct(DatabaseHandler $dbHandler)
     {
+        @trigger_error(
+            sprintf('%s is deprecated, use %s instead', self::class, DoctrineStorage::class),
+            E_USER_DEPRECATED
+        );
         $this->dbHandler = $dbHandler;
     }
 

--- a/eZ/Publish/Core/FieldType/User/UserStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/User/UserStorage/Gateway/DoctrineStorage.php
@@ -1,0 +1,236 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\User\UserStorage\Gateway;
+
+use Doctrine\DBAL\Connection;
+use eZ\Publish\Core\FieldType\User\UserStorage\Gateway;
+use PDO;
+
+/**
+ * User DoctrineStorage gateway.
+ */
+class DoctrineStorage extends Gateway
+{
+    const USER_TABLE = 'ezuser';
+    const USER_SETTING_TABLE = 'ezuser_setting';
+
+    /**
+     * @var \Doctrine\DBAL\Connection
+     */
+    protected $connection;
+
+    /**
+     * Default values for user fields.
+     *
+     * @var array
+     */
+    protected $defaultValues = [
+        'hasStoredLogin' => false,
+        'contentId' => null,
+        'login' => null,
+        'email' => null,
+        'passwordHash' => null,
+        'passwordHashType' => null,
+        'enabled' => false,
+        'maxLogin' => null,
+    ];
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFieldData($fieldId, $userId = null)
+    {
+        $userId = $userId ?: $this->fetchUserId($fieldId);
+        $userData = $this->fetchUserData($userId);
+
+        if (!isset($userData['login'])) {
+            return $this->defaultValues;
+        }
+
+        $result = array_merge(
+            $this->defaultValues,
+            [
+                'hasStoredLogin' => true,
+            ],
+            $userData,
+            $this->fetchUserSettings($userId)
+        );
+
+        return $result;
+    }
+
+    /**
+     * Map legacy database column names to property names.
+     *
+     * @return array
+     */
+    protected function getPropertyMap()
+    {
+        return [
+            'has_stored_login' => [
+                'name' => 'hasStoredlogin',
+                'cast' => function ($input) {
+                    return $input == '1';
+                },
+            ],
+            'contentobject_id' => [
+                'name' => 'contentId',
+                'cast' => 'intval',
+            ],
+            'login' => [
+                'name' => 'login',
+                'cast' => 'strval',
+            ],
+            'email' => [
+                'name' => 'email',
+                'cast' => 'strval',
+            ],
+            'password_hash' => [
+                'name' => 'passwordHash',
+                'cast' => 'strval',
+            ],
+            'password_hash_type' => [
+                'name' => 'passwordHashType',
+                'cast' => 'strval',
+            ],
+            'is_enabled' => [
+                'name' => 'enabled',
+                'cast' => function ($input) {
+                    return $input == '1';
+                },
+            ],
+            'max_login' => [
+                'name' => 'maxLogin',
+                'cast' => 'intval',
+            ],
+        ];
+    }
+
+    /**
+     * Convert the given database values to properties.
+     *
+     * @param array $databaseValues
+     *
+     * @return array
+     */
+    protected function convertColumnsToProperties(array $databaseValues)
+    {
+        $propertyValues = [];
+        $propertyMap = $this->getPropertyMap();
+
+        foreach ($databaseValues as $columnName => $value) {
+            $conversionFunction = $propertyMap[$columnName]['cast'];
+
+            $propertyValues[$propertyMap[$columnName]['name']] = $conversionFunction($value);
+        }
+
+        return $propertyValues;
+    }
+
+    /**
+     * Fetch user content object id for the given field id.
+     *
+     * @param int $fieldId
+     *
+     * @return int
+     */
+    protected function fetchUserId($fieldId)
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->select(
+                $this->connection->quoteIdentifier('contentobject_id')
+            )
+            ->from($this->connection->quoteIdentifier('ezcontentobject_attribute'))
+            ->where(
+                $query->expr()->eq(
+                    $this->connection->quoteIdentifier('id'),
+                    ':fieldId'
+                )
+            )
+            ->setParameter(':fieldId', $fieldId, PDO::PARAM_INT)
+        ;
+
+        $statement = $query->execute();
+
+        return intval($statement->fetchColumn());
+    }
+
+    /**
+     * Fetch user data.
+     *
+     * @param int $userId
+     *
+     * @return array
+     */
+    protected function fetchUserData($userId)
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->select(
+                $this->connection->quoteIdentifier('usr.contentobject_id'),
+                $this->connection->quoteIdentifier('usr.login'),
+                $this->connection->quoteIdentifier('usr.email'),
+                $this->connection->quoteIdentifier('usr.password_hash'),
+                $this->connection->quoteIdentifier('usr.password_hash_type')
+            )
+            ->from($this->connection->quoteIdentifier(self::USER_TABLE), 'usr')
+            ->where(
+                $query->expr()->eq(
+                    $this->connection->quoteIdentifier('usr.contentobject_id'),
+                    ':userId'
+                )
+            )
+            ->setParameter(':userId', $userId, PDO::PARAM_INT)
+        ;
+
+        $statement = $query->execute();
+
+        $rows = $statement->fetchAll(PDO::FETCH_ASSOC);
+
+        return isset($rows[0]) ? $this->convertColumnsToProperties($rows[0]) : [];
+    }
+
+    /**
+     * Fetch user settings.
+     *
+     * @param int $userId
+     *
+     * @return array
+     */
+    protected function fetchUserSettings($userId)
+    {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->select(
+                $this->connection->quoteIdentifier('s.is_enabled'),
+                $this->connection->quoteIdentifier('s.max_login')
+            )
+            ->from($this->connection->quoteIdentifier(self::USER_SETTING_TABLE), 's')
+            ->where(
+                $query->expr()->eq(
+                    $this->connection->quoteIdentifier('s.user_id'),
+                    ':userId'
+                )
+            )
+            ->setParameter(':userId', $userId, PDO::PARAM_INT)
+        ;
+
+        $statement = $query->execute();
+
+        $rows = $statement->fetchAll(PDO::FETCH_ASSOC);
+
+        return isset($rows[0]) ? $this->convertColumnsToProperties($rows[0]) : array();
+    }
+}

--- a/eZ/Publish/Core/FieldType/User/UserStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/User/UserStorage/Gateway/LegacyStorage.php
@@ -11,6 +11,9 @@ namespace eZ\Publish\Core\FieldType\User\UserStorage\Gateway;
 use eZ\Publish\Core\FieldType\User\UserStorage\Gateway;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 
+/**
+ * @deprecated since 6.11. Use {@see \eZ\Publish\Core\FieldType\User\UserStorage\Gateway\DoctrineStorage} instead.
+ */
 class LegacyStorage extends Gateway
 {
     /**
@@ -22,6 +25,10 @@ class LegacyStorage extends Gateway
 
     public function __construct(DatabaseHandler $dbHandler)
     {
+        @trigger_error(
+            sprintf('%s is deprecated, use %s instead', self::class, DoctrineStorage::class),
+            E_USER_DEPRECATED
+        );
         $this->dbHandler = $dbHandler;
     }
 

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -8,7 +8,7 @@ parameters:
     ezpublish.fieldType.ezmedia.storage_gateway.class: eZ\Publish\Core\FieldType\Media\MediaStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezrichtext.storage_gateway.class: eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezurl.storage_gateway.class: eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage
-    ezpublish.fieldType.ezuser.storage_gateway.class: eZ\Publish\Core\FieldType\User\UserStorage\Gateway\LegacyStorage
+    ezpublish.fieldType.ezuser.storage_gateway.class: eZ\Publish\Core\FieldType\User\UserStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezpage.storage_gateway.class: eZ\Publish\Core\FieldType\Page\PageStorage\Gateway\LegacyStorage
 
 services:
@@ -58,4 +58,4 @@ services:
 
     ezpublish.fieldType.ezuser.storage_gateway:
         class: "%ezpublish.fieldType.ezuser.storage_gateway.class%"
-        arguments: ["@ezpublish.api.storage_engine.legacy.dbhandler"]
+        arguments: ["@ezpublish.api.storage_engine.legacy.connection"]

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -4,7 +4,7 @@ parameters:
     ezpublish.fieldType.ezbinaryfile.storage_gateway.class: eZ\Publish\Core\FieldType\BinaryFile\BinaryFileStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezgmaplocation.storage_gateway.class: eZ\Publish\Core\FieldType\MapLocation\MapLocationStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezimage.storage_gateway.class: eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway\LegacyStorage
-    ezpublish.fieldType.ezkeyword.storage_gateway.class: eZ\Publish\Core\FieldType\Keyword\KeywordStorage\Gateway\LegacyStorage
+    ezpublish.fieldType.ezkeyword.storage_gateway.class: eZ\Publish\Core\FieldType\Keyword\KeywordStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezmedia.storage_gateway.class: eZ\Publish\Core\FieldType\Media\MediaStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezrichtext.storage_gateway.class: eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezurl.storage_gateway.class: eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\LegacyStorage
@@ -26,7 +26,7 @@ services:
 
     ezpublish.fieldType.ezkeyword.storage_gateway:
         class: "%ezpublish.fieldType.ezkeyword.storage_gateway.class%"
-        arguments: ["@ezpublish.api.storage_engine.legacy.dbhandler"]
+        arguments: ["@ezpublish.api.storage_engine.legacy.connection"]
 
     ezpublish.fieldType.ezmedia.storage_gateway:
         class: "%ezpublish.fieldType.ezmedia.storage_gateway.class%"

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -9,7 +9,7 @@ parameters:
     ezpublish.fieldType.ezrichtext.storage_gateway.class: eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezurl.storage_gateway.class: eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezuser.storage_gateway.class: eZ\Publish\Core\FieldType\User\UserStorage\Gateway\DoctrineStorage
-    ezpublish.fieldType.ezpage.storage_gateway.class: eZ\Publish\Core\FieldType\Page\PageStorage\Gateway\LegacyStorage
+    ezpublish.fieldType.ezpage.storage_gateway.class: eZ\Publish\Core\FieldType\Page\PageStorage\Gateway\DoctrineStorage
 
 services:
     ezpublish.persistence.legacy.external_storage_handler:
@@ -44,7 +44,7 @@ services:
 
     ezpublish.fieldType.ezpage.storage_gateway:
         class: "%ezpublish.fieldType.ezpage.storage_gateway.class%"
-        arguments: ["@ezpublish.api.storage_engine.legacy.dbhandler"]
+        arguments: ["@ezpublish.api.storage_engine.legacy.connection"]
 
     ezpublish.fieldType.ezimage.storage_gateway:
         class: "%ezpublish.fieldType.ezimage.storage_gateway.class%"

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -6,7 +6,7 @@ parameters:
     ezpublish.fieldType.ezimage.storage_gateway.class: eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezkeyword.storage_gateway.class: eZ\Publish\Core\FieldType\Keyword\KeywordStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezmedia.storage_gateway.class: eZ\Publish\Core\FieldType\Media\MediaStorage\Gateway\LegacyStorage
-    ezpublish.fieldType.ezrichtext.storage_gateway.class: eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\LegacyStorage
+    ezpublish.fieldType.ezrichtext.storage_gateway.class: eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezurl.storage_gateway.class: eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezuser.storage_gateway.class: eZ\Publish\Core\FieldType\User\UserStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezpage.storage_gateway.class: eZ\Publish\Core\FieldType\Page\PageStorage\Gateway\LegacyStorage
@@ -36,7 +36,7 @@ services:
         class: "%ezpublish.fieldType.ezrichtext.storage_gateway.class%"
         arguments:
             - "@ezpublish.fieldType.ezurl.storage_gateway"
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
+            - "@ezpublish.api.storage_engine.legacy.connection"
 
     ezpublish.fieldType.ezurl.storage_gateway:
         class: "%ezpublish.fieldType.ezurl.storage_gateway.class%"

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -1,11 +1,11 @@
 parameters:
     ezpublish.persistence.legacy.external_storage_handler.class: eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler
 
-    ezpublish.fieldType.ezbinaryfile.storage_gateway.class: eZ\Publish\Core\FieldType\BinaryFile\BinaryFileStorage\Gateway\LegacyStorage
+    ezpublish.fieldType.ezbinaryfile.storage_gateway.class: eZ\Publish\Core\FieldType\BinaryFile\BinaryFileStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezgmaplocation.storage_gateway.class: eZ\Publish\Core\FieldType\MapLocation\MapLocationStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezimage.storage_gateway.class: eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezkeyword.storage_gateway.class: eZ\Publish\Core\FieldType\Keyword\KeywordStorage\Gateway\DoctrineStorage
-    ezpublish.fieldType.ezmedia.storage_gateway.class: eZ\Publish\Core\FieldType\Media\MediaStorage\Gateway\LegacyStorage
+    ezpublish.fieldType.ezmedia.storage_gateway.class: eZ\Publish\Core\FieldType\Media\MediaStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezrichtext.storage_gateway.class: eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezurl.storage_gateway.class: eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezuser.storage_gateway.class: eZ\Publish\Core\FieldType\User\UserStorage\Gateway\DoctrineStorage
@@ -22,7 +22,7 @@ services:
 
     ezpublish.fieldType.ezbinaryfile.storage_gateway:
         class: "%ezpublish.fieldType.ezbinaryfile.storage_gateway.class%"
-        arguments: ["@ezpublish.api.storage_engine.legacy.dbhandler"]
+        arguments: ["@ezpublish.api.storage_engine.legacy.connection"]
 
     ezpublish.fieldType.ezkeyword.storage_gateway:
         class: "%ezpublish.fieldType.ezkeyword.storage_gateway.class%"
@@ -30,7 +30,7 @@ services:
 
     ezpublish.fieldType.ezmedia.storage_gateway:
         class: "%ezpublish.fieldType.ezmedia.storage_gateway.class%"
-        arguments: ["@ezpublish.api.storage_engine.legacy.dbhandler"]
+        arguments: ["@ezpublish.api.storage_engine.legacy.connection"]
 
     ezpublish.fieldType.ezrichtext.storage_gateway:
         class: "%ezpublish.fieldType.ezrichtext.storage_gateway.class%"

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -2,7 +2,7 @@ parameters:
     ezpublish.persistence.legacy.external_storage_handler.class: eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler
 
     ezpublish.fieldType.ezbinaryfile.storage_gateway.class: eZ\Publish\Core\FieldType\BinaryFile\BinaryFileStorage\Gateway\LegacyStorage
-    ezpublish.fieldType.ezgmaplocation.storage_gateway.class: eZ\Publish\Core\FieldType\MapLocation\MapLocationStorage\Gateway\LegacyStorage
+    ezpublish.fieldType.ezgmaplocation.storage_gateway.class: eZ\Publish\Core\FieldType\MapLocation\MapLocationStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezimage.storage_gateway.class: eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezkeyword.storage_gateway.class: eZ\Publish\Core\FieldType\Keyword\KeywordStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezmedia.storage_gateway.class: eZ\Publish\Core\FieldType\Media\MediaStorage\Gateway\LegacyStorage
@@ -54,7 +54,7 @@ services:
 
     ezpublish.fieldType.externalStorageHandler.ezgmaplocation.gateway:
         class: "%ezpublish.fieldType.ezgmaplocation.storage_gateway.class%"
-        arguments: ["@ezpublish.api.storage_engine.legacy.dbhandler"]
+        arguments: ["@ezpublish.api.storage_engine.legacy.connection"]
 
     ezpublish.fieldType.ezuser.storage_gateway:
         class: "%ezpublish.fieldType.ezuser.storage_gateway.class%"

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -3,7 +3,7 @@ parameters:
 
     ezpublish.fieldType.ezbinaryfile.storage_gateway.class: eZ\Publish\Core\FieldType\BinaryFile\BinaryFileStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezgmaplocation.storage_gateway.class: eZ\Publish\Core\FieldType\MapLocation\MapLocationStorage\Gateway\DoctrineStorage
-    ezpublish.fieldType.ezimage.storage_gateway.class: eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway\LegacyStorage
+    ezpublish.fieldType.ezimage.storage_gateway.class: eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezkeyword.storage_gateway.class: eZ\Publish\Core\FieldType\Keyword\KeywordStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezmedia.storage_gateway.class: eZ\Publish\Core\FieldType\Media\MediaStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezrichtext.storage_gateway.class: eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\DoctrineStorage
@@ -50,7 +50,7 @@ services:
         class: "%ezpublish.fieldType.ezimage.storage_gateway.class%"
         arguments:
             - "@ezpublish.core.io.image_fieldtype.legacy_url_redecorator"
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
+            - "@ezpublish.api.storage_engine.legacy.connection"
 
     ezpublish.fieldType.externalStorageHandler.ezgmaplocation.gateway:
         class: "%ezpublish.fieldType.ezgmaplocation.storage_gateway.class%"

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -7,7 +7,7 @@ parameters:
     ezpublish.fieldType.ezkeyword.storage_gateway.class: eZ\Publish\Core\FieldType\Keyword\KeywordStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezmedia.storage_gateway.class: eZ\Publish\Core\FieldType\Media\MediaStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezrichtext.storage_gateway.class: eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\LegacyStorage
-    ezpublish.fieldType.ezurl.storage_gateway.class: eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\LegacyStorage
+    ezpublish.fieldType.ezurl.storage_gateway.class: eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezuser.storage_gateway.class: eZ\Publish\Core\FieldType\User\UserStorage\Gateway\LegacyStorage
     ezpublish.fieldType.ezpage.storage_gateway.class: eZ\Publish\Core\FieldType\Page\PageStorage\Gateway\LegacyStorage
 
@@ -40,7 +40,7 @@ services:
 
     ezpublish.fieldType.ezurl.storage_gateway:
         class: "%ezpublish.fieldType.ezurl.storage_gateway.class%"
-        arguments: ["@ezpublish.api.storage_engine.legacy.dbhandler"]
+        arguments: ["@ezpublish.api.storage_engine.legacy.connection"]
 
     ezpublish.fieldType.ezpage.storage_gateway:
         class: "%ezpublish.fieldType.ezpage.storage_gateway.class%"

--- a/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
@@ -77,7 +77,7 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
         $fieldType->setTransformationProcessor($this->getTransformationProcessor());
 
         $urlRedecorator = self::$container->get('ezpublish.core.io.image_fieldtype.legacy_url_redecorator');
-
+        /** @var \eZ\Publish\Core\IO\UrlRedecorator $urlRedecorator */
         $this->ioService = self::$container->get('ezpublish.fieldType.ezimage.io_service');
 
         return $this->getHandler(
@@ -85,9 +85,9 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
             $fieldType,
             new Legacy\Content\FieldValue\Converter\ImageConverter($this->ioService, $urlRedecorator),
             new FieldType\Image\ImageStorage(
-                new FieldType\Image\ImageStorage\Gateway\LegacyStorage(
+                new FieldType\Image\ImageStorage\Gateway\DoctrineStorage(
                     $urlRedecorator,
-                    $this->getDatabaseHandler()
+                    $this->getDatabaseHandler()->getConnection()
                 ),
                 $this->ioService,
                 new FieldType\Image\PathGenerator\LegacyPathGenerator(),

--- a/eZ/Publish/SPI/Tests/FieldType/KeywordIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/KeywordIntegrationTest.php
@@ -60,7 +60,9 @@ class KeywordIntegrationTest extends BaseIntegrationTest
             $fieldType,
             new Legacy\Content\FieldValue\Converter\KeywordConverter(),
             new FieldType\Keyword\KeywordStorage(
-                new FieldType\Keyword\KeywordStorage\Gateway\LegacyStorage($this->getDatabaseHandler())
+                new FieldType\Keyword\KeywordStorage\Gateway\DoctrineStorage(
+                    $this->getDatabaseHandler()->getConnection()
+                )
             )
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/MapLocationIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/MapLocationIntegrationTest.php
@@ -60,8 +60,8 @@ class MapLocationIntegrationTest extends BaseIntegrationTest
             $fieldType,
             new Legacy\Content\FieldValue\Converter\MapLocationConverter(),
             new FieldType\MapLocation\MapLocationStorage(
-                new FieldType\MapLocation\MapLocationStorage\Gateway\LegacyStorage(
-                    $this->getDatabaseHandler()
+                new FieldType\MapLocation\MapLocationStorage\Gateway\DoctrineStorage(
+                    $this->getDatabaseHandler()->getConnection()
                 )
             )
         );

--- a/eZ/Publish/SPI/Tests/FieldType/RichTextIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/RichTextIntegrationTest.php
@@ -12,7 +12,7 @@ use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichTextConv
 use eZ\Publish\Core\FieldType;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\SPI\Persistence\Content\FieldTypeConstraints;
-use eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\LegacyStorage;
+use eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\DoctrineStorage;
 use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage as UrlGateway;
 
 /**
@@ -74,9 +74,9 @@ class RichTextIntegrationTest extends BaseIntegrationTest
             $fieldType,
             new RichTextConverter(),
             new FieldType\RichText\RichTextStorage(
-                new LegacyStorage(
+                new DoctrineStorage(
                     $urlGateway,
-                    $this->getDatabaseHandler()
+                    $this->getDatabaseHandler()->getConnection()
                 )
             )
         );

--- a/eZ/Publish/SPI/Tests/FieldType/RichTextIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/RichTextIntegrationTest.php
@@ -13,7 +13,7 @@ use eZ\Publish\Core\FieldType;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\SPI\Persistence\Content\FieldTypeConstraints;
 use eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\LegacyStorage;
-use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\LegacyStorage as UrlGateway;
+use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage as UrlGateway;
 
 /**
  * Integration test for legacy storage field types.
@@ -67,7 +67,7 @@ class RichTextIntegrationTest extends BaseIntegrationTest
         );
         $fieldType->setTransformationProcessor($this->getTransformationProcessor());
 
-        $urlGateway = new UrlGateway($this->getDatabaseHandler());
+        $urlGateway = new UrlGateway($this->getDatabaseHandler()->getConnection());
 
         return $this->getHandler(
             'ezrichtext',

--- a/eZ/Publish/SPI/Tests/FieldType/UrlIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/UrlIntegrationTest.php
@@ -60,7 +60,9 @@ class UrlIntegrationTest extends BaseIntegrationTest
             $fieldType,
             new Legacy\Content\FieldValue\Converter\UrlConverter(),
             new FieldType\Url\UrlStorage(
-                new FieldType\Url\UrlStorage\Gateway\LegacyStorage($this->getDatabaseHandler())
+                new FieldType\Url\UrlStorage\Gateway\DoctrineStorage(
+                    $this->getDatabaseHandler()->getConnection()
+                )
             )
         );
     }

--- a/eZ/Publish/SPI/Tests/FieldType/UserIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/UserIntegrationTest.php
@@ -62,7 +62,9 @@ class UserIntegrationTest extends BaseIntegrationTest
             $fieldType,
             new Legacy\Content\FieldValue\Converter\NullConverter(),
             new FieldType\User\UserStorage(
-                new FieldType\User\UserStorage\Gateway\LegacyStorage($this->getDatabaseHandler())
+                new FieldType\User\UserStorage\Gateway\DoctrineStorage(
+                    $this->getDatabaseHandler()->getConnection()
+                )
             )
         );
     }

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -54,6 +54,9 @@
         <testsuite name="eZ\Publish\API\Repository\Tests\Regression">
             <directory>eZ/Publish/API/Repository/Tests/Regression/</directory>
         </testsuite>
+        <testsuite name="eZ\Publish\Core\FieldType\Tests\Integration">
+            <directory>eZ/Publish/Core/FieldType/Tests/Integration</directory>
+        </testsuite>
     </testsuites>
     <filter>
         <whitelist>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
     </testsuite>
     <testsuite name="eZ\Publish\Core\FieldType">
       <directory>eZ/Publish/Core/FieldType/Tests</directory>
+      <exclude>eZ/Publish/Core/FieldType/Tests/Integration</exclude>
     </testsuite>
     <testsuite name="eZ\Publish\Core\Limitation">
       <directory>eZ/Publish/Core/Limitation/Tests</directory>


### PR DESCRIPTION
Part 2 of [EZP-26885](https://jira.ez.no/browse/EZP-26885) implementation (part 1: #1985).
------------

> We want to be able to use `\Doctrine\DBAL\Connection` for FieldTypes external storage directly.
> To achieve this, FieldType external storage needs to be injected with `DoctrineStorage` gateway which uses Doctrine instead of Legacy Connection Handler.

This PR, using changes from #1985, introduces FT ext. storage-specific DoctrineStorage gateway which gets injected with `\Doctrine\DBAL\Connection`.

**TODO**:
- [x] Remove TMP commit containing #1985 and rebase after it gets merged.
- [x] Create DoctrineStorage gateway for `Keyword` FT external storage (c1b2a9c).
- [x] Create DoctrineStorage gateway for  `Url` FT external storage (0f8d848).
- [x] Create DoctrineStorage gateway for  `RichText` FT external storage (83cad0f).
- [x] Create DoctrineStorage gateway for  `BinaryFile` and `Media` FT external storage (15ef9f5).
- [x] Create DoctrineStorage gateway for  `Image` FT external storage (e6031a4).
- [x] Create DoctrineStorage gateway for  `MapLocation` FT external storage (6acc88f).
- [x] Create DoctrineStorage gateway for  `User` FT external storage (b0eb5a8).
- [x] Create DoctrineStorage gateway for  `Page` FT external storage (656b9ed).
- [x] Add deprecation doc and warnings to the `LegacyStorage` gateways (84c8a7e).
- [x] Perform manual tests with web app.