### PR TITLE
Implement overlay Image filters

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayBaseLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayBaseLoader.php
@@ -16,22 +16,30 @@ class OverlayBaseLoader extends FilterLoaderWrapped
         if (!isset($options['opacity'], $options['startColor'], $options['endColor'], $options['linerClass'])) {
             throw new InvalidArgumentException('Missing one of required options');
         }
+        
+        $startOpacity = $endOpacity = $options['opacity'];
+        if (is_array($options['opacity'])) {
+            if (count($options['opacity']) < 2) {
+                throw new InvalidArgumentException('Opacity should contains 2 parameters or should be a string, array given');
+            }
+            list($startOpacity, $endOpacity) = $options['opacity'];
+        }
+
         $imageSize = $image->getSize();
         $palette = $image->palette();
 
         $startColor = $palette->color($options['startColor'], $options['opacity']);
         switch (true) {
-            case $options['endColor'] === $options['startColor']:
-                $endColor = $startColor;
-                break;
             case strpos($options['endColor'], '+') === 0:
-                $endColor = $startColor->lighten(str_replace('+', '', $options['endColor']));
+                $endColor = $palette->color($options['endColor'], $endOpacity)
+                    ->lighten(str_replace('+', '', $options['endColor']));
                 break;
             case strpos($options['endColor'], '-') === 0:
-                $endColor = $startColor->darken(str_replace('-', '', $options['endColor']));
+                $endColor = $palette->color($options['endColor'], $endOpacity)
+                    ->darken(str_replace('-', '', $options['endColor']));
                 break;
             default:
-                $endColor = $palette->color($options['endColor'], $options['opacity']);
+                $endColor = $palette->color($options['endColor'], $endOpacity);
                 break;
         }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayBaseLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayBaseLoader.php
@@ -16,7 +16,7 @@ class OverlayBaseLoader extends FilterLoaderWrapped
         if (!isset($options['opacity'], $options['startColor'], $options['endColor'], $options['linerClass'])) {
             throw new InvalidArgumentException('Missing one of required options');
         }
