### PR TITLE
EZEE-1716: Cannot render embedded ezimage in CollectionBlock Gallery View

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed_image.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed_image.html.twig
@@ -4,6 +4,6 @@
     {{ ez_render_field(
        content,
        image_field_identifier,
-       { parameters: { alias: objectParameters.size } }
+       { parameters: { alias: objectParameters.size|default('original') } }
     ) }}
 {% endif %}


### PR DESCRIPTION
# Fixes [EZEE-1716](https://jira.ez.no/browse/EZEE-1716)

`embed_image.html.twig` view should be responsible for handling missing `objectParameters` parameter because it's possible to render view without it *(e.g in case of Embed Block and Collection Block in EE)* and has a very specific default value.

Note: Contrary to the initial Jira issue description, problem exists independently of env or debug settings. It's just silent when debug is false as the Twig setting `twig.strict_variables` depends on the `%kernel.debug%` parameter.