### PR TITLE
Allow set root location by remote id - POC

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/RoutingListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/RoutingListener.php
@@ -10,6 +10,7 @@ namespace eZ\Bundle\EzPublishCoreBundle\EventListener;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\Routing\Generator;
+use eZ\Publish\Core\MVC\Symfony\Routing\RootLocationIdCalculator;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use eZ\Publish\Core\MVC\Symfony\Event\PostSiteAccessMatchEvent;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
@@ -35,11 +36,17 @@ class RoutingListener implements EventSubscriberInterface
      */
     private $urlAliasGenerator;
 
-    public function __construct(ConfigResolverInterface $configResolver, RouterInterface $urlAliasRouter, Generator $urlAliasGenerator)
+    /**
+     * @var \eZ\Publish\Core\MVC\Symfony\Routing\RootLocationIdCalculator
+     */
+    private $rootLocationIdCalculator;
+
+    public function __construct(ConfigResolverInterface $configResolver, RouterInterface $urlAliasRouter, Generator $urlAliasGenerator, RootLocationIdCalculator $rootLocationIdCalculator)
     {
         $this->configResolver = $configResolver;
         $this->urlAliasRouter = $urlAliasRouter;
         $this->urlAliasGenerator = $urlAliasGenerator;
+        $this->rootLocationIdCalculator = $rootLocationIdCalculator;
     }
 
     public static function getSubscribedEvents()
@@ -51,7 +58,7 @@ class RoutingListener implements EventSubscriberInterface
 
     public function onSiteAccessMatch(PostSiteAccessMatchEvent $event)
     {
-        $rootLocationId = $this->configResolver->getParameter('content.tree_root.location_id');
+        $rootLocationId = $this->rootLocationIdCalculator->getRootLocationId();
         $this->urlAliasRouter->setRootLocationId($rootLocationId);
         $this->urlAliasGenerator->setRootLocationId($rootLocationId);
         $this->urlAliasGenerator->setExcludedUriPrefixes($this->configResolver->getParameter('content.tree_root.excluded_uri_prefixes'));

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
@@ -65,6 +65,7 @@ services:
             - "@ezpublish.api.repository"
             - "@router.default"
             - "@ezpublish.config.resolver"
+            - "@ezpublish.root_location_id.calculator"
             - "%ezpublish.urlalias_generator.charmap%"
         parent: ezpublish.url_generator.base
 
@@ -92,7 +93,7 @@ services:
 
     ezpublish.siteaccess_listener.routing:
         class: "%ezpublish.siteaccess_listener.routing.class%"
-        arguments: ["@ezpublish.config.resolver", "@ezpublish.urlalias_router", "@ezpublish.urlalias_generator"]
+        arguments: ["@ezpublish.config.resolver", "@ezpublish.urlalias_router", "@ezpublish.urlalias_generator", "@ezpublish.root_location_id.calculator"]
         tags:
             - { name: kernel.event_subscriber }
 
@@ -135,3 +136,9 @@ services:
         tags:
             - { name: kernel.event_subscriber }
         arguments: ["@ezpublish.translation_helper"]
+
+    ezpublish.root_location_id.calculator:
+        class: eZ\Publish\Core\MVC\Symfony\Routing\RootLocationIdCalculator
+        arguments:
+            - '@ezpublish.config.resolver'
+            - '@ezpublish.api.service.location'

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -137,7 +137,7 @@ services:
 
     ezpublish.templating.global_helper.core:
         class: "%ezpublish.templating.global_helper.core.class%"
-        arguments: ["@ezpublish.config.resolver", "@ezpublish.api.service.location", "@router", "@ezpublish.translation_helper"]
+        arguments: ["@ezpublish.config.resolver", "@ezpublish.api.service.location", "@router", "@ezpublish.translation_helper", "@ezpublish.root_location_id.calculator"]
         calls:
             - [setRequestStack, ["@request_stack"]]
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/ContentTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/ContentTest.php
@@ -53,6 +53,27 @@ class ContentTest extends AbstractParserTestCase
         }
     }
 
