### PR TITLE
EZP-24800 Support allowed classes limitation for object relation fields

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
@@ -205,6 +205,8 @@
         {% endif %}
         </div>
     </li>
+    {{ block( 'settings_selection_content_types' ) }}
+
     {% set rootLocationId = settings.selectionRoot %}
     {{ block( 'settings_selectionroot' ) }}
 </ul>
@@ -232,21 +234,9 @@
         {% endif %}
         </div>
     </li>
-    <li class="ez-fielddefinition-setting allowed-content-types">
-        <div class="ez-fielddefinition-setting-name">{{ 'fielddefinition.allowed-content-types.label'|trans|desc("Allowed content types:")}}</div>
-        <div class="ez-fielddefinition-setting-value">
-        {% if settings.selectionContentTypes %}
-            {# TODO display content type name #}
-            <ul>
-            {% for typeIdentifier in settings.selectionContentTypes %}
-                <li>{{ typeIdentifier }}</li>
-            {% endfor %}
-            </ul>
-        {% else %}
-            <em>{{ 'fielddefinition.allowed-content-types.any'|trans|desc("Any")}}</em>
-        {% endif %}
-        </div>
-    </li>
+
+    {{ block( 'settings_selection_content_types' ) }}
+
     {% set rootLocationId = settings.selectionDefaultLocation %}
     {{ block( 'settings_selectionroot' ) }}
 </ul>
@@ -320,6 +310,24 @@
         {% else %}
             <em>{{ 'fielddefinition.selection-root.undefined'|trans|desc("No defined root")}}</em>
         {% endif %}
+        </div>
+    </li>
+{% endblock %}
+
+{% block settings_selection_content_types %}
+    <li class="ez-fielddefinition-setting allowed-content-types">
+        <div class="ez-fielddefinition-setting-name">{{ 'fielddefinition.allowed-content-types.label'|trans|desc("Allowed content types:")}}</div>
+        <div class="ez-fielddefinition-setting-value">
+            {% if settings.selectionContentTypes %}
+                {# TODO display content type name #}
+                <ul>
+                    {% for typeIdentifier in settings.selectionContentTypes %}
+                        <li>{{ typeIdentifier }}</li>
+                    {% endfor %}
+                </ul>
+            {% else %}
+                <em>{{ 'fielddefinition.allowed-content-types.any'|trans|desc("Any")}}</em>
+            {% endif %}
         </div>
     </li>
 {% endblock %}

--- a/eZ/Publish/API/Repository/Tests/FieldType/RelationIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/RelationIntegrationTest.php
@@ -80,20 +80,20 @@ class RelationIntegrationTest extends SearchBaseIntegrationTest
      */
     public function getSettingsSchema()
     {
-        return array(
-            'selectionMethod' => array(
+        return [
+            'selectionMethod' => [
                 'type' => 'int',
                 'default' => 0,
-            ),
-            'selectionRoot' => array(
+            ],
+            'selectionRoot' => [
                 'type' => 'string',
                 'default' => null,
-            ),
-            'selectionContentTypes' => array(
+            ],
+            'selectionContentTypes' => [
                 'type' => 'array',
-                'default' => array(),
-            ),
-        );
+                'default' => [],
+            ],
+        ];
     }
 
     /**
@@ -113,11 +113,11 @@ class RelationIntegrationTest extends SearchBaseIntegrationTest
      */
     public function getValidFieldSettings()
     {
-        return array(
+        return [
             'selectionMethod' => 0,
             'selectionRoot' => '1',
-            'selectionContentTypes' => array('blog_post'),
-        );
+            'selectionContentTypes' => ['blog_post'],
+        ];
     }
 
     /**
@@ -141,7 +141,12 @@ class RelationIntegrationTest extends SearchBaseIntegrationTest
      */
     public function getInvalidFieldSettings()
     {
-        return array('selectionMethod' => 'a', 'selectionRoot' => true, 'unknownSetting' => false, 'selectionContentTypes' => true);
+        return [
+            'selectionMethod' => 'a',
+            'selectionRoot' => true,
+            'unknownSetting' => false,
+            'selectionContentTypes' => true,
+        ];
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/FieldType/RelationIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/RelationIntegrationTest.php
@@ -87,7 +87,11 @@ class RelationIntegrationTest extends SearchBaseIntegrationTest
             ),
             'selectionRoot' => array(
                 'type' => 'string',
-                'default' => '',
+                'default' => null,
+            ),
+            'selectionContentTypes' => array(
+                'type' => 'array',
+                'default' => array(),
             ),
         );
     }
