### PR TITLE
EZP-27428: Implemented MultiLanguage logic for ObjectStateService

### DIFF
--- a/eZ/Publish/API/Repository/ObjectStateService.php
+++ b/eZ/Publish/API/Repository/ObjectStateService.php
@@ -39,31 +39,34 @@ interface ObjectStateService
      * Loads a object state group.
      *
      * @param mixed $objectStateGroupId
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the group was not found
      *
      * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup
      */
-    public function loadObjectStateGroup($objectStateGroupId);
+    public function loadObjectStateGroup($objectStateGroupId, array $prioritizedLanguages = []);
 
     /**
      * Loads all object state groups.
      *
      * @param int $offset
      * @param int $limit
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup[]
      */
-    public function loadObjectStateGroups($offset = 0, $limit = -1);
+    public function loadObjectStateGroups($offset = 0, $limit = -1, array $prioritizedLanguages = []);
 
     /**
      * This method returns the ordered list of object states of a group.
      *
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup $objectStateGroup
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState[]
      */
-    public function loadObjectStates(ObjectStateGroup $objectStateGroup);
+    public function loadObjectStates(ObjectStateGroup $objectStateGroup, array $prioritizedLanguages = []);
 
     /**
      * Updates an object state group.
@@ -107,12 +110,13 @@ interface ObjectStateService
      * Loads an object state.
      *
      * @param mixed $stateId
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the state was not found
      *
      * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState
      */
-    public function loadObjectState($stateId);
+    public function loadObjectState($stateId, array $prioritizedLanguages = []);
 
     /**
      * Updates an object state.

--- a/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
@@ -19,7 +19,7 @@ use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 /**
  * Test case for operations in the ObjectStateService using in memory storage.
  *
- * @see eZ\Publish\API\Repository\ObjectStateService
+ * @see \eZ\Publish\API\Repository\ObjectStateService
  * @group object-state
  */
 class ObjectStateServiceTest extends BaseTest
@@ -229,11 +229,11 @@ class ObjectStateServiceTest extends BaseTest
         $objectStateGroupCreate->defaultLanguageCode = 'eng-US';
         $objectStateGroupCreate->names = array(
             'eng-US' => 'Publishing',
-            'eng-GB' => 'Sindelfingen',
+            'ger-DE' => 'Sindelfingen',
         );
         $objectStateGroupCreate->descriptions = array(
             'eng-US' => 'Put something online',
-            'eng-GB' => 'Put something ton Sindelfingen.',
+            'ger-DE' => 'Put something ton Sindelfingen.',
         );
 
         $createdObjectStateGroup = $objectStateService->createObjectStateGroup(
@@ -260,19 +260,19 @@ class ObjectStateServiceTest extends BaseTest
     public function testCreateObjectStateGroupStructValues(ObjectStateGroup $createdObjectStateGroup)
     {
         $this->assertPropertiesCorrect(
-            array(
+            [
                 'identifier' => 'publishing',
                 'defaultLanguageCode' => 'eng-US',
-                'languageCodes' => array('eng-US', 'eng-GB'),
-                'names' => array(
+                'languageCodes' => ['eng-US', 'ger-DE'],
+                'names' => [
                     'eng-US' => 'Publishing',
-                    'eng-GB' => 'Sindelfingen',
-                ),
-                'descriptions' => array(
+                    'ger-DE' => 'Sindelfingen',
+                ],
+                'descriptions' => [
                     'eng-US' => 'Put something online',
-                    'eng-GB' => 'Put something ton Sindelfingen.',
-                ),
-            ),
+                    'ger-DE' => 'Put something ton Sindelfingen.',
+                ],
+            ],
             $createdObjectStateGroup
         );
         $this->assertNotNull($createdObjectStateGroup->id);
@@ -415,19 +415,25 @@ class ObjectStateServiceTest extends BaseTest
         $repository = $this->getRepository();
         $objectStateService = $repository->getObjectStateService();
 
-        $identifiersToCreate = array(
+        $identifiersToCreate = [
             'first',
             'second',
             'third',
-        );
+        ];
 
-        $createdStateGroups = array();
+        $createdStateGroups = [];
 
         $groupCreateStruct = $objectStateService->newObjectStateGroupCreateStruct('dummy');
 
         $groupCreateStruct->defaultLanguageCode = 'eng-US';
-        $groupCreateStruct->names = array('eng-US' => 'Foo');
-        $groupCreateStruct->descriptions = array('eng-US' => 'Foo Bar');
+        $groupCreateStruct->names = [
+            'eng-US' => 'Foo',
+            'ger-DE' => 'GerFoo',
+        ];
+        $groupCreateStruct->descriptions = [
+            'eng-US' => 'Foo Bar',
+            'ger-DE' => 'GerBar',
+        ];
 
         foreach ($identifiersToCreate as $identifier) {
             $groupCreateStruct->identifier = $identifier;
@@ -777,11 +783,13 @@ class ObjectStateServiceTest extends BaseTest
         );
         $objectStateCreateStruct->priority = 23;
         $objectStateCreateStruct->defaultLanguageCode = 'eng-US';
-        $objectStateCreateStruct->names = array(
+        $objectStateCreateStruct->names = [
             'eng-US' => 'Locked and Unlocked',
-        );
+            'ger-DE' => 'geschlossen und ungeschlossen',
+        ];
         $objectStateCreateStruct->descriptions = array(
             'eng-US' => 'A state between locked and unlocked.',
+            'ger-DE' => 'ein Zustand zwischen geschlossen und ungeschlossen.',
         );
 
         // Creates a new object state in the $loadObjectStateGroup with the
@@ -792,18 +800,15 @@ class ObjectStateServiceTest extends BaseTest
         );
         /* END: Use Case */
 
-        $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\ObjectState\\ObjectState',
-            $createdObjectState
-        );
+        $this->assertInstanceOf(ObjectState::class, $createdObjectState);
         // Object sequences are renumbered
         $objectStateCreateStruct->priority = 2;
 
