### PR TITLE
EZP-27608: [API] loadLocations() does not filter on permissions

### DIFF
--- a/eZ/Publish/API/Repository/Tests/LocationServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceAuthorizationTest.php
@@ -115,6 +115,35 @@ class LocationServiceAuthorizationTest extends BaseTest
     }
 
     /**
+     * Test for the loadLocations() method.
+     *
+     * @see \eZ\Publish\API\Repository\LocationService::loadLocations()
+     * @depends eZ\Publish\API\Repository\Tests\LocationServiceTest::testLoadLocations
+     */
+    public function testLoadLocationsNoAccess()
+    {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        $editorsGroupId = $this->generateId('group', 13);
+        $editorGroupContentInfo = $repository->getContentService()->loadContentInfo($editorsGroupId);
+
+        // this should return one location for admin
+        $locations = $locationService->loadLocations($editorGroupContentInfo);
+        $this->assertCount(1, $locations);
+        $this->assertInstanceOf(Location::class, $locations[0]);
+
+        $user = $this->createUserVersion1();
+
+        // Set current user to newly created user
+        $repository->getPermissionResolver()->setCurrentUserReference($user);
+
+        // This should return empty array given current user does not have read access
+        $locations = $locationService->loadLocations($editorGroupContentInfo);
+        $this->assertEmpty($locations);
+    }
+
+    /**
      * Test for the updateLocation() method.
      *
      * @see \eZ\Publish\API\Repository\LocationService::updateLocation()

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -231,19 +231,7 @@ class LocationService implements LocationServiceInterface
     }
 
     /**
-     * Loads the locations for the given content object.
-     *
-     * If a $rootLocation is given, only locations that belong to this location are returned.
-     * The location list is also filtered by permissions on reading locations.
-     *
-     * @todo permissions check is missing
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if there is no published version yet
-     *
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     * @param \eZ\Publish\API\Repository\Values\Content\Location $rootLocation
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\Location[] An array of {@link Location}
+     * {@inheritdoc}
      */
     public function loadLocations(ContentInfo $contentInfo, APILocation $rootLocation = null)
     {
@@ -256,9 +244,12 @@ class LocationService implements LocationServiceInterface
             $rootLocation !== null ? $rootLocation->id : null
         );
 
-        $locations = array();
+        $locations = [];
         foreach ($spiLocations as $spiLocation) {
-            $locations[] = $this->domainMapper->buildLocationDomainObject($spiLocation);
+            $location = $this->domainMapper->buildLocationDomainObject($spiLocation);
+            if ($this->repository->canUser('content', 'read', $location->getContentInfo(), $location)) {
+                $locations[] = $location;
+            }
         }
 
         return $locations;


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-27608

API docs actually says the returned locations should be filtered, so treating this as bug.


Todo:
- [x] Add integration test coverage