### PR TITLE
[7.0] Add SPI methods to load several ContentInfo & ContentType Groups

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/AbstractHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/AbstractHandler.php
@@ -49,4 +49,43 @@ abstract class AbstractHandler
         $this->persistenceHandler = $persistenceHandler;
         $this->logger = $logger;
     }
+
+    /**
+     * Helper for getting multiple cache items in one call and do the id extraction for you.
+     *
+     * Cache items must be stored with a key in the following format "${keyPrefix}${id}", like "ez-content-info-${id}",
+     * in order for this method to be able to prefix key on id's and also extract key prefix afterwards.
+     *
+     * @param array $ids
+     * @param string $keyPrefix
+     *
+     * @return array Format [id[] $cacheMisses, CacheItem[<id>] $list], list contains hits & misses (if there where any).
+     */
+    final protected function getMultipleCacheItems(array $ids, string $keyPrefix): array
+    {
+        if (empty($ids)) {
+            return [[], []];
+        }
+
+        $cacheKeys = [];
+        foreach (array_unique($ids) as $id) {
+            $cacheKeys[] = $keyPrefix . $id;
+        }
+
+        $list = [];
+        $cacheMisses = [];
+        $keyPrefixLength = strlen($keyPrefix);
+        foreach ($this->cache->getItems($cacheKeys) as $key => $cacheItem) {
+            $id = substr($key, $keyPrefixLength);
+            if ($cacheItem->isHit()) {
+                $list[$id] = $cacheItem->get();
+                continue;
+            }
+
+            $cacheMisses[] = $id;
+            $list[$id] = $cacheItem;
+        }
+
+        return [$cacheMisses, $list];
+    }
 }

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -96,6 +96,30 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
         return $contentInfo;
     }
 
