### PR TITLE
Fix EZP-27528: Multiple StateGroup limitations in one policy combine with the "or" relationship instead of the "and" one

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/ObjectStateLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/ObjectStateLimitationTest.php
@@ -8,7 +8,11 @@
  */
 namespace eZ\Publish\API\Repository\Tests\Values\User\Limitation;
 
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
 use eZ\Publish\API\Repository\Values\User\Limitation\ObjectStateLimitation;
+use eZ\Publish\API\Repository\Values\User\RoleCreateStruct;
 
 /**
  * Test case for the {@link \eZ\Publish\API\Repository\Values\User\Limitation\ObjectStateLimitation}
@@ -143,5 +147,187 @@ class ObjectStateLimitationTest extends BaseLimitationTest
 
         $contentService->deleteContent($draft->contentInfo);
         /* END: Use Case */
+    }
+
+    /**
+     * Tests an ObjectStateLimitation.
+     *
+     * Checks if the action is correctly forbidden when using ObjectStateLimitation
+     * with limitation values from two different StateGroups.
+     *
+     * @see \eZ\Publish\API\Repository\Values\User\Limitation\ObjectStateLimitation
+     *
+     * @throws \ErrorException
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @expectedExceptionMessage 'remove' 'content'
+     */
+    public function testObjectStateLimitationForbidVariant()
+    {
+        $repository = $this->getRepository();
+        $objectStateGroup = $this->createObjectStateGroup();
+        $objectState = $this->createObjectState($objectStateGroup);
+
+        $lockedState = $this->generateId('objectstate', 1);
+        $defaultStateFromAnotherGroup = $this->generateId('objectstate', $objectState->id);
+
+        $contentService = $repository->getContentService();
+        /* BEGIN: Use Case */
+        $user = $this->createUserVersion1();
+
+        $roleService = $repository->getRoleService();
+
+        $role = $roleService->loadRoleByIdentifier('Editor');
+
+        $removePolicy = null;
+        foreach ($role->getPolicies() as $policy) {
+            if ('content' !== $policy->module || 'remove' !== $policy->function) {
+                continue;
+            }
+            $removePolicy = $policy;
+            break;
+        }
+
+        $this->assertNotNull($removePolicy);
+
+        // Only allow deletion of content with locked state and the default state from another State Group
+        $policyUpdate = $roleService->newPolicyUpdateStruct();
+        $policyUpdate->addLimitation(
+            new ObjectStateLimitation(
+                [
+                    'limitationValues' => [
+                        $lockedState,
+                        $defaultStateFromAnotherGroup,
+                    ],
+                ]
+            )
+        );
+        $roleService->updatePolicy($removePolicy, $policyUpdate);
+
+        // Allow user to create everything
+        $policyCreate = $roleService->newPolicyCreateStruct('content', 'create');
+        $roleService->addPolicy($role, $policyCreate);
+
+        $roleService->assignRoleToUser($role, $user);
+
+        $repository->getPermissionResolver()->setCurrentUserReference($user);
+
+        $draft = $this->createWikiPageDraft();
+
+        $contentService->deleteContent($draft->contentInfo);
+        /* END: Use Case */
+    }
+
+    /**
+     * Create new State Group.
+     *
+     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup
+     */
+    private function createObjectStateGroup()
+    {
+        $objectStateService = $this->getRepository()->getObjectStateService();
+
+        $objectStateGroupCreateStruct = $objectStateService->newObjectStateGroupCreateStruct('second_group');
+        $objectStateGroupCreateStruct->defaultLanguageCode = 'eng-US';
+        $objectStateGroupCreateStruct->names = ['eng-US' => 'Second Group'];
+
+        return $objectStateService->createObjectStateGroup($objectStateGroupCreateStruct);
+    }
+
+    /**
+     * Create new State and assign it to the $objectStateGroup.
+     *
+     * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup $objectStateGroup
+     *
+     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState
+     */
+    private function createObjectState(ObjectStateGroup $objectStateGroup)
+    {
+        $objectStateService = $this->getRepository()->getObjectStateService();
+
+        $objectStateCreateStruct = $objectStateService->newObjectStateCreateStruct('default_state');
+        $objectStateCreateStruct->defaultLanguageCode = 'eng-US';
+        $objectStateCreateStruct->names = ['eng-US' => 'Default state'];
+
+        return $objectStateService->createObjectState($objectStateGroup, $objectStateCreateStruct);
+    }
+
+    /**
+     * Tests an ObjectStateLimitation.
+     *
+     * Checks if the search results are correctly filtered when using ObjectStateLimitation
+     * with limitation values from two different StateGroups.
+     *
+     * @see \eZ\Publish\API\Repository\Values\User\Limitation\ObjectStateLimitation
+     */
+    public function testObjectStateLimitationSearch()
+    {
+        $repository = $this->getRepository();
+        $objectStateGroup = $this->createObjectStateGroup();
+        $objectState = $this->createObjectState($objectStateGroup);
+
+        $lockedState = $this->generateId('objectstate', 1);
+        $defaultStateFromAnotherGroup = $this->generateId('objectstate', $objectState->id);
+
+        $roleService = $repository->getRoleService();
+        $roleName = 'role_with_object_state_limitation';
+        $roleCreateStruct = $roleService->newRoleCreateStruct($roleName);
+        $this->addPolicyToNewRole($roleCreateStruct, 'content', 'read', [
+            new ObjectStateLimitation([
+                'limitationValues' => [$lockedState, $defaultStateFromAnotherGroup],
+            ]),
+        ]);
+        $roleService->publishRoleDraft(
+            $roleService->createRole($roleCreateStruct)
+        );
+
+        $permissionResolver = $repository->getPermissionResolver();
+        $user = $this->createCustomUserVersion1('Test group', $roleName);
+        $adminUser = $permissionResolver->getCurrentUserReference();
+
+        $wikiPage = $this->createWikiPage();
+
+        $permissionResolver->setCurrentUserReference($user);
+
+        $query = new Query();
+        $query->filter = new Criterion\MatchAll();
+        $query->limit = 50;
+
+        $this->refreshSearch($repository);
+        $searchResultsBefore = $repository->getSearchService()->findContent($query);
+
+        $permissionResolver->setCurrentUserReference($adminUser);
+
+        //change the Object State to the one that doesn't match the Limitation
+        $stateService = $repository->getObjectStateService();
+        $stateService->setContentState(
+            $wikiPage->contentInfo,
+            $stateService->loadObjectStateGroup(2),
+            $stateService->loadObjectState(2)
+        );
+
+        $permissionResolver->setCurrentUserReference($user);
+
+        $this->refreshSearch($repository);
+        $searchResultsAfter = $repository->getSearchService()->findContent($query);
+
+        $this->assertEquals($searchResultsBefore->totalCount - 1, $searchResultsAfter->totalCount);
+    }
+
+    /**
+     * Add policy to a new role.
+     *
+     * @param \eZ\Publish\API\Repository\Values\User\RoleCreateStruct $roleCreateStruct
+     * @param string $module
+     * @param string $function
+     * @param \eZ\Publish\API\Repository\Values\User\Limitation[] $limitations
+     */
+    private function addPolicyToNewRole(RoleCreateStruct $roleCreateStruct, $module, $function, array $limitations)
+    {
+        $roleService = $this->getRepository()->getRoleService();
+        $policyCreateStruct = $roleService->newPolicyCreateStruct($module, $function);
+        foreach ($limitations as $limitation) {
+            $policyCreateStruct->addLimitation($limitation);
+        }
+        $roleCreateStruct->addPolicy($policyCreateStruct);
     }
 }

