### PR TITLE
EZP-27509: Improve UserService to load new translated API properties via prioritized languages list

### DIFF
--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -2189,6 +2189,41 @@ class UserServiceTest extends BaseTest
     }
 
     /**
+     * Test that multi-language logic for the loadUserByLogin method respects prioritized language list.
+     *
+     * @covers \eZ\Publish\API\Repository\UserService::loadUserByLogin
+     * @dataProvider getPrioritizedLanguageList
+     * @param string[] $prioritizedLanguages
+     * @param string|null $expectedLanguageCode language code of expected translation
+     */
+    public function testLoadUserByLoginWithPrioritizedLanguagesList(
+        array $prioritizedLanguages,
+        $expectedLanguageCode
+    ) {
+        $repository = $this->getRepository();
+        $userService = $repository->getUserService();
+        $user = $this->createMultiLanguageUser();
+
+        // load, with prioritized languages, the newly created user
+        $loadedUser = $userService->loadUserByLogin($user->login, $prioritizedLanguages);
+        if ($expectedLanguageCode === null) {
+            $expectedLanguageCode = $loadedUser->contentInfo->mainLanguageCode;
+        }
+
+        self::assertEquals(
+            $loadedUser->getName($expectedLanguageCode),
+            $loadedUser->getName()
+        );
+
+        foreach (['first_name', 'last_name', 'signature'] as $fieldIdentifier) {
+            self::assertEquals(
+                $loadedUser->getFieldValue($fieldIdentifier, $expectedLanguageCode),
+                $loadedUser->getFieldValue($fieldIdentifier)
+            );
+        }
+    }
+
+    /**
      * Get prioritized languages list data.
      *
      * Test cases using this data provider should expect the following arguments:

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -2224,6 +2224,46 @@ class UserServiceTest extends BaseTest
     }
 
     /**
+     * Test that multi-language logic for the loadUserByCredentials method respects
+     * prioritized language list.
+     *
+     * @covers \eZ\Publish\API\Repository\UserService::loadUserByCredentials
+     * @dataProvider getPrioritizedLanguageList
+     * @param string[] $prioritizedLanguages
+     * @param string|null $expectedLanguageCode language code of expected translation
+     */
+    public function testLoadUserByCredentialsWithPrioritizedLanguagesList(
+        array $prioritizedLanguages,
+        $expectedLanguageCode
+    ) {
+        $repository = $this->getRepository();
+        $userService = $repository->getUserService();
+        $user = $this->createMultiLanguageUser();
+
+        // load, with prioritized languages, the newly created user
+        $loadedUser = $userService->loadUserByCredentials(
+            $user->login,
+            'secret',
+            $prioritizedLanguages
+        );
+        if ($expectedLanguageCode === null) {
+            $expectedLanguageCode = $loadedUser->contentInfo->mainLanguageCode;
+        }
+
+        self::assertEquals(
+            $loadedUser->getName($expectedLanguageCode),
+            $loadedUser->getName()
+        );
+
+        foreach (['first_name', 'last_name', 'signature'] as $fieldIdentifier) {
+            self::assertEquals(
+                $loadedUser->getFieldValue($fieldIdentifier, $expectedLanguageCode),
+                $loadedUser->getFieldValue($fieldIdentifier)
+            );
+        }
+    }
+
+    /**
      * Get prioritized languages list data.
      *
      * Test cases using this data provider should expect the following arguments:

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -2264,6 +2264,44 @@ class UserServiceTest extends BaseTest
     }
 
     /**
+     * Test that multi-language logic for the loadUsersByEmail method respects
+     * prioritized language list.
+     *
+     * @covers \eZ\Publish\API\Repository\UserService::loadUsersByEmail
+     * @dataProvider getPrioritizedLanguageList
+     * @param string[] $prioritizedLanguages
+     * @param string|null $expectedLanguageCode language code of expected translation
+     */
+    public function testLoadUsersByEmailWithPrioritizedLanguagesList(
+        array $prioritizedLanguages,
+        $expectedLanguageCode
+    ) {
+        $repository = $this->getRepository();
+        $userService = $repository->getUserService();
+        $user = $this->createMultiLanguageUser();
+
+        // load, with prioritized languages, users by email
+        $loadedUsers = $userService->loadUsersByEmail($user->email, $prioritizedLanguages);
+
+        foreach ($loadedUsers as $loadedUser) {
+            if ($expectedLanguageCode === null) {
+                $expectedLanguageCode = $loadedUser->contentInfo->mainLanguageCode;
+            }
+            self::assertEquals(
+                $loadedUser->getName($expectedLanguageCode),
+                $loadedUser->getName()
+            );
+
+            foreach (['first_name', 'last_name', 'signature'] as $fieldIdentifier) {
+                self::assertEquals(
+                    $loadedUser->getFieldValue($fieldIdentifier, $expectedLanguageCode),
+                    $loadedUser->getFieldValue($fieldIdentifier)
+                );
+            }
+        }
+    }
+
+    /**
      * Get prioritized languages list data.
      *
      * Test cases using this data provider should expect the following arguments:

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -2302,6 +2302,37 @@ class UserServiceTest extends BaseTest
     }
 
     /**
+     * Test that multi-language logic for the loadUserGroupsOfUser method respects
+     * prioritized language list.
+     *
+     * @covers \eZ\Publish\API\Repository\UserService::loadUserGroupsOfUser
+     * @dataProvider getPrioritizedLanguageList
+     * @param string[] $prioritizedLanguages
+     * @param string|null $expectedLanguageCode language code of expected translation
+     */
+    public function testLoadUserGroupsOfUserWithPrioritizedLanguagesList(
+        array $prioritizedLanguages,
+        $expectedLanguageCode
+    ) {
+        $repository = $this->getRepository();
+        $userService = $repository->getUserService();
+        $userGroup = $this->createMultiLanguageUserGroup();
+        $user = $this->createMultiLanguageUser($userGroup->id);
+
+        $userGroups = $userService->loadUserGroupsOfUser($user, 0, 25, $prioritizedLanguages);
+        foreach ($userGroups as $userGroup) {
+            self::assertEquals(
+                $userGroup->getName($expectedLanguageCode),
+                $userGroup->getName()
+            );
+            self::assertEquals(
+                $userGroup->getFieldValue('description', $expectedLanguageCode),
+                $userGroup->getFieldValue('description')
+            );
+        }
+    }
+
+    /**
      * Get prioritized languages list data.
      *
      * Test cases using this data provider should expect the following arguments:

--- a/eZ/Publish/API/Repository/UserService.php
+++ b/eZ/Publish/API/Repository/UserService.php
@@ -189,10 +189,11 @@ interface UserService
      * several users having same email in the past (by means of a configuration option).
      *
      * @param string $email
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User[]
      */
