### PR TITLE
EZP-26878: "No default value" in content type view for a default value in some cases

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
@@ -7,7 +7,10 @@
 
 {% block ezstring_settings %}
 <ul class="ez-fielddefinition-settings ez-fielddefinition-{{ fielddefinition.fieldTypeIdentifier }}-settings">
-    {% set defaultValue = fielddefinition.defaultValue.text %}
+    {% set defaultValue = null %}
+    {% if fielddefinition.defaultValue.text is not same as('') %}
+        {% set defaultValue = fielddefinition.defaultValue.text %}
+    {% endif %}
     {{ block( 'settings_defaultvalue' ) }}
     <li class="ez-fielddefinition-setting max-length">
         <div class="ez-fielddefinition-setting-name">Max string length:</div>
@@ -38,10 +41,12 @@
 
 {% block ezcountry_settings %}
 <ul class="ez-fielddefinition-settings ez-fielddefinition-{{ fielddefinition.fieldTypeIdentifier }}-settings">
-    {% set defaultValue = '' %}
-    {% for country in fielddefinition.defaultValue.countries %}
-        {% set defaultValue = defaultValue ~ country.Name ~ ( not loop.last ? ', ' : '' ) %}
-    {% endfor %}
+    {% set defaultValue = null %}
+    {% if fielddefinition.defaultValue.countries %}
+        {% for country in fielddefinition.defaultValue.countries %}
+            {% set defaultValue = defaultValue ~ country.Name ~ ( not loop.last ? ', ' : '' ) %}
+        {% endfor %}
+    {% endif %}
     {{ block( 'settings_defaultvalue' ) }}
     {% set isMultiple = settings.isMultiple %}
     {{ block( 'settings_allowmultiple' ) }}
@@ -271,7 +276,10 @@
 
 {% block ezisbn_settings %}
 <ul class="ez-fielddefinition-settings ez-fielddefinition-{{ fielddefinition.fieldTypeIdentifier }}-settings">
-    {% set defaultValue = '' %}
+    {% set defaultValue = null %}
+    {% if fielddefinition.defaultValue.isbn %}
+        {% set defaultValue = fielddefinition.defaultValue.isbn %}
+    {% endif %}
     {{ block( 'settings_defaultvalue' ) }}
     {% set isISBN13 = settings.isISBN13 %}
     {{ block( 'settings_allowisbn13' ) }}
@@ -332,7 +340,7 @@
     <li class="ez-fielddefinition-setting default-value">
         <div class="ez-fielddefinition-setting-name">Default value:</div>
         <div class="ez-fielddefinition-setting-value">
-        {% if defaultValue %}
+        {% if defaultValue is not null %}
             {{ defaultValue }}
         {% else %}
             <em>No default value</em>


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-26878

# Description

This PR fixes  "No default value" displayed in content type view for following cases: 

* ezinteger = 0
* ezfloat = 0.0
* ezisbn (any value)
* ezstring = '0'

Malfunctioning found by QA when https://github.com/ezsystems/repository-forms/pull/119 was tested.