### PR TITLE
EZP-27666: Services should depend upon UrlRedecoratorInterface instead of UrlRedecorator

### DIFF
--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
@@ -10,7 +10,7 @@ namespace eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway;
 
 use Doctrine\DBAL\Connection;
 use DOMDocument;
-use eZ\Publish\Core\IO\UrlRedecorator;
+use eZ\Publish\Core\IO\UrlRedecoratorInterface;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway;
 use PDO;
@@ -41,11 +41,11 @@ class DoctrineStorage extends Gateway
     ];
 
     /**
-     * @var \eZ\Publish\Core\IO\UrlRedecorator
+     * @var \eZ\Publish\Core\IO\UrlRedecoratorInterface
      */
     private $redecorator;
 
-    public function __construct(UrlRedecorator $redecorator, Connection $connection)
+    public function __construct(UrlRedecoratorInterface $redecorator, Connection $connection)
     {
         $this->redecorator = $redecorator;
         $this->connection = $connection;

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/LegacyStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/LegacyStorage.php
@@ -8,7 +8,7 @@
  */
 namespace eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway;
 
-use eZ\Publish\Core\IO\UrlRedecorator;
+use eZ\Publish\Core\IO\UrlRedecoratorInterface;
 use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway;
@@ -37,11 +37,11 @@ class LegacyStorage extends Gateway
     ];
 
     /**
-     * @var \eZ\Publish\Core\IO\UrlRedecorator
+     * @var \eZ\Publish\Core\IO\UrlRedecoratorInterface
      */
     private $redecorator;
 
-    public function __construct(UrlRedecorator $redecorator, DatabaseHandler $dbHandler)
+    public function __construct(UrlRedecoratorInterface $redecorator, DatabaseHandler $dbHandler)
     {
         @trigger_error(
             sprintf('%s is deprecated, use %s instead', self::class, DoctrineStorage::class),

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
@@ -19,10 +19,10 @@ use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 
 class ImageConverter implements Converter
 {
-    /** @var IOServiceInterface */
+    /** @var \eZ\Publish\Core\IO\IOServiceInterface */
     private $imageIoService;
 
-    /** @var UrlRedecoratorInterface */
+    /** @var \eZ\Publish\Core\IO\UrlRedecoratorInterface */
     private $urlRedecorator;
 
     public function __construct(IOServiceInterface $imageIoService, UrlRedecoratorInterface $urlRedecorator)

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
@@ -9,7 +9,7 @@
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 
 use eZ\Publish\Core\IO\IOServiceInterface;
-use eZ\Publish\Core\IO\UrlRedecorator;
+use eZ\Publish\Core\IO\UrlRedecoratorInterface;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
@@ -22,10 +22,10 @@ class ImageConverter implements Converter
     /** @var IOServiceInterface */
     private $imageIoService;
 
-    /** @var UrlRedecorator */
+    /** @var UrlRedecoratorInterface */
     private $urlRedecorator;
 
-    public function __construct(IOServiceInterface $imageIoService, UrlRedecorator $urlRedecorator)
+    public function __construct(IOServiceInterface $imageIoService, UrlRedecoratorInterface $urlRedecorator)
     {
         $this->imageIoService = $imageIoService;
         $this->urlRedecorator = $urlRedecorator;

--- a/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
@@ -76,9 +76,9 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
         $fieldType = new FieldType\Image\Type();
         $fieldType->setTransformationProcessor($this->getTransformationProcessor());
 
-        $urlRedecorator = self::$container->get('ezpublish.core.io.image_fieldtype.legacy_url_redecorator');
-        /** @var \eZ\Publish\Core\IO\UrlRedecorator $urlRedecorator */
         $this->ioService = self::$container->get('ezpublish.fieldType.ezimage.io_service');
+        /** @var \eZ\Publish\Core\IO\UrlRedecoratorInterface $urlRedecorator */
+        $urlRedecorator = self::$container->get('ezpublish.core.io.image_fieldtype.legacy_url_redecorator');
 
         return $this->getHandler(
             'ezimage',


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27666

# Description:

This PR change a type hints from `eZ\Publish\Core\IO\UrlRedecorator` into `eZ\Publish\Core\IO\UrlRedecoratorInterface` in the following services:
* `eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\ImageConverter`
* `eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway\DoctrineStorage`
* `eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway\LegacyStorage`
