### PR TITLE
Missing import of \InvalidArgumentException class in ImageExtension

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ImageExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ImageExtension.php
@@ -13,6 +13,7 @@ use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\MVC\Exception\SourceImageNotFoundException;
 use eZ\Publish\SPI\Variation\VariationHandler;
+use InvalidArgumentException;
 use Twig_Extension;
 use Twig_SimpleFunction;
 


### PR DESCRIPTION
> JIRA: -

# Description 

This PR adds missing use statment of \InvalidArgumentException class in eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ImageExtension (used in line no. 71)