### PR TITLE
Fix EZP-27497: Large container class file when there are many siteaccesses

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Page.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Page.php
@@ -10,6 +10,7 @@ namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractParser;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigResolver;
 
@@ -78,8 +79,16 @@ class Page extends AbstractParser
 
         // filters blocks and layouts for each siteaccess to keep only
         // the enabled ones for this sa
+        $configResolver = new ConfigResolver(
+            $container->getParameter('ezpublish.siteaccess.groups_by_siteaccess'),
+            $container->getParameter('ezpublish.config.default_scope')
+        );
+        $configResolver->setContainer($container);
+
         foreach ($config['siteaccess']['list'] as $sa) {
-            $ezpageSettings = $container->getParameter("ezsettings.$sa.ezpage");
+            $siteAccess = new SiteAccess($sa);
+            $configResolver->setSiteAccess($siteAccess);
+            $ezpageSettings = $configResolver->getParameter('ezpage');
             foreach (array('layouts', 'blocks') as $type) {
                 $enabledKey = 'enabled' . ucfirst($type);
                 if (empty($ezpageSettings[$enabledKey])) {

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Templates.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Templates.php
@@ -41,7 +41,7 @@ class Templates extends AbstractParser
     public function preMap(array $config, ContextualizerInterface $contextualizer)
     {
         foreach ($config['siteaccess']['groups'] as $group => $saArray) {
-            if (isset($config['system'][$group][static::NODE_KEY])) {
+            if (!empty($config[$contextualizer->getSiteAccessNodeName()][$group][static::NODE_KEY])) {
                 $contextualizer->setContextualParameter(
                     static::NODE_KEY,
                     $group,

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/Contextualizer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/Contextualizer.php
@@ -100,6 +100,10 @@ class Contextualizer implements ContextualizerInterface
                 $scopeSettings = $config[$this->siteAccessNodeName][$scope][$id];
             }
 
+            if (empty($groupsSettings) && empty($scopeSettings)) {
+                continue;
+            }
+
             if ($options & static::MERGE_FROM_SECOND_LEVEL) {
                 // array_merge() has to be used because we don't
                 // know whether we have a hash or a plain array


### PR DESCRIPTION
[EZP-27497](https://jira.ez.no/browse/EZP-27497)

One of our sites has about 100 siteaccesses.
In eZ Platform 1.7 the container class file has a file size of over 30 MB.
I think we could skip merging of settings when there are no group or siteaccess settings.
Then the settings in default and global scope should be enough.

If you also think so, I can create a issue for it.