### PR TITLE
EZP-27713: As a Developer I want HttpCache to handle RemoveTranslationSignal

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/slot.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/slot.yml
@@ -18,6 +18,7 @@ parameters:
     ezpublish.http_cache.signalslot.unassign_user_from_user_group.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UnassignUserFromUserGroupSlot
     ezpublish.http_cache.signalslot.trash.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\TrashSlot
     ezpublish.http_cache.signalslot.recover.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\RecoverSlot
+    ezpublish.http_cache.signalslot.remove_translation.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\RemoveTranslationSlot
 
 services:
     ezpublish.http_cache.signalslot.http_cache:
@@ -132,3 +133,9 @@ services:
         parent: ezpublish.http_cache.signalslot.http_cache
         tags:
             - { name: ezpublish.api.slot, signal: TrashService\RecoverSignal }
+
+    ezpublish.http_cache.signalslot.remove_translation:
+        class: "%ezpublish.http_cache.signalslot.remove_translation.class%"
+        parent: ezpublish.http_cache.signalslot.http_cache
+        tags:
+            - { name: ezpublish.api.slot, signal: ContentService\RemoveTranslationSignal }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/RemoveTranslationSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/RemoveTranslationSlot.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling RemoveTranslationSignal.
+ *
+ * @deprecated since 6.11. The platform-http-cache package defines slots for http-cache multi-tagging.
+ */
+class RemoveTranslationSlot extends PurgeForContentHttpCacheSlot
+{
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\ContentService\RemoveTranslationSignal;
+    }
+}


### PR DESCRIPTION
Implements [EZP-27713](https://jira.ez.no/browse/EZP-27713)
----

This PR implements `RemoveTranslationSlot` in `eZ\Publish\Core\MVC\Symfony\Cache\Http` for HttpCache.

**Note**: for now please disregard TMP commits - just helpers to perform some tests.

**TODO**:
- [x] Implement `RemoveTranslationSlot` for HttpCache in 
- [x] Implement `RemoveTranslationSlot` for [ezplatform-http-cache Bundle](https://github.com/ezsystems/ezplatform-http-cache) (PR ezsystems/ezplatform-http-cache#13)
- [x] Remove TMP commits