### PR TITLE
EZP-28008: Clear remote id cache on meta data updates & remove inaccurate cache warmers

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
@@ -374,25 +374,25 @@ class ContentHandlerTest extends HandlerTest
             ->expects($this->once())
             ->method('updateMetadata')
             ->with(2, $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\MetadataUpdateStruct'))
-            ->will($this->returnValue(new ContentInfo(array('id' => 2))));
+            ->willReturn(new ContentInfo(array('id' => 2, 'currentVersionNo' => 3, 'remoteId' => 'o34')));
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
         $this->cacheMock
-            ->expects($this->once())
-            ->method('getItem')
+            ->expects($this->at(0))
+            ->method('clear')
+            ->with('content', 2, 3)
+            ->willReturn(null);
+
+        $this->cacheMock
+            ->expects($this->at(1))
+            ->method('clear')
             ->with('content', 'info', 2)
-            ->will($this->returnValue($cacheItemMock));
+            ->willReturn(null);
 
-        $cacheItemMock
-            ->expects($this->once())
-            ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\ContentInfo'))
-            ->will($this->returnValue($cacheItemMock));
-
-        $cacheItemMock
-            ->expects($this->once())
-            ->method('save')
-            ->with();
+        $this->cacheMock
+            ->expects($this->at(2))
+            ->method('clear')
+            ->with('content', 'info', 'remoteId', 'o34')
+            ->willReturn(null);
 
         $handler = $this->persistenceCacheHandler->contentHandler();
         $handler->updateMetadata(2, new MetadataUpdateStruct());
@@ -436,24 +436,6 @@ class ContentHandlerTest extends HandlerTest
             ->method('clear')
             ->with('content', 2, 1)
             ->will($this->returnValue(null));
-
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
-        $this->cacheMock
-            ->expects($this->once())
-            ->method('getItem')
-            ->with('content', 2, 1, ContentHandler::ALL_TRANSLATIONS_KEY)
-            ->will($this->returnValue($cacheItemMock));
-
-        $cacheItemMock
-            ->expects($this->once())
-            ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content'))
-            ->will($this->returnValue($cacheItemMock));
-
-        $cacheItemMock
-            ->expects($this->once())
-            ->method('save')
-            ->with();
 
         $handler = $this->persistenceCacheHandler->contentHandler();
         $handler->updateContent(2, 1, new UpdateStruct());


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-28008

Add cache clearing of remote id lookup of ContentInfo in updateMetadata() call.

Additionally remove unneeded cache warming in these cases as to make sure the 100% correct data retrieved on load is rather cached instead. In the case of `updateContent` it warms up content for all translations, however this might not even be used by the given setup if specific languages are always loaded. So reduce complexity here basically.