### PR TITLE
Fix EZP-27511: Content section not updated when moving content from one section to another

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
@@ -139,6 +139,7 @@ class LocationHandler extends AbstractHandler implements LocationHandlerInterfac
 
         $this->cache->clear('location');//TIMBER! (path[Identification]String)
         $this->cache->clear('user', 'role', 'assignments', 'byGroup');
+        $this->cache->clear('content');//TIMBER!
 
         return $return;
     }

--- a/eZ/Publish/Core/Persistence/Cache/Tests/LocationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/LocationHandlerTest.php
@@ -496,6 +496,12 @@ class LocationHandlerTest extends HandlerTest
             ->with('user', 'role', 'assignments', 'byGroup')
             ->will($this->returnValue(true));
 
+        $this->cacheMock
+            ->expects($this->at(2))
+            ->method('clear')
+            ->with('content')
+            ->will($this->returnValue(true));
+
         $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler');
         $this->persistenceHandlerMock
             ->expects($this->once())

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
@@ -351,6 +351,52 @@ class Handler implements BaseLocationHandler
             $destinationParentId,
             Gateway::NODE_ASSIGNMENT_OP_CODE_MOVE
         );
+
+        $sourceLocation = $this->load($sourceId);
+        $destinationParentSectionId = $this->getSectionId($destinationParentId);
+        $this->updateSubtreeSectionIfNecessary($sourceLocation, $destinationParentSectionId);
+    }
+
+    /**
+     * Retrieves section ID of the location's content.
+     *
+     * @param int $locationId
+     *
+     * @return int
+     */
+    private function getSectionId($locationId)
+    {
+        $location = $this->load($locationId);
+        $locationContentInfo = $this->contentHandler->loadContentInfo($location->contentId);
+
+        return $locationContentInfo->sectionId;
+    }
+
+    /**
+     * If the location is the main location for its content, updates subtree section.
+     *
+     * @param Location $location
+     * @param int $sectionId
+     */
+    private function updateSubtreeSectionIfNecessary(Location $location, $sectionId)
+    {
+        if ($this->isMainLocation($location)) {
+            $this->setSectionForSubtree($location->id, $sectionId);
+        }
+    }
+
+    /**
+     * Checks if the location is the main location for its content.
+     *
+     * @param Location $location
+     *
+     * @return bool
+     */
+    private function isMainLocation(Location $location)
+    {
+        $locationContentInfo = $this->contentHandler->loadContentInfo($location->contentId);
+
+        return $locationContentInfo->mainLocationId === $location->id;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
@@ -310,51 +310,10 @@ class Handler implements BaseLocationHandler
             );
         }
 
-        // If subtree root is main location for its content, update subtree section to the one of the
-        // parent location content
-        $subtreeRootContentInfo = $this->contentHandler->loadContentInfo($copiedSubtreeRootLocation->contentId);
-        if ($subtreeRootContentInfo->mainLocationId === $copiedSubtreeRootLocation->id) {
-            $this->setSectionForSubtree(
-                $copiedSubtreeRootLocation->id,
-                $this->contentHandler->loadContentInfo($this->load($destinationParentId)->contentId)->sectionId
-            );
-        }
+        $destinationParentSectionId = $this->getSectionId($destinationParentId);
+        $this->updateSubtreeSectionIfNecessary($copiedSubtreeRootLocation, $destinationParentSectionId);
 
         return $copiedSubtreeRootLocation;
-    }
-
-    /**
-     * Moves location identified by $sourceId into new parent identified by $destinationParentId.
-     *
-     * Performs a full move of the location identified by $sourceId to a new
-     * destination, identified by $destinationParentId. Relations do not need
-     * to be updated, since they refer to Content. URLs are not touched.
-     *
-     * @param mixed $sourceId
-     * @param mixed $destinationParentId
-     *
-     * @return bool
-     */
-    public function move($sourceId, $destinationParentId)
-    {
-        $sourceNodeData = $this->locationGateway->getBasicNodeData($sourceId);
-        $destinationNodeData = $this->locationGateway->getBasicNodeData($destinationParentId);
-
-        $this->locationGateway->moveSubtreeNodes(
-            $sourceNodeData,
-            $destinationNodeData
-        );
-
-        $this->locationGateway->updateNodeAssignment(
-            $sourceNodeData['contentobject_id'],
-            $sourceNodeData['parent_node_id'],
-            $destinationParentId,
-            Gateway::NODE_ASSIGNMENT_OP_CODE_MOVE
-        );
-
-        $sourceLocation = $this->load($sourceId);
-        $destinationParentSectionId = $this->getSectionId($destinationParentId);
-        $this->updateSubtreeSectionIfNecessary($sourceLocation, $destinationParentSectionId);
     }
 
     /**
@@ -397,6 +356,40 @@ class Handler implements BaseLocationHandler
         $locationContentInfo = $this->contentHandler->loadContentInfo($location->contentId);
 
         return $locationContentInfo->mainLocationId === $location->id;
+    }
+
+    /**
+     * Moves location identified by $sourceId into new parent identified by $destinationParentId.
+     *
+     * Performs a full move of the location identified by $sourceId to a new
+     * destination, identified by $destinationParentId. Relations do not need
+     * to be updated, since they refer to Content. URLs are not touched.
+     *
+     * @param mixed $sourceId
+     * @param mixed $destinationParentId
+     *
+     * @return bool
+     */
+    public function move($sourceId, $destinationParentId)
+    {
+        $sourceNodeData = $this->locationGateway->getBasicNodeData($sourceId);
+        $destinationNodeData = $this->locationGateway->getBasicNodeData($destinationParentId);
+
+        $this->locationGateway->moveSubtreeNodes(
+            $sourceNodeData,
+            $destinationNodeData
+        );
+
+        $this->locationGateway->updateNodeAssignment(
+            $sourceNodeData['contentobject_id'],
+            $sourceNodeData['parent_node_id'],
+            $destinationParentId,
+            Gateway::NODE_ASSIGNMENT_OP_CODE_MOVE
+        );
+
+        $sourceLocation = $this->load($sourceId);
+        $destinationParentSectionId = $this->getSectionId($destinationParentId);
+        $this->updateSubtreeSectionIfNecessary($sourceLocation, $destinationParentSectionId);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationHandlerTest.php
@@ -648,12 +648,6 @@ class LocationHandlerTest extends TestCase
                 ->with($contentId, $locationId);
         }
 