-    public function loadUsersByEmail($email);
+    public function loadUsersByEmail($email, array $prioritizedLanguages = []);
 
     /**
      * This method deletes a user.

--- a/eZ/Publish/API/Repository/UserService.php
+++ b/eZ/Publish/API/Repository/UserService.php
@@ -60,12 +60,13 @@ interface UserService
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
      * @param int $offset the start offset for paging
      * @param int $limit the number of user groups returned
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the user group
      */
-    public function loadSubUserGroups(UserGroup $userGroup, $offset = 0, $limit = 25);
+    public function loadSubUserGroups(UserGroup $userGroup, $offset = 0, $limit = 25, array $prioritizedLanguages = []);
 
     /**
      * Removes a user group.

--- a/eZ/Publish/API/Repository/UserService.php
+++ b/eZ/Publish/API/Repository/UserService.php
@@ -270,10 +270,11 @@ interface UserService
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
      * @param int $offset the start offset for paging
      * @param int $limit the number of users returned
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User[]
      */
-    public function loadUsersOfUserGroup(UserGroup $userGroup, $offset = 0, $limit = 25);
+    public function loadUsersOfUserGroup(UserGroup $userGroup, $offset = 0, $limit = 25, array $prioritizedLanguages = []);
 
     /**
      * Instantiate a user create class.

--- a/eZ/Publish/API/Repository/UserService.php
+++ b/eZ/Publish/API/Repository/UserService.php
@@ -156,13 +156,14 @@ interface UserService
      *
      * @param string $login
      * @param string $password the plain password
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if credentials are invalid
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user with the given credentials was not found
      */