+    /**
+     * @test
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage You cannot set location_id and location_remote_id tree_root params for the 'ezdemo_site' siteaccess at the same time
+     */
+    public function testThrowExceptionWhenNeeded()
+    {
+        $this->load(
+            array(
+                'system' => array(
+                    'ezdemo_site' => array(
+                        'content' => array(
+                            'tree_root' => array('location_id' => 123, 'location_remote_id' => 'location-remote-id-123'),
+                        ),
+                    ),
+                ),
+            )
+        );
+    }
+
     public function contentSettingsProvider()
     {
         return array(

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Routing\Generator;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\Routing\Generator;
+use eZ\Publish\Core\MVC\Symfony\Routing\RootLocationIdCalculator;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
@@ -55,6 +56,9 @@ class UrlAliasGenerator extends Generator
      */
     private $configResolver;
 
+    /** @var RootLocationIdCalculator */
+    private $rootLocationIdCalculator;
+
     /**
      * Array of characters that are potentially unsafe for output for (x)html, json, etc,
      * and respective url-encoded value.
@@ -63,11 +67,12 @@ class UrlAliasGenerator extends Generator
      */
     private $unsafeCharMap;
 
-    public function __construct(Repository $repository, RouterInterface $defaultRouter, ConfigResolverInterface $configResolver, array $unsafeCharMap = array())
+    public function __construct(Repository $repository, RouterInterface $defaultRouter, ConfigResolverInterface $configResolver, RootLocationIdCalculator $rootLocationIdCalculator, array $unsafeCharMap = array())
     {
         $this->repository = $repository;
         $this->defaultRouter = $defaultRouter;
         $this->configResolver = $configResolver;
+        $this->rootLocationIdCalculator = $rootLocationIdCalculator;
         $this->unsafeCharMap = $unsafeCharMap;
     }
 
@@ -95,7 +100,8 @@ class UrlAliasGenerator extends Generator
             $languages = $this->configResolver->getParameter('languages', null, $siteaccess);
             $urlAliases = $urlAliasService->listLocationAliases($location, false, null, null, $languages);
             // Use the target SiteAccess root location
-            $rootLocationId = $this->configResolver->getParameter('content.tree_root.location_id', null, $siteaccess);
+
+            $rootLocationId = $this->rootLocationIdCalculator->getRootLocationIdBySiteaccess($siteaccess);
         } else {
             $languages = null;
             $urlAliases = $urlAliasService->listLocationAliases($location, false);

--- a/eZ/Publish/Core/MVC/Symfony/Routing/RootLocationIdCalculator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/RootLocationIdCalculator.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * File containing the ContentTreeLocationRemoteIdAware trait.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Routing;
+
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+
+class RootLocationIdCalculator
+{
+    /**
+     * @var int|string
+     */
+    protected $rootLocationId;
+
+    /**
+     * @var array
+     */
+    protected $rootLocationIdsBySiteaccess = [];
+
+    /**
+     * @var ConfigResolverInterface
+     */
+    protected $configResolver;
+
+    /**
+     * @var LocationService
+     */
+    protected $locationService;
+
+    public function __construct(ConfigResolverInterface $configResolver, LocationService $locationService)
+    {
+        $this->configResolver = $configResolver;
+        $this->locationService = $locationService;
+    }
+
+    /**
+     * @return int|string
+     */
+    public function getRootLocationId()
+    {
+        if (null === $this->rootLocationId) {
+            $this->rootLocationId = $this->getRootLocationIdFromConfig();
+        }
+
+        return $this->rootLocationId;
+    }
+
+    /**
+     * @param $siteaccess
+     * @return mixed
+     */
+    public function getRootLocationIdBySiteaccess($siteaccess)
+    {
+        if (!isset($this->rootLocationIdsBySiteaccess[$siteaccess])) {
+            $this->rootLocationIdsBySiteaccess[$siteaccess] = $this->getRootLocationIdFromConfig($siteaccess);
+        }
+
+        return $this->rootLocationIdsBySiteaccess[$siteaccess];
+    }
+
+    /**
+     * Returns content.tree_root.location_id for the current siteaccess or for the passed siteaccess.
+     * In case content.tree_root.location_id is not present, it will calculate location id from the
+     * content.tree_root.location_remote_id param.
+     *
+     * @param null $siteaccess
+     * @return mixed
+     */
+    protected function getRootLocationIdFromConfig($siteaccess = null)
+    {
+        if ($this->configResolver->hasParameter('content.tree_root.location_id', null, $siteaccess)) {
+            return $this->configResolver->getParameter('content.tree_root.location_id', null, $siteaccess);
+        }
+
+        $locationRemoteId = $this->configResolver->getParameter('content.tree_root.location_remote_id', null, $siteaccess);
+
+        return $this->locationService->loadLocationByRemoteId($locationRemoteId)->id;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/RootLocationIdCalculatorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/RootLocationIdCalculatorTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/**
+ * File containing the RootLocationIdCalculatorTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Routing\Tests;
+
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\Routing\RootLocationIdCalculator;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+use PHPUnit\Framework\TestCase;
+
+class RootLocationIdCalculatorTest extends TestCase
+{
+    private $configResolver;
+
+    private $locationService;
+
+    private $rootLocationIdCalculator;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->configResolver = $this->getMock(ConfigResolverInterface::class);
+        $this->locationService = $this->getMock(LocationService::class);
+
+        $this->rootLocationIdCalculator = new RootLocationIdCalculator(
+            $this->configResolver,
+            $this->locationService
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function testGetRootLocationIdWhenUsingLocationId()
+    {
+        $rootLocationId = 123;
+
+        $this->configResolver
+            ->expects($this->once())
+            ->method('hasParameter')
+            ->with('content.tree_root.location_id')
+            ->will(
+                $this->returnValue(true)
+            );
+
+        $this->configResolver
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with('content.tree_root.location_id')
+            ->will(
+                $this->returnValue($rootLocationId)
+            );
+
+        $this->locationService
+            ->expects($this->never())
+            ->method($this->anything());
+
+        $this->assertSame($rootLocationId, $this->rootLocationIdCalculator->getRootLocationId());
+    }
+
+    /**
+     * @test
+     */
+    public function testGetRootLocationIdWhenUsingLocationRemoteId()
+    {
+        $rootLocationId = 123;
+        $rootLocationRemoteId = 'theRemoteLocationId';
+        $rootLocation = new Location(['id' => $rootLocationId]);
+
+        $this->configResolver
+            ->expects($this->once())
+            ->method('hasParameter')
+            ->with('content.tree_root.location_id')
+            ->will(
+                $this->returnValue(false)
+            );
+
+        $this->configResolver
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with('content.tree_root.location_remote_id')
+            ->will(
+                $this->returnValue($rootLocationRemoteId)
+            );
+
+        $this->locationService
+            ->expects($this->once())
+            ->method('loadLocationByRemoteId')
+            ->with($rootLocationRemoteId)
+            ->will(
+                $this->returnValue($rootLocation)
+            );
+
+        $this->assertSame($rootLocationId, $this->rootLocationIdCalculator->getRootLocationId());
+    }
+
+    /**
+     * @test
+     */
+    public function testGetRootLocationIdBySiteaccessWhenUsingLocationId()
+    {
+        $rootLocationId = 123;
+        $siteAccessName = 'foo';
+
+        $this->configResolver
+            ->expects($this->once())
+            ->method('hasParameter')
+            ->with('content.tree_root.location_id', null, 'foo')
+            ->will(
+                $this->returnValue(true)
+            );
+
+        $this->configResolver
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with('content.tree_root.location_id', null, 'foo')
+            ->will(
+                $this->returnValue($rootLocationId)
+            );
+
+        $this->locationService
+            ->expects($this->never())
+            ->method($this->anything());
+
+        $this->assertSame($rootLocationId, $this->rootLocationIdCalculator->getRootLocationIdBySiteaccess($siteAccessName));
+    }
+
+    /**
+     * @test
+     */
+    public function testGetRootLocationIdBySiteaccessWhenUsingLocationRemoteId()
+    {
+        $rootLocationId = 123;
+        $siteAccessName = 'foo';
+        $rootLocationRemoteId = 'theRemoteLocationId';
+        $rootLocation = new Location(['id' => $rootLocationId]);
+
+        $this->configResolver
+            ->expects($this->once())
+            ->method('hasParameter')
+            ->with('content.tree_root.location_id', null, 'foo')
+            ->will(
+                $this->returnValue(false)
+            );
+
+        $this->configResolver
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with('content.tree_root.location_remote_id', null, 'foo')
+            ->will(
+                $this->returnValue($rootLocationRemoteId)
+            );
+
+        $this->locationService
+            ->expects($this->once())
+            ->method('loadLocationByRemoteId')
+            ->with($rootLocationRemoteId)
+            ->will(
+                $this->returnValue($rootLocation)
+            );
+
+        $this->assertSame($rootLocationId, $this->rootLocationIdCalculator->getRootLocationIdBySiteaccess($siteAccessName));
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasRouterTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasRouterTest.php
@@ -15,6 +15,7 @@ use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\URLAlias;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator;
+use eZ\Publish\Core\MVC\Symfony\Routing\RootLocationIdCalculator;
 use eZ\Publish\Core\MVC\Symfony\Routing\UrlAliasRouter;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\View\Manager as ViewManager;
@@ -82,6 +83,9 @@ class UrlAliasRouterTest extends TestCase
                     $repository,
                     $this->getMock('Symfony\\Component\\Routing\\RouterInterface'),
                     $this->getMock('eZ\Publish\Core\MVC\ConfigResolverInterface'),
+                    $this->getMockBuilder(RootLocationIdCalculator::class)
+                        ->disableOriginalConstructor()
+                        ->getMock(),
                 )
             )
             ->getMock();

--- a/eZ/Publish/Core/MVC/Symfony/Templating/GlobalHelper.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/GlobalHelper.php
@@ -12,6 +12,7 @@ use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\Helper\TranslationHelper;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\RequestStackAware;
+use eZ\Publish\Core\MVC\Symfony\Routing\RootLocationIdCalculator;
 use eZ\Publish\Core\MVC\Symfony\Routing\UrlAliasRouter;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -43,16 +44,20 @@ class GlobalHelper
      */
     protected $translationHelper;
 
+    protected $rootLocationIdCalculator;
+
     public function __construct(
         ConfigResolverInterface $configResolver,
         LocationService $locationService,
         RouterInterface $router,
-        TranslationHelper $translationHelper
+        TranslationHelper $translationHelper,
+        RootLocationIdCalculator $rootLocationIdCalculator
     ) {
         $this->configResolver = $configResolver;
         $this->locationService = $locationService;
         $this->router = $router;
         $this->translationHelper = $translationHelper;
+        $this->rootLocationIdCalculator = $rootLocationIdCalculator;
     }
 
     /**
@@ -143,9 +148,7 @@ class GlobalHelper
      */
     public function getRootLocation()
     {
-        return $this->locationService->loadLocation(
-            $this->configResolver->getParameter('content.tree_root.location_id')
-        );
+        return $this->locationService->loadLocation($this->rootLocationIdCalculator->getRootLocationId());
     }
 
     /**

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/GlobalHelperTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/GlobalHelperTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests;
 
+use eZ\Publish\Core\MVC\Symfony\Routing\RootLocationIdCalculator;
 use eZ\Publish\Core\MVC\Symfony\Templating\GlobalHelper;
 use Symfony\Component\HttpFoundation\Request;
 use eZ\Publish\Core\MVC\Symfony\Routing\UrlAliasRouter;
@@ -46,6 +47,8 @@ class GlobalHelperTest extends TestCase
      */
     protected $translationHelper;
 
+    protected $rootLocationIdCalculator;
+
     protected function setUp()
     {
         parent::setUp();
@@ -57,7 +60,10 @@ class GlobalHelperTest extends TestCase
         $this->translationHelper = $this->getMockBuilder('eZ\Publish\Core\Helper\TranslationHelper')
             ->disableOriginalConstructor()
             ->getMock();
-        $this->helper = new GlobalHelper($this->configResolver, $this->locationService, $this->router, $this->translationHelper);
+        $this->rootLocationIdCalculator = $this->getMockBuilder(RootLocationIdCalculator::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->helper = new GlobalHelper($this->configResolver, $this->locationService, $this->router, $this->translationHelper, $this->rootLocationIdCalculator);
     }
 
     public function testGetSiteaccess()
@@ -155,10 +161,9 @@ class GlobalHelperTest extends TestCase
     public function testGetRootLocation()
     {
         $rootLocationId = 2;
-        $this->configResolver
+        $this->rootLocationIdCalculator
             ->expects($this->once())
-            ->method('getParameter')
-            ->with('content.tree_root.location_id')
+            ->method('getRootLocationId')
             ->will($this->returnValue($rootLocationId));
 
         $rootLocation = $this


### PR DESCRIPTION
This is not intended to be merged yet. I would like to know your opinion about this proposal. it will allow to use location remote id to set the root location id for a siteacess. 

in my idea, ,there's a trait (i guess name and namespace probably needs to be changed). this trait is used from the classes that were using the content.tree_root.location_id para before. 

Tests will be updated if you think this proposal is a starting point :)

Use example
```yml
# System settings, grouped by siteaccess and/or siteaccess group
    system:
        site:
            content:
                tree_root:
                    #location_id: 2
                    location_remote_id: e494293f8e7caef8e0536a0d67acf250 # location_remote_id will be used if set even if location_id is also set. 
```

Side note:
Problem here is if you use this functionality you will be adding a new db query. First idea i had is to do this when compiling the container. I mean something like:
if the location_remote_id param is set, then calculate location id and modify content.tree_root.location_id with its value, but, to get the location i needed the repository and it looks i can't use it until container build process has ended...

Any idea will be very welcome