### PR TITLE
Fix EZP-27490: Exception when running config:dump-reference

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -25,7 +25,6 @@ use Symfony\Component\Config\FileLocator;
 use InvalidArgumentException;
 use Symfony\Component\Yaml\Yaml;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface;
-use RuntimeException;
 
 class EzPublishCoreExtension extends Extension implements PrependExtensionInterface
 {
@@ -517,10 +516,6 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
      */
     public function addConfigParser(ParserInterface $configParser)
     {
-        if ($this->mainConfigParser !== null) {
-            throw new RuntimeException('Main config parser is already instantiated');
-        }
-
         $this->configParsers[] = $configParser;
     }
 


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-27490

This patch removes the exception when the main config parser is already instantiated as this is not necessary and blocks config:dump-reference command (at least using Symfony 3.3).