### PR TITLE
EZP-27551 Proper handling of missing images

### DIFF
--- a/eZ/Publish/Core/FieldType/Image/IO/Legacy.php
+++ b/eZ/Publish/Core/FieldType/Image/IO/Legacy.php
@@ -12,6 +12,7 @@ use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\IO\IOServiceInterface;
 use eZ\Publish\Core\IO\Values\BinaryFile;
 use eZ\Publish\Core\IO\Values\BinaryFileCreateStruct;
+use eZ\Publish\Core\IO\Values\MissingBinaryFile;
 
 /**
  * Legacy Image IOService.
@@ -149,7 +150,13 @@ class Legacy implements IOServiceInterface
     public function loadBinaryFileByUri($binaryFileUri)
     {
         try {
-            return $this->publishedIOService->loadBinaryFileByUri($binaryFileUri);
+            $image = $this->publishedIOService->loadBinaryFileByUri($binaryFileUri);
+
+            if ($image instanceof MissingBinaryFile) {
+                $image = $this->draftIOService->loadBinaryFileByUri($binaryFileUri);
+            }
+
+            return $image;
         } catch (InvalidArgumentException $prefixException) {
             // InvalidArgumentException means that the prefix didn't match, NotFound can pass through
             try {

--- a/eZ/Publish/Core/FieldType/Image/IO/Legacy.php
+++ b/eZ/Publish/Core/FieldType/Image/IO/Legacy.php
@@ -153,7 +153,7 @@ class Legacy implements IOServiceInterface
             $image = $this->publishedIOService->loadBinaryFileByUri($binaryFileUri);
 
             if ($image instanceof MissingBinaryFile) {
-                $image = $this->draftIOService->loadBinaryFileByUri($binaryFileUri);
+                throw new InvalidArgumentException();
             }
 
             return $image;

--- a/eZ/Publish/Core/FieldType/Image/IO/Legacy.php
+++ b/eZ/Publish/Core/FieldType/Image/IO/Legacy.php
@@ -153,7 +153,7 @@ class Legacy implements IOServiceInterface
             $image = $this->publishedIOService->loadBinaryFileByUri($binaryFileUri);
 
             if ($image instanceof MissingBinaryFile) {
-                throw new InvalidArgumentException();
+                throw new InvalidArgumentException('binaryFileUri', sprintf("Can't find file with url {0}", $binaryFileUri));
             }
 
             return $image;

--- a/eZ/Publish/Core/IO/TolerantIOService.php
+++ b/eZ/Publish/Core/IO/TolerantIOService.php
@@ -98,12 +98,16 @@ class TolerantIOService extends IOService
 
     public function loadBinaryFileByUri($binaryFileUri)
     {
+        $binaryFileId = $this->binarydataHandler->getIdFromUri($binaryFileUri);
         try {
-            $binaryFileId = $this->removeUriPrefix($this->binarydataHandler->getIdFromUri($binaryFileUri));
+            $binaryFileId = $this->removeUriPrefix($binaryFileId);
         } catch (InvalidArgumentException $e) {
             $this->logMissingFile($binaryFileUri);
 
-            return new MissingBinaryFile(['uri' => $binaryFileUri]);
+            return new MissingBinaryFile([
+                'id' => $binaryFileId,
+                'uri' => $binaryFileUri,
+            ]);
         }
 
         try {


### PR DESCRIPTION
This is a fix for https://jira.ez.no/browse/EZP-27551

## Description

After changes in EZP-26175, specifically in 1a5f7d7 method `loadBinaryFileByUri` is no longer throwing an `InvalidArgumentException` but returns `MissingBinaryFile` instead. This is a bug introduced in `5.4.10` release.

There are two issues with that:
1. You cannot construct `MissingBinaryFile` without an `id` property because it will throw an exception.
2. Method `loadBinaryFileByUri` will fallback to `draftIOService` only in case of `InvalidArgumentException` which is no longer a case.

Important note: this is just a quick fix for a fatal error. However this topic still requires some work, which turns out not to be so straigth forward, that's why I decided to split it into separate PRs. Images which are not uploaded (in content which is not published, still being a draft) will not appear on preview. This didn't work in previous versions either. There's a ticket for that one here https://jira.ez.no/browse/EZP-27123. (the root of the issue is that [isDraftImagePath](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/FieldType/Image/IO/Legacy.php#L239) does not recognize draft image properly)

