### PR TITLE
[POC] EZP-27924: As a Developer I want lazy loading of content type groups

### DIFF
--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -812,15 +812,7 @@ class ContentTypeService implements ContentTypeServiceInterface
             throw $e;
         }
 
-        return $this->contentTypeDomainMapper->buildContentTypeDraftDomainObject(
-            $spiContentType,
-            array_map(
-                function ($id) {
-                    return $this->contentTypeHandler->loadGroup($id);
-                },
-                $spiContentType->groupIds
-            )
-        );
+        return $this->contentTypeDomainMapper->buildContentTypeDraftDomainObject($spiContentType);
     }
 
     /**
@@ -860,12 +852,6 @@ class ContentTypeService implements ContentTypeServiceInterface
 
         return $this->contentTypeDomainMapper->buildContentTypeDomainObject(
             $spiContentType,
-            array_map(
-                function ($id) {
-                    return $this->contentTypeHandler->loadGroup($id);
-                },
-                $spiContentType->groupIds
-            ),
             $prioritizedLanguages
         );
     }
@@ -885,12 +871,6 @@ class ContentTypeService implements ContentTypeServiceInterface
 
         return $this->contentTypeDomainMapper->buildContentTypeDomainObject(
             $spiContentType,
-            array_map(
-                function ($id) {
-                    return $this->contentTypeHandler->loadGroup($id);
-                },
-                $spiContentType->groupIds
-            ),
             $prioritizedLanguages
         );
     }
@@ -904,12 +884,6 @@ class ContentTypeService implements ContentTypeServiceInterface
 
         return $this->contentTypeDomainMapper->buildContentTypeDomainObject(
             $spiContentType,
-            array_map(
-                function ($id) {
-                    return $this->contentTypeHandler->loadGroup($id);
-                },
-                $spiContentType->groupIds
-            ),
             $prioritizedLanguages
         );
     }
@@ -936,15 +910,7 @@ class ContentTypeService implements ContentTypeServiceInterface
             throw new NotFoundException('ContentType owned by someone else', $contentTypeId);
         }
 
-        return $this->contentTypeDomainMapper->buildContentTypeDraftDomainObject(
-            $spiContentType,
-            array_map(
-                function ($id) {
-                    return $this->contentTypeHandler->loadGroup($id);
-                },
-                $spiContentType->groupIds
-            )
-        );
+        return $this->contentTypeDomainMapper->buildContentTypeDraftDomainObject($spiContentType);
     }
 
     /**
@@ -961,12 +927,6 @@ class ContentTypeService implements ContentTypeServiceInterface
         foreach ($spiContentTypes as $spiContentType) {
             $contentTypes[] = $this->contentTypeDomainMapper->buildContentTypeDomainObject(
                 $spiContentType,
-                array_map(
-                    function ($id) {
-                        return $this->contentTypeHandler->loadGroup($id);
-                    },
-                    $spiContentType->groupIds
-                ),
                 $prioritizedLanguages
             );
         }
@@ -1017,15 +977,7 @@ class ContentTypeService implements ContentTypeServiceInterface
             }
         }
 
-        return $this->contentTypeDomainMapper->buildContentTypeDraftDomainObject(
-            $spiContentType,
-            array_map(
-                function ($id) {
-                    return $this->contentTypeHandler->loadGroup($id);
-                },
-                $spiContentType->groupIds
-            )
-        );
+        return $this->contentTypeDomainMapper->buildContentTypeDraftDomainObject($spiContentType);
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Helper/ContentTypeDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/ContentTypeDomainMapper.php
@@ -20,6 +20,7 @@ use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentTypeDraft;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentTypeGroup;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\Repository\Values\GeneratorCollection;
 use eZ\Publish\SPI\FieldType\FieldType as SPIFieldType;
 use eZ\Publish\SPI\Persistence\Content\Type as SPIContentType;
 use eZ\Publish\SPI\Persistence\Content\Type\Group as SPIContentTypeGroup;
@@ -97,7 +98,10 @@ class ContentTypeDomainMapper
             array(
                 'names' => $spiContentType->name,
                 'descriptions' => $spiContentType->description,
-                'contentTypeGroups' => $this->generateContentTypeGroupDomainObjects($spiContentType, $prioritizedLanguages),
+                'contentTypeGroups' =>
+                    new GeneratorCollection(
+                        $this->generateContentTypeGroupDomainObjects($spiContentType, $prioritizedLanguages)
+                    ),
                 'fieldDefinitions' => $fieldDefinitions,
                 'id' => $spiContentType->id,
                 'status' => $spiContentType->status,

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -888,6 +888,7 @@ class Repository implements RepositoryInterface
         }
 
         $this->contentTypeDomainMapper = new Helper\ContentTypeDomainMapper(
+            $this->persistenceHandler->contentTypeHandler(),
             $this->persistenceHandler->contentLanguageHandler(),
             $this->getFieldTypeRegistry()
         );

--- a/eZ/Publish/Core/Repository/Values/ContentType/ContentType.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/ContentType.php
@@ -46,7 +46,7 @@ class ContentType extends APIContentType
     /**
      * Holds the collection of contenttypegroups the contenttype is assigned to.
      *
-     * @var \eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup[]
+     * @var \eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup[]|\Generator
      */
     protected $contentTypeGroups = [];
 
