### PR TITLE
EZP-27359: Restore interface test to check if FOSJsRouting is there

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -102,7 +102,7 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
         // Slots
         $loader->load('slot.yml');
 
-        if ($container->hasExtension('fos_js_routing')) {
+        if (interface_exists('FOS\JsRoutingBundle\Extractor\ExposedRoutesExtractorInterface')) {
             $loader->load('routing/js_routing.yml');
         }
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-27359

# Description

This reverts the *last minute* change done in https://github.com/ezsystems/ezpublish-kernel/pull/2025 (see https://github.com/ezsystems/ezpublish-kernel/commit/4afcf2a55465dc5d3eea085235e64fd31aab6823 / https://github.com/ezsystems/ezpublish-kernel/pull/2025#discussion_r123692900).

It seems at this stage, the extensions are not available (`$container->hasExtension('fos_js_routing')` is false, and `$container->getExtensions()` returns an empty array).

@emodric @lolautruche @bdunogier feel free to suggest something else, as long as we get `/admin` URIs in the Hybrid Platform UI, that's fine :)

# Tests

manual tests