### PR TITLE
EZP-27773: Validation of depth level of url alias in the Legacy UrlAlias Handler

### DIFF
--- a/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
@@ -942,4 +942,22 @@ class URLAliasServiceTest extends BaseTest
         $loadedAlias = $urlAliasService->lookUp('/Contact-Us', 'ger-DE');
         /* END: Use Case */
     }
+
+    /**
+     * Test for the lookUp() method.
+     *
+     * @see \eZ\Publish\API\Repository\URLAliasService::lookUp($url, $languageCode)
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testLookUpThrowsInvalidArgumentException()
+    {
+        $repository = $this->getRepository();
+
+        /* BEGIN: Use Case */
+        $urlAliasService = $repository->getURLAliasService();
+
+        // Throws InvalidArgumentException
+        $loadedAlias = $urlAliasService->lookUp(str_repeat('/1', 99), 'ger-DE');
+        /* END: Use Case */
+    }
 }

--- a/eZ/Publish/API/Repository/URLAliasService.php
+++ b/eZ/Publish/API/Repository/URLAliasService.php
@@ -100,6 +100,7 @@ interface URLAliasService
      * @param string $languageCode
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the path does not exist or is not valid for the given language
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the path exceeded maximum depth level
      *
      * @return \eZ\Publish\API\Repository\Values\Content\URLAlias
      */

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
@@ -70,6 +70,22 @@ class UrlAliasHandlerTest extends TestCase
         $handler->lookup('wooden/iron');
     }
 
+    /**
+     * Test for the lookup() method.
+     *
+     * Trying to lookup URL alias with exceeded path segments limit
+     *
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Handler::lookup
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @group location
+     * @group case-correction
+     */
+    public function testLookupThrowsInvalidArgumentException()
+    {
+        $handler = $this->getHandler();
+        $handler->lookup(str_repeat('/1', 99));
+    }
+
     public function providerForTestLookupLocationUrlAlias()
     {
         return array(

--- a/eZ/Publish/Core/Repository/URLAliasService.php
+++ b/eZ/Publish/Core/Repository/URLAliasService.php
@@ -608,6 +608,7 @@ class URLAliasService implements URLAliasServiceInterface
      * looks up the URLAlias for the given url.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the path does not exist or is not valid for the given language
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the path exceeded maximum depth level
      *
      * @param string $url
      * @param string $languageCode


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27773

## Description

This PR adds limitation for the depth level of URL alias in the `eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Handler::lookup` method. Without it, some URLs are end up with the fallowing database error: 
```SQLSTATE[HY000]: General error: 1116 Too many tables; MariaDB can only use 61 tables in a join at ...```  (see JIRA issue for more details)

## Steps to reproduce

Try access the URL with more than 60 segments like:

`http://SOME_EZP_INSTALLATION/0/1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16/17/18/19/20/21/22/23/24/25/26/27/28/29/30/31/32/33/34/35/36/37/38/39/40/41/42/43/44/45/46/47/48/49/50/51/52/53/54/55/56/57/58/59/60/61/62/63/64/65/66/67/68/69/70/71/72/73/74/75/76/77/78/79/80/81/82/83/84/85/86/87/88/89/90/91/92/93/94/95/96/97/98/99`

## TODO

- [X] Patch
- [x] Unit test
- [x] Integration test