### PR TITLE
EZP-27752: As a REST Consumer I want to remove translation from all Versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
       env: BEHAT_OPTS="--profile=core --tags=~@broken" RUN_INSTALL=1 SYMFONY_ENV=behat SYMFONY_DEBUG=1
 # 7.0
     - php: 7.0
-      env: REST_TEST_CONFIG="phpunit-functional-rest.xml" RUN_INSTALL=1 SYMFONY_ENV=behat SYMFONY_DEBUG=1
+      env: REST_TEST_CONFIG="phpunit-functional-rest.xml" RUN_INSTALL=1 SYMFONY_ENV=behat SYMFONY_DEBUG=1 SF_CMD="ez:behat:create-language 'pol-PL' 'Polish (polski)'"
     - php: 7.0
       env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" RUN_INSTALL=1 SYMFONY_ENV=behat
     - php: 7.0
@@ -67,6 +67,8 @@ before_script:
   - if [ "$TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_unittest.sh ; fi
   - if [ "$BEHAT_OPTS" != "" ] ; then ./bin/.travis/prepare_behat.sh ; fi
   - if [ "$REST_TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_behat.sh ; fi
+  # Execute Symfony command if specified
+  - if [ "$SF_CMD" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "app/console $SF_CMD" ; fi
   # Detecting timezone issues by testing on random timezone
   - TEST_TIMEZONES=("America/New_York" "Asia/Calcutta" "UTC")
   - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}

--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -226,7 +226,8 @@ Resource                                                          POST          
 /                                                                 .                   list root resources     .                            .
 /content/objects                                                  create new content  .                       .                            .
 /content/objects/<ID>                                             .                   load content            update content meta data     delete content   copy content
-/content/objects/<ID>/<lang_code>                                 .                   .                       .                            delete language
+/content/objects/<ID>/translations/<languageCode>                 .                   .                       .                            delete
+                                                                                                                                           translation
                                                                                                                                            from content
 /content/objects/<ID>/versions                                    .                   load all versions       .                            .
                                                                                       (version infos)
@@ -1020,6 +1021,23 @@ Example
 
     HTTP/1.1 201 Created
     Location: /content/objects/74
+
+Delete (permanently) Translation from all Versions of a Content
+```````````````````````````````````````````````````````````````
+:Resource: /content/objects/<ID>/translations/<languageCode>
+:Method: DELETE
+:Description: Permanently delete a Translation from all Versions of a Content
+:Response:
+
+.. code:: http
+
+    HTTP/1.1 204 No Content
+
+:Error Codes:
+                :404: if the Content item was not found
+                :401: If the user is not authorized to delete Content (content/remove policy)
+                :406: if the given Translation does not exist for the Content
+                :409: if the specified Translation is the only one any Version has or is the Main Translation
 
 
 Managing Versions

--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -236,7 +236,9 @@ Resource                                                          POST          
                                                                                                                                                              version
 /content/objects/<ID>/versions/<no>                               .                   get a specific version  update a version/draft       delete version    create draft
                                                                                                                                                              from version
-/content/objects/<ID>/versions/<no>/translations/<languageCode>   .                   .                       .                            delete translation
+/content/objects/<ID>/versions/<no>/translations/<languageCode>   .                   .                       .                            delete
+                                                                                                                                           translation
+                                                                                                                                           from version
 /content/objects/<ID>/versions/<no>/relations                     create new relation load relations of vers. .                            .
 /content/objects/<ID>/versions/<no>/relations/<ID>                .                   load relation details   .                            delete relation
 /content/objects/<ID>/locations                                   create location     load locations of cont- .                            .
@@ -1474,7 +1476,7 @@ Delete Content Version
     :403: If the version is in state published
 
 Delete Content Version Draft Translation
-``````````````````````
+````````````````````````````````````````
 :Resource: /content/objects/<ID>/versions/<versionNo>/translations/<languageCode>
 :Method: DELETE
 :Description: Removes a translation from a version draft
@@ -1492,7 +1494,7 @@ Delete Content Version Draft Translation
         :409: if the specified translation is the only one the Version has or is the main translation
 
 Example (workflow) of deleting translation from a published Content
-'''''''''''
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
 .. code:: http
 

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/routing.yml
@@ -95,6 +95,12 @@ ezpublish_rest_copyContent:
     requirements:
         contentId: \d+
 
+ezpublish_rest_deleteContentTranslation:
+    path: /content/objects/{contentId}/translations/{languageCode}
+    defaults:
+        _controller: ezpublish_rest.controller.content:deleteContentTranslation
+    methods: [DELETE]
+
 ezpublish_rest_redirectCurrentVersionRelations:
     path: /content/objects/{contentId}/relations
     defaults:

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ContentTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ContentTest.php
@@ -503,6 +503,98 @@ XML;
     }
 
     /**
+     * Covers DELETE /content/objects/<contentId>/translations/<languageCode>.
+     */
+    public function testDeleteTranslation()
+    {
+        // create independent Content
+        $content = $this->createContentDraft(
+            '/api/ezp/v2/content/types/1',
+            '/api/ezp/v2/content/locations/1/2',
+            '/api/ezp/v2/content/sections/1',
+            '/api/ezp/v2/user/users/14',
+            [
+                'name' => [
+                    'eng-GB' => $this->addTestSuffix(__FUNCTION__),
+                ],
+            ]
+        );
+        $restContentHref = $content['_href'];
+        $restContentVersionHref = "{$content['Versions']['_href']}/{$content['currentVersionNo']}";
+        $this->publishContentVersionDraft($restContentVersionHref);
+        $restContentVersionHref = $this->createDraftFromVersion($content['CurrentVersion']['_href']);
+
+        // create pol-PL Translation
+        $translationToDelete = 'pol-PL';
+        $this->createVersionTranslation($restContentVersionHref, $translationToDelete, 'Polish');
+        $this->publishContentVersionDraft($restContentVersionHref);
+
+        // delete Translation
+        $response = $this->sendHttpRequest(
+            $this->createHttpRequest('DELETE', "{$restContentHref}/translations/{$translationToDelete}")
+        );
+        self::assertHttpResponseCodeEquals($response, 204);
+
+        // check that deleted Translation no longer exists
+        $response = $this->sendHttpRequest(
+            $this->createHttpRequest('GET', "$restContentHref/versions", '', 'VersionList+json')
+        );
+        self::assertHttpResponseCodeEquals($response, 200);
+        $versionList = json_decode($response->getContent(), true);
+        foreach ($versionList['VersionList']['VersionItem'] as $versionItem) {
+            self::assertNotContains($translationToDelete, $versionItem['VersionInfo']['languageCodes']);
+            foreach ($versionItem['VersionInfo']['names']['value'] as $name) {
+                self::assertNotEquals($translationToDelete, $name['_languageCode']);
+            }
+        }
+
+        return $restContentHref;
+    }
+
+    /**
+     * Test that deleting content which has Version(s) with single Translation being deleted is supported.
+     *
+     * Covers DELETE /content/objects/<contentId>/translations/<languageCode>.
+     *
+     * @depends testDeleteTranslation
+     *
+     * @param string $restContentHref
+     */
+    public function testDeleteTranslationOfContentWithSingleTranslationVersion($restContentHref)
+    {
+        // create draft independent from other tests
+        $restContentVersionHref = $this->createDraftFromVersion("$restContentHref/versions/1");
+
+        // create pol-PL Translation to have more than one Translation
+        $this->createVersionTranslation($restContentVersionHref, 'pol-PL', 'Polish');
+        $this->publishContentVersionDraft($restContentVersionHref);
+
+        // change Main Translation to just created pol-PL
+        $this->updateMainTranslation($restContentHref, 'pol-PL');
+
+        // delete eng-GB Translation
+        $translationToDelete = 'eng-GB';
+        $response = $this->sendHttpRequest(
+            $this->createHttpRequest('DELETE', "{$restContentHref}/translations/{$translationToDelete}")
+        );
+        self::assertHttpResponseCodeEquals($response, 204);
+
+        // check that deleted Translation no longer exists
+        $response = $this->sendHttpRequest(
+            $this->createHttpRequest('GET', "$restContentHref/versions", '', 'VersionList+json')
+        );
+        self::assertHttpResponseCodeEquals($response, 200);
+        $versionList = json_decode($response->getContent(), true);
+        foreach ($versionList['VersionList']['VersionItem'] as $versionItem) {
+            self::assertNotEmpty($versionItem['VersionInfo']['languageCodes']);
+            self::assertNotContains($translationToDelete, $versionItem['VersionInfo']['languageCodes']);
+            foreach ($versionItem['VersionInfo']['names']['value'] as $name) {
+                self::assertNotEquals($translationToDelete, $name['_languageCode']);
+            }
+        }
+    }
+
+    /**
      * Publish another Version with new Translation.
      *
      * @param string $restContentVersionHref
@@ -577,5 +669,128 @@ XML;
         $document = new \DOMDocument();
         $document->loadXML($responseBody);
         $document->schemaValidate(__DIR__ . '/xsd/Version.xsd');
+    }
+
+    /**
+     * Create new Content Draft.
+     *
+     * @param string $restContentTypeHref Content Type REST resource link
+     * @param string $restParentLocationHref Parent Location REST resource link
+     * @param string $restSectionHref Section REST resource link
+     * @param string $restUserHref User REST resource link
+     * @param array $fieldValues multilingual field values <code>['fieldIdentifier' => ['languageCode' => 'value']]</code>
+     *
+     * @return array Content structure decoded from JSON
+     */
+    private function createContentDraft($restContentTypeHref, $restParentLocationHref, $restSectionHref, $restUserHref, array $fieldValues)
+    {
+        $remoteId = md5(microtime() . uniqid());
+        $modificationDate = new \DateTime();
+
+        $fieldsXML = '';
+        foreach ($fieldValues as $fieldIdentifier => $multilingualValues) {
+            foreach ($multilingualValues as $languageCode => $fieldValue) {
+                $fieldsXML .= <<< XML
+<field>
+  <fieldDefinitionIdentifier>{$fieldIdentifier}</fieldDefinitionIdentifier>
+  <languageCode>{$languageCode}</languageCode>
+  <fieldValue>{$fieldValue}</fieldValue>
+</field>
+XML;
+            }
+        }
+
+        $body = <<< XML
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentCreate>
+  <ContentType href="{$restContentTypeHref}" />
+  <mainLanguageCode>eng-GB</mainLanguageCode>
+  <LocationCreate>
+    <ParentLocation href="{$restParentLocationHref}" />
+    <priority>0</priority>
+    <hidden>false</hidden>
+    <sortField>PATH</sortField>
+    <sortOrder>ASC</sortOrder>
+  </LocationCreate>
+  <Section href="{$restSectionHref}" />
+  <alwaysAvailable>true</alwaysAvailable>
+  <remoteId>{$remoteId}</remoteId>
+  <User href="{$restUserHref}" />
+  <modificationDate>{$modificationDate->format('c')}</modificationDate>
+  <fields>
+    {$fieldsXML}
+  </fields>
+</ContentCreate>
+XML;
+        $request = $this->createHttpRequest('POST', '/api/ezp/v2/content/objects', 'ContentCreate+xml', 'ContentInfo+json');
+        $request->setContent($body);
+
+        $response = $this->sendHttpRequest($request);
+
+        self::assertHttpResponseCodeEquals($response, 201);
+        self::assertHttpResponseHasHeader($response, 'Location');
+
+        $href = $response->getHeader('Location');
+        $this->addCreatedElement($href);
+
+        $content = json_decode($response->getContent(), true);
+        self::assertNotEmpty($content['Content']);
+
+        return $content['Content'];
+    }
+
+    /**
+     * Create Draft of a given Content and versionNo.
+     *
+     * @param string $restContentVersionHref REST resource link of Content Version
+     *
+     * @return string Content Version Draft REST resource link
+     */
+    private function createDraftFromVersion($restContentVersionHref)
+    {
+        $response = $this->sendHttpRequest(
+            $this->createHttpRequest('COPY', "{$restContentVersionHref}")
+        );
+        self::assertHttpResponseCodeEquals($response, 201);
+
+        $href = $response->getHeader('Location');
+        self::assertNotEmpty($href);
+
+        return $href;
+    }
+
+    /**
+     * Publish Content Version Draft given by REST resource link.
+     *
+     * @param string $restContentVersionHref REST resource link of Version Draft
+     */
+    private function publishContentVersionDraft($restContentVersionHref)
+    {
+        $response = $this->sendHttpRequest(
+            $this->createHttpRequest('PUBLISH', $restContentVersionHref)
+        );
+        self::assertHttpResponseCodeEquals($response, 204);
+    }
+
+    /**
+     * Update Main Translation of a Content.
+     *
+     * @param string $restContentHref REST resource link of Content
+     * @param string $languageCode new Main Translation language code
+     */
+    private function updateMainTranslation($restContentHref, $languageCode)
+    {
+        $content = <<< XML
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentUpdate>
+  <mainLanguageCode>{$languageCode}</mainLanguageCode>
+</ContentUpdate>
+XML;
+
+        $request = $this->createHttpRequest('PATCH', $restContentHref, 'ContentUpdate+xml', 'ContentInfo+json');
+        $request->setContent($content);
+        $response = $this->sendHttpRequest($request);
+
+        self::assertHttpResponseCodeEquals($response, 200);
     }
 }

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ContentTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ContentTest.php
@@ -514,7 +514,8 @@ XML;
      */
     private function createVersionTranslation($restContentVersionHref, $languageCode, $languageName)
     {
-        $this->ensureLanguageExists($languageCode, $languageName);
+        // @todo Implement EZP-21171 to check if Language exists and add it
+        // for now adding is done by ez:behat:create-language command executed in Travis job
 
         $xml = <<< XML
 <VersionUpdate>
@@ -535,17 +536,6 @@ XML;
         );
 
         self::assertHttpResponseCodeEquals($response, 200);
-    }
-
-    /**
-     * Make REST API calls to check if the given Language exists and create it if it doesn't.
-     *
-     * @param string $languageCode
-     * @param string $languageName
-     */
-    private function ensureLanguageExists($languageCode, $languageName)
-    {
-        self::markTestIncomplete('@todo: Implement EZP-21171');
     }
 
     /**

--- a/eZ/Bundle/PlatformBehatBundle/Command/CreateLanguageCommand.php
+++ b/eZ/Bundle/PlatformBehatBundle/Command/CreateLanguageCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformBehatBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class CreateLanguageCommand extends ContainerAwareCommand
+{
+    /**
+     * @var \eZ\Publish\API\Repository\LanguageService
+     */
+    private $languageService;
+
+    /**
+     * @var \eZ\Publish\API\Repository\UserService
+     */
+    private $userService;
+
+    /**
+     * @var \eZ\Publish\API\Repository\PermissionResolver
+     */
+    private $permissionResolver;
+
+    protected function configure()
+    {
+        $this
+            ->setName('ez:behat:create-language')
+            ->setDescription('Create a Language')
+            ->addArgument('language-code', InputArgument::REQUIRED)
+            ->addArgument('language-name', InputArgument::OPTIONAL, 'Language name', '')
+            ->addArgument(
+                'user',
+                InputArgument::OPTIONAL,
+                'eZ Platform User with access to content / translations',
+                'admin'
+            );
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        parent::initialize($input, $output);
+
+        $repository = $this->getContainer()->get('ezpublish.api.repository');
+        $this->languageService = $repository->getContentLanguageService();
+        $this->permissionResolver = $repository->getPermissionResolver();
+        $this->userService = $repository->getUserService();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        // set user with proper permissions to create language (content / translations)
+        $this->permissionResolver->setCurrentUserReference(
+            $this->userService->loadUserByLogin(
+                $input->getArgument('user')
+            )
+        );
+
+        $languageCreateStruct = $this->languageService->newLanguageCreateStruct();
+        $languageCreateStruct->languageCode = $input->getArgument('language-code');
+        $languageCreateStruct->name = $input->getArgument('language-name');
+
+        $this->languageService->createLanguage($languageCreateStruct);
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Controller/Content.php
+++ b/eZ/Publish/Core/REST/Server/Controller/Content.php
@@ -316,6 +316,39 @@ class Content extends RestController
     }
 
     /**
+     * Deletes a translation from all the Versions of the given Content Object.
+     *
+     * If any non-published Version contains only the Translation to be deleted, that entire Version will be deleted
+     *
+     * @param int $contentId
+     * @param string $languageCode
+     *
+     * @return \eZ\Publish\Core\REST\Server\Values\NoContent
+     *
+     * @throws \Exception
+     */
+    public function deleteContentTranslation($contentId, $languageCode)
+    {
+        $contentService = $this->repository->getContentService();
+
+        $this->repository->beginTransaction();
+        try {
+            $contentInfo = $contentService->loadContentInfo($contentId);
+            $contentService->deleteTranslation(
+                $contentInfo,
+                $languageCode
+            );
+
+            $this->repository->commit();
+
+            return new Values\NoContent();
+        } catch (\Exception $e) {
+            $this->repository->rollback();
+            throw $e;
+        }
+    }
+
+    /**
      * Returns a list of all versions of the content. This method does not
      * include fields and relations in the Version elements of the response.
      *


### PR DESCRIPTION
REST endpoint for deleting Translation from all Versions
----

| Question | Answer |
|---|---|
| **Status** | Ready for a review |
| **Issue** | [EZP-27752](https://jira.ez.no/browse/EZP-27752) |
| **REST API** | `DELETE /content/objects/<ID>/translations/<languageCode>` |
| **Target version** | `6.13` |

This PR implements REST API endpoint for PHP API `ContentService::deleteTranslation` which removes a Translation given by the language code from all the Versions of a Content item.

**TODO**:
- [x] Rebase after [EZP-28271](https://jira.ez.no/browse/EZP-28271) (#2160) gets merged
- [x] Remove unnecessary code after [EZP-28271](https://jira.ez.no/browse/EZP-28271) improvement
- [x] Rebase after #2130 gets merged (and remove TMP commit)
- [x] Create route and controller for REST endpoint
- [x] Implement workaround until [EZP-21171](https://jira.ez.no/browse/EZP-21171) is finished.
- [x] Improve Functional Test Case to cover issues reported by Customers.
- [x] Improve REST endpoint to cover these cases
- [x] Update REST endpoint Spec (changed path)
- [x] Decide whether endpoint route path is valid (see Jira issue or [review comment](#discussion_r131658130)).
- [x] Decide if we want to wait for [EZP-21171](https://jira.ez.no/browse/EZP-21171) to be able to test this.
- [x] QA check.