### PR TITLE
EZP-27508: As a Developer I want an API that removes a translation from a version

### DIFF
--- a/doc/specifications/translations/removal.md
+++ b/doc/specifications/translations/removal.md
@@ -57,3 +57,54 @@ class RemoveTranslationSignal extends Signal
     public $languageCode;
 }
 ```
+
+## Removing the specific language translation from a Content Object Version Draft
+
+For the cases of preserving Version history, PHP API introduces the `deleteTranslationFromDraft`
+method on `ContentService` which removes the specific Translation from the given
+Content Object Version Draft.
+
+**Note**: A PHP API Consumer is responsible for creating Content Object Version Draft
+and publishing it after translation removal.
+
+**Note**: To remove main Translation, main language needs to be changed manually using
+`ContentService::updateContentMetadata` method first.
+
+```php
+/**
+ * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the specified Translation
+ *         is the only one the Content Draft has or it is the main Translation of a Content Object.
+ * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed
+ *         to edit the Content (in one of the locations of the given Content Object).
+ * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if languageCode argument
+ *         is invalid for the given Draft.
+ * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if specified Version was not found
+ *
+ * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo Content Version Draft
+ * @param string $languageCode Language code of the Translation to be removed
+ *
+ * @return \eZ\Publish\API\Repository\Values\Content\Content Content Draft w/o the specified Translation
+ */
+public function deleteTranslationFromDraft(VersionInfo $versionInfo, $languageCode);
+```
+
+Since the returned Content Draft is to be published, both Search and HttpCache are already handled
+by `PublishVersion` Slots once call to `publishVersion()` is made.
+
+### Example usage of deleteTranslationFromDraft API
+
+```php
+$repository->beginTransaction();
+/** @var \eZ\Publish\API\Repository\Repository $repository */
+try {
+    $versionInfo = $contentService->loadVersionInfoById($contentId, $versionNo);
+    $contentDraft = $contentService->createContentDraft($versionInfo->contentInfo, $versionInfo);
+    $contentDraft = $contentService->deleteTranslationFromDraft($contentDraft->versionInfo, $languageCode);
+    $contentService->publishVersion($contentDraft->versionInfo);
+
+    $repository->commit();
+} catch (\Exception $e) {
+    $repository->rollback();
+    throw $e;
+}
+```

--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -427,6 +427,26 @@ interface ContentService
     public function removeTranslation(ContentInfo $contentInfo, $languageCode);
 
     /**
+     * Delete specified Translation from a Content Draft.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the specified Translation
+     *         is the only one the Content Draft has or it is the main Translation of a Content Object.
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed
+     *         to edit the Content (in one of the locations of the given Content Object).
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if languageCode argument
+     *         is invalid for the given Draft.
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if specified Version was not found
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo Content Version Draft
+     * @param string $languageCode Language code of the Translation to be removed
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content Content Draft w/o the specified Translation
+     *
+     * @since 6.12
+     */
+    public function deleteTranslationFromDraft(VersionInfo $versionInfo, $languageCode);
+
+    /**
      * Instantiates a new content create struct object.
      *
      * alwaysAvailable is set to the ContentType's defaultAlwaysAvailable

--- a/eZ/Publish/API/Repository/Tests/BaseContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseContentServiceTest.php
@@ -327,6 +327,59 @@ abstract class BaseContentServiceTest extends BaseTest
     }
 
     /**
+     * Create Content Draft with custom field values in multiple languages and generated remoteId.
+     *
+     * @param string $contentTypeIdentifier
+     * @param int $parentLocationId
+     * @param string $mainLanguageCode
+     * @param array $multilingualFieldValues map of <code>['fieldIdentifier' => ['languageCode' => 'field value']]</code>
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content Content Draft
+     */
+    protected function createMultilingualContentDraft(
+        $contentTypeIdentifier,
+        $parentLocationId,
+        $mainLanguageCode,
+        array $multilingualFieldValues
+    ) {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+        $contentTypeService = $repository->getContentTypeService();
+        $locationService = $repository->getLocationService();
+
+        // Load content type
+        $contentType = $contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
+
+        // Prepare new Content Object
+        $contentCreateStruct = $contentService->newContentCreateStruct(
+            $contentType,
+            $mainLanguageCode
+        );
+
+        foreach ($multilingualFieldValues as $fieldIdentifier => $multilingualFieldValue) {
+            foreach ($multilingualFieldValue as $languageCode => $fieldValue) {
+                $contentCreateStruct->setField($fieldIdentifier, $fieldValue, $languageCode);
+            }
+        }
+
+        $contentCreateStruct->sectionId = $this->generateId('section', 1);
+        $contentCreateStruct->alwaysAvailable = true;
+
+        // Prepare Location
+        $locationCreateStruct = $locationService->newLocationCreateStruct(
+            $this->generateId('location', $parentLocationId)
+        );
+
+        // Create a draft
+        $contentDraft = $contentService->createContent(
+            $contentCreateStruct,
+            [$locationCreateStruct]
+        );
+
+        return $contentDraft;
+    }
+
+    /**
      * Create Content Draft with custom field values and generated remoteId.
      *
      * @param string $contentTypeIdentifier

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -319,4 +319,23 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
         $this->cache->clear('content', $contentId);
         $this->cache->clear('content', 'info', $contentId);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteTranslationFromDraft($contentId, $versionNo, $languageCode)
+    {
+        $this->logger->logCall(
+            __METHOD__,
+            ['content' => $contentId, 'version' => $versionNo, 'languageCode' => $languageCode]
+        );
+        $content = $this->persistenceHandler->contentHandler()->deleteTranslationFromDraft(
+            $contentId,
+            $versionNo,
+            $languageCode
+        );
+        $this->cache->clear('content', $contentId, $versionNo);
+
+        return $content;
+    }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldHandler.php
@@ -445,4 +445,27 @@ class FieldHandler
         }
         $this->contentGateway->deleteFields($contentId, $versionInfo->versionNo);
     }
+
+    /**
+     * Deletes translated fields and their external storage data for the given $versionInfo.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\VersionInfo $versionInfo
+     * @param string $languageCode
+     */
+    public function deleteTranslationFromVersionFields(VersionInfo $versionInfo, $languageCode)
+    {
+        $fieldTypeIdsMap = $this->contentGateway->getFieldIdsByType(
+            $versionInfo->contentInfo->id,
+            $versionInfo->versionNo,
+            $languageCode
+        );
+        foreach ($fieldTypeIdsMap as $fieldType => $ids) {
+            $this->storageHandler->deleteFieldData($fieldType, $versionInfo, $ids);
+        }
+        $this->contentGateway->deleteTranslatedFields(
+            $languageCode,
+            $versionInfo->contentInfo->id,
+            $versionInfo->versionNo
+        );
+    }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
@@ -401,4 +401,14 @@ abstract class Gateway
      * @param string $languageCode language code of the translation
      */
     abstract public function removeTranslationFromContent($contentId, $languageCode);
+
+    /**
+     * Delete Content fields (attributes) for the given Translation.
+     * If $versionNo is given, fields for that Version only will be deleted.
+     *
+     * @param string $languageCode
+     * @param int $contentId
+     * @param int $versionNo (optional) filter by versionNo
+     */
+    abstract public function deleteTranslatedFields($languageCode, $contentId, $versionNo = null);
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
@@ -243,13 +243,15 @@ abstract class Gateway
     /**
      * Returns all field IDs of $contentId grouped by their type.
      * If $versionNo is set only field IDs for that version are returned.
+     * If $languageCode is set, only field IDs for that language are returned.
      *
      * @param int $contentId
      * @param int|null $versionNo
+     * @param string|null $languageCode
      *
      * @return int[][]
      */
-    abstract public function getFieldIdsByType($contentId, $versionNo = null);
+    abstract public function getFieldIdsByType($contentId, $versionNo = null, $languageCode = null);
 
     /**
      * Deletes relations to and from $contentId.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
@@ -413,4 +413,13 @@ abstract class Gateway
      * @param int $versionNo (optional) filter by versionNo
      */
     abstract public function deleteTranslatedFields($languageCode, $contentId, $versionNo = null);
+
+    /**
+     * Delete the specified Translation from the given Version.
+     *
+     * @param int $contentId
+     * @param int $versionNo
+     * @param string $languageCode
+     */
+    abstract public function deleteTranslationFromVersion($contentId, $versionNo, $languageCode);
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -1961,7 +1961,8 @@ class DoctrineDatabase extends Gateway
             $this->deleteTranslationFromContentVersions($contentId, $language->id);
             $this->deleteTranslationFromContentObject($contentId, $language->id);
 
-            $this->deleteTranslationFromContentAttributes($contentId, $languageCode);
+            // @todo: move this to field handler when fixing EZP-27949
+            $this->deleteTranslatedFields($languageCode, $contentId);
             $this->deleteTranslationFromContentNames($contentId, $languageCode);
 
             $this->connection->commit();
@@ -1972,12 +1973,14 @@ class DoctrineDatabase extends Gateway
     }
 
     /**
-     * Delete translation from the ezcontentobject_attribute table.
+     * Delete Content fields (attributes) for the given Translation.
+     * If $versionNo is given, fields for that Version only will be deleted.
      *
-     * @param int $contentId
      * @param string $languageCode
+     * @param int $contentId
+     * @param int $versionNo (optional) filter by versionNo
      */
-    private function deleteTranslationFromContentAttributes($contentId, $languageCode)
+    public function deleteTranslatedFields($languageCode, $contentId, $versionNo = null)
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -1992,14 +1995,21 @@ class DoctrineDatabase extends Gateway
             )
         ;
 
+        if (null !== $versionNo) {
+            $query
+                ->andWhere('version = :versionNo')
+                ->setParameter(':versionNo', $versionNo)
+            ;
+        }
+
         $query->execute();
     }
 
     /**
      * Delete translation from the ezcontentobject_name table.
      *
-     * @param $contentId
-     * @param $languageCode
+     * @param int $contentId
+     * @param string $languageCode
      */
     private function deleteTranslationFromContentNames($contentId, $languageCode)
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -1146,13 +1146,15 @@ class DoctrineDatabase extends Gateway
     /**
      * Returns all field IDs of $contentId grouped by their type.
      * If $versionNo is set only field IDs for that version are returned.
+     * If $languageCode is set, only field IDs for that language are returned.
      *
      * @param int $contentId
      * @param int|null $versionNo
+     * @param string|null $languageCode
      *
      * @return int[][]
      */
-    public function getFieldIdsByType($contentId, $versionNo = null)
+    public function getFieldIdsByType($contentId, $versionNo = null, $languageCode = null)
     {
         $query = $this->dbHandler->createSelectQuery();
         $query->select(
@@ -1172,6 +1174,15 @@ class DoctrineDatabase extends Gateway
                 $query->expr->eq(
                     $this->dbHandler->quoteColumn('version'),
                     $query->bindValue($versionNo, null, \PDO::PARAM_INT)
+                )
+            );
+        }
+
+        if (isset($languageCode)) {
+            $query->where(
+                $query->expr->eq(
+                    $this->dbHandler->quoteColumn('language_code'),
+                    $query->bindValue($languageCode, null, \PDO::PARAM_STR)
                 )
             );
         }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
@@ -747,4 +747,23 @@ class ExceptionConversion extends Gateway
             throw new RuntimeException('Database error', 0, $e);
         }
     }
+
+    /**
+     * Delete Content fields (attributes) for the given Translation.
+     * If $versionNo is given, fields for that Version only will be deleted.
+     *
+     * @param string $languageCode
+     * @param int $contentId
+     * @param int $versionNo (optional) filter by versionNo
+     */
+    public function deleteTranslatedFields($languageCode, $contentId, $versionNo = null)
+    {
+        try {
+            return $this->innerGateway->deleteTranslatedFields($languageCode, $contentId, $versionNo);
+        } catch (DBALException $e) {
+            throw new RuntimeException('Database error', 0, $e);
+        } catch (PDOException $e) {
+            throw new RuntimeException('Database error', 0, $e);
+        }
+    }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
@@ -440,16 +440,18 @@ class ExceptionConversion extends Gateway
     /**
      * Returns all field IDs of $contentId grouped by their type.
      * If $versionNo is set only field IDs for that version are returned.
+     * If $languageCode is set, only field IDs for that language are returned.
      *
      * @param int $contentId
      * @param int|null $versionNo
+     * @param string|null $languageCode
      *
      * @return int[][]
      */
-    public function getFieldIdsByType($contentId, $versionNo = null)
+    public function getFieldIdsByType($contentId, $versionNo = null, $languageCode = null)
     {
         try {
-            return $this->innerGateway->getFieldIdsByType($contentId, $versionNo);
+            return $this->innerGateway->getFieldIdsByType($contentId, $versionNo, $languageCode);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
@@ -768,4 +768,22 @@ class ExceptionConversion extends Gateway
             throw new RuntimeException('Database error', 0, $e);
         }
     }
+
+    /**
+     * Delete the specified Translation from the given Version.
+     *
+     * @param int $contentId
+     * @param int $versionNo
+     * @param string $languageCode
+     */
+    public function deleteTranslationFromVersion($contentId, $versionNo, $languageCode)
+    {
+        try {
+            return $this->innerGateway->deleteTranslationFromVersion($contentId, $versionNo, $languageCode);
+        } catch (DBALException $e) {
+            throw new RuntimeException('Database error', 0, $e);
+        } catch (PDOException $e) {
+            throw new RuntimeException('Database error', 0, $e);
+        }
+    }
 }

--- a/eZ/Publish/Core/REST/Client/ContentService.php
+++ b/eZ/Publish/Core/REST/Client/ContentService.php
@@ -771,6 +771,14 @@ class ContentService implements APIContentService, Sessionable
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function deleteTranslationFromDraft(VersionInfo $versionInfo, $languageCode)
+    {
+        throw new \Exception('@todo: Implement.');
+    }
+
+    /**
      * Instantiates a new TranslationInfo object.
      *
      * @return \eZ\Publish\API\Repository\Values\Content\TranslationInfo

--- a/eZ/Publish/Core/SignalSlot/ContentService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentService.php
@@ -659,6 +659,29 @@ class ContentService implements ContentServiceInterface
     }
 
     /**
+     * Delete specified Translation from a Content Draft.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the specified Translation
+     *         is the only one the Content Draft has or it is the main Translation of a Content Object.
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed
+     *         to edit the Content (in one of the locations of the given Content Object).
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if languageCode argument
+     *         is invalid for the given Draft.
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if specified Version was not found
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo Content Version Draft
+     * @param string $languageCode Language code of the Translation to be removed
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Content Content Draft w/o the specified Translation
+     *
+     * @since 6.12
+     */
+    public function deleteTranslationFromDraft(VersionInfo $versionInfo, $languageCode)
+    {
+        return $this->service->deleteTranslationFromDraft($versionInfo, $languageCode);
+    }
+
+    /**
      * Instantiates a new content create struct object.
      *
      * alwaysAvailable is set to the ContentType's defaultAlwaysAvailable

--- a/eZ/Publish/SPI/Persistence/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Handler.php
@@ -266,4 +266,15 @@ interface Handler
      * @param string $languageCode language code of the translation
      */
     public function removeTranslationFromContent($contentId, $languageCode);
+
+    /**
+     * Remove the specified Translation from the given Version Draft of a Content Object.
+     *
+     * @param int $contentId
+     * @param int $versionNo
+     * @param string $languageCode
+     *
+     * @return \eZ\Publish\SPI\Persistence\Content The Content Draft w/o removed Translation
+     */
+    public function deleteTranslationFromDraft($contentId, $versionNo, $languageCode);
 }


### PR DESCRIPTION
# Implements [EZP-27508](https://jira.ez.no/browse/EZP-27508)

This PR implements PHP API method:
```
ContentService::deleteTranslationFromDraft(VersionInfo $versionInfo, $languageCode);
```
 which deletes the Translation specified by a language code from a Content Object Version Draft.

Related PRs:
- #2001 - initial discussions for similar feature removing Translation from the entire Content, naming introduced there will be changed according to [this conclusion](https://github.com/ezsystems/ezpublish-kernel/pull/2081#issuecomment-334177307)
- #2086 - REST endpoint using PHP API implemented by this PR.

Note: It's a responsibility of PHP API Consumer to first create Draft and then publish it after removing language. Moreover, if a Translation is the main one, it needs to be changed manually using `ContentService::updateContentMetadata` first.

**TODO**:
- [x] Create spec for `ContentService::deleteTranslation` method.
- [x] See if what spec describes is technically possible (issue with merging field/translation when publishing)
- [x] Implement the method on PHP API interface and implementing layers.
- [x] Improve Spec.
- [x] Create integration tests.
- [x] Delete external storage data for removed fields.
- [x] Rebase and reorder commits before merge.
- [x] Fix naming of API method.
- [x] **Rebase before merge**

*Note: created branch on `ezsystems` so dependent features can temporarily target to this branch (currently it's impossible to change base fork, only base branch can be changed)*