+    public function loadContentInfoList(array $contentIds)
+    {
+        list($cacheMisses, $list) = $this->getMultipleCacheItems($contentIds, 'ez-content-info-');
+        if (empty($cacheMisses)) {
+            return $list;
+        }
+
+        // Load cache misses
+        $this->logger->logCall(__METHOD__, array('content' => $cacheMisses));
+        $cacheMissList = $this->persistenceHandler->contentHandler()->loadContentInfoList($cacheMisses);
+
+        // Populate cache misses with data and set final info data instead on list
+        foreach ($cacheMissList as $id => $contentInfo) {
+            $this->cache->save(
+                $list[$id]
+                    ->set($contentInfo)
+                    ->tag($this->getCacheTags($contentInfo))
+            );
+            $list[$id] = $contentInfo;
+        }
+
+        return $list;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
@@ -74,6 +74,7 @@ class ContentHandlerTest extends AbstractCacheHandlerTest
             ['load', [2, 1], 'ez-content-2-1-' . ContentHandler::ALL_TRANSLATIONS_KEY, $content],
             ['load', [2, 1, ['eng-GB', 'eng-US']], 'ez-content-2-1-eng-GB|eng-US', $content],
             ['loadContentInfo', [2], 'ez-content-info-2', $info],
+            ['loadContentInfoList', [[2]], 'ez-content-info-2', [2 => $info], true],
             ['loadContentInfoByRemoteId', ['3d8jrj'], 'ez-content-info-byRemoteId-3d8jrj', $info],
             ['loadVersionInfo', [2, 1], 'ez-content-version-info-2-1', $version],
             ['listVersions', [2], 'ez-content-2-version-list', [$version]],

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentTypeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentTypeHandlerTest.php
@@ -80,6 +80,7 @@ class ContentTypeHandlerTest extends AbstractCacheHandlerTest
         // string $method, array $arguments, string $key, mixed? $data
         return [
             ['loadGroup', [3], 'ez-content-type-group-3', $group],
+            ['loadGroups', [[3]], 'ez-content-type-group-3', [3 => $group], true],
             ['loadGroupByIdentifier', ['content'], 'ez-content-type-group-content-by-identifier', $group],
             ['loadContentTypes', [3, 0], 'ez-content-type-list-by-group-3', [$type]],
             ['load', [5, 0], 'ez-content-type-5-0', $type],

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
@@ -176,6 +176,18 @@ abstract class Gateway
      */
     abstract public function loadContentInfo($contentId);
 
+     /**
+      * Loads rows of info for content identified by $contentIds.
+      *
+      * @see loadContentInfo For the returned structure.
+      * @see \eZ\Publish\SPI\Persistence\Content\Handler::loadContentInfoList For how this will only return items found and not throw.
+      *
+      * @param array $contentIds
+      *
+      * @return array[]
+      */
+     abstract public function loadContentInfoList(array $contentIds);
+
     /**
      * Loads version info for content identified by $contentId and $versionNo.
      * Will basically return a hash containing all field values from ezcontentobject_version table plus following keys:

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -850,51 +850,29 @@ class DoctrineDatabase extends Gateway
     }
 
     /**
-     * @see loadContentInfo(), loadContentInfoByRemoteId()
+     * @see loadContentInfo(), loadContentInfoByRemoteId(), loadContentInfoList()
      *
      * @param string $column
-     * @param mixed $id
-     *
-     * @throws \eZ\Publish\Core\Base\Exceptions\NotFoundException
+     * @param array $ids Array of int, or if $bindype is set to Connection::PARAM_STR_ARRAY then array of string
+     * @param int $bindType One of Connection::PARAM_*_ARRAY constants.
      *
      * @return array
      */
-    private function internalLoadContentInfo($column, $id)
+    private function internalLoadContentInfo(string $column, array $ids, int $bindType = Connection::PARAM_INT_ARRAY): array
     {
-        /** @var $query \eZ\Publish\Core\Persistence\Database\SelectQuery */
-        $query = $this->dbHandler->createSelectQuery();
-        $query->select(
-            'ezcontentobject.*',
-            $this->dbHandler->aliasedColumn($query, 'main_node_id', 'ezcontentobject_tree')
-        )->from(
-            $this->dbHandler->quoteTable('ezcontentobject')
-        )->leftJoin(
-            $this->dbHandler->quoteTable('ezcontentobject_tree'),
-            $query->expr->lAnd(
-                $query->expr->eq(
-                    $this->dbHandler->quoteColumn('contentobject_id', 'ezcontentobject_tree'),
-                    $this->dbHandler->quoteColumn('id', 'ezcontentobject')
-                ),
-                $query->expr->eq(
-                    $this->dbHandler->quoteColumn('main_node_id', 'ezcontentobject_tree'),
-                    $this->dbHandler->quoteColumn('node_id', 'ezcontentobject_tree')
-                )
-            )
-        )->where(
-            $query->expr->eq(
-                $this->dbHandler->quoteColumn($column, 'ezcontentobject'),
-                $query->bindValue($id, null, $column === 'id' ? PDO::PARAM_INT : PDO::PARAM_STR)
-            )
-        );
-        $statement = $query->prepare();
-        $statement->execute();
-        $row = $statement->fetch(PDO::FETCH_ASSOC);
+        $q = $this->connection->createQueryBuilder();
+        $q
+            ->select('c.*', 't.main_node_id AS ezcontentobject_tree_main_node_id')
+            ->from('ezcontentobject', 'c')
+            ->leftJoin(
+                'c',
+                'ezcontentobject_tree',
+                't',
+                'c.id = t.contentobject_id AND t.node_id = t.main_node_id'
+            )->where("c.${column} IN (:ids)")
+            ->setParameter('ids', $ids, $bindType);
 
-        if (empty($row)) {
-            throw new NotFound('content', "$column: $id");
-        }
-
-        return $row;
+        return $q->execute()->fetchAll();
     }
 
     /**
@@ -911,7 +889,17 @@ class DoctrineDatabase extends Gateway
      */
     public function loadContentInfo($contentId)
     {
-        return $this->internalLoadContentInfo('id', $contentId);
+        $results = $this->internalLoadContentInfo('id', [$contentId]);
+        if (empty($results)) {
+            throw new NotFound('content', "id: $contentId");
+        }
+
+        return $results[0];
+    }
+
+    public function loadContentInfoList(array $contentIds)
+    {
+        return $this->internalLoadContentInfo('id', $contentIds);
     }
 
     /**
@@ -927,7 +915,12 @@ class DoctrineDatabase extends Gateway
      */
     public function loadContentInfoByRemoteId($remoteId)
     {
-        return $this->internalLoadContentInfo('remote_id', $remoteId);
+        $results = $this->internalLoadContentInfo('remote_id', [$remoteId], Connection::PARAM_STR_ARRAY);
+        if (empty($results)) {
+            throw new NotFound('content', "remote_id: $remoteId");
+        }
+
+        return $results[0];
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
@@ -319,6 +319,17 @@ class ExceptionConversion extends Gateway
         }
     }
 
+    public function loadContentInfoList(array $contentIds)
+    {
+        try {
+            return $this->innerGateway->loadContentInfoList($contentIds);
+        } catch (DBALException $e) {
+            throw new RuntimeException('Database error', 0, $e);
+        } catch (PDOException $e) {
+            throw new RuntimeException('Database error', 0, $e);
+        }
+    }
+
     /**
      * Loads version info for content identified by $contentId and $versionNo.
      * Will basically return a hash containing all field values from ezcontentobject_version table plus following keys:

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -339,6 +339,20 @@ class Handler implements BaseContentHandler
         return $this->treeHandler->loadContentInfo($contentId);
     }
 
+    public function loadContentInfoList(array $contentIds)
+    {
+        $list = $this->mapper->extractContentInfoFromRows(
+            $this->contentGateway->loadContentInfoList($contentIds)
+        );
+
+        $listByContentId = [];
+        foreach ($list as $item) {
+            $listByContentId[$item->id] = $item;
+        }
+
+        return $listByContentId;
+    }
+
     /**
      * Returns the metadata object for a content identified by $remoteId.
      *

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
@@ -63,18 +63,18 @@ abstract class Gateway
     abstract public function deleteGroup($groupId);
 
     /**
-     * Returns an array with data about the Group with $groupId.
+     * Returns an array with data about the Group(s) with $groupIds.
      *
-     * @param int $groupId
+     * @param int[] $groupIds
      *
      * @return array
      */
-    abstract public function loadGroupData($groupId);
+    abstract public function loadGroupData(array $groupIds);
 
     /**
      * Returns an array with data about the Group with $identifier.
      *
-     * @param int $identifier
+     * @param string $identifier
      *
      * @return array
      */

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
@@ -128,17 +128,10 @@ class ExceptionConversion extends Gateway
         }
     }
 