-        return array(
+        return [
             $loadedObjectStateGroup,
             $objectStateCreateStruct,
             $createdObjectState,
-        );
+        ];
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
@@ -262,7 +262,7 @@ class ObjectStateServiceTest extends BaseTest
         $this->assertPropertiesCorrect(
             [
                 'identifier' => 'publishing',
-                'defaultLanguageCode' => 'eng-US',
+                'mainLanguageCode' => 'eng-US',
                 'languageCodes' => ['eng-US', 'ger-DE'],
                 'names' => [
                     'eng-US' => 'Publishing',
@@ -341,7 +341,7 @@ class ObjectStateServiceTest extends BaseTest
             [
                 'id' => 2,
                 'identifier' => 'ez_lock',
-                'defaultLanguageCode' => 'eng-US',
+                'mainLanguageCode' => 'eng-US',
                 'languageCodes' => ['eng-US'],
                 'names' => ['eng-US' => 'Lock'],
                 'descriptions' => ['eng-US' => ''],
@@ -672,7 +672,7 @@ class ObjectStateServiceTest extends BaseTest
             [
                 'id' => 2,
                 'identifier' => 'ez_lock',
-                'defaultLanguageCode' => 'eng-GB',
+                'mainLanguageCode' => 'eng-GB',
                 'languageCodes' => ['eng-GB'],
                 'names' => ['eng-GB' => 'Test'],
                 // descriptions array should have an empty value for eng-GB
@@ -849,7 +849,7 @@ class ObjectStateServiceTest extends BaseTest
             [
                 'identifier' => 'test',
                 'priority' => 0,
-                'defaultLanguageCode' => 'eng-GB',
+                'mainLanguageCode' => 'eng-GB',
                 'languageCodes' => ['eng-GB'],
                 'names' => ['eng-GB' => 'Test'],
                 'descriptions' => ['eng-GB' => 'Test description'],
@@ -983,7 +983,7 @@ class ObjectStateServiceTest extends BaseTest
                 'id' => 2,
                 'identifier' => 'locked',
                 'priority' => 1,
-                'defaultLanguageCode' => 'eng-US',
+                'mainLanguageCode' => 'eng-US',
                 'languageCodes' => array(0 => 'eng-US'),
                 'names' => array('eng-US' => 'Locked'),
                 'descriptions' => array('eng-US' => ''),
@@ -1281,7 +1281,7 @@ class ObjectStateServiceTest extends BaseTest
                 'id' => 1,
                 'identifier' => 'test',
                 'priority' => 0,
-                'defaultLanguageCode' => 'eng-US',
+                'mainLanguageCode' => 'eng-US',
                 'languageCodes' => ['eng-US'],
                 'names' => ['eng-US' => 'Test'],
                 // Original value of empty description for eng-US should be kept
@@ -1360,7 +1360,7 @@ class ObjectStateServiceTest extends BaseTest
                 'id' => $loadedObjectState->id,
                 'identifier' => $updateStateStruct->identifier,
                 'priority' => $loadedObjectState->priority,
-                'defaultLanguageCode' => $updateStateStruct->defaultLanguageCode,
+                'mainLanguageCode' => $updateStateStruct->defaultLanguageCode,
                 'languageCodes' => array('eng-US', 'ger-DE'),
                 'names' => $updateStateStruct->names,
                 'descriptions' => $updateStateStruct->descriptions,

--- a/eZ/Publish/API/Repository/Tests/_fixtures/generate-fixtures.php
+++ b/eZ/Publish/API/Repository/Tests/_fixtures/generate-fixtures.php
@@ -677,7 +677,7 @@ function generateObjectStateGroupFixture(array $fixture)
         $groups[$data['id']] = array(
             'id'                  => $data['id'],
             'identifier'          => $data['identifier'],
-            'defaultLanguageCode' => $languageCodes[$data['default_language_id']],
+            'mainLanguageCode' => $languageCodes[$data['default_language_id']],
             'names'               => array(),
             'descriptions'        => array(),
         );
@@ -715,7 +715,7 @@ function generateObjectStateFixture(array $fixture)
             'id'                  => $data['id'],
             'identifier'          => $data['identifier'],
             'priority'            => (int)$data['priority'],
-            'defaultLanguageCode' => $languageCodes[$data['default_language_id']],
+            'mainLanguageCode' => $languageCodes[$data['default_language_id']],
             'languageCodes'       => resolveLanguageMask($languageCodes, $data['language_mask']),
             'stateGroup'          => '$scopeValues["groups"][' . valueToString($data['group_id']) . ']',
             'names'               => array(),

--- a/eZ/Publish/API/Repository/Values/ObjectState/ObjectState.php
+++ b/eZ/Publish/API/Repository/Values/ObjectState/ObjectState.php
@@ -18,7 +18,8 @@ use eZ\Publish\SPI\Repository\Values\MultiLanguageName;
  * @property-read mixed $id the id of the content type group
  * @property-read string $identifier the identifier of the content type group
  * @property-read int $priority the priority in the group ordering
- * @property-read string $defaultLanguageCode the default language of the object state group names and description used for fallback.
+ * @property-read string $mainLanguageCode the default language of the object state names and descriptions used for fallback.
+ * @property-read string $defaultLanguageCode deprecated, use $mainLanguageCode
  * @property-read string[] $languageCodes the available languages
  */
 abstract class ObjectState extends ValueObject implements MultiLanguageName, MultiLanguageDescription
@@ -43,13 +44,6 @@ abstract class ObjectState extends ValueObject implements MultiLanguageName, Mul
      * @var int
      */
     protected $priority;
-
-    /**
-     * The default language code.
-     *
-     * @var string
-     */
-    protected $defaultLanguageCode;
 
     /**
      * The available language codes for names an descriptions.

--- a/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateGroup.php
+++ b/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateGroup.php
@@ -17,7 +17,8 @@ use eZ\Publish\SPI\Repository\Values\MultiLanguageName;
  *
  * @property-read mixed $id the id of the content type group
  * @property-read string $identifier the identifier of the content type group
- * @property-read string $defaultLanguageCode, the default language code of the object state group names and description used for fallback.
+ * @property-read string $mainLanguageCode the default language of the object state group names and description used for fallback.
+ * @property-read string $defaultLanguageCode deprecated, use $mainLanguageCode
  * @property-read string[] $languageCodes the available languages
  */
 abstract class ObjectStateGroup extends ValueObject implements MultiLanguageName, MultiLanguageDescription

--- a/eZ/Publish/Core/REST/Client/Input/Parser/ObjectState.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/ObjectState.php
@@ -52,7 +52,7 @@ class ObjectState extends BaseParser
                 'id' => $data['_href'],
                 'identifier' => $data['identifier'],
                 'priority' => (int)$data['priority'],
-                'defaultLanguageCode' => $data['defaultLanguageCode'],
+                'mainLanguageCode' => $data['defaultLanguageCode'],
                 'languageCodes' => explode(',', $data['languageCodes']),
                 'names' => $names,
                 'descriptions' => $descriptions,

--- a/eZ/Publish/Core/REST/Client/Input/Parser/ObjectStateGroup.php
+++ b/eZ/Publish/Core/REST/Client/Input/Parser/ObjectStateGroup.php
@@ -51,7 +51,7 @@ class ObjectStateGroup extends BaseParser
             array(
                 'id' => $data['_href'],
                 'identifier' => $data['identifier'],
-                'defaultLanguageCode' => $data['defaultLanguageCode'],
+                'mainLanguageCode' => $data['defaultLanguageCode'],
                 'languageCodes' => explode(',', $data['languageCodes']),
                 'names' => $names,
                 'descriptions' => $descriptions,

--- a/eZ/Publish/Core/REST/Client/ObjectStateService.php
+++ b/eZ/Publish/Core/REST/Client/ObjectStateService.php
@@ -6,7 +6,6 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-
 namespace eZ\Publish\Core\REST\Client;
 
 use eZ\Publish\Core\REST\Common\RequestParser;
@@ -103,15 +102,9 @@ class ObjectStateService implements APIObjectStateService, Sessionable
     }
 
     /**
-     * Loads a object state group.
-     *
-     * @param mixed $objectStateGroupId
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the group was not found
-     *
-     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup
+     * {@inheritdoc}
      */
-    public function loadObjectStateGroup($objectStateGroupId)
+    public function loadObjectStateGroup($objectStateGroupId, array $prioritizedLanguages = [])
     {
         $response = $this->client->request(
             'GET',
@@ -125,16 +118,9 @@ class ObjectStateService implements APIObjectStateService, Sessionable
     }
 
     /**
-     * Loads all object state groups.
-     *
-     * @param int $offset
-     * @param int $limit
-     *
-     * @todo Implement offset & limit
-     *
-     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup[]
+     * {@inheritdoc}
      */
-    public function loadObjectStateGroups($offset = 0, $limit = -1)
+    public function loadObjectStateGroups($offset = 0, $limit = -1, array $prioritizedLanguages = [])
     {
         $response = $this->client->request(
             'GET',
@@ -148,13 +134,9 @@ class ObjectStateService implements APIObjectStateService, Sessionable
     }
 
     /**
-     * This method returns the ordered list of object states of a group.
-     *
-     * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup $objectStateGroup
-     *
-     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState[]
+     * {@inheritdoc}
      */
-    public function loadObjectStates(ObjectStateGroup $objectStateGroup)
+    public function loadObjectStates(ObjectStateGroup $objectStateGroup, array $prioritizedLanguages = [])
     {
         $values = $this->requestParser->parse('objectstategroup', $objectStateGroup->id);
         $response = $this->client->request(
@@ -251,15 +233,9 @@ class ObjectStateService implements APIObjectStateService, Sessionable
     }
 
     /**
-     * Loads an object state.
-     *
-     * @param mixed $stateId
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the state was not found
-     *
-     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState
+     * {@inheritdoc}
      */
-    public function loadObjectState($stateId)
+    public function loadObjectState($stateId, array $prioritizedLanguages = [])
     {
         $response = $this->client->request(
             'GET',

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ObjectStateGroupTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ObjectStateGroupTest.php
@@ -30,7 +30,7 @@ class ObjectStateGroupTest extends ValueObjectVisitorBaseTest
             array(
                 'id' => 42,
                 'identifier' => 'test-group',
-                'defaultLanguageCode' => 'eng-GB',
+                'mainLanguageCode' => 'eng-GB',
                 'languageCodes' => array('eng-GB', 'eng-US'),
                 'names' => array(
                     'eng-GB' => 'Group name EN',

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestObjectStateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestObjectStateTest.php
@@ -33,7 +33,7 @@ class RestObjectStateTest extends ValueObjectVisitorBaseTest
                     'id' => 42,
                     'identifier' => 'test-state',
                     'priority' => '0',
-                    'defaultLanguageCode' => 'eng-GB',
+                    'mainLanguageCode' => 'eng-GB',
                     'languageCodes' => array('eng-GB', 'eng-US'),
                     'names' => array(
                         'eng-GB' => 'State name EN',

--- a/eZ/Publish/Core/Repository/ObjectStateService.php
+++ b/eZ/Publish/Core/Repository/ObjectStateService.php
@@ -580,7 +580,7 @@ class ObjectStateService implements ObjectStateServiceInterface
                 'id' => $spiObjectState->id,
                 'identifier' => $spiObjectState->identifier,
                 'priority' => $spiObjectState->priority,
-                'defaultLanguageCode' => $spiObjectState->defaultLanguage,
+                'mainLanguageCode' => $spiObjectState->defaultLanguage,
                 'languageCodes' => $spiObjectState->languageCodes,
                 'names' => $spiObjectState->name,
                 'descriptions' => $spiObjectState->description,
@@ -606,7 +606,7 @@ class ObjectStateService implements ObjectStateServiceInterface
             [
                 'id' => $spiObjectStateGroup->id,
                 'identifier' => $spiObjectStateGroup->identifier,
-                'defaultLanguageCode' => $spiObjectStateGroup->defaultLanguage,
+                'mainLanguageCode' => $spiObjectStateGroup->defaultLanguage,
                 'languageCodes' => $spiObjectStateGroup->languageCodes,
                 'names' => $spiObjectStateGroup->name,
                 'descriptions' => $spiObjectStateGroup->description,

--- a/eZ/Publish/Core/Repository/ObjectStateService.php
+++ b/eZ/Publish/Core/Repository/ObjectStateService.php
@@ -492,7 +492,7 @@ class ObjectStateService implements ObjectStateServiceInterface
             $objectStateGroup->id
         );
 
-        return $this->buildDomainObjectStateObject($spiObjectState);
+        return $this->buildDomainObjectStateObject($spiObjectState, $objectStateGroup);
     }
 
     /**

--- a/eZ/Publish/Core/Repository/ObjectStateService.php
+++ b/eZ/Publish/Core/Repository/ObjectStateService.php
@@ -115,36 +115,28 @@ class ObjectStateService implements ObjectStateServiceInterface
     }
 
     /**
-     * Loads a object state group.
-     *
-     * @param mixed $objectStateGroupId
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the group was not found
-     *
-     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup
+     * {@inheritdoc}
      */
-    public function loadObjectStateGroup($objectStateGroupId)
+    public function loadObjectStateGroup($objectStateGroupId, array $prioritizedLanguages = [])
     {
         $spiObjectStateGroup = $this->objectStateHandler->loadGroup($objectStateGroupId);
 
-        return $this->buildDomainObjectStateGroupObject($spiObjectStateGroup);
+        return $this->buildDomainObjectStateGroupObject($spiObjectStateGroup, $prioritizedLanguages);
     }
 
     /**
-     * Loads all object state groups.
-     *
-     * @param int $offset
-     * @param int $limit
-     *
-     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup[]
+     * {@inheritdoc}
      */
-    public function loadObjectStateGroups($offset = 0, $limit = -1)
+    public function loadObjectStateGroups($offset = 0, $limit = -1, array $prioritizedLanguages = [])
     {
         $spiObjectStateGroups = $this->objectStateHandler->loadAllGroups($offset, $limit);
 
         $objectStateGroups = array();
         foreach ($spiObjectStateGroups as $spiObjectStateGroup) {
-            $objectStateGroups[] = $this->buildDomainObjectStateGroupObject($spiObjectStateGroup);
+            $objectStateGroups[] = $this->buildDomainObjectStateGroupObject(
+                $spiObjectStateGroup,
+                $prioritizedLanguages
+            );
         }
 
         return $objectStateGroups;
@@ -154,16 +146,23 @@ class ObjectStateService implements ObjectStateServiceInterface
      * This method returns the ordered list of object states of a group.
      *
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup $objectStateGroup
+     * @param string[] $prioritizedLanguages
      *
      * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState[]
      */
-    public function loadObjectStates(APIObjectStateGroup $objectStateGroup)
-    {
+    public function loadObjectStates(
+        APIObjectStateGroup $objectStateGroup,
+        array $prioritizedLanguages = []
+    ) {
         $spiObjectStates = $this->objectStateHandler->loadObjectStates($objectStateGroup->id);
 
         $objectStates = array();
         foreach ($spiObjectStates as $spiObjectState) {
-            $objectStates[] = $this->buildDomainObjectStateObject($spiObjectState, $objectStateGroup);
+            $objectStates[] = $this->buildDomainObjectStateObject(
+                $spiObjectState,
+                $objectStateGroup,
+                $prioritizedLanguages
+            );
         }
 
         return $objectStates;
@@ -312,19 +311,13 @@ class ObjectStateService implements ObjectStateServiceInterface
     }
 
     /**
-     * Loads an object state.
-     *
-     * @param mixed $stateId
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the state was not found
-     *
-     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState
+     * {@inheritdoc}
      */
-    public function loadObjectState($stateId)
+    public function loadObjectState($stateId, array $prioritizedLanguages = [])
     {
         $spiObjectState = $this->objectStateHandler->load($stateId);
 
-        return $this->buildDomainObjectStateObject($spiObjectState);
+        return $this->buildDomainObjectStateObject($spiObjectState, null, $prioritizedLanguages);
     }
 
     /**
@@ -571,15 +564,19 @@ class ObjectStateService implements ObjectStateServiceInterface
      *
      * @param \eZ\Publish\SPI\Persistence\Content\ObjectState $spiObjectState
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup $objectStateGroup
+     * @param string[] $prioritizedLanguages
      *
      * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState
      */
-    protected function buildDomainObjectStateObject(SPIObjectState $spiObjectState, APIObjectStateGroup $objectStateGroup = null)
-    {
+    protected function buildDomainObjectStateObject(
+        SPIObjectState $spiObjectState,
+        APIObjectStateGroup $objectStateGroup = null,
+        array $prioritizedLanguages = []
+    ) {
         $objectStateGroup = $objectStateGroup ?: $this->loadObjectStateGroup($spiObjectState->groupId);
 
         return new ObjectState(
-            array(
+            [
                 'id' => $spiObjectState->id,
                 'identifier' => $spiObjectState->identifier,
                 'priority' => $spiObjectState->priority,
@@ -588,7 +585,8 @@ class ObjectStateService implements ObjectStateServiceInterface
                 'names' => $spiObjectState->name,
                 'descriptions' => $spiObjectState->description,
                 'objectStateGroup' => $objectStateGroup,
-            )
+                'prioritizedLanguages' => $prioritizedLanguages,
+            ]
         );
     }
 
@@ -596,20 +594,24 @@ class ObjectStateService implements ObjectStateServiceInterface
      * Converts the object state group SPI value object to API value object.
      *
      * @param \eZ\Publish\SPI\Persistence\Content\ObjectState\Group $spiObjectStateGroup
+     * @param array $prioritizedLanguages
      *
      * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup
      */
-    protected function buildDomainObjectStateGroupObject(SPIObjectStateGroup $spiObjectStateGroup)
-    {
+    protected function buildDomainObjectStateGroupObject(
+        SPIObjectStateGroup $spiObjectStateGroup,
+        array $prioritizedLanguages = []
+    ) {
         return new ObjectStateGroup(
-            array(
+            [
                 'id' => $spiObjectStateGroup->id,
                 'identifier' => $spiObjectStateGroup->identifier,
                 'defaultLanguageCode' => $spiObjectStateGroup->defaultLanguage,
                 'languageCodes' => $spiObjectStateGroup->languageCodes,
                 'names' => $spiObjectStateGroup->name,
                 'descriptions' => $spiObjectStateGroup->description,
-            )
+                'prioritizedLanguages' => $prioritizedLanguages,
+            ]
         );
     }
 

--- a/eZ/Publish/Core/Repository/Tests/Values/MultiLanguageTestTrait.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/MultiLanguageTestTrait.php
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Repository\Tests\Values;
+
+use eZ\Publish\SPI\Repository\Values\MultiLanguageDescription;
+use eZ\Publish\SPI\Repository\Values\MultiLanguageName;
+use ReflectionClass;
+
+/**
+ * Test internal functionality defined by MultiLanguage* Traits.
+ *
+ * Note: this test trait assumes object defines names and descriptions in eng-US and pol-PL.
+ */
+trait MultiLanguageTestTrait
+{
+    /**
+     * @depends testNewClassWithMultiLanguageProperties
+     *
+     * @param \eZ\Publish\SPI\Repository\Values\MultiLanguageName $object tested ValueObject
+     */
+    public function testGetMultiLanguagePrioritizedName($object)
+    {
+        if (!$object instanceof MultiLanguageName) {
+            self::markTestSkipped(
+                get_class($object) . ' does not implement ' . MultiLanguageName::class
+            );
+        }
+
+        $names = $object->getNames();
+        self::assertSame($names['pol-PL'], $object->getName());
+        self::assertSame($names['eng-US'], $object->getName('eng-US'));
+        self::assertSame($names['pol-PL'], $object->getName('pol-PL'));
+    }
+
+    /**
+     * @depends testNewClassWithMultiLanguageProperties
+     *
+     * @param \eZ\Publish\SPI\Repository\Values\MultiLanguageName $object tested ValueObject
+     */
+    public function testGetMultiLanguageDefaultName($object)
+    {
+        if (!$object instanceof MultiLanguageName) {
+            self::markTestSkipped(
+                get_class($object) . ' does not implement ' . MultiLanguageName::class
+            );
+        }
+
+        $reflection = new ReflectionClass($object);
+        $prioritizedLanguagesProperty = $reflection->getProperty('prioritizedLanguages');
+        $defaultLanguageProperty = $reflection->getProperty('mainLanguageCode');
+
+        // set not defined language to force default one
+        $prioritizedLanguagesProperty->setAccessible(true);
+        $prioritizedLanguagesProperty->setValue($object, ['ger-DE']);
+
+        $names = $object->getNames();
+        self::assertSame($names['eng-US'], $object->getName());
+
+        // set other defined language as default
+        $defaultLanguageProperty->setAccessible(true);
+        $defaultLanguageProperty->setValue($object, 'pol-PL');
+        self::assertSame($names['pol-PL'], $object->getName());
+    }
+
+    /**
+     * @depends testNewClassWithMultiLanguageProperties
+     *
+     * @param \eZ\Publish\SPI\Repository\Values\MultiLanguageDescription $object tested ValueObject
+     */
+    public function testGetMultiLanguagePrioritizedDescription($object)
+    {
+        if (!$object instanceof MultiLanguageDescription) {
+            self::markTestSkipped(
+                get_class($object) . ' does not implement ' . MultiLanguageDescription::class
+            );
+        }
+
+        $names = $object->getDescriptions();
+        self::assertSame($names['pol-PL'], $object->getDescription());
+        self::assertSame($names['eng-US'], $object->getDescription('eng-US'));
+        self::assertSame($names['pol-PL'], $object->getDescription('pol-PL'));
+    }
+
+    /**
+     * @depends testNewClassWithMultiLanguageProperties
+     *
+     * @param \eZ\Publish\SPI\Repository\Values\MultiLanguageDescription $object tested ValueObject
+     */
+    public function testGetMultiLanguageDefaultDescription($object)
+    {
+        if (!$object instanceof MultiLanguageDescription) {
+            self::markTestSkipped(
+                get_class($object) . ' does not implement ' . MultiLanguageDescription::class
+            );
+        }
+
+        $reflection = new ReflectionClass($object);
+        $prioritizedLanguagesProperty = $reflection->getProperty('prioritizedLanguages');
+
+        $defaultLanguageProperty = $reflection->getProperty('mainLanguageCode');
+        $defaultLanguageProperty->setAccessible(true);
+
+        // set not defined language to force default one
+        $prioritizedLanguagesProperty->setAccessible(true);
+        $prioritizedLanguagesProperty->setValue($object, ['ger-DE']);
+
+        $descriptions = $object->getDescriptions();
+        foreach ($descriptions as $languageCode => $description) {
+            // set $languageCode as default
+            $defaultLanguageProperty->setValue($object, $languageCode);
+            self::assertSame($description, $object->getDescription());
+        }
+    }
+}

--- a/eZ/Publish/Core/Repository/Tests/Values/ObjectState/ObjectStateGroupTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/ObjectState/ObjectStateGroupTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\Repository\Tests\Values\ObjectState;
 
 use eZ\Publish\API\Repository\Tests\Values\ValueObjectTestTrait;
+use eZ\Publish\Core\Repository\Tests\Values\MultiLanguageTestTrait;
 use eZ\Publish\Core\Repository\Values\ObjectState\ObjectStateGroup;
 use PHPUnit_Framework_TestCase;
 
@@ -18,6 +19,7 @@ use PHPUnit_Framework_TestCase;
 class ObjectStateGroupTest extends PHPUnit_Framework_TestCase
 {
     use ValueObjectTestTrait;
+    use MultiLanguageTestTrait;
 
     /**
      * Test a new class and default values on properties.
@@ -32,13 +34,43 @@ class ObjectStateGroupTest extends PHPUnit_Framework_TestCase
             [
                 'id' => null,
                 'identifier' => null,
-                'defaultLanguageCode' => null,
+                'mainLanguageCode' => null,
                 'languageCodes' => null,
                 'names' => [],
                 'descriptions' => [],
             ],
             $objectStateGroup
         );
+    }
+
+    /**
+     * Test a new class with unified multi language logic properties.
+     *
+     * @return \eZ\Publish\Core\Repository\Values\ObjectState\ObjectStateGroup
+     */
+    public function testNewClassWithMultiLanguageProperties()
+    {
+        $properties = [
+            'names' => [
+                'eng-US' => 'Name',
+                'pol-PL' => 'Nazwa',
+            ],
+            'descriptions' => [
+                'eng-US' => 'Description',
+                'pol-PL' => 'Opis',
+            ],
+            'mainLanguageCode' => 'eng-US',
+            'prioritizedLanguages' => ['pol-PL', 'eng-US'],
+        ];
+
+        $objectStateGroup = new ObjectStateGroup($properties);
+        $this->assertPropertiesCorrect($properties, $objectStateGroup);
+
+        // BC test:
+        self::assertTrue(isset($objectStateGroup->defaultLanguageCode));
+        self::assertSame('eng-US', $objectStateGroup->defaultLanguageCode);
+
+        return $objectStateGroup;
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Tests/Values/ObjectState/ObjectStateTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/ObjectState/ObjectStateTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\Repository\Tests\Values\ObjectState;
 
 use eZ\Publish\API\Repository\Tests\Values\ValueObjectTestTrait;
+use eZ\Publish\Core\Repository\Tests\Values\MultiLanguageTestTrait;
 use eZ\Publish\Core\Repository\Values\ObjectState\ObjectState;
 use PHPUnit_Framework_TestCase;
 
@@ -18,6 +19,7 @@ use PHPUnit_Framework_TestCase;
 class ObjectStateTest extends PHPUnit_Framework_TestCase
 {
     use ValueObjectTestTrait;
+    use MultiLanguageTestTrait;
 
     /**
      * Test a new class and default values on properties.
@@ -33,13 +35,43 @@ class ObjectStateTest extends PHPUnit_Framework_TestCase
                 'id' => null,
                 'identifier' => null,
                 'priority' => null,
-                'defaultLanguageCode' => null,
+                'mainLanguageCode' => null,
                 'languageCodes' => null,
                 'names' => [],
                 'descriptions' => [],
             ],
             $objectState
         );
+    }
+
+    /**
+     * Test a new class with unified multi language logic properties.
+     *
+     * @return \eZ\Publish\Core\Repository\Values\ObjectState\ObjectState
+     */
+    public function testNewClassWithMultiLanguageProperties()
+    {
+        $properties = [
+            'names' => [
+                'eng-US' => 'Name',
+                'pol-PL' => 'Nazwa',
+            ],
+            'descriptions' => [
+                'eng-US' => 'Description',
+                'pol-PL' => 'Opis',
+            ],
+            'mainLanguageCode' => 'eng-US',
+            'prioritizedLanguages' => ['pol-PL', 'eng-US'],
+        ];
+
+        $objectState = new ObjectState($properties);
+        $this->assertPropertiesCorrect($properties, $objectState);
+
+        // BC test:
+        self::assertTrue(isset($objectState->defaultLanguageCode));
+        self::assertSame('eng-US', $objectState->defaultLanguageCode);
+
+        return $objectState;
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Values/ObjectState/ObjectState.php
+++ b/eZ/Publish/Core/Repository/Values/ObjectState/ObjectState.php
@@ -9,9 +9,6 @@
 namespace eZ\Publish\Core\Repository\Values\ObjectState;
 
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectState as APIObjectState;
-use eZ\Publish\Core\Repository\Values\MultiLanguageDescriptionTrait;
-use eZ\Publish\Core\Repository\Values\MultiLanguageNameTrait;
-use eZ\Publish\Core\Repository\Values\MultiLanguageTrait;
 
 /**
  * This class represents a object state value.
@@ -26,14 +23,31 @@ use eZ\Publish\Core\Repository\Values\MultiLanguageTrait;
  */
 class ObjectState extends APIObjectState
 {
-    use MultiLanguageTrait;
-    use MultiLanguageNameTrait;
-    use MultiLanguageDescriptionTrait;
-
     /**
      * @var \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup
      */
     protected $objectStateGroup;
+
+    /**
+     * Holds the collection of names with languageCode keys.
+     *
+     * @var string[]
+     */
+    protected $names = [];
+
+    /**
+     * Holds the collection of descriptions with languageCode keys.
+     *
+     * @var string[]
+     */
+    protected $descriptions = [];
+
+    /**
+     * Prioritized languages provided by user when retrieving object using API.
+     *
+     * @var string[]
+     */
+    protected $prioritizedLanguages = [];
 
     /**
      * The object state group this object state belongs to.
@@ -43,5 +57,57 @@ class ObjectState extends APIObjectState
     public function getObjectStateGroup()
     {
         return $this->objectStateGroup;
+    }
+
+    /**
+     * {@inheritdoc}.
+     */
+    public function getNames()
+    {
+        return $this->names;
+    }
+
+    /**
+     * {@inheritdoc}.
+     */
+    public function getName($languageCode = null)
+    {
+        if (!empty($languageCode)) {
+            return isset($this->names[$languageCode]) ? $this->names[$languageCode] : null;
+        }
+
+        foreach ($this->prioritizedLanguages as $prioritizedLanguageCode) {
+            if (isset($this->names[$prioritizedLanguageCode])) {
+                return $this->names[$prioritizedLanguageCode];
+            }
+        }
+
+        return $this->names[$this->defaultLanguageCode];
+    }
+
+    /**
+     * {@inheritdoc}.
+     */
+    public function getDescriptions()
+    {
+        return $this->descriptions;
+    }
+
+    /**
+     * {@inheritdoc}.
+     */
+    public function getDescription($languageCode = null)
+    {
+        if (!empty($languageCode)) {
+            return isset($this->descriptions[$languageCode]) ? $this->descriptions[$languageCode] : null;
+        }
+
+        foreach ($this->prioritizedLanguages as $prioritizedLanguageCode) {
+            if (isset($this->descriptions[$prioritizedLanguageCode])) {
+                return $this->descriptions[$prioritizedLanguageCode];
+            }
+        }
+
+        return $this->descriptions[$this->defaultLanguageCode];
     }
 }

--- a/eZ/Publish/Core/Repository/Values/ObjectState/ObjectStateGroup.php
+++ b/eZ/Publish/Core/Repository/Values/ObjectState/ObjectStateGroup.php
@@ -9,9 +9,6 @@
 namespace eZ\Publish\Core\Repository\Values\ObjectState;
 
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup as APIObjectStateGroup;
-use eZ\Publish\Core\Repository\Values\MultiLanguageDescriptionTrait;
-use eZ\Publish\Core\Repository\Values\MultiLanguageNameTrait;
-use eZ\Publish\Core\Repository\Values\MultiLanguageTrait;
 
 /**
  * This class represents an object state group value.
@@ -25,7 +22,76 @@ use eZ\Publish\Core\Repository\Values\MultiLanguageTrait;
  */
 class ObjectStateGroup extends APIObjectStateGroup
 {
-    use MultiLanguageTrait;
-    use MultiLanguageNameTrait;
-    use MultiLanguageDescriptionTrait;
+    /**
+     * Holds the collection of names with languageCode keys.
+     *
+     * @var string[]
+     */
+    protected $names = [];
+
+    /**
+     * Holds the collection of descriptions with languageCode keys.
+     *
+     * @var string[]
+     */
+    protected $descriptions = [];
+
+    /**
+     * Prioritized languages provided by user when retrieving object using API.
+     *
+     * @var string[]
+     */
+    protected $prioritizedLanguages = [];
+
+    /**
+     * {@inheritdoc}.
+     */
+    public function getNames()
+    {
+        return $this->names;
+    }
+
+    /**
+     * {@inheritdoc}.
+     */
+    public function getName($languageCode = null)
+    {
+        if (!empty($languageCode)) {
+            return isset($this->names[$languageCode]) ? $this->names[$languageCode] : null;
+        }
+
+        foreach ($this->prioritizedLanguages as $prioritizedLanguageCode) {
+            if (isset($this->names[$prioritizedLanguageCode])) {
+                return $this->names[$prioritizedLanguageCode];
+            }
+        }
+
+        return $this->names[$this->defaultLanguageCode];
+    }
+
+    /**
+     * {@inheritdoc}.
+     */
+    public function getDescriptions()
+    {
+        return $this->descriptions;
+    }
+
+    /**
+     * {@inheritdoc}.
+     */
+    public function getDescription($languageCode = null)
+    {
+        if (!empty($languageCode)) {
+            return isset($this->descriptions[$languageCode]) ? $this->descriptions[$languageCode] : null;
+        }
+
+        foreach ($this->prioritizedLanguages as $prioritizedLanguageCode) {
+            if (isset($this->descriptions[$prioritizedLanguageCode])) {
+                return $this->descriptions[$prioritizedLanguageCode];
+            }
+        }
+
+        return $this->descriptions[$this->defaultLanguageCode];
+    }
 }

--- a/eZ/Publish/Core/Repository/Values/ObjectState/ObjectStateGroup.php
+++ b/eZ/Publish/Core/Repository/Values/ObjectState/ObjectStateGroup.php
@@ -9,89 +9,58 @@
 namespace eZ\Publish\Core\Repository\Values\ObjectState;
 
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup as APIObjectStateGroup;
+use eZ\Publish\Core\Repository\Values\MultiLanguageDescriptionTrait;
+use eZ\Publish\Core\Repository\Values\MultiLanguageNameTrait;
+use eZ\Publish\Core\Repository\Values\MultiLanguageTrait;
 
 /**
  * This class represents an object state group value.
  *
  * @property-read mixed $id the id of the content type group
  * @property-read string $identifier the identifier of the content type group
- * @property-read string $defaultLanguageCode, the default language code of the object state group names and description used for fallback.
+ * @property-read string $mainLanguageCode the default language of the object state group names and description used for fallback.
+ * @property-read string $defaultLanguageCode deprecated, use $mainLanguageCode
  * @property-read string[] $languageCodes the available languages
  *
  * @internal Meant for internal use by Repository, type hint against API object instead.
  */
 class ObjectStateGroup extends APIObjectStateGroup
 {
-    /**
-     * Holds the collection of names with languageCode keys.
-     *
-     * @var string[]
-     */
-    protected $names = [];
+    use MultiLanguageTrait;
+    use MultiLanguageNameTrait;
+    use MultiLanguageDescriptionTrait;
 
     /**
-     * Holds the collection of descriptions with languageCode keys.
+     * Magic getter for BC reasons.
      *
-     * @var string[]
+     * @param string $property
+     * @return mixed
      */
-    protected $descriptions = [];
-
-    /**
-     * Prioritized languages provided by user when retrieving object using API.
-     *
-     * @var string[]
-     */
-    protected $prioritizedLanguages = [];
-
-    /**
-     * {@inheritdoc}.
-     */
-    public function getNames()
+    public function __get($property)
     {
-        return $this->names;
+        if ($property === 'defaultLanguageCode') {
+            @trigger_error(
+                __CLASS__ . '::$defaultLanguageCode is deprecated. Use mainLanguageCode',
+                E_USER_DEPRECATED
+            );
+
+            return $this->mainLanguageCode;
+        }
+
+        return parent::__get($property);
     }
 
-    /**
-     * {@inheritdoc}.
-     */
-    public function getName($languageCode = null)
+    public function __isset($property)
     {
-        if (!empty($languageCode)) {
-            return isset($this->names[$languageCode]) ? $this->names[$languageCode] : null;
+        if ($property === 'defaultLanguageCode') {
+            @trigger_error(
+                __CLASS__ . '::$defaultLanguageCode is deprecated. Use mainLanguageCode',
+                E_USER_DEPRECATED
+            );
+
+            return true;
         }
 
-        foreach ($this->prioritizedLanguages as $prioritizedLanguageCode) {
-            if (isset($this->names[$prioritizedLanguageCode])) {
-                return $this->names[$prioritizedLanguageCode];
-            }
-        }
-
-        return $this->names[$this->defaultLanguageCode];
-    }
-
-    /**
-     * {@inheritdoc}.
-     */
-    public function getDescriptions()
-    {
-        return $this->descriptions;
-    }
-
-    /**
-     * {@inheritdoc}.
-     */
-    public function getDescription($languageCode = null)
-    {
-        if (!empty($languageCode)) {
-            return isset($this->descriptions[$languageCode]) ? $this->descriptions[$languageCode] : null;
-        }
-
-        foreach ($this->prioritizedLanguages as $prioritizedLanguageCode) {
-            if (isset($this->descriptions[$prioritizedLanguageCode])) {
-                return $this->descriptions[$prioritizedLanguageCode];
-            }
-        }
-
-        return $this->descriptions[$this->defaultLanguageCode];
+        return parent::__isset($property);
     }
 }

--- a/eZ/Publish/Core/SignalSlot/ObjectStateService.php
+++ b/eZ/Publish/Core/SignalSlot/ObjectStateService.php
@@ -84,42 +84,27 @@ class ObjectStateService implements ObjectStateServiceInterface
     }
 
     /**
-     * Loads a object state group.
-     *
-     * @param mixed $objectStateGroupId
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the group was not found
-     *
-     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup
+     * {@inheritdoc}
      */
-    public function loadObjectStateGroup($objectStateGroupId)
+    public function loadObjectStateGroup($objectStateGroupId, array $prioritizedLanguages = [])
     {
-        return $this->service->loadObjectStateGroup($objectStateGroupId);
+        return $this->service->loadObjectStateGroup($objectStateGroupId, $prioritizedLanguages);
     }
 
     /**
-     * Loads all object state groups.
-     *
-     * @param int $offset
-     * @param int $limit
-     *
-     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup[]
+     * {@inheritdoc}
      */
-    public function loadObjectStateGroups($offset = 0, $limit = -1)
+    public function loadObjectStateGroups($offset = 0, $limit = -1, array $prioritizedLanguages = [])
     {
-        return $this->service->loadObjectStateGroups($offset, $limit);
+        return $this->service->loadObjectStateGroups($offset, $limit, $prioritizedLanguages);
     }
 
     /**
-     * This method returns the ordered list of object states of a group.
-     *
-     * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup $objectStateGroup
-     *
-     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState[]
+     * {@inheritdoc}
      */
-    public function loadObjectStates(ObjectStateGroup $objectStateGroup)
+    public function loadObjectStates(ObjectStateGroup $objectStateGroup, array $prioritizedLanguages = [])
     {
-        return $this->service->loadObjectStates($objectStateGroup);
+        return $this->service->loadObjectStates($objectStateGroup, $prioritizedLanguages);
     }
 
     /**
@@ -198,17 +183,11 @@ class ObjectStateService implements ObjectStateServiceInterface
     }
 
     /**
-     * Loads an object state.
-     *
-     * @param mixed $stateId
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the state was not found
-     *
-     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState
+     * {@inheritdoc}
      */
-    public function loadObjectState($stateId)
+    public function loadObjectState($stateId, array $prioritizedLanguages = [])
     {
-        return $this->service->loadObjectState($stateId);
+        return $this->service->loadObjectState($stateId, $prioritizedLanguages);
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/Tests/ObjectStateServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ObjectStateServiceTest.php
@@ -55,145 +55,145 @@ class ObjectStateServiceTest extends ServiceTest
         );
         $contentInfo = $this->getContentInfo($contentId, $contentRemoteId);
 
-        return array(
-            array(
+        return [
+            [
                 'createObjectStateGroup',
-                array($objectStateGroupCreateStruct),
+                [$objectStateGroupCreateStruct],
                 $objectStateGroup,
                 1,
                 'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\CreateObjectStateGroupSignal',
-                array('objectStateGroupId' => $objectStateGroupId),
-            ),
-            array(
+                ['objectStateGroupId' => $objectStateGroupId],
+            ],
+            [
                 'loadObjectStateGroup',
-                array(4),
+                [4, []],
                 $objectStateGroup,
                 0,
-            ),
-            array(
+            ],
+            [
                 'loadObjectStateGroups',
-                array(1, 1),
-                array($objectStateGroup),
+                [1, 1, []],
+                [$objectStateGroup],
                 0,
-            ),
-            array(
+            ],
+            [
                 'loadObjectStates',
-                array($objectStateGroup),
-                array($objectState),
+                [$objectStateGroup, []],
+                [$objectState],
                 0,
-            ),
-            array(
+            ],
+            [
                 'updateObjectStateGroup',
-                array($objectStateGroup, $objectStateGroupUpdateStruct),
+                [$objectStateGroup, $objectStateGroupUpdateStruct],
                 $objectStateGroup,
                 1,
                 'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\UpdateObjectStateGroupSignal',
-                array('objectStateGroupId' => $objectStateGroupId),
-            ),
-            array(
+                ['objectStateGroupId' => $objectStateGroupId],
+            ],
+            [
                 'deleteObjectStateGroup',
-                array($objectStateGroup),
+                [$objectStateGroup],
                 null,
                 1,
                 'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\DeleteObjectStateGroupSignal',
-                array('objectStateGroupId' => $objectStateGroupId),
-            ),
-            array(
+                ['objectStateGroupId' => $objectStateGroupId],
+            ],
+            [
                 'createObjectState',
-                array($objectStateGroup, $objectStateCreateStruct),
+                [$objectStateGroup, $objectStateCreateStruct],
                 $objectState,
                 1,
                 'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\CreateObjectStateSignal',
-                array(
+                [
                     'objectStateGroupId' => $objectStateGroupId,
                     'objectStateId' => $objectStateId,
-                ),
-            ),
-            array(
+                ],
+            ],
+            [
                 'loadObjectState',
-                array($objectStateId),
+                [$objectStateId, []],
                 $objectState,
                 0,
-            ),
-            array(
+            ],
+            [
                 'updateObjectState',
-                array($objectState, $objectStateUpdateStruct),
+                [$objectState, $objectStateUpdateStruct],
                 $objectState,
                 1,
                 'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\UpdateObjectStateSignal',
-                array(
+                [
                     'objectStateId' => $objectStateId,
-                ),
-            ),
-            array(
+                ],
+            ],
+            [
                 'setPriorityOfObjectState',
-                array($objectState, $priority),
+                [$objectState, $priority],
                 null,
                 1,
                 'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\SetPriorityOfObjectStateSignal',
-                array(
+                [
                     'objectStateId' => $objectStateId,
                     'priority' => $priority,
-                ),
-            ),
-            array(
+                ],
+            ],
+            [
                 'deleteObjectState',
-                array($objectState),
+                [$objectState],
                 null,
                 1,
                 'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\DeleteObjectStateSignal',
-                array(
+                [
                     'objectStateId' => $objectStateId,
-                ),
-            ),
-            array(
+                ],
+            ],
+            [
                 'setContentState',
-                array($contentInfo, $objectStateGroup, $objectState),
+                [$contentInfo, $objectStateGroup, $objectState],
                 null,
                 1,
                 'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\SetContentStateSignal',
-                array(
+                [
                     'objectStateId' => $objectStateId,
                     'contentId' => $contentId,
                     'objectStateGroupId' => $objectStateGroupId,
-                ),
-            ),
-            array(
+                ],
+            ],
+            [
                 'getContentState',
-                array($contentInfo, $objectStateGroup),
+                [$contentInfo, $objectStateGroup],
                 $objectState,
                 0,
-            ),
-            array(
+            ],
+            [
                 'getContentCount',
-                array($objectState),
+                [$objectState],
                 35,
                 0,
-            ),
-            array(
+            ],
+            [
                 'newObjectStateGroupCreateStruct',
-                array('identifier'),
+                ['identifier'],
                 $objectStateGroupCreateStruct,
                 0,
-            ),
-            array(
+            ],
+            [
                 'newObjectStateGroupUpdateStruct',
-                array(),
+                [],
                 $objectStateGroupUpdateStruct,
                 0,
-            ),
-            array(
+            ],
+            [
                 'newObjectStateUpdateStruct',
-                array(),
+                [],
                 $objectStateUpdateStruct,
                 0,
-            ),
-            array(
+            ],
+            [
                 'newObjectStateCreateStruct',
-                array('identifier'),
+                ['identifier'],
                 $objectStateCreateStruct,
                 0,
-            ),
-        );
+            ],
+        ];
     }
 }


### PR DESCRIPTION
Part of [EZP-27428](https://jira.ez.no/browse/EZP-27428) implementation for #2002
----
**Target branch**: `language_match_api_logic`

This PR refactors ObjectState-related code to implement multi-language / unified logic introduced in #2002.

**TODO**:
- [x] Implement unified language for `ObjectStateService`.
- [x] Refactor `ObjectStateService` integration tests to use unified names and descriptions (so test code can be reused for new tests).
- [x] Add `ObjectStateService` integration tests for new multi-language / unified logic.
- [x] Align other existing tests with the changes.
- [x] Optimize Core `ObjectStateService::getContentState`.
- [x] Remove TMP commit.