### PR TITLE
Too many parameters passed to changeMainLocation method call

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/TreeHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/TreeHandler.php
@@ -195,9 +195,7 @@ class TreeHandler
 
                 $this->changeMainLocation(
                     $contentId,
-                    $newMainLocationRow['node_id'],
-                    $newMainLocationRow['contentobject_version'],
-                    $newMainLocationRow['parent_node_id']
+                    $newMainLocationRow['node_id']
                 );
             }
         }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/TreeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/TreeHandlerTest.php
@@ -231,7 +231,7 @@ class TreeHandlerTest extends TestCase
         $treeHandler
             ->expects($this->once())
             ->method('changeMainLocation')
-            ->with(102, 203, 1, 204);
+            ->with(102, 203);
         $this->getLocationGatewayMock()
             ->expects($this->at(11))
             ->method('removeLocation')


### PR DESCRIPTION
> JIRA: -

# Description

Method `eZ\Publish\Core\Persistence\Legacy\Content\TreeHandler::changeMainLocation` expects only two arguments, but four are passed when `changeMainLocation` method call in  `eZ\Publish\Core\Persistence\Legacy\Content\TreeHandler::removeSubtree`.