### PR TITLE
EZP-27621: Add http cache ttl setting for error pages to be able to set separately

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Content.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Content.php
@@ -30,7 +30,8 @@ class Content extends AbstractParser
                 ->children()
                     ->booleanNode('view_cache')->defaultValue(true)->end()
                     ->booleanNode('ttl_cache')->defaultValue(true)->end()
-                    ->scalarNode('default_ttl')->info('Default value for TTL cache, in seconds')->defaultValue(60)->end()
+                    ->scalarNode('default_ttl')->info('Default value for TTL cache, for responses considered OK (200, 204, 304), in seconds')->defaultValue(600)->end()
+                    ->scalarNode('default_error_ttl')->info('Default value for TTL cache on error, for responses not considered as OK, in seconds')->defaultValue(10)->end()
                     ->arrayNode('tree_root')
                         ->canBeUnset()
                         ->children()
@@ -55,6 +56,7 @@ class Content extends AbstractParser
             $contextualizer->setContextualParameter('content.view_cache', $currentScope, $scopeSettings['content']['view_cache']);
             $contextualizer->setContextualParameter('content.ttl_cache', $currentScope, $scopeSettings['content']['ttl_cache']);
             $contextualizer->setContextualParameter('content.default_ttl', $currentScope, $scopeSettings['content']['default_ttl']);
+            $contextualizer->setContextualParameter('content.default_error_ttl', $currentScope, $scopeSettings['content']['default_error_ttl']);
 
             if (isset($scopeSettings['content']['tree_root'])) {
                 $contextualizer->setContextualParameter(

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -84,7 +84,8 @@ parameters:
     # Content settings
     ezsettings.default.content.view_cache: true         # Whether to use content view cache or not (Etag/Last-Modified based)
     ezsettings.default.content.ttl_cache: true          # Whether to use TTL Cache for content (i.e. Max-Age response header)
-    ezsettings.default.content.default_ttl: 60          # Default TTL cache value for content
+    ezsettings.default.content.default_ttl: 600         # Default TTL cache value for content
+    ezsettings.default.content.default_error_ttl: 10    # Default TTL cache value for content on cacheable error view responses
     ezsettings.default.content.tree_root.location_id: 2 # Root locationId for routing and link generation. Useful for multisite apps with one repository.
     ezsettings.default.content.tree_root.excluded_uri_prefixes: [] # URI prefixes that are allowed to be outside the content tree
     ezsettings.default.content.field_groups.list: ['content', 'metadata']

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -300,6 +300,7 @@ services:
             - $content.view_cache$
             - $content.ttl_cache$
             - $content.default_ttl$
+            - $content.default_error_ttl$
         tags:
             - { name: kernel.event_subscriber }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/ContentTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/ContentTest.php
@@ -32,7 +32,8 @@ class ContentTest extends AbstractParserTestCase
 
         $this->assertConfigResolverParameterValue('content.view_cache', true, 'ezdemo_site');
         $this->assertConfigResolverParameterValue('content.ttl_cache', true, 'ezdemo_site');
-        $this->assertConfigResolverParameterValue('content.default_ttl', 60, 'ezdemo_site');
+        $this->assertConfigResolverParameterValue('content.default_ttl', 600, 'ezdemo_site');
+        $this->assertConfigResolverParameterValue('content.default_error_ttl', 10, 'ezdemo_site');
     }
 
     /**
@@ -76,12 +77,14 @@ class ContentTest extends AbstractParserTestCase
                         'view_cache' => false,
                         'ttl_cache' => false,
                         'default_ttl' => 123,
+                        'default_error_ttl' => 234,
                     ),
                 ),
                 array(
                     'content.view_cache' => false,
                     'content.ttl_cache' => false,
                     'content.default_ttl' => 123,
+                    'content.default_error_ttl' => 234,
                 ),
             ),
             array(
@@ -93,7 +96,7 @@ class ContentTest extends AbstractParserTestCase
                 array(
                     'content.view_cache' => false,
                     'content.ttl_cache' => true,
-                    'content.default_ttl' => 60,
+                    'content.default_ttl' => 600,
                 ),
             ),
             array(
@@ -105,7 +108,7 @@ class ContentTest extends AbstractParserTestCase
                 array(
                     'content.view_cache' => true,
                     'content.ttl_cache' => true,
-                    'content.default_ttl' => 60,
+                    'content.default_ttl' => 600,
                     'content.tree_root.location_id' => 123,
                 ),
             ),
@@ -121,7 +124,8 @@ class ContentTest extends AbstractParserTestCase
                 array(
                     'content.view_cache' => true,
                     'content.ttl_cache' => true,
-                    'content.default_ttl' => 60,
+                    'content.default_ttl' => 600,
+                    'content.default_error_ttl' => 10,
                     'content.tree_root.location_id' => 456,
                     'content.tree_root.excluded_uri_prefixes' => array('/media/images', '/products'),
                 ),


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-27621

Fixes issue where user can't increase ttl as error pages and redirects will get the same ttl, on for instance temprary 404's or 500's this is not something they want to happen.

### Review

Especially would like input on:
- Naming ... Anything more suitable then "error" which better covers redirects? Issue asks for "temprary" responses, might be better?
- Status codes _(I opted to reuse exposed method on Response object here for simplicity, hence OK: 200 and Empty: 204 + 305)_
- Proposed TTL values, ok as default now that temporary responses have own ttl?

