### PR TITLE
[PostgreSQL] Fix sequence naming for External Storage Gateways

### DIFF
--- a/eZ/Publish/SPI/FieldType/StorageGateway.php
+++ b/eZ/Publish/SPI/FieldType/StorageGateway.php
@@ -17,7 +17,7 @@ abstract class StorageGateway
      * Get sequence name bound to database table and column.
      *
      * Note: must be compatible with:
-     * @see \eZ\Publish\Core\Persistence\Doctrine\ConnectionHandler\PostgresConnectionHandler::quoteIdentifier
+     * @see \eZ\Publish\Core\Persistence\Doctrine\ConnectionHandler\PostgresConnectionHandler::getSequenceName
      *
      * @param string $table
      * @param string $column
@@ -25,7 +25,6 @@ abstract class StorageGateway
      */
     protected function getSequenceName($table, $column)
     {
-        // @todo: change to <table>_<column>_seq when merged into 7.0
-        return sprintf('%s_s', $table);
+        return sprintf('%s_%s_seq', $table, $column);
     }
 }


### PR DESCRIPTION
This PR is a follow-up on #1906 and #1985 fixing PostgreSQL sequence names for `7.0`.

Notes for reviewers:
- If DBMS driver wrapper (e.g. Doctrine `MySqlPlatform`) does not support sequences, sequence name is ignored, so this is fine for MySQL.
- I couldn't reuse `eZ\Publish\Core\Persistence\Doctrine\ConnectionHandler\PostgresConnectionHandler::getSequenceName` because we aim to deprecate entire namespace and eventually remove it once we create Improved Storage Engine. Maybe then we'll find a better place for this method.

// side: @andrerom this bugfix is so simple I didn't feel a need for an issue, but I could create one if you wish :)