### PR TITLE
EZP-27453: Match against ContentValueView and not ContentView

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/Content.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/Content.php
@@ -11,7 +11,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id;
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\MultipleValued;
 use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
-use eZ\Publish\Core\MVC\Symfony\View\ContentView;
+use eZ\Publish\Core\MVC\Symfony\View\ContentValueView;
 use eZ\Publish\Core\MVC\Symfony\View\View;
 
 class Content extends MultipleValued
@@ -42,7 +42,7 @@ class Content extends MultipleValued
 
     public function match(View $view)
     {
-        if (!$view instanceof ContentView) {
+        if (!$view instanceof ContentValueView) {
             return false;
         }
 

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/ContentType.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/ContentType.php
@@ -11,7 +11,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id;
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\MultipleValued;
 use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
-use eZ\Publish\Core\MVC\Symfony\View\ContentView;
+use eZ\Publish\Core\MVC\Symfony\View\ContentValueView;
 use eZ\Publish\Core\MVC\Symfony\View\View;
 
 class ContentType extends MultipleValued
@@ -42,7 +42,7 @@ class ContentType extends MultipleValued
 
     public function match(View $view)
     {
-        if (!$view instanceof ContentView) {
+        if (!$view instanceof ContentValueView) {
             return false;
         }
 

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/Remote.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/Remote.php
@@ -11,7 +11,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id;
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\MultipleValued;
 use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
-use eZ\Publish\Core\MVC\Symfony\View\ContentView;
+use eZ\Publish\Core\MVC\Symfony\View\ContentValueView;
 use eZ\Publish\Core\MVC\Symfony\View\View;
 
 class Remote extends MultipleValued
@@ -42,7 +42,7 @@ class Remote extends MultipleValued
 
     public function match(View $view)
     {
-        if (!$view instanceof ContentView) {
+        if (!$view instanceof ContentValueView) {
             return false;
         }
 

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/Section.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/Section.php
@@ -11,7 +11,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id;
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\MultipleValued;
 use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
-use eZ\Publish\Core\MVC\Symfony\View\ContentView;
+use eZ\Publish\Core\MVC\Symfony\View\ContentValueView;
 use eZ\Publish\Core\MVC\Symfony\View\View;
 
 class Section extends MultipleValued
@@ -42,7 +42,7 @@ class Section extends MultipleValued
 
     public function match(View $view)
     {
-        if (!$view instanceof ContentView) {
+        if (!$view instanceof ContentValueView) {
             return false;
         }
 

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Identifier/Section.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Identifier/Section.php
@@ -12,7 +12,7 @@ use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\MultipleValued;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
-use eZ\Publish\Core\MVC\Symfony\View\ContentView;
+use eZ\Publish\Core\MVC\Symfony\View\ContentValueView;
 use eZ\Publish\Core\MVC\Symfony\View\View;
 
 class Section extends MultipleValued
@@ -59,7 +59,7 @@ class Section extends MultipleValued
 
     public function match(View $view)
     {
-        if (!$view instanceof ContentView) {
+        if (!$view instanceof ContentValueView) {
             return false;
         }
 


### PR DESCRIPTION
`ContentBased` matchers:
* Id/Content
* Id/ContentType
* Id/Remote
* Id/Section
* Identifier/Section

should in `match()` method check against `eZ\Publish\Core\MVC\Symfony\View\ContentValueView` interface, rather than `eZ\Publish\Core\MVC\Symfony\View\ContentView` which is concrete implementation.

[Jira](https://jira.ez.no/browse/EZP-27453)