-        $this->contentHandler
-            ->expects($this->at($lastContentHandlerIndex + 1))
-            ->method('loadContentInfo')
-            ->with(21)
-            ->will($this->returnValue(new ContentInfo(array('mainLocationId' => 1010))));
-
         $handler
             ->expects($this->once())
             ->method('load')
@@ -661,10 +655,16 @@ class LocationHandlerTest extends TestCase
             ->will($this->returnValue(new Location(array('contentId' => $destinationData['contentobject_id']))));
 
         $this->contentHandler
-            ->expects($this->at($lastContentHandlerIndex + 2))
+            ->expects($this->at($lastContentHandlerIndex + 1))
             ->method('loadContentInfo')
             ->with($destinationData['contentobject_id'])
             ->will($this->returnValue(new ContentInfo(array('sectionId' => 12345))));
+
+        $this->contentHandler
+            ->expects($this->at($lastContentHandlerIndex + 2))
+            ->method('loadContentInfo')
+            ->with(21)
+            ->will($this->returnValue(new ContentInfo(array('mainLocationId' => 1010))));
 
         $handler
             ->expects($this->once())

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationHandlerTest.php
@@ -67,6 +67,7 @@ class LocationHandlerTest extends TestCase
         $this->locationGateway = $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Gateway');
         $this->locationMapper = $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Mapper');
         $this->treeHandler = $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\TreeHandler', array(), array(), '', false);
+        $this->contentHandler = $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Handler', array(), array(), '', false);
     }
 
     protected function getLocationHandler()
@@ -76,7 +77,7 @@ class LocationHandlerTest extends TestCase
         return new Handler(
             $this->locationGateway,
             $this->locationMapper,
-            $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Handler', array(), array(), '', false),
+            $this->contentHandler,
             $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\ObjectState\\Handler', array(), array(), '', false),
             $this->treeHandler
         );
@@ -211,6 +212,7 @@ class LocationHandlerTest extends TestCase
         $destinationData = array(
             'node_id' => 77,
             'path_string' => '/1/2/77/',
+            'contentobject_id' => 68,
         );
         $this->locationGateway
             ->expects($this->at(1))
@@ -227,6 +229,42 @@ class LocationHandlerTest extends TestCase
             ->expects($this->once())
             ->method('updateNodeAssignment')
             ->with(67, 2, 77, 5);
+
+        $this->treeHandler
+            ->expects($this->at(0))
+            ->method('loadLocation')
+            ->with($sourceData['node_id'])
+            ->will($this->returnValue(
+                new Location(
+                    array(
+                        'id' => $sourceData['node_id'],
+                        'contentId' => $sourceData['contentobject_id'],
+                    )
+                )
+            ));
+
+        $this->treeHandler
+            ->expects($this->at(1))
+            ->method('loadLocation')
+            ->with($destinationData['node_id'])
+            ->will($this->returnValue(new Location(array('contentId' => $destinationData['contentobject_id']))));
+
+        $this->contentHandler
+            ->expects($this->at(0))
+            ->method('loadContentInfo')
+            ->with($destinationData['contentobject_id'])
+            ->will($this->returnValue(new ContentInfo(array('sectionId' => 12345))));
+
+        $this->contentHandler
+            ->expects($this->at(1))
+            ->method('loadContentInfo')
+            ->with($sourceData['contentobject_id'])
+            ->will($this->returnValue(new ContentInfo(array('mainLocationId' => 69))));
+
+        $this->treeHandler
+            ->expects($this->once())
+            ->method('setSectionForSubtree')
+            ->with(69, 12345);
 
         $handler->move(69, 77);
     }


### PR DESCRIPTION
> [EZP-27511](https://jira.ez.no/browse/EZP-27511)
#
Moving the content from one section to another doesn't change the section. This behaviour was different in 5.x.
I noticed that Content/Location/Handler::copySubtree() function is updating the section when it is necessary, so I implemented that behaviour in Content/Location/Handler::move() function as well.
The change in Cache/LocationHandler::move() function comes from the fact that Cache/LocationHandler:setSectionForSubtree() function is clearing the content cache and as move() is now calling copySubtree(), it should be cleared there as well.