@@ -88,6 +88,16 @@ class ContentType extends APIContentType
      */
     public function getContentTypeGroups()
     {
+        // If value is a generator, get the values and set them back so they can be iterated again later
+        if ($this->contentTypeGroups instanceof \Generator) {
+            $contentTypeGroups = [];
+            foreach ($this->contentTypeGroups as $contentTypeGroup) {
+                $contentTypeGroups[] = $contentTypeGroup;
+            }
+
+            $this->contentTypeGroups = $contentTypeGroups;
+        }
+
         return $this->contentTypeGroups;
     }
 
@@ -131,5 +141,24 @@ class ContentType extends APIContentType
         }
 
         return null;
+    }
+
+    public function __get($property)
+    {
+        switch ($property) {
+            case 'contentTypeGroups':
+                return $this->getContentTypeGroups();
+        }
+
+        return parent::__get($property);
+    }
+
+    public function __isset($property)
+    {
+        if ($property === 'contentTypeGroups') {
+            return true;
+        }
+
+        return parent::__isset($property);
     }
 }

--- a/eZ/Publish/Core/Repository/Values/ContentType/ContentType.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/ContentType.php
@@ -46,7 +46,7 @@ class ContentType extends APIContentType
     /**
      * Holds the collection of contenttypegroups the contenttype is assigned to.
      *
-     * @var \eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup[]|\Generator
+     * @var \eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup[]
      */
     protected $contentTypeGroups = [];
 
@@ -88,16 +88,6 @@ class ContentType extends APIContentType
      */
     public function getContentTypeGroups()
     {
-        // If value is a generator, get the values and set them back so they can be iterated again later
-        if ($this->contentTypeGroups instanceof \Generator) {
-            $contentTypeGroups = [];
-            foreach ($this->contentTypeGroups as $contentTypeGroup) {
-                $contentTypeGroups[] = $contentTypeGroup;
-            }
-
-            $this->contentTypeGroups = $contentTypeGroups;
-        }
-
         return $this->contentTypeGroups;
     }
 
@@ -141,24 +131,5 @@ class ContentType extends APIContentType
         }
 
         return null;
-    }
-
-    public function __get($property)
-    {
-        switch ($property) {
-            case 'contentTypeGroups':
-                return $this->getContentTypeGroups();
-        }
-
-        return parent::__get($property);
-    }
-
-    public function __isset($property)
-    {
-        if ($property === 'contentTypeGroups') {
-            return true;
-        }
-
-        return parent::__isset($property);
     }
 }

