### PR TITLE
EZP-27665: [PostgreSQL] Users with uppercase characters in login are not authorized

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -269,9 +269,11 @@ abstract class BaseTest extends TestCase
     /**
      * Create a user in editor user group.
      *
+     * @param string $login
+     *
      * @return \eZ\Publish\API\Repository\Values\User\User
      */
-    protected function createUserVersion1()
+    protected function createUserVersion1($login = 'user')
     {
         $repository = $this->getRepository();
 
@@ -283,8 +285,8 @@ abstract class BaseTest extends TestCase
 
         // Instantiate a create struct with mandatory properties
         $userCreate = $userService->newUserCreateStruct(
-            'user',
-            'user@example.com',
+            $login,
+            "{$login}@example.com",
             'secret',
             'eng-US'
         );

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -1197,10 +1197,10 @@ class UserServiceTest extends BaseTest
         $userService = $repository->getUserService();
 
         /* BEGIN: Use Case */
-        $user = $this->createUserVersion1();
+        $user = $this->createUserVersion1('User');
 
         // Load the newly created user
-        $userReloaded = $userService->loadUserByLogin('user');
+        $userReloaded = $userService->loadUserByLogin('User');
         /* END: Use Case */
 
         $this->assertPropertiesCorrect(

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
@@ -177,7 +177,7 @@ class DoctrineDatabase extends Gateway
             )
         )->where(
             $query->expr->eq(
-                $this->handler->quoteColumn('login', 'ezuser'),
+                $query->expr->lower($this->handler->quoteColumn('login', 'ezuser')),
                 // Index is case in-sensitive, on some db's lowercase, so we lowercase $login
                 $query->bindValue(mb_strtolower($login, 'UTF-8'), null, \PDO::PARAM_STR)
             )


### PR DESCRIPTION
Fixes [EZP-27665](https://jira.ez.no/browse/EZP-27665)
----
This PR is a follow-up on #1682 and [EZP-19123](https://jira.ez.no/browse/EZP-19123) for PostgreSQL database.

While the fix applied there to the PostgreSQL schema:
`CREATE UNIQUE INDEX ezuser_login ON ezuser USING btree ((lower(login)));`
covers disallowing inserting login that differs only by case from an existing one, it doesn't solve querying for that login.

According to this doc:
https://www.postgresql.org/docs/current/static/indexes-expressional.html
to fully utilize the index mentioned above, we also need to use it in the query.

Ref.: [failing PostgreSQL integration test on Travis](https://travis-ci.org/ezsystems/ezpublish-kernel/jobs/253254086#L831).

Side note: SQLite is also case sensitive, so test also fails for it.

The solution is to surround [column in this query](https://github.com/ezsystems/ezpublish-kernel/blob/v6.7.4/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php#L180) with the database function `lower` (we already have our own wrapper for this, so it's cross-DBMS).

It shouldn't be a BC break because we already query there against lowercase `$login` value.
