### PR TITLE
BinaryFileCreateStruct->mtime should be a DateTime

### DIFF
--- a/eZ/Publish/Core/IO/IOService.php
+++ b/eZ/Publish/Core/IO/IOService.php
@@ -236,7 +236,7 @@ class IOService implements IOServiceInterface
         $spiBinaryCreateStruct->size = $binaryFileCreateStruct->size;
         $spiBinaryCreateStruct->setInputStream($binaryFileCreateStruct->inputStream);
         $spiBinaryCreateStruct->mimeType = $binaryFileCreateStruct->mimeType;
-        $spiBinaryCreateStruct->mtime = time();
+        $spiBinaryCreateStruct->mtime = new \DateTime();
 
         return $spiBinaryCreateStruct;
     }


### PR DESCRIPTION
Tentative fix for https://jira.ez.no/browse/EZP-27553

Followup to "Fix broken LegacyDFSCluster::create()" https://github.com/ezsystems/ezpublish-kernel/commit/2b74e9df15620b98f45cd31ce25efc14f1de4569

Currently no idea why this should fail in 1.10 when it works in 1.9.

(yes, this PR should be against 6.9...)