### PR TITLE
[Travis] Switch SYMFONY_ENV to behat for scenarios on PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,9 @@ matrix:
       env: BEHAT_OPTS="--profile=core --tags=~@broken" RUN_INSTALL=1 SYMFONY_ENV=behat SYMFONY_DEBUG=1
 # 7.0
     - php: 7.0
-      env: REST_TEST_CONFIG="phpunit-functional-rest.xml" RUN_INSTALL=1 SYMFONY_ENV=dev SYMFONY_DEBUG=1
+      env: REST_TEST_CONFIG="phpunit-functional-rest.xml" RUN_INSTALL=1 SYMFONY_ENV=behat SYMFONY_DEBUG=1
     - php: 7.0
-      env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" RUN_INSTALL=1
+      env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" RUN_INSTALL=1 SYMFONY_ENV=behat
     - php: 7.0
       env: ELASTICSEARCH_VERSION="1.4.2" TEST_CONFIG="phpunit-integration-legacy-elasticsearch.xml" SYMFONY_VERSION="~2.8.0"
     - php: 7.0


### PR DESCRIPTION
Fix failing behat tests by switching `SYMFONY_ENV` to `behat`
----

Travis recently updated Trusty, since then some behat scenarios [fail](https://travis-ci.org/ezsystems/ezpublish-kernel/builds/246249820).

Behat scenarios fail when trying to perform `ezplatform:install`. However I think it's rather related to cache warmup.

The error and its stack trace:
`PHP Fatal error:  Uncaught Symfony\Component\Filesystem\Exception\IOException: Unable to write to the "/var/www" directory. in /var/www/vendor/symfony/symfony/src/Symfony/Component/Filesystem/Filesystem.php:581
Stack trace:
#0 /var/www/vendor/ezsystems/ezplatform-design-engine/bundle/DependencyInjection/Compiler/PHPStormPass.php(48): Symfony\Component\Filesystem\Filesystem->dumpFile('/var/www/ide-tw...', '{"namespaces":[...')`

Possible solutions:
1. Judging from the source of this error - `ezplatform-design-engine/bundle/DependencyInjection/Compiler/PHPStormPass.php` - we should skip this compiler pass on Travis.
2. Add `group:deprecated-2017Q2` as described [here](https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch).

Trying to achieve option 1...