-    /**
-     * Returns an array with data about the Group with $groupId.
-     *
-     * @param int $groupId
-     *
-     * @return array
-     */
-    public function loadGroupData($groupId)
+    public function loadGroupData(array $groupIds)
     {
         try {
-            return $this->innerGateway->loadGroupData($groupId);
+            return $this->innerGateway->loadGroupData($groupIds);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
@@ -117,7 +117,7 @@ class Handler implements BaseContentTypeHandler
     public function loadGroup($groupId)
     {
         $groups = $this->mapper->extractGroupsFromRows(
-            $this->contentTypeGateway->loadGroupData($groupId)
+            $this->contentTypeGateway->loadGroupData([$groupId])
         );
 
         if (count($groups) !== 1) {
@@ -125,6 +125,23 @@ class Handler implements BaseContentTypeHandler
         }
 
         return $groups[0];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadGroups(array $groupIds)
+    {
+        $groups = $this->mapper->extractGroupsFromRows(
+            $this->contentTypeGateway->loadGroupData($groupIds)
+        );
+
+        $listByGroupIds = [];
+        foreach ($groups as $group) {
+            $listByGroupIds[$group->id] = $group;
+        }
+
+        return $listByGroupIds;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/MemoryCachingHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/MemoryCachingHandler.php
@@ -118,6 +118,23 @@ class MemoryCachingHandler implements BaseContentTypeHandler
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function loadGroups(array $groupIds)
+    {
+        $groups = [];
+        foreach ($groupIds as $groupId) {
+            if (isset($this->groups[$groupId])) {
+                $groups[$groupId] = $this->groups[$groupId];
+            } else {
+                $groups[$groupId] = $this->groups[$groupId] = $this->innerHandler->loadGroup($groupId);
+            }
+        }
+
+        return $groups;
+    }
+
+    /**
      * @param string $identifier
      *
      * @return \eZ\Publish\SPI\Persistence\Content\Type\Group

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
@@ -201,7 +201,7 @@ class ContentTypeHandlerTest extends TestCase
         $gatewayMock = $this->getGatewayMock();
         $gatewayMock->expects($this->once())
             ->method('loadGroupData')
-            ->with($this->equalTo(23))
+            ->with($this->equalTo([23]))
             ->will($this->returnValue(array()));
 
         $mapperMock = $this->getMapperMock();

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php
@@ -286,7 +286,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
         );
 
         $gateway = $this->getGateway();
-        $data = $gateway->loadGroupData(2);
+        $data = $gateway->loadGroupData([2]);
 
         $this->assertEquals(
             array(
@@ -1280,6 +1280,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
         if (!isset($this->gateway)) {
             $this->gateway = new DoctrineDatabase(
                 $this->getDatabaseHandler(),
+                $this->getDatabaseConnection(),
                 $this->getLanguageMaskGenerator()
             );
         }

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -814,12 +814,7 @@ class ContentTypeService implements ContentTypeServiceInterface
 
         return $this->contentTypeDomainMapper->buildContentTypeDraftDomainObject(
             $spiContentType,
-            array_map(
-                function ($id) {
-                    return $this->contentTypeHandler->loadGroup($id);
-                },
-                $spiContentType->groupIds
-            )
+            $this->contentTypeHandler->loadGroups($spiContentType->groupIds)
         );
     }
 
@@ -860,12 +855,7 @@ class ContentTypeService implements ContentTypeServiceInterface
 
         return $this->contentTypeDomainMapper->buildContentTypeDomainObject(
             $spiContentType,
-            array_map(
-                function ($id) {
-                    return $this->contentTypeHandler->loadGroup($id);
-                },
-                $spiContentType->groupIds
-            ),
+            $this->contentTypeHandler->loadGroups($spiContentType->groupIds),
             $prioritizedLanguages
         );
     }
@@ -885,12 +875,7 @@ class ContentTypeService implements ContentTypeServiceInterface
 
         return $this->contentTypeDomainMapper->buildContentTypeDomainObject(
             $spiContentType,
-            array_map(
-                function ($id) {
-                    return $this->contentTypeHandler->loadGroup($id);
-                },
-                $spiContentType->groupIds
-            ),
+            $this->contentTypeHandler->loadGroups($spiContentType->groupIds),
             $prioritizedLanguages
         );
     }
@@ -904,12 +889,7 @@ class ContentTypeService implements ContentTypeServiceInterface
 
         return $this->contentTypeDomainMapper->buildContentTypeDomainObject(
             $spiContentType,
-            array_map(
-                function ($id) {
-                    return $this->contentTypeHandler->loadGroup($id);
-                },
-                $spiContentType->groupIds
-            ),
+            $this->contentTypeHandler->loadGroups($spiContentType->groupIds),
             $prioritizedLanguages
         );
     }
@@ -938,12 +918,7 @@ class ContentTypeService implements ContentTypeServiceInterface
 
         return $this->contentTypeDomainMapper->buildContentTypeDraftDomainObject(
             $spiContentType,
-            array_map(
-                function ($id) {
-                    return $this->contentTypeHandler->loadGroup($id);
-                },
-                $spiContentType->groupIds
-            )
+            $this->contentTypeHandler->loadGroups($spiContentType->groupIds)
         );
     }
 
@@ -961,12 +936,7 @@ class ContentTypeService implements ContentTypeServiceInterface
         foreach ($spiContentTypes as $spiContentType) {
             $contentTypes[] = $this->contentTypeDomainMapper->buildContentTypeDomainObject(
                 $spiContentType,
-                array_map(
-                    function ($id) {
-                        return $this->contentTypeHandler->loadGroup($id);
-                    },
-                    $spiContentType->groupIds
-                ),
+                $this->contentTypeHandler->loadGroups($spiContentType->groupIds),
                 $prioritizedLanguages
             );
         }
@@ -1019,12 +989,7 @@ class ContentTypeService implements ContentTypeServiceInterface
 
         return $this->contentTypeDomainMapper->buildContentTypeDraftDomainObject(
             $spiContentType,
-            array_map(
-                function ($id) {
-                    return $this->contentTypeHandler->loadGroup($id);
-                },
-                $spiContentType->groupIds
-            )
+            $this->contentTypeHandler->loadGroups($spiContentType->groupIds)
         );
     }
 

--- a/eZ/Publish/Core/Repository/SearchService.php
+++ b/eZ/Publish/Core/Repository/SearchService.php
@@ -309,12 +309,6 @@ class SearchService implements SearchServiceInterface
 
         $result = $this->searchHandler->findLocations($query, $languageFilter);
 
-        foreach ($result->searchHits as $hit) {
-            $hit->valueObject = $this->domainMapper->buildLocationDomainObject(
-                $hit->valueObject
-            );
-        }
-
-        return $result;
+        return $this->domainMapper->buildLocationDomainObjectsOnSearchResult($result);
     }
 }

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
@@ -669,13 +669,18 @@ class SearchTest extends BaseServiceMockTest
         $spiLocation = new SPILocation();
         $locationMock = $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\Content\\Location');
 
+        $permissionsCriterionHandlerMock->expects($this->once())
+            ->method('addPermissionsCriterion')
+            ->with($criterionMock)
+            ->will($this->returnValue(true));
+
         /* @var \PHPUnit_Framework_MockObject_MockObject $searchHandlerMock */
         $searchHandlerMock->expects($this->once())
             ->method('findLocations')
             ->with($this->equalTo($query))
             ->will(
                 $this->returnValue(
-                    new SearchResult(
+                    $spiResult = new SearchResult(
                         array(
                             'searchHits' => array(new SearchHit(array('valueObject' => $spiLocation))),
                             'totalCount' => 1,
@@ -684,25 +689,22 @@ class SearchTest extends BaseServiceMockTest
                 )
             );
 
-        $domainMapperMock->expects($this->once())
-            ->method('buildLocationDomainObject')
-            ->with($this->equalTo($spiLocation))
-            ->will($this->returnValue($locationMock));
+        $endResult = new SearchResult(
+            [
+                'searchHits' => [new SearchHit(['valueObject' => $locationMock])],
+                'totalCount' => 1,
+            ]
+        );
 
-        $permissionsCriterionHandlerMock->expects($this->once())
-            ->method('addPermissionsCriterion')
-            ->with($criterionMock)
-            ->will($this->returnValue(true));
+        $domainMapperMock->expects($this->once())
+            ->method('buildLocationDomainObjectsOnSearchResult')
+            ->with($this->equalTo($spiResult))
+            ->will($this->returnValue($endResult));
 
         $result = $service->findLocations($query, array(), true);
 
         $this->assertEquals(
-            new SearchResult(
-                array(
-                    'searchHits' => array(new SearchHit(array('valueObject' => $locationMock))),
-                    'totalCount' => 1,
-                )
-            ),
+            $endResult,
             $result
         );
     }
@@ -738,7 +740,7 @@ class SearchTest extends BaseServiceMockTest
             ->with($this->equalTo($handlerQuery))
             ->will(
                 $this->returnValue(
-                    new SearchResult(
+                    $spiResult = new SearchResult(
                         array(
                             'searchHits' => array(new SearchHit(array('valueObject' => $spiLocation))),
                             'totalCount' => 1,
@@ -747,20 +749,22 @@ class SearchTest extends BaseServiceMockTest
                 )
             );
 
+        $endResult = new SearchResult(
+            [
+                'searchHits' => [new SearchHit(['valueObject' => $locationMock])],
+                'totalCount' => 1,
+            ]
+        );
+
         $domainMapperMock->expects($this->once())
-            ->method('buildLocationDomainObject')
-            ->with($this->equalTo($spiLocation))
-            ->will($this->returnValue($locationMock));
+            ->method('buildLocationDomainObjectsOnSearchResult')
+            ->with($this->equalTo($spiResult))
+            ->will($this->returnValue($endResult));
 
         $result = $service->findLocations($serviceQuery, array(), false);
 
         $this->assertEquals(
-            new SearchResult(
-                array(
-                    'searchHits' => array(new SearchHit(array('valueObject' => $locationMock))),
-                    'totalCount' => 1,
-                )
-            ),
+            $endResult,
             $result
         );
     }
@@ -824,10 +828,6 @@ class SearchTest extends BaseServiceMockTest
 
         $spiLocation = new SPILocation();
         $locationMock = $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\Content\\Location');
-        $domainMapperMock->expects($this->once())
-            ->method('buildLocationDomainObject')
-            ->with($this->equalTo($spiLocation))
-            ->will($this->returnValue($locationMock));
 
         /* @var \PHPUnit_Framework_MockObject_MockObject $searchHandlerMock */
         $searchHandlerMock
@@ -843,7 +843,7 @@ class SearchTest extends BaseServiceMockTest
             )
             ->will(
                 $this->returnValue(
-                    new SearchResult(
+                    $spiResult = new SearchResult(
                         array(
                             'searchHits' => array(new SearchHit(array('valueObject' => $spiLocation))),
                             'totalCount' => 1,
@@ -852,15 +852,22 @@ class SearchTest extends BaseServiceMockTest
                 )
             );
 
+        $endResult = new SearchResult(
+            [
+                'searchHits' => [new SearchHit(['valueObject' => $locationMock])],
+                'totalCount' => 1,
+            ]
+        );
+
+        $domainMapperMock->expects($this->once())
+            ->method('buildLocationDomainObjectsOnSearchResult')
+            ->with($this->equalTo($spiResult))
+            ->will($this->returnValue($endResult));
+
         $result = $service->findLocations(new LocationQuery(), array(), false);
 
         $this->assertEquals(
-            new SearchResult(
-                array(
-                    'searchHits' => array(new SearchHit(array('valueObject' => $locationMock))),
-                    'totalCount' => 1,
-                )
-            ),
+            $endResult,
             $result
         );
     }

--- a/eZ/Publish/Core/Search/Common/Slot/AbstractSubtree.php
+++ b/eZ/Publish/Core/Search/Common/Slot/AbstractSubtree.php
@@ -20,8 +20,9 @@ abstract class AbstractSubtree extends Slot
         $contentHandler = $this->persistenceHandler->contentHandler();
         $locationHandler = $this->persistenceHandler->locationHandler();
 
-        $processedContentIdSet = array();
+        $processedContentIdSet = [];
         $subtreeIds = $locationHandler->loadSubtreeIds($locationId);
+        $contentInfoList = $contentHandler->loadContentInfoList(array_values($subtreeIds));
 
         foreach ($subtreeIds as $locationId => $contentId) {
             $this->searchHandler->indexLocation(
@@ -35,7 +36,7 @@ abstract class AbstractSubtree extends Slot
             $this->searchHandler->indexContent(
                 $contentHandler->load(
                     $contentId,
-                    $contentHandler->loadContentInfo($contentId)->currentVersionNo
+                    $contentInfoList[$contentId]->currentVersionNo
                 )
             );
 

--- a/eZ/Publish/Core/Search/Common/Slot/CopySubtree.php
+++ b/eZ/Publish/Core/Search/Common/Slot/CopySubtree.php
@@ -9,12 +9,11 @@
 namespace eZ\Publish\Core\Search\Common\Slot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
-use eZ\Publish\Core\Search\Common\Slot;
 
 /**
  * A Search Engine slot handling CopySubtreeSignal.
  */
-class CopySubtree extends Slot
+class CopySubtree extends AbstractSubtree
 {
     /**
      * Receive the given $signal and react on it.
@@ -27,18 +26,6 @@ class CopySubtree extends Slot
             return;
         }
 
-        $contentHandler = $this->persistenceHandler->contentHandler();
-
-        foreach ($this->persistenceHandler->locationHandler()->loadSubtreeIds($signal->targetNewSubtreeId) as $contentId) {
-            $contentInfo = $contentHandler->loadContentInfo($contentId);
-            $this->searchHandler->indexContent(
-                $contentHandler->load($contentInfo->id, $contentInfo->currentVersionNo)
-            );
-
-            $locations = $this->persistenceHandler->locationHandler()->loadLocationsByContent($contentInfo->id);
-            foreach ($locations as $location) {
-                $this->searchHandler->indexLocation($location);
-            }
-        }
+        $this->indexSubtree($signal->targetNewSubtreeId);
     }
 }

--- a/eZ/Publish/Core/Search/Common/Slot/Recover.php
+++ b/eZ/Publish/Core/Search/Common/Slot/Recover.php
@@ -9,12 +9,11 @@
 namespace eZ\Publish\Core\Search\Common\Slot;
 
 use eZ\Publish\Core\SignalSlot\Signal;
-use eZ\Publish\Core\Search\Common\Slot;
 
 /**
  * A Search Engine slot handling RecoverSignal.
  */
-class Recover extends Slot
+class Recover extends AbstractSubtree
 {
     /**
      * Receive the given $signal and react on it.
@@ -27,17 +26,6 @@ class Recover extends Slot
             return;
         }
 
-        $contentHandler = $this->persistenceHandler->contentHandler();
-
-        foreach ($this->persistenceHandler->locationHandler()->loadSubtreeIds($signal->newLocationId) as $contentId) {
-            $contentInfo = $contentHandler->loadContentInfo($contentId);
-            $this->searchHandler->indexContent(
-                $contentHandler->load($contentInfo->id, $contentInfo->currentVersionNo)
-            );
-
-            $this->searchHandler->indexLocation(
-                $this->persistenceHandler->locationHandler()->load($signal->newLocationId)
-            );
-        }
+        $this->indexSubtree($signal->newLocationId);
     }
 }

--- a/eZ/Publish/Core/Search/Common/Slot/SwapLocation.php
+++ b/eZ/Publish/Core/Search/Common/Slot/SwapLocation.php
@@ -26,13 +26,19 @@ class SwapLocation extends Slot
         if (!$signal instanceof Signal\LocationService\SwapLocationSignal) {
             return;
         }
-        $content1Info = $this->persistenceHandler->contentHandler()->loadContentInfo($signal->content1Id);
-        $content2Info = $this->persistenceHandler->contentHandler()->loadContentInfo($signal->content2Id);
+
+        $contentInfoList = $this->persistenceHandler->contentHandler()->loadContentInfoList([$signal->content1Id, $signal->content2Id]);
         $this->searchHandler->indexContent(
-            $this->persistenceHandler->contentHandler()->load($content1Info->id, $content1Info->currentVersionNo)
+            $this->persistenceHandler->contentHandler()->load(
+                $signal->content1Id,
+                $contentInfoList[$signal->content1Id]->currentVersionNo
+            )
         );
         $this->searchHandler->indexContent(
-            $this->persistenceHandler->contentHandler()->load($content2Info->id, $content2Info->currentVersionNo)
+            $this->persistenceHandler->contentHandler()->load(
+                $signal->content2Id,
+                $contentInfoList[$signal->content2Id]->currentVersionNo
+            )
         );
         $this->searchHandler->indexLocation($this->persistenceHandler->locationHandler()->load($signal->location1Id));
         $this->searchHandler->indexLocation($this->persistenceHandler->locationHandler()->load($signal->location2Id));

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentSortTest.php
@@ -119,6 +119,7 @@ class HandlerContentSortTest extends LanguageAwareTestCase
             $this->contentTypeHandler = new ContentTypeHandler(
                 new ContentTypeGateway(
                     $this->getDatabaseHandler(),
+                    $this->getDatabaseConnection(),
                     $this->getLanguageMaskGenerator()
                 ),
                 new ContentTypeMapper(

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
@@ -238,6 +238,7 @@ class HandlerContentTest extends LanguageAwareTestCase
             $this->contentTypeHandler = new ContentTypeHandler(
                 new ContentTypeGateway(
                     $this->getDatabaseHandler(),
+                    $this->getDatabaseConnection(),
                     $this->getLanguageMaskGenerator()
                 ),
                 new ContentTypeMapper($this->getConverterRegistry()),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\Search\Legacy\Tests\Content\Location;
+namespace eZ\Publish\Core\Search\Legacy\Tests\Content;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\Content\LanguageAwareTestCase;
 use eZ\Publish\Core\Search\Legacy\Content;
@@ -143,6 +143,7 @@ class HandlerLocationSortTest extends LanguageAwareTestCase
             $this->contentTypeHandler = new ContentTypeHandler(
                 new ContentTypeGateway(
                     $this->getDatabaseHandler(),
+                    $this->getDatabaseConnection(),
                     $this->getLanguageMaskGenerator()
                 ),
                 new ContentTypeMapper($this->getConverterRegistry()),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
@@ -6,7 +6,7 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\Search\Legacy\Tests\Content\Location;
+namespace eZ\Publish\Core\Search\Legacy\Tests\Content;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\Content\LanguageAwareTestCase;
 use eZ\Publish\Core\Persistence;
@@ -211,6 +211,7 @@ class HandlerLocationTest extends LanguageAwareTestCase
             $this->contentTypeHandler = new ContentTypeHandler(
                 new ContentTypeGateway(
                     $this->getDatabaseHandler(),
+                    $this->getDatabaseConnection(),
                     $this->getLanguageMaskGenerator()
                 ),
                 new ContentTypeMapper($this->getConverterRegistry()),

--- a/eZ/Publish/Core/settings/storage_engines/legacy/content_type.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/content_type.yml
@@ -16,6 +16,7 @@ services:
         class: "%ezpublish.persistence.legacy.content_type.gateway.class%"
         arguments:
             - "@ezpublish.api.storage_engine.legacy.dbhandler"
+            - "@ezpublish.api.storage_engine.legacy.connection"
             - "@ezpublish.persistence.legacy.language.mask_generator"
 
     ezpublish.persistence.legacy.content_type.gateway.exception_conversion:

--- a/eZ/Publish/SPI/Persistence/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Handler.php
@@ -77,6 +77,18 @@ interface Handler
     public function loadContentInfo($contentId);
 
     /**
+     * Return list of unique Content Info, with content id as key.
+     *
+     * Missing items (NotFound) will be missing from the array and not cause an exception, it's up
+     * to calling logic to determine if this should cause exception or not.
+     *
+     * @param array $contentIds
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content\ContentInfo[]
+     */
+    public function loadContentInfoList(array $contentIds);
+
+    /**
      * Returns the metadata object for a content identified by $remoteId.
      *
      * @param mixed $remoteId

--- a/eZ/Publish/SPI/Persistence/Content/Type/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/Handler.php
@@ -44,6 +44,18 @@ interface Handler
     public function loadGroup($groupId);
 
     /**
+     * Return list of unique Content Type Groups, with group id as key.
+     *
+     * Missing items (NotFound) will be missing from the array and not cause an exception, it's up
+     * to calling logic to determine if this should cause exception or not.
+     *
+     * @param array $groupIds
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content\Type\Group[]
+     */
+    public function loadGroups(array $groupIds);
+
+    /**
      * Loads Type Group by identifier.
      *
      * Legacy note: Uses name for identifier.


### PR DESCRIPTION
> Issue: see #2070 for where story will end up once user impact is defined, this PR is all internal refactoring for 2.0.


This PR implements  #2070 specification proposal for a couple of specific corner cases needed by Repository itself, theoretically improving performance a bit for some common use cases:
- ContentHandler->loadContentInfoList(): Needed for avoiding loading content info in a loop in  Location Search Result domain mapper, and in Subtree related signals
- ContentTypeHandler->loadGroups(): Needed when building Content Type API objects avoiding that content type groups are loaded in a loop given content type is often loaded next to content.


Implementation notes:
- Changes affected places in Legacy StorageEngine to rather use Doctrine QueryBuilder instead of the old Zeta DB compatibility layer, as Doctrine allows us to bind arrays of values which fits well with the use case here. Also the Doctrine DBAL Query Builder is easier to use once you get past the fact it is heavily under documented.
- Some subtree signals were simplified to re-use the now more improved AbstractSubtree signal
- As we are still on PHPUnit 4 I could not add type hints on return types on SPI interfaces, we can easily add that later if we want, however the right type hint here is _iterable_ and it was not added before PHP 7.1. Also the phpdoc type hint is more specific here for the value types anyway.
