### PR TITLE
EZP-27764: Translation removal does not update language mask for URL alias

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -305,6 +305,23 @@ class UrlAliasHandler extends AbstractHandler implements UrlAliasHandlerInterfac
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function translationRemoved(array $locationIds, $languageCode)
+    {
+        $this->logger->logCall(
+            __METHOD__,
+            ['locations' => implode(',', $locationIds), 'language' => $languageCode]
+        );
+
+        $this->persistenceHandler->urlAliasHandler()->translationRemoved($locationIds, $languageCode);
+
+        foreach ($locationIds as $locationId) {
+            $this->clearLocation($locationId);
+        }
+    }
+
+    /**
      * @param $locationId
      */
     protected function clearLocation($locationId)

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -2034,7 +2034,7 @@ class DoctrineDatabase extends Gateway
             ->where('id = :contentId')
             ->andWhere(
             // make sure removed translation is not the last one (incl. alwaysAvailable)
-                $query->expr()->orX(
+                $query->expr()->andX(
                     'language_mask & ~ ' . $languageId . ' <> 0',
                     'language_mask & ~ ' . $languageId . ' <> 1'
                 )
@@ -2079,7 +2079,7 @@ class DoctrineDatabase extends Gateway
             ->where('contentobject_id = :contentId')
             ->andWhere(
             // make sure removed translation is not the last one (incl. alwaysAvailable)
-                $query->expr()->orX(
+                $query->expr()->andX(
                     'language_mask & ~ ' . $languageId . ' <> 0',
                     'language_mask & ~ ' . $languageId . ' <> 1'
                 )

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway.php
@@ -227,4 +227,12 @@ abstract class Gateway
      * @return int
      */
     abstract public function getLocationContentMainLanguageId($locationId);
+
+    /**
+     * Removes languageId of removed translation from lang_mask and deletes single language rows for multiple Locations.
+     *
+     * @param int $languageId Language Id to be removed
+     * @param string[] $actions actions for which to perform the update
+     */
+    abstract public function bulkRemoveTranslation($languageId, $actions);
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/ExceptionConversion.php
@@ -400,4 +400,18 @@ class ExceptionConversion extends Gateway
             throw new \RuntimeException('Database error', 0, $e);
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function bulkRemoveTranslation($languageId, $actions)
+    {
+        try {
+            return $this->innerGateway->bulkRemoveTranslation($languageId, $actions);
+        } catch (DBALException $e) {
+            throw new \RuntimeException('Database error', 0, $e);
+        } catch (PDOException $e) {
+            throw new \RuntimeException('Database error', 0, $e);
+        }
+    }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
@@ -803,6 +803,23 @@ class Handler implements UrlAliasHandlerInterface
     }
 
     /**
+     * Notifies the underlying engine that Locations Content Translation was removed.
+     *
+     * @param int[] $locationIds all Locations of the Content that got Translation removed
+     * @param string $languageCode language code of the removed Translation
+     */
+    public function translationRemoved(array $locationIds, $languageCode)
+    {
+        $languageId = $this->languageHandler->loadByLanguageCode($languageCode)->id;
+
+        $actions = [];
+        foreach ($locationIds as $locationId) {
+            $actions[] = 'eznode:' . $locationId;
+        }
+        $this->gateway->bulkRemoveTranslation($languageId, $actions);
+    }
+
+    /**
      * Recursively removes aliases by given $id and $action.
      *
      * $original parameter is used to limit removal of moved Location aliases to history entries only.

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\Repository;
 
 use eZ\Publish\API\Repository\ContentService as ContentServiceInterface;
 use eZ\Publish\API\Repository\Repository as RepositoryInterface;
+use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\SPI\Persistence\Handler;
 use eZ\Publish\API\Repository\Values\Content\ContentUpdateStruct as APIContentUpdateStruct;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
@@ -1939,6 +1940,13 @@ class ContentService implements ContentServiceInterface
         $this->repository->beginTransaction();
         try {
             $this->persistenceHandler->contentHandler()->removeTranslationFromContent($contentInfo->id, $languageCode);
+            $locationIds = array_map(
+                function (Location $location) {
+                    return $location->id;
+                },
+                $this->repository->getLocationService()->loadLocations($contentInfo)
+            );
+            $this->persistenceHandler->urlAliasHandler()->translationRemoved($locationIds, $languageCode);
             $this->repository->commit();
         } catch (Exception $e) {
             $this->repository->rollback();

--- a/eZ/Publish/SPI/Persistence/Content/UrlAlias/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/UrlAlias/Handler.php
@@ -160,4 +160,12 @@ interface Handler
      * @param mixed $locationId
      */
     public function locationDeleted($locationId);
+
+    /**
+     * Notifies the underlying engine that Locations Content Translation was removed.
+     *
+     * @param int[] $locationIds all Locations of the Content that got Translation removed
+     * @param string $languageCode language code of the removed Translation
+     */
+    public function translationRemoved(array $locationIds, $languageCode);
 }


### PR DESCRIPTION
Fixes [EZP-27764](https://jira.ez.no/browse/EZP-27764)
----

This PR fixes the bug related to URL aliases not being updated after translation removal, discovered by @rpmsauron while testing [EZP-27713](https://jira.ez.no/browse/EZP-27713).

The database table `ezurlalias_ml` contains column `lang_mask` which also needs to be updated after translation removal.

I've identified two cases for which to apply the fix:
1. `ezurlalias_ml` row can contain URL alias related to only one language with or without `alwaysAvailable` bit. This occurs when field based on which URL alias is generated is different in the specific translation.
2.  `ezurlalias_ml` row can contain URL alias related to multiple languages basically when links don't differ.

Fix:
1. Update `lang_mask` by removing `languageId` of removed translation.
2. Delete rows which as a result of this operation contain only 0 or 1 (depending on `alwaysAvailable` bit).

**TODO**:
- [x] Create integration test checking URL aliases after translation removal.
- [x] Add handling of translation removal to `UrlAliasHandler` to fix the root cause of the bug.
- [x] Fix erroneous where clause discovered while solving this issue.