-    public function loadUserByCredentials($login, $password);
+    public function loadUserByCredentials($login, $password, array $prioritizedLanguages = []);
 
     /**
      * Loads a user for the given login.

--- a/eZ/Publish/API/Repository/UserService.php
+++ b/eZ/Publish/API/Repository/UserService.php
@@ -129,12 +129,13 @@ interface UserService
      * Loads a user.
      *
      * @param mixed $userId
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user with the given id was not found
      */
-    public function loadUser($userId);
+    public function loadUser($userId, array $prioritizedLanguages = []);
 
     /**
      * Loads anonymous user.

--- a/eZ/Publish/API/Repository/UserService.php
+++ b/eZ/Publish/API/Repository/UserService.php
@@ -171,12 +171,13 @@ interface UserService
      * with mysql before in eZ Publish 3.x/4.x/5.x.
      *
      * @param string $login
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user with the given credentials was not found
      */
-    public function loadUserByLogin($login);
+    public function loadUserByLogin($login, array $prioritizedLanguages = []);
 
     /**
      * Loads a user for the given email.

--- a/eZ/Publish/API/Repository/UserService.php
+++ b/eZ/Publish/API/Repository/UserService.php
@@ -256,10 +256,11 @@ interface UserService
      * @param \eZ\Publish\API\Repository\Values\User\User $user
      * @param int $offset the start offset for paging
      * @param int $limit the number of user groups returned
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
      */
-    public function loadUserGroupsOfUser(User $user, $offset = 0, $limit = 25);
+    public function loadUserGroupsOfUser(User $user, $offset = 0, $limit = 25, array $prioritizedLanguages = []);
 
     /**
      * Loads the users of a user group.

--- a/eZ/Publish/API/Repository/UserService.php
+++ b/eZ/Publish/API/Repository/UserService.php
@@ -45,13 +45,14 @@ interface UserService
      * Loads a user group for the given id.
      *
      * @param mixed $id
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a user group
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the user group with the given id was not found
      */
