### PR TITLE
EZP-27886: [PAPI] Wrong policy function name used by ContentService::removeTranslation

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -5325,7 +5325,7 @@ class ContentServiceTest extends BaseContentServiceTest
      *
      * @covers \eZ\Publish\Core\Repository\ContentService::removeTranslation
      * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     * @expectedExceptionMessage User does not have access to 'delete' 'content'
+     * @expectedExceptionMessage User does not have access to 'remove' 'content'
      */
     public function testRemoveTranslationThrowsUnauthorizedException()
     {

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1900,10 +1900,10 @@ class ContentService implements ContentServiceInterface
         $versions = [];
         foreach ($this->loadVersions($contentInfo) as $versionInfo) {
             // check if user is authorized to delete Version
-            if (!$this->repository->canUser('content', 'delete', $versionInfo)) {
+            if (!$this->repository->canUser('content', 'remove', $versionInfo)) {
                 throw new UnauthorizedException(
                     'content',
-                    'delete',
+                    'remove',
                     [
                         'contentId' => $contentInfo->id,
                         'versionNo' => $versionInfo->versionNo,


### PR DESCRIPTION
# Fixes [EZP-27886](https://jira.ez.no/browse/EZP-27886)

PHP `ContentService::removeTranslation` uses `content / delete` but the actual proper module / function name should be `content / remove`

Backported to `6.11` as this feature exists since `v6.11.0`

**TODO**:
- [x] Fix function name in Core implementation
- [x] Align integration test with the fix