### PR TITLE
Make MigrationHandler::setIODataHandlersByIdentifiers() not final

### DIFF
--- a/eZ/Bundle/EzPublishIOBundle/Migration/MigrationHandler.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/MigrationHandler.php
@@ -45,7 +45,7 @@ abstract class MigrationHandler implements MigrationHandlerInterface
         $this->logger = $logger;
     }
 
-    final public function setIODataHandlersByIdentifiers(
+    public function setIODataHandlersByIdentifiers(
         $fromMetadataHandlerIdentifier,
         $fromBinarydataHandlerIdentifier,
         $toMetadataHandlerIdentifier,


### PR DESCRIPTION
> Fixes https://jira.ez.no/browse/EZP-27564
> QA confirmed in origin issue: https://jira.ez.no/browse/EZP-25946

Follow-up to https://github.com/ezsystems/ezpublish-kernel/pull/1972/ as QA found it didn't work. The data handler factories are not set when calling MigrationHandler::setIODataHandlersByIdentifiers(), see https://github.com/ezsystems/ezpublish-kernel/blob/efafb63fe3442c14d6b5d90c9db9ef58839605b7/eZ/Bundle/EzPublishIOBundle/Migration/MigrationHandler.php#L54
This seems to be because of a fairly last minute change in the final-ness to solve a lazy-loading problem.

This experimentally solves it by un-final-ising the method. Not sure yet if kosher. ~If we do this, we may need to do the same for the logging methods as they might have the same problem~ They don't. Why? Beats me. 😖

@bdunogier @andrerom Do you grok why those member variables where not set, before this? I see no mention of such behaviour in PHP docs. It could be an artifact of lazy loading.