### PR TITLE
Backport EZP-27399: Tag failing Scenario as broken because of security issue fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
     - php: 7.0
       env: REST_TEST_CONFIG="phpunit-functional-rest.xml" RUN_INSTALL=1 SYMFONY_ENV=dev SYMFONY_DEBUG=1
     - php: 7.0
-      env: BEHAT_OPTS="--profile=rest --suite=fullJson" RUN_INSTALL=1
+      env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" RUN_INSTALL=1
     - php: 7.0
       env: ELASTICSEARCH_VERSION="1.4.2" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml" SYMFONY_VERSION="~2.8.0"
     - php: 7.0

--- a/eZ/Bundle/EzPublishRestBundle/Features/Content/user_content.feature
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Content/user_content.feature
@@ -3,6 +3,7 @@ Feature: users can be manipulated using the Content API
     Background:
         Given I have "administrator" permissions
 
+    @broken
     Scenario: Creating and publishing a user with the Content API works
          When I create a "POST" request to "/content/objects"
           And I set header "content-type" with "ContentCreate" object


### PR DESCRIPTION
Backport fix related to [EZP-27399](https://jira.ez.no/browse/EZP-27399)
----

This PR backports #2015 to **6.7**