### PR TITLE
EZP-27399: Tag failing Scenario as broken because of security issue fix

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Features/Content/user_content.feature
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Content/user_content.feature
@@ -2,7 +2,8 @@ Feature: users can be manipulated using the Content API
 
     Background:
         Given I have "administrator" permissions
-
+	
+    @broken
     Scenario: Creating and publishing a user with the Content API works
          When I create a "POST" request to "/content/objects"
           And I set header "content-type" with "ContentCreate" object


### PR DESCRIPTION
Ticket: http://jira.ez.no/browse/EZP-27399

Current Scenario is broken because of how Behat works. Behat prepares `Request` body by processing the `ValueObject` through `OutputVisitor`. It triggers the `postProcessValueHash` method of `FieldTypeProcessor`s and, in this case, it removes `passwordHash` and `passwordHashType`.

https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/EzRest.php#L285

Issue is only on Behat side and does not affect how application works. In long term it would be best to replace use of `OutputVisitor` in behat to dedicated service responsible for preparing content of the Request body. 