### PR TITLE
EZP-27358: Google maps key & scrollWheel not correctly working

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
@@ -168,6 +168,7 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
             $contextualizer->setContextualParameter('binary_dir', $currentScope, $scopeSettings['binary_dir']);
         }
         if (isset($scopeSettings['api_keys']['google_maps'])) {
+            $contextualizer->setContextualParameter('api_keys', $currentScope, ['google_maps' => $scopeSettings['api_keys']['google_maps']]);
             $contextualizer->setContextualParameter('api_keys.google_maps', $currentScope, $scopeSettings['api_keys']['google_maps']);
         }
 

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
@@ -168,7 +168,7 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
             $contextualizer->setContextualParameter('binary_dir', $currentScope, $scopeSettings['binary_dir']);
         }
         if (isset($scopeSettings['api_keys']['google_maps'])) {
-            $contextualizer->setContextualParameter('api_keys', $currentScope, ['google_maps' => $scopeSettings['api_keys']['google_maps']]);
+            $contextualizer->setContextualParameter('api_keys', $currentScope, $scopeSettings['api_keys']);
             $contextualizer->setContextualParameter('api_keys.google_maps', $currentScope, $scopeSettings['api_keys']['google_maps']);
         }
 

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
@@ -67,9 +67,11 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
             ->end()
             ->arrayNode('api_keys')
                 ->info('Collection of API keys')
+                ->addDefaultsIfNotSet()
                 ->children()
                     ->scalarNode('google_maps')
                         ->info('Google Maps API Key, required as of Google Maps v3 to make sure maps show up correctly.')
+                        ->defaultNull()
                     ->end()
                 ->end()
             ->end()
@@ -167,9 +169,10 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
         if (isset($scopeSettings['binary_dir'])) {
             $contextualizer->setContextualParameter('binary_dir', $currentScope, $scopeSettings['binary_dir']);
         }
-        if (isset($scopeSettings['api_keys']['google_maps'])) {
-            $contextualizer->setContextualParameter('api_keys', $currentScope, $scopeSettings['api_keys']);
-            $contextualizer->setContextualParameter('api_keys.google_maps', $currentScope, $scopeSettings['api_keys']['google_maps']);
+
+        $contextualizer->setContextualParameter('api_keys', $currentScope, $scopeSettings['api_keys']);
+        foreach ($scopeSettings['api_keys'] as $key => $value) {
+            $contextualizer->setContextualParameter('api_keys.' . $key, $currentScope, $value);
         }
 
         // session_name setting is deprecated in favor of session.name

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -311,7 +311,6 @@
 
     {% set zoom = parameters.zoom|default( defaultZoom ) %}
     {% set mapType = parameters.mapType|default( defaultMapType ) %}
-    {% set scrollWheel = parameters.scrollWheel|default( defaultScrollWheel ) %}
 
     {% set mapWidth, mapHeight = defaultWidth, defaultHeight %}
     {% if parameters.width is defined %}
@@ -335,6 +334,11 @@
     {% set draggable = defaultDraggable %}
     {% if parameters.draggable is defined and not parameters.draggable %}
         {% set draggable = 'false' %}
+    {% endif %}
+
+    {% set scrollWheel = defaultScrollWheel %}
+    {% if parameters.scrollWheel is defined and not parameters.scrollWheel %}
+        {% set scrollWheel = 'false' %}
     {% endif %}
 
     {% if showInfo %}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/CommonTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/CommonTest.php
@@ -169,6 +169,25 @@ class CommonTest extends AbstractParserTestCase
         $this->assertConfigResolverParameterValue('anonymous_user_id', $anonymousUserId, 'ezdemo_site');
     }
 
+    public function testApiKeysSettings()
+    {
+        $key = 'my_key';
+        $this->load(
+            array(
+                'system' => array(
+                    'ezdemo_group' => array(
+                        'api_keys' => array(
+                            'google_maps' => $key,
+                        ),
+                    ),
+                ),
+            )
+        );
+
+        $this->assertConfigResolverParameterValue('api_keys', ['google_maps' => $key], 'ezdemo_site');
+        $this->assertConfigResolverParameterValue('api_keys.google_maps', $key, 'ezdemo_site');
+    }
+
     public function testUserSettings()
     {
         $layout = 'somelayout.html.twig';


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-27358

Fixes two issues found in the original work:
- Google maps key not injected into Platform UI	
- Google maps scrollWeel is internally a string, externally boolean


Todo:
- [x] Tests