-    public function loadUserGroup($id);
+    public function loadUserGroup($id, array $prioritizedLanguages = []);
 
     /**
      * Loads the sub groups of a user group.

--- a/eZ/Publish/Core/REST/Client/UserService.php
+++ b/eZ/Publish/Core/REST/Client/UserService.php
@@ -100,16 +100,7 @@ class UserService implements APIUserService, Sessionable
     }
 
     /**
-     * Loads a user group for the given id.
-     *
-     * @param mixed $id
-     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\UserGroup
-     *
-     * @throws \Exception Method is not implemented
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a user group
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the user group with the given id was not found
+     * {@inheritdoc}
      */
     public function loadUserGroup($id, array $prioritizedLanguages = [])
     {
@@ -117,17 +108,7 @@ class UserService implements APIUserService, Sessionable
     }
 
     /**
-     * Loads the sub groups of a user group.
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
-     * @param int $offset the start offset for paging
-     * @param int $limit the number of user groups returned
-     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
-     *
-     * @throws \Exception Method is not implemented
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the user group
+     * {@inheritdoc}
      */
     public function loadSubUserGroups(UserGroup $userGroup, $offset = 0, $limit = 25, array $prioritizedLanguages = [])
     {
@@ -201,14 +182,7 @@ class UserService implements APIUserService, Sessionable
     }
 
     /**
-     * Loads a user.
-     *
-     * @param mixed $userId
-     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\User
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user with the given id was not found
+     * {@inheritdoc}
      */
     public function loadUser($userId, array $prioritizedLanguages = [])
     {
@@ -229,17 +203,7 @@ class UserService implements APIUserService, Sessionable
     }
 
     /**
-     * Loads a user for the given login and password.
-     *
-     * @param string $login
-     * @param string $password the plain password
-     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\User
-     *
-     * @throws \Exception Method is not implemented
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentValue if credentials are invalid
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user with the given credentials was not found
+     * {@inheritdoc}
      */
     public function loadUserByCredentials($login, $password, array $prioritizedLanguages = [])
     {
@@ -247,15 +211,7 @@ class UserService implements APIUserService, Sessionable
     }
 
     /**
-     * Loads a user for the given login.
-     *
-     * @param string $login
-     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\User
-     *
-     * @throws \Exception Method is not implemented
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user with the given credentials was not found
+     * {@inheritdoc}
      */
     public function loadUserByLogin($login, array $prioritizedLanguages = [])
     {
@@ -263,17 +219,7 @@ class UserService implements APIUserService, Sessionable
     }
 
     /**
-     * Loads a user for the given email.
-     *
-     * Returns an array of Users since eZ Publish has under certain circumstances allowed
-     * several users having same email in the past (by means of a configuration option).
-     *
-     * @param string $email
-     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\User[]
-     *
-     * @throws \Exception Method is not implemented
+     * {@inheritdoc}
      */
     public function loadUsersByEmail($email, array $prioritizedLanguages = [])
     {
@@ -341,18 +287,7 @@ class UserService implements APIUserService, Sessionable
     }
 
     /**
-     * Loads the user groups the user belongs to.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed read the user or user group
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
-     * @param int $offset the start offset for paging
-     * @param int $limit the number of user groups returned
-     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
-     *
-     * @throws \Exception Method is not implemented
+     * {@inheritdoc}
      */
     public function loadUserGroupsOfUser(User $user, $offset = 0, $limit = 25, array $prioritizedLanguages = [])
     {
@@ -360,17 +295,7 @@ class UserService implements APIUserService, Sessionable
     }
 
     /**
-     * Loads the users of a user group.
-     *
-     * @throws \Exception Method is not implemented
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the users or user group
-     *
-     * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
-     * @param int $offset the start offset for paging
-     * @param int $limit the number of users returned
-     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
-     *
-     * @return \eZ\Publish\API\Repository\Values\User\User[]
+     * {@inheritdoc}
      */
     public function loadUsersOfUserGroup(
         UserGroup $userGroup,

--- a/eZ/Publish/Core/REST/Client/UserService.php
+++ b/eZ/Publish/Core/REST/Client/UserService.php
@@ -204,12 +204,13 @@ class UserService implements APIUserService, Sessionable
      * Loads a user.
      *
      * @param mixed $userId
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user with the given id was not found
      */
-    public function loadUser($userId)
+    public function loadUser($userId, array $prioritizedLanguages = [])
     {
         throw new \Exception('@todo: Implement.');
     }

--- a/eZ/Publish/Core/REST/Client/UserService.php
+++ b/eZ/Publish/Core/REST/Client/UserService.php
@@ -233,13 +233,15 @@ class UserService implements APIUserService, Sessionable
      *
      * @param string $login
      * @param string $password the plain password
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User
      *
+     * @throws \Exception Method is not implemented
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentValue if credentials are invalid
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user with the given credentials was not found
      */
-    public function loadUserByCredentials($login, $password)
+    public function loadUserByCredentials($login, $password, array $prioritizedLanguages = [])
     {
         throw new \Exception('@todo: Implement.');
     }

--- a/eZ/Publish/Core/REST/Client/UserService.php
+++ b/eZ/Publish/Core/REST/Client/UserService.php
@@ -248,12 +248,14 @@ class UserService implements APIUserService, Sessionable
      * Loads a user for the given login.
      *
      * @param string $login
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User
      *
+     * @throws \Exception Method is not implemented
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user with the given credentials was not found
      */
-    public function loadUserByLogin($login)
+    public function loadUserByLogin($login, array $prioritizedLanguages = [])
     {
         throw new \Exception('@todo: Implement.');
     }

--- a/eZ/Publish/Core/REST/Client/UserService.php
+++ b/eZ/Publish/Core/REST/Client/UserService.php
@@ -348,10 +348,13 @@ class UserService implements APIUserService, Sessionable
      * @param \eZ\Publish\API\Repository\Values\User\User $user
      * @param int $offset the start offset for paging
      * @param int $limit the number of user groups returned
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
+     *
+     * @throws \Exception Method is not implemented
      */
-    public function loadUserGroupsOfUser(User $user, $offset = 0, $limit = 25)
+    public function loadUserGroupsOfUser(User $user, $offset = 0, $limit = 25, array $prioritizedLanguages = [])
     {
         throw new \Exception('@todo: Implement.');
     }

--- a/eZ/Publish/Core/REST/Client/UserService.php
+++ b/eZ/Publish/Core/REST/Client/UserService.php
@@ -6,7 +6,6 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-
 namespace eZ\Publish\Core\REST\Client;
 
 use eZ\Publish\API\Repository\UserService as APIUserService;
@@ -104,13 +103,15 @@ class UserService implements APIUserService, Sessionable
      * Loads a user group for the given id.
      *
      * @param mixed $id
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup
      *
+     * @throws \Exception Method is not implemented
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a user group
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the user group with the given id was not found
      */
-    public function loadUserGroup($id)
+    public function loadUserGroup($id, array $prioritizedLanguages = [])
     {
         throw new \Exception('@todo: Implement.');
     }
@@ -216,7 +217,6 @@ class UserService implements APIUserService, Sessionable
      *
      * @deprecated since 5.3, use loadUser( $anonymousUserId ) instead
      *
-     * @uses loadUser()
      *
      * @return \eZ\Publish\API\Repository\Values\User\User
      */

--- a/eZ/Publish/Core/REST/Client/UserService.php
+++ b/eZ/Publish/Core/REST/Client/UserService.php
@@ -269,10 +269,13 @@ class UserService implements APIUserService, Sessionable
      * several users having same email in the past (by means of a configuration option).
      *
      * @param string $email
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User[]
+     *
+     * @throws \Exception Method is not implemented
      */
-    public function loadUsersByEmail($email)
+    public function loadUsersByEmail($email, array $prioritizedLanguages = [])
     {
         throw new \Exception('@todo: Implement.');
     }

--- a/eZ/Publish/Core/REST/Client/UserService.php
+++ b/eZ/Publish/Core/REST/Client/UserService.php
@@ -362,16 +362,22 @@ class UserService implements APIUserService, Sessionable
     /**
      * Loads the users of a user group.
      *
+     * @throws \Exception Method is not implemented
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the users or user group
      *
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
      * @param int $offset the start offset for paging
      * @param int $limit the number of users returned
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User[]
      */
-    public function loadUsersOfUserGroup(UserGroup $userGroup, $offset = 0, $limit = 25)
-    {
+    public function loadUsersOfUserGroup(
+        UserGroup $userGroup,
+        $offset = 0,
+        $limit = 25,
+        array $prioritizedLanguages = []
+    ) {
         throw new \Exception('@todo: Implement.');
     }
 

--- a/eZ/Publish/Core/REST/Client/UserService.php
+++ b/eZ/Publish/Core/REST/Client/UserService.php
@@ -122,12 +122,14 @@ class UserService implements APIUserService, Sessionable
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
      * @param int $offset the start offset for paging
      * @param int $limit the number of user groups returned
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
      *
+     * @throws \Exception Method is not implemented
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the user group
      */
-    public function loadSubUserGroups(UserGroup $userGroup, $offset = 0, $limit = 25)
+    public function loadSubUserGroups(UserGroup $userGroup, $offset = 0, $limit = 25, array $prioritizedLanguages = [])
     {
         throw new \Exception('@todo: Implement.');
     }

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -157,12 +157,13 @@ class UserService implements UserServiceInterface
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
      * @param int $offset the start offset for paging
      * @param int $limit the number of user groups returned
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the user group
      */
-    public function loadSubUserGroups(APIUserGroup $userGroup, $offset = 0, $limit = 25)
+    public function loadSubUserGroups(APIUserGroup $userGroup, $offset = 0, $limit = 25, array $prioritizedLanguages = [])
     {
         $locationService = $this->repository->getLocationService();
 
@@ -188,7 +189,8 @@ class UserService implements UserServiceInterface
         foreach ($searchResult->searchHits as $searchHit) {
             $subUserGroups[] = $this->buildDomainUserGroupObject(
                 $this->repository->getContentService()->internalLoadContent(
-                    $searchHit->valueObject->contentInfo->id
+                    $searchHit->valueObject->contentInfo->id,
+                    $prioritizedLanguages
                 )
             );
         }

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -548,13 +548,14 @@ class UserService implements UserServiceInterface
      *
      * @param string $login
      * @param string $password the plain password
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if credentials are invalid
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user with the given credentials was not found
      */
-    public function loadUserByCredentials($login, $password)
+    public function loadUserByCredentials($login, $password, array $prioritizedLanguages = [])
     {
         if (!is_string($login) || empty($login)) {
             throw new InvalidArgumentValue('login', $login);
@@ -579,7 +580,7 @@ class UserService implements UserServiceInterface
             throw new NotFoundException('user', $login);
         }
 
-        return $this->buildDomainUserObject($spiUser);
+        return $this->buildDomainUserObject($spiUser, null, $prioritizedLanguages);
     }
 
     /**

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -137,15 +137,16 @@ class UserService implements UserServiceInterface
      * Loads a user group for the given id.
      *
      * @param mixed $id
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a user group
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the user group with the given id was not found
      */
-    public function loadUserGroup($id)
+    public function loadUserGroup($id, array $prioritizedLanguages = [])
     {
-        $content = $this->repository->getContentService()->loadContent($id);
+        $content = $this->repository->getContentService()->loadContent($id, $prioritizedLanguages);
 
         return $this->buildDomainUserGroupObject($content);
     }

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -490,15 +490,16 @@ class UserService implements UserServiceInterface
      * Loads a user.
      *
      * @param mixed $userId
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user with the given id was not found
      */
-    public function loadUser($userId)
+    public function loadUser($userId, array $prioritizedLanguages = [])
     {
         /** @var \eZ\Publish\API\Repository\Values\Content\Content $content */
-        $content = $this->repository->getContentService()->internalLoadContent($userId);
+        $content = $this->repository->getContentService()->internalLoadContent($userId, $prioritizedLanguages);
         // Get spiUser value from Field Value
         foreach ($content->getFields() as $field) {
             if (!$field->value instanceof UserValue) {

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -588,12 +588,13 @@ class UserService implements UserServiceInterface
      * {@inheritdoc}
      *
      * @param string $login
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user with the given credentials was not found
      */
-    public function loadUserByLogin($login)
+    public function loadUserByLogin($login, array $prioritizedLanguages = [])
     {
         if (!is_string($login) || empty($login)) {
             throw new InvalidArgumentValue('login', $login);
@@ -601,7 +602,7 @@ class UserService implements UserServiceInterface
 
         $spiUser = $this->userHandler->loadByLogin($login);
 
-        return $this->buildDomainUserObject($spiUser);
+        return $this->buildDomainUserObject($spiUser, null, $prioritizedLanguages);
     }
 
     /**
@@ -1080,13 +1081,20 @@ class UserService implements UserServiceInterface
      *
      * @param \eZ\Publish\SPI\Persistence\User $spiUser
      * @param \eZ\Publish\API\Repository\Values\Content\Content|null $content
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User
      */
-    protected function buildDomainUserObject(SPIUser $spiUser, APIContent $content = null)
-    {
+    protected function buildDomainUserObject(
+        SPIUser $spiUser,
+        APIContent $content = null,
+        array $prioritizedLanguages = []
+    ) {
         if ($content === null) {
-            $content = $this->repository->getContentService()->internalLoadContent($spiUser->id);
+            $content = $this->repository->getContentService()->internalLoadContent(
+                $spiUser->id,
+                $prioritizedLanguages
+            );
         }
 
         return new User(

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -612,10 +612,11 @@ class UserService implements UserServiceInterface
      * {@inheritdoc}
      *
      * @param string $email
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User[]
      */
-    public function loadUsersByEmail($email)
+    public function loadUsersByEmail($email, array $prioritizedLanguages = [])
     {
         if (!is_string($email) || empty($email)) {
             throw new InvalidArgumentValue('email', $email);
@@ -623,7 +624,7 @@ class UserService implements UserServiceInterface
 
         $users = array();
         foreach ($this->userHandler->loadByEmail($email) as $spiUser) {
-            $users[] = $this->buildDomainUserObject($spiUser);
+            $users[] = $this->buildDomainUserObject($spiUser, null, $prioritizedLanguages);
         }
 
         return $users;

--- a/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
@@ -242,7 +242,13 @@ class UserServiceTest extends ServiceTest
             ),
             array(
                 'loadUserGroupsOfUser',
-                array($user, 1, 1),
+                array($user, 1, 1, array()),
+                array($userGroup),
+                0,
+            ),
+            array(
+                'loadUserGroupsOfUser',
+                array($user, 1, 1, array('eng-GB', 'eng-US')),
                 array($userGroup),
                 0,
             ),

--- a/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
@@ -150,7 +150,13 @@ class UserServiceTest extends ServiceTest
             ),
             array(
                 'loadUser',
-                array($userId),
+                array($userId, array()),
+                $user,
+                0,
+            ),
+            array(
+                'loadUser',
+                array($userId, array('eng-GB', 'eng-US')),
                 $user,
                 0,
             ),

--- a/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
@@ -168,7 +168,13 @@ class UserServiceTest extends ServiceTest
             ),
             array(
                 'loadUserByCredentials',
-                array('admin', 'with great power comes great responsibility'),
+                array('admin', 'with great power comes great responsibility', array()),
+                $user,
+                0,
+            ),
+            array(
+                'loadUserByCredentials',
+                array('admin', 'with great power comes great responsibility', array('eng-GB', 'eng-US')),
                 $user,
                 0,
             ),

--- a/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
@@ -103,7 +103,13 @@ class UserServiceTest extends ServiceTest
             ),
             array(
                 'loadSubUserGroups',
-                array($parentGroup, 1, 1),
+                array($parentGroup, 1, 1, array()),
+                array($userGroup),
+                0,
+            ),
+            array(
+                'loadSubUserGroups',
+                array($parentGroup, 1, 1, array('eng-GB', 'eng-US')),
                 array($userGroup),
                 0,
             ),

--- a/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
@@ -192,7 +192,13 @@ class UserServiceTest extends ServiceTest
             ),
             array(
                 'loadUsersByEmail',
-                array('admin@ez.no'),
+                array('admin@ez.no', array()),
+                array($user),
+                0,
+            ),
+            array(
+                'loadUsersByEmail',
+                array('admin@ez.no', array('eng-GB', 'eng-US')),
                 array($user),
                 0,
             ),

--- a/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
@@ -174,7 +174,13 @@ class UserServiceTest extends ServiceTest
             ),
             array(
                 'loadUserByLogin',
-                array('admin'),
+                array('admin', array()),
+                $user,
+                0,
+            ),
+            array(
+                'loadUserByLogin',
+                array('admin', array('eng-GB', 'eng-US')),
                 $user,
                 0,
             ),

--- a/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
@@ -254,7 +254,13 @@ class UserServiceTest extends ServiceTest
             ),
             array(
                 'loadUsersOfUserGroup',
-                array($userGroup, 1, 1),
+                array($userGroup, 1, 1, array()),
+                array($user),
+                0,
+            ),
+            array(
+                'loadUsersOfUserGroup',
+                array($userGroup, 1, 1, array('eng-GB', 'eng-US')),
                 array($user),
                 0,
             ),

--- a/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
@@ -91,7 +91,13 @@ class UserServiceTest extends ServiceTest
             ),
             array(
                 'loadUserGroup',
-                array($userGroupId),
+                array($userGroupId, array()),
+                $userGroup,
+                0,
+            ),
+            array(
+                'loadUserGroup',
+                array($userGroupId, array('eng-GB', 'eng-US')),
                 $userGroup,
                 0,
             ),

--- a/eZ/Publish/Core/SignalSlot/UserService.php
+++ b/eZ/Publish/Core/SignalSlot/UserService.php
@@ -264,15 +264,16 @@ class UserService implements UserServiceInterface
      *
      * @param string $login
      * @param string $password the plain password
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if credentials are invalid
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user with the given credentials was not found
      */
-    public function loadUserByCredentials($login, $password)
+    public function loadUserByCredentials($login, $password, array $prioritizedLanguages = [])
     {
-        return $this->service->loadUserByCredentials($login, $password);
+        return $this->service->loadUserByCredentials($login, $password, $prioritizedLanguages);
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/UserService.php
+++ b/eZ/Publish/Core/SignalSlot/UserService.php
@@ -299,12 +299,13 @@ class UserService implements UserServiceInterface
      * {@inheritdoc}
      *
      * @param string $email
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User[]
      */
-    public function loadUsersByEmail($email)
+    public function loadUsersByEmail($email, array $prioritizedLanguages = [])
     {
-        return $this->service->loadUsersByEmail($email);
+        return $this->service->loadUsersByEmail($email, $prioritizedLanguages);
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/UserService.php
+++ b/eZ/Publish/Core/SignalSlot/UserService.php
@@ -232,14 +232,15 @@ class UserService implements UserServiceInterface
      * Loads a user.
      *
      * @param mixed $userId
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user with the given id was not found
      */
-    public function loadUser($userId)
+    public function loadUser($userId, array $prioritizedLanguages = [])
     {
-        return $this->service->loadUser($userId);
+        return $this->service->loadUser($userId, $prioritizedLanguages);
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/UserService.php
+++ b/eZ/Publish/Core/SignalSlot/UserService.php
@@ -112,14 +112,15 @@ class UserService implements UserServiceInterface
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
      * @param int $offset the start offset for paging
      * @param int $limit the number of user groups returned
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to read the user group
      */
-    public function loadSubUserGroups(UserGroup $userGroup, $offset = 0, $limit = 25)
+    public function loadSubUserGroups(UserGroup $userGroup, $offset = 0, $limit = 25, array $prioritizedLanguages = [])
     {
-        return $this->service->loadSubUserGroups($userGroup, $offset, $limit);
+        return $this->service->loadSubUserGroups($userGroup, $offset, $limit, $prioritizedLanguages);
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/UserService.php
+++ b/eZ/Publish/Core/SignalSlot/UserService.php
@@ -281,14 +281,15 @@ class UserService implements UserServiceInterface
      * {@inheritdoc}
      *
      * @param string $login
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if a user with the given credentials was not found
      */
-    public function loadUserByLogin($login)
+    public function loadUserByLogin($login, array $prioritizedLanguages = [])
     {
-        return $this->service->loadUserByLogin($login);
+        return $this->service->loadUserByLogin($login, $prioritizedLanguages);
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/UserService.php
+++ b/eZ/Publish/Core/SignalSlot/UserService.php
@@ -94,15 +94,16 @@ class UserService implements UserServiceInterface
      * Loads a user group for the given id.
      *
      * @param mixed $id
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to create a user group
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the user group with the given id was not found
      */
-    public function loadUserGroup($id)
+    public function loadUserGroup($id, array $prioritizedLanguages = [])
     {
-        return $this->service->loadUserGroup($id);
+        return $this->service->loadUserGroup($id, $prioritizedLanguages);
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/UserService.php
+++ b/eZ/Publish/Core/SignalSlot/UserService.php
@@ -416,12 +416,13 @@ class UserService implements UserServiceInterface
      * @param \eZ\Publish\API\Repository\Values\User\User $user
      * @param int $offset the start offset for paging
      * @param int $limit the number of user groups returned
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\UserGroup[]
      */
-    public function loadUserGroupsOfUser(User $user, $offset = 0, $limit = 25)
+    public function loadUserGroupsOfUser(User $user, $offset = 0, $limit = 25, array $prioritizedLanguages = [])
     {
-        return $this->service->loadUserGroupsOfUser($user, $offset, $limit);
+        return $this->service->loadUserGroupsOfUser($user, $offset, $limit, $prioritizedLanguages);
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/UserService.php
+++ b/eZ/Publish/Core/SignalSlot/UserService.php
@@ -433,12 +433,22 @@ class UserService implements UserServiceInterface
      * @param \eZ\Publish\API\Repository\Values\User\UserGroup $userGroup
      * @param int $offset the start offset for paging
      * @param int $limit the number of users returned
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @return \eZ\Publish\API\Repository\Values\User\User[]
      */
-    public function loadUsersOfUserGroup(UserGroup $userGroup, $offset = 0, $limit = 25)
-    {
-        return $this->service->loadUsersOfUserGroup($userGroup, $offset, $limit);
+    public function loadUsersOfUserGroup(
+        UserGroup $userGroup,
+        $offset = 0,
+        $limit = 25,
+        array $prioritizedLanguages = []
+    ) {
+        return $this->service->loadUsersOfUserGroup(
+            $userGroup,
+            $offset,
+            $limit,
+            $prioritizedLanguages
+        );
     }
 
     /**


### PR DESCRIPTION
Implements [EZP-27509](https://jira.ez.no/browse/EZP-27509)
----

This PR adds prioritized languages list support to the `UserService::load*` methods.

**TODO**:
- [x] Add prioritized languages list to `loadUserGroup` + add an integration test.
- [x] Add prioritized languages list to `loadSubUserGroups` + add an integration test.
- [x] Add prioritized languages list to `loadUser` + add an integration test.
- [x] Add prioritized languages list to `loadUserByCredentials` + add an integration test.
- [x] Add prioritized languages list to `loadUserByLogin` + add an integration test.
- [x] Add prioritized languages list to `loadUsersByEmail` + add an integration test.
- [x] Add prioritized languages list to `loadUserGroupsOfUser` + add an integration test.
- [x] Add prioritized languages list to `loadUsersOfUserGroup` + add an integration test.
- ~Add prioritized languages list to `loadAnonymousUser` + add an integration test.~ // deprecated