### PR TITLE
Fix EZP-27791: Mark "_ez_user_hash" route as non siteaccess aware by default

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
@@ -1,7 +1,7 @@
 parameters:
     # Redefining the default router class to implement the RequestMatcherInterface
     router.class: eZ\Bundle\EzPublishCoreBundle\Routing\DefaultRouter
-    ezpublish.default_router.non_siteaccess_aware_routes: ['_assetic_', '_wdt', '_profiler', '_configurator_']
+    ezpublish.default_router.non_siteaccess_aware_routes: ['_assetic_', '_wdt', '_profiler', '_configurator_', '_ez_user_hash']
     # characters that may require encoding in the urlalias generator
     ezpublish.urlalias_generator.charmap:
         "\"" : "%22"


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-27791

# Description

This PR change the configuration of default router by adding _ez_user_hash to non siteaccess aware routes.

In the siteaccess matching configuration based on URI, the HTTP proxy is unable to get the proper user hash, because we cut off the siteacceess prefix from URI before router match the request. See JIRA issue for more information.