@@ -109,7 +113,11 @@ class RelationIntegrationTest extends SearchBaseIntegrationTest
      */
     public function getValidFieldSettings()
     {
-        return array('selectionMethod' => 0, 'selectionRoot' => '1');
+        return array(
+            'selectionMethod' => 0,
+            'selectionRoot' => '1',
+            'selectionContentTypes' => array('blog_post'),
+        );
     }
 
     /**
@@ -133,7 +141,7 @@ class RelationIntegrationTest extends SearchBaseIntegrationTest
      */
     public function getInvalidFieldSettings()
     {
-        return array('selectionMethod' => 'a', 'selectionRoot' => true, 'unknownSetting' => false);
+        return array('selectionMethod' => 'a', 'selectionRoot' => true, 'unknownSetting' => false, 'selectionContentTypes' => true);
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/Relation/Type.php
+++ b/eZ/Publish/Core/FieldType/Relation/Type.php
@@ -29,20 +29,20 @@ class Type extends FieldType
     const SELECTION_BROWSE = 0;
     const SELECTION_DROPDOWN = 1;
 
-    protected $settingsSchema = array(
-        'selectionMethod' => array(
+    protected $settingsSchema = [
+        'selectionMethod' => [
             'type' => 'int',
             'default' => self::SELECTION_BROWSE,
-        ),
-        'selectionRoot' => array(
+        ],
+        'selectionRoot' => [
             'type' => 'string',
             'default' => null,
-        ),
-        'selectionContentTypes' => array(
+        ],
+        'selectionContentTypes' => [
             'type' => 'array',
-            'default' => array(),
-        ),
-    );
+            'default' => [],
+        ],
+    ];
 
     /**
      * @see \eZ\Publish\Core\FieldType\FieldType::validateFieldSettings()
@@ -100,9 +100,9 @@ class Type extends FieldType
                         $validationErrors[] = new ValidationError(
                             "Setting '%setting%' value must be of array type",
                             null,
-                            array(
+                            [
                                 '%setting%' => $name,
-                            ),
+                            ],
                             "[$name]"
                         );
                     }

--- a/eZ/Publish/Core/FieldType/Relation/Type.php
+++ b/eZ/Publish/Core/FieldType/Relation/Type.php
@@ -38,6 +38,10 @@ class Type extends FieldType
             'type' => 'string',
             'default' => null,
         ),
+        'selectionContentTypes' => array(
+            'type' => 'array',
+            'default' => array(),
+        ),
     );
 
     /**
@@ -83,6 +87,18 @@ class Type extends FieldType
                     if (!is_int($value) && !is_string($value) && $value !== null) {
                         $validationErrors[] = new ValidationError(
                             "Setting '%setting%' value must be of either null, string or integer",
+                            null,
+                            array(
+                                '%setting%' => $name,
+                            ),
+                            "[$name]"
+                        );
+                    }
+                    break;
+                case 'selectionContentTypes':
+                    if (!is_array($value)) {
+                        $validationErrors[] = new ValidationError(
+                            "Setting '%setting%' value must be of array type",
                             null,
                             array(
                                 '%setting%' => $name,

--- a/eZ/Publish/Core/FieldType/Tests/RelationTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RelationTest.php
@@ -52,20 +52,20 @@ class RelationTest extends FieldTypeTest
      */
     protected function getSettingsSchemaExpectation()
     {
-        return array(
-            'selectionMethod' => array(
+        return [
+            'selectionMethod' => [
                 'type' => 'int',
                 'default' => RelationType::SELECTION_BROWSE,
-            ),
-            'selectionRoot' => array(
+            ],
+            'selectionRoot' => [
                 'type' => 'string',
                 'default' => null,
-            ),
-            'selectionContentTypes' => array(
+            ],
+            'selectionContentTypes' => [
                 'type' => 'array',
-                'default' => array(),
-            ),
-        );
+                'default' => [],
+            ],
+        ];
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/Tests/RelationTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RelationTest.php
@@ -61,6 +61,10 @@ class RelationTest extends FieldTypeTest
                 'type' => 'string',
                 'default' => null,
             ),
+            'selectionContentTypes' => array(
+                'type' => 'array',
+                'default' => array(),
+            ),
         );
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RelationConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RelationConverter.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 
+use DOMDocument;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
@@ -66,30 +67,101 @@ class RelationConverter implements Converter
      */
     public function toStorageFieldDefinition(FieldDefinition $fieldDef, StorageFieldDefinition $storageDef)
     {
-        // Selection method, 0 = browse, 1 = dropdown
-        $storageDef->dataInt1 = (int)$fieldDef->fieldTypeConstraints->fieldSettings['selectionMethod'];
+        $fieldSettings = $fieldDef->fieldTypeConstraints->fieldSettings;
+        $doc = new DOMDocument('1.0', 'utf-8');
+        $root = $doc->createElement('related-objects');
+        $doc->appendChild($root);
 
-        // Selection root, location ID
-        $storageDef->dataInt2 = (int)$fieldDef->fieldTypeConstraints->fieldSettings['selectionRoot'];
+        $constraints = $doc->createElement('constraints');
+        if (!empty($fieldSettings['selectionContentTypes'])) {
+            foreach ($fieldSettings['selectionContentTypes'] as $typeIdentifier) {
+                $allowedClass = $doc->createElement('allowed-class');
+                $allowedClass->setAttribute('contentclass-identifier', $typeIdentifier);
+                $constraints->appendChild($allowedClass);
+                unset($allowedClass);
+            }
+        }
+        $root->appendChild($constraints);
+
+        $selectionType = $doc->createElement('selection_type');
+        if (isset($fieldSettings['selectionMethod'])) {
+            $selectionType->setAttribute('value', (int)$fieldSettings['selectionMethod']);
+        } else {
+            $selectionType->setAttribute('value', 0);
+        }
+        $root->appendChild($selectionType);
+
+        $defaultLocation = $doc->createElement('contentobject-placement');
+        if (!empty($fieldSettings['selectionRoot'])) {
+            $defaultLocation->setAttribute('node-id', (int)$fieldSettings['selectionRoot']);
+        }
+        $root->appendChild($defaultLocation);
+
+        $doc->appendChild($root);
+        $storageDef->dataText5 = $doc->saveXML();
     }
 
     /**
      * Converts field definition data in $storageDef into $fieldDef.
      *
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition $storageDef
+     * <?xml version="1.0" encoding="utf-8"?>
+     * <related-objects>
+     *   <constraints>
+     *     <allowed-class contentclass-identifier="blog_post"/>
+     *   </constraints>
+     *   <selection_type value="1"/>
+     *   <contentobject-placement node-id="67"/>
+     * </related-objects>
+     *
+     * <?xml version="1.0" encoding="utf-8"?>
+     * <related-objects>
+     *   <constraints/>
+     *   <selection_type value="0"/>
+     *   <contentobject-placement/>
+     * </related-objects>
+     *
      * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDef
+     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition $storageDef
      */
     public function toFieldDefinition(StorageFieldDefinition $storageDef, FieldDefinition $fieldDef)
     {
-        // Selection method, 0 = browse, 1 = dropdown
-        $fieldDef->fieldTypeConstraints->fieldSettings['selectionMethod'] = $storageDef->dataInt1;
+        // default settings
+        // use dataInt1 and dataInt2 fields as default for backward compatibility
+        $fieldDef->fieldTypeConstraints->fieldSettings = array(
+            'selectionMethod' => $storageDef->dataInt1,
+            'selectionRoot' => $storageDef->dataInt2 === 0 ? '' : $storageDef->dataInt2,
+            'selectionContentTypes' => array(),
+        );
 
-        // Selection root, location ID
+        if ($storageDef->dataText5 === null) {
+            return;
+        }
 
-        $fieldDef->fieldTypeConstraints->fieldSettings['selectionRoot'] =
-            $storageDef->dataInt2 === 0
-            ? ''
-            : $storageDef->dataInt2;
+        // read settings from storage
+        $fieldSettings = &$fieldDef->fieldTypeConstraints->fieldSettings;
+        $dom = new DOMDocument('1.0', 'utf-8');
+        if (empty($storageDef->dataText5) || $dom->loadXML($storageDef->dataText5) !== true) {
+            return;
+        }
+
+        if ($selectionType = $dom->getElementsByTagName('selection_type')) {
+            $fieldSettings['selectionMethod'] = (int)$selectionType->item(0)->getAttribute('value');
+        }
+
+        if (
+            ($defaultLocation = $dom->getElementsByTagName('contentobject-placement')) &&
+            $defaultLocation->item(0)->hasAttribute('node-id')
+        ) {
+            $fieldSettings['selectionRoot'] = (int)$defaultLocation->item(0)->getAttribute('node-id');
+        }
+
+        if (!($constraints = $dom->getElementsByTagName('constraints'))) {
+            return;
+        }
+
+        foreach ($constraints->item(0)->getElementsByTagName('allowed-class') as $allowedClass) {
+            $fieldSettings['selectionContentTypes'][] = $allowedClass->getAttribute('contentclass-identifier');
+        }
     }
 
     /**
@@ -99,7 +171,7 @@ class RelationConverter implements Converter
      * "sort_key_int" or "sort_key_string". This column is then used for
      * filtering and sorting for this type.
      *
-     * @return false
+     * @return string
      */
     public function getIndexColumn()
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RelationConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RelationConverter.php
@@ -53,9 +53,9 @@ class RelationConverter implements Converter
      */
     public function toFieldValue(StorageFieldValue $value, FieldValue $fieldValue)
     {
-        $fieldValue->data = array(
+        $fieldValue->data = [
             'destinationContentId' => $value->dataInt ?: null,
-        );
+        ];
         $fieldValue->sortKey = (int)$value->sortKeyInt;
     }
 
