### PR TITLE
EZP-27441: Error when translate a content with no image

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
@@ -1069,4 +1069,27 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
             $fieldType->isEmptyValue($loadedContent->getField('data')->value)
         );
     }
+
+    /**
+     * Test creating new translation from existing content with empty field.
+     */
+    public function testUpdateContentWithNewTranslationOnEmptyField()
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+
+        $content = $this->testCreateContentWithEmptyFieldValue();
+        $publishedContent = $contentService->publishVersion($content->versionInfo);
+
+        $contentDraft = $contentService->createContentDraft($publishedContent->contentInfo);
+        $updateStruct = $contentService->newContentUpdateStruct();
+        $updateStruct->setField(
+            'data',
+            $publishedContent->getFieldValue('data', 'eng-US'),
+            'eng-US'
+        );
+        $updateStruct->initialLanguageCode = 'eng-GB';
+        $updatedContentDraft = $contentService->updateContent($contentDraft->versionInfo, $updateStruct);
+        $contentService->publishVersion($updatedContentDraft->versionInfo);
+    }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
@@ -66,6 +66,7 @@ class ImageConverter implements Converter
         return $this->fillXml(
             array_merge(
                 array(
+                    'uri' => '',
                     'path' => '',
                     'width' => '',
                     'height' => '',

--- a/eZ/Publish/SPI/Persistence/Content/Field.php
+++ b/eZ/Publish/SPI/Persistence/Content/Field.php
@@ -53,4 +53,16 @@ class Field extends ValueObject
      * @todo Normally we would use a create struct here
      */
     public $versionNo;
+
+    /**
+     * Clone object properties.
+     *
+     * Note: `clone` keyword performs shallow copy of an object.
+     * For properties being objects this means that a reference
+     * is copied instead of the actual object.
+     */
+    public function __clone()
+    {
+        $this->value = clone $this->value;
+    }
 }


### PR DESCRIPTION
Fixes [EZP-27441](https://jira.ez.no/browse/EZP-27441)
----
> Target branch: **6.7**

When Content with empty Image FT gets translated, `ImageConverter` and `ImageStorage` try to access unset properties.

This PR contains the fix for the actual, root cause of the error described in the issue which is shallow clone of `eZ\Publish\SPI\Persistence\Content\Field`.

When a Persistence Field [is copied before the update](https://github.com/ezsystems/ezpublish-kernel/blob/v6.7.3/eZ/Publish/Core/Persistence/Legacy/Content/FieldHandler.php#L333), its `value` property, which is an object (`eZ\Publish\SPI\Persistence\Content\FieldValue`) gets copied as a reference. Thus `updateField` operates also directly on this object leaving it in unwanted state for the future creation of an empty field from a default language Value. [Here](https://github.com/ezsystems/ezpublish-kernel/blob/v6.7.3/eZ/Publish/Core/FieldType/Image/ImageStorage.php#L109) field `data` should be `null`, however it is not as a side effect of mentioned update.

**TODO**:
- [x] Create Field Type integration test.
- [x] Ensure `ImageConverter::fillXml` always gets proper default values for an empty image field.
- [x] Fix cloning of `eZ\Publish\SPI\Persistence\Content\Field`.
- [ ] Get feedback on open question below.

Open question
----
We could implement `__clone` directly on API ValueObject like this:
```php
public function __clone()
{
    foreach ($this->getProperties() as $property) {
        if (!property_exists($this, $property) || !is_object($this->$property)) {
            continue;
        }

        $this->$property = clone $this->$property;
    }
}
```

**Pros**:
- Handle it globally as cloning object references is almost never expected behavior.

**Cons**:
- System-wide increase of time and memory complexity.
- The above code does not account for lists (arrays) of objects.