### PR TITLE
EZP-27097: Can't copy objects to an authorized location limited by policies

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseContentServiceTest.php
@@ -325,4 +325,49 @@ abstract class BaseContentServiceTest extends BaseTest
 
         return $contentVersion2;
     }
+
+    /**
+     * Create Content Draft with custom field values and generated remoteId.
+     *
+     * @param string $contentTypeIdentifier
+     * @param int $parentLocationId
+     * @param array $fieldValues map of <code>['fieldIdentifier' => 'field value']</code>
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content Content Draft
+     */
+    protected function createContentDraft(
+        $contentTypeIdentifier,
+        $parentLocationId,
+        array $fieldValues
+    ) {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+        $contentTypeService = $repository->getContentTypeService();
+        $locationService = $repository->getLocationService();
+
+        // Load content type
+        $contentType = $contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
+
+        // Prepare new Content Object
+        $contentCreateStruct = $contentService->newContentCreateStruct($contentType, 'eng-US');
+
+        foreach ($fieldValues as $fieldIdentifier => $fieldValue) {
+            $contentCreateStruct->setField($fieldIdentifier, $fieldValue);
+        }
+
+        $contentCreateStruct->sectionId = $this->generateId('section', 1);
+        $contentCreateStruct->alwaysAvailable = true;
+
+        // Prepare Location
+        $locationCreateStruct = $locationService->newLocationCreateStruct(
+            $this->generateId('location', $parentLocationId)
+        );
+        // Create a draft
+        $contentDraft = $contentService->createContent(
+            $contentCreateStruct,
+            [$locationCreateStruct]
+        );
+
+        return $contentDraft;
+    }
 }

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1615,14 +1615,17 @@ class ContentService implements ContentServiceInterface
      */
     public function copyContent(ContentInfo $contentInfo, LocationCreateStruct $destinationLocationCreateStruct, APIVersionInfo $versionInfo = null)
     {
-        if (!$this->repository->canUser('content', 'create', $contentInfo, $destinationLocationCreateStruct)) {
+        $destinationLocation = $this->repository->getLocationService()->loadLocation(
+            $destinationLocationCreateStruct->parentLocationId
+        );
+        if (!$this->repository->canUser('content', 'create', $contentInfo, [$destinationLocation])) {
             throw new UnauthorizedException(
                 'content',
                 'create',
-                array(
+                [
                     'parentLocationId' => $destinationLocationCreateStruct->parentLocationId,
                     'sectionId' => $contentInfo->sectionId,
-                )
+                ]
             );
         }
 

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -5246,6 +5246,21 @@ class ContentTest extends BaseServiceMockTest
         $contentService = $this->getPartlyMockedContentService(array('internalLoadContentInfo'));
         $contentInfo = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
         $locationCreateStruct = new LocationCreateStruct();
+        $location = new Location(['id' => $locationCreateStruct->parentLocationId]);
+        $locationServiceMock = $this->getLocationServiceMock();
+
+        $repository->expects($this->once())
+            ->method('getLocationService')
+            ->will($this->returnValue($locationServiceMock))
+        ;
+
+        $locationServiceMock->expects($this->once())
+            ->method('loadLocation')
+            ->with(
+                $locationCreateStruct->parentLocationId
+            )
+            ->will($this->returnValue($location))
+        ;
 
         $contentInfo->expects($this->any())
             ->method('__get')
@@ -5258,7 +5273,7 @@ class ContentTest extends BaseServiceMockTest
                 'content',
                 'create',
                 $contentInfo,
-                $locationCreateStruct
+                [$location]
             )
             ->will($this->returnValue(false));
 
@@ -5280,10 +5295,17 @@ class ContentTest extends BaseServiceMockTest
         $locationServiceMock = $this->getLocationServiceMock();
         $contentInfoMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
         $locationCreateStruct = new LocationCreateStruct();
+        $location = new Location(['id' => $locationCreateStruct->parentLocationId]);
 
-        $repositoryMock->expects($this->exactly(2))
+        $repositoryMock->expects($this->exactly(3))
             ->method('getLocationService')
             ->will($this->returnValue($locationServiceMock));
+
+        $locationServiceMock->expects($this->once())
+            ->method('loadLocation')
+            ->with($locationCreateStruct->parentLocationId)
+            ->will($this->returnValue($location))
+        ;
 
         $contentInfoMock->expects($this->any())
             ->method('__get')
@@ -5317,7 +5339,7 @@ class ContentTest extends BaseServiceMockTest
                 'content',
                 'create',
                 $contentInfoMock,
-                $locationCreateStruct
+                [$location]
             )
             ->will($this->returnValue(true));
 
@@ -5376,10 +5398,17 @@ class ContentTest extends BaseServiceMockTest
         $locationServiceMock = $this->getLocationServiceMock();
         $contentInfoMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
         $locationCreateStruct = new LocationCreateStruct();
+        $location = new Location(['id' => $locationCreateStruct->parentLocationId]);
 
-        $repositoryMock->expects($this->exactly(2))
+        $repositoryMock->expects($this->exactly(3))
             ->method('getLocationService')
             ->will($this->returnValue($locationServiceMock));
+
+        $locationServiceMock->expects($this->once())
+            ->method('loadLocation')
+            ->with($locationCreateStruct->parentLocationId)
+            ->will($this->returnValue($location))
+        ;
 
         $contentInfoMock->expects($this->any())
             ->method('__get')
@@ -5413,7 +5442,7 @@ class ContentTest extends BaseServiceMockTest
                 'content',
                 'create',
                 $contentInfoMock,
-                $locationCreateStruct
+                [$location]
             )
             ->will($this->returnValue(true));
 
@@ -5474,6 +5503,20 @@ class ContentTest extends BaseServiceMockTest
         /** @var \PHPUnit_Framework_MockObject_MockObject $contentHandlerMock */
         $contentHandlerMock = $this->getPersistenceMock()->contentHandler();
         $locationCreateStruct = new LocationCreateStruct();
+        $location = new Location(['id' => $locationCreateStruct->parentLocationId]);
+        $locationServiceMock = $this->getLocationServiceMock();
+
+        $repositoryMock->expects($this->once())
+            ->method('getLocationService')
+            ->will($this->returnValue($locationServiceMock))
+        ;
+
+        $locationServiceMock->expects($this->once())
+            ->method('loadLocation')
+            ->with($locationCreateStruct->parentLocationId)
+            ->will($this->returnValue($location))
+        ;
+
         $contentInfoMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
         $contentInfoMock->expects($this->any())
             ->method('__get')
@@ -5490,7 +5533,7 @@ class ContentTest extends BaseServiceMockTest
                 'content',
                 'create',
                 $contentInfoMock,
-                $locationCreateStruct
+                [$location]
             )
             ->will($this->returnValue(true));
 


### PR DESCRIPTION
Fixes [EZP-27097](https://jira.ez.no/browse/EZP-27097)
----

User authorized by Node (Location) Limitation policy on content/create and content/publish is unable to copy content to that location.

- [x] Create integration test to prove bug exists in the API / permission layer.
- [x] Find the root cause and fix the bug.