### PR TITLE
Fix EZP-27876: Replace strlen with mb_strlen in length validation of TextLine field value

### DIFF
--- a/eZ/Publish/Core/FieldType/Tests/StringLengthValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/StringLengthValidatorTest.php
@@ -168,6 +168,7 @@ class StringLengthValidatorTest extends TestCase
             array('hello'),
             array('hello!'),
             array('0123456789'),
+            array('♔♕♖♗♘♙♚♛♜♝'),
         );
     }
 
@@ -227,6 +228,12 @@ class StringLengthValidatorTest extends TestCase
                 'The string can not exceed %size% character.',
                 'The string can not exceed %size% characters.',
                 array('%size%' => $this->getMaxStringLength()),
+            ),
+            array(
+                'ABC♔',
+                'The string can not be shorter than %size% character.',
+                'The string can not be shorter than %size% characters.',
+                array('%size%' => $this->getMinStringLength()),
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/TextLineTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/TextLineTest.php
@@ -544,6 +544,16 @@ class TextLineTest extends FieldTypeTest
                 ),
                 new TextLineValue('lililili'),
             ),
+            array(
+                array(
+                    'validatorConfiguration' => array(
+                        'StringLengthValidator' => array(
+                            'maxStringLength' => 10,
+                        ),
+                    ),
+                ),
+                new TextLineValue('♔♕♖♗♘♙♚♛♜♝'),
+            ),
         );
     }
 
@@ -680,6 +690,27 @@ class TextLineTest extends FieldTypeTest
                         'The string can not be shorter than %size% characters.',
                         array(
                             '%size%' => 10,
+                        ),
+                        'text'
+                    ),
+                ),
+            ),
+            array(
+                array(
+                    'validatorConfiguration' => array(
+                        'StringLengthValidator' => array(
+                            'minStringLength' => 5,
+                            'maxStringLength' => 10,
+                        ),
+                    ),
+                ),
+                new TextLineValue('ABC♔'),
+                array(
+                    new ValidationError(
+                        'The string can not be shorter than %size% character.',
+                        'The string can not be shorter than %size% characters.',
+                        array(
+                            '%size%' => 5,
                         ),
                         'text'
                     ),

--- a/eZ/Publish/Core/FieldType/TextLine/Type.php
+++ b/eZ/Publish/Core/FieldType/TextLine/Type.php
@@ -91,7 +91,7 @@ class Type extends FieldType
         if (isset($constraints['maxStringLength']) &&
             $constraints['maxStringLength'] !== false &&
             $constraints['maxStringLength'] !== 0 &&
-            strlen($fieldValue->text) > $constraints['maxStringLength']) {
+            mb_strlen($fieldValue->text) > $constraints['maxStringLength']) {
             $validationErrors[] = new ValidationError(
                 'The string can not exceed %size% character.',
                 'The string can not exceed %size% characters.',
@@ -105,7 +105,7 @@ class Type extends FieldType
         if (isset($constraints['minStringLength']) &&
             $constraints['minStringLength'] !== false &&
             $constraints['minStringLength'] !== 0 &&
-            strlen($fieldValue->text) < $constraints['minStringLength']) {
+            mb_strlen($fieldValue->text) < $constraints['minStringLength']) {
             $validationErrors[] = new ValidationError(
                 'The string can not be shorter than %size% character.',
                 'The string can not be shorter than %size% characters.',

--- a/eZ/Publish/Core/FieldType/Validator/StringLengthValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/StringLengthValidator.php
@@ -112,7 +112,7 @@ class StringLengthValidator extends Validator
 
         if ($this->constraints['maxStringLength'] !== false &&
             $this->constraints['maxStringLength'] !== 0 &&
-            strlen($value->text) > $this->constraints['maxStringLength']) {
+            mb_strlen($value->text) > $this->constraints['maxStringLength']) {
             $this->errors[] = new ValidationError(
                 'The string can not exceed %size% character.',
                 'The string can not exceed %size% characters.',
@@ -124,7 +124,7 @@ class StringLengthValidator extends Validator
         }
         if ($this->constraints['minStringLength'] !== false &&
             $this->constraints['minStringLength'] !== 0 &&
-            strlen($value->text) < $this->constraints['minStringLength']) {
+            mb_strlen($value->text) < $this->constraints['minStringLength']) {
             $this->errors[] = new ValidationError(
                 'The string can not be shorter than %size% character.',
                 'The string can not be shorter than %size% characters.',


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27876

# Description

This PR replace `strlen` with `mb_strlen` in length validation of TextLine field value (users expects length as number of characters instead of number of bytes) 
