### PR TITLE
EZP-27428: Added mainLanguageCode support to FieldDefinition

### DIFF
--- a/eZ/Publish/API/Repository/Values/ContentType/FieldDefinition.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/FieldDefinition.php
@@ -27,6 +27,7 @@ use eZ\Publish\SPI\Repository\Values\MultiLanguageDescription;
  * @property-read bool $isSearchable indicates if the field is searchable
  * @property-read bool $isInfoCollector indicates if this field is used for information collection
  * @property-read $defaultValue the default value of the field
+ * @property-read string $mainLanguageCode main language code inherited from the content type
  */
 abstract class FieldDefinition extends ValueObject implements MultiLanguageName, MultiLanguageDescription
 {

--- a/eZ/Publish/Core/Repository/Helper/ContentTypeDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/ContentTypeDomainMapper.php
@@ -84,7 +84,11 @@ class ContentTypeDomainMapper
 
         $fieldDefinitions = array();
         foreach ($spiContentType->fieldDefinitions as $spiFieldDefinition) {
-            $fieldDefinitions[] = $this->buildFieldDefinitionDomainObject($spiFieldDefinition, $prioritizedLanguages);
+            $fieldDefinitions[] = $this->buildFieldDefinitionDomainObject(
+                $spiFieldDefinition,
+                $mainLanguageCode,
+                $prioritizedLanguages
+            );
         }
 
         return new ContentType(
@@ -225,7 +229,7 @@ class ContentTypeDomainMapper
      *
      * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition
      */
-    public function buildFieldDefinitionDomainObject(SPIFieldDefinition $spiFieldDefinition, array $prioritizedLanguages = [])
+    public function buildFieldDefinitionDomainObject(SPIFieldDefinition $spiFieldDefinition, $mainLanguageCode, array $prioritizedLanguages = [])
     {
         /** @var $fieldType \eZ\Publish\SPI\FieldType\FieldType */
         $fieldType = $this->fieldTypeRegistry->getFieldType($spiFieldDefinition->fieldType);
@@ -246,6 +250,7 @@ class ContentTypeDomainMapper
                 'fieldSettings' => (array)$spiFieldDefinition->fieldTypeConstraints->fieldSettings,
                 'validatorConfiguration' => (array)$spiFieldDefinition->fieldTypeConstraints->validators,
                 'prioritizedLanguages' => $prioritizedLanguages,
+                'mainLanguageCode' => $mainLanguageCode,
             )
         );
 

--- a/eZ/Publish/Core/Repository/Helper/NameSchemaService.php
+++ b/eZ/Publish/Core/Repository/Helper/NameSchemaService.php
@@ -237,7 +237,8 @@ class NameSchemaService
                     foreach ($contentType->fieldDefinitions as $spiFieldDefinition) {
                         if ($spiFieldDefinition->identifier === $fieldDefinitionIdentifier) {
                             $fieldDefinition = $this->contentTypeDomainMapper->buildFieldDefinitionDomainObject(
-                                $spiFieldDefinition
+                                $spiFieldDefinition,
+                                $languageCode
                             );
                             break;
                         }

--- a/eZ/Publish/Core/Repository/Values/ContentType/FieldDefinition.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/FieldDefinition.php
@@ -30,6 +30,7 @@ use eZ\Publish\Core\Repository\Values\MultiLanguageTrait;
  * @property-read bool $isSearchable indicates if the field is searchable
  * @property-read bool $isInfoCollector indicates if this field is used for information collection
  * @property-read mixed $defaultValue the default value of the field
+ * @property-read string $mainLanguageCode main language code inherited from the content type
  *
  * @internal Meant for internal use by Repository, type hint against API object instead.
  */


### PR DESCRIPTION
Part of [EZP-27428](https://jira.ez.no/browse/EZP-27428) implementation for #2002
----
**Target branch**: `language_match_api_logic`

This PR adds support (setting, usage, tests) for `FieldDefinition::$mainLanguageCode` property which was introduced in `MultiLanguageTrait`.

**TODO**:
- [x] Set `mainLanguageCode` when building FieldDefinition domain object.
- [x] Add integration tests checking if fallback to `mainLanguageCode` for getName and getDescription works properly.
- [x] Refactor existing tests.
- [x] Check if Travis agrees.
- [x] Remove TMP commit.