### PR TITLE
Fix EZP-28099: Wrong Urls at equal beginning path prefixes

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -114,7 +114,7 @@ class UrlAliasGenerator extends Generator
             if ($rootLocationId !== null) {
                 $pathPrefix = $this->getPathPrefixByRootLocationId($rootLocationId, $languages, $siteaccess);
                 // "/" cannot be considered as a path prefix since it's root, so we ignore it.
-                if ($pathPrefix !== '/' && mb_stripos($path, $pathPrefix) === 0) {
+                if ($pathPrefix !== '/' && ($path === $pathPrefix || mb_stripos($path, $pathPrefix . '/') === 0)) {
                     $path = mb_substr($path, mb_strlen($pathPrefix));
                 } elseif ($pathPrefix !== '/' && !$this->isUriPrefixExcluded($path) && $this->logger !== null) {
                     // Location path is outside configured content tree and doesn't have an excluded prefix.

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
@@ -415,6 +415,12 @@ class UrlAliasGeneratorTest extends TestCase
                 '/shared/some-content',
                 '/my/root-folder',
             ),
+            array(
+                new UrlAlias(array('path' => '/products/ez-publish')),
+                false,
+                '/products/ez-publish',
+                '/prod',
+            ),
         );
     }
 


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-28099

If you have 2 path prefixes that starts with the same name.
e.g.
- eZ Platform
- eZ Platform Enterprise

And generate a link from the short path prefix to the large. The url is generate without leading slash and with half path prefix.
e.g.
`-Enterprise/Imprint`
instead of
`/eZ-Platform-Enterprise/Imprint`