--- a/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
@@ -222,7 +222,7 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
      * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
-     * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface|\eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOperator
      */
     public function getCriterion(APILimitationValue $value, APIUserReference $currentUser)
     {

--- a/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
@@ -116,6 +116,8 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
             throw new InvalidArgumentException('$value', 'Must be of type: APIObjectStateLimitation');
         }
 
+        $limitationValues = $value->limitationValues;
+
         if ($object instanceof Content) {
             $object = $object->getVersionInfo()->getContentInfo();
         } elseif ($object instanceof VersionInfo) {
@@ -124,11 +126,11 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
             throw new InvalidArgumentException('$object', 'Must be of type: Content, VersionInfo or ContentInfo');
         }
 
-        if (empty($value->limitationValues)) {
+        if (empty($limitationValues)) {
             return false;
         }
 
-        $objectStateIdArray = array();
+        $objectStateIdsToVerify = array();
         $objectStateHandler = $this->persistence->objectStateHandler();
         $stateGroups = $objectStateHandler->loadAllGroups();
 
@@ -156,20 +158,62 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
                     );
                 }
 
-                $objectStateIdArray[] = $defaultStateId;
+                if ($this->isStateGroupUsedForLimitation($stateGroup->id, $limitationValues)) {
+                    $objectStateIdsToVerify[] = $defaultStateId;
+                }
             }
         } else {
-            /*
-             * @var $object ContentInfo
-             */
             foreach ($stateGroups as $stateGroup) {
-                $objectStateIdArray[] = $objectStateHandler->getContentState($object->id, $stateGroup->id)->id;
+                if ($this->isStateGroupUsedForLimitation($stateGroup->id, $limitationValues)) {
+                    $objectStateIdsToVerify[] = $objectStateHandler->getContentState($object->id, $stateGroup->id)->id;
+                }
             }
         }
 
