### PR TITLE
[Elastic] fix searchEngine keep object after emptyTrash, send trashSignal for each Object

### DIFF
--- a/eZ/Publish/Core/SignalSlot/TrashService.php
+++ b/eZ/Publish/Core/SignalSlot/TrashService.php
@@ -135,10 +135,30 @@ class TrashService implements TrashServiceInterface
      */
     public function emptyTrash()
     {
+    
+        //get contentobject id to reindex before deleting them
+        $trashedItems = $this->service->findTrashItems(new \eZ\Publish\API\Repository\Values\Content\Query());
+
         $returnValue = $this->service->emptyTrash();
+
+        foreach ($trashedItems->items as $item) {
+            $this->signalDispatcher->emit(
+                new TrashSignal(
+                    array(
+                        'locationId' => $item->id,
+                        'parentLocationId' => $item->parentLocationId,
+                        'contentId' => $item->contentId,
+                        'contentTrashed' => true,
+                    )
+                )
+            );
+        }
+
         $this->signalDispatcher->emit(new EmptyTrashSignal(array()));
 
         return $returnValue;
+
+
     }
 
     /**

--- a/eZ/Publish/Core/SignalSlot/TrashService.php
+++ b/eZ/Publish/Core/SignalSlot/TrashService.php
@@ -135,30 +135,28 @@ class TrashService implements TrashServiceInterface
      */
     public function emptyTrash()
     {
-    
         //get contentobject id to reindex before deleting them
         $trashedItems = $this->service->findTrashItems(new \eZ\Publish\API\Repository\Values\Content\Query());
 
         $returnValue = $this->service->emptyTrash();
 
-        foreach ($trashedItems->items as $item) {
-            $this->signalDispatcher->emit(
-                new TrashSignal(
-                    array(
-                        'locationId' => $item->id,
-                        'parentLocationId' => $item->parentLocationId,
-                        'contentId' => $item->contentId,
-                        'contentTrashed' => true,
+        if(!empty($trashedItems)){
+            foreach ($trashedItems->items as $item) {
+                $this->signalDispatcher->emit(
+                    new TrashSignal(
+                        array(
+                            'locationId' => $item->id,
+                            'parentLocationId' => $item->parentLocationId,
+                            'contentId' => $item->contentId,
+                            'contentTrashed' => true,
+                        )
                     )
-                )
-            );
+                );
+            }
         }
-
         $this->signalDispatcher->emit(new EmptyTrashSignal(array()));
 
         return $returnValue;
-
-
     }
 
     /**


### PR DESCRIPTION
Hi,

I'm using Elastic Search as search engine and made a lot of override to get it work ^^

I still have one issue needing a fix on the master.

Here the case, when you are using a search engine (solr, es) you need to delete items. When you send the empty trash, as the databse is empty we cannot retrieve the list of object to delete.

So i've this patch to send a trashSignal on each object so we can remove it from the index.

Many regards,
Hadi