### PR TITLE
Fix EZP-27510: ConfigResolver default scope is not updated when SiteAccess is matched

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
@@ -88,7 +88,6 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
     public function setSiteAccess(SiteAccess $siteAccess = null)
     {
         $this->siteAccess = $siteAccess;
-        $this->defaultScope = $siteAccess->name;
     }
 
     /**
@@ -127,7 +126,7 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
     public function hasParameter($paramName, $namespace = null, $scope = null)
     {
         $namespace = $namespace ?: $this->defaultNamespace;
-        $scope = $scope ?: $this->defaultScope;
+        $scope = $scope ?: $this->getDefaultScope();
 
         $defaultScopeParamName = "$namespace." . self::SCOPE_DEFAULT . ".$paramName";
         $globalScopeParamName = "$namespace." . self::SCOPE_GLOBAL . ".$paramName";
@@ -167,7 +166,7 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
     public function getParameter($paramName, $namespace = null, $scope = null)
     {
         $namespace = $namespace ?: $this->defaultNamespace;
-        $scope = $scope ?: $this->defaultScope;
+        $scope = $scope ?: $this->getDefaultScope();
         $triedScopes = array();
 
         // Global scope
@@ -183,7 +182,7 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
         if ($this->container->hasParameter($relativeScopeParamName)) {
             return $this->container->getParameter($relativeScopeParamName);
         }
-        $triedScopes[] = $this->defaultScope;
+        $triedScopes[] = $scope;
         unset($relativeScopeParamName);
 
         // Relative scope, siteaccess group wise
@@ -235,7 +234,7 @@ class ConfigResolver implements VersatileScopeInterface, SiteAccessAware, Contai
 
     public function getDefaultScope()
     {
-        return $this->defaultScope;
+        return $this->defaultScope ?: $this->siteAccess->name;
     }
 
     public function setDefaultScope($scope)


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-27510

This patch ensures that the ConfigResolver's default scope is always the SiteAccess name, unless otherwise provided.

Kind of relates to
https://github.com/ezsystems/ezpublish-kernel/pull/1440 by @wizhippo