### PR TITLE
Old url aliases should redirect instead of forward

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/RequestEventListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/RequestEventListener.php
@@ -130,7 +130,7 @@ class RequestEventListener implements EventSubscriberInterface
                 }
                 $event->setResponse(
                     new RedirectResponse(
-                        $semanticPathinfo . ($queryString ? "?$queryString" : ''),
+                        $event->getRequest()->getBaseUrl() . $semanticPathinfo . ($queryString ? "?$queryString" : ''),
                         301,
                         $headers
                     )

--- a/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
@@ -186,15 +186,9 @@ class UrlAliasRouter implements ChainedRouterInterface, RequestMatcherInterface
                     break;
 
                 case URLAlias::VIRTUAL:
-                    // Handle case-correction redirect
-                    if ($this->needsCaseRedirect($urlAlias, $requestedPath, $pathPrefix)) {
-                        $request->attributes->set('semanticPathinfo', $this->removePathPrefix($urlAlias->path, $pathPrefix));
-                        $request->attributes->set('needsRedirect', true);
-                    } else {
-                        // Virtual aliases should load the Content at homepage URL
-                        $request->attributes->set('semanticPathinfo', '/');
-                        $request->attributes->set('needsForward', true);
-                    }
+                    // Virtual aliases should load the Content at homepage URL
+                    $request->attributes->set('semanticPathinfo', '/');
+                    $request->attributes->set('needsRedirect', true);
 
                     break;
             }


### PR DESCRIPTION
I think we should redirect to the start page.
Why should these url alias only forward?