@@ -104,21 +104,23 @@ class RelationConverter implements Converter
     /**
      * Converts field definition data in $storageDef into $fieldDef.
      *
-     * <?xml version="1.0" encoding="utf-8"?>
-     * <related-objects>
-     *   <constraints>
-     *     <allowed-class contentclass-identifier="blog_post"/>
-     *   </constraints>
-     *   <selection_type value="1"/>
-     *   <contentobject-placement node-id="67"/>
-     * </related-objects>
+     * <code>
+     *   <?xml version="1.0" encoding="utf-8"?>
+     *   <related-objects>
+     *     <constraints>
+     *       <allowed-class contentclass-identifier="blog_post"/>
+     *     </constraints>
+     *     <selection_type value="1"/>
+     *     <contentobject-placement node-id="67"/>
+     *   </related-objects>
      *
-     * <?xml version="1.0" encoding="utf-8"?>
-     * <related-objects>
-     *   <constraints/>
-     *   <selection_type value="0"/>
-     *   <contentobject-placement/>
-     * </related-objects>
+     *   <?xml version="1.0" encoding="utf-8"?>
+     *   <related-objects>
+     *     <constraints/>
+     *     <selection_type value="0"/>
+     *     <contentobject-placement/>
+     *   </related-objects>
+     * </code>
      *
      * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDef
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition $storageDef
@@ -127,11 +129,11 @@ class RelationConverter implements Converter
     {
         // default settings
         // use dataInt1 and dataInt2 fields as default for backward compatibility
-        $fieldDef->fieldTypeConstraints->fieldSettings = array(
+        $fieldDef->fieldTypeConstraints->fieldSettings = [
             'selectionMethod' => $storageDef->dataInt1,
             'selectionRoot' => $storageDef->dataInt2 === 0 ? '' : $storageDef->dataInt2,
-            'selectionContentTypes' => array(),
-        );
+            'selectionContentTypes' => [],
+        ];
 
         if ($storageDef->dataText5 === null) {
             return;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RelationListConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RelationListConverter.php
@@ -161,25 +161,27 @@ class RelationListConverter implements Converter
     /**
      * Converts field definition data in $storageDef into $fieldDef.
      *
-     * <?xml version="1.0" encoding="utf-8"?>
-     * <related-objects>
-     *   <constraints>
-     *     <allowed-class contentclass-identifier="blog_post"/>
-     *   </constraints>
-     *   <type value="2"/>
-     *   <selection_type value="1"/>
-     *   <object_class value=""/>
-     *   <contentobject-placement node-id="67"/>
-     * </related-objects>
+     * <code>
+     *   <?xml version="1.0" encoding="utf-8"?>
+     *   <related-objects>
+     *     <constraints>
+     *       <allowed-class contentclass-identifier="blog_post"/>
+     *     </constraints>
+     *     <type value="2"/>
+     *     <selection_type value="1"/>
+     *     <object_class value=""/>
+     *     <contentobject-placement node-id="67"/>
+     *   </related-objects>
      *
-     * <?xml version="1.0" encoding="utf-8"?>
-     * <related-objects>
-     *   <constraints/>
-     *   <type value="2"/>
-     *   <selection_type value="0"/>
-     *   <object_class value=""/>
-     *   <contentobject-placement/>
-     * </related-objects>
+     *   <?xml version="1.0" encoding="utf-8"?>
+     *   <related-objects>
+     *     <constraints/>
+     *     <type value="2"/>
+     *     <selection_type value="0"/>
+     *     <object_class value=""/>
+     *     <contentobject-placement/>
+     *   </related-objects>
+     * </code>
      *
      * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition $storageDef
      * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDef

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/RelationTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/RelationTest.php
@@ -38,17 +38,17 @@ class RelationTest extends PHPUnit_Framework_TestCase
     public function testToStorageFieldDefinition()
     {
         $fieldDefinition = new PersistenceFieldDefinition(
-            array(
+            [
                 'fieldTypeConstraints' => new FieldTypeConstraints(
-                    array(
-                        'fieldSettings' => array(
+                    [
+                        'fieldSettings' => [
                             'selectionMethod' => Type::SELECTION_BROWSE,
                             'selectionRoot' => 12345,
-                            'selectionContentTypes' => array('article', 'blog_post'),
-                        ),
-                    )
+                            'selectionContentTypes' => ['article', 'blog_post'],
+                        ],
+                    ]
                 ),
-            )
+            ]
         );
 
         $expectedStorageFieldDefinition = new StorageFieldDefinition();

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/RelationTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/RelationTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * File containing the RelationTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;
+
+use eZ\Publish\Core\FieldType\RelationList\Type;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RelationConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition as PersistenceFieldDefinition;
+use eZ\Publish\SPI\Persistence\Content\FieldTypeConstraints;
+use PHPUnit_Framework_TestCase;
+
+/**
+ * Test case for Relation converter in Legacy storage.
+ */
+class RelationTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RelationConverter
+     */
+    protected $converter;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->converter = new RelationConverter();
+    }
+
+    /**
+     * @group fieldType
+     * @group relationlist
+     */
+    public function testToStorageFieldDefinition()
+    {
+        $fieldDefinition = new PersistenceFieldDefinition(
+            array(
+                'fieldTypeConstraints' => new FieldTypeConstraints(
+                    array(
+                        'fieldSettings' => array(
+                            'selectionMethod' => Type::SELECTION_BROWSE,
+                            'selectionRoot' => 12345,
+                            'selectionContentTypes' => array('article', 'blog_post'),
+                        ),
+                    )
+                ),
+            )
+        );
+
+        $expectedStorageFieldDefinition = new StorageFieldDefinition();
+        $expectedStorageFieldDefinition->dataText5 = <<<EOT
+<?xml version="1.0" encoding="utf-8"?>
+<related-objects><constraints><allowed-class contentclass-identifier="article"/><allowed-class contentclass-identifier="blog_post"/></constraints><selection_type value="0"/><contentobject-placement node-id="12345"/></related-objects>
+
+EOT;
+
+        $actualStorageFieldDefinition = new StorageFieldDefinition();
+
+        $this->converter->toStorageFieldDefinition($fieldDefinition, $actualStorageFieldDefinition);
+
+        $this->assertEquals(
+            $expectedStorageFieldDefinition,
+            $actualStorageFieldDefinition
+        );
+    }
+}

