### PR TITLE
Fix EZP-21753: Wrong language_id value in ezcontentobject_name table …

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -1523,7 +1523,7 @@ class DoctrineDatabase extends Gateway
             $q->bindValue($version, null, \PDO::PARAM_INT)
         )->set(
             $this->dbHandler->quoteColumn('language_id'),
-            $q->bindValue($language->id, null, \PDO::PARAM_INT)
+            '(' . $this->getLanguageQuery()->getQuery() . ')'
         )->set(
             $this->dbHandler->quoteColumn('content_translation'),
             $q->bindValue($language->languageCode)
@@ -1534,7 +1534,54 @@ class DoctrineDatabase extends Gateway
             $this->dbHandler->quoteColumn('name'),
             $q->bindValue($name)
         );
+        $q->bindValue($language->id, ':languageId', \PDO::PARAM_INT);
+        $q->bindValue($contentId, ':contentId', \PDO::PARAM_INT);
         $q->prepare()->execute();
+    }
+
+    /**
+     * Returns a language sub select query for setName.
+     *
+     * @return \eZ\Publish\Core\Persistence\Database\SelectQuery
+     */
+    private function getLanguageQuery()
+    {
+        $languageQuery = $this->dbHandler->createSelectQuery();
+        $languageQuery
+            ->select(
+                $languageQuery->expr->searchedCase(
+                    [
+                        $languageQuery->expr->lAnd(
+                            $languageQuery->expr->eq(
+                                $this->dbHandler->quoteColumn('initial_language_id'),
+                                ':languageId'
+                            ),
+                            // wrap bitwise check into another "neq" to provide cross-DBMS compatibility
+                            $languageQuery->expr->neq(
+                                $languageQuery->expr->bitAnd(
+                                    $this->dbHandler->quoteColumn('language_mask'),
+                                    ':languageId'
+                                ),
+                                0
+                            )
+                        ),
+                        $languageQuery->expr->bitOr(
+                            ':languageId',
+                            1
+                        ),
+                    ],
+                    ':languageId'
+                )
+            )
+            ->from('ezcontentobject')
+            ->where(
+                $languageQuery->expr->eq(
+                    'id',
+                    ':contentId'
+                )
+            );
+
+        return $languageQuery;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Gateway/DoctrineDatabaseTest.php
@@ -1201,21 +1201,26 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
      */
     public function testSetName()
     {
-        $beforeCount = array(
-            'all' => $this->countContentNames(),
-            'this' => $this->countContentNames(14),
+        $this->insertDatabaseFixture(
+            __DIR__ . '/../_fixtures/contentobjects.php'
         );
 
         $gateway = $this->getDatabaseGateway();
 
         $gateway->setName(14, 2, 'Hello world!', 'eng-GB');
 
+        $query = $this->getDatabaseHandler()->createSelectQuery();
         $this->assertQueryResult(
             array(array('eng-GB', 2, 14, 4, 'Hello world!', 'eng-GB')),
-            $this->getDatabaseHandler()
-                ->createSelectQuery()
-                ->select('*')
+            $query->select('*')
                 ->from('ezcontentobject_name')
+                ->where(
+                    $query->expr->lAnd(
+                        $query->expr->eq('contentobject_id', 14),
+                        $query->expr->eq('content_version', 2),
+                        $query->expr->eq('content_translation', $query->bindValue('eng-GB'))
+                    )
+                )
         );
     }
 


### PR DESCRIPTION
…after updating a always available content

JIRA: https://jira.ez.no/browse/EZP-21753