--- a/eZ/Publish/Core/Repository/Values/GeneratorCollection.php
+++ b/eZ/Publish/Core/Repository/Values/GeneratorCollection.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Repository\Values;
+
+use ArrayAccess;
+use Countable;
+use Generator;
+use Iterator;
+
+/**
+ * Class GeneratorCollection, allows for lazy loaded arrays using Generators.
+ *
+ * This collection class takes Generator as argument, and allows user to threat it like any kind of iterable. It will take
+ * care about storing the values returned from generator so user can iterate over it several times, it also allows for
+ * count usage and offset usage.
+ */
+class GeneratorCollection implements Iterator, ArrayAccess, Countable
+{
+    private $array = [];
+    private $generator;
+    private $generatorUsed = false;
+
+    /**
+     * GeneratorCollection constructor.
+     *
+     * @param Generator $generator
+     */
+    public function __construct(Generator $generator)
+    {
+        $this->generator = $generator;
+    }
+
+    public function rewind()
+    {
+        if (isset($this->generator)) {
+            // If generator has already been used, given generators can't start over we will need to load all
+            if ($this->generatorUsed) {
+                $this->loadAll();
+            } else {
+                $this->generatorUsed = true;
+                $this->generator->rewind();
+            }
+        }
+
+        reset($this->array);
+    }
+
+    public function current()
+    {
+        if (isset($this->generator)) {
+            // As the generator is iterated, set the values on array here so we can also iterate on it later
+            return $this->array[$this->generator->key()] = $this->generator->current();
+        }
+
+        return current($this->array);
+    }
+
+    public function key()
+    {
+        if (isset($this->generator)) {
+            return $this->generator->key();
+        }
+
+        return key($this->array);
+    }
+
+    public function next()
+    {
+        if (isset($this->generator)) {
+            $this->generatorUsed = true;
+            $this->generator->next();
+        }
+
+        next($this->array);
+    }
+
+    public function valid()
+    {
+        if (isset($this->generator)) {
+            if ($this->generator->valid()) {
+                return true;
+            }
+
+            // If not valid we are at the end of the array, for future iteration we'll unset this and use array only
+            unset($this->generator);
+        }
+
+        return key($this->array) !== null;
+    }
+
+    public function offsetExists($offset)
+    {
+        if (isset($this->generator)) {
+            $this->loadAll();
+        }
+
+        return isset($this->array[$offset]);
+    }
+
+    public function offsetGet($offset)
+    {
+        if (isset($this->generator)) {
+            $this->loadAll();
+        }
+
+        return $this->array[$offset];
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        // Read only collection, so not handled here (for making it writable it would have to loadAll first if needed)
+    }
+
+    public function offsetUnset($offset)
+    {
+        // Read only collection, so not handled here (for making it writable it would have to loadAll first if needed)
+    }
+
+    public function count()
+    {
+        if (isset($this->generator)) {
+            $this->loadAll();
+        }
+        return count($this->array);
+    }
+
+    /**
+     * Loads the whole/remaining items in the Generator into internal array.
+     */
+    private function loadAll()
+    {
+        // As we might have loaded some elements already we use array union to retain everything
+        $this->array = iterator_to_array($this->generator) + $this->array;
+        unset($this->generator);
+    }
+}


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-27924

As a Developer I want `$contentType->contentTypeGroups` to be loaded lazily since I usually don't need to iterate on them, I mainly need to get info on the type only and don't want to see it slowed down by group loading and it's object mapping.

# Implementation
This is done using [Generator](http://php.net/generator) under the hood atm here, as it avoid having to inject services. Besides saving on unneeded loads, doing this kind of changes several places on the api should theoretically have the benefit of reducing memory consumption as well _(when the properties are not used)_.

## TBD on use of Generatos
- A: Settle on a way to hide generators from api consumers, either:
    1. like first commit where we let value object take generator and deal with extracting array on use
    2. like second commit where the property changes from being plain array to a Lazy Collection that takes generator as input _(`iterable`, but not accepted as array type any longer), this has benefit of hiding the logic from value object completely and can slightly more effectively try to gradually unroll the data into memory instead of in bulk like A.1. option.
- ~~B: Expose Generators to end users to get full benefits of the memory savings, documentation the downsides of not being able to iterate over several times and also not `count()` array~~ _to many downsides, we will do this in lower levels like SPI and gateways and what not, but not API_
- ~~C: Don't use generators at all, inject service into Value object even if that gives us circular reference and duplicate load logic in value object~~ _To much logic in value objects_

## Review Note
If we go down this road there will be several other places that might receive same treatment, for instance we might decide to reuse this technique adding `$content->locations`, `$location->parents` and other similar array collections where filtering is usually not needed. For other similar use cases see work done in [recent versions](https://github.com/netgen/ezplatform-site-api/releases) of NetGen SiteAPI for instance _(approach: re maps value objects into cusotm extended once and injects services for lazy loading)_