--- a/eZ/Publish/SPI/Tests/FieldType/RelationIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/RelationIntegrationTest.php
@@ -75,7 +75,8 @@ class RelationIntegrationTest extends BaseIntegrationTest
             array(
                 'fieldSettings' => array(
                     'selectionMethod' => 0,
-                    'selectionRoot' => '',
+                    'selectionRoot' => null,
+                    'selectionContentTypes' => array(),
                 ),
             )
         );
@@ -92,7 +93,8 @@ class RelationIntegrationTest extends BaseIntegrationTest
     {
         $fieldSettings = array(
             'selectionMethod' => 0,
-            'selectionRoot' => '',
+            'selectionRoot' => null,
+            'selectionContentTypes' => array(),
         );
 
         return array(


### PR DESCRIPTION
This PR adds allowed classes to single object relation field. @andrerom suggested this PR, which does the same for legacy:
https://github.com/ezsystems/ezpublish-legacy/pull/1201

This feature requires changes in 3 bundles, so I have 3 PRs. The other 2:
* https://github.com/ezsystems/PlatformUIBundle/pull/878
* https://github.com/ezsystems/repository-forms/pull/127

I made the storage of the settings in xml in the dataText5 field. It is compatible with the old way, but it drops that schema on the next save of the content type. So if someone has stuff in dataInt1 and dataInt2 cause of an upgrade, then those will work, but when someone saves the content type, then they will be emptied and converted to xml into dataText5.

I didnt include the `type` and `object_class` deprecated xml tags in this xml.

I ran test with this command: `bin/phpunit vendor/ezsystems/ezpublish-kernel/ --testsuite "eZ\Publish\Core\FieldType" --filter "RelationTest"`