-        
+
         $startOpacity = $endOpacity = $options['opacity'];
         if (is_array($options['opacity'])) {
             if (count($options['opacity']) < 2) {

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayBaseLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayBaseLoader.php
@@ -14,7 +14,7 @@ class OverlayBaseLoader extends FilterLoaderWrapped
     public function load(ImageInterface $image, array $options = array())
     {
         if (!isset($options['opacity'], $options['startColor'], $options['endColor'], $options['linerClass'])) {
-            throw new InvalidArgumentException('Missing liner option');
+            throw new InvalidArgumentException('Missing one of required options');
         }
         $imageSize = $image->getSize();
         $palette = $image->palette();

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayBaseLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayBaseLoader.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader;
+
+use Imagine\Filter\Basic\Fill;
+use Imagine\Image\Fill\Gradient\Horizontal;
+use Imagine\Image\Fill\Gradient\Vertical;
+use Imagine\Image\ImageInterface;
+use Imagine\Image\Point;
+use Imagine\Exception\InvalidArgumentException;
+
+class OverlayBaseLoader extends FilterLoaderWrapped
+{
+    public function load(ImageInterface $image, array $options = array())
+    {
+        if (!isset($options['opacity'], $options['startColor'], $options['endColor'], $options['linerClass'])) {
+            throw new InvalidArgumentException('Missing liner option');
+        }
+        $imageSize = $image->getSize();
+        $palette   = $image->palette();
+
+        $startColor = $palette->color($options['startColor'], $options['opacity']);
+        switch (true) {
+            case $options['endColor'] === $options['startColor']:
+                $endColor = $startColor;
+                break;
+            case strpos($options['endColor'], '+') === 0:
+                $endColor = $startColor->lighten(str_replace('+', '', $options['endColor']));
+                break;
+            case strpos($options['endColor'], '-') === 0:
+                $endColor = $startColor->darken(str_replace('-', '', $options['endColor']));
+                break;
+            default:
+                $endColor = $palette->color($options['endColor'], $options['opacity']);
+                break;
+        }
+
+        if ($options['linerClass'] === Horizontal::class) {
+            $linerSize = $imageSize->getWidth();
+        } else {
+            $linerSize = $imageSize->getHeight();
+        }
+
+        $overlay = $image->copy();
+        /** @var Horizontal|Vertical $liner */
+        $liner   = new $options['linerClass']($linerSize, $startColor, $endColor);
+        $filter  = new Fill($liner);
+        $overlay = $filter->apply($overlay);
+
+        return $image->paste($overlay, new Point(0, 0));
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayBaseLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayBaseLoader.php
@@ -17,7 +17,7 @@ class OverlayBaseLoader extends FilterLoaderWrapped
             throw new InvalidArgumentException('Missing liner option');
         }
         $imageSize = $image->getSize();
-        $palette   = $image->palette();
+        $palette = $image->palette();
 
         $startColor = $palette->color($options['startColor'], $options['opacity']);
         switch (true) {
@@ -43,8 +43,8 @@ class OverlayBaseLoader extends FilterLoaderWrapped
 
         $overlay = $image->copy();
         /** @var Horizontal|Vertical $liner */
-        $liner   = new $options['linerClass']($linerSize, $startColor, $endColor);
-        $filter  = new Fill($liner);
+        $liner = new $options['linerClass']($linerSize, $startColor, $endColor);
+        $filter = new Fill($liner);
         $overlay = $filter->apply($overlay);
 
         return $image->paste($overlay, new Point(0, 0));

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayBaseLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayBaseLoader.php
@@ -22,7 +22,7 @@ class OverlayBaseLoader extends FilterLoaderWrapped
         $verticalLinerClass = Vertical::class;
         if (!\in_array($options['linerClass'], [$horizontalLinerClass, $verticalLinerClass], true)){
             throw new InvalidArgumentException(
-                'Unsuported the "linerClass" it should be "' . $horizontalLinerClass . '" or "'
+                'Unsupported the "linerClass" it should be "' . $horizontalLinerClass . '" or "'
                 . $verticalLinerClass . '"'
             );
         }
@@ -58,11 +58,11 @@ class OverlayBaseLoader extends FilterLoaderWrapped
         if ($options['linerClass'] === $horizontalLinerClass) {
             $imageWidth = $imageSize->getWidth();
             $liner = new Horizontal($imageWidth, $startColor, $endColor);
-            $overlay->crop($startPoint, new Box($imageWidth, 1));
+            $overlay->crop($startPoint, new Box($imageWidth, 1)); // crop overlay to 1px height
         } else {
             $imageHeight = $imageSize->getHeight();
             $liner = new Vertical($imageHeight, $startColor, $endColor);
-            $overlay->crop($startPoint, new Box(1, $imageHeight));
+            $overlay->crop($startPoint, new Box(1, $imageHeight)); // crop overlay to 1px width
         }
 
         $filler = new Fill($liner);

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayBaseLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayBaseLoader.php
@@ -22,7 +22,7 @@ class OverlayBaseLoader extends FilterLoaderWrapped
         $verticalLinerClass = Vertical::class;
         if (!\in_array($options['linerClass'], [$horizontalLinerClass, $verticalLinerClass], true)){
             throw new InvalidArgumentException(
-                'Unsupported the "linerClass" it should be "' . $horizontalLinerClass . '" or "'
+                'Unsupported "linerClass", expected: "' . $horizontalLinerClass . '" or "'
                 . $verticalLinerClass . '"'
             );
         }

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayBaseLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayBaseLoader.php
@@ -38,11 +38,11 @@ class OverlayBaseLoader extends FilterLoaderWrapped
         $palette = $image->palette();
         $startColor = $palette->color($options['startColor'], $options['opacity']);
         switch (true) {
-            case strpos($options['endColor'], '+') === 0:
+            case \is_string($options['endColor']) && strpos($options['endColor'], '+') === 0:
                 $endColor = $palette->color($options['endColor'], $endOpacity)
                     ->lighten(str_replace('+', '', $options['endColor']));
                 break;
-            case strpos($options['endColor'], '-') === 0:
+            case \is_string($options['endColor']) && strpos($options['endColor'], '-') === 0:
                 $endColor = $palette->color($options['endColor'], $endOpacity)
                     ->darken(str_replace('-', '', $options['endColor']));
                 break;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayGradientHorizontalLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayGradientHorizontalLoader.php
@@ -28,7 +28,7 @@ class OverlayGradientHorizontalLoader extends FilterLoaderWrapped
             'opacity' => $options[0],
             'startColor' => $options[1],
             'endColor' => $options[2],
-            'linerClass' => Horizontal::class
+            'linerClass' => Horizontal::class,
         ]);
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayGradientHorizontalLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayGradientHorizontalLoader.php
@@ -14,20 +14,20 @@ class OverlayGradientHorizontalLoader extends FilterLoaderWrapped
             throw new InvalidArgumentException('Missing opacity and/or colors option(s)');
         }
 
-        if (isset($options['opacity'])){
+        if (isset($options['opacity'])) {
             $options[0] = $options['opacity'];
         }
-        if (isset($options['start_color'])){
+        if (isset($options['start_color'])) {
             $options[1] = $options['start_color'];
         }
-        if (isset($options['end_color'])){
+        if (isset($options['end_color'])) {
             $options[2] = $options['end_color'];
         }
 
         return $this->innerLoader->load($image, [
-            'opacity'    => $options[0],
+            'opacity' => $options[0],
             'startColor' => $options[1],
-            'endColor'   => $options[2],
+            'endColor' => $options[2],
             'linerClass' => Horizontal::class
         ]);
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayGradientHorizontalLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayGradientHorizontalLoader.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader;
+
+use Imagine\Image\Fill\Gradient\Horizontal;
+use Imagine\Image\ImageInterface;
+use Imagine\Exception\InvalidArgumentException;
+
+class OverlayGradientHorizontalLoader extends FilterLoaderWrapped
+{
+    public function load(ImageInterface $image, array $options = array())
+    {
+        if (count($options) < 3) {
+            throw new InvalidArgumentException('Missing opacity and/or colors option(s)');
+        }
+
+        if (isset($options['opacity'])){
+            $options[0] = $options['opacity'];
+        }
+        if (isset($options['start_color'])){
+            $options[1] = $options['start_color'];
+        }
+        if (isset($options['end_color'])){
+            $options[2] = $options['end_color'];
+        }
+
+        return $this->innerLoader->load($image, [
+            'opacity'    => $options[0],
+            'startColor' => $options[1],
+            'endColor'   => $options[2],
+            'linerClass' => Horizontal::class
+        ]);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayGradientVerticalLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayGradientVerticalLoader.php
@@ -14,20 +14,20 @@ class OverlayGradientVerticalLoader extends FilterLoaderWrapped
             throw new InvalidArgumentException('Missing opacity and/or colors option(s)');
         }
 
-        if (isset($options['opacity'])){
+        if (isset($options['opacity'])) {
             $options[0] = $options['opacity'];
         }
-        if (isset($options['start_color'])){
+        if (isset($options['start_color'])) {
             $options[1] = $options['start_color'];
         }
-        if (isset($options['end_color'])){
+        if (isset($options['end_color'])) {
             $options[2] = $options['end_color'];
         }
 
         return $this->innerLoader->load($image, [
-            'opacity'    => $options[0],
+            'opacity' => $options[0],
             'startColor' => $options[1],
-            'endColor'   => $options[2],
+            'endColor' => $options[2],
             'linerClass' => Vertical::class
         ]);
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayGradientVerticalLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayGradientVerticalLoader.php
@@ -28,7 +28,7 @@ class OverlayGradientVerticalLoader extends FilterLoaderWrapped
             'opacity' => $options[0],
             'startColor' => $options[1],
             'endColor' => $options[2],
-            'linerClass' => Vertical::class
+            'linerClass' => Vertical::class,
         ]);
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayGradientVerticalLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayGradientVerticalLoader.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader;
+
+use Imagine\Image\Fill\Gradient\Vertical;
+use Imagine\Image\ImageInterface;
+use Imagine\Exception\InvalidArgumentException;
+
+class OverlayGradientVerticalLoader extends FilterLoaderWrapped
+{
+    public function load(ImageInterface $image, array $options = array())
+    {
+        if (count($options) < 3) {
+            throw new InvalidArgumentException('Missing opacity and/or colors option(s)');
+        }
+
+        if (isset($options['opacity'])){
+            $options[0] = $options['opacity'];
+        }
+        if (isset($options['start_color'])){
+            $options[1] = $options['start_color'];
+        }
+        if (isset($options['end_color'])){
+            $options[2] = $options['end_color'];
+        }
+
+        return $this->innerLoader->load($image, [
+            'opacity'    => $options[0],
+            'startColor' => $options[1],
+            'endColor'   => $options[2],
+            'linerClass' => Vertical::class
+        ]);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayLoader.php
@@ -13,17 +13,17 @@ class OverlayLoader extends FilterLoaderWrapped
         if (count($options) < 2) {
             throw new InvalidArgumentException('Missing opacity and/or color option(s)');
         }
-        if (isset($options['opacity'])){
+        if (isset($options['opacity'])) {
             $options[0] = $options['opacity'];
         }
-        if (isset($options['color'])){
+        if (isset($options['color'])) {
             $options[1] = $options['color'];
         }
 
         return $this->innerLoader->load($image, [
-            'opacity'    => $options[0],
+            'opacity' => $options[0],
             'startColor' => $options[1],
-            'endColor'   => $options[1],
+            'endColor' => $options[1],
             'linerClass' => Horizontal::class
         ]);
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayLoader.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader;
+
+use Imagine\Image\Fill\Gradient\Horizontal;
+use Imagine\Image\ImageInterface;
+use Imagine\Exception\InvalidArgumentException;
+
+class OverlayLoader extends FilterLoaderWrapped
+{
+    public function load(ImageInterface $image, array $options = array())
+    {
+        if (count($options) < 2) {
+            throw new InvalidArgumentException('Missing opacity and/or color option(s)');
+        }
+        if (isset($options['opacity'])){
+            $options[0] = $options['opacity'];
+        }
+        if (isset($options['color'])){
+            $options[1] = $options['color'];
+        }
+
+        return $this->innerLoader->load($image, [
+            'opacity'    => $options[0],
+            'startColor' => $options[1],
+            'endColor'   => $options[1],
+            'linerClass' => Horizontal::class
+        ]);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayLoader.php
@@ -24,7 +24,7 @@ class OverlayLoader extends FilterLoaderWrapped
             'opacity' => $options[0],
             'startColor' => $options[1],
             'endColor' => $options[1],
-            'linerClass' => Horizontal::class
+            'linerClass' => Horizontal::class,
         ]);
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/OverlayLoader.php
@@ -10,14 +10,16 @@ class OverlayLoader extends FilterLoaderWrapped
 {
     public function load(ImageInterface $image, array $options = array())
     {
-        if (count($options) < 2) {
+        if (\count($options) < 2) {
             throw new InvalidArgumentException('Missing opacity and/or color option(s)');
         }
-        if (isset($options['opacity'])) {
+        if (isset($options['opacity'], $options['color'])) {
             $options[0] = $options['opacity'];
-        }
-        if (isset($options['color'])) {
             $options[1] = $options['color'];
+        }
+
+        if (!isset($options[0], $options[1])) {
+            throw new InvalidArgumentException('Unsupported configuration');
         }
 
         return $this->innerLoader->load($image, [

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -19,7 +19,11 @@ parameters:
     ezpublish.image_alias.imagine.filter.loader.reduce_noise.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\ReduceNoiseFilterLoader
     ezpublish.image_alias.imagine.filter.loader.grayscale.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\GrayscaleFilterLoader
     ezpublish.image_alias.imagine.filter.loader.swirl.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\SwirlFilterLoader
-
+    ezpublish.image_alias.imagine.filter.overlay_base.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\OverlayBaseLoader
+    ezpublish.image_alias.imagine.filter.overlay.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\OverlayLoader
+    ezpublish.image_alias.imagine.filter.overlay_gradient_vertical.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\OverlayGradientVerticalLoader
+    ezpublish.image_alias.imagine.filter.overlay_gradient_horizontal.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\OverlayGradientHorizontalLoader
+    
     ezpublish.image_alias.imagine.filter.unsupported.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\UnsupportedFilter
     ezpublish.image_alias.imagine.filter.reduce_noise.imagick.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Imagick\ReduceNoiseFilter
     ezpublish.image_alias.imagine.filter.reduce_noise.gmagick.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Gmagick\ReduceNoiseFilter
@@ -194,7 +198,38 @@ services:
         public: false
         tags:
             - { name: liip_imagine.filter.loader, loader: "colorspace/gray" }
-
+    
+    ezpublish.image_alias.imagine.filter.loader.overlay_base:
+        class: "%ezpublish.image_alias.imagine.filter.loader.overlay_base.class%"
+        public: false
+    
+    ezpublish.image_alias.imagine.filter.overlay_base:
+        abstract: true
+        public: false
+        calls:
+           - [setInnerLoader, ["@ezpublish.image_alias.imagine.filter.loader.overlay_base"]]
+    
+    ezpublish.image_alias.imagine.filter.loader.overlay:
+        parent: ezpublish.image_alias.imagine.filter.overlay_base
+        class: "%ezpublish.image_alias.imagine.filter.loader.overlay.class%"
+        public: false
+        tags:
+            - { name: liip_imagine.filter.loader, loader: "overlay" }
+    
+    ezpublish.image_alias.imagine.filter.loader.overlay_gradient_horizontal:
+        parent: ezpublish.image_alias.imagine.filter.overlay_base
+        class: "%ezpublish.image_alias.imagine.filter.loader.overlay_gradient_horizontal.class%"
+        public: false
+        tags:
+            - { name: liip_imagine.filter.loader, loader: "overlay/gradienthorizontal" }
+    
+    ezpublish.image_alias.imagine.filter.loader.overlay_gradient_vertical:
+        parent: ezpublish.image_alias.imagine.filter.overlay_base
+        class: "%ezpublish.image_alias.imagine.filter.loader.overlay_gradient_vertical.class%"
+        public: false
+        tags:
+            - { name: liip_imagine.filter.loader, loader: "overlay/gradientvertical" }  
+    
     ezpublish.image_alias.variation_purger:
         # < platform 2015.05
         # alias: ezpublish.image_alias.variation_purger.legacy_storage_image_file

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -19,10 +19,10 @@ parameters:
     ezpublish.image_alias.imagine.filter.loader.reduce_noise.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\ReduceNoiseFilterLoader
     ezpublish.image_alias.imagine.filter.loader.grayscale.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\GrayscaleFilterLoader
     ezpublish.image_alias.imagine.filter.loader.swirl.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\SwirlFilterLoader
-    ezpublish.image_alias.imagine.filter.overlay_base.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\OverlayBaseLoader
-    ezpublish.image_alias.imagine.filter.overlay.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\OverlayLoader
-    ezpublish.image_alias.imagine.filter.overlay_gradient_vertical.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\OverlayGradientVerticalLoader
-    ezpublish.image_alias.imagine.filter.overlay_gradient_horizontal.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\OverlayGradientHorizontalLoader
+    ezpublish.image_alias.imagine.filter.loader.overlay_base.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\OverlayBaseLoader
+    ezpublish.image_alias.imagine.filter.loader.overlay.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\OverlayLoader
+    ezpublish.image_alias.imagine.filter.loader.overlay_gradient_vertical.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\OverlayGradientVerticalLoader
+    ezpublish.image_alias.imagine.filter.loader.overlay_gradient_horizontal.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\OverlayGradientHorizontalLoader
     
     ezpublish.image_alias.imagine.filter.unsupported.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\UnsupportedFilter
     ezpublish.image_alias.imagine.filter.reduce_noise.imagick.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Imagick\ReduceNoiseFilter

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayBaseLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayBaseLoaderTest.php
@@ -2,20 +2,19 @@
 
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;
 
-use eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\CropFilterLoader;
+use eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\OverlayBaseLoader;
 use Imagine\Image\BoxInterface;
 use Imagine\Image\Fill\Gradient\Horizontal;
 use Imagine\Image\Fill\Gradient\Vertical;
 use Imagine\Image\ImageInterface;
 use Imagine\Image\Palette\Color\ColorInterface;
 use Imagine\Image\Palette\PaletteInterface;
-use ImagineCustomBundle\Loader\OverlayBaseLoader;
 use PHPUnit\Framework\TestCase;
 
 class OverlayBaseLoaderTest extends TestCase
 {
     /**
-     * @var CropFilterLoader
+     * @var OverlayBaseLoader
      */
     private $loader;
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayBaseLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayBaseLoaderTest.php
@@ -36,21 +36,17 @@ class OverlayBaseLoaderTest extends TestCase
     public function loadInvalidProvider()
     {
         return [
-            [[]],
-            [['opacity' => 30]],
-            [['opacity' => 30, 'startColor' => [0, 0, 0]]],
-            [['opacity' => 30, 'startColor' => [0, 0, 0], 'endColor' => [0, 0, 0]]],
-            [['opacity' => 30, 'startColor' => [0, 0, 0], 'endColor' => [0, 0, 0], 'linerClass' => '']],
-            [['opacity' => 30, 'startColor' => [0, 0, 0], 'linerClass' => Horizontal::class]],
-            [['opacity' => 30, 'startColor' => [0, 0, 0], 'linerClass' => Vertical::class]],
-            [['opacity' => 30, 'startColor' => [0, 0, 0], 'linerClass' => Vertical::class]],
-            [['opacity' => 30, 'endColor' => [0, 0, 0], 'linerClass' => Vertical::class]],
-            [['opacity' => 30, 'endColor' => [0, 0, 0], 'linerClass' => Vertical::class]],
-            [['startColor' => [0, 0, 0], 'endColor' => [0, 0, 0], 'linerClass' => Vertical::class]],
-            [['startColor' => [0, 0, 0], 'endColor' => [0, 0, 0], 'linerClass' => Vertical::class]],
-            [['opacity' => [30], 'startColor' => [0, 0, 0], 'endColor' => [0, 0, 0], 'linerClass' => Vertical::class]],
-            [['foo' => 'bar']],
-            [[123, null]],
+            'missing_all_params' => [[]],
+            'missing_start_end_colors_liner_class' => [['opacity' => 30]],
+            'missing_end_color_liner_class' => [['opacity' => 30, 'startColor' => [0, 0, 0]]],
+            'missing_liner_class' => [['opacity' => 30, 'startColor' => [0, 0, 0], 'endColor' => [0, 0, 0]]],
+            'invalid)liner_class' => [['opacity' => 30, 'startColor' => [0, 0, 0], 'endColor' => [0, 0, 0], 'linerClass' => '']],
+            'liner_horizontal_missing_end_color' => [['opacity' => 30, 'startColor' => [0, 0, 0], 'linerClass' => Horizontal::class]],
+            'liner_vertical_missing_end_color' => [['opacity' => 30, 'startColor' => [0, 0, 0], 'linerClass' => Vertical::class]],
+            'liner_vertical_missing_start_color' => [['opacity' => 30, 'endColor' => [0, 0, 0], 'linerClass' => Vertical::class]],
+            'liner_horizontal_missing_start_color' => [['opacity' => 30, 'endColor' => [0, 0, 0], 'linerClass' => Horizontal::class]],
+            'missing_opacity' => [['startColor' => [0, 0, 0], 'endColor' => [0, 0, 0], 'linerClass' => Vertical::class]],
+            'invalid_opacity' => [['opacity' => [30], 'startColor' => [0, 0, 0], 'endColor' => [0, 0, 0], 'linerClass' => Vertical::class]],
         ];
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayBaseLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayBaseLoaderTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\CropFilterLoader;
+use Imagine\Image\BoxInterface;
+use Imagine\Image\Fill\Gradient\Horizontal;
+use Imagine\Image\Fill\Gradient\Vertical;
+use Imagine\Image\ImageInterface;
+use Imagine\Image\Palette\Color\ColorInterface;
+use Imagine\Image\Palette\PaletteInterface;
+use ImagineCustomBundle\Loader\OverlayBaseLoader;
+use PHPUnit\Framework\TestCase;
+
+class OverlayBaseLoaderTest extends TestCase
+{
+    /**
+     * @var CropFilterLoader
+     */
+    private $loader;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->loader = new OverlayBaseLoader();
+    }
+
+    /**
+     * @expectedException \Imagine\Exception\InvalidArgumentException
+     * @dataProvider loadInvalidProvider
+     */
+    public function testLoadInvalidOptions(array $options)
+    {
+        $this->loader->load($this->createMock(ImageInterface::class), $options);
+    }
+
+    public function loadInvalidProvider()
+    {
+        return [
+            [[]],
+            [['opacity' => 30]],
+            [['opacity' => 30, 'startColor' => [0, 0, 0]]],
+            [['opacity' => 30, 'startColor' => [0, 0, 0], 'endColor' => [0, 0, 0]]],
+            [['opacity' => 30, 'startColor' => [0, 0, 0], 'endColor' => [0, 0, 0], 'linerClass' => '']],
+            [['opacity' => 30, 'startColor' => [0, 0, 0], 'linerClass' => Horizontal::class]],
+            [['opacity' => 30, 'startColor' => [0, 0, 0], 'linerClass' => Vertical::class]],
+            [['opacity' => 30, 'startColor' => [0, 0, 0], 'linerClass' => Vertical::class]],
+            [['opacity' => 30, 'endColor' => [0, 0, 0], 'linerClass' => Vertical::class]],
+            [['opacity' => 30, 'endColor' => [0, 0, 0], 'linerClass' => Vertical::class]],
+            [['startColor' => [0, 0, 0], 'endColor' => [0, 0, 0], 'linerClass' => Vertical::class]],
+            [['startColor' => [0, 0, 0], 'endColor' => [0, 0, 0], 'linerClass' => Vertical::class]],
+            [['opacity' => [30], 'startColor' => [0, 0, 0], 'endColor' => [0, 0, 0], 'linerClass' => Vertical::class]],
+            [['foo' => 'bar']],
+            [[123, null]],
+        ];
+    }
+
+    public function testOverlayLoad()
+    {
+        $options = [
+            'opacity'    => 30,
+            'startColor' => [0, 0, 0],
+            'endColor'   => [0, 0, 0],
+            'linerClass' => Horizontal::class
+        ];
+
+        $image = $this->createMock(ImageInterface::class);
+        $image
+            ->expects($this->once())
+            ->method('copy')
+            ->will($this->returnValue($image));
+        $image
+            ->expects($this->once())
+            ->method('fill')
+            ->will($this->returnValue($image));
+        $image
+            ->expects($this->once())
+            ->method('paste')
+            ->will($this->returnValue($image));
+
+        $palette = $this->createMock(PaletteInterface::class);
+        $palette
+            ->expects($this->exactly(2))
+            ->method('color')
+            ->with($options['startColor'], $options['opacity'])
+            ->will($this->returnValue($this->createMock(ColorInterface::class)));
+
+        $image
+            ->expects($this->once())
+            ->method('palette')
+            ->will($this->returnValue($palette));
+
+        $box = $this->createMock(BoxInterface::class);
+        $box
+            ->expects($this->any())
+            ->method('getWidth')
+            ->will($this->returnValue(100));
+        $image
+            ->expects($this->once())
+            ->method('getSize')
+            ->will($this->returnValue($box));
+
+
+        $this->assertSame($image, $this->loader->load($image, $options));
+    }
+
+
+    public function testOverlayGradientHorizontalLoad()
+    {
+        $options = [
+            'opacity'    => 30,
+            'startColor' => [0, 0, 0],
+            'endColor'   => [0, 0, 0],
+            'linerClass' => Horizontal::class
+        ];
+
+        $image = $this->createMock(ImageInterface::class);
+        $image
+            ->expects($this->once())
+            ->method('copy')
+            ->will($this->returnValue($image));
+        $image
+            ->expects($this->once())
+            ->method('fill')
+            ->will($this->returnValue($image));
+        $image
+            ->expects($this->once())
+            ->method('paste')
+            ->will($this->returnValue($image));
+
+        $palette = $this->createMock(PaletteInterface::class);
+        $palette
+            ->expects($this->exactly(2))
+            ->method('color')
+            ->with($options['startColor'], $options['opacity'])
+            ->will($this->returnValue($this->createMock(ColorInterface::class)));
+        $image
+            ->expects($this->once())
+            ->method('palette')
+            ->will($this->returnValue($palette));
+
+        $box = $this->createMock(BoxInterface::class);
+        $box
+            ->expects($this->any())
+            ->method('getWidth')
+            ->will($this->returnValue(100));
+        $image
+            ->expects($this->once())
+            ->method('getSize')
+            ->will($this->returnValue($box));
+
+        $this->assertSame($image, $this->loader->load($image, $options));
+    }
+
+    public function testOverlayGradientVerticalLoad()
+    {
+        $options = [
+            'opacity'    => 30,
+            'startColor' => [0, 0, 0],
+            'endColor'   => [0, 0, 0],
+            'linerClass' => Vertical::class
+        ];
+
+        $image = $this->createMock(ImageInterface::class);
+        $image
+            ->expects($this->once())
+            ->method('copy')
+            ->will($this->returnValue($image));
+        $image
+            ->expects($this->once())
+            ->method('fill')
+            ->will($this->returnValue($image));
+        $image
+            ->expects($this->once())
+            ->method('paste')
+            ->will($this->returnValue($image));
+
+        $palette = $this->createMock(PaletteInterface::class);
+        $palette
+            ->expects($this->exactly(2))
+            ->method('color')
+            ->with($options['startColor'], $options['opacity'])
+            ->will($this->returnValue($this->createMock(ColorInterface::class)));
+        $image
+            ->expects($this->once())
+            ->method('palette')
+            ->will($this->returnValue($palette));
+
+
+        $box = $this->createMock(BoxInterface::class);
+        $box
+            ->expects($this->any())
+            ->method('getHeight')
+            ->will($this->returnValue(100));
+        $image
+            ->expects($this->once())
+            ->method('getSize')
+            ->will($this->returnValue($box));
+
+        $this->assertSame($image, $this->loader->load($image, $options));
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayGradientHorizontalLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayGradientHorizontalLoaderTest.php
@@ -40,10 +40,10 @@ class OverlayGradientHorizontalLoaderTest extends TestCase
     public function loadInvalidProvider()
     {
         return [
-            [[]],
-            [[123]],
-            [['foo' => 'bar']],
-            [[123, 456]],
+            'empty_params' => [[]],
+            'missed_start_end_colors' => [[123]],
+            'face_params' => [['foo' => 'bar']],
+            'missed_end_color' => [[123, 456]],
         ];
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayGradientHorizontalLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayGradientHorizontalLoaderTest.php
@@ -2,10 +2,10 @@
 
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;
 
+use eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\OverlayBaseLoader;
+use eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\OverlayGradientHorizontalLoader;
 use Imagine\Image\Fill\Gradient\Horizontal;
 use Imagine\Image\ImageInterface;
-use ImagineCustomBundle\Loader\OverlayBaseLoader;
-use ImagineCustomBundle\Loader\OverlayGradientHorizontalLoader;
 use PHPUnit\Framework\TestCase;
 
 class OverlayGradientHorizontalLoaderTest extends TestCase

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayGradientHorizontalLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayGradientHorizontalLoaderTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;
+
+use Imagine\Image\Fill\Gradient\Horizontal;
+use Imagine\Image\ImageInterface;
+use ImagineCustomBundle\Loader\OverlayBaseLoader;
+use ImagineCustomBundle\Loader\OverlayGradientHorizontalLoader;
+use PHPUnit\Framework\TestCase;
+
+class OverlayGradientHorizontalLoaderTest extends TestCase
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject
+     */
+    private $innerLoader;
+
+    /**
+     * @var OverlayGradientHorizontalLoader
+     */
+    private $loader;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->innerLoader = $this->createMock(OverlayBaseLoader::class);
+        $this->loader      = new OverlayGradientHorizontalLoader();
+        $this->loader->setInnerLoader($this->innerLoader);
+    }
+
+    /**
+     * @expectedException \Imagine\Exception\InvalidArgumentException
+     * @dataProvider loadInvalidProvider
+     */
+    public function testLoadInvalidOptions(array $options)
+    {
+        $this->loader->load($this->createMock(ImageInterface::class), $options);
+    }
+
+    public function loadInvalidProvider()
+    {
+        return [
+            [[]],
+            [[123]],
+            [['foo' => 'bar']],
+            [[123, 456]],
+        ];
+    }
+
+    public function testLoad()
+    {
+        $opacity    = 30;
+        $startColor = [0, 0, 0];
+        $endColor   = '+125';
+
+        $image = $this->createMock(ImageInterface::class);
+        $this->innerLoader
+            ->expects($this->once())
+            ->method('load')
+            ->with($image, [
+                'opacity'    => $opacity,
+                'startColor' => $startColor,
+                'endColor'   => $endColor,
+                'linerClass' => Horizontal::class
+            ])
+            ->will($this->returnValue($image));
+
+        $this->assertSame($image, $this->loader->load($image, [$opacity, $startColor, $endColor]));
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayGradientHorizontalLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayGradientHorizontalLoaderTest.php
@@ -42,7 +42,7 @@ class OverlayGradientHorizontalLoaderTest extends TestCase
         return [
             'empty_params' => [[]],
             'missed_start_end_colors' => [[123]],
-            'face_params' => [['foo' => 'bar']],
+            'fake_params' => [['foo' => 'bar']],
             'missed_end_color' => [[123, 456]],
         ];
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayGradientVerticalLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayGradientVerticalLoaderTest.php
@@ -42,7 +42,7 @@ class OverlayGradientVerticalLoaderTest extends TestCase
         return [
             'empty_params' => [[]],
             'missing_start_end_colors' => [[123]],
-            'face_params' => [['foo' => 'bar']],
+            'fake_params' => [['foo' => 'bar']],
             'missing_end_color' => [[123, 456]],
         ];
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayGradientVerticalLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayGradientVerticalLoaderTest.php
@@ -24,7 +24,7 @@ class OverlayGradientVerticalLoaderTest extends TestCase
     {
         parent::setUp();
         $this->innerLoader = $this->createMock(OverlayBaseLoader::class);
-        $this->loader      = new OverlayGradientVerticalLoader();
+        $this->loader = new OverlayGradientVerticalLoader();
         $this->loader->setInnerLoader($this->innerLoader);
     }
 
@@ -49,9 +49,9 @@ class OverlayGradientVerticalLoaderTest extends TestCase
 
     public function testLoad()
     {
-        $opacity    = 30;
+        $opacity = 30;
         $startColor = [0, 0, 0];
-        $endColor   = '+125';
+        $endColor = '+125';
 
         $image = $this->createMock(ImageInterface::class);
         $this->innerLoader

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayGradientVerticalLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayGradientVerticalLoaderTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;
+
+use Imagine\Image\Fill\Gradient\Vertical;
+use Imagine\Image\ImageInterface;
+use ImagineCustomBundle\Loader\OverlayBaseLoader;
+use ImagineCustomBundle\Loader\OverlayGradientVerticalLoader;
+use PHPUnit\Framework\TestCase;
+
+class OverlayGradientVerticalLoaderTest extends TestCase
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject
+     */
+    private $innerLoader;
+
+    /**
+     * @var OverlayGradientVerticalLoader
+     */
+    private $loader;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->innerLoader = $this->createMock(OverlayBaseLoader::class);
+        $this->loader      = new OverlayGradientVerticalLoader();
+        $this->loader->setInnerLoader($this->innerLoader);
+    }
+
+    /**
+     * @expectedException \Imagine\Exception\InvalidArgumentException
+     * @dataProvider loadInvalidProvider
+     */
+    public function testLoadInvalidOptions(array $options)
+    {
+        $this->loader->load($this->createMock(ImageInterface::class), $options);
+    }
+
+    public function loadInvalidProvider()
+    {
+        return [
+            [[]],
+            [[123]],
+            [['foo' => 'bar']],
+            [[123, 456]],
+        ];
+    }
+
+    public function testLoad()
+    {
+        $opacity    = 30;
+        $startColor = [0, 0, 0];
+        $endColor   = '+125';
+
+        $image = $this->createMock(ImageInterface::class);
+        $this->innerLoader
+            ->expects($this->once())
+            ->method('load')
+            ->with($image, [
+                'opacity'    => $opacity,
+                'startColor' => $startColor,
+                'endColor'   => $endColor,
+                'linerClass' => Vertical::class
+            ])
+            ->will($this->returnValue($image));
+
+        $this->assertSame($image, $this->loader->load($image, [$opacity, $startColor, $endColor]));
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayGradientVerticalLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayGradientVerticalLoaderTest.php
@@ -40,10 +40,10 @@ class OverlayGradientVerticalLoaderTest extends TestCase
     public function loadInvalidProvider()
     {
         return [
-            [[]],
-            [[123]],
-            [['foo' => 'bar']],
-            [[123, 456]],
+            'empty_params' => [[]],
+            'missing_start_end_colors' => [[123]],
+            'face_params' => [['foo' => 'bar']],
+            'missing_end_color' => [[123, 456]],
         ];
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayGradientVerticalLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayGradientVerticalLoaderTest.php
@@ -2,10 +2,10 @@
 
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;
 
+use eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\OverlayBaseLoader;
+use eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\OverlayGradientVerticalLoader;
 use Imagine\Image\Fill\Gradient\Vertical;
 use Imagine\Image\ImageInterface;
-use ImagineCustomBundle\Loader\OverlayBaseLoader;
-use ImagineCustomBundle\Loader\OverlayGradientVerticalLoader;
 use PHPUnit\Framework\TestCase;
 
 class OverlayGradientVerticalLoaderTest extends TestCase

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayLoaderTest.php
@@ -40,10 +40,10 @@ class OverlayLoaderTest extends TestCase
     public function loadInvalidProvider()
     {
         return [
-            [[]],
-            [[123]],
-            [['foo' => 'bar']],
-            [[123, null]],
+            'empty_params' => [[]],
+            'missing_color' => [[123]],
+            'fake_params' => [['foo' => 'bar']],
+            'empty_color' => [[123, null]],
         ];
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayLoaderTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;
+
+use Imagine\Image\Fill\Gradient\Horizontal;
+use Imagine\Image\ImageInterface;
+use ImagineCustomBundle\Loader\OverlayBaseLoader;
+use ImagineCustomBundle\Loader\OverlayLoader;
+use PHPUnit\Framework\TestCase;
+
+class OverlayLoaderTest extends TestCase
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject
+     */
+    private $innerLoader;
+
+    /**
+     * @var OverlayLoader
+     */
+    private $loader;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->innerLoader = $this->createMock(OverlayBaseLoader::class);
+        $this->loader      = new OverlayLoader();
+        $this->loader->setInnerLoader($this->innerLoader);
+    }
+
+    /**
+     * @expectedException \Imagine\Exception\InvalidArgumentException
+     * @dataProvider loadInvalidProvider
+     */
+    public function testLoadInvalidOptions(array $options)
+    {
+        $this->loader->load($this->createMock(ImageInterface::class), $options);
+    }
+
+    public function loadInvalidProvider()
+    {
+        return [
+            [[]],
+            [[123]],
+            [['foo' => 'bar']],
+            [[123, null]],
+        ];
+    }
+
+    public function testLoad()
+    {
+        $opacity = 30;
+        $color   = [0, 0, 0];
+
+        $image = $this->createMock(ImageInterface::class);
+        $this->innerLoader
+            ->expects($this->once())
+            ->method('load')
+            ->with($image, [
+                'opacity'    => $opacity,
+                'startColor' => $color,
+                'endColor'   => $color,
+                'linerClass' => Horizontal::class
+            ])
+            ->will($this->returnValue($image));
+
+        $this->assertSame($image, $this->loader->load($image, [$opacity, $color, $color]));
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/OverlayLoaderTest.php
@@ -2,10 +2,10 @@
 
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;
 
+use eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\OverlayBaseLoader;
+use eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader\OverlayLoader;
 use Imagine\Image\Fill\Gradient\Horizontal;
 use Imagine\Image\ImageInterface;
-use ImagineCustomBundle\Loader\OverlayBaseLoader;
-use ImagineCustomBundle\Loader\OverlayLoader;
 use PHPUnit\Framework\TestCase;
 
 class OverlayLoaderTest extends TestCase
@@ -24,7 +24,7 @@ class OverlayLoaderTest extends TestCase
     {
         parent::setUp();
         $this->innerLoader = $this->createMock(OverlayBaseLoader::class);
-        $this->loader      = new OverlayLoader();
+        $this->loader = new OverlayLoader();
         $this->loader->setInnerLoader($this->innerLoader);
     }
 
@@ -50,7 +50,7 @@ class OverlayLoaderTest extends TestCase
     public function testLoad()
     {
         $opacity = 30;
-        $color   = [0, 0, 0];
+        $color = [0, 0, 0];
 
         $image = $this->createMock(ImageInterface::class);
         $this->innerLoader


### PR DESCRIPTION
Add new imagine filter Loaders (OverlayLoader, OverlayGradientVerticalLoader, OverlayGradientHorizontalLoader)

Usage
--------------------------

```yaml
# app/config/ezplatform.yml

ezpublish:
    system:
        site_group:
            image_variations:
                overlay_image_alias_color_array_RGB:
                    reference: null
                    filters:
                        - { name: overlay, params: {opacity: 30, color: [0, 0, 0]} }
                overlay_image_alias_color_hexadecimal:
                    reference: null
                    filters:
                        - { name: overlay, params: [ 30,  "#fff"] }
                overlay_image_alias_color_integer:
                    reference: null
                    filters:
                        - { name: overlay, params: [ 30,  16777215] }
                overlay_image_alias_color_integer:
                    reference: null
                    filters:
                        - { name: overlay/gradientvertical, params: [ 30,  16777215, 105050] }
                overlay_image_alias_start_color_integer_end_color_darken_on_125:
                    reference: null
                    filters:
                        - { name: overlay/gradientvertical, params: [ 30,  16777215, "-125"] }
                overlay_image_alias_start_color_array_end_color_lighten_on_125:
                    reference: null
                    filters:
                        - { name: overlay/gradienthorizontal, params: {opacity: 30, start_color: [0, 0, 0], end_color: "+125"} }
                overlay_image_alias_start_color_array_end_color_hexadecimal:
                    reference: null
                    filters:
                        - { name: overlay/gradienthorizontal, params: {opacity: 30, start_color: [0, 0, 0], end_color: "#fff"} }
                overlay_image_alias_colors_array_opacity_array:
                    reference: null
                    filters:
                        - { name: overlay/gradienthorizontal, params: {opacity: [30, 90], start_color: [0,0,0], end_color: [0, 0, 0]} }

```

Available params
--------------------------

```
name: overlay | overlay/gradienthorizontal | overlay/gradientvertical
params: array ([30, '#fff']) | associative array ( {opacity: 30, start_color: "#fff", end_color: "#fff"} )
      opacity|firstAttribute:      # integer|array (60 - start opasity, 30 - end opacity)
      start_color|secondAttribute: # integer|array|string(hexadecimal)|string(lighten first "+")|string(darken first "-")
      start_color|secondAttribute: # integer|array|string(hexadecimal)|string(lighten first "+")|string(darken first "-")
```