-        $intersect = array_intersect($value->limitationValues, $objectStateIdArray);
+        return $this->areObjectStatesMatchingTheLimitation($objectStateIdsToVerify, $limitationValues);
+    }
 
-        return !empty($intersect);
+    /**
+     * Checks if the State Group contains at least one State that is used by Limitation.
+     *
+     * @param int $stateGroupId
+     * @param string[] $limitationValues
+     *
+     * @return bool
+     */
+    private function isStateGroupUsedForLimitation($stateGroupId, array $limitationValues)
+    {
+        $objectStateHandler = $this->persistence->objectStateHandler();
+        $states = $objectStateHandler->loadObjectStates($stateGroupId);
+
+        foreach ($states as $state) {
+            // check using loose types as limitation values are strings and id's can be int
+            if (in_array($state->id, $limitationValues)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Verifies if all the Object States are matching the Limitation Values.
+     *
+     * @param int[] $objectStateIds
+     * @param string[] $limitationValues
+     *
+     * @return bool
+     */
+    private function areObjectStatesMatchingTheLimitation(array $objectStateIds, array $limitationValues)
+    {
+        foreach ($objectStateIds as $objectStateId) {
+            // check using loose types as limitation values are strings and id's can be int
+            if (!in_array($objectStateId, $limitationValues)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -192,8 +236,46 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
             return new Criterion\ObjectStateId($value->limitationValues[0]);
         }
 
-        // several limitation values: IN operation
-        return new Criterion\ObjectStateId($value->limitationValues);
+        $groupedLimitationValues = $this->groupLimitationValues($value->limitationValues);
+
+        if (count($groupedLimitationValues) === 1) {
+            // one group, several limitation values: IN operation
+            return new Criterion\ObjectStateId($groupedLimitationValues[0]);
+        }
+
+        // limitations from different groups require logical AND between them
+        $criterions = [];
+        foreach ($groupedLimitationValues as $limitationGroup) {
+            $criterions[] = new Criterion\ObjectStateId($limitationGroup);
+        }
+
+        return new Criterion\LogicalAnd($criterions);
+    }
+
+    /**
+     * Groups limitation values by the State Group.
+     *
+     * @param string[] $limitationValues
+     *
+     * @return int[][]
+     */
+    private function groupLimitationValues(array $limitationValues)
+    {
+        $objectStateHandler = $this->persistence->objectStateHandler();
+        $stateGroups = $objectStateHandler->loadAllGroups();
+        $groupedLimitationValues = [];
+        foreach ($stateGroups as $stateGroup) {
+            $states = $objectStateHandler->loadObjectStates($stateGroup->id);
+            $stateIds = array_map(function ($state) {
+                return $state->id;
+            }, $states);
+            $limitationValuesGroup = array_intersect($stateIds, $limitationValues);
+            if (!empty($limitationValuesGroup)) {
+                $groupedLimitationValues[] = array_values($limitationValuesGroup);
+            }
+        }
+
+        return $groupedLimitationValues;
     }
 
     /**

--- a/eZ/Publish/Core/Limitation/Tests/ObjectStateLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/ObjectStateLimitationTypeTest.php
@@ -1,0 +1,313 @@
+<?php
+
+/**
+ * File containing a Test Case for LimitationType class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Limitation\Tests;
+
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ObjectStateId;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\API\Repository\Values\User\Limitation\ObjectStateLimitation;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\Limitation\ObjectStateLimitationType;
+use eZ\Publish\SPI\Persistence\Content\ObjectState;
+use eZ\Publish\SPI\Persistence\Content\ObjectState\Group;
+use eZ\Publish\SPI\Persistence\Content\ObjectState\Handler;
+
+/**
+ * Test Case for LimitationType.
+ */
+class ObjectStateLimitationTypeTest extends Base
+{
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\ObjectState\Handler|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $objectStateHandlerMock;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\ObjectState\Group[]
+     */
+    private $allObjectStateGroups;
+
+    /**
+     * @var array
+     */
+    private $loadObjectStatesMap;
+
+    /**
+     * Setup Handler mock.
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->objectStateHandlerMock = $this->getMock(
+            Handler::class,
+            [],
+            [],
+            '',
+            false
+        );
+
+        $this->allObjectStateGroups = [
+            new Group(['id' => 1]),
+            new Group(['id' => 2]),
+        ];
+
+        $this->loadObjectStatesMap = [
+            [
+                1,
+                [
+                    new ObjectState(['id' => 1, 'priority' => 1]),
+                    new ObjectState(['id' => 2, 'priority' => 0]),
+                ],
+            ],
+            [
+                2,
+                [
+                    new ObjectState(['id' => 3, 'priority' => 1]),
+                    new ObjectState(['id' => 4, 'priority' => 0]),
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Tear down Handler mock.
+     */
+    public function tearDown()
+    {
+        unset($this->objectStateHandlerMock);
+
+        parent::tearDown();
+    }
+
+    /**
+     * @return \eZ\Publish\Core\Limitation\ObjectStateLimitationType
+     */
+    public function testConstruct()
+    {
+        return new ObjectStateLimitationType($this->getPersistenceMock());
+    }
+
+    /**
+     * @return array
+     */
+    public function providerForTestEvaluate()
+    {
+        return [
+            // ContentInfo, published, no access
+            [
+                'limitation' => new ObjectStateLimitation(),
+                'object' => new ContentInfo(['id' => 1, 'published' => true]),
+                'expected' => false,
+            ],
+            // ContentInfo, published, no access
+            [
+                'limitation' => new ObjectStateLimitation(['limitationValues' => [2]]),
+                'object' => new ContentInfo(['id' => 1, 'published' => true]),
+                'expected' => false,
+            ],
+            // ContentInfo, published, no access
+            [
+                'limitation' => new ObjectStateLimitation(['limitationValues' => [2, 3]]),
+                'object' => new ContentInfo(['id' => 1, 'published' => true]),
+                'expected' => false,
+            ],
+            // ContentInfo, published, no access
+            [
+                'limitation' => new ObjectStateLimitation(['limitationValues' => [2, 4]]),
+                'object' => new ContentInfo(['id' => 1, 'published' => true]),
+                'expected' => false,
+            ],
+            // ContentInfo, published, with access
+            [
+                'limitation' => new ObjectStateLimitation(['limitationValues' => [1]]),
+                'object' => new ContentInfo(['id' => 1, 'published' => true]),
+                'expected' => true,
+            ],
+            // ContentInfo, published, with access
+            [
+                'limitation' => new ObjectStateLimitation(['limitationValues' => [1, 3]]),
+                'object' => new ContentInfo(['id' => 1, 'published' => true]),
+                'expected' => true,
+            ],
+            // ContentInfo, not published, no access
+            [
+                'limitation' => new ObjectStateLimitation(['limitationValues' => [2]]),
+                'object' => new ContentInfo(['id' => 1, 'published' => false]),
+                'expected' => false,
+            ],
+            // ContentInfo, published, with access
+            [
+                'limitation' => new ObjectStateLimitation(['limitationValues' => [1, 3]]),
+                'object' => new ContentInfo(['id' => 1, 'published' => false]),
+                'expected' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestEvaluate
+     */
+    public function testEvaluate(
+        ObjectStateLimitation $limitation,
+        ValueObject $object,
+        $expected
+    ) {
+        $getContentStateMap = [
+            [
+                1,
+                1,
+                new ObjectState(['id' => 1]),
+            ],
+            [
+                1,
+                2,
+                new ObjectState(['id' => 3]),
+            ],
+        ];
+
+        if (!empty($limitation->limitationValues)) {
+            $this->getPersistenceMock()
+                 ->method('objectStateHandler')
+                 ->willReturn($this->objectStateHandlerMock);
+
+            $this->objectStateHandlerMock
+                ->method('loadAllGroups')
+                ->willReturn($this->allObjectStateGroups);
+
+            $this->objectStateHandlerMock
+                ->method('loadObjectStates')
+                ->willReturnMap($this->loadObjectStatesMap);
+
+            $this->objectStateHandlerMock
+                ->method('getContentState')
+                ->willReturnMap($getContentStateMap);
+        } else {
+            $this->getPersistenceMock()
+                 ->expects($this->never())
+                 ->method($this->anything());
+        }
+
+        $userMock = $this->getUserMock();
+        $userMock
+            ->expects($this->never())
+            ->method($this->anything());
+
+        // Need to create inline instead of depending on testConstruct() to get correct mock instance
+        $limitationType = $this->testConstruct();
+
+        $value = $limitationType->evaluate(
+            $limitation,
+            $userMock,
+            $object
+        );
+
+        self::assertInternalType('boolean', $value);
+        self::assertEquals($expected, $value);
+    }
+
+    /**
+     * @depends testConstruct
+     * @expectedException \RuntimeException
+     *
+     * @param \eZ\Publish\Core\Limitation\ObjectStateLimitationType $limitationType
+     */
+    public function testGetCriterionInvalidValue(ObjectStateLimitationType $limitationType)
+    {
+        $limitationType->getCriterion(
+            new ObjectStateLimitation([]),
+            $this->getUserMock()
+        );
+    }
+
+    /**
+     * @depends testConstruct
+     *
+     * @param \eZ\Publish\Core\Limitation\ObjectStateLimitationType $limitationType
+     */
+    public function testGetCriterionSingleValue(ObjectStateLimitationType $limitationType)
+    {
+        $criterion = $limitationType->getCriterion(
+            new ObjectStateLimitation(['limitationValues' => [2]]),
+            $this->getUserMock()
+        );
+
+        self::assertInstanceOf(ObjectStateId::class, $criterion);
+        self::assertInternalType('array', $criterion->value);
+        self::assertInternalType('string', $criterion->operator);
+        self::assertEquals(Operator::EQ, $criterion->operator);
+        self::assertEquals([2], $criterion->value);
+    }
+
+    public function testGetCriterionMultipleValuesFromSingleGroup()
+    {
+        $this->getPersistenceMock()
+             ->method('objectStateHandler')
+             ->willReturn($this->objectStateHandlerMock);
+
+        $this->objectStateHandlerMock
+            ->method('loadAllGroups')
+            ->willReturn($this->allObjectStateGroups);
+
+        $this->objectStateHandlerMock
+            ->method('loadObjectStates')
+            ->willReturnMap($this->loadObjectStatesMap);
+
+        // Need to create inline instead of depending on testConstruct() to get correct mock instance
+        $limitationType = $this->testConstruct();
+
+        $criterion = $limitationType->getCriterion(
+            new ObjectStateLimitation(['limitationValues' => [1, 2]]),
+            $this->getUserMock()
+        );
+
+        self::assertInstanceOf(ObjectStateId::class, $criterion);
+        self::assertInternalType('array', $criterion->value);
+        self::assertInternalType('string', $criterion->operator);
+        self::assertEquals(Operator::IN, $criterion->operator);
+        self::assertEquals([1, 2], $criterion->value);
+    }
+
+    public function testGetCriterionMultipleValuesFromMultipleGroups()
+    {
+        $this->getPersistenceMock()
+             ->method('objectStateHandler')
+             ->willReturn($this->objectStateHandlerMock);
+
+        $this->objectStateHandlerMock
+            ->method('loadAllGroups')
+            ->willReturn($this->allObjectStateGroups);
+
+        $this->objectStateHandlerMock
+            ->method('loadObjectStates')
+            ->willReturnMap($this->loadObjectStatesMap);
+
+        // Need to create inline instead of depending on testConstruct() to get correct mock instance
+        $limitationType = $this->testConstruct();
+
+        $criterion = $limitationType->getCriterion(
+            new ObjectStateLimitation(['limitationValues' => [1, 2, 3]]),
+            $this->getUserMock()
+        );
+
+        self::assertInstanceOf(LogicalAnd::class, $criterion);
+        self::assertInternalType('array', $criterion->criteria);
+
+        self::assertInternalType('array', $criterion->criteria[0]->value);
+        self::assertInternalType('string', $criterion->criteria[0]->operator);
+        self::assertEquals(Operator::IN, $criterion->criteria[0]->operator);
+        self::assertEquals([1, 2], $criterion->criteria[0]->value);
+
+        self::assertInternalType('array', $criterion->criteria[1]->value);
+        self::assertInternalType('string', $criterion->criteria[1]->operator);
+        self::assertEquals(Operator::IN, $criterion->criteria[1]->operator);
+        self::assertEquals([3], $criterion->criteria[1]->value);
+    }
+}

--- a/eZ/Publish/SPI/Limitation/Type.php
+++ b/eZ/Publish/SPI/Limitation/Type.php
@@ -107,7 +107,7 @@ interface Type
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
      * @param \eZ\Publish\API\Repository\Values\User\UserReference $currentUser
      *
-     * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface|\eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOperator
      */
     public function getCriterion(APILimitationValue $value, APIUserReference $currentUser);
 


### PR DESCRIPTION
> [EZP-27528](https://jira.ez.no/browse/EZP-27528)
#
Excerpt from the JIRA:
> When using multiple StateGroup limitations in one policy they combine using the "or" relationship instead of the "and" one. This means only one of these limitations must apply in order for the policy to work. Other limitations combine using the "and" relationship.

I found out that all the StateGroup limitations from one policy are combined together and verified against the object states. This means only one match is required for all StateGroup limitations to pass.
In this PR I changed this behaviour to at first find out which StateGroups are used for the limitation and then try to match all of them separately against the object states. If at least one of them doesn't match, then the StateGroup limitation fails.

As the ObjectStateLimitationType didn't have any tests, I added some basic tests to cover the fixed behaviour.

TODO:
- [x] reflect the new logic in `getCriterion` to make sure search queries don't try to fetch the disallowed content
- [x] _integration_ test coverage on both cases _(evaluate as used on load, and criteria as used on queries)_