### PR TITLE
EZP-27562 escaping square brackets chars in urls

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/FieldType/RichText/Converter/Html5Input.php
+++ b/eZ/Bundle/EzPublishCoreBundle/FieldType/RichText/Converter/Html5Input.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\FieldType\RichText\Converter;
 
+use DOMDocument;
 use eZ\Publish\Core\FieldType\RichText\Converter\Xslt as XsltConverter;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 
@@ -21,5 +22,28 @@ class Html5Input extends XsltConverter
         $customStylesheets = $configResolver->getParameter('fieldtypes.ezrichtext.input_custom_xsl');
         $customStylesheets = $customStylesheets ?: array();
         parent::__construct($stylesheet, $customStylesheets);
+    }
+
+    /**
+     * Method checks if document contains any links with '[' or ']' sign an replaces it to its html entities version.
+     *
+     * @param DOMDocument $document
+     *
+     * @return DOMDocument
+     */
+    public function convert(DOMDocument $document)
+    {
+        // EZP-27562 - links containing [ or ] sign results in xml validation error
+        foreach ($document->getElementsByTagName('a') as $link) {
+            $href = $link->getAttribute('href');
+            if ($href !== '') {
+                $href = str_replace('[', '%5B', $href);
+                $href = str_replace(']', '%5D', $href);
+
+                $link->setAttribute('href', $href);
+            }
+        }
+
+        return parent::convert($document);
     }
 }


### PR DESCRIPTION
This is a fix for https://jira.ez.no/browse/EZP-27562

## Description
XML being submitted from rich text editor is [validated](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/FieldType/RichText/Validator.php#L93) by [relaxNGValidate](http://php.net/manual/en/domdocument.relaxngvalidate.php) method. It is using a [set of rules](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/docbook.rng).

Passing xml with url containing `[` or `]` (for example `http://test.com/[test]`) results in validation error. The rule which is causing this is [anyURI](https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/FieldType/RichText/Resources/schemas/docbook/docbook.rng#L206) 

This PR fixes it in not the most beautiful way: by using `str_replace` on both `[` and `]`

I was thinking about using methods like `urlencode`, `htmlspecialchars` etc but what we deal with is  full url, so running any of the these methods will encode whole string, including `:` and `/` from `http://`.

From the other hand there are methods like [parse_url](http://php.net/manual/en/function.parse-url.php) and [http_build_url](http://php.net/manual/pl/function.http-build-url.php) but latter requires installing php extension.

So this solution seems to be simplest of ones which are coming to my mind.
Or any of you have a better idea?
