### PR TITLE
Fix-EZP-26794: Unable to login as admin after trying to login with an user which group as no role

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Security/EventListener/SecurityListener.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/EventListener/SecurityListener.php
@@ -27,7 +27,6 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent as BaseInteractiveLoginEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
 use Symfony\Component\Security\Core\User\UserInterface;

--- a/eZ/Publish/Core/MVC/Symfony/Security/EventListener/SecurityListener.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/EventListener/SecurityListener.php
@@ -169,8 +169,7 @@ class SecurityListener implements EventSubscriberInterface
      *
      * @param BaseInteractiveLoginEvent $event
      *
-     * @throws \Symfony\Component\Security\Core\Exception\AuthenticationException
-     *         Contains an UnauthorizedSiteAccessException as the previous exception.
+     * @throws \eZ\Publish\Core\MVC\Symfony\Security\Exception\UnauthorizedSiteAccessException
      */
     public function checkSiteAccessPermission(BaseInteractiveLoginEvent $event)
     {
@@ -183,8 +182,7 @@ class SecurityListener implements EventSubscriberInterface
         }
 
         if (!$this->hasAccess($siteAccess, $originalUser->getUsername())) {
-            $siteAccessException = new UnauthorizedSiteAccessException($siteAccess, $originalUser->getUsername());
-            throw new AuthenticationException($siteAccessException->getMessage(), 0, $siteAccessException);
+            throw new UnauthorizedSiteAccessException($siteAccess, $originalUser->getUsername());
         }
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/EventListener/SecurityListenerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/EventListener/SecurityListenerTest.php
@@ -173,7 +173,7 @@ class SecurityListenerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
+     * @expectedException \eZ\Publish\Core\MVC\Symfony\Security\Exception\UnauthorizedSiteAccessException
      */
     public function testCheckSiteAccessPermissionDenied()
     {

--- a/eZ/Publish/Core/REST/Server/Controller/SessionController.php
+++ b/eZ/Publish/Core/REST/Server/Controller/SessionController.php
@@ -92,6 +92,7 @@ class SessionController extends Controller
             // Already logged in with another user, this will be converted to HTTP status 409
             return new Values\Conflict();
         } catch (AuthenticationException $e) {
+            $this->authenticator->logout($request);
             throw new UnauthorizedException('Invalid login or password', $request->getPathInfo());
         } catch (AccessDeniedException $e) {
             $this->authenticator->logout($request);


### PR DESCRIPTION
**JIRA issue:** [https://jira.ez.no/browse/EZP-26794](https://jira.ez.no/browse/EZP-26794)

### Description:
Related to @bdunogier solution described in PR #1944 `AbstractAuthenticationListener` should catch `AuthenticationException` and after that session token should be set to `null` by invoking `onFailure()`.

Maybe I’m wrong, but I think this solution is not working because `AuthenticationException` is thrown but can not be caught inside `AbstractAuthenticationListener::handle()` since `AbstractAuthenticationListener::requiresAuthentication()` returns `false`. 
Therefore `AbstractAuthenticationListener::onFailure()` is never called and session cookies stay kept in the browser. 
Exception is caught directly in `\eZ\Publish\Core\REST\Server\Controller\SessionController::createSessionAction()` and that is why I decided to add `logout()` call there.

Furthermore, I think that thrown exception type should be changed back to `UnauthorizedSiteAccessException` (inherits from `AccessDeniedException`). It will be more clear. The exception is thrown because the user doesn’t have permissions to access SiteAccess instead of incorrect credentials, which are checked before and must be correct to be able to check SiteAccess permissions.