### PR TITLE
[Spec] Aligned removeTranslation Spec after adding Slots

### DIFF
--- a/doc/specifications/translations/removal.md
+++ b/doc/specifications/translations/removal.md
@@ -57,7 +57,3 @@ class RemoveTranslationSignal extends Signal
     public $languageCode;
 }
 ```
-
-**NOTE:** Search engine reindexing and HttpCache refreshing **have to be done manually** after
-performing this operation, until SearchEngine and HttpCache have been gotten support for
-the corresponding `RemoveTranslationSignal`.


### PR DESCRIPTION
Spec/Doc follow-up after [EZP-27712](https://jira.ez.no/browse/EZP-27712) and [EZP-27713](https://jira.ez.no/browse/EZP-27713)
----

The note in the spec is no longer valid since 
- ezsystems/ezpublish-kernel#2060
- ezsystems/ezplatform-solr-search-engine#98
- ezsystems/ezpublish-kernel#2062
- ezsystems/ezplatform-http-cache#13

got merged.

*Sorry, I forgot about that ;)*