### PR TITLE
Fix-EZP-27373: Error when edit empty not required date

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
@@ -638,6 +638,20 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
     }
 
     /**
+     * Test that publishing (and thus indexing) content with an empty field value does not fail.
+     *
+     * @depends testCreateContentWithEmptyFieldValue
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $contentDraft
+     */
+    public function testPublishContentWithEmptyFieldValue(Content $contentDraft)
+    {
+        $this->getRepository(false)->getContentService()->publishVersion(
+            $contentDraft->versionInfo
+        );
+    }
+
+    /**
      * @depends testCreateContentWithEmptyFieldValue
      */
     public function testCreatedEmptyFieldValue($content)

--- a/eZ/Publish/Core/FieldType/Date/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Date/SearchField.php
@@ -29,12 +29,17 @@ class SearchField implements Indexable
      */
     public function getIndexData(Field $field, FieldDefinition $fieldDefinition)
     {
-        $dateTime = new DateTime("@{$field->value->data['timestamp']}");
+        if ($field->value->data !== null) {
+            $dateTime = new DateTime("@{$field->value->data['timestamp']}");
+            $value = $dateTime->format('Y-m-d\\Z');
+        } else {
+            $value = null;
+        }
 
         return array(
             new Search\Field(
                 'value',
-                $dateTime->format('Y-m-d\\Z'),
+                $value,
                 new Search\FieldType\DateField()
             ),
         );

--- a/eZ/Publish/Core/Search/Elasticsearch/Content/FieldValueMapper/GeoLocationMapper.php
+++ b/eZ/Publish/Core/Search/Elasticsearch/Content/FieldValueMapper/GeoLocationMapper.php
@@ -38,6 +38,10 @@ class GeoLocationMapper extends FieldValueMapper
      */
     public function map(Field $field)
     {
+        if (!isset($field->value['latitude'], $field->value['longitude'])) {
+            return null;
+        }
+
         return [
             'lat' => $field->value['latitude'],
             'lon' => $field->value['longitude'],


### PR DESCRIPTION
JIRA issue: [https://jira.ez.no/browse/EZP-27373](https://jira.ez.no/browse/EZP-27373)

### Description
If `Date` FieldType is used and **Searchable** setting is checked and also default value is set to **Empty** then it is impossible to save content without setting the value of this field. 
API returns an error as described in issue.