### PR TITLE
Update tests to work PHPUnit v5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     },
     "require-dev": {
         "mikey179/vfsStream": "1.1.0",
-        "phpunit/phpunit": "^4.8.35",
+        "phpunit/phpunit": "^5.7",
         "matthiasnoback/symfony-dependency-injection-test": "0.*",
         "mockery/mockery": "~0.9.4",
         "symfony/assetic-bundle": "~2.3",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
         "mikey179/vfsStream": "1.1.0",
         "phpunit/phpunit": "^5.7",
         "matthiasnoback/symfony-dependency-injection-test": "0.*",
-        "mockery/mockery": "~0.9.4",
         "symfony/assetic-bundle": "~2.3",
         "ezsystems/behatbundle": "^6.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "require-dev": {
         "mikey179/vfsStream": "1.1.0",
         "phpunit/phpunit": "^5.7",
-        "matthiasnoback/symfony-dependency-injection-test": "0.*",
+        "matthiasnoback/symfony-dependency-injection-test": "~1.0",
         "symfony/assetic-bundle": "~2.3",
         "ezsystems/behatbundle": "^6.1"
     },

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/ConsoleContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/ConsoleContext.php
@@ -7,7 +7,7 @@ use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use EzSystems\BehatBundle\Context\EzContext;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
-use PHPUnit_Framework_Assert as Assertion;
+use PHPUnit\Framework\Assert as Assertion;
 
 class ConsoleContext extends EzContext implements Context, SnippetAcceptingContext
 {

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/ContentPreviewContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/ContentPreviewContext.php
@@ -11,7 +11,7 @@ use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use EzSystems\BehatBundle\Context\Browser\Context as BrowserContext;
 use EzSystems\PlatformBehatBundle\Context\SubContext\DeprecationNoticeSupressor;
-use PHPUnit_Framework_Assert as Assertion;
+use PHPUnit\Framework\Assert as Assertion;
 
 class ContentPreviewContext extends BrowserContext implements Context, SnippetAcceptingContext
 {

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/ContentTypeContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/ContentTypeContext.php
@@ -11,7 +11,7 @@ use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Exceptions as ApiExceptions;
 use eZ\Publish\API\Repository\Repository;
 use Behat\Gherkin\Node\TableNode;
-use PHPUnit_Framework_Assert as Assertion;
+use PHPUnit\Framework\Assert as Assertion;
 
 /**
  * Sentences for Content Types.

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/QueryControllerContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/QueryControllerContext.php
@@ -13,7 +13,7 @@ use Behat\MinkExtension\Context\RawMinkContext;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use EzSystems\PlatformBehatBundle\Context\RepositoryContext;
-use PHPUnit_Framework_Assert;
+use PHPUnit\Framework\Assert;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Yaml\Yaml;
 
@@ -162,7 +162,7 @@ class QueryControllerContext extends RawMinkContext implements Context
                     $exceptionLines[] = trim($html);
                 }
                 $message = 'An exception occurred during rendering:' . implode("\n", $exceptionLines);
-                PHPUnit_Framework_Assert::assertTrue(false, $message);
+                Assert::assertTrue(false, $message);
             }
         }
         $this->assertSession()->statusCodeEquals(200);
@@ -209,7 +209,7 @@ class QueryControllerContext extends RawMinkContext implements Context
             }
         }
 
-        PHPUnit_Framework_Assert::assertTrue(
+        Assert::assertTrue(
             $variableFound,
             "The $twigVariableName twig variable was not set"
         );

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/RoleContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/RoleContext.php
@@ -6,7 +6,7 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;
 
 use Behat\Behat\Context\Context;
-use PHPUnit_Framework_Assert as Assertion;
+use PHPUnit\Framework\Assert as Assertion;
 use EzSystems\PlatformBehatBundle\Context\RepositoryContext;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\RoleService;

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/UserContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/UserContext.php
@@ -7,7 +7,7 @@ namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;
 
 use Behat\Gherkin\Node\TableNode;
 use Behat\Behat\Context\Context;
-use PHPUnit_Framework_Assert as Assertion;
+use PHPUnit\Framework\Assert as Assertion;
 use EzSystems\PlatformBehatBundle\Context\RepositoryContext;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\UserService;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/ApiLoader/CacheFactoryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/ApiLoader/CacheFactoryTest.php
@@ -26,8 +26,8 @@ class CacheFactoryTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->configResolver = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
-        $this->container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $this->configResolver = $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
+        $this->container = $this->createMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/ApiLoader/LazyRepositoryFactoryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/ApiLoader/LazyRepositoryFactoryTest.php
@@ -15,7 +15,7 @@ class LazyRepositoryFactoryTest extends TestCase
 {
     public function testBuildRepository()
     {
-        $repositoryMock = $this->getMock('eZ\\Publish\\API\\Repository\\Repository');
+        $repositoryMock = $this->createMock('eZ\\Publish\\API\\Repository\\Repository');
         $factory = new LazyRepositoryFactory($repositoryMock);
         $lazyRepository = $factory->buildRepository();
         $this->assertInternalType('callable', $lazyRepository);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/ApiLoader/RepositoryConfigurationProviderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/ApiLoader/RepositoryConfigurationProviderTest.php
@@ -99,6 +99,6 @@ class RepositoryConfigurationProviderTest extends TestCase
      */
     protected function getConfigResolverMock()
     {
-        return $this->getMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
+        return $this->createMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/ApiLoader/StorageConnectionFactoryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/ApiLoader/StorageConnectionFactoryTest.php
@@ -28,14 +28,14 @@ class StorageConnectionFactoryTest extends TestCase
             ),
         );
 
-        $configResolver = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
+        $configResolver = $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
         $configResolver
             ->expects($this->once())
             ->method('getParameter')
             ->with('repository')
             ->will($this->returnValue($repositoryAlias));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container
             ->expects($this->once())
             ->method('has')
@@ -80,7 +80,7 @@ class StorageConnectionFactoryTest extends TestCase
             ),
         );
 
-        $configResolver = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
+        $configResolver = $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
         $configResolver
             ->expects($this->once())
             ->method('getParameter')
@@ -89,7 +89,7 @@ class StorageConnectionFactoryTest extends TestCase
 
         $repositoryConfigurationProvider = new RepositoryConfigurationProvider($configResolver, $repositories);
         $factory = new StorageConnectionFactory($repositoryConfigurationProvider);
-        $factory->setContainer($this->getMock('Symfony\Component\DependencyInjection\ContainerInterface'));
+        $factory->setContainer($this->createMock('Symfony\Component\DependencyInjection\ContainerInterface'));
         $factory->getConnection();
     }
 
@@ -113,7 +113,7 @@ class StorageConnectionFactoryTest extends TestCase
             ->method('getRepositoryConfig')
             ->will($this->returnValue($repositoryConfig));
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $container
             ->expects($this->once())
             ->method('has')

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/ApiLoader/StorageEngineFactoryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/ApiLoader/StorageEngineFactoryTest.php
@@ -24,9 +24,9 @@ class StorageEngineFactoryTest extends TestCase
         $factory = new StorageEngineFactory($repositoryConfigurationProvider);
 
         $storageEngines = array(
-            'foo' => $this->getMock('eZ\Publish\SPI\Persistence\Handler'),
-            'bar' => $this->getMock('eZ\Publish\SPI\Persistence\Handler'),
-            'baz' => $this->getMock('eZ\Publish\SPI\Persistence\Handler'),
+            'foo' => $this->createMock('eZ\Publish\SPI\Persistence\Handler'),
+            'bar' => $this->createMock('eZ\Publish\SPI\Persistence\Handler'),
+            'baz' => $this->createMock('eZ\Publish\SPI\Persistence\Handler'),
         );
 
         foreach ($storageEngines as $identifier => $persistenceHandler) {
@@ -52,11 +52,11 @@ class StorageEngineFactoryTest extends TestCase
                 ),
             ),
         );
-        $expectedStorageEngine = $this->getMock('eZ\Publish\SPI\Persistence\Handler');
+        $expectedStorageEngine = $this->createMock('eZ\Publish\SPI\Persistence\Handler');
         $storageEngines = array(
             'foo' => $expectedStorageEngine,
-            'bar' => $this->getMock('eZ\Publish\SPI\Persistence\Handler'),
-            'baz' => $this->getMock('eZ\Publish\SPI\Persistence\Handler'),
+            'bar' => $this->createMock('eZ\Publish\SPI\Persistence\Handler'),
+            'baz' => $this->createMock('eZ\Publish\SPI\Persistence\Handler'),
         );
         $repositoryConfigurationProvider = new RepositoryConfigurationProvider($configResolver, $repositories);
         $factory = new StorageEngineFactory($repositoryConfigurationProvider);
@@ -94,9 +94,9 @@ class StorageEngineFactoryTest extends TestCase
         );
 
         $storageEngines = array(
-            'foo' => $this->getMock('eZ\Publish\SPI\Persistence\Handler'),
-            'bar' => $this->getMock('eZ\Publish\SPI\Persistence\Handler'),
-            'baz' => $this->getMock('eZ\Publish\SPI\Persistence\Handler'),
+            'foo' => $this->createMock('eZ\Publish\SPI\Persistence\Handler'),
+            'bar' => $this->createMock('eZ\Publish\SPI\Persistence\Handler'),
+            'baz' => $this->createMock('eZ\Publish\SPI\Persistence\Handler'),
         );
 
         $repositoryConfigurationProvider = new RepositoryConfigurationProvider($configResolver, $repositories);
@@ -111,7 +111,7 @@ class StorageEngineFactoryTest extends TestCase
             ->with('repository')
             ->will($this->returnValue($repositoryAlias));
 
-        $this->assertSame($this->getMock('eZ\Publish\SPI\Persistence\Handler'), $factory->buildStorageEngine());
+        $this->assertSame($this->createMock('eZ\Publish\SPI\Persistence\Handler'), $factory->buildStorageEngine());
     }
 
     /**
@@ -119,6 +119,6 @@ class StorageEngineFactoryTest extends TestCase
      */
     protected function getConfigResolverMock()
     {
-        return $this->getMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
+        return $this->createMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Assetic/AssetFactoryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Assetic/AssetFactoryTest.php
@@ -27,8 +27,8 @@ class AssetFactoryTest extends BaseTest
     protected function setUp()
     {
         parent::setUp();
-        $this->configResolver = $this->getMock('\eZ\Publish\Core\MVC\ConfigResolverInterface');
-        $this->parser = $this->getMock(
+        $this->configResolver = $this->createMock('\eZ\Publish\Core\MVC\ConfigResolverInterface');
+        $this->parser = $this->createMock(
             '\eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\DynamicSettingParserInterface'
         );
     }
@@ -36,9 +36,9 @@ class AssetFactoryTest extends BaseTest
     protected function getAssetFactory()
     {
         $assetFactory = new AssetFactory(
-            $this->getMock('\Symfony\Component\HttpKernel\KernelInterface'),
-            $this->getMock('\Symfony\Component\DependencyInjection\ContainerInterface'),
-            $this->getMock('\Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface'),
+            $this->createMock('\Symfony\Component\HttpKernel\KernelInterface'),
+            $this->createMock('\Symfony\Component\DependencyInjection\ContainerInterface'),
+            $this->createMock('\Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface'),
             '/root/dir/'
         );
         $assetFactory->setConfigResolver($this->configResolver);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Cache/Http/VarnishProxyClientFactoryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Cache/Http/VarnishProxyClientFactoryTest.php
@@ -33,7 +33,7 @@ class VarnishProxyClientFactoryTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->configResolver = $this->getMock('\eZ\Publish\Core\MVC\ConfigResolverInterface');
+        $this->configResolver = $this->createMock('\eZ\Publish\Core\MVC\ConfigResolverInterface');
         $this->proxyClientClass = '\FOS\HttpCache\ProxyClient\Varnish';
         $this->factory = new VarnishProxyClientFactory($this->configResolver, new DynamicSettingParser(), $this->proxyClientClass);
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/ChainConfigResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/ChainConfigResolverTest.php
@@ -185,7 +185,7 @@ class ChainConfigResolverTest extends TestCase
      */
     public function testGetParameter($paramName, $namespace, $scope, $expectedValue)
     {
-        $resolver = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
+        $resolver = $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
         $resolver
             ->expects($this->once())
             ->method('getParameter')
@@ -216,7 +216,7 @@ class ChainConfigResolverTest extends TestCase
         $namespace = 'yetAnotherNamespace';
         $scope = 'mySiteaccess';
 
-        $resolver1 = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
+        $resolver1 = $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
         $resolver1
             ->expects($this->once())
             ->method('hasParameter')
@@ -224,7 +224,7 @@ class ChainConfigResolverTest extends TestCase
             ->will($this->returnValue(false));
         $this->chainResolver->addResolver($resolver1);
 
-        $resolver2 = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
+        $resolver2 = $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
         $resolver2
             ->expects($this->once())
             ->method('hasParameter')
@@ -232,7 +232,7 @@ class ChainConfigResolverTest extends TestCase
             ->will($this->returnValue(true));
         $this->chainResolver->addResolver($resolver2);
 
-        $resolver3 = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
+        $resolver3 = $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
         $resolver3
             ->expects($this->never())
             ->method('hasParameter');
@@ -247,7 +247,7 @@ class ChainConfigResolverTest extends TestCase
         $namespace = 'yetAnotherNamespace';
         $scope = 'mySiteaccess';
 
-        $resolver = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
+        $resolver = $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
         $resolver
             ->expects($this->once())
             ->method('hasParameter')
@@ -264,9 +264,9 @@ class ChainConfigResolverTest extends TestCase
     private function createResolverMocks()
     {
         return array(
-            $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface'),
-            $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface'),
-            $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface'),
+            $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface'),
+            $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface'),
+            $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface'),
         );
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/ConfigResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/ConfigResolverTest.php
@@ -28,7 +28,7 @@ class ConfigResolverTest extends TestCase
     {
         parent::setUp();
         $this->siteAccess = new SiteAccess('test');
-        $this->containerMock = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $this->containerMock = $this->createMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Converter/ContentParamConverterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Converter/ContentParamConverterTest.php
@@ -26,7 +26,7 @@ class ContentParamConverterTest extends AbstractParamConverterTest
 
     public function setUp()
     {
-        $this->contentServiceMock = $this->getMock('eZ\\Publish\\API\\Repository\\ContentService');
+        $this->contentServiceMock = $this->createMock('eZ\\Publish\\API\\Repository\\ContentService');
 
         $this->converter = new ContentParamConverter($this->contentServiceMock);
     }
@@ -46,7 +46,7 @@ class ContentParamConverterTest extends AbstractParamConverterTest
     public function testApplyContent()
     {
         $id = 42;
-        $valueObject = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Content');
+        $valueObject = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Content');
 
         $this->contentServiceMock
             ->expects($this->once())

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Converter/LocationParamConverterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Converter/LocationParamConverterTest.php
@@ -26,7 +26,7 @@ class LocationParamConverterTest extends AbstractParamConverterTest
 
     public function setUp()
     {
-        $this->locationServiceMock = $this->getMock('eZ\\Publish\\API\\Repository\\LocationService');
+        $this->locationServiceMock = $this->createMock('eZ\\Publish\\API\\Repository\\LocationService');
 
         $this->converter = new LocationParamConverter($this->locationServiceMock);
     }
@@ -46,7 +46,7 @@ class LocationParamConverterTest extends AbstractParamConverterTest
     public function testApplyLocation()
     {
         $id = 42;
-        $valueObject = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Location');
+        $valueObject = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Location');
 
         $this->locationServiceMock
             ->expects($this->once())

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ConfigParserTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ConfigParserTest.php
@@ -22,7 +22,7 @@ class ConfigParserTest extends TestCase
     {
         new ConfigParser(
             array(
-                $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
+                $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
                 new stdClass(),
             )
         );
@@ -31,9 +31,9 @@ class ConfigParserTest extends TestCase
     public function testConstruct()
     {
         $innerParsers = array(
-            $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
-            $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
-            $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
+            $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
+            $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
+            $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
         );
         $configParser = new ConfigParser($innerParsers);
         $this->assertSame($innerParsers, $configParser->getConfigParsers());
@@ -45,9 +45,9 @@ class ConfigParserTest extends TestCase
         $this->assertSame(array(), $configParser->getConfigParsers());
 
         $innerParsers = array(
-            $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
-            $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
-            $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
+            $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
+            $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
+            $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
         );
         $configParser->setConfigParsers($innerParsers);
         $this->assertSame($innerParsers, $configParser->getConfigParsers());
@@ -56,8 +56,8 @@ class ConfigParserTest extends TestCase
     public function testMapConfig()
     {
         $parsers = array(
-            $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
-            $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
+            $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
+            $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
         );
         $configParser = new ConfigParser($parsers);
 
@@ -66,7 +66,7 @@ class ConfigParserTest extends TestCase
             'some' => 'thing',
         );
         $currentScope = 'the_current_scope';
-        $contextualizer = $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface');
+        $contextualizer = $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface');
 
         foreach ($parsers as $parser) {
             /* @var \PHPUnit_Framework_MockObject_MockObject $parser */
@@ -82,8 +82,8 @@ class ConfigParserTest extends TestCase
     public function testPrePostMap()
     {
         $parsers = array(
-            $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
-            $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
+            $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
+            $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
         );
         $configParser = new ConfigParser($parsers);
 
@@ -91,7 +91,7 @@ class ConfigParserTest extends TestCase
             'foo' => 'bar',
             'some' => 'thing',
         );
-        $contextualizer = $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface');
+        $contextualizer = $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface');
 
         foreach ($parsers as $parser) {
             /* @var \PHPUnit_Framework_MockObject_MockObject $parser */
@@ -112,8 +112,8 @@ class ConfigParserTest extends TestCase
     public function testAddSemanticConfig()
     {
         $parsers = array(
-            $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
-            $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
+            $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
+            $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterface'),
         );
         $configParser = new ConfigParser($parsers);
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/CommonTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/CommonTest.php
@@ -23,7 +23,7 @@ class CommonTest extends AbstractParserTestCase
 
     protected function getContainerExtensions()
     {
-        $this->suggestionCollector = $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Suggestion\ConfigSuggestion\SuggestionCollectorInterface');
+        $this->suggestionCollector = $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Suggestion\Collector\SuggestionCollectorInterface');
 
         return array(new EzPublishCoreExtension(array(new Common())));
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/SiteAccessAware/ConfigurationProcessorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/SiteAccessAware/ConfigurationProcessorTest.php
@@ -19,7 +19,7 @@ class ConfigurationProcessorTest extends TestCase
     {
         $namespace = 'ez_test';
         $siteAccessNodeName = 'foo';
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $siteAccessList = array('test', 'bar');
         $groupsBySa = array('test' => array('group1', 'group2'), 'bar' => array('group1', 'group3'));
         ConfigurationProcessor::setAvailableSiteAccesses($siteAccessList);
@@ -42,7 +42,7 @@ class ConfigurationProcessorTest extends TestCase
     {
         $namespace = 'ez_test';
         $siteAccessNodeName = 'foo';
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $processor = new ConfigurationProcessor($container, $namespace, $siteAccessNodeName);
 
         $this->assertInstanceOf(
@@ -50,7 +50,7 @@ class ConfigurationProcessorTest extends TestCase
             $processor->getContextualizer()
         );
 
-        $newContextualizer = $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface');
+        $newContextualizer = $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface');
         $processor->setContextualizer($newContextualizer);
         $this->assertSame($newContextualizer, $processor->getContextualizer());
     }
@@ -62,7 +62,7 @@ class ConfigurationProcessorTest extends TestCase
     {
         $namespace = 'ez_test';
         $siteAccessNodeName = 'foo';
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $processor = new ConfigurationProcessor($container, $namespace, $siteAccessNodeName);
 
         $processor->mapConfig(array(), new stdClass());
@@ -72,7 +72,7 @@ class ConfigurationProcessorTest extends TestCase
     {
         $namespace = 'ez_test';
         $saNodeName = 'foo';
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $processor = new ConfigurationProcessor($container, $namespace, $saNodeName);
         $expectedContextualizer = $processor->getContextualizer();
 
@@ -112,7 +112,7 @@ class ConfigurationProcessorTest extends TestCase
     {
         $namespace = 'ez_test';
         $saNodeName = 'foo';
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $processor = new ConfigurationProcessor($container, $namespace, $saNodeName);
         $contextualizer = $processor->getContextualizer();
 
@@ -138,7 +138,7 @@ class ConfigurationProcessorTest extends TestCase
             ),
         );
 
-        $mapper = $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ConfigurationMapperInterface');
+        $mapper = $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ConfigurationMapperInterface');
         $mapper
             ->expects($this->exactly(count($config[$saNodeName])))
             ->method('mapConfig')
@@ -158,7 +158,7 @@ class ConfigurationProcessorTest extends TestCase
     {
         $namespace = 'ez_test';
         $saNodeName = 'foo';
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $processor = new ConfigurationProcessor($container, $namespace, $saNodeName);
         $contextualizer = $processor->getContextualizer();
 
@@ -184,7 +184,7 @@ class ConfigurationProcessorTest extends TestCase
             ),
         );
 
-        $mapper = $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\HookableConfigurationMapperInterface');
+        $mapper = $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\HookableConfigurationMapperInterface');
         $mapper
             ->expects($this->once())
             ->method('preMap')
@@ -212,9 +212,9 @@ class ConfigurationProcessorTest extends TestCase
     {
         $namespace = 'ez_test';
         $saNodeName = 'foo';
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $processor = new ConfigurationProcessor($container, $namespace, $saNodeName);
-        $contextualizer = $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface');
+        $contextualizer = $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface');
         $processor->setContextualizer($contextualizer);
 
         $sa1Config = array(
@@ -248,9 +248,9 @@ class ConfigurationProcessorTest extends TestCase
     {
         $namespace = 'ez_test';
         $saNodeName = 'foo';
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $processor = new ConfigurationProcessor($container, $namespace, $saNodeName);
-        $contextualizer = $this->getMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface');
+        $contextualizer = $this->createMock('eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface');
         $processor->setContextualizer($contextualizer);
 
         $sa1Config = array(

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/SiteAccessAware/ContextualizerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/SiteAccessAware/ContextualizerTest.php
@@ -41,7 +41,7 @@ class ContextualizerTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $this->contextualizer = new Contextualizer($this->container, $this->namespace, $this->saNodeName, $this->availableSAs, $this->groupsBySA);
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Security/PolicyProvider/YamlPolicyProviderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Security/PolicyProvider/YamlPolicyProviderTest.php
@@ -28,7 +28,7 @@ class YamlPolicyProviderTest extends TestCase
             ],
         ];
 
-        $configBuilder = $this->getMock('\eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigBuilderInterface');
+        $configBuilder = $this->createMock('\eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigBuilderInterface');
         foreach ($files as $file) {
             $configBuilder
                 ->expects($this->once())
@@ -65,7 +65,7 @@ class YamlPolicyProviderTest extends TestCase
             ],
         ];
 
-        $configBuilder = $this->getMock('\eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigBuilderInterface');
+        $configBuilder = $this->createMock('\eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ConfigBuilderInterface');
         $configBuilder
             ->expects($this->exactly(count($files)))
             ->method('addResource')

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ConfigScopeListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ConfigScopeListenerTest.php
@@ -34,11 +34,11 @@ class ConfigScopeListenerTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->configResolver = $this->getMock('eZ\Publish\Core\MVC\Symfony\Configuration\VersatileScopeInterface');
-        $this->viewManager = $this->getMock('eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs\ViewManager');
+        $this->configResolver = $this->createMock('eZ\Publish\Core\MVC\Symfony\Configuration\VersatileScopeInterface');
+        $this->viewManager = $this->createMock('eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs\ViewManager');
         $this->viewProviders = array(
-            $this->getMock('eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs\ViewProvider'),
-            $this->getMock('eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs\ViewProvider'),
+            $this->createMock('eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs\ViewProvider'),
+            $this->createMock('eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs\ViewProvider'),
         );
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ConsoleCommandListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ConsoleCommandListenerTest.php
@@ -62,7 +62,7 @@ class ConsoleCommandListenerTest extends TestCase
     {
         parent::setUp();
         $this->siteAccess = new SiteAccess();
-        $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $this->dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $this->listener = new ConsoleCommandListener('default', $this->siteAccessList, $this->dispatcher);
         $this->listener->setSiteAccess($this->siteAccess);
         $this->dispatcher->addSubscriber($this->listener);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/DynamicSettingsListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/DynamicSettingsListenerTest.php
@@ -34,11 +34,11 @@ class DynamicSettingsListenerTest extends TestCase
         parent::setUp();
         // @deprecated Remove once we are Sf 3.x only, for Symfony 2.x compatibility
         if (interface_exists('Symfony\\Component\\DependencyInjection\\IntrospectableContainerInterface')) {
-            $this->container = $this->getMock('\Symfony\Component\DependencyInjection\IntrospectableContainerInterface');
+            $this->container = $this->createMock('\Symfony\Component\DependencyInjection\IntrospectableContainerInterface');
         } else {
-            $this->container = $this->getMock('\Symfony\Component\DependencyInjection\ContainerInterface');
+            $this->container = $this->createMock('\Symfony\Component\DependencyInjection\ContainerInterface');
         }
-        $this->expressionLanguage = $this->getMock('\Symfony\Component\DependencyInjection\ExpressionLanguage');
+        $this->expressionLanguage = $this->createMock('\Symfony\Component\DependencyInjection\ExpressionLanguage');
     }
 
     public function testGetSubscribedEvents()
@@ -100,7 +100,7 @@ class DynamicSettingsListenerTest extends TestCase
             ->method('set')
             ->with('bar.baz', null);
 
-        $updateableService1 = $this->getMock('\eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs\FooServiceInterface');
+        $updateableService1 = $this->createMock('\eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs\FooServiceInterface');
         $dynamicSetting1 = 'foo';
         $this->container
             ->expects($this->at(4))
@@ -116,7 +116,7 @@ class DynamicSettingsListenerTest extends TestCase
             ->method('someMethod')
             ->with($dynamicSetting1);
 
-        $updateableService2 = $this->getMock('\eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs\FooServiceInterface');
+        $updateableService2 = $this->createMock('\eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs\FooServiceInterface');
         $dynamicSetting2 = array('foo' => 'bar');
         $this->container
             ->expects($this->at(6))
@@ -174,7 +174,7 @@ class DynamicSettingsListenerTest extends TestCase
             ->method('set')
             ->with('bar.baz', null);
 
-        $updateableService1 = $this->getMock('\eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs\FooServiceInterface');
+        $updateableService1 = $this->createMock('\eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs\FooServiceInterface');
         $dynamicSetting1 = 'foo';
         $this->container
             ->expects($this->at(4))
@@ -190,7 +190,7 @@ class DynamicSettingsListenerTest extends TestCase
             ->method('someMethod')
             ->with($dynamicSetting1);
 
-        $updateableService2 = $this->getMock('\eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs\FooServiceInterface');
+        $updateableService2 = $this->createMock('\eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs\FooServiceInterface');
         $dynamicSetting2 = array('foo' => 'bar');
         $this->container
             ->expects($this->at(6))

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ExceptionListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ExceptionListenerTest.php
@@ -45,7 +45,7 @@ class ExceptionListenerTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->translator = $this->getMock('\Symfony\Component\Translation\TranslatorInterface');
+        $this->translator = $this->createMock('\Symfony\Component\Translation\TranslatorInterface');
         $this->listener = new ExceptionListener($this->translator);
     }
 
@@ -64,7 +64,7 @@ class ExceptionListenerTest extends TestCase
     private function generateExceptionEvent(Exception $exception)
     {
         return new GetResponseForExceptionEvent(
-            $this->getMock('\Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock('\Symfony\Component\HttpKernel\HttpKernelInterface'),
             new Request(),
             'master',
             $exception

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/IndexRequestListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/IndexRequestListenerTest.php
@@ -46,7 +46,7 @@ class IndexRequestListenerTest extends TestCase
     {
         parent::setUp();
 
-        $this->configResolver = $this->getMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
+        $this->configResolver = $this->createMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
 
         $this->indexRequestEventListener = new IndexRequestListener($this->configResolver);
 
@@ -55,7 +55,7 @@ class IndexRequestListenerTest extends TestCase
             ->setMethods(array('getSession', 'hasSession'))
             ->getMock();
 
-        $this->httpKernel = $this->getMock('Symfony\\Component\\HttpKernel\\HttpKernelInterface');
+        $this->httpKernel = $this->createMock('Symfony\\Component\\HttpKernel\\HttpKernelInterface');
         $this->event = new GetResponseEvent(
             $this->httpKernel,
             $this->request,

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/LocaleListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/LocaleListenerTest.php
@@ -37,21 +37,21 @@ class LocaleListenerTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $this->localeConverter = $this->getMock('eZ\Publish\Core\MVC\Symfony\Locale\LocaleConverterInterface');
-        $this->configResolver = $this->getMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
+        $this->container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->localeConverter = $this->createMock('eZ\Publish\Core\MVC\Symfony\Locale\LocaleConverterInterface');
+        $this->configResolver = $this->createMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
 
         $this->requestStack = new RequestStack();
-        $parameterBagMock = $this->getMock('Symfony\\Component\\HttpFoundation\\ParameterBag');
+        $parameterBagMock = $this->createMock('Symfony\\Component\\HttpFoundation\\ParameterBag');
         $parameterBagMock->expects($this->never())->method($this->anything());
 
-        $requestMock = $this->getMock('Symfony\\Component\\HttpFoundation\\Request');
+        $requestMock = $this->createMock('Symfony\\Component\\HttpFoundation\\Request');
         $requestMock->attributes = $parameterBagMock;
 
-        $requestMock->expects($this->any())
-            ->method('__get')
-            ->with($this->equalTo('attributes'))
-            ->will($this->returnValue($parameterBagMock));
+//        $requestMock->expects($this->any())
+//            ->method('__get')
+//            ->with($this->equalTo('attributes'))
+//            ->will($this->returnValue($parameterBagMock));
 
         $this->requestStack->push($requestMock);
     }
@@ -82,7 +82,7 @@ class LocaleListenerTest extends TestCase
         $request = new Request();
         $localeListener->onKernelRequest(
             new GetResponseEvent(
-                $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
+                $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
                 $request,
                 HttpKernelInterface::MASTER_REQUEST
             )

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/OriginalRequestListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/OriginalRequestListenerTest.php
@@ -31,7 +31,7 @@ class OriginalRequestListenerTest extends TestCase
     {
         $request = new Request();
         $event = new GetResponseEvent(
-            $this->getMock('\Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock('\Symfony\Component\HttpKernel\HttpKernelInterface'),
             $request,
             HttpKernelInterface::SUB_REQUEST
         );
@@ -45,7 +45,7 @@ class OriginalRequestListenerTest extends TestCase
     {
         $request = new Request();
         $event = new GetResponseEvent(
-            $this->getMock('\Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock('\Symfony\Component\HttpKernel\HttpKernelInterface'),
             $request,
             HttpKernelInterface::MASTER_REQUEST
         );
@@ -71,7 +71,7 @@ class OriginalRequestListenerTest extends TestCase
         $request->headers->set('x-fos-original-url', $originalUri);
         $request->headers->set('x-fos-original-accept', $originalAccept);
         $event = new GetResponseEvent(
-            $this->getMock('\Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock('\Symfony\Component\HttpKernel\HttpKernelInterface'),
             $request,
             HttpKernelInterface::MASTER_REQUEST
         );

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RequestEventListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RequestEventListenerTest.php
@@ -60,9 +60,9 @@ class RequestEventListenerTest extends TestCase
     {
         parent::setUp();
 
-        $this->configResolver = $this->getMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
-        $this->router = $this->getMock('Symfony\Component\Routing\RouterInterface');
-        $this->logger = $this->getMock('Psr\\Log\\LoggerInterface');
+        $this->configResolver = $this->createMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
+        $this->router = $this->createMock('Symfony\Component\Routing\RouterInterface');
+        $this->logger = $this->createMock('Psr\\Log\\LoggerInterface');
 
         $this->requestEventListener = new RequestEventListener($this->configResolver, $this->router, 'foobar', $this->logger);
 
@@ -71,7 +71,7 @@ class RequestEventListenerTest extends TestCase
             ->setMethods(array('getSession', 'hasSession'))
             ->getMock();
 
-        $this->httpKernel = $this->getMock('Symfony\\Component\\HttpKernel\\HttpKernelInterface');
+        $this->httpKernel = $this->createMock('Symfony\\Component\\HttpKernel\\HttpKernelInterface');
         $this->event = new GetResponseEvent(
             $this->httpKernel,
             $this->request,
@@ -184,7 +184,7 @@ class RequestEventListenerTest extends TestCase
     {
         $queryParameters = array('some' => 'thing');
         $cookieParameters = array('cookie' => 'value');
-        $siteaccessMatcher = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\URILexer');
+        $siteaccessMatcher = $this->createMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\URILexer');
         $siteaccess = new SiteAccess('test', 'foo', $siteaccessMatcher);
         $semanticPathinfo = '/foo/something';
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RoutingListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RoutingListenerTest.php
@@ -36,8 +36,8 @@ class RoutingListenerTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $this->configResolver = $this->getMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
+        $this->container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->configResolver = $this->createMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
         $this->urlAliasRouter = $this
             ->getMockBuilder('eZ\Bundle\EzPublishCoreBundle\Routing\UrlAliasRouter')
             ->disableOriginalConstructor()

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SessionInitByPostListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SessionInitByPostListenerTest.php
@@ -31,7 +31,7 @@ class SessionInitByPostListenerTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->session = $this->getMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
+        $this->session = $this->createMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
         $this->listener = new SessionInitByPostListener($this->session);
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SessionSetDynamicNameListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SessionSetDynamicNameListenerTest.php
@@ -87,7 +87,7 @@ class SessionSetDynamicNameListenerTest extends TestCase
         $listener = new SessionSetDynamicNameListener(
             $this->configResolver,
             $this->session,
-            $this->getMock('Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface')
+            $this->createMock('Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface')
         );
         $listener->onSiteAccessMatch(new PostSiteAccessMatchEvent(new SiteAccess(), new Request(), HttpKernelInterface::SUB_REQUEST));
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SiteAccessListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SiteAccessListenerTest.php
@@ -42,7 +42,7 @@ class SiteAccessListenerTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this->container = $this->createMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $this->router = $this
             ->getMockBuilder('eZ\Bundle\EzPublishCoreBundle\Routing\DefaultRouter')
             ->disableOriginalConstructor()
@@ -96,14 +96,14 @@ class SiteAccessListenerTest extends TestCase
         $semanticPathinfoPos = strpos($uri, $expectedSemanticPathinfo);
         if ($semanticPathinfoPos !== 0) {
             $semanticPathinfo = substr($uri, $semanticPathinfoPos);
-            $matcher = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\URILexer');
+            $matcher = $this->createMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\URILexer');
             $matcher
                 ->expects($this->once())
                 ->method('analyseURI')
                 ->with($uri)
                 ->will($this->returnValue($semanticPathinfo));
         } else {
-            $matcher = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher');
+            $matcher = $this->createMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher');
         }
 
         $defaultSiteAccess = new SiteAccess('default');
@@ -132,7 +132,7 @@ class SiteAccessListenerTest extends TestCase
     public function testOnSiteAccessMatchSubRequest($uri, $semanticPathinfo, $vpString, $expectedViewParameters)
     {
         $defaultSiteAccess = new SiteAccess('default');
-        $siteAccess = new SiteAccess('test', 'test', $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher'));
+        $siteAccess = new SiteAccess('test', 'test', $this->createMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher'));
         $request = Request::create($uri);
         $request->attributes->set('semanticPathinfo', $semanticPathinfo);
         if (!empty($vpString)) {

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
@@ -57,10 +57,10 @@ class ViewControllerListenerTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->controllerResolver = $this->getMock('Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface');
-        $this->viewBuilderRegistry = $this->getMock('eZ\Publish\Core\MVC\Symfony\View\Builder\ViewBuilderRegistry');
-        $this->eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $this->logger = $this->getMock('Psr\\Log\\LoggerInterface');
+        $this->controllerResolver = $this->createMock('Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface');
+        $this->viewBuilderRegistry = $this->createMock('eZ\Publish\Core\MVC\Symfony\View\Builder\ViewBuilderRegistry');
+        $this->eventDispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $this->logger = $this->createMock('Psr\\Log\\LoggerInterface');
         $this->controllerListener = new ViewControllerListener(
             $this->controllerResolver,
             $this->viewBuilderRegistry,
@@ -78,7 +78,7 @@ class ViewControllerListenerTest extends TestCase
             ->method('getRequest')
             ->will($this->returnValue($this->request));
 
-        $this->viewBuilderMock = $this->getMock('eZ\Publish\Core\MVC\Symfony\View\Builder\ViewBuilder');
+        $this->viewBuilderMock = $this->createMock('eZ\Publish\Core\MVC\Symfony\View\Builder\ViewBuilder');
     }
 
     public function testGetSubscribedEvents()

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventSubscriber/CrowdinRequestLocaleSubscriberTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventSubscriber/CrowdinRequestLocaleSubscriberTest.php
@@ -6,12 +6,12 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventSubscriber;
 
 use eZ\Bundle\EzPublishCoreBundle\EventSubscriber\CrowdinRequestLocaleSubscriber;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class CrowdinRequestLocaleSubscriberTest extends PHPUnit_Framework_TestCase
+class CrowdinRequestLocaleSubscriberTest extends TestCase
 {
     /**
      * @dataProvider testSetRequestsProvider

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/DecoratedFragmentRendererTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/DecoratedFragmentRendererTest.php
@@ -24,12 +24,12 @@ class DecoratedFragmentRendererTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->innerRenderer = $this->getMock('Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface');
+        $this->innerRenderer = $this->createMock('Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface');
     }
 
     public function testSetFragmentPathNotRoutableRenderer()
     {
-        $matcher = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\URILexer');
+        $matcher = $this->createMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\URILexer');
         $siteAccess = new SiteAccess('test', 'test', $matcher);
         $matcher
             ->expects($this->never())
@@ -42,7 +42,7 @@ class DecoratedFragmentRendererTest extends TestCase
 
     public function testSetFragmentPath()
     {
-        $matcher = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\URILexer');
+        $matcher = $this->createMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\URILexer');
         $siteAccess = new SiteAccess('test', 'test', $matcher);
         $matcher
             ->expects($this->once())
@@ -50,7 +50,7 @@ class DecoratedFragmentRendererTest extends TestCase
             ->with('/foo')
             ->will($this->returnValue('/bar/foo'));
 
-        $innerRenderer = $this->getMock('Symfony\Component\HttpKernel\Fragment\RoutableFragmentRenderer');
+        $innerRenderer = $this->createMock('Symfony\Component\HttpKernel\Fragment\RoutableFragmentRenderer');
         $innerRenderer
             ->expects($this->once())
             ->method('setFragmentPath')

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasCleanerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasCleanerTest.php
@@ -26,7 +26,7 @@ class AliasCleanerTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->resolver = $this->getMock('\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface');
+        $this->resolver = $this->createMock('\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface');
         $this->aliasCleaner = new AliasCleaner($this->resolver);
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasGeneratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasGeneratorTest.php
@@ -54,14 +54,14 @@ class AliasGeneratorTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->dataLoader = $this->getMock('\Liip\ImagineBundle\Binary\Loader\LoaderInterface');
+        $this->dataLoader = $this->createMock('\Liip\ImagineBundle\Binary\Loader\LoaderInterface');
         $this->filterManager = $this
             ->getMockBuilder('\Liip\ImagineBundle\Imagine\Filter\FilterManager')
             ->disableOriginalConstructor()
             ->getMock();
-        $this->ioResolver = $this->getMock('\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface');
+        $this->ioResolver = $this->createMock('\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface');
         $this->filterConfiguration = new FilterConfiguration();
-        $this->logger = $this->getMock('\Psr\Log\LoggerInterface');
+        $this->logger = $this->createMock('\Psr\Log\LoggerInterface');
         $this->aliasGenerator = new AliasGenerator(
             $this->dataLoader,
             $this->filterManager,
@@ -82,10 +82,10 @@ class AliasGeneratorTest extends TestCase
     public function supportsValueProvider()
     {
         return array(
-            array($this->getMock('\eZ\Publish\Core\FieldType\Value'), false),
+            array($this->createMock('\eZ\Publish\Core\FieldType\Value'), false),
             array(new TextLineValue(), false),
             array(new ImageValue(), true),
-            array($this->getMock('\eZ\Publish\Core\FieldType\Image\Value'), true),
+            array($this->createMock('\eZ\Publish\Core\FieldType\Image\Value'), true),
         );
     }
 
@@ -94,7 +94,7 @@ class AliasGeneratorTest extends TestCase
      */
     public function testGetVariationWrongValue()
     {
-        $field = new Field(array('value' => $this->getMock('eZ\Publish\Core\FieldType\Value')));
+        $field = new Field(array('value' => $this->createMock('eZ\Publish\Core\FieldType\Value')));
         $this->aliasGenerator->getVariation($field, new VersionInfo(), 'foo');
     }
 
@@ -118,7 +118,7 @@ class AliasGeneratorTest extends TestCase
             ->expects($this->once())
             ->method('debug');
 
-        $binary = $this->getMock('\Liip\ImagineBundle\Binary\BinaryInterface');
+        $binary = $this->createMock('\Liip\ImagineBundle\Binary\BinaryInterface');
         $this->dataLoader
             ->expects($this->once())
             ->method('find')
@@ -215,7 +215,7 @@ class AliasGeneratorTest extends TestCase
             ->expects($this->once())
             ->method('debug');
 
-        $binary = $this->getMock('\Liip\ImagineBundle\Binary\BinaryInterface');
+        $binary = $this->createMock('\Liip\ImagineBundle\Binary\BinaryInterface');
         $this->dataLoader
             ->expects($this->once())
             ->method('find')

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/BinaryLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/BinaryLoaderTest.php
@@ -37,8 +37,8 @@ class BinaryLoaderTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->ioService = $this->getMock('eZ\Publish\Core\IO\IOServiceInterface');
-        $this->extensionGuesser = $this->getMock('Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface');
+        $this->ioService = $this->createMock('eZ\Publish\Core\IO\IOServiceInterface');
+        $this->extensionGuesser = $this->createMock('Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesserInterface');
         $this->binaryLoader = new BinaryLoader($this->ioService, $this->extensionGuesser);
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/FilterConfigurationTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/FilterConfigurationTest.php
@@ -26,7 +26,7 @@ class FilterConfigurationTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->configResolver = $this->getMock('\eZ\Publish\Core\MVC\ConfigResolverInterface');
+        $this->configResolver = $this->createMock('\eZ\Publish\Core\MVC\ConfigResolverInterface');
         $this->filterConfiguration = new FilterConfiguration();
         $this->filterConfiguration->setConfigResolver($this->configResolver);
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/BorderFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/BorderFilterLoaderTest.php
@@ -20,7 +20,7 @@ class BorderFilterLoaderTest extends TestCase
     public function testLoadInvalidOptions(array $options)
     {
         $loader = new BorderFilterLoader();
-        $loader->load($this->getMock('\Imagine\Image\ImageInterface'), $options);
+        $loader->load($this->createMock('\Imagine\Image\ImageInterface'), $options);
     }
 
     public function loadInvalidProvider()
@@ -34,10 +34,10 @@ class BorderFilterLoaderTest extends TestCase
 
     public function testLoadDefaultColor()
     {
-        $image = $this->getMock('\Imagine\Image\ImageInterface');
+        $image = $this->createMock('\Imagine\Image\ImageInterface');
         $options = array(10, 10);
 
-        $palette = $this->getMock('\Imagine\Image\Palette\PaletteInterface');
+        $palette = $this->createMock('\Imagine\Image\Palette\PaletteInterface');
         $image
             ->expects($this->once())
             ->method('palette')
@@ -46,9 +46,9 @@ class BorderFilterLoaderTest extends TestCase
             ->expects($this->once())
             ->method('color')
             ->with(BorderFilterLoader::DEFAULT_BORDER_COLOR)
-            ->will($this->returnValue($this->getMock('\Imagine\Image\Palette\Color\ColorInterface')));
+            ->will($this->returnValue($this->createMock('\Imagine\Image\Palette\Color\ColorInterface')));
 
-        $box = $this->getMock('\Imagine\Image\BoxInterface');
+        $box = $this->createMock('\Imagine\Image\BoxInterface');
         $image
             ->expects($this->once())
             ->method('getSize')
@@ -62,7 +62,7 @@ class BorderFilterLoaderTest extends TestCase
             ->method('getHeight')
             ->will($this->returnValue(100));
 
-        $drawer = $this->getMock('\Imagine\Draw\DrawerInterface');
+        $drawer = $this->createMock('\Imagine\Draw\DrawerInterface');
         $image
             ->expects($this->once())
             ->method('draw')
@@ -81,10 +81,10 @@ class BorderFilterLoaderTest extends TestCase
      */
     public function testLoad($thickX, $thickY, $color)
     {
-        $image = $this->getMock('\Imagine\Image\ImageInterface');
+        $image = $this->createMock('\Imagine\Image\ImageInterface');
         $options = array($thickX, $thickY, $color);
 
-        $palette = $this->getMock('\Imagine\Image\Palette\PaletteInterface');
+        $palette = $this->createMock('\Imagine\Image\Palette\PaletteInterface');
         $image
             ->expects($this->once())
             ->method('palette')
@@ -93,9 +93,9 @@ class BorderFilterLoaderTest extends TestCase
             ->expects($this->once())
             ->method('color')
             ->with($color)
-            ->will($this->returnValue($this->getMock('\Imagine\Image\Palette\Color\ColorInterface')));
+            ->will($this->returnValue($this->createMock('\Imagine\Image\Palette\Color\ColorInterface')));
 
-        $box = $this->getMock('\Imagine\Image\BoxInterface');
+        $box = $this->createMock('\Imagine\Image\BoxInterface');
         $image
             ->expects($this->once())
             ->method('getSize')
@@ -109,7 +109,7 @@ class BorderFilterLoaderTest extends TestCase
             ->method('getHeight')
             ->will($this->returnValue(1000));
 
-        $drawer = $this->getMock('\Imagine\Draw\DrawerInterface');
+        $drawer = $this->createMock('\Imagine\Draw\DrawerInterface');
         $image
             ->expects($this->once())
             ->method('draw')

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/CropFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/CropFilterLoaderTest.php
@@ -26,7 +26,7 @@ class CropFilterLoaderTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->innerLoader = $this->getMock('\Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
+        $this->innerLoader = $this->createMock('\Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
         $this->loader = new CropFilterLoader();
         $this->loader->setInnerLoader($this->innerLoader);
     }
@@ -37,7 +37,7 @@ class CropFilterLoaderTest extends TestCase
      */
     public function testLoadInvalidOptions(array $options)
     {
-        $this->loader->load($this->getMock('\Imagine\Image\ImageInterface'), $options);
+        $this->loader->load($this->createMock('\Imagine\Image\ImageInterface'), $options);
     }
 
     public function loadInvalidProvider()
@@ -58,7 +58,7 @@ class CropFilterLoaderTest extends TestCase
         $offsetX = 100;
         $offsetY = 200;
 
-        $image = $this->getMock('\Imagine\Image\ImageInterface');
+        $image = $this->createMock('\Imagine\Image\ImageInterface');
         $this->innerLoader
             ->expects($this->once())
             ->method('load')

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/GrayscaleFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/GrayscaleFilterLoaderTest.php
@@ -15,8 +15,8 @@ class GrayscaleFilterLoaderTest extends TestCase
 {
     public function testLoad()
     {
-        $image = $this->getMock('\Imagine\Image\ImageInterface');
-        $effects = $this->getMock('\Imagine\Effects\EffectsInterface');
+        $image = $this->createMock('\Imagine\Image\ImageInterface');
+        $effects = $this->createMock('\Imagine\Effects\EffectsInterface');
         $image
             ->expects($this->once())
             ->method('effects')

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ReduceNoiseFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ReduceNoiseFilterLoaderTest.php
@@ -26,7 +26,7 @@ class ReduceNoiseFilterLoaderTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->filter = $this->getMock('\eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\FilterInterface');
+        $this->filter = $this->createMock('\eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\FilterInterface');
         $this->loader = new ReduceNoiseFilterLoader($this->filter);
     }
 
@@ -35,6 +35,6 @@ class ReduceNoiseFilterLoaderTest extends TestCase
      */
     public function testLoadInvalidDriver()
     {
-        $this->loader->load($this->getMock('\Imagine\Image\ImageInterface'));
+        $this->loader->load($this->createMock('\Imagine\Image\ImageInterface'));
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleDownOnlyFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleDownOnlyFilterLoaderTest.php
@@ -27,7 +27,7 @@ class ScaleDownOnlyFilterLoaderTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->innerLoader = $this->getMock('Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
+        $this->innerLoader = $this->createMock('Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
         $this->loader = new ScaleDownOnlyFilterLoader();
         $this->loader->setInnerLoader($this->innerLoader);
     }
@@ -38,7 +38,7 @@ class ScaleDownOnlyFilterLoaderTest extends TestCase
      */
     public function testLoadInvalidOptions(array $options)
     {
-        $this->loader->load($this->getMock('\Imagine\Image\ImageInterface'), $options);
+        $this->loader->load($this->createMock('\Imagine\Image\ImageInterface'), $options);
     }
 
     public function loadInvalidProvider()
@@ -53,7 +53,7 @@ class ScaleDownOnlyFilterLoaderTest extends TestCase
     public function testLoad()
     {
         $options = array(123, 456);
-        $image = $this->getMock('\Imagine\Image\ImageInterface');
+        $image = $this->createMock('\Imagine\Image\ImageInterface');
         $this->innerLoader
             ->expects($this->once())
             ->method('load')

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleExactFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleExactFilterLoaderTest.php
@@ -26,7 +26,7 @@ class ScaleExactFilterLoaderTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->innerLoader = $this->getMock('\Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
+        $this->innerLoader = $this->createMock('\Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
         $this->loader = new ScaleExactFilterLoader();
         $this->loader->setInnerLoader($this->innerLoader);
     }
@@ -37,7 +37,7 @@ class ScaleExactFilterLoaderTest extends TestCase
      */
     public function testLoadInvalidOptions(array $options)
     {
-        $this->loader->load($this->getMock('\Imagine\Image\ImageInterface'), $options);
+        $this->loader->load($this->createMock('\Imagine\Image\ImageInterface'), $options);
     }
 
     public function loadInvalidProvider()
@@ -52,7 +52,7 @@ class ScaleExactFilterLoaderTest extends TestCase
     public function testLoad()
     {
         $options = array(123, 456);
-        $image = $this->getMock('\Imagine\Image\ImageInterface');
+        $image = $this->createMock('\Imagine\Image\ImageInterface');
         $this->innerLoader
             ->expects($this->once())
             ->method('load')

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleFilterLoaderTest.php
@@ -27,7 +27,7 @@ class ScaleFilterLoaderTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->innerLoader = $this->getMock('\Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
+        $this->innerLoader = $this->createMock('\Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
         $this->loader = new ScaleFilterLoader();
         $this->loader->setInnerLoader($this->innerLoader);
     }
@@ -38,7 +38,7 @@ class ScaleFilterLoaderTest extends TestCase
      */
     public function testLoadInvalidOptions(array $options)
     {
-        $this->loader->load($this->getMock('\Imagine\Image\ImageInterface'), $options);
+        $this->loader->load($this->createMock('\Imagine\Image\ImageInterface'), $options);
     }
 
     public function loadInvalidProvider()
@@ -58,7 +58,7 @@ class ScaleFilterLoaderTest extends TestCase
         $origHeight = 377;
         $box = new Box($origWidth, $origHeight);
 
-        $image = $this->getMock('\Imagine\Image\ImageInterface');
+        $image = $this->createMock('\Imagine\Image\ImageInterface');
         $image
             ->expects($this->once())
             ->method('getSize')
@@ -81,7 +81,7 @@ class ScaleFilterLoaderTest extends TestCase
         $origHeight = 377;
         $box = new Box($origWidth, $origHeight);
 
-        $image = $this->getMock('\Imagine\Image\ImageInterface');
+        $image = $this->createMock('\Imagine\Image\ImageInterface');
         $image
             ->expects($this->once())
             ->method('getSize')

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleHeightDownOnlyFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleHeightDownOnlyFilterLoaderTest.php
@@ -27,7 +27,7 @@ class ScaleHeightDownOnlyFilterLoaderTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->innerLoader = $this->getMock('Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
+        $this->innerLoader = $this->createMock('Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
         $this->loader = new ScaleHeightDownOnlyFilterLoader();
         $this->loader->setInnerLoader($this->innerLoader);
     }
@@ -37,13 +37,13 @@ class ScaleHeightDownOnlyFilterLoaderTest extends TestCase
      */
     public function testLoadInvalid()
     {
-        $this->loader->load($this->getMock('\Imagine\Image\ImageInterface'), array());
+        $this->loader->load($this->createMock('\Imagine\Image\ImageInterface'), array());
     }
 
     public function testLoad()
     {
         $height = 123;
-        $image = $this->getMock('\Imagine\Image\ImageInterface');
+        $image = $this->createMock('\Imagine\Image\ImageInterface');
         $this->innerLoader
             ->expects($this->once())
             ->method('load')

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleHeightFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleHeightFilterLoaderTest.php
@@ -26,7 +26,7 @@ class ScaleHeightFilterLoaderTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->innerLoader = $this->getMock('\Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
+        $this->innerLoader = $this->createMock('\Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
         $this->loader = new ScaleHeightFilterLoader();
         $this->loader->setInnerLoader($this->innerLoader);
     }
@@ -36,13 +36,13 @@ class ScaleHeightFilterLoaderTest extends TestCase
      */
     public function testLoadFail()
     {
-        $this->loader->load($this->getMock('\Imagine\Image\ImageInterface', array()));
+        $this->loader->load($this->createMock('\Imagine\Image\ImageInterface', array()));
     }
 
     public function testLoad()
     {
         $height = 123;
-        $image = $this->getMock('\Imagine\Image\ImageInterface');
+        $image = $this->createMock('\Imagine\Image\ImageInterface');
         $this->innerLoader
             ->expects($this->once())
             ->method('load')

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScalePercentFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScalePercentFilterLoaderTest.php
@@ -27,7 +27,7 @@ class ScalePercentFilterLoaderTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->innerLoader = $this->getMock('\Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
+        $this->innerLoader = $this->createMock('\Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
         $this->loader = new ScalePercentFilterLoader();
         $this->loader->setInnerLoader($this->innerLoader);
     }
@@ -38,7 +38,7 @@ class ScalePercentFilterLoaderTest extends TestCase
      */
     public function testLoadInvalidOptions(array $options)
     {
-        $this->loader->load($this->getMock('\Imagine\Image\ImageInterface'), $options);
+        $this->loader->load($this->createMock('\Imagine\Image\ImageInterface'), $options);
     }
 
     public function loadInvalidProvider()
@@ -60,7 +60,7 @@ class ScalePercentFilterLoaderTest extends TestCase
         $expectedHeight = ($origHeight * $heightPercent) / 100;
 
         $box = new Box($origWidth, $origHeight);
-        $image = $this->getMock('\Imagine\Image\ImageInterface');
+        $image = $this->createMock('\Imagine\Image\ImageInterface');
         $image
             ->expects($this->once())
             ->method('getSize')

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleWidthDownOnlyFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleWidthDownOnlyFilterLoaderTest.php
@@ -27,7 +27,7 @@ class ScaleWidthDownOnlyFilterLoaderTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->innerLoader = $this->getMock('Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
+        $this->innerLoader = $this->createMock('Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
         $this->loader = new ScaleWidthDownOnlyFilterLoader();
         $this->loader->setInnerLoader($this->innerLoader);
     }
@@ -37,13 +37,13 @@ class ScaleWidthDownOnlyFilterLoaderTest extends TestCase
      */
     public function testLoadInvalid()
     {
-        $this->loader->load($this->getMock('\Imagine\Image\ImageInterface'), array());
+        $this->loader->load($this->createMock('\Imagine\Image\ImageInterface'), array());
     }
 
     public function testLoad()
     {
         $width = 123;
-        $image = $this->getMock('\Imagine\Image\ImageInterface');
+        $image = $this->createMock('\Imagine\Image\ImageInterface');
         $this->innerLoader
             ->expects($this->once())
             ->method('load')

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleWidthFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleWidthFilterLoaderTest.php
@@ -26,7 +26,7 @@ class ScaleWidthFilterLoaderTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->innerLoader = $this->getMock('\Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
+        $this->innerLoader = $this->createMock('\Liip\ImagineBundle\Imagine\Filter\Loader\LoaderInterface');
         $this->loader = new ScaleWidthFilterLoader();
         $this->loader->setInnerLoader($this->innerLoader);
     }
@@ -36,13 +36,13 @@ class ScaleWidthFilterLoaderTest extends TestCase
      */
     public function testLoadFail()
     {
-        $this->loader->load($this->getMock('\Imagine\Image\ImageInterface', array()));
+        $this->loader->load($this->createMock('\Imagine\Image\ImageInterface', array()));
     }
 
     public function testLoad()
     {
         $width = 123;
-        $image = $this->getMock('\Imagine\Image\ImageInterface');
+        $image = $this->createMock('\Imagine\Image\ImageInterface');
         $this->innerLoader
             ->expects($this->once())
             ->method('load')

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/SwirlFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/SwirlFilterLoaderTest.php
@@ -26,13 +26,13 @@ class SwirlFilterLoaderTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->filter = $this->getMock('\eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\FilterInterface');
+        $this->filter = $this->createMock('\eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\FilterInterface');
         $this->loader = new SwirlFilterLoader($this->filter);
     }
 
     public function testLoadNoOption()
     {
-        $image = $this->getMock('\Imagine\Image\ImageInterface');
+        $image = $this->createMock('\Imagine\Image\ImageInterface');
         $this->filter
             ->expects($this->never())
             ->method('setOption');
@@ -51,7 +51,7 @@ class SwirlFilterLoaderTest extends TestCase
      */
     public function testLoadWithOption($degrees)
     {
-        $image = $this->getMock('\Imagine\Image\ImageInterface');
+        $image = $this->createMock('\Imagine\Image\ImageInterface');
         $this->filter
             ->expects($this->once())
             ->method('setOption')

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/UnsupportedFilterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/UnsupportedFilterTest.php
@@ -18,6 +18,6 @@ class UnsupportedFilterTest extends AbstractFilterTest
     public function testLoad()
     {
         $filter = new UnsupportedFilter();
-        $filter->apply($this->getMock('\Imagine\Image\ImageInterface'));
+        $filter->apply($this->createMock('\Imagine\Image\ImageInterface'));
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/IORepositoryResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/IORepositoryResolverTest.php
@@ -55,13 +55,13 @@ class IORepositoryResolverTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->ioService = $this->getMock('eZ\Publish\Core\IO\IOServiceInterface');
+        $this->ioService = $this->createMock('eZ\Publish\Core\IO\IOServiceInterface');
         $this->requestContext = new RequestContext();
-        $this->configResolver = $this->getMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
+        $this->configResolver = $this->createMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
         $this->filterConfiguration = new FilterConfiguration();
         $this->filterConfiguration->setConfigResolver($this->configResolver);
-        $this->variationPurger = $this->getMock('eZ\Publish\SPI\Variation\VariationPurger');
-        $this->variationPathGenerator = $this->getMock('eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator');
+        $this->variationPurger = $this->createMock('eZ\Publish\SPI\Variation\VariationPurger');
+        $this->variationPathGenerator = $this->createMock('eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator');
         $this->imageResolver = new IORepositoryResolver(
             $this->ioService,
             $this->requestContext,

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/IOVariationPurgerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/IOVariationPurgerTest.php
@@ -12,7 +12,7 @@ class IOVariationPurgerTest extends TestCase
 {
     public function testPurgesAliasList()
     {
-        $ioService = $this->getMock('eZ\Publish\Core\IO\IOServiceInterface');
+        $ioService = $this->createMock('eZ\Publish\Core\IO\IOServiceInterface');
         $ioService
             ->expects($this->exactly(2))
             ->method('deleteDirectory')

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/ImageFileVariationPurgerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/ImageFileVariationPurgerTest.php
@@ -23,8 +23,8 @@ class ImageFileVariationPurgerTest extends TestCase
 
     public function setUp()
     {
-        $this->ioServiceMock = $this->getMock('eZ\Publish\Core\IO\IOServiceInterface');
-        $this->pathGeneratorMock = $this->getMock('eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator');
+        $this->ioServiceMock = $this->createMock('eZ\Publish\Core\IO\IOServiceInterface');
+        $this->pathGeneratorMock = $this->createMock('eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator');
     }
 
     public function testIteratesOverItems()

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/LegacyStorageImageFileListTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/LegacyStorageImageFileListTest.php
@@ -18,7 +18,7 @@ class LegacyStorageImageFileListTest extends TestCase
 
     public function setUp()
     {
-        $this->rowReaderMock = $this->getMock('eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\ImageFileRowReader');
+        $this->rowReaderMock = $this->createMock('eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger\ImageFileRowReader');
         $this->fileList = new LegacyStorageImageFileList(
             $this->rowReaderMock,
             'var/ezdemo_site/storage',

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Matcher/BaseMatcherFactoryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Matcher/BaseMatcherFactoryTest.php
@@ -24,7 +24,7 @@ abstract class BaseMatcherFactoryTest extends TestCase
      */
     protected function getResolverMock($matcherServiceIdentifier)
     {
-        $resolverMock = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
+        $resolverMock = $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
         $resolverMock
         ->expects($this->atLeastOnce())
         ->method('getParameter')

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Matcher/BlockMatcherFactoryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Matcher/BlockMatcherFactoryTest.php
@@ -18,7 +18,7 @@ class BlockMatcherFactoryTest extends BaseMatcherFactoryTest
     {
         $matcherServiceIdentifier = 'my.matcher.service';
         $resolverMock = $this->getResolverMock($matcherServiceIdentifier);
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $container = $this->createMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
         $container
             ->expects($this->atLeastOnce())
             ->method('has')
@@ -35,12 +35,12 @@ class BlockMatcherFactoryTest extends BaseMatcherFactoryTest
             ->will(
                 $this->returnValueMap(
                     array(
-                        array($matcherServiceIdentifier, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\Matcher\\Block\\MatcherInterface')),
+                        array($matcherServiceIdentifier, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $this->createMock('eZ\\Publish\\Core\\MVC\\Symfony\\Matcher\\Block\\MatcherInterface')),
                     )
                 )
             );
 
-        $matcherFactory = new BlockMatcherFactory($resolverMock, $this->getMock('eZ\\Publish\\API\\Repository\\Repository'));
+        $matcherFactory = new BlockMatcherFactory($resolverMock, $this->createMock('eZ\\Publish\\API\\Repository\\Repository'));
         $matcherFactory->setContainer($container);
         $matcherFactory->match($this->getBlockMock());
     }
@@ -48,8 +48,8 @@ class BlockMatcherFactoryTest extends BaseMatcherFactoryTest
     public function testSetSiteAccessNull()
     {
         $matcherServiceIdentifier = 'my.matcher.service';
-        $resolverMock = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $resolverMock = $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
+        $container = $this->createMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
 
         $resolverMock
             ->expects($this->once())
@@ -69,7 +69,7 @@ class BlockMatcherFactoryTest extends BaseMatcherFactoryTest
                     )
                 )
             );
-        $matcherFactory = new BlockMatcherFactory($resolverMock, $this->getMock('eZ\\Publish\\API\\Repository\\Repository'));
+        $matcherFactory = new BlockMatcherFactory($resolverMock, $this->createMock('eZ\\Publish\\API\\Repository\\Repository'));
         $matcherFactory->setContainer($container);
         $matcherFactory->setSiteAccess();
     }
@@ -77,8 +77,8 @@ class BlockMatcherFactoryTest extends BaseMatcherFactoryTest
     public function testSetSiteAccess()
     {
         $matcherServiceIdentifier = 'my.matcher.service';
-        $resolverMock = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $resolverMock = $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
+        $container = $this->createMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
 
         $siteAccessName = 'siteaccess_name';
         $updatedMatchConfig = array(
@@ -114,7 +114,7 @@ class BlockMatcherFactoryTest extends BaseMatcherFactoryTest
                     )
                 )
             );
-        $matcherFactory = new BlockMatcherFactory($resolverMock, $this->getMock('eZ\\Publish\\API\\Repository\\Repository'));
+        $matcherFactory = new BlockMatcherFactory($resolverMock, $this->createMock('eZ\\Publish\\API\\Repository\\Repository'));
         $matcherFactory->setContainer($container);
         $matcherFactory->setSiteAccess(new SiteAccess($siteAccessName));
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Matcher/ContentMatcherFactoryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Matcher/ContentMatcherFactoryTest.php
@@ -18,7 +18,7 @@ class ContentMatcherFactoryTest extends BaseMatcherFactoryTest
     {
         $matcherServiceIdentifier = 'my.matcher.service';
         $resolverMock = $this->getResolverMock($matcherServiceIdentifier);
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $container = $this->createMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
         $container
             ->expects($this->atLeastOnce())
             ->method('has')
@@ -38,13 +38,13 @@ class ContentMatcherFactoryTest extends BaseMatcherFactoryTest
                         array(
                             $matcherServiceIdentifier,
                             ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE,
-                            $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\Matcher\\ViewMatcherInterface'),
+                            $this->createMock('eZ\\Publish\\Core\\MVC\\Symfony\\Matcher\\ViewMatcherInterface'),
                         ),
                     )
                 )
             );
 
-        $matcherFactory = new ContentMatcherFactory($resolverMock, $this->getMock('eZ\\Publish\\API\\Repository\\Repository'));
+        $matcherFactory = new ContentMatcherFactory($resolverMock, $this->createMock('eZ\\Publish\\API\\Repository\\Repository'));
         $matcherFactory->setContainer($container);
         $matcherFactory->match($this->getContentInfoMock(), 'full');
     }
@@ -52,8 +52,8 @@ class ContentMatcherFactoryTest extends BaseMatcherFactoryTest
     public function testSetSiteAccessNull()
     {
         $matcherServiceIdentifier = 'my.matcher.service';
-        $resolverMock = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $resolverMock = $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
+        $container = $this->createMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
 
         $resolverMock
             ->expects($this->once())
@@ -73,7 +73,7 @@ class ContentMatcherFactoryTest extends BaseMatcherFactoryTest
                     )
                 )
             );
-        $matcherFactory = new ContentMatcherFactory($resolverMock, $this->getMock('eZ\\Publish\\API\\Repository\\Repository'));
+        $matcherFactory = new ContentMatcherFactory($resolverMock, $this->createMock('eZ\\Publish\\API\\Repository\\Repository'));
         $matcherFactory->setContainer($container);
         $matcherFactory->setSiteAccess();
     }
@@ -81,8 +81,8 @@ class ContentMatcherFactoryTest extends BaseMatcherFactoryTest
     public function testSetSiteAccess()
     {
         $matcherServiceIdentifier = 'my.matcher.service';
-        $resolverMock = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $resolverMock = $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
+        $container = $this->createMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
 
         $siteAccessName = 'siteaccess_name';
         $updatedMatchConfig = array(
@@ -118,7 +118,7 @@ class ContentMatcherFactoryTest extends BaseMatcherFactoryTest
                     )
                 )
             );
-        $matcherFactory = new ContentMatcherFactory($resolverMock, $this->getMock('eZ\\Publish\\API\\Repository\\Repository'));
+        $matcherFactory = new ContentMatcherFactory($resolverMock, $this->createMock('eZ\\Publish\\API\\Repository\\Repository'));
         $matcherFactory->setContainer($container);
         $matcherFactory->setSiteAccess(new SiteAccess($siteAccessName));
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Matcher/LocationMatcherFactoryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Matcher/LocationMatcherFactoryTest.php
@@ -18,7 +18,7 @@ class LocationMatcherFactoryTest extends BaseMatcherFactoryTest
     {
         $matcherServiceIdentifier = 'my.matcher.service';
         $resolverMock = $this->getResolverMock($matcherServiceIdentifier);
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $container = $this->createMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
         $container
             ->expects($this->atLeastOnce())
             ->method('has')
@@ -38,13 +38,13 @@ class LocationMatcherFactoryTest extends BaseMatcherFactoryTest
                         array(
                             $matcherServiceIdentifier,
                             ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE,
-                            $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\Matcher\\ViewMatcherInterface'),
+                            $this->createMock('eZ\\Publish\\Core\\MVC\\Symfony\\Matcher\\ViewMatcherInterface'),
                         ),
                     )
                 )
             );
 
-        $matcherFactory = new LocationMatcherFactory($resolverMock, $this->getMock('eZ\\Publish\\API\\Repository\\Repository'));
+        $matcherFactory = new LocationMatcherFactory($resolverMock, $this->createMock('eZ\\Publish\\API\\Repository\\Repository'));
         $matcherFactory->setContainer($container);
         $matcherFactory->match($this->getLocationMock(), 'full');
     }
@@ -52,8 +52,8 @@ class LocationMatcherFactoryTest extends BaseMatcherFactoryTest
     public function testSetSiteAccessNull()
     {
         $matcherServiceIdentifier = 'my.matcher.service';
-        $resolverMock = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $resolverMock = $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
+        $container = $this->createMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
 
         $resolverMock
             ->expects($this->once())
@@ -73,7 +73,7 @@ class LocationMatcherFactoryTest extends BaseMatcherFactoryTest
                     )
                 )
             );
-        $matcherFactory = new LocationMatcherFactory($resolverMock, $this->getMock('eZ\\Publish\\API\\Repository\\Repository'));
+        $matcherFactory = new LocationMatcherFactory($resolverMock, $this->createMock('eZ\\Publish\\API\\Repository\\Repository'));
         $matcherFactory->setContainer($container);
         $matcherFactory->setSiteAccess();
     }
@@ -81,8 +81,8 @@ class LocationMatcherFactoryTest extends BaseMatcherFactoryTest
     public function testSetSiteAccess()
     {
         $matcherServiceIdentifier = 'my.matcher.service';
-        $resolverMock = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
-        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $resolverMock = $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
+        $container = $this->createMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
 
         $siteAccessName = 'siteaccess_name';
         $updatedMatchConfig = array(
@@ -118,7 +118,7 @@ class LocationMatcherFactoryTest extends BaseMatcherFactoryTest
                     )
                 )
             );
-        $matcherFactory = new LocationMatcherFactory($resolverMock, $this->getMock('eZ\\Publish\\API\\Repository\\Repository'));
+        $matcherFactory = new LocationMatcherFactory($resolverMock, $this->createMock('eZ\\Publish\\API\\Repository\\Repository'));
         $matcherFactory->setContainer($container);
         $matcherFactory->setSiteAccess(new SiteAccess($siteAccessName));
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Routing/DefaultRouterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Routing/DefaultRouterTest.php
@@ -37,8 +37,8 @@ class DefaultRouterTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
-        $this->configResolver = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
+        $this->container = $this->createMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $this->configResolver = $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
         $this->requestContext = new RequestContext();
     }
 
@@ -108,7 +108,7 @@ class DefaultRouterTest extends TestCase
      */
     public function testGenerateNoSiteAccess($url)
     {
-        $generator = $this->getMock('Symfony\\Component\\Routing\\Generator\\UrlGeneratorInterface');
+        $generator = $this->createMock('Symfony\\Component\\Routing\\Generator\\UrlGeneratorInterface');
         $generator
             ->expects($this->once())
             ->method('generate')
@@ -150,7 +150,7 @@ class DefaultRouterTest extends TestCase
     {
         $routeName = $routeName ?: __METHOD__;
         $nonSiteAccessAwareRoutes = array('_dontwantsiteaccess');
-        $generator = $this->getMock('Symfony\\Component\\Routing\\Generator\\UrlGeneratorInterface');
+        $generator = $this->createMock('Symfony\\Component\\Routing\\Generator\\UrlGeneratorInterface');
         $generator
             ->expects($this->once())
             ->method('generate')
@@ -166,7 +166,7 @@ class DefaultRouterTest extends TestCase
 
         // If matcher is URILexer, we make it act as it's supposed to, prepending the siteaccess.
         if ($isMatcherLexer) {
-            $matcher = $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\URILexer');
+            $matcher = $this->createMock('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\URILexer');
             // Route is siteaccess aware, we're expecting analyseLink() to be called
             if (!in_array($routeName, $nonSiteAccessAwareRoutes)) {
                 $matcher
@@ -181,7 +181,7 @@ class DefaultRouterTest extends TestCase
                     ->method('analyseLink');
             }
         } else {
-            $matcher = $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\Matcher');
+            $matcher = $this->createMock('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\Matcher');
         }
 
         $sa = new SiteAccess($saName, 'test', $matcher);
@@ -231,8 +231,8 @@ class DefaultRouterTest extends TestCase
         $urlGenerated = 'http://phoenix-rises.fm/foo/bar';
 
         $siteAccessName = 'foo_test';
-        $siteAccessRouter = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface');
-        $versatileMatcher = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher');
+        $siteAccessRouter = $this->createMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface');
+        $versatileMatcher = $this->createMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher');
         $simplifiedRequest = new SimplifiedRequest(
             array(
                 'host' => 'phoenix-rises.fm',
@@ -249,7 +249,7 @@ class DefaultRouterTest extends TestCase
             ->with($siteAccessName)
             ->will($this->returnValue(new SiteAccess($siteAccessName, 'foo', $versatileMatcher)));
 
-        $generator = $this->getMock('Symfony\Component\Routing\Generator\UrlGeneratorInterface');
+        $generator = $this->createMock('Symfony\Component\Routing\Generator\UrlGeneratorInterface');
         $generator
             ->expects($this->at(0))
             ->method('setContext')
@@ -266,7 +266,7 @@ class DefaultRouterTest extends TestCase
 
         $router = new DefaultRouter($this->container, 'foo', array(), $this->requestContext);
         $router->setConfigResolver($this->configResolver);
-        $router->setSiteAccess(new SiteAccess('test', 'test', $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher')));
+        $router->setSiteAccess(new SiteAccess('test', 'test', $this->createMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher')));
         $router->setSiteAccessRouter($siteAccessRouter);
         $refRouter = new ReflectionObject($router);
         $refGenerator = $refRouter->getProperty('generator');

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Routing/UrlAliasRouterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Routing/UrlAliasRouterTest.php
@@ -29,7 +29,7 @@ class UrlAliasRouterTest extends BaseUrlAliasRouterTest
 
     protected function setUp()
     {
-        $this->configResolver = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
+        $this->configResolver = $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
         $this->configResolver
             ->expects($this->any())
             ->method('getParameter')
@@ -58,8 +58,8 @@ class UrlAliasRouterTest extends BaseUrlAliasRouterTest
      */
     protected function resetConfigResolver()
     {
-        $this->configResolver = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
-        $this->container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $this->configResolver = $this->createMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
+        $this->container = $this->createMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
         $this->router->setConfigResolver($this->configResolver);
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/SignalSlot/SymfonyEventConverterSlotTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/SignalSlot/SymfonyEventConverterSlotTest.php
@@ -20,13 +20,13 @@ class SymfonyEventConverterSlotTest extends TestCase
      */
     public function testReceive()
     {
-        $eventDispatcher = $this->getMock('Symfony\\Component\\EventDispatcher\\EventDispatcherInterface');
+        $eventDispatcher = $this->createMock('Symfony\\Component\\EventDispatcher\\EventDispatcherInterface');
         $eventDispatcher
             ->expects($this->once())
             ->method('dispatch')
             ->with(MVCEvents::API_SIGNAL, $this->isInstanceOf('eZ\\Publish\\Core\\MVC\\Symfony\\Event\\SignalEvent'));
 
         $slot = new SymfonyEventConverterSlot($eventDispatcher);
-        $slot->receive($this->getMock('eZ\\Publish\\Core\\SignalSlot\\Signal'));
+        $slot->receive($this->createMock('eZ\\Publish\\Core\\SignalSlot\\Signal'));
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/SiteAccess/MatcherBuilderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/SiteAccess/MatcherBuilderTest.php
@@ -22,7 +22,7 @@ class MatcherBuilderTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $this->container = $this->createMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
     }
 
     /**
@@ -36,7 +36,7 @@ class MatcherBuilderTest extends TestCase
             ->expects($this->never())
             ->method('get');
         $matcherBuilder = new MatcherBuilder($this->container);
-        $matcher = $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\Matcher');
+        $matcher = $this->createMock('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\Matcher');
         $builtMatcher = $matcherBuilder->buildMatcher('\\' . get_class($matcher), array(), new SimplifiedRequest());
         $this->assertInstanceOf(get_class($matcher), $builtMatcher);
     }
@@ -54,7 +54,7 @@ class MatcherBuilderTest extends TestCase
             ->expects($this->once())
             ->method('get')
             ->with($serviceId)
-            ->will($this->returnValue($this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\Matcher')));
+            ->will($this->returnValue($this->createMock('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\Matcher')));
         $matcherBuilder = new MatcherBuilder($this->container);
         $matcherBuilder->buildMatcher("@$serviceId", array(), new SimplifiedRequest());
     }
@@ -66,7 +66,7 @@ class MatcherBuilderTest extends TestCase
     public function testBuildMatcherService()
     {
         $serviceId = 'foo';
-        $matcher = $this->getMock('eZ\\Bundle\\EzPublishCoreBundle\\SiteAccess\\Matcher');
+        $matcher = $this->createMock('eZ\\Bundle\\EzPublishCoreBundle\\SiteAccess\\Matcher');
         $this->container
             ->expects($this->once())
             ->method('get')

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Translation/GlobCollectorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Translation/GlobCollectorTest.php
@@ -9,8 +9,9 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Translation;
 
 use eZ\Bundle\EzPublishCoreBundle\Translation\GlobCollector;
+use PHPUnit\Framework\TestCase;
 
-class GlobCollectorTest extends \PHPUnit_Framework_TestCase
+class GlobCollectorTest extends TestCase
 {
     public function testCollect()
     {

--- a/eZ/Bundle/EzPublishDebugBundle/Tests/Collector/EzPublishCoreCollectorTest.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Tests/Collector/EzPublishCoreCollectorTest.php
@@ -29,7 +29,7 @@ class EzPublishCoreCollectorTest extends TestCase
 
     public function testAddGetCollector()
     {
-        $collector = $this->getMock('\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
+        $collector = $this->createMock('\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
         $name = 'foobar';
         $collector
             ->expects($this->once())
@@ -45,20 +45,20 @@ class EzPublishCoreCollectorTest extends TestCase
      */
     public function testGetInvalidCollector()
     {
-        $collector = $this->getMock('\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
+        $collector = $this->createMock('\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
         $this->mainCollector->addCollector($collector);
         $this->assertSame($collector, $this->mainCollector->getCollector('foo'));
     }
 
     public function testGetAllCollectors()
     {
-        $collector1 = $this->getMock('\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
+        $collector1 = $this->createMock('\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
         $nameCollector1 = 'collector1';
         $collector1
             ->expects($this->once())
             ->method('getName')
             ->will($this->returnValue($nameCollector1));
-        $collector2 = $this->getMock('\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
+        $collector2 = $this->createMock('\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
         $nameCollector2 = 'collector2';
         $collector2
             ->expects($this->once())
@@ -79,7 +79,7 @@ class EzPublishCoreCollectorTest extends TestCase
 
     public function testGetToolbarTemplateNothing()
     {
-        $collector = $this->getMock('\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
+        $collector = $this->createMock('\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
         $name = 'foobar';
         $collector
             ->expects($this->once())
@@ -91,7 +91,7 @@ class EzPublishCoreCollectorTest extends TestCase
 
     public function testGetToolbarTemplate()
     {
-        $collector = $this->getMock('\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
+        $collector = $this->createMock('\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
         $name = 'foobar';
         $collector
             ->expects($this->once())
@@ -105,7 +105,7 @@ class EzPublishCoreCollectorTest extends TestCase
 
     public function testGetPanelTemplateNothing()
     {
-        $collector = $this->getMock('\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
+        $collector = $this->createMock('\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
         $name = 'foobar';
         $collector
             ->expects($this->once())
@@ -117,7 +117,7 @@ class EzPublishCoreCollectorTest extends TestCase
 
     public function testGetPanelTemplate()
     {
-        $collector = $this->getMock('\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
+        $collector = $this->createMock('\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
         $name = 'foobar';
         $collector
             ->expects($this->once())
@@ -131,13 +131,13 @@ class EzPublishCoreCollectorTest extends TestCase
 
     public function testCollect()
     {
-        $collector1 = $this->getMock('\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
+        $collector1 = $this->createMock('\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
         $nameCollector1 = 'collector1';
         $collector1
             ->expects($this->once())
             ->method('getName')
             ->will($this->returnValue($nameCollector1));
-        $collector2 = $this->getMock('\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
+        $collector2 = $this->createMock('\Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface');
         $nameCollector2 = 'collector2';
         $collector2
             ->expects($this->once())

--- a/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/Compiler/IOConfigurationPassTest.php
+++ b/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/Compiler/IOConfigurationPassTest.php
@@ -35,8 +35,8 @@ class IOConfigurationPassTest extends AbstractCompilerPassTestCase
 
     protected function registerCompilerPass(ContainerBuilder $container)
     {
-        $this->metadataConfigurationFactoryMock = $this->getMock('\eZ\Bundle\EzPublishIOBundle\DependencyInjection\ConfigurationFactory');
-        $this->binarydataConfigurationFactoryMock = $this->getMock('\eZ\Bundle\EzPublishIOBundle\DependencyInjection\ConfigurationFactory');
+        $this->metadataConfigurationFactoryMock = $this->createMock('\eZ\Bundle\EzPublishIOBundle\DependencyInjection\ConfigurationFactory');
+        $this->binarydataConfigurationFactoryMock = $this->createMock('\eZ\Bundle\EzPublishIOBundle\DependencyInjection\ConfigurationFactory');
 
         $container->addCompilerPass(
             new IOConfigurationPass(

--- a/eZ/Bundle/EzPublishIOBundle/Tests/EventListener/StreamFileListenerTest.php
+++ b/eZ/Bundle/EzPublishIOBundle/Tests/EventListener/StreamFileListenerTest.php
@@ -32,9 +32,9 @@ class StreamFileListenerTest extends TestCase
 
     public function setUp()
     {
-        $this->ioServiceMock = $this->getMock('eZ\Publish\Core\IO\IOServiceInterface');
+        $this->ioServiceMock = $this->createMock('eZ\Publish\Core\IO\IOServiceInterface');
 
-        $this->configResolverMock = $this->getMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
+        $this->configResolverMock = $this->createMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
 
         $this->eventListener = new StreamFileListener($this->ioServiceMock, $this->configResolverMock);
     }
@@ -159,7 +159,7 @@ class StreamFileListenerTest extends TestCase
     protected function createEvent($request)
     {
         $event = new GetResponseEvent(
-            $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
             $request,
             HttpKernelInterface::MASTER_REQUEST
         );

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/RestContext.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/RestContext.php
@@ -15,7 +15,7 @@ use EzSystems\BehatBundle\Context\Api\Context;
 use EzSystems\BehatBundle\Helper\Gherkin as GherkinHelper;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use Behat\Gherkin\Node\TableNode;
-use PHPUnit_Framework_Assert as Assertion;
+use PHPUnit\Framework\Assert as Assertion;
 use Exception;
 
 /**

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/ContentTypeGroup.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/ContentTypeGroup.php
@@ -10,7 +10,7 @@ namespace eZ\Bundle\EzPublishRestBundle\Features\Context\SubContext;
 
 use EzSystems\BehatBundle\Helper\Gherkin as GherkinHelper;
 use Behat\Gherkin\Node\TableNode;
-use PHPUnit_Framework_Assert as Assertion;
+use PHPUnit\Framework\Assert as Assertion;
 
 trait ContentTypeGroup
 {

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/EzRest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/EzRest.php
@@ -14,7 +14,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\Core\REST\Server\Values\SessionInput;
 use eZ\Publish\Core\REST\Common\Message;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
-use PHPUnit_Framework_Assert as Assertion;
+use PHPUnit\Framework\Assert as Assertion;
 
 /**
  * EzRest is the responsible to have all the specific REST actions of eZ Publish.

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/User.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/User.php
@@ -6,7 +6,7 @@ namespace eZ\Bundle\EzPublishRestBundle\Features\Context\SubContext;
 
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\Core\Base\Exceptions\BadStateException;
-use PHPUnit_Framework_Assert as Assertion;
+use PHPUnit\Framework\Assert as Assertion;
 
 /**
  * @method \eZ\Publish\API\Repository\Repository getRepository()

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/Views.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/SubContext/Views.php
@@ -8,7 +8,7 @@ use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\Core\REST\Client\Values\View;
-use PHPUnit_Framework_Assert as Assertion;
+use PHPUnit\Framework\Assert as Assertion;
 
 /**
  * @method mixed getResponseObject

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/UserContentContext.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/UserContentContext.php
@@ -21,7 +21,7 @@ use eZ\Publish\Core\REST\Client\Values\Content\Content;
 use eZ\Publish\Core\REST\Client\Values\Content\VersionUpdate;
 use eZ\Publish\Core\REST\Server\Values\RestContentCreateStruct;
 use eZ\Publish\Core\REST\Server\Values\Version;
-use PHPUnit_Framework_Assert as Assertion;
+use PHPUnit\Framework\Assert as Assertion;
 
 class UserContentContext extends RawMinkContext implements Context, SnippetAcceptingContext, MinkAwareContext
 {

--- a/eZ/Bundle/EzPublishRestBundle/Tests/CorsOptions/RestProviderTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/CorsOptions/RestProviderTest.php
@@ -115,7 +115,7 @@ class RestProviderTest extends TestCase
      */
     protected function getRequestMatcherMock()
     {
-        $mock = $this->getMock('Symfony\Component\Routing\Matcher\RequestMatcherInterface');
+        $mock = $this->createMock('Symfony\Component\Routing\Matcher\RequestMatcherInterface');
 
         if ($this->matchRequestResult instanceof Exception) {
             $mock->expects($this->any())

--- a/eZ/Bundle/EzPublishRestBundle/Tests/EventListener/CsrfListenerTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/EventListener/CsrfListenerTest.php
@@ -170,7 +170,7 @@ class CsrfListenerTest extends EventListenerTest
      */
     protected function getCsrfProviderMock()
     {
-        $provider = $this->getMock('\Symfony\Component\Security\Csrf\CsrfTokenManagerInterface');
+        $provider = $this->createMock('\Symfony\Component\Security\Csrf\CsrfTokenManagerInterface');
         $provider->expects($this->any())
             ->method('isTokenValid')
             ->will(
@@ -211,7 +211,7 @@ class CsrfListenerTest extends EventListenerTest
     protected function getSessionMock()
     {
         if (!isset($this->sessionMock)) {
-            $this->sessionMock = $this->getMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
+            $this->sessionMock = $this->createMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
             $this->sessionMock
                 ->expects($this->atLeastOnce())
                 ->method('isStarted')
@@ -296,7 +296,7 @@ class CsrfListenerTest extends EventListenerTest
     protected function getEventDispatcherMock()
     {
         if (!isset($this->eventDispatcherMock)) {
-            $this->eventDispatcherMock = $this->getMock(
+            $this->eventDispatcherMock = $this->createMock(
                 'Symfony\Component\EventDispatcher\EventDispatcherInterface'
             );
         }

--- a/eZ/Bundle/EzPublishRestBundle/Tests/EventListener/EventListenerTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/EventListener/EventListenerTest.php
@@ -83,7 +83,7 @@ abstract class EventListenerTest extends TestCase
     protected function getRequestAttributesMock()
     {
         if (!isset($this->requestAttributesMock)) {
-            $this->requestAttributesMock = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+            $this->requestAttributesMock = $this->createMock('Symfony\Component\HttpFoundation\ParameterBag');
             $this->requestAttributesMock
                 ->expects($this->once())
                 ->method('get')
@@ -100,7 +100,7 @@ abstract class EventListenerTest extends TestCase
     protected function getRequestMock()
     {
         if (!isset($this->requestMock)) {
-            $this->requestMock = $this->getMock('Symfony\Component\HttpFoundation\Request');
+            $this->requestMock = $this->createMock('Symfony\Component\HttpFoundation\Request');
             $this->requestMock->attributes = $this->getRequestAttributesMock();
             $this->requestMock->headers = $this->getRequestHeadersMock();
 
@@ -125,7 +125,7 @@ abstract class EventListenerTest extends TestCase
     protected function getRequestHeadersMock()
     {
         if (!isset($this->requestHeadersMock)) {
-            $this->requestHeadersMock = $this->getMock('Symfony\Component\HttpFoundation\ParameterBag');
+            $this->requestHeadersMock = $this->createMock('Symfony\Component\HttpFoundation\ParameterBag');
         }
 
         return $this->requestHeadersMock;

--- a/eZ/Bundle/EzPublishRestBundle/Tests/EventListener/RequestListenerTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/EventListener/RequestListenerTest.php
@@ -113,7 +113,7 @@ class RequestListenerTest extends EventListenerTest
      */
     public function getVisitorDispatcherMock()
     {
-        return $this->getMock(
+        return $this->createMock(
             'eZ\Publish\Core\REST\Server\View\AcceptHeaderVisitorDispatcher'
         );
     }
@@ -124,7 +124,7 @@ class RequestListenerTest extends EventListenerTest
     protected function performFakeRequest($uri, $type = HttpKernelInterface::MASTER_REQUEST)
     {
         $event = new GetResponseEvent(
-            $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
             Request::create($uri),
             $type
         );

--- a/eZ/Bundle/EzPublishRestBundle/Tests/EventListener/ResponseListenerTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/EventListener/ResponseListenerTest.php
@@ -113,7 +113,7 @@ class ResponseListenerTest extends EventListenerTest
     public function getVisitorDispatcherMock()
     {
         if (!isset($this->visitorDispatcherMock)) {
-            $this->visitorDispatcherMock = $this->getMock(
+            $this->visitorDispatcherMock = $this->createMock(
                 'eZ\Publish\Core\REST\Server\View\AcceptHeaderVisitorDispatcher'
             );
         }

--- a/eZ/Bundle/EzPublishRestBundle/Tests/RequestParser/RouterTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/RequestParser/RouterTest.php
@@ -152,7 +152,7 @@ class RouterTest extends TestCase
     private function getRouterMock()
     {
         if (!isset($this->router)) {
-            $this->router = $this->getMock('Symfony\\Cmf\\Component\\Routing\\ChainRouter');
+            $this->router = $this->createMock('Symfony\\Cmf\\Component\\Routing\\ChainRouter');
 
             $this->router
                 ->expects($this->any())

--- a/eZ/Publish/API/Repository/Tests/Values/Content/LanguageTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/Content/LanguageTest.php
@@ -10,9 +10,9 @@ namespace eZ\Publish\API\Repository\Tests\Values\Content;
 
 use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Tests\Values\ValueObjectTestTrait;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class LanguageTest extends PHPUnit_Framework_TestCase
+class LanguageTest extends TestCase
 {
     use ValueObjectTestTrait;
 

--- a/eZ/Publish/API/Repository/Tests/Values/Content/SectionTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/Content/SectionTest.php
@@ -10,9 +10,9 @@ namespace eZ\Publish\API\Repository\Tests\Values\Content;
 
 use eZ\Publish\API\Repository\Tests\Values\ValueObjectTestTrait;
 use eZ\Publish\API\Repository\Values\Content\Section;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class SectionTest extends PHPUnit_Framework_TestCase
+class SectionTest extends TestCase
 {
     use ValueObjectTestTrait;
 

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/Storage/ExternalStorageRegistryPassTest.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/Storage/ExternalStorageRegistryPassTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\Base\Tests\Container\Compiler\Storage;
 
 use eZ\Publish\Core\Base\Container\Compiler\Storage\ExternalStorageRegistryPass;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use eZ\Publish\Core\Base\Tests\Container\Compiler\Stubs\GatewayBasedStorageHandler;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -67,9 +68,7 @@ class ExternalStorageRegistryPassTest extends AbstractCompilerPassTestCase
     public function testRegisterExternalStorageHandlerWithGateway()
     {
         $handlerDef = new Definition();
-        $handlerDef->setClass(
-            'eZ\Publish\Core\Base\Tests\Container\Compiler\Stubs\GatewayBasedStorageHandler'
-        );
+        $handlerDef->setClass(GatewayBasedStorageHandler::class);
         $fieldTypeIdentifier = 'field_type_identifier';
         $handlerDef->addTag('ezpublish.fieldType.externalStorageHandler', array('alias' => $fieldTypeIdentifier));
         $storageHandlerServiceId = 'external_storage_handler_id';
@@ -105,9 +104,7 @@ class ExternalStorageRegistryPassTest extends AbstractCompilerPassTestCase
     public function testRegisterExternalStorageHandlerWithoutRegisteredGateway()
     {
         $handlerDef = new Definition();
-        $handlerDef->setClass(
-            'eZ\Publish\Core\Base\Tests\Container\Compiler\Stubs\GatewayBasedStorageHandler'
-        );
+        $handlerDef->setClass(GatewayBasedStorageHandler::class);
         $fieldTypeIdentifier = 'field_type_identifier';
         $handlerDef->addTag('ezpublish.fieldType.externalStorageHandler', array('alias' => $fieldTypeIdentifier));
         $storageHandlerServiceId = 'external_storage_handler_id';
@@ -128,9 +125,7 @@ class ExternalStorageRegistryPassTest extends AbstractCompilerPassTestCase
     public function testRegisterExternalStorageHandlerWithGatewayNoAlias()
     {
         $handlerDef = new Definition();
-        $handlerDef->setClass(
-            'eZ\Publish\Core\Base\Tests\Container\Compiler\Stubs\GatewayBasedStorageHandler'
-        );
+        $handlerDef->setClass(GatewayBasedStorageHandler::class);
         $fieldTypeIdentifier = 'field_type_identifier';
         $handlerDef->addTag('ezpublish.fieldType.externalStorageHandler', array('alias' => $fieldTypeIdentifier));
         $storageHandlerServiceId = 'external_storage_handler_id';
@@ -157,9 +152,7 @@ class ExternalStorageRegistryPassTest extends AbstractCompilerPassTestCase
     public function testRegisterExternalStorageHandlerWithGatewayNoIdentifier()
     {
         $handlerDef = new Definition();
-        $handlerDef->setClass(
-            'eZ\Publish\Core\Base\Tests\Container\Compiler\Stubs\GatewayBasedStorageHandler'
-        );
+        $handlerDef->setClass(GatewayBasedStorageHandler::class);
         $fieldTypeIdentifier = 'field_type_identifier';
         $handlerDef->addTag('ezpublish.fieldType.externalStorageHandler', array('alias' => $fieldTypeIdentifier));
         $storageHandlerServiceId = 'external_storage_handler_id';

--- a/eZ/Publish/Core/FieldType/Tests/APIFieldTypeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/APIFieldTypeTest.php
@@ -9,6 +9,10 @@
 namespace eZ\Publish\Core\FieldType\Tests;
 
 use eZ\Publish\Core\Repository\Values\ContentType\FieldType;
+use eZ\Publish\Core\FieldType\Value;
+use eZ\Publish\SPI\FieldType\FieldType as SPIFieldType;
+use eZ\Publish\SPI\FieldType\ValidationError;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition as APIFieldDefinition;
 use PHPUnit\Framework\TestCase;
 
 class APIFieldTypeTest extends TestCase
@@ -26,7 +30,7 @@ class APIFieldTypeTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->innerFieldType = $this->getMock('\eZ\Publish\SPI\FieldType\FieldType');
+        $this->innerFieldType = $this->createMock(SPIFieldType::class);
         $this->fieldType = new FieldType($this->innerFieldType);
     }
 
@@ -47,9 +51,9 @@ class APIFieldTypeTest extends TestCase
     {
         $validatorConfig = ['foo' => 'bar'];
         $validationErrors = [
-            $this->getMock('\eZ\Publish\SPI\FieldType\ValidationError'),
-            $this->getMock('\eZ\Publish\SPI\FieldType\ValidationError'),
-            $this->getMock('\eZ\Publish\SPI\FieldType\ValidationError'),
+            $this->createMock(ValidationError::class),
+            $this->createMock(ValidationError::class),
+            $this->createMock(ValidationError::class),
         ];
         $this->innerFieldType
             ->expects($this->once())
@@ -77,9 +81,9 @@ class APIFieldTypeTest extends TestCase
     {
         $fieldSettings = ['foo' => 'bar'];
         $validationErrors = [
-            $this->getMock('\eZ\Publish\SPI\FieldType\ValidationError'),
-            $this->getMock('\eZ\Publish\SPI\FieldType\ValidationError'),
-            $this->getMock('\eZ\Publish\SPI\FieldType\ValidationError'),
+            $this->createMock(ValidationError::class),
+            $this->createMock(ValidationError::class),
+            $this->createMock(ValidationError::class),
         ];
         $this->innerFieldType
             ->expects($this->once())
@@ -92,8 +96,8 @@ class APIFieldTypeTest extends TestCase
 
     public function testValidateValueNoError()
     {
-        $fieldDefinition = $this->getMockForAbstractClass('\eZ\Publish\API\Repository\Values\ContentType\FieldDefinition');
-        $value = $this->getMockForAbstractClass('\eZ\Publish\Core\FieldType\Value');
+        $fieldDefinition = $this->getMockForAbstractClass(APIFieldDefinition::class);
+        $value = $this->getMockForAbstractClass(Value::class);
         $validationErrors = [];
         $this->innerFieldType
             ->expects($this->once())
@@ -106,12 +110,12 @@ class APIFieldTypeTest extends TestCase
 
     public function testValidateValue()
     {
-        $fieldDefinition = $this->getMockForAbstractClass('\eZ\Publish\API\Repository\Values\ContentType\FieldDefinition');
-        $value = $this->getMockForAbstractClass('\eZ\Publish\Core\FieldType\Value');
+        $fieldDefinition = $this->getMockForAbstractClass(APIFieldDefinition::class);
+        $value = $this->getMockForAbstractClass(Value::class);
         $validationErrors = [
-            $this->getMock('\eZ\Publish\SPI\FieldType\ValidationError'),
-            $this->getMock('\eZ\Publish\SPI\FieldType\ValidationError'),
-            $this->getMock('\eZ\Publish\SPI\FieldType\ValidationError'),
+            $this->createMock(ValidationError::class),
+            $this->createMock(ValidationError::class),
+            $this->createMock(ValidationError::class),
         ];
         $this->innerFieldType
             ->expects($this->once())

--- a/eZ/Publish/Core/FieldType/Tests/AuthorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/AuthorTest.php
@@ -10,7 +10,10 @@ namespace eZ\Publish\Core\FieldType\Tests;
 
 use eZ\Publish\Core\FieldType\Author\Type as AuthorType;
 use eZ\Publish\Core\FieldType\Author\Value as AuthorValue;
+use eZ\Publish\Core\FieldType\Author\AuthorCollection;
 use eZ\Publish\Core\FieldType\Author\Author;
+use eZ\Publish\Core\FieldType\Value;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 /**
  * @group fieldType
@@ -110,15 +113,15 @@ class AuthorTest extends FieldTypeTest
         return array(
             array(
                 'My name',
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 23,
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 array('foo'),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }
@@ -355,7 +358,7 @@ class AuthorTest extends FieldTypeTest
     public function testAcceptValueInvalidType()
     {
         $ft = $this->createFieldTypeUnderTest();
-        $ft->acceptValue($this->getMock('eZ\\Publish\\Core\\FieldType\\Value'));
+        $ft->acceptValue($this->createMock(Value::class));
     }
 
     /**
@@ -390,7 +393,7 @@ class AuthorTest extends FieldTypeTest
     public function testBuildFieldValueWithoutParam()
     {
         $value = new AuthorValue();
-        self::assertInstanceOf('eZ\\Publish\\Core\\FieldType\\Author\\AuthorCollection', $value->authors);
+        self::assertInstanceOf(AuthorCollection::class, $value->authors);
         self::assertSame(array(), $value->authors->getArrayCopy());
     }
 
@@ -400,7 +403,7 @@ class AuthorTest extends FieldTypeTest
     public function testBuildFieldValueWithParam()
     {
         $value = new AuthorValue($this->authors);
-        self::assertInstanceOf('eZ\\Publish\\Core\\FieldType\\Author\\AuthorCollection', $value->authors);
+        self::assertInstanceOf(AuthorCollection::class, $value->authors);
         self::assertSame($this->authors, $value->authors->getArrayCopy());
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/BinaryBaseTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/BinaryBaseTest.php
@@ -8,6 +8,9 @@
  */
 namespace eZ\Publish\Core\FieldType\Tests;
 
+use eZ\Publish\Core\FieldType\Value;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+
 /**
  * Base class for binary field types.
  *
@@ -36,12 +39,12 @@ abstract class BinaryBaseTest extends FieldTypeTest
     {
         return array(
             array(
-                $this->getMockForAbstractClass('eZ\Publish\Core\FieldType\Value'),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                $this->getMockForAbstractClass(Value::class),
+                InvalidArgumentException::class,
             ),
             array(
                 array('id' => '/foo/bar'),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/BinaryFileTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/BinaryFileTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\FieldType\Tests;
 
 use eZ\Publish\Core\FieldType\BinaryFile\Type as BinaryFileType;
 use eZ\Publish\Core\FieldType\BinaryFile\Value as BinaryFileValue;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue;
 
 /**
  * @group fieldType
@@ -47,7 +48,7 @@ class BinaryFileTest extends BinaryBaseTest
         $binaryFileInput = array(
             array(
                 new BinaryFileValue(array('id' => '/foo/bar')),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentValue',
+                InvalidArgumentValue::class,
             ),
         );
 

--- a/eZ/Publish/Core/FieldType/Tests/CheckboxTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/CheckboxTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\FieldType\Tests;
 
 use eZ\Publish\Core\FieldType\Checkbox\Type as Checkbox;
 use eZ\Publish\Core\FieldType\Checkbox\Value as CheckboxValue;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 /**
  * @group fieldType
@@ -94,11 +95,11 @@ class CheckboxTest extends FieldTypeTest
         return array(
             array(
                 23,
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new CheckboxValue(42),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/CountryTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/CountryTest.php
@@ -11,6 +11,8 @@ namespace eZ\Publish\Core\FieldType\Tests;
 use eZ\Publish\Core\FieldType\Country\Type as Country;
 use eZ\Publish\Core\FieldType\Country\Value as CountryValue;
 use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\FieldType\Country\Exception\InvalidValue;
 
 /**
  * @group fieldType
@@ -144,19 +146,19 @@ class CountryTest extends FieldTypeTest
         return array(
             array(
                 'LegoLand',
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 array('Norway', 'France', 'LegoLand'),
-                'eZ\\Publish\\Core\\FieldType\\Country\\Exception\\InvalidValue',
+                InvalidValue::class,
             ),
             array(
                 array('FR', 'BE', 'LE'),
-                'eZ\\Publish\\Core\\FieldType\\Country\\Exception\\InvalidValue',
+                InvalidValue::class,
             ),
             array(
                 array('FRE', 'BEL', 'LEG'),
-                'eZ\\Publish\\Core\\FieldType\\Country\\Exception\\InvalidValue',
+                InvalidValue::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/DateAndTimeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/DateAndTimeTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\FieldType\Tests;
 
 use eZ\Publish\Core\FieldType\DateAndTime\Type as DateAndTime;
 use eZ\Publish\Core\FieldType\DateAndTime\Value as DateAndTimeValue;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use DateInterval;
 use stdClass;
 
@@ -107,7 +108,7 @@ class DateAndTimeTest extends FieldTypeTest
         return array(
             array(
                 array(),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/DateTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/DateTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\FieldType\Tests;
 
 use eZ\Publish\Core\FieldType\Date\Type as Date;
 use eZ\Publish\Core\FieldType\Date\Value as DateValue;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use DateTime;
 use DateTimeZone;
 
@@ -99,7 +100,7 @@ class DateTest extends FieldTypeTest
         return array(
             array(
                 array(),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/EmailAddressTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/EmailAddressTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\FieldType\Tests;
 use eZ\Publish\Core\FieldType\EmailAddress\Type as EmailAddressType;
 use eZ\Publish\Core\FieldType\EmailAddress\Value as EmailAddressValue;
 use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 /**
  * @group fieldType
@@ -108,11 +109,11 @@ class EmailAddressTest extends FieldTypeTest
         return array(
             array(
                 23,
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new EmailAddressValue(23),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/EmailAddressValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/EmailAddressValidatorTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\FieldType\Tests;
 
 use eZ\Publish\Core\FieldType\EmailAddress\Value as EmailAddressValue;
 use eZ\Publish\Core\FieldType\Validator\EmailAddressValidator;
+use eZ\Publish\Core\FieldType\Validator;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -25,7 +26,7 @@ class EmailAddressValidatorTest extends TestCase
     public function testConstructor()
     {
         $this->assertInstanceOf(
-            'eZ\\Publish\\Core\\FieldType\\Validator',
+            Validator::class,
             new EmailAddressValidator()
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/FieldTypeMockTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FieldTypeMockTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\FieldType\Tests;
 
 use PHPUnit\Framework\TestCase;
+use eZ\Publish\Core\FieldType\FieldType;
 
 class FieldTypeMockTest extends TestCase
 {
@@ -19,7 +20,7 @@ class FieldTypeMockTest extends TestCase
     {
         /** @var \eZ\Publish\Core\FieldType\FieldType|\PHPUnit_Framework_MockObject_MockObject $stub */
         $stub = $this->getMockForAbstractClass(
-            '\\eZ\\Publish\\Core\\FieldType\\FieldType',
+            FieldType::class,
             array(),
             '',
             false
@@ -39,7 +40,7 @@ class FieldTypeMockTest extends TestCase
     {
         /** @var \eZ\Publish\Core\FieldType\FieldType|\PHPUnit_Framework_MockObject_MockObject $stub */
         $stub = $this->getMockForAbstractClass(
-            '\\eZ\\Publish\\Core\\FieldType\\FieldType',
+            FieldType::class,
             array(),
             '',
             false,
@@ -168,7 +169,7 @@ class FieldTypeMockTest extends TestCase
     {
         /** @var \eZ\Publish\Core\FieldType\FieldType|\PHPUnit_Framework_MockObject_MockObject $stub */
         $stub = $this->getMockForAbstractClass(
-            '\\eZ\\Publish\\Core\\FieldType\\FieldType',
+            FieldType::class,
             array(),
             '',
             false
@@ -183,7 +184,7 @@ class FieldTypeMockTest extends TestCase
     {
         /** @var \eZ\Publish\Core\FieldType\FieldType|\PHPUnit_Framework_MockObject_MockObject $stub */
         $stub = $this->getMockForAbstractClass(
-            '\\eZ\\Publish\\Core\\FieldType\\FieldType',
+            FieldType::class,
             array(),
             '',
             false,
@@ -214,7 +215,7 @@ class FieldTypeMockTest extends TestCase
     {
         /** @var \eZ\Publish\Core\FieldType\FieldType|\PHPUnit_Framework_MockObject_MockObject $stub */
         $stub = $this->getMockForAbstractClass(
-            '\\eZ\\Publish\\Core\\FieldType\\FieldType',
+            FieldType::class,
             array(),
             '',
             false,

--- a/eZ/Publish/Core/FieldType/Tests/FieldTypeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FieldTypeTest.php
@@ -10,7 +10,10 @@ namespace eZ\Publish\Core\FieldType\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Exception;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition as APIFieldDefinition;
 use eZ\Publish\SPI\FieldType\Value as SPIValue;
+use eZ\Publish\Core\Persistence\TransformationProcessor;
+use eZ\Publish\SPI\FieldType\ValidationError;
 
 abstract class FieldTypeTest extends TestCase
 {
@@ -27,7 +30,7 @@ abstract class FieldTypeTest extends TestCase
     protected function getTransformationProcessorMock()
     {
         return $this->getMockForAbstractClass(
-            'eZ\\Publish\\Core\\Persistence\\TransformationProcessor',
+            TransformationProcessor::class,
             array(),
             '',
             false,
@@ -430,7 +433,7 @@ abstract class FieldTypeTest extends TestCase
         return array(
             array(
                 array(),
-                $this->getMock('eZ\\Publish\\SPI\\FieldType\\Value'),
+                $this->createMock(SPIValue::class),
             ),
         );
     }
@@ -504,7 +507,7 @@ abstract class FieldTypeTest extends TestCase
         return array(
             array(
                 array(),
-                $this->getMock('eZ\\Publish\\SPI\\FieldType\\Value'),
+                $this->createMock(SPIValue::class),
                 array(),
             ),
         );
@@ -764,7 +767,7 @@ abstract class FieldTypeTest extends TestCase
 
         foreach ($validationResult as $actualResultElement) {
             $this->assertInstanceOf(
-                'eZ\\Publish\\SPI\\FieldType\\ValidationError',
+                ValidationError::class,
                 $actualResultElement,
                 'Validation result of incorrect type.'
             );
@@ -819,7 +822,7 @@ abstract class FieldTypeTest extends TestCase
 
         foreach ($validationResult as $actualResultElement) {
             $this->assertInstanceOf(
-                'eZ\\Publish\\SPI\\FieldType\\ValidationError',
+                ValidationError::class,
                 $actualResultElement,
                 'Validation result of incorrect type.'
             );
@@ -950,9 +953,7 @@ abstract class FieldTypeTest extends TestCase
         $fieldType = $this->getFieldTypeUnderTest();
 
         /** @var \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition|\PHPUnit_Framework_MockObject_MockObject $fieldDefinitionMock */
-        $fieldDefinitionMock = $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Values\\ContentType\\FieldDefinition'
-        );
+        $fieldDefinitionMock = $this->createMock(APIFieldDefinition::class);
 
         foreach ($fieldDefinitionData as $method => $data) {
             if ($method === 'validatorConfiguration') {

--- a/eZ/Publish/Core/FieldType/Tests/FileSizeValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FileSizeValidatorTest.php
@@ -11,6 +11,11 @@ namespace eZ\Publish\Core\FieldType\Tests;
 use eZ\Publish\Core\FieldType\BinaryFile\Value as BinaryFileValue;
 use eZ\Publish\Core\FieldType\Validator\FileSizeValidator;
 use eZ\Publish\Core\IO\Values\BinaryFile;
+use eZ\Publish\Core\FieldType\Validator;
+use eZ\Publish\API\Repository\IOServiceInterface;
+use eZ\Publish\API\Repository\Values\Translation\Message;
+use eZ\Publish\SPI\FieldType\ValidationError;
+use eZ\Publish\API\Repository\Values\Translation\Plural;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -33,7 +38,7 @@ class FileSizeValidatorTest extends TestCase
     public function testConstructor()
     {
         $this->assertInstanceOf(
-            'eZ\\Publish\\Core\\FieldType\\Validator',
+            Validator::class,
             new FileSizeValidator()
         );
     }
@@ -156,7 +161,7 @@ class FileSizeValidatorTest extends TestCase
     protected function getBinaryFileValue($size)
     {
         $this->markTestSkipped('BinaryFile field type does not use this validator anymore.');
-        $value = new BinaryFileValue($this->getMock('eZ\\Publish\\API\\Repository\\IOServiceInterface'));
+        $value = new BinaryFileValue($this->createMock(IOServiceInterface::class));
         $value->file = new BinaryFile(array('size' => $size));
 
         return $value;
@@ -186,11 +191,11 @@ class FileSizeValidatorTest extends TestCase
         $messages = $validator->getMessage();
         $this->assertCount(1, $messages);
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\FieldType\\ValidationError',
+            ValidationError::class,
             $messages[0]
         );
         $this->assertInstanceOf(
-            'eZ\\Publish\\API\\Repository\\Values\\Translation\\Plural',
+            Plural::class,
             $messages[0]->getTranslatableMessage()
         );
         $this->assertEquals(
@@ -261,7 +266,7 @@ class FileSizeValidatorTest extends TestCase
         $messages = $validator->validateConstraints($constraints);
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\API\\Repository\\Values\\Translation\\Message',
+            Message::class,
             $messages[0]->getTranslatableMessage()
         );
         $this->assertEquals(

--- a/eZ/Publish/Core/FieldType/Tests/FloatTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FloatTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\FieldType\Tests;
 use eZ\Publish\Core\FieldType\Float\Type as FloatType;
 use eZ\Publish\Core\FieldType\Float\Value as FloatValue;
 use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 /**
  * @group fieldType
@@ -106,15 +107,15 @@ class FloatTest extends FieldTypeTest
         return array(
             array(
                 'foo',
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 array(),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new FloatValue('foo'),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/FloatValueValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FloatValueValidatorTest.php
@@ -10,6 +10,9 @@ namespace eZ\Publish\Core\FieldType\Tests;
 
 use eZ\Publish\Core\FieldType\Float\Value as FloatValue;
 use eZ\Publish\Core\FieldType\Validator\FloatValueValidator;
+use eZ\Publish\Core\FieldType\Validator;
+use eZ\Publish\SPI\FieldType\ValidationError;
+use eZ\Publish\API\Repository\Values\Translation\Message;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -40,7 +43,7 @@ class FloatValueValidatorTest extends TestCase
     public function testConstructor()
     {
         $this->assertInstanceOf(
-            'eZ\\Publish\\Core\\FieldType\\Validator',
+            Validator::class,
             new FloatValueValidator()
         );
     }
@@ -188,11 +191,11 @@ class FloatValueValidatorTest extends TestCase
         $messages = $validator->getMessage();
         $this->assertCount(1, $messages);
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\FieldType\\ValidationError',
+            ValidationError::class,
             $messages[0]
         );
         $this->assertInstanceOf(
-            'eZ\\Publish\\API\\Repository\\Values\\Translation\\Message',
+            Message::class,
             $messages[0]->getTranslatableMessage()
         );
         $this->assertEquals(
@@ -274,7 +277,7 @@ class FloatValueValidatorTest extends TestCase
 
         foreach ($expectedMessages as $index => $expectedMessage) {
             $this->assertInstanceOf(
-                'eZ\\Publish\\API\\Repository\\Values\\Translation\\Message',
+                Message::class,
                 $messages[0]->getTranslatableMessage()
             );
             $this->assertEquals(

--- a/eZ/Publish/Core/FieldType/Tests/ISBNTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ISBNTest.php
@@ -13,6 +13,7 @@ namespace eZ\Publish\Core\FieldType\Tests;
 use eZ\Publish\Core\FieldType\ISBN\Type as ISBN;
 use eZ\Publish\Core\FieldType\ISBN\Value as ISBNValue;
 use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 /**
  * @group fieldType
@@ -102,19 +103,19 @@ class ISBNTest extends FieldTypeTest
         return array(
             array(
                 1234567890,
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 array(),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new \stdClass(),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 44.55,
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/Image/IO/LegacyTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Image/IO/LegacyTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\FieldType\Tests\Image\IO;
 
 use eZ\Publish\Core\FieldType\Image\IO\Legacy as LegacyIOService;
 use eZ\Publish\Core\FieldType\Image\IO\OptionsProvider;
+use eZ\Publish\Core\IO\IOServiceInterface;
 use eZ\Publish\Core\IO\Values\BinaryFile;
 use eZ\Publish\Core\IO\Values\BinaryFileCreateStruct;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
@@ -38,8 +39,8 @@ class LegacyTest extends TestCase
 
     public function setUp()
     {
-        $this->publishedIoServiceMock = $this->getMock('eZ\Publish\Core\IO\IOServiceInterface');
-        $this->draftIoServiceMock = $this->getMock('eZ\Publish\Core\IO\IOServiceInterface');
+        $this->publishedIoServiceMock = $this->createMock(IOServiceInterface::class);
+        $this->draftIoServiceMock = $this->createMock(IOServiceInterface::class);
         $optionsProvider = new OptionsProvider(
             array(
                 'var_dir' => 'var/test',

--- a/eZ/Publish/Core/FieldType/Tests/ImageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageTest.php
@@ -11,6 +11,8 @@ namespace eZ\Publish\Core\FieldType\Tests;
 use eZ\Publish\Core\FieldType\Image\Type as ImageType;
 use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
 use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\SPI\FieldType\BinaryBase\MimeTypeDetector;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 /**
  * @group fieldType
@@ -29,13 +31,7 @@ class ImageTest extends FieldTypeTest
     protected function getMimeTypeDetectorMock()
     {
         if (!isset($this->mimeTypeDetectorMock)) {
-            $this->mimeTypeDetectorMock = $this->getMock(
-                'eZ\\Publish\\SPI\\FieldType\\BinaryBase\\MimeTypeDetector',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->mimeTypeDetectorMock = $this->createMock(MimeTypeDetector::class);
         }
 
         return $this->mimeTypeDetectorMock;
@@ -125,7 +121,7 @@ class ImageTest extends FieldTypeTest
         return array(
             array(
                 'foo',
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new ImageValue(
@@ -133,7 +129,7 @@ class ImageTest extends FieldTypeTest
                         'id' => 'non/existent/path',
                     )
                 ),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new ImageValue(
@@ -142,7 +138,7 @@ class ImageTest extends FieldTypeTest
                         'fileName' => array(),
                     )
                 ),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new ImageValue(
@@ -152,7 +148,7 @@ class ImageTest extends FieldTypeTest
                         'fileSize' => 'truebar',
                     )
                 ),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new ImageValue(
@@ -163,7 +159,7 @@ class ImageTest extends FieldTypeTest
                         'alternativeText' => array(),
                     )
                 ),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/IntegerTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/IntegerTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\FieldType\Tests;
 use eZ\Publish\Core\FieldType\Integer\Type as Integer;
 use eZ\Publish\Core\FieldType\Integer\Value as IntegerValue;
 use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 /**
  * @group fieldType
@@ -104,15 +105,15 @@ class IntegerTest extends FieldTypeTest
         return array(
             array(
                 'foo',
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 array(),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new IntegerValue('foo'),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/IntegerValueValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/IntegerValueValidatorTest.php
@@ -10,6 +10,9 @@ namespace eZ\Publish\Core\FieldType\Tests;
 
 use eZ\Publish\Core\FieldType\Integer\Value as IntegerValue;
 use eZ\Publish\Core\FieldType\Validator\IntegerValueValidator;
+use eZ\Publish\Core\FieldType\Validator;
+use eZ\Publish\SPI\FieldType\ValidationError;
+use eZ\Publish\API\Repository\Values\Translation\Message;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -40,7 +43,7 @@ class IntegerValueValidatorTest extends TestCase
     public function testConstructor()
     {
         $this->assertInstanceOf(
-            'eZ\\Publish\\Core\\FieldType\\Validator',
+            Validator::class,
             new IntegerValueValidator()
         );
     }
@@ -190,11 +193,11 @@ class IntegerValueValidatorTest extends TestCase
         $messages = $validator->getMessage();
         $this->assertCount(1, $messages);
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\FieldType\\ValidationError',
+            ValidationError::class,
             $messages[0]
         );
         $this->assertInstanceOf(
-            'eZ\\Publish\\API\\Repository\\Values\\Translation\\Message',
+            Message::class,
             $messages[0]->getTranslatableMessage()
         );
         $this->assertEquals(
@@ -276,7 +279,7 @@ class IntegerValueValidatorTest extends TestCase
 
         foreach ($expectedMessages as $index => $expectedMessage) {
             $this->assertInstanceOf(
-                'eZ\\Publish\\API\\Repository\\Values\\Translation\\Message',
+                Message::class,
                 $messages[0]->getTranslatableMessage()
             );
             $this->assertEquals(

--- a/eZ/Publish/Core/FieldType/Tests/KeywordTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/KeywordTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\FieldType\Tests;
 
 use eZ\Publish\Core\FieldType\Keyword\Type as KeywordType;
 use eZ\Publish\Core\FieldType\Keyword\Value as KeywordValue;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 /**
  * @group fieldType
@@ -92,7 +93,7 @@ class KeywordTest extends FieldTypeTest
         return array(
             array(
                 23,
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/MapLocationTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/MapLocationTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\FieldType\Tests;
 
 use eZ\Publish\Core\FieldType\MapLocation;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 class MapLocationTest extends FieldTypeTest
 {
@@ -87,7 +88,7 @@ class MapLocationTest extends FieldTypeTest
         return array(
             array(
                 'some string',
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new MapLocation\Value(
@@ -95,7 +96,7 @@ class MapLocationTest extends FieldTypeTest
                         'latitude' => 'foo',
                     )
                 ),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new MapLocation\Value(
@@ -104,7 +105,7 @@ class MapLocationTest extends FieldTypeTest
                         'longitude' => 'bar',
                     )
                 ),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new MapLocation\Value(
@@ -114,7 +115,7 @@ class MapLocationTest extends FieldTypeTest
                         'address' => array(),
                     )
                 ),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/MediaTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/MediaTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\FieldType\Tests;
 
 use eZ\Publish\Core\FieldType\Media\Type as MediaType;
 use eZ\Publish\Core\FieldType\Media\Value as MediaValue;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 /**
  * @group fieldType
@@ -57,27 +58,27 @@ class MediaTest extends BinaryBaseTest
         $binaryFileInput = array(
             array(
                 new MediaValue(array('id' => '/foo/bar')),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new MediaValue(array('hasController' => 'yes')),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new MediaValue(array('autoplay' => 'yes')),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new MediaValue(array('loop' => 'yes')),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new MediaValue(array('height' => array())),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new MediaValue(array('width' => array())),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
 

--- a/eZ/Publish/Core/FieldType/Tests/Page/BlockTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Page/BlockTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\FieldType\Tests\Page;
 
 use eZ\Publish\Core\FieldType\Page\Parts\Block;
+use eZ\Publish\Core\FieldType\Page\Parts\Item;
 use PHPUnit\Framework\TestCase;
 
 class BlockTest extends TestCase
@@ -29,10 +30,7 @@ class BlockTest extends TestCase
      */
     public function testGetState()
     {
-        $item = $this
-            ->getMockBuilder('eZ\\Publish\\Core\\FieldType\\Page\\Parts\\Item')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $item = $this->createMock(Item::class);
 
         $properties = array(
             'id' => '4efd68496edd8184aade729b4d2ee17b',

--- a/eZ/Publish/Core/FieldType/Tests/Page/PageServiceTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Page/PageServiceTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\FieldType\Tests\Page;
 
+use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\Core\FieldType\Page\PageStorage;
 use eZ\Publish\Core\FieldType\Page\Parts\Block;
@@ -15,6 +16,7 @@ use eZ\Publish\Core\FieldType\Page\Parts\Item;
 use eZ\Publish\Core\FieldType\Page\Parts\Page;
 use eZ\Publish\Core\FieldType\Page\Parts\Zone;
 use eZ\Publish\Core\FieldType\Page\Value;
+use eZ\Publish\Core\FieldType\Page\PageService;
 use eZ\Publish\Core\Repository\Values\Content\Content;
 use PHPUnit\Framework\TestCase;
 
@@ -23,7 +25,7 @@ class PageServiceTest extends TestCase
     /**
      * Class to instantiate to get the page service.
      */
-    const PAGESERVICE_CLASS = 'eZ\\Publish\\Core\\FieldType\\Page\\PageService';
+    const PAGESERVICE_CLASS = PageService::class;
 
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
@@ -56,11 +58,8 @@ class PageServiceTest extends TestCase
         $this->zoneDefinition = $this->getZoneDefinition();
         $this->blockDefinition = $this->getBlockDefinition();
 
-        $this->storageGateway = $this
-            ->getMockBuilder(PageStorage\Gateway::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->contentService = $this->getMock('eZ\\Publish\\API\\Repository\\ContentService');
+        $this->storageGateway = $this->createMock(PageStorage\Gateway::class);
+        $this->contentService = $this->createMock(ContentService::class);
         $pageServiceClass = static::PAGESERVICE_CLASS;
         $this->pageService = new $pageServiceClass(
             $this->contentService,

--- a/eZ/Publish/Core/FieldType/Tests/PageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/PageTest.php
@@ -13,6 +13,8 @@ use eZ\Publish\Core\FieldType\Page\Value as PageValue;
 use eZ\Publish\Core\FieldType\Page\Parts\Page as Page;
 use eZ\Publish\Core\FieldType\Page\Parts;
 use eZ\Publish\Core\FieldType\Page\HashConverter;
+use eZ\Publish\Core\FieldType\Page\PageService;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use DateTime;
 
 /**
@@ -40,10 +42,7 @@ class PageTest extends FieldTypeTest
     private function getPageServiceMock()
     {
         if (!isset($this->pageServiceMock)) {
-            $this->pageServiceMock = $this
-                ->getMockBuilder('eZ\\Publish\\Core\\FieldType\\Page\\PageService')
-                ->disableOriginalConstructor()
-                ->getMock();
+            $this->pageServiceMock = $this->createMock(PageService::class);
             $this->pageServiceMock->expects($this->any())
                 ->method('getAvailableZoneLayouts')
                 ->will($this->returnValue(array('2ZonesLayout1', '2ZonesLayout2')));
@@ -225,7 +224,7 @@ class PageTest extends FieldTypeTest
         return array(
             array(
                 new \stdClass(),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/RatingTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RatingTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\FieldType\Tests;
 use eZ\Publish\Core\FieldType\Rating\Type as Rating;
 use eZ\Publish\Core\FieldType\Rating\Value;
 use eZ\Publish\SPI\FieldType\Value as SPIValue;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use ReflectionObject;
 
 /**
@@ -96,15 +97,15 @@ class RatingTest extends FieldTypeTest
         return array(
             array(
                 'sindelfingen',
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 array(),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new Value('sindelfingen'),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/RelationListTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RelationListTest.php
@@ -13,6 +13,7 @@ use eZ\Publish\Core\FieldType\RelationList\Value;
 use eZ\Publish\API\Repository\Values\Content\Relation;
 use eZ\Publish\SPI\FieldType\Value as SPIValue;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 class RelationListTest extends FieldTypeTest
 {
@@ -107,7 +108,7 @@ class RelationListTest extends FieldTypeTest
         return array(
             array(
                 true,
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/RelationTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RelationTest.php
@@ -12,6 +12,7 @@ use eZ\Publish\Core\FieldType\Relation\Type as RelationType;
 use eZ\Publish\Core\FieldType\Relation\Value;
 use eZ\Publish\API\Repository\Values\Content\Relation;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\SPI\FieldType\Value as SPIValue;
 
 class RelationTest extends FieldTypeTest
@@ -106,7 +107,7 @@ class RelationTest extends FieldTypeTest
         return array(
             array(
                 true,
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/LinkTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/LinkTest.php
@@ -8,11 +8,17 @@
  */
 namespace eZ\Publish\Core\FieldType\Tests\RichText\Converter;
 
+use eZ\Publish\API\Repository\Values\Content\ContentInfo as APIContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
 use eZ\Publish\Core\FieldType\RichText\Converter\Link;
+use eZ\Publish\Core\Repository\ContentService;
+use eZ\Publish\Core\Repository\LocationService;
+use eZ\Publish\Core\MVC\Symfony\Routing\UrlAliasRouter;
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException as APINotFoundException;
 use eZ\Publish\Core\Base\Exceptions\UnauthorizedException as APIUnauthorizedException;
 use DOMDocument;
+use Psr\Log\LoggerInterface;
 
 /**
  * Tests the Link converter
@@ -25,9 +31,7 @@ class LinkTest extends TestCase
      */
     protected function getMockContentService()
     {
-        return $this->getMockBuilder('eZ\Publish\Core\Repository\ContentService')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(ContentService::class);
     }
 
     /**
@@ -35,9 +39,7 @@ class LinkTest extends TestCase
      */
     protected function getMockLocationService()
     {
-        return $this->getMockBuilder('eZ\Publish\Core\Repository\LocationService')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(LocationService::class);
     }
 
     /**
@@ -45,10 +47,7 @@ class LinkTest extends TestCase
      */
     protected function getMockUrlAliasRouter()
     {
-        return $this
-            ->getMockBuilder('eZ\\Publish\\Core\\MVC\\Symfony\\Routing\\UrlAliasRouter')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(UrlAliasRouter::class);
     }
 
     /**
@@ -218,7 +217,7 @@ class LinkTest extends TestCase
         $locationService = $this->getMockLocationService();
         $urlAliasRouter = $this->getMockUrlAliasRouter();
 
-        $location = $this->getMock('eZ\Publish\API\Repository\Values\Content\Location');
+        $location = $this->createMock(APILocation::class);
 
         $locationService->expects($this->once())
             ->method('loadLocation')
@@ -323,7 +322,7 @@ class LinkTest extends TestCase
         $locationService = $this->getMockLocationService();
         $urlAliasRouter = $this->getMockUrlAliasRouter();
 
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger = $this->createMock(LoggerInterface::class);
 
         $logger->expects($this->once())
             ->method($logType)
@@ -422,8 +421,8 @@ class LinkTest extends TestCase
         $locationService = $this->getMockLocationService();
         $urlAliasRouter = $this->getMockUrlAliasRouter();
 
-        $contentInfo = $this->getMock('eZ\Publish\API\Repository\Values\Content\ContentInfo');
-        $location = $this->getMock('eZ\Publish\API\Repository\Values\Content\Location');
+        $contentInfo = $this->createMock(APIContentInfo::class);
+        $location = $this->createMock(APILocation::class);
 
         $contentInfo->expects($this->once())
             ->method('__get')
@@ -538,7 +537,7 @@ class LinkTest extends TestCase
         $locationService = $this->getMockLocationService();
         $urlAliasRouter = $this->getMockUrlAliasRouter();
 
-        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger = $this->createMock(LoggerInterface::class);
 
         $logger->expects($this->once())
             ->method($logType)

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Render/EmbedTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Render/EmbedTest.php
@@ -10,7 +10,9 @@ namespace eZ\Publish\Core\FieldType\Tests\RichText\Converter\Render;
 
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\FieldType\RichText\Converter\Render\Embed;
+use eZ\Publish\Core\FieldType\RichText\RendererInterface;
 use DOMDocument;
+use Psr\Log\LoggerInterface;
 
 class EmbedTest extends TestCase
 {
@@ -532,9 +534,7 @@ class EmbedTest extends TestCase
      */
     protected function getRendererMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\Core\\FieldType\\RichText\\RendererInterface'
-        );
+        return $this->createMock(RendererInterface::class);
     }
 
     /**
@@ -547,8 +547,6 @@ class EmbedTest extends TestCase
      */
     protected function getLoggerMock()
     {
-        return $this->getMock(
-            'Psr\\Log\\LoggerInterface'
-        );
+        return $this->createMock(LoggerInterface::class);
     }
 }

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Render/TemplateTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Render/TemplateTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\FieldType\Tests\RichText\Converter\Render;
 
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\FieldType\RichText\Converter\Render\Template;
+use eZ\Publish\Core\FieldType\RichText\RendererInterface;
 use DOMDocument;
 
 class TemplateTest extends TestCase
@@ -284,8 +285,6 @@ class TemplateTest extends TestCase
      */
     protected function getRendererMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\Core\\FieldType\\RichText\\RendererInterface'
-        );
+        return $this->createMock(RendererInterface::class);
     }
 }

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/EzxmlToDocbookTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/EzxmlToDocbookTest.php
@@ -23,7 +23,7 @@ class EzxmlToDocbookTest extends BaseTest
     {
         parent::setUp();
 
-        if (!class_exists('eZ\Publish\Core\FieldType\XmlText\Converter\Expanding')) {
+        if (!class_exists(Expanding::class)) {
             $this->markTestSkipped('This tests requires XmlText field type');
         }
     }

--- a/eZ/Publish/Core/FieldType/Tests/RichText/RichTextStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/RichTextStorageTest.php
@@ -14,6 +14,7 @@ use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class RichTextStorageTest extends TestCase
 {
@@ -342,14 +343,15 @@ class RichTextStorageTest extends TestCase
      */
     protected function getPartlyMockedStorage(StorageGateway $gateway)
     {
-        return $this->getMock(
-            RichTextStorage::class,
-            null,
-            [
-                $gateway,
-                $this->getLoggerMock(),
-            ]
-        );
+        return $this->getMockBuilder(RichTextStorage::class)
+            ->setConstructorArgs(
+                [
+                    $gateway,
+                    $this->getLoggerMock(),
+                ]
+            )
+            ->setMethods(null)
+            ->getMock();
     }
 
     /**
@@ -372,7 +374,7 @@ class RichTextStorageTest extends TestCase
     {
         if (!isset($this->loggerMock)) {
             $this->loggerMock = $this->getMockForAbstractClass(
-                'Psr\\Log\\LoggerInterface'
+                LoggerInterface::class
             );
         }
 
@@ -390,10 +392,7 @@ class RichTextStorageTest extends TestCase
     protected function getGatewayMock()
     {
         if (!isset($this->gatewayMock)) {
-            $this->gatewayMock = $this
-                ->getMockBuilder(RichTextStorage\Gateway::class)
-                ->disableOriginalConstructor()
-                ->getMock();
+            $this->gatewayMock = $this->createMock(RichTextStorage\Gateway::class);
         }
 
         return $this->gatewayMock;

--- a/eZ/Publish/Core/FieldType/Tests/RichTextTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichTextTest.php
@@ -8,15 +8,18 @@
  */
 namespace eZ\Publish\Core\FieldType\Tests;
 
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition as APIFieldDefinition;
 use eZ\Publish\Core\FieldType\RichText\Normalizer\Aggregate;
 use eZ\Publish\Core\FieldType\RichText\Type as RichTextType;
 use eZ\Publish\Core\FieldType\RichText\Value;
+use eZ\Publish\Core\FieldType\Value as CoreValue;
 use eZ\Publish\Core\FieldType\RichText\ConverterDispatcher;
 use eZ\Publish\Core\FieldType\RichText\ValidatorDispatcher;
 use eZ\Publish\Core\FieldType\RichText\Validator;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\Content\Relation;
+use eZ\Publish\Core\Persistence\TransformationProcessor;
 use eZ\Publish\Core\FieldType\ValidationError;
 use Exception;
 use PHPUnit\Framework\TestCase;
@@ -54,7 +57,7 @@ class RichTextTest extends TestCase
     protected function getTransformationProcessorMock()
     {
         return $this->getMockForAbstractClass(
-            'eZ\\Publish\\Core\\Persistence\\TransformationProcessor',
+            TransformationProcessor::class,
             array(),
             '',
             false,
@@ -94,7 +97,7 @@ class RichTextTest extends TestCase
      */
     public function testAcceptValueInvalidType()
     {
-        $this->getFieldType()->acceptValue($this->getMockBuilder('eZ\\Publish\\Core\\FieldType\\Value')->disableOriginalConstructor()->getMock());
+        $this->getFieldType()->acceptValue($this->createMock(CoreValue::class));
     }
 
     public static function providerForTestAcceptValueValidFormat()
@@ -241,9 +244,7 @@ class RichTextTest extends TestCase
         $value = new Value($xmlString);
 
         /** @var \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition|\PHPUnit_Framework_MockObject_MockObject $fieldDefinitionMock */
-        $fieldDefinitionMock = $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Values\\ContentType\\FieldDefinition'
-        );
+        $fieldDefinitionMock = $this->createMock(APIFieldDefinition::class);
 
         $validationErrors = $fieldType->validate($fieldDefinitionMock, $value);
 

--- a/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
@@ -12,6 +12,7 @@ use eZ\Publish\Core\FieldType\Selection\Type as Selection;
 use eZ\Publish\Core\FieldType\Selection\Value as SelectionValue;
 use eZ\Publish\SPI\FieldType\Value as SPIValue;
 use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 /**
  * @group fieldType
@@ -105,11 +106,11 @@ class SelectionTest extends FieldTypeTest
         return array(
             array(
                 23,
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 'sindelfingen',
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/StringLengthValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/StringLengthValidatorTest.php
@@ -8,8 +8,12 @@
  */
 namespace eZ\Publish\Core\FieldType\Tests;
 
+use eZ\Publish\API\Repository\Values\Translation\Message;
 use eZ\Publish\Core\FieldType\TextLine\Value as TextLineValue;
 use eZ\Publish\Core\FieldType\Validator\StringLengthValidator;
+use eZ\Publish\Core\FieldType\Validator;
+use eZ\Publish\API\Repository\Values\Translation\Plural;
+use eZ\Publish\SPI\FieldType\ValidationError;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -40,7 +44,7 @@ class StringLengthValidatorTest extends TestCase
     public function testConstructor()
     {
         $this->assertInstanceOf(
-            'eZ\\Publish\\Core\\FieldType\\Validator',
+            Validator::class,
             new StringLengthValidator()
         );
     }
@@ -187,11 +191,11 @@ class StringLengthValidatorTest extends TestCase
         $messages = $validator->getMessage();
         $this->assertCount(1, $messages);
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\FieldType\\ValidationError',
+            ValidationError::class,
             $messages[0]
         );
         $this->assertInstanceOf(
-            'eZ\\Publish\\API\\Repository\\Values\\Translation\\Plural',
+            Plural::class,
             $messages[0]->getTranslatableMessage()
         );
         $this->assertEquals(
@@ -297,7 +301,7 @@ class StringLengthValidatorTest extends TestCase
 
         foreach ($expectedMessages as $index => $expectedMessage) {
             $this->assertInstanceOf(
-                'eZ\\Publish\\API\\Repository\\Values\\Translation\\Message',
+                Message::class,
                 $messages[0]->getTranslatableMessage()
             );
             $this->assertEquals(

--- a/eZ/Publish/Core/FieldType/Tests/TextBlockTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/TextBlockTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\FieldType\Tests;
 
 use eZ\Publish\Core\FieldType\TextBlock\Type as TextBlockType;
 use eZ\Publish\Core\FieldType\TextBlock\Value as TextBlockValue;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 /**
  * @group fieldType
@@ -99,11 +100,11 @@ class TextBlockTest extends FieldTypeTest
         return array(
             array(
                 23,
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new TextBlockValue(23),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/TextLineTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/TextLineTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\FieldType\Tests;
 use eZ\Publish\Core\FieldType\TextLine\Type as TextLineType;
 use eZ\Publish\Core\FieldType\TextLine\Value as TextLineValue;
 use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 /**
  * @group fieldType
@@ -106,11 +107,11 @@ class TextLineTest extends FieldTypeTest
         return array(
             array(
                 23,
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new TextLineValue(23),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/TimeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/TimeTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\FieldType\Tests;
 
 use eZ\Publish\Core\FieldType\Time\Type as Time;
 use eZ\Publish\Core\FieldType\Time\Value as TimeValue;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use DateTime;
 
 /**
@@ -102,7 +103,7 @@ class TimeTest extends FieldTypeTest
         return array(
             array(
                 array(),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/Url/UrlStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Url/UrlStorageTest.php
@@ -14,6 +14,7 @@ use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class UrlStorageTest extends TestCase
 {
@@ -195,14 +196,15 @@ class UrlStorageTest extends TestCase
      */
     protected function getPartlyMockedStorage(StorageGateway $gateway)
     {
-        return $this->getMock(
-            UrlStorage::class,
-            null,
-            array(
-                $gateway,
-                $this->getLoggerMock(),
+        return $this->getMockBuilder(UrlStorage::class)
+            ->setMethods(null)
+            ->setConstructorArgs(
+                array(
+                    $gateway,
+                    $this->getLoggerMock(),
+                )
             )
-        );
+            ->getMock();
     }
 
     /**
@@ -225,7 +227,7 @@ class UrlStorageTest extends TestCase
     {
         if (!isset($this->loggerMock)) {
             $this->loggerMock = $this->getMockForAbstractClass(
-                'Psr\\Log\\LoggerInterface'
+                LoggerInterface::class
             );
         }
 
@@ -243,11 +245,7 @@ class UrlStorageTest extends TestCase
     protected function getGatewayMock()
     {
         if (!isset($this->gatewayMock)) {
-            $this->gatewayMock = $this
-                ->getMockBuilder(UrlStorage\Gateway::class)
-                ->disableOriginalConstructor()
-                ->getMock()
-            ;
+            $this->gatewayMock = $this->createMock(UrlStorage\Gateway::class);
         }
 
         return $this->gatewayMock;

--- a/eZ/Publish/Core/FieldType/Tests/UrlTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/UrlTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\FieldType\Tests;
 
 use eZ\Publish\Core\FieldType\Url\Type as UrlType;
 use eZ\Publish\Core\FieldType\Url\Value as UrlValue;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 /**
  * @group fieldType
@@ -92,11 +93,11 @@ class UrlTest extends FieldTypeTest
         return array(
             array(
                 23,
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
             array(
                 new UrlValue(23),
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/UserTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/UserTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\FieldType\Tests;
 
 use eZ\Publish\Core\FieldType\User\Type as UserType;
 use eZ\Publish\Core\FieldType\User\Value as UserValue;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 /**
  * @group fieldType
@@ -92,7 +93,7 @@ class UserTest extends FieldTypeTest
         return array(
             array(
                 23,
-                'eZ\\Publish\\Core\\Base\\Exceptions\\InvalidArgumentException',
+                InvalidArgumentException::class,
             ),
         );
     }

--- a/eZ/Publish/Core/Helper/Tests/ContentInfoLocationLoader/SudoMainLocationLoaderTest.php
+++ b/eZ/Publish/Core/Helper/Tests/ContentInfoLocationLoader/SudoMainLocationLoaderTest.php
@@ -9,6 +9,13 @@ use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Helper\ContentInfoLocationLoader\SudoMainLocationLoader;
 use eZ\Publish\Core\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\Core\Repository\Repository;
+use eZ\Publish\Core\Repository\Permission\PermissionResolver;
+use eZ\Publish\Core\Repository\Helper\RoleDomainMapper;
+use eZ\Publish\Core\Repository\Helper\LimitationService;
+use eZ\Publish\SPI\Persistence\User\Handler as SPIUserHandler;
+use eZ\Publish\API\Repository\Values\User\UserReference;
 use PHPUnit\Framework\TestCase;
 
 class SudoMainLocationLoaderTest extends TestCase
@@ -98,7 +105,7 @@ class SudoMainLocationLoaderTest extends TestCase
         static $repositoryMock;
 
         if ($repositoryMock === null) {
-            $repositoryClass = 'eZ\Publish\Core\Repository\Repository';
+            $repositoryClass = Repository::class;
 
             $repositoryMock = $this
                 ->getMockBuilder($repositoryClass)
@@ -124,7 +131,7 @@ class SudoMainLocationLoaderTest extends TestCase
 
         if ($mock === null) {
             $mock = $this
-                ->getMockBuilder('eZ\Publish\API\Repository\LocationService')
+                ->getMockBuilder(LocationService::class)
                 ->getMock();
         }
 
@@ -137,22 +144,22 @@ class SudoMainLocationLoaderTest extends TestCase
     private function getPermissionResolverMock()
     {
         return $this
-            ->getMockBuilder('eZ\Publish\Core\Repository\Permission\PermissionResolver')
+            ->getMockBuilder(PermissionResolver::class)
             ->setMethods(null)
             ->setConstructorArgs(
                 [
                     $this
-                        ->getMockBuilder('eZ\Publish\Core\Repository\Helper\RoleDomainMapper')
+                        ->getMockBuilder(RoleDomainMapper::class)
                         ->disableOriginalConstructor()
                         ->getMock(),
                     $this
-                        ->getMockBuilder('eZ\Publish\Core\Repository\Helper\LimitationService')
+                        ->getMockBuilder(LimitationService::class)
                         ->getMock(),
                     $this
-                        ->getMockBuilder('eZ\Publish\SPI\Persistence\User\Handler')
+                        ->getMockBuilder(SPIUserHandler::class)
                         ->getMock(),
                     $this
-                        ->getMockBuilder('eZ\Publish\API\Repository\Values\User\UserReference')
+                        ->getMockBuilder(UserReference::class)
                         ->getMock(),
                 ]
             )

--- a/eZ/Publish/Core/Helper/Tests/ContentPreviewHelperTest.php
+++ b/eZ/Publish/Core/Helper/Tests/ContentPreviewHelperTest.php
@@ -8,10 +8,14 @@
  */
 namespace eZ\Publish\Core\Helper\Tests;
 
+use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
+use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
 use eZ\Publish\Core\Helper\ContentPreviewHelper;
 use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use PHPUnit\Framework\TestCase;
 
 class ContentPreviewHelperTest extends TestCase
@@ -34,8 +38,8 @@ class ContentPreviewHelperTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $this->siteAccessRouter = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface');
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->siteAccessRouter = $this->createMock(SiteAccessRouterInterface::class);
         $this->previewHelper = new ContentPreviewHelper($this->eventDispatcher, $this->siteAccessRouter);
     }
 
@@ -92,7 +96,7 @@ class ContentPreviewHelperTest extends TestCase
     public function testPreviewedContent()
     {
         $this->assertNull($this->previewHelper->getPreviewedContent());
-        $content = $this->getMock('\eZ\Publish\API\Repository\Values\Content\Content');
+        $content = $this->createMock(APIContent::class);
         $this->previewHelper->setPreviewedContent($content);
         $this->assertSame($content, $this->previewHelper->getPreviewedContent());
     }
@@ -100,7 +104,7 @@ class ContentPreviewHelperTest extends TestCase
     public function testPreviewedLocation()
     {
         $this->assertNull($this->previewHelper->getPreviewedLocation());
-        $location = $this->getMock('\eZ\Publish\API\Repository\Values\Content\Location');
+        $location = $this->createMock(APILocation::class);
         $this->previewHelper->setPreviewedLocation($location);
         $this->assertSame($location, $this->previewHelper->getPreviewedLocation());
     }

--- a/eZ/Publish/Core/Helper/Tests/FieldHelperTest.php
+++ b/eZ/Publish/Core/Helper/Tests/FieldHelperTest.php
@@ -11,10 +11,14 @@ namespace eZ\Publish\Core\Helper\Tests;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\FieldTypeService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
 use eZ\Publish\Core\FieldType\TextLine\Type as TextLineType;
 use eZ\Publish\Core\FieldType\TextLine\Value;
 use eZ\Publish\Core\Helper\FieldHelper;
+use eZ\Publish\Core\Helper\TranslationHelper;
 use PHPUnit\Framework\TestCase;
 
 class FieldHelperTest extends TestCase
@@ -42,12 +46,9 @@ class FieldHelperTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->fieldTypeServiceMock = $this->getMock('eZ\\Publish\\API\\Repository\\FieldTypeService');
-        $this->contentTypeServiceMock = $this->getMock('eZ\\Publish\\API\\Repository\\ContentTypeService');
-        $this->translationHelper = $this
-            ->getMockBuilder('eZ\\Publish\\Core\\Helper\\TranslationHelper')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->fieldTypeServiceMock = $this->createMock(FieldTypeService::class);
+        $this->contentTypeServiceMock = $this->createMock(ContentTypeService::class);
+        $this->translationHelper = $this->createMock(TranslationHelper::class);
         $this->fieldHelper = new FieldHelper($this->translationHelper, $this->contentTypeServiceMock, $this->fieldTypeServiceMock);
     }
 
@@ -55,7 +56,7 @@ class FieldHelperTest extends TestCase
     {
         $contentTypeId = 123;
         $contentInfo = new ContentInfo(array('contentTypeId' => $contentTypeId));
-        $content = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Content');
+        $content = $this->createMock(APIContent::class);
         $content
             ->expects($this->any())
             ->method('__get')
@@ -67,8 +68,8 @@ class FieldHelperTest extends TestCase
         $emptyValue = $textLineFT->getEmptyValue();
         $emptyField = new Field(array('fieldDefIdentifier' => $fieldDefIdentifier, 'value' => $emptyValue));
 
-        $contentType = $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType');
-        $fieldDefinition = $this->getMockBuilder('eZ\\Publish\\API\\Repository\\Values\\ContentType\\FieldDefinition')
+        $contentType = $this->getMockForAbstractClass(ContentType::class);
+        $fieldDefinition = $this->getMockBuilder(FieldDefinition::class)
             ->setConstructorArgs(array(array('fieldTypeIdentifier' => 'ezstring')))
             ->getMockForAbstractClass();
         $contentType
@@ -102,7 +103,7 @@ class FieldHelperTest extends TestCase
     {
         $contentTypeId = 123;
         $contentInfo = new ContentInfo(array('contentTypeId' => $contentTypeId));
-        $content = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Content');
+        $content = $this->createMock(APIContent::class);
         $content
             ->expects($this->any())
             ->method('__get')
@@ -114,8 +115,8 @@ class FieldHelperTest extends TestCase
         $nonEmptyValue = new Value('Vive le sucre !!!');
         $emptyField = new Field(array('fieldDefIdentifier' => 'ezstring', 'value' => $nonEmptyValue));
 
-        $contentType = $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType');
-        $fieldDefinition = $this->getMockBuilder('eZ\\Publish\\API\\Repository\\Values\\ContentType\\FieldDefinition')
+        $contentType = $this->getMockForAbstractClass(ContentType::class);
+        $fieldDefinition = $this->getMockBuilder(FieldDefinition::class)
             ->setConstructorArgs(array(array('fieldTypeIdentifier' => 'ezstring')))
             ->getMockForAbstractClass();
         $contentType

--- a/eZ/Publish/Core/Helper/Tests/FieldsGroups/ArrayTranslatorFieldsGroupsListTest.php
+++ b/eZ/Publish/Core/Helper/Tests/FieldsGroups/ArrayTranslatorFieldsGroupsListTest.php
@@ -5,6 +5,7 @@
 namespace eZ\Publish\Core\Helper\Tests\FieldsGroups;
 
 use eZ\Publish\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList;
+use Symfony\Component\Translation\TranslatorInterface;
 use PHPUnit\Framework\TestCase;
 
 class ArrayTranslatorFieldsGroupsListTest extends TestCase
@@ -80,7 +81,7 @@ class ArrayTranslatorFieldsGroupsListTest extends TestCase
     private function getTranslatorMock()
     {
         if ($this->translatorMock === null) {
-            $this->translatorMock = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+            $this->translatorMock = $this->createMock(TranslatorInterface::class);
         }
 
         return $this->translatorMock;

--- a/eZ/Publish/Core/Helper/Tests/FieldsGroups/RepositoryConfigFieldsGroupsListFactoryTest.php
+++ b/eZ/Publish/Core/Helper/Tests/FieldsGroups/RepositoryConfigFieldsGroupsListFactoryTest.php
@@ -5,6 +5,8 @@
 namespace eZ\Publish\Core\Helper\Tests\FieldsGroups;
 
 use eZ\Publish\Core\Helper\FieldsGroups\RepositoryConfigFieldsGroupsListFactory;
+use eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider;
+use Symfony\Component\Translation\TranslatorInterface;
 use PHPUnit\Framework\TestCase;
 
 class RepositoryConfigFieldsGroupsListFactoryTest extends TestCase
@@ -38,10 +40,7 @@ class RepositoryConfigFieldsGroupsListFactoryTest extends TestCase
     protected function getRepositoryConfigMock()
     {
         if (!isset($this->repositoryConfigMock)) {
-            $this->repositoryConfigMock = $this
-                ->getMockBuilder('eZ\Bundle\EzPublishCoreBundle\ApiLoader\RepositoryConfigurationProvider')
-                ->disableOriginalConstructor()
-                ->getMock();
+            $this->repositoryConfigMock = $this->createMock(RepositoryConfigurationProvider::class);
         }
 
         return $this->repositoryConfigMock;
@@ -53,7 +52,7 @@ class RepositoryConfigFieldsGroupsListFactoryTest extends TestCase
     protected function getTranslatorMock()
     {
         if (!isset($this->translatorMock)) {
-            $this->translatorMock = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+            $this->translatorMock = $this->createMock(TranslatorInterface::class);
         }
 
         return $this->translatorMock;

--- a/eZ/Publish/Core/Helper/Tests/PreviewLocationProviderTest.php
+++ b/eZ/Publish/Core/Helper/Tests/PreviewLocationProviderTest.php
@@ -8,8 +8,13 @@
  */
 namespace eZ\Publish\Core\Helper\Tests;
 
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo as APIContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
 use eZ\Publish\Core\Helper\PreviewLocationProvider;
 use eZ\Publish\Core\Repository\Values\Content\Location;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as SPILocationHandler;
 use PHPUnit\Framework\TestCase;
 
 class PreviewLocationProviderTest extends TestCase
@@ -30,9 +35,9 @@ class PreviewLocationProviderTest extends TestCase
     {
         parent::setUp();
 
-        $this->contentService = $this->getMock('eZ\Publish\API\Repository\ContentService');
-        $this->locationService = $this->getMock('eZ\Publish\API\Repository\LocationService');
-        $this->locationHandler = $this->getMock('eZ\Publish\SPI\Persistence\Content\Location\Handler');
+        $this->contentService = $this->createMock(ContentService::class);
+        $this->locationService = $this->createMock(LocationService::class);
+        $this->locationHandler = $this->createMock(SPILocationHandler::class);
         $this->provider = new PreviewLocationProvider($this->locationService, $this->contentService, $this->locationHandler);
     }
 
@@ -42,7 +47,7 @@ class PreviewLocationProviderTest extends TestCase
         $parentLocationId = 456;
 
         $contentInfo = $this
-            ->getMockBuilder('eZ\Publish\API\Repository\Values\Content\ContentInfo')
+            ->getMockBuilder(APIContentInfo::class)
             ->setConstructorArgs(array(array('id' => $contentId)))
             ->getMockForAbstractClass();
 
@@ -63,7 +68,7 @@ class PreviewLocationProviderTest extends TestCase
             ->will($this->returnValue(array(new Location(array('id' => $parentLocationId)))));
 
         $location = $this->provider->loadMainLocation($contentId);
-        $this->assertInstanceOf('eZ\Publish\API\Repository\Values\Content\Location', $location);
+        $this->assertInstanceOf(APILocation::class, $location);
         $this->assertSame($contentInfo, $location->contentInfo);
         $this->assertNull($location->id);
         $this->assertEquals($parentLocationId, $location->parentLocationId);
@@ -74,11 +79,11 @@ class PreviewLocationProviderTest extends TestCase
         $contentId = 123;
         $locationId = 456;
         $contentInfo = $this
-            ->getMockBuilder('eZ\Publish\API\Repository\Values\Content\ContentInfo')
+            ->getMockBuilder(APIContentInfo::class)
             ->setConstructorArgs(array(array('id' => $contentId, 'mainLocationId' => $locationId)))
             ->getMockForAbstractClass();
         $location = $this
-            ->getMockBuilder('eZ\Publish\Core\Repository\Values\Content\Location')
+            ->getMockBuilder(Location::class)
             ->setConstructorArgs(array(array('id' => $locationId, 'contentInfo' => $contentInfo)))
             ->getMockForAbstractClass();
         $this->contentService
@@ -103,7 +108,7 @@ class PreviewLocationProviderTest extends TestCase
         $contentId = 123;
 
         $contentInfo = $this
-            ->getMockBuilder('eZ\Publish\API\Repository\Values\Content\ContentInfo')
+            ->getMockBuilder(APIContentInfo::class)
             ->setConstructorArgs(array(array('id' => $contentId)))
             ->getMockForAbstractClass();
         $this->contentService
@@ -117,7 +122,7 @@ class PreviewLocationProviderTest extends TestCase
             ->with($contentId)
             ->will($this->returnValue(array()));
 
-        $this->locationHandler->expects($this->never())->method('loadLocation');
+        $this->locationHandler->expects($this->never())->method('loadLocationsByContent');
 
         $this->assertNull($this->provider->loadMainLocation($contentId));
     }

--- a/eZ/Publish/Core/Helper/Tests/TranslationHelperTest.php
+++ b/eZ/Publish/Core/Helper/Tests/TranslationHelperTest.php
@@ -8,13 +8,16 @@
  */
 namespace eZ\Publish\Core\Helper\Tests;
 
+use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
 use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\Helper\TranslationHelper;
+use Psr\Log\LoggerInterface;
 
 class TranslationHelperTest extends TestCase
 {
@@ -53,9 +56,9 @@ class TranslationHelperTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->configResolver = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
-        $this->contentService = $this->getMock('eZ\\Publish\\API\\Repository\\ContentService');
-        $this->logger = $this->getMock('Psr\Log\LoggerInterface');
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
+        $this->contentService = $this->createMock(ContentService::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
         $this->siteAccessByLanguages = array(
             'fre-FR' => array('fre'),
             'eng-GB' => array('my_siteaccess', 'eng'),

--- a/eZ/Publish/Core/IO/Tests/IOBinarydataHandler/FlysystemTest.php
+++ b/eZ/Publish/Core/IO/Tests/IOBinarydataHandler/FlysystemTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\IO\Tests\IOBinarydataHandler;
 use eZ\Publish\Core\IO\IOBinarydataHandler\Flysystem;
 use League\Flysystem\FileExistsException;
 use League\Flysystem\FileNotFoundException;
+use League\Flysystem\FilesystemInterface;
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\SPI\IO\BinaryFileCreateStruct as SPIBinaryFileCreateStruct;
 
@@ -24,7 +25,7 @@ class FlysystemTest extends TestCase
 
     public function setUp()
     {
-        $this->filesystem = $this->getMock('League\Flysystem\FilesystemInterface');
+        $this->filesystem = $this->createMock(FilesystemInterface::class);
         $this->handler = new Flysystem($this->filesystem);
     }
 

--- a/eZ/Publish/Core/IO/Tests/IOMetadataHandler/FlysystemTest.php
+++ b/eZ/Publish/Core/IO/Tests/IOMetadataHandler/FlysystemTest.php
@@ -12,6 +12,7 @@ use eZ\Publish\Core\IO\IOMetadataHandler\Flysystem;
 use eZ\Publish\SPI\IO\BinaryFile as SPIBinaryFile;
 use eZ\Publish\SPI\IO\BinaryFileCreateStruct as SPIBinaryFileCreateStruct;
 use League\Flysystem\FileNotFoundException;
+use League\Flysystem\FilesystemInterface;
 use PHPUnit\Framework\TestCase;
 use DateTime;
 
@@ -25,7 +26,7 @@ class FlysystemTest extends TestCase
 
     public function setUp()
     {
-        $this->filesystem = $this->getMock('League\Flysystem\FilesystemInterface');
+        $this->filesystem = $this->createMock(FilesystemInterface::class);
         $this->handler = new Flysystem($this->filesystem);
     }
 
@@ -57,7 +58,7 @@ class FlysystemTest extends TestCase
 
         $spiBinaryFile = $this->handler->create($spiCreateStruct);
 
-        $this->assertInstanceOf('eZ\Publish\SPI\IO\BinaryFile', $spiBinaryFile);
+        $this->assertInstanceOf(SPIBinaryFile::class, $spiBinaryFile);
         $this->assertEquals($expectedSpiBinaryFile, $spiBinaryFile);
     }
 
@@ -89,7 +90,7 @@ class FlysystemTest extends TestCase
 
         $spiBinaryFile = $this->handler->load('prefix/my/file.png');
 
-        $this->assertInstanceOf('eZ\Publish\SPI\IO\BinaryFile', $spiBinaryFile);
+        $this->assertInstanceOf(SPIBinaryFile::class, $spiBinaryFile);
         $this->assertEquals($expectedSpiBinaryFile, $spiBinaryFile);
     }
 

--- a/eZ/Publish/Core/IO/Tests/IOMetadataHandler/LegacyDFSClusterTest.php
+++ b/eZ/Publish/Core/IO/Tests/IOMetadataHandler/LegacyDFSClusterTest.php
@@ -11,6 +11,9 @@ namespace eZ\Publish\Core\IO\Tests\IOMetadataHandler;
 use eZ\Publish\Core\IO\IOMetadataHandler\LegacyDFSCluster;
 use eZ\Publish\SPI\IO\BinaryFile as SPIBinaryFile;
 use eZ\Publish\SPI\IO\BinaryFileCreateStruct as SPIBinaryFileCreateStruct;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Statement;
+use eZ\Publish\Core\IO\UrlDecorator;
 use PHPUnit\Framework\TestCase;
 use DateTime;
 
@@ -27,8 +30,8 @@ class LegacyDFSClusterTest extends TestCase
 
     public function setUp()
     {
-        $this->dbalMock = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
-        $this->urlDecoratorMock = $this->getMock('eZ\Publish\Core\IO\UrlDecorator');
+        $this->dbalMock = $this->createMock(Connection::class);
+        $this->urlDecoratorMock = $this->createMock(UrlDecorator::class);
 
         $this->handler = new LegacyDFSCluster(
             $this->dbalMock,
@@ -65,7 +68,7 @@ class LegacyDFSClusterTest extends TestCase
 
         $spiBinary = $this->handler->create($spiCreateStruct);
 
-        $this->assertInstanceOf('eZ\Publish\SPI\IO\BinaryFile', $spiBinary);
+        $this->assertInstanceOf(SPIBinaryFile::class, $spiBinary);
 
         $this->assertEquals($mtimeExpected, $spiBinary->mtime);
     }
@@ -232,6 +235,6 @@ class LegacyDFSClusterTest extends TestCase
      */
     protected function createDbalStatementMock()
     {
-        return $this->getMock('Doctrine\DBAL\Driver\Statement');
+        return $this->createMock(Statement::class);
     }
 }

--- a/eZ/Publish/Core/IO/Tests/IOServiceTest.php
+++ b/eZ/Publish/Core/IO/Tests/IOServiceTest.php
@@ -10,6 +10,8 @@ namespace eZ\Publish\Core\IO\Tests;
 
 use eZ\Publish\Core\IO\Exception\BinaryFileNotFoundException;
 use eZ\Publish\Core\IO\IOService;
+use eZ\Publish\Core\IO\IOBinarydataHandler;
+use eZ\Publish\Core\IO\IOMetadataHandler;
 use eZ\Publish\Core\IO\Values\BinaryFile;
 use eZ\Publish\Core\IO\Values\BinaryFileCreateStruct;
 use eZ\Publish\SPI\IO\BinaryFile as SPIBinaryFile;
@@ -39,9 +41,9 @@ class IOServiceTest extends TestCase
     {
         parent::setUp();
 
-        $this->binarydataHandlerMock = $this->getMock('eZ\Publish\Core\IO\IOBinarydataHandler');
-        $this->metadataHandlerMock = $this->getMock('eZ\Publish\Core\IO\IOMetadataHandler');
-        $this->mimeTypeDetectorMock = $this->getMock('eZ\\Publish\\SPI\\IO\\MimeTypeDetector');
+        $this->binarydataHandlerMock = $this->createMock(IOBinarydataHandler::class);
+        $this->metadataHandlerMock = $this->createMock(IOMetadataHandler::class);
+        $this->mimeTypeDetectorMock = $this->createMock(MimeTypeDetector::class);
 
         $this->IOService = new IOService(
             $this->metadataHandlerMock,
@@ -103,7 +105,7 @@ class IOServiceTest extends TestCase
             $file
         );
 
-        self::assertInstanceOf('eZ\\Publish\\Core\\IO\\Values\\BinaryFileCreateStruct', $binaryCreateStruct);
+        self::assertInstanceOf(BinaryFileCreateStruct::class, $binaryCreateStruct);
         self::assertNull($binaryCreateStruct->id);
         self::assertTrue(is_resource($binaryCreateStruct->inputStream));
         self::assertEquals(filesize(__FILE__), $binaryCreateStruct->size);
@@ -151,7 +153,7 @@ class IOServiceTest extends TestCase
             ->will($this->returnValue($spiBinaryFile));
 
         $binaryFile = $this->IOService->createBinaryFile($createStruct);
-        self::assertInstanceOf('eZ\Publish\Core\IO\Values\BinaryFile', $binaryFile);
+        self::assertInstanceOf(BinaryFile::class, $binaryFile);
         self::assertEquals($createStruct->id, $binaryFile->id);
         self::assertEquals($createStruct->size, $binaryFile->size);
 

--- a/eZ/Publish/Core/IO/Tests/UrlRedecoratorTest.php
+++ b/eZ/Publish/Core/IO/Tests/UrlRedecoratorTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\IO\Tests;
 
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\IO\UrlRedecorator;
+use eZ\Publish\Core\IO\UrlDecorator;
 
 class UrlRedecoratorTest extends TestCase
 {
@@ -25,8 +26,8 @@ class UrlRedecoratorTest extends TestCase
     public function setUp()
     {
         $this->redecorator = new UrlRedecorator(
-            $this->sourceDecoratorMock = $this->getMock('eZ\Publish\Core\IO\UrlDecorator'),
-            $this->targetDecoratorMock = $this->getMock('eZ\Publish\Core\IO\UrlDecorator')
+            $this->sourceDecoratorMock = $this->createMock(UrlDecorator::class),
+            $this->targetDecoratorMock = $this->createMock(UrlDecorator::class)
         );
     }
 

--- a/eZ/Publish/Core/Limitation/Tests/Base.php
+++ b/eZ/Publish/Core/Limitation/Tests/Base.php
@@ -9,6 +9,8 @@
 namespace eZ\Publish\Core\Limitation\Tests;
 
 use PHPUnit\Framework\TestCase;
+use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\SPI\Persistence\Handler as SPIHandler;
 
 abstract class Base extends TestCase
 {
@@ -33,13 +35,7 @@ abstract class Base extends TestCase
             return $this->persistenceHandlerMock;
         }
 
-        return $this->persistenceHandlerMock = $this->getMock(
-            'eZ\\Publish\\SPI\\Persistence\\Handler',
-            $mockMethods,
-            array(),
-            '',
-            false
-        );
+        return $this->persistenceHandlerMock = $this->createMock(SPIHandler::class);
     }
 
     /**
@@ -53,13 +49,10 @@ abstract class Base extends TestCase
             return $this->userMock;
         }
 
-        return $this->userMock = $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Values\\User\\User',
-            $mockMethods,
-            array(),
-            '',
-            false
-        );
+        return $this->userMock = $this->getMockBuilder(APIUser::class)
+            ->setConstructorArgs(array())
+            ->setMethods($mockMethods)
+            ->getMock();
     }
 
     /**

--- a/eZ/Publish/Core/Limitation/Tests/BlockingLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/BlockingLimitationTypeTest.php
@@ -12,6 +12,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\API\Repository\Values\User\Limitation\BlockingLimitation;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\MatchNone;
 use eZ\Publish\API\Repository\Values\User\Limitation\ObjectStateLimitation;
 use eZ\Publish\Core\Limitation\BlockingLimitationType;
 use eZ\Publish\Core\Repository\Values\Content\Location;
@@ -142,7 +143,7 @@ class BlockingLimitationTypeTest extends Base
         $expected = array('test', 'test' => 9);
         $value = $limitationType->buildValue($expected);
 
-        self::assertInstanceOf('\eZ\Publish\API\Repository\Values\User\Limitation\BlockingLimitation', $value);
+        self::assertInstanceOf(BlockingLimitation::class, $value);
         self::assertInternalType('array', $value->limitationValues);
         self::assertEquals($expected, $value->limitationValues);
     }
@@ -275,7 +276,7 @@ class BlockingLimitationTypeTest extends Base
             $this->getUserMock()
         );
 
-        self::assertInstanceOf('\eZ\Publish\API\Repository\Values\Content\Query\Criterion\MatchNone', $criterion);
+        self::assertInstanceOf(MatchNone::class, $criterion);
         self::assertInternalType('null', $criterion->value);
         self::assertInternalType('null', $criterion->operator);
     }

--- a/eZ/Publish/Core/Limitation/Tests/ContentTypeLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/ContentTypeLimitationTypeTest.php
@@ -8,9 +8,12 @@
  */
 namespace eZ\Publish\Core\Limitation\Tests;
 
+use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeId;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\API\Repository\Values\User\Limitation\ContentTypeLimitation;
 use eZ\Publish\API\Repository\Values\User\Limitation\ObjectStateLimitation;
@@ -18,6 +21,7 @@ use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Limitation\ContentTypeLimitationType;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\Core\Repository\Values\Content\ContentCreateStruct;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as SPIHandler;
 
 /**
  * Test Case for LimitationType.
@@ -35,14 +39,7 @@ class ContentTypeLimitationTypeTest extends Base
     public function setUp()
     {
         parent::setUp();
-
-        $this->contentTypeHandlerMock = $this->getMock(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $this->contentTypeHandlerMock = $this->createMock(SPIHandler::class);
     }
 
     /**
@@ -206,7 +203,7 @@ class ContentTypeLimitationTypeTest extends Base
         $expected = array('test', 'test' => 9);
         $value = $limitationType->buildValue($expected);
 
-        self::assertInstanceOf('\eZ\Publish\API\Repository\Values\User\Limitation\ContentTypeLimitation', $value);
+        self::assertInstanceOf(ContentTypeLimitation::class, $value);
         self::assertInternalType('array', $value->limitationValues);
         self::assertEquals($expected, $value->limitationValues);
     }
@@ -217,21 +214,8 @@ class ContentTypeLimitationTypeTest extends Base
     public function providerForTestEvaluate()
     {
         // Mocks for testing Content & VersionInfo objects, should only be used once because of expect rules.
-        $contentMock = $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\Content',
-            array(),
-            array(),
-            '',
-            false
-        );
-
-        $versionInfoMock = $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $contentMock = $this->createMock(APIContent::class);
+        $versionInfoMock = $this->createMock(APIVersionInfo::class);
 
         $contentMock
             ->expects($this->once())
@@ -243,13 +227,7 @@ class ContentTypeLimitationTypeTest extends Base
             ->method('getContentInfo')
             ->will($this->returnValue(new ContentInfo(array('contentTypeId' => 66))));
 
-        $versionInfoMock2 = $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $versionInfoMock2 = $this->createMock(APIVersionInfo::class);
 
         $versionInfoMock2
             ->expects($this->once())
@@ -420,7 +398,7 @@ class ContentTypeLimitationTypeTest extends Base
             $this->getUserMock()
         );
 
-        self::assertInstanceOf('\eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeId', $criterion);
+        self::assertInstanceOf(ContentTypeId::class, $criterion);
         self::assertInternalType('array', $criterion->value);
         self::assertInternalType('string', $criterion->operator);
         self::assertEquals(Operator::EQ, $criterion->operator);
@@ -439,7 +417,7 @@ class ContentTypeLimitationTypeTest extends Base
             $this->getUserMock()
         );
 
-        self::assertInstanceOf('\eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeId', $criterion);
+        self::assertInstanceOf(ContentTypeId::class, $criterion);
         self::assertInternalType('array', $criterion->value);
         self::assertInternalType('string', $criterion->operator);
         self::assertEquals(Operator::IN, $criterion->operator);

--- a/eZ/Publish/Core/Limitation/Tests/LocationLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/LocationLimitationTypeTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\Core\Limitation\Tests;
 
+use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
@@ -15,10 +17,12 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\API\Repository\Values\User\Limitation\LocationLimitation;
 use eZ\Publish\API\Repository\Values\User\Limitation\ObjectStateLimitation;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LocationId;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Limitation\LocationLimitationType;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\Core\Repository\Values\Content\ContentCreateStruct;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as SPIHandler;
 
 /**
  * Test Case for LimitationType.
@@ -36,14 +40,7 @@ class LocationLimitationTypeTest extends Base
     public function setUp()
     {
         parent::setUp();
-
-        $this->locationHandlerMock = $this->getMock(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $this->locationHandlerMock = $this->createMock(SPIHandler::class);
     }
 
     /**
@@ -207,7 +204,7 @@ class LocationLimitationTypeTest extends Base
         $expected = array('test', 'test' => 9);
         $value = $limitationType->buildValue($expected);
 
-        self::assertInstanceOf('\eZ\Publish\API\Repository\Values\User\Limitation\LocationLimitation', $value);
+        self::assertInstanceOf(LocationLimitation::class, $value);
         self::assertInternalType('array', $value->limitationValues);
         self::assertEquals($expected, $value->limitationValues);
     }
@@ -218,21 +215,8 @@ class LocationLimitationTypeTest extends Base
     public function providerForTestEvaluate()
     {
         // Mocks for testing Content & VersionInfo objects, should only be used once because of expect rules.
-        $contentMock = $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\Content',
-            array(),
-            array(),
-            '',
-            false
-        );
-
-        $versionInfoMock = $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $contentMock = $this->createMock(APIContent::class);
+        $versionInfoMock = $this->createMock(APIVersionInfo::class);
 
         $contentMock
             ->expects($this->once())
@@ -244,13 +228,7 @@ class LocationLimitationTypeTest extends Base
             ->method('getContentInfo')
             ->will($this->returnValue(new ContentInfo(array('published' => true))));
 
-        $versionInfoMock2 = $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $versionInfoMock2 = $this->createMock(APIVersionInfo::class);
 
         $versionInfoMock2
             ->expects($this->once())
@@ -499,7 +477,7 @@ class LocationLimitationTypeTest extends Base
             $this->getUserMock()
         );
 
-        self::assertInstanceOf('\eZ\Publish\API\Repository\Values\Content\Query\Criterion\LocationId', $criterion);
+        self::assertInstanceOf(LocationId::class, $criterion);
         self::assertInternalType('array', $criterion->value);
         self::assertInternalType('string', $criterion->operator);
         self::assertEquals(Operator::EQ, $criterion->operator);
@@ -518,7 +496,7 @@ class LocationLimitationTypeTest extends Base
             $this->getUserMock()
         );
 
-        self::assertInstanceOf('\eZ\Publish\API\Repository\Values\Content\Query\Criterion\LocationId', $criterion);
+        self::assertInstanceOf(LocationId::class, $criterion);
         self::assertInternalType('array', $criterion->value);
         self::assertInternalType('string', $criterion->operator);
         self::assertEquals(Operator::IN, $criterion->operator);

--- a/eZ/Publish/Core/Limitation/Tests/NewObjectStateLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/NewObjectStateLimitationTypeTest.php
@@ -19,6 +19,7 @@ use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\Core\Repository\Values\ObjectState\ObjectState;
+use eZ\Publish\SPI\Persistence\Content\ObjectState\Handler as SPIHandler;
 
 /**
  * Test Case for LimitationType.
@@ -36,14 +37,7 @@ class NewObjectStateLimitationTypeTest extends Base
     public function setUp()
     {
         parent::setUp();
-
-        $this->objectStateHandlerMock = $this->getMock(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Handler',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $this->objectStateHandlerMock = $this->createMock(SPIHandler::class);
     }
 
     /**
@@ -207,7 +201,7 @@ class NewObjectStateLimitationTypeTest extends Base
         $expected = array('test', 'test' => 9);
         $value = $limitationType->buildValue($expected);
 
-        self::assertInstanceOf('\eZ\Publish\API\Repository\Values\User\Limitation\NewObjectStateLimitation', $value);
+        self::assertInstanceOf(NewObjectStateLimitation::class, $value);
         self::assertInternalType('array', $value->limitationValues);
         self::assertEquals($expected, $value->limitationValues);
     }

--- a/eZ/Publish/Core/Limitation/Tests/ObjectStateLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/ObjectStateLimitationTypeTest.php
@@ -17,7 +17,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\Core\Limitation\ObjectStateLimitationType;
 use eZ\Publish\SPI\Persistence\Content\ObjectState;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\Group;
-use eZ\Publish\SPI\Persistence\Content\ObjectState\Handler;
+use eZ\Publish\SPI\Persistence\Content\ObjectState\Handler as SPIHandler;
 
 /**
  * Test Case for LimitationType.
@@ -46,13 +46,7 @@ class ObjectStateLimitationTypeTest extends Base
     {
         parent::setUp();
 
-        $this->objectStateHandlerMock = $this->getMock(
-            Handler::class,
-            [],
-            [],
-            '',
-            false
-        );
+        $this->objectStateHandlerMock = $this->createMock(SPIHandler::class);
 
         $this->allObjectStateGroups = [
             new Group(['id' => 1]),

--- a/eZ/Publish/Core/Limitation/Tests/ParentContentTypeLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/ParentContentTypeLimitationTypeTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\Core\Limitation\Tests;
 
+use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
@@ -20,6 +22,8 @@ use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\Core\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo as SPIContentInfo;
 use eZ\Publish\SPI\Persistence\Content\Location as SPILocation;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as SPIContentTypeHandler;
+use eZ\Publish\SPI\Persistence\Content\Handler as SPIContentHandler;
 
 /**
  * Test Case for LimitationType.
@@ -47,28 +51,9 @@ class ParentContentTypeLimitationTypeTest extends Base
     public function setUp()
     {
         parent::setUp();
-
-        $this->locationHandlerMock = $this->getMock(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler',
-            array(),
-            array(),
-            '',
-            false
-        );
-        $this->contentTypeHandlerMock = $this->getMock(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler',
-            array(),
-            array(),
-            '',
-            false
-        );
-        $this->contentHandlerMock = $this->getMock(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Handler',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $this->locationHandlerMock = $this->createMock(SPILocation\Handler::class);
+        $this->contentTypeHandlerMock = $this->createMock(SPIContentTypeHandler::class);
+        $this->contentHandlerMock = $this->createMock(SPIContentHandler::class);
     }
 
     /**
@@ -236,20 +221,14 @@ class ParentContentTypeLimitationTypeTest extends Base
         $expected = array('test', 'test' => '1');
         $value = $limitationType->buildValue($expected);
 
-        self::assertInstanceOf('\eZ\Publish\API\Repository\Values\User\Limitation\ParentContentTypeLimitation', $value);
+        self::assertInstanceOf(ParentContentTypeLimitation::class, $value);
         self::assertInternalType('array', $value->limitationValues);
         self::assertEquals($expected, $value->limitationValues);
     }
 
     protected function getTestEvaluateContentMock()
     {
-        $contentMock = $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\Content',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $contentMock = $this->createMock(APIContent::class);
 
         $contentMock
             ->expects($this->once())
@@ -261,13 +240,7 @@ class ParentContentTypeLimitationTypeTest extends Base
 
     protected function getTestEvaluateVersionInfoMock()
     {
-        $versionInfoMock = $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $versionInfoMock = $this->createMock(APIVersionInfo::class);
 
         $versionInfoMock
             ->expects($this->once())

--- a/eZ/Publish/Core/Limitation/Tests/ParentDepthLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/ParentDepthLimitationTypeTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\Core\Limitation\Tests;
 
+use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
@@ -17,6 +19,7 @@ use eZ\Publish\API\Repository\Values\User\Limitation\ObjectStateLimitation;
 use eZ\Publish\Core\Limitation\ParentDepthLimitationType;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\Core\Repository\Values\Content\ContentCreateStruct;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as SPILocationHandler;
 
 /**
  * Test Case for LimitationType.
@@ -34,14 +37,7 @@ class ParentDepthLimitationTypeTest extends Base
     public function setUp()
     {
         parent::setUp();
-
-        $this->locationHandlerMock = $this->getMock(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler',
-            [],
-            [],
-            '',
-            false
-        );
+        $this->locationHandlerMock = $this->createMock(SPILocationHandler::class);
     }
 
     /**
@@ -144,7 +140,7 @@ class ParentDepthLimitationTypeTest extends Base
         $value = $limitationType->buildValue($expected);
 
         self::assertInstanceOf(
-            '\eZ\Publish\API\Repository\Values\User\Limitation\ParentDepthLimitation',
+           ParentDepthLimitation::class,
             $value
         );
         self::assertInternalType('array', $value->limitationValues);
@@ -157,21 +153,8 @@ class ParentDepthLimitationTypeTest extends Base
     public function providerForTestEvaluate()
     {
         // Mocks for testing Content & VersionInfo objects, should only be used once because of expect rules.
-        $contentMock = $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\Content',
-            [],
-            [],
-            '',
-            false
-        );
-
-        $versionInfoMock = $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo',
-            [],
-            [],
-            '',
-            false
-        );
+        $contentMock = $this->createMock(APIContent::class);
+        $versionInfoMock = $this->createMock(APIVersionInfo::class);
 
         $contentMock
             ->expects($this->once())
@@ -183,13 +166,7 @@ class ParentDepthLimitationTypeTest extends Base
             ->method('getContentInfo')
             ->will($this->returnValue(new ContentInfo(['published' => true])));
 
-        $versionInfoMock2 = $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo',
-            [],
-            [],
-            '',
-            false
-        );
+        $versionInfoMock2 = $this->createMock(APIVersionInfo::class);
 
         $versionInfoMock2
             ->expects($this->once())

--- a/eZ/Publish/Core/Limitation/Tests/SectionLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/SectionLimitationTypeTest.php
@@ -8,7 +8,10 @@
  */
 namespace eZ\Publish\Core\Limitation\Tests;
 
+use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
 use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\SectionId;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
@@ -21,6 +24,7 @@ use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\Core\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\SPI\Persistence\Content\Section as SPISection;
 use eZ\Publish\SPI\Limitation\Type as LimitationType;
+use eZ\Publish\SPI\Persistence\Content\Section\Handler as SPISectionHandler;
 
 /**
  * Test Case for LimitationType.
@@ -38,14 +42,7 @@ class SectionLimitationTypeTest extends Base
     public function setUp()
     {
         parent::setUp();
-
-        $this->sectionHandlerMock = $this->getMock(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Section\\Handler',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $this->sectionHandlerMock = $this->createMock(SPISectionHandler::class);
     }
 
     /**
@@ -217,7 +214,7 @@ class SectionLimitationTypeTest extends Base
         $expected = array('test', 'test' => '33');
         $value = $limitationType->buildValue($expected);
 
-        self::assertInstanceOf('\eZ\Publish\API\Repository\Values\User\Limitation\SectionLimitation', $value);
+        self::assertInstanceOf(SectionLimitation::class, $value);
         self::assertInternalType('array', $value->limitationValues);
         self::assertEquals($expected, $value->limitationValues);
     }
@@ -228,21 +225,8 @@ class SectionLimitationTypeTest extends Base
     public function providerForTestEvaluate()
     {
         // Mocks for testing Content & VersionInfo objects, should only be used once because of expect rules.
-        $contentMock = $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\Content',
-            array(),
-            array(),
-            '',
-            false
-        );
-
-        $versionInfoMock = $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $contentMock = $this->createMock(APIContent::class);
+        $versionInfoMock = $this->createMock(APIVersionInfo::class);
 
         $contentMock
             ->expects($this->once())
@@ -254,13 +238,7 @@ class SectionLimitationTypeTest extends Base
             ->method('getContentInfo')
             ->will($this->returnValue(new ContentInfo(array('sectionId' => 2))));
 
-        $versionInfoMock2 = $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $versionInfoMock2 = $this->createMock(APIVersionInfo::class);
 
         $versionInfoMock2
             ->expects($this->once())
@@ -471,7 +449,7 @@ class SectionLimitationTypeTest extends Base
             $this->getUserMock()
         );
 
-        self::assertInstanceOf('\eZ\Publish\API\Repository\Values\Content\Query\Criterion\SectionId', $criterion);
+        self::assertInstanceOf(SectionId::class, $criterion);
         self::assertInternalType('array', $criterion->value);
         self::assertInternalType('string', $criterion->operator);
         self::assertEquals(Operator::EQ, $criterion->operator);
@@ -490,7 +468,7 @@ class SectionLimitationTypeTest extends Base
             $this->getUserMock()
         );
 
-        self::assertInstanceOf('\eZ\Publish\API\Repository\Values\Content\Query\Criterion\SectionId', $criterion);
+        self::assertInstanceOf(SectionId::class, $criterion);
         self::assertInternalType('array', $criterion->value);
         self::assertInternalType('string', $criterion->operator);
         self::assertEquals(Operator::IN, $criterion->operator);

--- a/eZ/Publish/Core/Limitation/Tests/SubtreeLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/SubtreeLimitationTypeTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\Core\Limitation\Tests;
 
+use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
@@ -15,12 +17,15 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\API\Repository\Values\User\Limitation\SubtreeLimitation;
 use eZ\Publish\API\Repository\Values\User\Limitation\ObjectStateLimitation;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree;
+use eZ\Publish\Core\Repository\Values\Content\Query\Criterion\PermissionSubtree;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Limitation\SubtreeLimitationType;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\Core\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\SPI\Persistence\Content\Location as SPILocation;
 use eZ\Publish\SPI\Limitation\Type as LimitationType;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as SPILocationHandler;
 
 /**
  * Test Case for LimitationType.
@@ -38,14 +43,7 @@ class SubtreeLimitationTypeTest extends Base
     public function setUp()
     {
         parent::setUp();
-
-        $this->locationHandlerMock = $this->getMock(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $this->locationHandlerMock = $this->createMock(SPILocationHandler::class);
     }
 
     /**
@@ -248,7 +246,7 @@ class SubtreeLimitationTypeTest extends Base
         $expected = array('test', 'test' => '/1/999/');
         $value = $limitationType->buildValue($expected);
 
-        self::assertInstanceOf('\eZ\Publish\API\Repository\Values\User\Limitation\SubtreeLimitation', $value);
+        self::assertInstanceOf(SubtreeLimitation::class, $value);
         self::assertInternalType('array', $value->limitationValues);
         self::assertEquals($expected, $value->limitationValues);
     }
@@ -259,21 +257,8 @@ class SubtreeLimitationTypeTest extends Base
     public function providerForTestEvaluate()
     {
         // Mocks for testing Content & VersionInfo objects, should only be used once because of expect rules.
-        $contentMock = $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\Content',
-            array(),
-            array(),
-            '',
-            false
-        );
-
-        $versionInfoMock = $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $contentMock = $this->createMock(APIContent::class);
+        $versionInfoMock = $this->createMock(APIVersionInfo::class);
 
         $contentMock
             ->expects($this->once())
@@ -285,13 +270,7 @@ class SubtreeLimitationTypeTest extends Base
             ->method('getContentInfo')
             ->will($this->returnValue(new ContentInfo(array('published' => true))));
 
-        $versionInfoMock2 = $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $versionInfoMock2 = $this->createMock(APIVersionInfo::class);
 
         $versionInfoMock2
             ->expects($this->once())
@@ -555,11 +534,8 @@ class SubtreeLimitationTypeTest extends Base
         );
 
         // Assert that $criterion is instance of API type (for Solr/ES), and internal type(optimization for SQL engines)
-        self::assertInstanceOf('eZ\\Publish\\API\\Repository\\Values\\Content\\Query\\Criterion\\Subtree', $criterion);
-        self::assertInstanceOf(
-            'eZ\\Publish\\Core\\Repository\\Values\\Content\\Query\\Criterion\\PermissionSubtree',
-            $criterion
-        );
+        self::assertInstanceOf(Subtree::class, $criterion);
+        self::assertInstanceOf(PermissionSubtree::class, $criterion);
         self::assertInternalType('array', $criterion->value);
         self::assertInternalType('string', $criterion->operator);
         self::assertEquals(Operator::EQ, $criterion->operator);
@@ -579,11 +555,8 @@ class SubtreeLimitationTypeTest extends Base
         );
 
         // Assert that $criterion is instance of API type (for Solr/ES), and internal type(optimization for SQL engines)
-        self::assertInstanceOf('eZ\\Publish\\API\\Repository\\Values\\Content\\Query\\Criterion\\Subtree', $criterion);
-        self::assertInstanceOf(
-            'eZ\\Publish\\Core\\Repository\\Values\\Content\\Query\\Criterion\\PermissionSubtree',
-            $criterion
-        );
+        self::assertInstanceOf(Subtree::class, $criterion);
+        self::assertInstanceOf(PermissionSubtree::class, $criterion);
         self::assertInternalType('array', $criterion->value);
         self::assertInternalType('string', $criterion->operator);
         self::assertEquals(Operator::IN, $criterion->operator);

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/EventListener/AssignedLocationsListenerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/EventListener/AssignedLocationsListenerTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\EventListener;
 
+use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\Core\MVC\Symfony\Event\ContentCacheClearEvent;
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\EventListener\AssignedLocationsListener;
@@ -30,7 +31,7 @@ class AssignedLocationsListenerTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->locationService = $this->getMock('\eZ\Publish\API\Repository\LocationService');
+        $this->locationService = $this->createMock(LocationService::class);
         $this->listener = new AssignedLocationsListener($this->locationService);
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/EventListener/ParentLocationsListenerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/EventListener/ParentLocationsListenerTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\EventListener;
 
+use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\Core\MVC\Symfony\Event\ContentCacheClearEvent;
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\EventListener\ParentLocationsListener;
@@ -30,7 +31,7 @@ class ParentLocationsListenerTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->locationService = $this->getMock('\eZ\Publish\API\Repository\LocationService');
+        $this->locationService = $this->createMock(LocationService::class);
         $this->listener = new ParentLocationsListener($this->locationService);
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/EventListener/RelatedLocationsListenerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/EventListener/RelatedLocationsListenerTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\EventListener;
 
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\EventListener\RelatedLocationsListener;
 use eZ\Publish\Core\MVC\Symfony\Event\ContentCacheClearEvent;
@@ -15,6 +17,12 @@ use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\Core\Repository\Values\Content\Relation;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use eZ\Publish\Core\Repository\Permission\PermissionResolver;
+use eZ\Publish\Core\Repository\Helper\RoleDomainMapper;
+use eZ\Publish\Core\Repository\Helper\LimitationService;
+use eZ\Publish\SPI\Persistence\User\Handler as SPIUserHandler;
+use eZ\Publish\API\Repository\Values\User\UserReference;
+use eZ\Publish\Core\Repository\Repository;
 use PHPUnit\Framework\TestCase;
 
 class RelatedLocationsListenerTest extends TestCase
@@ -43,12 +51,12 @@ class RelatedLocationsListenerTest extends TestCase
     {
         parent::setUp();
         $this->repository = $this
-            ->getMockBuilder('\eZ\Publish\Core\Repository\Repository')
+            ->getMockBuilder(Repository::class)
             ->disableOriginalConstructor()
             ->setMethods(['getContentService', 'getLocationService', 'getPermissionResolver'])
             ->getMock();
-        $this->contentService = $this->getMock('\eZ\Publish\API\Repository\ContentService');
-        $this->locationService = $this->getMock('\eZ\Publish\API\Repository\LocationService');
+        $this->contentService = $this->createMock(ContentService::class);
+        $this->locationService = $this->createMock(LocationService::class);
         $this->repository
             ->expects($this->any())
             ->method('getContentService')
@@ -68,23 +76,14 @@ class RelatedLocationsListenerTest extends TestCase
     private function getPermissionResolverMock()
     {
         return $this
-            ->getMockBuilder('\eZ\Publish\Core\Repository\Permission\PermissionResolver')
+            ->getMockBuilder(PermissionResolver::class)
             ->setMethods(null)
             ->setConstructorArgs(
                 [
-                    $this
-                        ->getMockBuilder('eZ\Publish\Core\Repository\Helper\RoleDomainMapper')
-                        ->disableOriginalConstructor()
-                        ->getMock(),
-                    $this
-                        ->getMockBuilder('eZ\Publish\Core\Repository\Helper\LimitationService')
-                        ->getMock(),
-                    $this
-                        ->getMockBuilder('eZ\Publish\SPI\Persistence\User\Handler')
-                        ->getMock(),
-                    $this
-                        ->getMockBuilder('eZ\Publish\API\Repository\Values\User\UserReference')
-                        ->getMock(),
+                    $this->createMock(RoleDomainMapper::class),
+                    $this->createMock(LimitationService::class),
+                    $this->createMock(SPIUserHandler::class),
+                    $this->createMock(UserReference::class),
                 ]
             )
             ->getMock();

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/FOSPurgeClientTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/FOSPurgeClientTest.php
@@ -9,6 +9,9 @@
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http;
 
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\FOSPurgeClient;
+use FOS\HttpCacheBundle\CacheManager;
+use FOS\HttpCache\ProxyClient\ProxyClientInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use PHPUnit\Framework\TestCase;
 
 class FOSPurgeClientTest extends TestCase
@@ -26,13 +29,11 @@ class FOSPurgeClientTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->cacheManager = $this->getMockBuilder('\FOS\HttpCacheBundle\CacheManager')
+        $this->cacheManager = $this->getMockBuilder(CacheManager::class)
             ->setConstructorArgs(
                 array(
-                    $this->getMock('\FOS\HttpCache\ProxyClient\ProxyClientInterface'),
-                    $this->getMock(
-                        '\Symfony\Component\Routing\Generator\UrlGeneratorInterface'
-                    ),
+                    $this->createMock(ProxyClientInterface::class),
+                    $this->createMock(UrlGeneratorInterface::class),
                 )
             )
             ->getMock();

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/InstantCachePurgerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/InstantCachePurgerTest.php
@@ -9,12 +9,15 @@
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\InstantCachePurger;
+use eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface;
 use eZ\Publish\Core\MVC\Symfony\Event\ContentCacheClearEvent;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class InstantCachePurgerTest extends TestCase
 {
@@ -36,9 +39,9 @@ class InstantCachePurgerTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->purgeClient = $this->getMock('\eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface');
-        $this->contentService = $this->getMock('\eZ\Publish\API\Repository\ContentService');
-        $this->eventDispatcher = $this->getMock('\Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $this->purgeClient = $this->createMock(PurgeClientInterface::class);
+        $this->contentService = $this->createMock(ContentService::class);
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
     }
 
     public function testPurge()

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/LocalPurgeClientTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/LocalPurgeClientTest.php
@@ -21,6 +21,7 @@ function time()
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests;
 
 use eZ\Publish\Core\MVC\Symfony\Cache\Http\LocalPurgeClient;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\ContentPurger;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -32,7 +33,7 @@ class LocalPurgeClientTest extends TestCase
         $expectedBanRequest = Request::create('http://localhost', 'BAN');
         $expectedBanRequest->headers->set('X-Location-Id', '(' . implode('|', $locationIds) . ')');
 
-        $cacheStore = $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\Cache\\Http\\ContentPurger');
+        $cacheStore = $this->createMock(ContentPurger::class);
         $cacheStore
             ->expects($this->once())
             ->method('purgeByRequest')
@@ -44,7 +45,7 @@ class LocalPurgeClientTest extends TestCase
 
     public function testPurgeAll()
     {
-        $cacheStore = $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\Cache\\Http\\ContentPurger');
+        $cacheStore = $this->createMock(ContentPurger::class);
         $cacheStore
             ->expects($this->once())
             ->method('purgeAllContent');

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/LocationAwareStoreTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/LocationAwareStoreTest.php
@@ -86,7 +86,7 @@ class LocationAwareStoreTest extends TestCase
      */
     private function getFilesystemMock()
     {
-        return $this->getMock('Symfony\\Component\\Filesystem\\Filesystem');
+        return $this->createMock(Filesystem::class);
     }
 
     public function testPurgeByRequestSingleLocation()

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/AbstractSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/AbstractSlotTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
+use eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger;
 use PHPUnit\Framework\TestCase;
 
 abstract class AbstractSlotTest extends TestCase implements SlotTest
@@ -24,7 +25,7 @@ abstract class AbstractSlotTest extends TestCase implements SlotTest
 
     public function setUp()
     {
-        $this->cachePurgerMock = $this->getMock('eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger');
+        $this->cachePurgerMock = $this->createMock(GatewayCachePurger::class);
         $this->slot = $this->createSlot();
         self::$signal = $this->createSignal();
     }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/AssignSectionSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/AssignSectionSlotTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\SectionService\AssignSectionSignal;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\AssignSectionSlot;
 
 class AssignSectionSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
 {
@@ -19,11 +20,11 @@ class AssignSectionSlotTest extends AbstractPurgeForContentSlotTest implements S
 
     public function getSlotClass()
     {
-        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\AssignSectionSlot';
+        return AssignSectionSlot::class;
     }
 
     public static function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\SectionService\AssignSectionSignal'];
+        return [AssignSectionSignal::class];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/CopyContentSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/CopyContentSlotTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\ContentService\CopyContentSignal;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\CopyContentSlot;
 
 class CopyContentSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
 {
@@ -19,11 +20,11 @@ class CopyContentSlotTest extends AbstractPurgeForContentSlotTest implements Slo
 
     public function getSlotClass()
     {
-        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\CopyContentSlot';
+        return CopyContentSlot::class;
     }
 
     public static function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\ContentService\CopyContentSignal'];
+        return [CopyContentSignal::class];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/CreateLocationSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/CreateLocationSlotTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\LocationService\CreateLocationSignal;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\CreateLocationSlot;
 
 class CreateLocationSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
 {
@@ -19,11 +20,11 @@ class CreateLocationSlotTest extends AbstractPurgeForContentSlotTest implements 
 
     public function getSlotClass()
     {
-        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\CreateLocationSlot';
+        return CreateLocationSlot::class;
     }
 
     public static function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\CreateLocationSignal'];
+        return [CreateLocationSignal::class];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/DeleteContentSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/DeleteContentSlotTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteContentSignal;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\DeleteContentSlot;
 
 class DeleteContentSlotTest extends AbstractPurgeAllSlotTest implements SlotTest, PurgeAllExpectation
 {
@@ -19,11 +20,11 @@ class DeleteContentSlotTest extends AbstractPurgeAllSlotTest implements SlotTest
 
     public function getSlotClass()
     {
-        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\DeleteContentSlot';
+        return DeleteContentSlot::class;
     }
 
     public static function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteContentSignal'];
+        return [DeleteContentSignal::class];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/DeleteLocationSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/DeleteLocationSlotTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\LocationService\DeleteLocationSignal;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\DeleteLocationSlot;
 
 class DeleteLocationSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
 {
@@ -21,11 +22,11 @@ class DeleteLocationSlotTest extends AbstractPurgeForContentSlotTest implements 
 
     public function getSlotClass()
     {
-        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\DeleteLocationSlot';
+        return DeleteLocationSlot::class;
     }
 
     public static function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\DeleteLocationSignal'];
+        return [DeleteLocationSignal::class];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/DeleteVersionSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/DeleteVersionSlotTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteVersionSignal;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\DeleteVersionSlot;
 
 class DeleteVersionSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
 {
@@ -19,11 +20,11 @@ class DeleteVersionSlotTest extends AbstractPurgeForContentSlotTest implements S
 
     public function getSlotClass()
     {
-        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\DeleteVersionSlot';
+        return DeleteVersionSlot::class;
     }
 
     public static function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteVersionSignal'];
+        return [DeleteVersionSignal::class];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/HideLocationSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/HideLocationSlotTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\LocationService\HideLocationSignal;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\HideLocationSlot;
 
 class HideLocationSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
 {
@@ -19,11 +20,11 @@ class HideLocationSlotTest extends AbstractPurgeForContentSlotTest implements Sl
 
     public function getSlotClass()
     {
-        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\HideLocationSlot';
+        return HideLocationSlot::class;
     }
 
     public static function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\HideLocationSignal'];
+        return [HideLocationSignal::class];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/MoveSubtreeSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/MoveSubtreeSlotTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\LocationService\MoveSubtreeSignal;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\MoveSubtreeSlot;
 
 class MoveSubtreeSlotTest extends AbstractPurgeAllSlotTest implements SlotTest
 {
@@ -19,11 +20,11 @@ class MoveSubtreeSlotTest extends AbstractPurgeAllSlotTest implements SlotTest
 
     public function getSlotClass()
     {
-        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\MoveSubtreeSlot';
+        return MoveSubtreeSlot::class;
     }
 
     public static function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\MoveSubtreeSignal'];
+        return [MoveSubtreeSignal::class];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/PublishVersionSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/PublishVersionSlotTest.php
@@ -9,12 +9,13 @@
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\ContentService\PublishVersionSignal;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\PublishVersionSlot;
 
 class PublishVersionSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
 {
     public function getSlotClass()
     {
-        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\PublishVersionSlot';
+        return PublishVersionSlot::class;
     }
 
     public static function createSignal()
@@ -24,6 +25,6 @@ class PublishVersionSlotTest extends AbstractPurgeForContentSlotTest implements 
 
     public static function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\ContentService\PublishVersionSignal'];
+        return [PublishVersionSignal::class];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/RecoverSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/RecoverSlotTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\TrashService\RecoverSignal;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\RecoverSlot;
 
 class RecoverSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
 {
@@ -21,11 +22,11 @@ class RecoverSlotTest extends AbstractPurgeForContentSlotTest implements SlotTes
 
     public function getSlotClass()
     {
-        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\RecoverSlot';
+        return RecoverSlot::class;
     }
 
     public static function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\TrashService\RecoverSignal'];
+        return [RecoverSignal::class];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/SetContentStateSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/SetContentStateSlotTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
 use eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\SetContentStateSignal;
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\SetContentStateSlot;
 
 class SetContentStateSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
 {
@@ -19,11 +20,11 @@ class SetContentStateSlotTest extends AbstractPurgeForContentSlotTest implements
 
     public function getSlotClass()
     {
-        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\SetContentStateSlot';
+        return SetContentStateSlot::class;
     }
 
     public static function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\SetContentStateSignal'];
+        return [SetContentStateSignal::class];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/SwapLocationSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/SwapLocationSlotTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\SetContentStateSlot;
 use eZ\Publish\Core\SignalSlot\Signal\LocationService\SwapLocationSignal;
 
 /**
@@ -27,11 +28,11 @@ class SwapLocationSlotTest extends AbstractPurgeForContentSlotTest implements Sl
 
     public function getSlotClass()
     {
-        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\SetContentStateSlot';
+        return SetContentStateSlot::class;
     }
 
     public static function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\SetContentStateSignal'];
+        return [SetContentStateSignal::class];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/TrashSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/TrashSlotTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\TrashSlot;
 use eZ\Publish\Core\SignalSlot\Signal\TrashService\TrashSignal;
 
 class TrashSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
@@ -21,11 +22,11 @@ class TrashSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest,
 
     public function getSlotClass()
     {
-        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\TrashSlot';
+        return TrashSlot::class;
     }
 
     public static function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\TrashService\TrashSignal'];
+        return [TrashSignal::class];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/UnassignUserFromUserGroupSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/UnassignUserFromUserGroupSlotTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UnassignUserFromUserGroupSlot;
 use eZ\Publish\Core\SignalSlot\Signal\UserService\UnAssignUserFromUserGroupSignal;
 
 class UnassignUserFromUserGroupSlotTest extends AbstractPurgeAllSlotTest implements SlotTest
@@ -19,11 +20,11 @@ class UnassignUserFromUserGroupSlotTest extends AbstractPurgeAllSlotTest impleme
 
     public function getSlotClass()
     {
-        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UnassignUserFromUserGroupSlot';
+        return UnassignUserFromUserGroupSlot::class;
     }
 
     public static function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\UserService\UnAssignUserFromUserGroupSignal'];
+        return [UnAssignUserFromUserGroupSignal::class];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/UnhideLocationSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/UnhideLocationSlotTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UnhideLocationSlot;
 use eZ\Publish\Core\SignalSlot\Signal\LocationService\UnhideLocationSignal;
 
 class UnhideLocationSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
@@ -19,11 +20,11 @@ class UnhideLocationSlotTest extends AbstractPurgeForContentSlotTest implements 
 
     public function getSlotClass()
     {
-        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UnhideLocationSlot';
+        return UnhideLocationSlot::class;
     }
 
     public static function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\UnhideLocationSignal'];
+        return [UnhideLocationSignal::class];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/UpdateLocationSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/UpdateLocationSlotTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UpdateLocationSlot;
 use eZ\Publish\Core\SignalSlot\Signal\LocationService\UpdateLocationSignal;
 
 class UpdateLocationSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
@@ -19,11 +20,11 @@ class UpdateLocationSlotTest extends AbstractPurgeForContentSlotTest implements 
 
     public function getSlotClass()
     {
-        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UpdateLocationSlot';
+        return UpdateLocationSlot::class;
     }
 
     public static function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\LocationService\UpdateLocationSignal'];
+        return [UpdateLocationSignal::class];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/UpdateUserSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/UpdateUserSlotTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
 
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UpdateUserSlot;
 use eZ\Publish\Core\SignalSlot\Signal\UserService\UpdateUserSignal;
 
 class UpdateUserSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
@@ -19,11 +20,11 @@ class UpdateUserSlotTest extends AbstractPurgeForContentSlotTest implements Slot
 
     public function getSlotClass()
     {
-        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UpdateUserSlot';
+        return UpdateUserSlot::class;
     }
 
     public static function getReceivedSignalClasses()
     {
-        return ['eZ\Publish\Core\SignalSlot\Signal\UserService\UpdateUserSignal'];
+        return [UpdateUserSignal::class];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Tests/Controller/Content/PreviewControllerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Tests/Controller/Content/PreviewControllerTest.php
@@ -9,17 +9,22 @@
 namespace eZ\Publish\Core\MVC\Symfony\Controller\Tests\Controller\Content;
 
 use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
 use eZ\Publish\Core\Helper\PreviewLocationProvider;
+use eZ\Publish\Core\Helper\ContentPreviewHelper;
 use eZ\Publish\Core\MVC\Symfony\Controller\Content\PreviewController;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\View\CustomLocationControllerChecker;
 use eZ\Publish\Core\MVC\Symfony\View\ViewManagerInterface;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute as AuthorizationAttribute;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class PreviewControllerTest extends TestCase
 {
@@ -52,18 +57,12 @@ class PreviewControllerTest extends TestCase
     {
         parent::setUp();
 
-        $this->contentService = $this->getMock('eZ\Publish\API\Repository\ContentService');
-        $this->httpKernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
-        $this->previewHelper = $this
-            ->getMockBuilder('eZ\Publish\Core\Helper\ContentPreviewHelper')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->authorizationChecker = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
-        $this->locationProvider = $this
-            ->getMockBuilder('eZ\Publish\Core\Helper\PreviewLocationProvider')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->controllerChecker = $this->getMock('eZ\Publish\Core\MVC\Symfony\View\CustomLocationControllerChecker');
+        $this->contentService = $this->createMock(ContentService::class);
+        $this->httpKernel = $this->createMock(HttpKernelInterface::class);
+        $this->previewHelper = $this->createMock(ContentPreviewHelper::class);
+        $this->authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
+        $this->locationProvider = $this->createMock(PreviewLocationProvider::class);
+        $this->controllerChecker = $this->createMock(CustomLocationControllerChecker::class);
     }
 
     /**
@@ -109,8 +108,8 @@ class PreviewControllerTest extends TestCase
         $contentId = 123;
         $lang = 'eng-GB';
         $versionNo = 3;
-        $content = $this->getMock('eZ\Publish\API\Repository\Values\Content\Content');
-        $contentInfo = $this->getMockBuilder('eZ\Publish\API\Repository\Values\Content\ContentInfo')
+        $content = $this->createMock(Content::class);
+        $contentInfo = $this->getMockBuilder(ContentInfo::class)
             ->setConstructorArgs(array(array('id' => $contentId)))
             ->getMockForAbstractClass();
 
@@ -118,7 +117,7 @@ class PreviewControllerTest extends TestCase
             ->expects($this->once())
             ->method('loadMainLocation')
             ->with($contentId)
-            ->will($this->returnValue($this->getMock('eZ\Publish\API\Repository\Values\Content\Location')));
+            ->will($this->returnValue($this->createMock(Location::class)));
         $this->contentService
             ->expects($this->once())
             ->method('loadContent')
@@ -139,8 +138,8 @@ class PreviewControllerTest extends TestCase
         $lang = 'eng-GB';
         $versionNo = 3;
         $locationId = 456;
-        $content = $this->getMock('eZ\Publish\API\Repository\Values\Content\Content');
-        $location = $this->getMockBuilder('eZ\Publish\API\Repository\Values\Content\Location')
+        $content = $this->createMock(Content::class);
+        $location = $this->getMockBuilder(Location::class)
             ->setConstructorArgs(array(array('id' => $locationId)))
             ->getMockForAbstractClass();
 
@@ -165,7 +164,9 @@ class PreviewControllerTest extends TestCase
         $previewSiteAccess = new SiteAccess($previewSiteAccessName, 'preview');
         $previousSiteAccessName = 'foo';
         $previousSiteAccess = new SiteAccess($previousSiteAccessName);
-        $request = $this->getMock('Symfony\Component\HttpFoundation\Request', array('duplicate'));
+        $request = $this->getMockBuilder(Request::class)
+            ->setMethods(array('duplicate'))
+            ->getMock();
 
         // PreviewHelper expectations
         $this->previewHelper
@@ -228,8 +229,8 @@ class PreviewControllerTest extends TestCase
         $lang = 'eng-GB';
         $versionNo = 3;
         $locationId = 456;
-        $content = $this->getMock('eZ\Publish\API\Repository\Values\Content\Content');
-        $location = $this->getMockBuilder('eZ\Publish\API\Repository\Values\Content\Location')
+        $content = $this->createMock(Content::class);
+        $location = $this->getMockBuilder(Location::class)
             ->setConstructorArgs(array(array('id' => $locationId)))
             ->getMockForAbstractClass();
 
@@ -252,7 +253,9 @@ class PreviewControllerTest extends TestCase
 
         $previousSiteAccessName = 'foo';
         $previousSiteAccess = new SiteAccess($previousSiteAccessName);
-        $request = $this->getMock('Symfony\Component\HttpFoundation\Request', array('duplicate'));
+        $request = $this->getMockBuilder(Request::class)
+            ->setMethods(array('duplicate'))
+            ->getMock();
 
         $this->previewHelper
             ->expects($this->once())

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Tests/ControllerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Tests/ControllerTest.php
@@ -8,7 +8,10 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Controller\Tests;
 
+use eZ\Publish\Core\MVC\Symfony\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Templating\EngineInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -33,9 +36,9 @@ class ControllerTest extends TestCase
 
     protected function setUp()
     {
-        $this->templateEngineMock = $this->getMock('Symfony\\Component\\Templating\\EngineInterface');
-        $this->containerMock = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
-        $this->controller = $this->getMockForAbstractClass('eZ\\Publish\\Core\\MVC\\Symfony\\Controller\\Controller');
+        $this->templateEngineMock = $this->createMock(EngineInterface::class);
+        $this->containerMock = $this->createMock(ContainerInterface::class);
+        $this->controller = $this->getMockForAbstractClass(Controller::class);
         $this->controller->setContainer($this->containerMock);
         $this->containerMock
             ->expects($this->any())
@@ -58,7 +61,7 @@ class ControllerTest extends TestCase
             ->with($view, $params)
             ->will($this->returnValue($tplResult));
         $response = $this->controller->render($view, $params);
-        self::assertInstanceOf('Symfony\\Component\\HttpFoundation\\Response', $response);
+        self::assertInstanceOf(Response::class, $response);
         self::assertSame($tplResult, $response->getContent());
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/Event/Tests/InteractiveLoginEventTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/Tests/InteractiveLoginEventTest.php
@@ -9,16 +9,18 @@
 namespace eZ\Publish\Core\MVC\Symfony\Event\Tests;
 
 use eZ\Publish\Core\MVC\Symfony\Event\InteractiveLoginEvent;
+use eZ\Publish\API\Repository\Values\User\User;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class InteractiveLoginEventTest extends TestCase
 {
     public function testGetSetAPIUser()
     {
-        $event = new InteractiveLoginEvent(new Request(), $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface'));
+        $event = new InteractiveLoginEvent(new Request(), $this->createMock(TokenInterface::class));
         $this->assertFalse($event->hasAPIUser());
-        $apiUser = $this->getMock('eZ\Publish\API\Repository\Values\User\User');
+        $apiUser = $this->createMock(User::class);
         $event->setApiUser($apiUser);
         $this->assertTrue($event->hasAPIUser());
         $this->assertSame($apiUser, $event->getAPIUser());

--- a/eZ/Publish/Core/MVC/Symfony/Event/Tests/SignalEventTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/Tests/SignalEventTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Event\Tests;
 
 use eZ\Publish\Core\MVC\Symfony\Event\SignalEvent;
+use eZ\Publish\Core\SignalSlot\Signal;
 use PHPUnit\Framework\TestCase;
 
 class SignalEventTest extends TestCase
@@ -19,7 +20,7 @@ class SignalEventTest extends TestCase
      */
     public function testGetSignal()
     {
-        $signal = $this->getMock('eZ\\Publish\\Core\\SignalSlot\\Signal');
+        $signal = $this->createMock(Signal::class);
         $event = new SignalEvent($signal);
         $this->assertSame($signal, $event->getSignal());
     }

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/LanguageSwitchListenerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/LanguageSwitchListenerTest.php
@@ -12,6 +12,7 @@ use eZ\Publish\Core\MVC\Symfony\Event\RouteReferenceGenerationEvent;
 use eZ\Publish\Core\MVC\Symfony\EventListener\LanguageSwitchListener;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\Routing\RouteReference;
+use eZ\Publish\Core\Helper\TranslationHelper;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -25,7 +26,7 @@ class LanguageSwitchListenerTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->translationHelper = $this->getMockBuilder('eZ\Publish\Core\Helper\TranslationHelper')
+        $this->translationHelper = $this->getMockBuilder(TranslationHelper::class)
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/SiteAccessMatchListenerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/SiteAccessMatchListenerTest.php
@@ -13,10 +13,13 @@ use eZ\Publish\Core\MVC\Symfony\EventListener\SiteAccessMatchListener;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 class SiteAccessMatchListenerTest extends TestCase
@@ -44,11 +47,9 @@ class SiteAccessMatchListenerTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->saRouter = $this->getMockBuilder('\eZ\Publish\Core\MVC\Symfony\SiteAccess\Router')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->eventDispatcher = $this->getMock('\Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $this->userHashMatcher = $this->getMock('\Symfony\Component\HttpFoundation\RequestMatcherInterface');
+        $this->saRouter = $this->createMock(Router::class);
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->userHashMatcher = $this->createMock(RequestMatcherInterface::class);
         $this->listener = new SiteAccessMatchListener($this->saRouter, $this->eventDispatcher, $this->userHashMatcher);
     }
 
@@ -64,7 +65,7 @@ class SiteAccessMatchListenerTest extends TestCase
     {
         $request = new Request();
         $event = new GetResponseEvent(
-            $this->getMock('\Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock(HttpKernelInterface::class),
             $request,
             HttpKernelInterface::MASTER_REQUEST
         );
@@ -92,7 +93,7 @@ class SiteAccessMatchListenerTest extends TestCase
         $request = new Request();
         $request->attributes->set('serialized_siteaccess', serialize($siteAccess));
         $event = new GetResponseEvent(
-            $this->getMock('\Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock(HttpKernelInterface::class),
             $request,
             HttpKernelInterface::MASTER_REQUEST
         );
@@ -124,7 +125,7 @@ class SiteAccessMatchListenerTest extends TestCase
         $request = new Request();
         $request->attributes->set('siteaccess', $siteAccess);
         $event = new GetResponseEvent(
-            $this->getMock('\Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock(HttpKernelInterface::class),
             $request,
             HttpKernelInterface::MASTER_REQUEST
         );
@@ -158,7 +159,7 @@ class SiteAccessMatchListenerTest extends TestCase
         $path = '/foo/bar';
         $request = Request::create(sprintf('%s://%s:%d%s', $scheme, $host, $port, $path));
         $event = new GetResponseEvent(
-            $this->getMock('\Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock(HttpKernelInterface::class),
             $request,
             HttpKernelInterface::MASTER_REQUEST
         );
@@ -207,7 +208,7 @@ class SiteAccessMatchListenerTest extends TestCase
         $request = Request::create('http://localhost/_fos_user_hash');
         $request->attributes->set('_ez_original_request', $originalRequest);
         $event = new GetResponseEvent(
-            $this->getMock('\Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $this->createMock(HttpKernelInterface::class),
             $request,
             HttpKernelInterface::MASTER_REQUEST
         );

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/Page/ParameterProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/Page/ParameterProviderTest.php
@@ -8,7 +8,9 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\FieldType\Tests\Page;
 
+use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\Core\MVC\Symfony\FieldType\Page\ParameterProvider;
+use eZ\Publish\Core\FieldType\Page\PageService;
 use PHPUnit\Framework\TestCase;
 
 class ParameterProviderTest extends TestCase
@@ -18,11 +20,8 @@ class ParameterProviderTest extends TestCase
      */
     public function testGetViewParameters()
     {
-        $pageService = $this
-            ->getMockBuilder('eZ\\Publish\\Core\\FieldType\\Page\\PageService')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $field = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Field');
+        $pageService = $this->createMock(PageService::class);
+        $field = $this->createMock(Field::class);
         $parameterProvider = new ParameterProvider($pageService);
         $this->assertSame(
             array('pageService' => $pageService),

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/RichText/RendererTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/RichText/RendererTest.php
@@ -8,12 +8,18 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\FieldType\Tests\RichText;
 
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\MVC\Symfony\FieldType\RichText\Renderer;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Exception;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Templating\EngineInterface;
 
 class RendererTest extends TestCase
 {
@@ -769,7 +775,7 @@ class RendererTest extends TestCase
         $isInline = true;
         $isDenied = false;
         $result = 'result';
-        $mockLocation = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Location');
+        $mockLocation = $this->createMock(Location::class);
 
         $mockLocation
             ->expects($this->once())
@@ -820,7 +826,7 @@ class RendererTest extends TestCase
         $parameters = array('parameters');
         $isInline = true;
         $isDenied = false;
-        $mockLocation = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Location');
+        $mockLocation = $this->createMock(Location::class);
 
         $mockLocation
             ->expects($this->once())
@@ -868,7 +874,7 @@ class RendererTest extends TestCase
         $parameters = array('parameters');
         $isInline = true;
         $isDenied = false;
-        $mockLocation = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Location');
+        $mockLocation = $this->createMock(Location::class);
 
         $mockLocation
             ->expects($this->once())
@@ -962,7 +968,7 @@ class RendererTest extends TestCase
         $viewType = 'embedTest';
         $parameters = array('parameters');
         $isInline = true;
-        $mockLocation = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Location');
+        $mockLocation = $this->createMock(Location::class);
 
         $mockLocation
             ->expects($this->once())
@@ -1202,7 +1208,7 @@ class RendererTest extends TestCase
         $locationId = 42;
         $viewType = 'embedTest';
         $parameters = array('parameters');
-        $mockLocation = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Location');
+        $mockLocation = $this->createMock(Location::class);
 
         if (isset($deniedException)) {
             $renderer
@@ -1297,19 +1303,20 @@ class RendererTest extends TestCase
      */
     protected function getMockedRenderer(array $methods = array())
     {
-        return $this->getMock(
-            'eZ\\Publish\\Core\\MVC\\Symfony\\FieldType\\RichText\\Renderer',
-            $methods,
-            array(
-                $this->repositoryMock,
-                $this->authorizationCheckerMock,
-                $this->configResolverMock,
-                $this->templateEngineMock,
-                'test.name.space.tag',
-                'test.name.space.embed',
-                $this->loggerMock,
+        return $this->getMockBuilder(Renderer::class)
+            ->setConstructorArgs(
+                array(
+                    $this->repositoryMock,
+                    $this->authorizationCheckerMock,
+                    $this->configResolverMock,
+                    $this->templateEngineMock,
+                    'test.name.space.tag',
+                    'test.name.space.embed',
+                    $this->loggerMock,
+                )
             )
-        );
+            ->setMethods($methods)
+            ->getMock();
     }
 
     /**
@@ -1322,9 +1329,7 @@ class RendererTest extends TestCase
      */
     protected function getRepositoryMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\API\\Repository\\Repository'
-        );
+        return $this->createMock(Repository::class);
     }
 
     /**
@@ -1337,9 +1342,7 @@ class RendererTest extends TestCase
      */
     protected function getAuthorizationCheckerMock()
     {
-        return $this->getMock(
-            'Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface'
-        );
+        return $this->createMock(AuthorizationCheckerInterface::class);
     }
 
     /**
@@ -1352,9 +1355,7 @@ class RendererTest extends TestCase
      */
     protected function getConfigResolverMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\Core\\MVC\\ConfigResolverInterface'
-        );
+        return $this->createMock(ConfigResolverInterface::class);
     }
 
     /**
@@ -1367,9 +1368,7 @@ class RendererTest extends TestCase
      */
     protected function getTemplateEngineMock()
     {
-        return $this->getMock(
-            'Symfony\\Component\\Templating\\EngineInterface'
-        );
+        return $this->createMock(EngineInterface::class);
     }
 
     /**
@@ -1382,8 +1381,6 @@ class RendererTest extends TestCase
      */
     protected function getLoggerMock()
     {
-        return $this->getMock(
-            'Psr\\Log\\LoggerInterface'
-        );
+        return $this->createMock(LoggerInterface::class);
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/View/ParameterProvider/LocaleParameterProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/View/ParameterProvider/LocaleParameterProviderTest.php
@@ -10,8 +10,11 @@ namespace eZ\Publish\Core\MVC\Symfony\FieldType\Tests\View\ParameterProvider;
 
 use eZ\Publish\Core\MVC\Symfony\FieldType\View\ParameterProvider\LocaleParameterProvider;
 use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\MVC\Symfony\Locale\LocaleConverterInterface;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpFoundation\ParameterBag;
 
 class LocaleParameterProviderTest extends TestCase
 {
@@ -40,7 +43,7 @@ class LocaleParameterProviderTest extends TestCase
     protected function getRequestStackMock($hasLocale)
     {
         $requestStack = new RequestStack();
-        $parameterBagMock = $this->getMock('Symfony\\Component\\HttpFoundation\\ParameterBag');
+        $parameterBagMock = $this->createMock(ParameterBag::class);
 
         $parameterBagMock->expects($this->any())
             ->method('has')
@@ -52,13 +55,8 @@ class LocaleParameterProviderTest extends TestCase
             ->with($this->equalTo('_locale'))
             ->will($this->returnValue('fr_FR'));
 
-        $requestMock = $this->getMock('Symfony\\Component\\HttpFoundation\\Request');
+        $requestMock = $this->createMock(Request::class);
         $requestMock->attributes = $parameterBagMock;
-
-        $requestMock->expects($this->any())
-            ->method('__get')
-            ->with($this->equalTo('attributes'))
-            ->will($this->returnValue($parameterBagMock));
 
         $requestStack->push($requestMock);
 
@@ -67,7 +65,7 @@ class LocaleParameterProviderTest extends TestCase
 
     protected function getLocaleConverterMock()
     {
-        $mock = $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\Locale\\LocaleConverterInterface');
+        $mock = $this->createMock(LocaleConverterInterface::class);
 
         $mock->expects($this->any())
             ->method('convertToPOSIX')

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/View/ParameterProviderRegistryTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/View/ParameterProviderRegistryTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\FieldType\Tests\View;
 
+use eZ\Publish\Core\MVC\Symfony\FieldType\View\ParameterProviderInterface;
 use eZ\Publish\Core\MVC\Symfony\FieldType\View\ParameterProviderRegistry;
 use PHPUnit\Framework\TestCase;
 
@@ -22,7 +23,7 @@ class ParameterProviderRegistryTest extends TestCase
         $registry = new ParameterProviderRegistry();
         $this->assertFalse($registry->hasParameterProvider('foo'));
         $registry->setParameterProvider(
-            $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\FieldType\\View\\ParameterProviderInterface'),
+            $this->createMock(ParameterProviderInterface::class),
             'foo'
         );
         $this->assertTrue($registry->hasParameterProvider('foo'));
@@ -45,7 +46,7 @@ class ParameterProviderRegistryTest extends TestCase
      */
     public function testGetParameterProvider()
     {
-        $provider = $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\FieldType\\View\\ParameterProviderInterface');
+        $provider = $this->createMock(ParameterProviderInterface::class);
         $registry = new ParameterProviderRegistry();
         $registry->setParameterProvider($provider, 'foo');
         $this->assertSame($provider, $registry->getParameterProvider('foo'));

--- a/eZ/Publish/Core/MVC/Symfony/Locale/Tests/LocaleConverterTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Locale/Tests/LocaleConverterTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Locale\Tests;
 
 use eZ\Publish\Core\MVC\Symfony\Locale\LocaleConverter;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class LocaleConverterTest extends TestCase
 {
@@ -37,7 +38,7 @@ class LocaleConverterTest extends TestCase
             'cro-HR' => 'hr_HR',
         );
 
-        $this->logger = $this->getMock('Psr\\Log\\LoggerInterface');
+        $this->logger = $this->createMock(LoggerInterface::class);
         $this->localeConverter = new LocaleConverter($this->conversionMap, $this->logger);
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/AbstractMatcherFactoryTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/AbstractMatcherFactoryTest.php
@@ -12,6 +12,7 @@ use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\Core\FieldType\Page\Parts\Block;
 use eZ\Publish\Core\MVC\Symfony\View\BlockView;
 use eZ\Publish\Core\MVC\Symfony\View\ContentView;
+use eZ\Publish\Core\Repository\Repository;
 use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
@@ -164,10 +165,8 @@ abstract class AbstractMatcherFactoryTest extends TestCase
      */
     protected function getRepositoryMock()
     {
-        return $this
-            ->getMockBuilder('eZ\\Publish\\Core\\Repository\\Repository')
-            ->disableOriginalConstructor()
-            ->getMock();
+        return $this->createMock(Repository::class);
+
     }
 
     /**

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/AbstractMatcherFactoryTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/AbstractMatcherFactoryTest.php
@@ -166,7 +166,6 @@ abstract class AbstractMatcherFactoryTest extends TestCase
     protected function getRepositoryMock()
     {
         return $this->createMock(Repository::class);
-
     }
 
     /**

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/Block/MultipleValuedTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/Block/MultipleValuedTest.php
@@ -9,6 +9,8 @@
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\Block;
 
 use PHPUnit\Framework\TestCase;
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\Core\MVC\Symfony\Matcher\Block\MultipleValued;
 
 class MultipleValuedTest extends TestCase
 {
@@ -54,13 +56,13 @@ class MultipleValuedTest extends TestCase
     public function testInjectRepository()
     {
         $matcher = $this->getMultipleValuedMatcherMock();
-        $repositoryMock = $this->getMock('eZ\\Publish\\API\\Repository\\Repository');
+        $repositoryMock = $this->createMock(Repository::class);
         $matcher->setRepository($repositoryMock);
         $this->assertSame($repositoryMock, $matcher->getRepository());
     }
 
     private function getMultipleValuedMatcherMock()
     {
-        return $this->getMockForAbstractClass('eZ\\Publish\\Core\\MVC\\Symfony\\Matcher\\Block\\MultipleValued');
+        return $this->getMockForAbstractClass(MultipleValued::class);
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/BlockMatcherFactoryTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/BlockMatcherFactoryTest.php
@@ -8,9 +8,12 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests;
 
+use eZ\Publish\Core\MVC\Symfony\Matcher\BlockMatcherFactory;
+use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id\Location;
+
 class BlockMatcherFactoryTest extends AbstractMatcherFactoryTest
 {
-    protected $matcherFactoryClass = 'eZ\\Publish\\Core\\MVC\\Symfony\\Matcher\\BlockMatcherFactory';
+    protected $matcherFactoryClass = BlockMatcherFactory::class;
 
     /**
      * Returns a valid ValueObject (supported by current MatcherFactory), that will match the test rules.
@@ -51,7 +54,7 @@ class BlockMatcherFactoryTest extends AbstractMatcherFactoryTest
                     'test' => array(
                         'template' => 'foo.html.twig',
                         'match' => array(
-                            '\\eZ\\Publish\\Core\\MVC\\Symfony\\Matcher\\ContentBased\\Id\\Location' => true,
+                            Location::class => true,
                         ),
                     ),
                 ),

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/BaseTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/BaseTest.php
@@ -8,6 +8,15 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased;
 
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\Core\Repository\Permission\PermissionResolver;
+use eZ\Publish\Core\Repository\Helper\RoleDomainMapper;
+use eZ\Publish\API\Repository\Values\User\UserReference;
+use eZ\Publish\SPI\Persistence\User\Handler as SPIUserHandler;
+use eZ\Publish\Core\Repository\Helper\LimitationService;
+use eZ\Publish\Core\MVC\Symfony\View\Provider\Location\Configured;
+use eZ\Publish\Core\Repository\Repository;
 use PHPUnit\Framework\TestCase;
 
 abstract class BaseTest extends TestCase
@@ -31,7 +40,7 @@ abstract class BaseTest extends TestCase
     protected function getPartiallyMockedViewProvider(array $matchingConfig = array())
     {
         return $this
-            ->getMockBuilder('eZ\\Publish\\Core\\MVC\\Symfony\\View\\Provider\\Location\\Configured')
+            ->getMockBuilder(Configured::class)
             ->setConstructorArgs(
                 array(
                     $this->repositoryMock,
@@ -47,7 +56,7 @@ abstract class BaseTest extends TestCase
      */
     protected function getRepositoryMock()
     {
-        $repositoryClass = 'eZ\\Publish\\Core\\Repository\\Repository';
+        $repositoryClass = Repository::class;
 
         return $this
             ->getMockBuilder($repositoryClass)
@@ -69,7 +78,7 @@ abstract class BaseTest extends TestCase
     protected function getLocationMock(array $properties = array())
     {
         return $this
-            ->getMockBuilder('eZ\\Publish\\API\\Repository\\Values\\Content\\Location')
+            ->getMockBuilder(Location::class)
             ->setConstructorArgs(array($properties))
             ->getMockForAbstractClass();
     }
@@ -82,7 +91,7 @@ abstract class BaseTest extends TestCase
     protected function getContentInfoMock(array $properties = array())
     {
         return $this->
-            getMockBuilder('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo')
+            getMockBuilder(ContentInfo::class)
             ->setConstructorArgs(array($properties))
             ->getMockForAbstractClass();
     }
@@ -90,23 +99,14 @@ abstract class BaseTest extends TestCase
     protected function getPermissionResolverMock()
     {
         return $this
-            ->getMockBuilder('\eZ\Publish\Core\Repository\Permission\PermissionResolver')
+            ->getMockBuilder(PermissionResolver::class)
             ->setMethods(null)
             ->setConstructorArgs(
                 [
-                    $this
-                        ->getMockBuilder('eZ\Publish\Core\Repository\Helper\RoleDomainMapper')
-                        ->disableOriginalConstructor()
-                        ->getMock(),
-                    $this
-                        ->getMockBuilder('eZ\Publish\Core\Repository\Helper\LimitationService')
-                        ->getMock(),
-                    $this
-                        ->getMockBuilder('eZ\Publish\SPI\Persistence\User\Handler')
-                        ->getMock(),
-                    $this
-                        ->getMockBuilder('eZ\Publish\API\Repository\Values\User\UserReference')
-                        ->getMock(),
+                    $this->createMock(RoleDomainMapper::class),
+                    $this->createMock(LimitationService::class),
+                    $this->createMock(SPIUserHandler::class),
+                    $this->createMock(UserReference::class),
                 ]
             )
             ->getMock();

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/DepthTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/DepthTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased;
 
+use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Depth as DepthMatcher;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Repository;
@@ -131,10 +132,7 @@ class DepthTest extends BaseTest
      */
     private function generateRepositoryMockForDepth($depth)
     {
-        $locationServiceMock = $this
-            ->getMockBuilder('eZ\\Publish\\API\\Repository\\LocationService')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $locationServiceMock = $this->createMock(LocationService::class);
         $locationServiceMock->expects($this->once())
             ->method('loadLocation')
             ->with(42)

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ContentTypeGroupTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ContentTypeGroupTest.php
@@ -8,6 +8,9 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher\Id;
 
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id\ContentTypeGroup as ContentTypeGroupIdMatcher;
 use eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\BaseTest;
 use eZ\Publish\API\Repository\Repository;
@@ -156,11 +159,8 @@ class ContentTypeGroupTest extends BaseTest
      */
     private function generateRepositoryMockForContentTypeGroupId($contentTypeGroupId)
     {
-        $contentTypeServiceMock = $this
-            ->getMockBuilder('eZ\\Publish\\API\\Repository\\ContentTypeService')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $contentTypeMock = $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType');
+        $contentTypeServiceMock = $this->createMock(ContentTypeService::class);
+        $contentTypeMock = $this->getMockForAbstractClass(ContentType::class);
         $contentTypeServiceMock->expects($this->once())
             ->method('loadContentType')
             ->with(42)
@@ -172,9 +172,9 @@ class ContentTypeGroupTest extends BaseTest
                     array(
                         // First a group that will never match, then the right group.
                         // This ensures to test even if the content type belongs to several groups at once.
-                        $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentTypeGroup'),
+                        $this->getMockForAbstractClass(ContentTypeGroup::class),
                         $this
-                            ->getMockBuilder('eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentTypeGroup')
+                            ->getMockBuilder(ContentTypeGroup::class)
                             ->setConstructorArgs(array(array('id' => $contentTypeGroupId)))
                             ->getMockForAbstractClass(),
                     )

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ParentContentTypeTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ParentContentTypeTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher\Id;
 
+use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id\ParentContentType as ParentContentTypeMatcher;
 use eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\BaseTest;
 use eZ\Publish\API\Repository\Repository;
@@ -42,10 +43,8 @@ class ParentContentTypeTest extends BaseTest
                 $this->returnValue($parentContentInfo)
             );
 
-        $locationServiceMock = $this
-            ->getMockBuilder('eZ\\Publish\\API\\Repository\\LocationService')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $locationServiceMock = $this->createMock(LocationService::class);
+
         $locationServiceMock->expects($this->atLeastOnce())
             ->method('loadLocation')
             ->will(

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ParentLocationTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ParentLocationTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher\Id;
 
+use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id\ParentLocation as ParentLocationIdMatcher;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\BaseTest;
@@ -122,10 +123,7 @@ class ParentLocationTest extends BaseTest
      */
     private function generateRepositoryMockForParentLocationId($parentLocationId)
     {
-        $locationServiceMock = $this
-            ->getMockBuilder('eZ\\Publish\\API\\Repository\\LocationService')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $locationServiceMock = $this->createMock(LocationService::class);
         $locationServiceMock->expects($this->once())
             ->method('loadLocation')
             ->with(42)

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Identifier/ContentTypeTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Identifier/ContentTypeTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher\Identifier;
 
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\BaseTest;
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Identifier\ContentType as ContentTypeIdentifierMatcher;
 use eZ\Publish\API\Repository\Repository;
@@ -159,15 +161,12 @@ class ContentTypeTest extends BaseTest
     private function generateRepositoryMockForContentTypeIdentifier($contentTypeIdentifier)
     {
         $contentTypeMock = $this
-            ->getMockBuilder('eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType')
+            ->getMockBuilder(ContentType::class)
             ->setConstructorArgs(
                 array(array('identifier' => $contentTypeIdentifier))
             )
             ->getMockForAbstractClass();
-        $contentTypeServiceMock = $this
-            ->getMockBuilder('eZ\\Publish\\API\\Repository\\ContentTypeService')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $contentTypeServiceMock = $this->createMock(ContentTypeService::class);
         $contentTypeServiceMock->expects($this->once())
             ->method('loadContentType')
             ->with(42)

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Identifier/ParentContentTypeTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Identifier/ParentContentTypeTest.php
@@ -8,6 +8,9 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher\Identifier;
 
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Identifier\ParentContentType as ParentContentTypeMatcher;
 use eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\BaseTest;
 use eZ\Publish\API\Repository\Repository;
@@ -42,10 +45,7 @@ class ParentContentTypeTest extends BaseTest
                 $this->returnValue($parentContentInfo)
             );
 
-        $locationServiceMock = $this
-            ->getMockBuilder('eZ\\Publish\\API\\Repository\\LocationService')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $locationServiceMock = $this->createMock(LocationService::class);
         $locationServiceMock->expects($this->atLeastOnce())
             ->method('loadLocation')
             ->will(
@@ -58,17 +58,14 @@ class ParentContentTypeTest extends BaseTest
                 $this->returnValue($this->getLocationMock())
             );
 
-        $contentTypeServiceMock = $this
-            ->getMockBuilder('eZ\\Publish\\API\\Repository\\ContentTypeService')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $contentTypeServiceMock = $this->createMock(ContentTypeService::class);
         $contentTypeServiceMock->expects($this->once())
             ->method('loadContentType')
             ->with(42)
             ->will(
                 $this->returnValue(
                     $this
-                        ->getMockBuilder('eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType')
+                        ->getMockBuilder(ContentType::class)
                         ->setConstructorArgs(
                             array(
                                 array('identifier' => $contentTypeIdentifier),

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Identifier/SectionTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Identifier/SectionTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher\Identifier;
 
+use eZ\Publish\API\Repository\SectionService;
+use eZ\Publish\API\Repository\Values\Content\Section;
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Identifier\Section as SectionIdentifierMatcher;
 use eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\BaseTest;
 use eZ\Publish\API\Repository\Repository;
@@ -34,16 +36,13 @@ class SectionTest extends BaseTest
      */
     private function generateRepositoryMockForSectionIdentifier($sectionIdentifier)
     {
-        $sectionServiceMock = $this
-            ->getMockBuilder('eZ\\Publish\\API\\Repository\\SectionService')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $sectionServiceMock = $this->createMock(SectionService::class);
         $sectionServiceMock->expects($this->once())
             ->method('loadSection')
             ->will(
                 $this->returnValue(
                     $this
-                        ->getMockBuilder('eZ\\Publish\\API\\Repository\\Values\\Content\\Section')
+                        ->getMockBuilder(Section::class)
                         ->setConstructorArgs(
                             array(
                                 array('identifier' => $sectionIdentifier),

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/MultipleValuedTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/MultipleValuedTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher;
 
 use eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\BaseTest;
+use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\MultipleValued;
 
 class MultipleValuedTest extends BaseTest
 {
@@ -60,6 +61,6 @@ class MultipleValuedTest extends BaseTest
 
     private function getMultipleValuedMatcherMock()
     {
-        return $this->getMockForAbstractClass('eZ\\Publish\\Core\\MVC\\Symfony\\Matcher\\ContentBased\\MultipleValued');
+        return $this->getMockForAbstractClass(MultipleValued::class);
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/UrlAliasTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/UrlAliasTest.php
@@ -8,6 +8,9 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Matcher;
 
+use eZ\Publish\API\Repository\URLAliasService;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\URLAlias;
 use eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\UrlAlias as UrlAliasMatcher;
 use eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\BaseTest;
 use eZ\Publish\API\Repository\Repository;
@@ -65,28 +68,25 @@ class UrlAliasTest extends BaseTest
         // First an url alias that will never match, then the right url alias.
         // This ensures to test even if the location has several url aliases.
         $urlAliasList = array(
-            $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\URLAlias'),
+            $this->createMock(URLAlias::class),
             $this
-                ->getMockBuilder('eZ\\Publish\\API\\Repository\\Values\\Content\\URLAlias')
+                ->getMockBuilder(URLAlias::class)
                 ->setConstructorArgs(array(array('path' => $path)))
                 ->getMockForAbstractClass(),
         );
 
-        $urlAliasServiceMock = $this
-            ->getMockBuilder('eZ\\Publish\\API\\Repository\\URLAliasService')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $urlAliasServiceMock = $this->createMock(URLAliasService::class);
         $urlAliasServiceMock->expects($this->at(0))
             ->method('listLocationAliases')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\API\\Repository\\Values\\Content\\Location'),
+                $this->isInstanceOf(Location::class),
                 true
             )
             ->will($this->returnValue(array()));
         $urlAliasServiceMock->expects($this->at(1))
             ->method('listLocationAliases')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\API\\Repository\\Values\\Content\\Location'),
+                $this->isInstanceOf(Location::class),
                 false
             )
             ->will($this->returnValue($urlAliasList));

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBasedMatcherFactoryTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBasedMatcherFactoryTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests;
 
+use eZ\Publish\Core\MVC\Symfony\Matcher\Block\Type;
+
 abstract class ContentBasedMatcherFactoryTest extends AbstractMatcherFactoryTest
 {
     /**
@@ -27,7 +29,7 @@ abstract class ContentBasedMatcherFactoryTest extends AbstractMatcherFactoryTest
                     'test' => array(
                         'template' => 'foo.html.twig',
                         'match' => array(
-                            '\\eZ\Publish\Core\MVC\Symfony\Matcher\Block\\Type' => true,
+                            Type::class => true,
                         ),
                     ),
                 ),

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentMatcherFactoryTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentMatcherFactoryTest.php
@@ -8,9 +8,11 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests;
 
+use eZ\Publish\Core\MVC\Symfony\Matcher\ContentMatcherFactory;
+
 class ContentMatcherFactoryTest extends ContentBasedMatcherFactoryTest
 {
-    protected $matcherFactoryClass = 'eZ\\Publish\\Core\\MVC\\Symfony\\Matcher\\ContentMatcherFactory';
+    protected $matcherFactoryClass = ContentMatcherFactory::class;
 
     /**
      * Returns a valid ValueObject (supported by current MatcherFactory), that will match the test rules.

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/LocationMatcherFactoryTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/LocationMatcherFactoryTest.php
@@ -8,9 +8,11 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests;
 
+use eZ\Publish\Core\MVC\Symfony\Matcher\LocationMatcherFactory;
+
 class LocationMatcherFactoryTest extends ContentBasedMatcherFactoryTest
 {
-    protected $matcherFactoryClass = 'eZ\\Publish\\Core\\MVC\\Symfony\\Matcher\\LocationMatcherFactory';
+    protected $matcherFactoryClass = LocationMatcherFactory::class;
 
     /**
      * Returns a valid ValueObject (supported by current MatcherFactory), that will match the test rules.

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/GeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/GeneratorTest.php
@@ -9,8 +9,12 @@
 namespace eZ\Publish\Core\MVC\Symfony\Routing\Tests;
 
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\URILexer;
 use eZ\Publish\Core\Repository\Values\Content\Location;
+use eZ\Publish\Core\MVC\Symfony\Routing\Generator;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RequestContext;
 
@@ -34,9 +38,9 @@ class GeneratorTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->siteAccessRouter = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface');
-        $this->logger = $this->getMock('Psr\\Log\\LoggerInterface');
-        $this->generator = $this->getMockForAbstractClass('eZ\Publish\Core\MVC\Symfony\Routing\Generator');
+        $this->siteAccessRouter = $this->createMock(SiteAccessRouterInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->generator = $this->getMockForAbstractClass(Generator::class);
         $this->generator->setSiteAccessRouter($this->siteAccessRouter);
         $this->generator->setLogger($this->logger);
     }
@@ -61,7 +65,7 @@ class GeneratorTest extends TestCase
      */
     public function testSimpleGenerate($urlResource, array $parameters, $referenceType)
     {
-        $matcher = $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\URILexer');
+        $matcher = $this->createMock(URILexer::class);
         $this->generator->setSiteAccess(new SiteAccess('test', 'fake', $matcher));
 
         $baseUrl = '/base/url';
@@ -94,7 +98,7 @@ class GeneratorTest extends TestCase
      */
     public function testGenerateWithSiteAccessNoReverseMatch($urlResource, array $parameters, $referenceType)
     {
-        $matcher = $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\URILexer');
+        $matcher = $this->createMock(URILexer::class);
         $this->generator->setSiteAccess(new SiteAccess('test', 'test', $matcher));
 
         $baseUrl = '/base/url';

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/RouteReferenceGeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/RouteReferenceGeneratorTest.php
@@ -16,6 +16,7 @@ use eZ\Publish\Core\Repository\Values\Content\Location;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class RouteReferenceGeneratorTest extends TestCase
 {
@@ -27,7 +28,7 @@ class RouteReferenceGeneratorTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $this->dispatcher = $this->createMock(EventDispatcherInterface::class);
     }
 
     public function testGenerateNullResource()
@@ -50,7 +51,7 @@ class RouteReferenceGeneratorTest extends TestCase
         $generator = new RouteReferenceGenerator($this->dispatcher);
         $generator->setRequestStack($requestStack);
         $reference = $generator->generate();
-        $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\Routing\RouteReference', $reference);
+        $this->assertInstanceOf(RouteReference::class, $reference);
         $this->assertSame($currentRouteName, $reference->getRoute());
         $this->assertSame($currentRouteParams, $reference->getParams());
     }
@@ -77,7 +78,7 @@ class RouteReferenceGeneratorTest extends TestCase
         $generator = new RouteReferenceGenerator($this->dispatcher);
         $generator->setRequestStack($requestStack);
         $reference = $generator->generate(null, $passedParams);
-        $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\Routing\RouteReference', $reference);
+        $this->assertInstanceOf(RouteReference::class, $reference);
         $this->assertSame($currentRouteName, $reference->getRoute());
         $this->assertSame($expectedParams, $reference->getParams());
     }
@@ -105,7 +106,7 @@ class RouteReferenceGeneratorTest extends TestCase
         $generator = new RouteReferenceGenerator($this->dispatcher);
         $generator->setRequestStack($requestStack);
         $reference = $generator->generate($resource, $params);
-        $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\Routing\RouteReference', $reference);
+        $this->assertInstanceOf(RouteReference::class, $reference);
         $this->assertSame($resource, $reference->getRoute());
         $this->assertSame($params, $reference->getParams());
     }
@@ -128,7 +129,7 @@ class RouteReferenceGeneratorTest extends TestCase
         $generator = new RouteReferenceGenerator($this->dispatcher);
         $generator->setRequestStack($requestStack);
         $reference = $generator->generate();
-        $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\Routing\RouteReference', $reference);
+        $this->assertInstanceOf(RouteReference::class, $reference);
     }
 
     public function generateGenerator()

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
@@ -8,12 +8,24 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Routing\Tests;
 
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\URLAliasService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\URLAlias;
+use eZ\Publish\API\Repository\Values\User\UserReference;
 use eZ\Publish\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator;
+use eZ\Publish\Core\Repository\Permission\PermissionResolver;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\Repository\Helper\LimitationService;
+use eZ\Publish\Core\Repository\Helper\RoleDomainMapper;
+use eZ\Publish\Core\Repository\Repository;
 use eZ\Publish\Core\Repository\Values\Content\Location;
+use eZ\Publish\SPI\Persistence\User\Handler as SPIUserHandler;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Routing\RouterInterface;
 
 class UrlAliasGeneratorTest extends TestCase
 {
@@ -60,11 +72,11 @@ class UrlAliasGeneratorTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->router = $this->getMock('Symfony\\Component\\Routing\\RouterInterface');
-        $this->logger = $this->getMock('Psr\\Log\\LoggerInterface');
-        $this->siteAccessRouter = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface');
-        $this->configResolver = $this->getMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
-        $repositoryClass = 'eZ\\Publish\\Core\\Repository\\Repository';
+        $this->router = $this->createMock(RouterInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->siteAccessRouter = $this->createMock(SiteAccessRouterInterface::class);
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
+        $repositoryClass = Repository::class;
         $this->repository = $repository = $this
             ->getMockBuilder($repositoryClass)
             ->disableOriginalConstructor()
@@ -75,8 +87,8 @@ class UrlAliasGeneratorTest extends TestCase
                 )
             )
             ->getMock();
-        $this->urlAliasService = $this->getMock('eZ\\Publish\\API\\Repository\\URLAliasService');
-        $this->locationService = $this->getMock('eZ\\Publish\\API\\Repository\\LocationService');
+        $this->urlAliasService = $this->createMock(URLAliasService::class);
+        $this->locationService = $this->createMock(LocationService::class);
         $this->repository
             ->expects($this->any())
             ->method('getURLAliasService')
@@ -181,7 +193,7 @@ class UrlAliasGeneratorTest extends TestCase
             ->with($location, false)
             ->will($this->returnValue(array($urlAlias)));
 
-        $this->urlAliasGenerator->setSiteAccess(new SiteAccess('test', 'fake', $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\URILexer')));
+        $this->urlAliasGenerator->setSiteAccess(new SiteAccess('test', 'fake', $this->createMock(SiteAccess\URILexer::class)));
 
         $this->assertSame($expected, $this->urlAliasGenerator->doGenerate($location, $parameters));
     }
@@ -272,7 +284,7 @@ class UrlAliasGeneratorTest extends TestCase
                 )
             );
 
-        $this->urlAliasGenerator->setSiteAccess(new SiteAccess('test', 'fake', $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\URILexer')));
+        $this->urlAliasGenerator->setSiteAccess(new SiteAccess('test', 'fake', $this->createMock(SiteAccess\URILexer::class)));
 
         $this->assertSame($expected, $this->urlAliasGenerator->doGenerate($location, $parameters));
     }
@@ -421,23 +433,14 @@ class UrlAliasGeneratorTest extends TestCase
     protected function getPermissionResolverMock()
     {
         return $this
-            ->getMockBuilder('\eZ\Publish\Core\Repository\Permission\PermissionResolver')
+            ->getMockBuilder(PermissionResolver::class)
             ->setMethods(null)
             ->setConstructorArgs(
                 [
-                    $this
-                        ->getMockBuilder('eZ\Publish\Core\Repository\Helper\RoleDomainMapper')
-                        ->disableOriginalConstructor()
-                        ->getMock(),
-                    $this
-                        ->getMockBuilder('eZ\Publish\Core\Repository\Helper\LimitationService')
-                        ->getMock(),
-                    $this
-                        ->getMockBuilder('eZ\Publish\SPI\Persistence\User\Handler')
-                        ->getMock(),
-                    $this
-                        ->getMockBuilder('eZ\Publish\API\Repository\Values\User\UserReference')
-                        ->getMock(),
+                    $this->createMock(RoleDomainMapper::class),
+                    $this->createMock(LimitationService::class),
+                    $this->createMock(SPIUserHandler::class),
+                    $this->createMock(UserReference::class),
                 ]
             )
             ->getMock();

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasRouterTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasRouterTest.php
@@ -14,15 +14,20 @@ use eZ\Publish\API\Repository\URLAliasService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\URLAlias;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator;
 use eZ\Publish\Core\MVC\Symfony\Routing\UrlAliasRouter;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher;
 use eZ\Publish\Core\MVC\Symfony\View\Manager as ViewManager;
+use eZ\Publish\Core\Repository\Repository;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\RouterInterface;
 
 class UrlAliasRouterTest extends TestCase
 {
@@ -61,7 +66,7 @@ class UrlAliasRouterTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $repositoryClass = 'eZ\\Publish\\Core\\Repository\\Repository';
+        $repositoryClass = Repository::class;
         $this->repository = $repository = $this
             ->getMockBuilder($repositoryClass)
             ->disableOriginalConstructor()
@@ -72,16 +77,16 @@ class UrlAliasRouterTest extends TestCase
                 )
             )
             ->getMock();
-        $this->urlAliasService = $this->getMock('eZ\\Publish\\API\\Repository\\URLAliasService');
-        $this->locationService = $this->getMock('eZ\\Publish\\API\\Repository\\LocationService');
-        $this->contentService = $this->getMock('eZ\\Publish\\API\\Repository\\ContentService');
+        $this->urlAliasService = $this->createMock(URLAliasService::class);
+        $this->locationService = $this->createMock(LocationService::class);
+        $this->contentService = $this->createMock(ContentService::class);
         $this->urlALiasGenerator = $this
-            ->getMockBuilder('eZ\\Publish\\Core\\MVC\\Symfony\\Routing\\Generator\\UrlAliasGenerator')
+            ->getMockBuilder(UrlAliasGenerator::class)
             ->setConstructorArgs(
                 array(
                     $repository,
-                    $this->getMock('Symfony\\Component\\Routing\\RouterInterface'),
-                    $this->getMock('eZ\Publish\Core\MVC\ConfigResolverInterface'),
+                    $this->createMock(RouterInterface::class),
+                    $this->createMock(ConfigResolverInterface::class),
                 )
             )
             ->getMock();
@@ -144,7 +149,7 @@ class UrlAliasRouterTest extends TestCase
 
     public function testGetRouteCollection()
     {
-        $this->assertInstanceOf('Symfony\\Component\\Routing\\RouteCollection', $this->router->getRouteCollection());
+        $this->assertInstanceOf(RouteCollection::class, $this->router->getRouteCollection());
     }
 
     /**
@@ -161,7 +166,7 @@ class UrlAliasRouterTest extends TestCase
             new SiteAccess(
                 'test',
                 'fake',
-                $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\Matcher')
+                $this->createMock(Matcher::class)
             )
         );
 

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/AnonymousAuthenticationProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/AnonymousAuthenticationProviderTest.php
@@ -8,9 +8,13 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\Authentication;
 
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\Security\Authentication\AnonymousAuthenticationProvider;
 use eZ\Publish\Core\Repository\Values\User\UserReference;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 class AnonymousAuthenticationProviderTest extends TestCase
 {
@@ -27,8 +31,8 @@ class AnonymousAuthenticationProviderTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->repository = $this->getMock('eZ\Publish\API\Repository\Repository');
-        $this->configResolver = $this->getMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
+        $this->repository = $this->createMock(Repository::class);
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
     }
 
     public function testAuthenticate()
@@ -50,8 +54,8 @@ class AnonymousAuthenticationProviderTest extends TestCase
         $authProvider->setRepository($this->repository);
         $authProvider->setConfigResolver($this->configResolver);
         $anonymousToken = $this
-            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken')
-            ->setConstructorArgs(array($key, $this->getMock('Symfony\Component\Security\Core\User\UserInterface')))
+            ->getMockBuilder(AnonymousToken::class)
+            ->setConstructorArgs(array($key, $this->createMock(UserInterface::class)))
             ->getMockForAbstractClass();
         $this->assertSame($anonymousToken, $authProvider->authenticate($anonymousToken));
     }

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\Authentication;
 
 use eZ\Publish\Core\MVC\Symfony\Security\Authentication\DefaultAuthenticationSuccessHandler;
 use eZ\Publish\Core\MVC\Symfony\Security\HttpUtils;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
 
@@ -25,7 +26,7 @@ class DefaultAuthenticationSuccessHandlerTest extends TestCase
         $this->assertSame('/', $options['default_target_path']);
 
         $defaultPage = '/foo/bar';
-        $configResolver = $this->getMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
+        $configResolver = $this->createMock(ConfigResolverInterface::class);
         $configResolver
             ->expects($this->once())
             ->method('getParameter')

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RepositoryAuthenticationProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RepositoryAuthenticationProviderTest.php
@@ -8,10 +8,17 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\Authentication;
 
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\API\Repository\Values\User\User as APIUser;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\MVC\Symfony\Security\Authentication\RepositoryAuthenticationProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use eZ\Publish\Core\MVC\Symfony\Security\User;
 
 class RepositoryAuthenticationProviderTest extends TestCase
@@ -34,11 +41,11 @@ class RepositoryAuthenticationProviderTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->encoderFactory = $this->getMock('Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface');
-        $repository = $this->repository = $this->getMock('eZ\Publish\API\Repository\Repository');
+        $this->encoderFactory = $this->createMock(EncoderFactoryInterface::class);
+        $repository = $this->repository = $this->createMock(Repository::class);
         $this->authProvider = new RepositoryAuthenticationProvider(
-            $this->getMock('Symfony\Component\Security\Core\User\UserProviderInterface'),
-            $this->getMock('Symfony\Component\Security\Core\User\UserCheckerInterface'),
+            $this->createMock(UserProviderInterface::class),
+            $this->createMock(UserCheckerInterface::class),
             'foo',
             $this->encoderFactory
         );
@@ -48,13 +55,13 @@ class RepositoryAuthenticationProviderTest extends TestCase
     public function testAuthenticationNotEzUser()
     {
         $password = 'some_encoded_password';
-        $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $user = $this->createMock(UserInterface::class);
         $user
             ->expects($this->any())
             ->method('getPassword')
             ->will($this->returnValue($password));
 
-        $tokenUser = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $tokenUser = $this->createMock(UserInterface::class);
         $tokenUser
             ->expects($this->any())
             ->method('getPassword')
@@ -71,7 +78,7 @@ class RepositoryAuthenticationProviderTest extends TestCase
      */
     public function testCheckAuthenticationCredentialsChanged()
     {
-        $apiUser = $this->getMockBuilder('eZ\Publish\API\Repository\Values\User\User')
+        $apiUser = $this->getMockBuilder(APIUser::class)
             ->setConstructorArgs([['passwordHash' => 'some_encoded_password']])
             ->setMethods(['getUserId'])
             ->getMockForAbstractClass();
@@ -82,11 +89,11 @@ class RepositoryAuthenticationProviderTest extends TestCase
         $tokenUser = new User($apiUser);
         $token = new UsernamePasswordToken($tokenUser, 'foo', 'bar');
 
-        $renewedApiUser = $this->getMockBuilder('eZ\Publish\API\Repository\Values\User\User')
+        $renewedApiUser = $this->getMockBuilder(APIUser::class)
             ->setConstructorArgs(array(array('passwordHash' => 'renewed_encoded_password')))
             ->getMockForAbstractClass();
 
-        $user = $this->getMock('eZ\Publish\Core\MVC\Symfony\Security\User');
+        $user = $this->createMock(User::class);
         $user
             ->expects($this->any())
             ->method('getAPIUser')
@@ -101,14 +108,14 @@ class RepositoryAuthenticationProviderTest extends TestCase
     {
         $password = 'encoded_password';
 
-        $apiUser = $this->getMockBuilder('eZ\Publish\API\Repository\Values\User\User')
+        $apiUser = $this->getMockBuilder(APIUser::class)
             ->setConstructorArgs(array(array('passwordHash' => $password)))
             ->setMethods(['getUserId'])
             ->getMockForAbstractClass();
         $tokenUser = new User($apiUser);
         $token = new UsernamePasswordToken($tokenUser, 'foo', 'bar');
 
-        $user = $this->getMock('eZ\Publish\Core\MVC\Symfony\Security\User');
+        $user = $this->createMock(User::class);
         $user
             ->expects($this->once())
             ->method('getAPIUser')
@@ -129,12 +136,12 @@ class RepositoryAuthenticationProviderTest extends TestCase
      */
     public function testCheckAuthenticationFailed()
     {
-        $user = $this->getMock('eZ\Publish\Core\MVC\Symfony\Security\User');
+        $user = $this->createMock(User::class);
         $userName = 'my_username';
         $password = 'foo';
         $token = new UsernamePasswordToken($userName, $password, 'bar');
 
-        $userService = $this->getMock('eZ\Publish\API\Repository\UserService');
+        $userService = $this->createMock(UserService::class);
         $userService
             ->expects($this->once())
             ->method('loadUserByCredentials')
@@ -152,13 +159,13 @@ class RepositoryAuthenticationProviderTest extends TestCase
 
     public function testCheckAuthentication()
     {
-        $user = $this->getMock('eZ\Publish\Core\MVC\Symfony\Security\User');
+        $user = $this->createMock(User::class);
         $userName = 'my_username';
         $password = 'foo';
         $token = new UsernamePasswordToken($userName, $password, 'bar');
 
-        $apiUser = $this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\User\User');
-        $userService = $this->getMock('eZ\Publish\API\Repository\UserService');
+        $apiUser = $this->getMockForAbstractClass(APIUser::class);
+        $userService = $this->createMock(UserService::class);
         $userService
             ->expects($this->once())
             ->method('loadUserByCredentials')

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/HttpUtilsTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/HttpUtilsTest.php
@@ -21,7 +21,7 @@ class HttpUtilsTest extends TestCase
      */
     public function testGenerateUriStandard($uri, $isUriRouteName, $expected)
     {
-        $urlGenerator = $this->getMock('Symfony\Component\Routing\Generator\UrlGeneratorInterface');
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $httpUtils = new HttpUtils($urlGenerator);
         $httpUtils->setSiteAccess(new SiteAccess());
         $request = Request::create('http://ezpublish.dev/');
@@ -58,7 +58,7 @@ class HttpUtilsTest extends TestCase
     {
         $siteAccess = new SiteAccess('test', 'test');
         if ($uri[0] === '/') {
-            $matcher = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\URILexer');
+            $matcher = $this->createMock(SiteAccess\URILexer::class);
             $matcher
                 ->expects($this->once())
                 ->method('analyseLink')
@@ -67,7 +67,7 @@ class HttpUtilsTest extends TestCase
             $siteAccess->matcher = $matcher;
         }
 
-        $urlGenerator = $this->getMock('Symfony\Component\Routing\Generator\UrlGeneratorInterface');
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
         $httpUtils = new HttpUtils($urlGenerator);
         $httpUtils->setSiteAccess($siteAccess);
         $request = Request::create('http://ezpublish.dev/');
@@ -113,7 +113,7 @@ class HttpUtilsTest extends TestCase
     {
         $siteAccess = new SiteAccess('test', 'test');
         if ($siteAccessUri !== null) {
-            $matcher = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\URILexer');
+            $matcher = $this->createMock(SiteAccess\URILexer::class);
             $matcher
                 ->expects($this->once())
                 ->method('analyseLink')

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/InteractiveLoginTokenTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/InteractiveLoginTokenTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests;
 
 use eZ\Publish\Core\MVC\Symfony\Security\InteractiveLoginToken;
+use eZ\Publish\Core\MVC\Symfony\Security\UserInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Role\Role;
 
@@ -16,7 +17,7 @@ class InteractiveLoginTokenTest extends TestCase
 {
     public function testConstruct()
     {
-        $user = $this->getMock('eZ\Publish\Core\MVC\Symfony\Security\UserInterface');
+        $user = $this->createMock(UserInterface::class);
         $originalTokenType = 'FooBar';
         $credentials = 'my_credentials';
         $providerKey = 'key';
@@ -41,7 +42,7 @@ class InteractiveLoginTokenTest extends TestCase
 
     public function testSerialize()
     {
-        $user = $this->getMock('eZ\Publish\Core\MVC\Symfony\Security\UserInterface');
+        $user = $this->createMock(UserInterface::class);
         $originalTokenType = 'FooBar';
         $credentials = 'my_credentials';
         $providerKey = 'key';

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/User/HashGeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/User/HashGeneratorTest.php
@@ -9,6 +9,8 @@
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\User;
 
 use eZ\Publish\Core\MVC\Symfony\Security\User\HashGenerator;
+use eZ\Publish\SPI\User\Identity;
+use eZ\Publish\SPI\User\IdentityAware;
 use PHPUnit\Framework\TestCase;
 
 class HashGeneratorTest extends TestCase
@@ -21,11 +23,11 @@ class HashGeneratorTest extends TestCase
     {
         $hashGenerator = new HashGenerator();
         $identityDefiners = array(
-            $this->getMock('eZ\\Publish\\SPI\\User\\IdentityAware'),
-            $this->getMock('eZ\\Publish\\SPI\\User\\IdentityAware'),
-            $this->getMock('eZ\\Publish\\SPI\\User\\IdentityAware'),
-            $this->getMock('eZ\\Publish\\SPI\\User\\IdentityAware'),
-            $this->getMock('eZ\\Publish\\SPI\\User\\IdentityAware'),
+            $this->createMock(IdentityAware::class),
+            $this->createMock(IdentityAware::class),
+            $this->createMock(IdentityAware::class),
+            $this->createMock(IdentityAware::class),
+            $this->createMock(IdentityAware::class),
         );
 
         foreach ($identityDefiners as $definer) {
@@ -42,7 +44,7 @@ class HashGeneratorTest extends TestCase
     public function testSetIdentity()
     {
         $hashGenerator = new HashGenerator();
-        $identity = $this->getMock('eZ\\Publish\\SPI\\User\\Identity');
+        $identity = $this->createMock(Identity::class);
         $hashGenerator->setIdentity($identity);
         $this->assertSame($identity, $hashGenerator->getIdentity());
     }
@@ -57,14 +59,14 @@ class HashGeneratorTest extends TestCase
     public function testGenerate()
     {
         $hashGenerator = new HashGenerator();
-        $identity = $this->getMock('eZ\\Publish\\SPI\\User\\Identity');
+        $identity = $this->createMock(Identity::class);
         $hashGenerator->setIdentity($identity);
         $identityDefiners = array(
-            $this->getMock('eZ\\Publish\\SPI\\User\\IdentityAware'),
-            $this->getMock('eZ\\Publish\\SPI\\User\\IdentityAware'),
-            $this->getMock('eZ\\Publish\\SPI\\User\\IdentityAware'),
-            $this->getMock('eZ\\Publish\\SPI\\User\\IdentityAware'),
-            $this->getMock('eZ\\Publish\\SPI\\User\\IdentityAware'),
+            $this->createMock(IdentityAware::class),
+            $this->createMock(IdentityAware::class),
+            $this->createMock(IdentityAware::class),
+            $this->createMock(IdentityAware::class),
+            $this->createMock(IdentityAware::class),
         );
 
         /** @var $definer \PHPUnit_Framework_MockObject_MockObject */

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/User/Identifier/RoleContextProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/User/Identifier/RoleContextProviderTest.php
@@ -8,7 +8,18 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\User\Identifier;
 
+use eZ\Publish\API\Repository\RoleService;
+use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation;
+use eZ\Publish\API\Repository\Values\User\Role;
+use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\UserReference;
 use eZ\Publish\Core\MVC\Symfony\Security\User\ContextProvider\RoleContextProvider;
+use eZ\Publish\Core\Repository\Helper\LimitationService;
+use eZ\Publish\Core\Repository\Helper\RoleDomainMapper;
+use eZ\Publish\Core\Repository\Permission\PermissionResolver;
+use eZ\Publish\Core\Repository\Repository;
+use eZ\Publish\Core\Repository\Values\User\UserRoleAssignment;
+use eZ\Publish\SPI\Persistence\User\Handler as SPIUserHandler;
 use FOS\HttpCache\UserContext\UserContext;
 use PHPUnit\Framework\TestCase;
 
@@ -28,12 +39,12 @@ class RoleContextProviderTest extends TestCase
     {
         parent::setUp();
         $this->repositoryMock = $this
-            ->getMockBuilder('eZ\\Publish\\Core\\Repository\\Repository')
+            ->getMockBuilder(Repository::class)
             ->disableOriginalConstructor()
             ->setMethods(array('getRoleService', 'getCurrentUser', 'getPermissionResolver'))
             ->getMock();
 
-        $this->roleServiceMock = $this->getMock('eZ\\Publish\\API\\Repository\\RoleService');
+        $this->roleServiceMock = $this->createMock(RoleService::class);
 
         $this->repositoryMock
             ->expects($this->any())
@@ -47,7 +58,7 @@ class RoleContextProviderTest extends TestCase
 
     public function testSetIdentity()
     {
-        $user = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
+        $user = $this->createMock(APIUser::class);
         $userContext = new UserContext();
 
         $this->repositoryMock
@@ -127,7 +138,7 @@ class RoleContextProviderTest extends TestCase
     private function generateRoleAssignmentMock(array $properties = array())
     {
         return $this
-            ->getMockBuilder('eZ\\Publish\\Core\\Repository\\Values\\User\\UserRoleAssignment')
+            ->getMockBuilder(UserRoleAssignment::class)
             ->setConstructorArgs(array($properties))
             ->getMockForAbstractClass();
     }
@@ -135,7 +146,7 @@ class RoleContextProviderTest extends TestCase
     private function generateRoleMock(array $properties = array())
     {
         return $this
-            ->getMockBuilder('eZ\\Publish\\API\\Repository\\Values\\User\\Role')
+            ->getMockBuilder(Role::class)
             ->setConstructorArgs(array($properties))
             ->getMockForAbstractClass();
     }
@@ -143,7 +154,7 @@ class RoleContextProviderTest extends TestCase
     private function generateLimitationMock(array $properties = array())
     {
         $limitationMock = $this
-            ->getMockBuilder('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation')
+            ->getMockBuilder(RoleLimitation::class)
             ->setConstructorArgs(array($properties))
             ->getMockForAbstractClass();
         $limitationMock
@@ -157,23 +168,14 @@ class RoleContextProviderTest extends TestCase
     protected function getPermissionResolverMock()
     {
         return $this
-            ->getMockBuilder('\eZ\Publish\Core\Repository\Permission\PermissionResolver')
+            ->getMockBuilder(PermissionResolver::class)
             ->setMethods(null)
             ->setConstructorArgs(
                 [
-                    $this
-                        ->getMockBuilder('eZ\Publish\Core\Repository\Helper\RoleDomainMapper')
-                        ->disableOriginalConstructor()
-                        ->getMock(),
-                    $this
-                        ->getMockBuilder('eZ\Publish\Core\Repository\Helper\LimitationService')
-                        ->getMock(),
-                    $this
-                        ->getMockBuilder('eZ\Publish\SPI\Persistence\User\Handler')
-                        ->getMock(),
-                    $this
-                        ->getMockBuilder('eZ\Publish\API\Repository\Values\User\UserReference')
-                        ->getMock(),
+                    $this->createMock(RoleDomainMapper::class),
+                    $this->createMock(LimitationService::class),
+                    $this->createMock(SPIUserHandler::class),
+                    $this->createMock(UserReference::class),
                 ]
             )
             ->getMock();

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/User/ProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/User/ProviderTest.php
@@ -8,13 +8,19 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\User;
 
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\MVC\Symfony\Security\User\Provider;
+use eZ\Publish\Core\MVC\Symfony\Security\UserInterface;
 use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Repository\Values\User\User;
+use eZ\Publish\Core\MVC\Symfony\Security\User as MVCUser;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
 
 class ProviderTest extends TestCase
 {
@@ -36,8 +42,8 @@ class ProviderTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->userService = $this->getMock('eZ\Publish\API\Repository\UserService');
-        $this->repository = $this->getMock('eZ\Publish\API\Repository\Repository');
+        $this->userService = $this->createMock(UserService::class);
+        $this->repository = $this->createMock(Repository::class);
         $this->repository
             ->expects($this->any())
             ->method('getUserService')
@@ -47,7 +53,7 @@ class ProviderTest extends TestCase
 
     public function testLoadUserByUsernameAlreadyUserObject()
     {
-        $user = $this->getMock('eZ\Publish\Core\MVC\Symfony\Security\UserInterface');
+        $user = $this->createMock(UserInterface::class);
         $this->assertSame($user, $this->userProvider->loadUserByUsername($user));
     }
 
@@ -68,7 +74,7 @@ class ProviderTest extends TestCase
     public function testLoadUserByUsername()
     {
         $username = 'foobar';
-        $apiUser = $this->getMock('eZ\Publish\API\Repository\Values\User\User');
+        $apiUser = $this->createMock(APIUser::class);
         $this->userService
             ->expects($this->once())
             ->method('loadUserByLogin')
@@ -76,7 +82,7 @@ class ProviderTest extends TestCase
             ->will($this->returnValue($apiUser));
 
         $user = $this->userProvider->loadUserByUsername($username);
-        $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\Security\UserInterface', $user);
+        $this->assertInstanceOf(UserInterface::class, $user);
         $this->assertSame($apiUser, $user->getAPIUser());
         $this->assertSame(array('ROLE_USER'), $user->getRoles());
     }
@@ -86,7 +92,7 @@ class ProviderTest extends TestCase
      */
     public function testRefreshUserNotSupported()
     {
-        $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $user = $this->createMock(SymfonyUserInterface::class);
         $this->userProvider->refreshUser($user);
     }
 
@@ -105,7 +111,7 @@ class ProviderTest extends TestCase
             )
         );
         $refreshedAPIUser = clone $apiUser;
-        $user = $this->getMock('eZ\Publish\Core\MVC\Symfony\Security\UserInterface');
+        $user = $this->createMock(UserInterface::class);
         $user
             ->expects($this->once())
             ->method('getAPIUser')
@@ -146,7 +152,7 @@ class ProviderTest extends TestCase
                 ),
             )
         );
-        $user = $this->getMock('eZ\Publish\Core\MVC\Symfony\Security\UserInterface');
+        $user = $this->createMock(UserInterface::class);
         $user
             ->expects($this->once())
             ->method('getAPIUser')
@@ -172,17 +178,17 @@ class ProviderTest extends TestCase
     public function supportsClassProvider()
     {
         return array(
-            array('Symfony\Component\Security\Core\User\UserInterface', false),
-            array('eZ\Publish\Core\MVC\Symfony\Security\User', true),
-            array(get_class($this->getMock('eZ\Publish\Core\MVC\Symfony\Security\User')), true),
+            array(SymfonyUserInterface::class, false),
+            array(MVCUser::class, true),
+            array(get_class($this->createMock(MVCUser::class)), true),
         );
     }
 
     public function testLoadUserByAPIUser()
     {
-        $apiUser = $this->getMock('eZ\Publish\API\Repository\Values\User\User');
+        $apiUser = $this->createMock(APIUser::class);
         $user = $this->userProvider->loadUserByAPIUser($apiUser);
-        $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\Security\User', $user);
+        $this->assertInstanceOf(MVCUser::class, $user);
         $this->assertSame($apiUser, $user->getAPIUser());
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests;
 
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\User\User as APIUser;
 use eZ\Publish\Core\MVC\Symfony\Security\ReferenceUserInterface;
 use eZ\Publish\Core\Repository\Values\User\UserReference;
 use PHPUnit\Framework\TestCase;
@@ -20,7 +22,7 @@ class UserTest extends TestCase
         $login = 'my_username';
         $passwordHash = 'encoded_password';
         $apiUser = $this
-            ->getMockBuilder('eZ\Publish\API\Repository\Values\User\User')
+            ->getMockBuilder(APIUser::class)
             ->setConstructorArgs(
                 array(
                     array(
@@ -54,7 +56,7 @@ class UserTest extends TestCase
     public function testIsEqualTo()
     {
         $userId = 123;
-        $apiUser = $this->getMock('eZ\Publish\API\Repository\Values\User\User');
+        $apiUser = $this->createMock(APIUser::class);
         $apiUser
             ->expects($this->once())
             ->method('getUserId')
@@ -63,7 +65,7 @@ class UserTest extends TestCase
 
         $user = new User($apiUser, $roles);
 
-        $apiUser2 = $this->getMock('eZ\Publish\API\Repository\Values\User\User');
+        $apiUser2 = $this->createMock(APIUser::class);
         $apiUser2
             ->expects($this->once())
             ->method('getUserId')
@@ -75,7 +77,7 @@ class UserTest extends TestCase
 
     public function testIsNotEqualTo()
     {
-        $apiUser = $this->getMock('eZ\Publish\API\Repository\Values\User\User');
+        $apiUser = $this->createMock(APIUser::class);
         $apiUser
             ->expects($this->once())
             ->method('getUserId')
@@ -84,7 +86,7 @@ class UserTest extends TestCase
 
         $user = new User($apiUser, $roles);
 
-        $apiUser2 = $this->getMock('eZ\Publish\API\Repository\Values\User\User');
+        $apiUser2 = $this->createMock(APIUser::class);
         $apiUser2
             ->expects($this->once())
             ->method('getUserId')
@@ -97,7 +99,7 @@ class UserTest extends TestCase
     public function testIsEqualToNotSameUserType()
     {
         $user = new User();
-        $user2 = $this->getMock(ReferenceUserInterface::class);
+        $user2 = $this->createMock(ReferenceUserInterface::class);
         $user2
             ->expects($this->once())
             ->method('getAPIUserReference')
@@ -107,7 +109,7 @@ class UserTest extends TestCase
 
     public function testSetAPIUser()
     {
-        $apiUser = $this->getMock('eZ\Publish\API\Repository\Values\User\User');
+        $apiUser = $this->createMock(APIUser::class);
         $user = new User();
         $user->setAPIUser($apiUser);
         $this->assertSame($apiUser, $user->getAPIUser());
@@ -117,10 +119,10 @@ class UserTest extends TestCase
     {
         $fullName = 'My full name';
         $userContentInfo = $this
-            ->getMockBuilder('eZ\Publish\API\Repository\Values\Content\ContentInfo')
+            ->getMockBuilder(ContentInfo::class)
             ->setConstructorArgs(array(array('name' => $fullName)))
             ->getMockForAbstractClass();
-        $apiUser = $this->getMock('eZ\Publish\API\Repository\Values\User\User');
+        $apiUser = $this->createMock(APIUser::class);
         $apiUser
             ->expects($this->any())
             ->method('__get')

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserWrappedTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserWrappedTest.php
@@ -8,10 +8,12 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests;
 
+use eZ\Publish\API\Repository\Values\User\User as APIUser;
 use eZ\Publish\Core\MVC\Symfony\Security\UserInterface;
 use eZ\Publish\Core\MVC\Symfony\Security\UserWrapped;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\User\EquatableInterface;
+use Symfony\Component\Security\Core\User\UserInterface as SymfonyUserInterface;
 use Symfony\Component\Security\Core\User\User;
 
 class UserWrappedTest extends TestCase
@@ -24,27 +26,27 @@ class UserWrappedTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->apiUser = $this->getMock('eZ\Publish\API\Repository\Values\User\User');
+        $this->apiUser = $this->createMock(APIUser::class);
     }
 
     public function testGetSetAPIUser()
     {
-        $originalUser = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $originalUser = $this->createMock(SymfonyUserInterface::class);
         $userWrapped = new UserWrapped($originalUser, $this->apiUser);
         $this->assertSame($this->apiUser, $userWrapped->getAPIUser());
 
-        $newApiUser = $this->getMock('eZ\Publish\API\Repository\Values\User\User');
+        $newApiUser = $this->createMock(APIUser::class);
         $userWrapped->setAPIUser($newApiUser);
         $this->assertSame($newApiUser, $userWrapped->getAPIUser());
     }
 
     public function testGetSetWrappedUser()
     {
-        $originalUser = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $originalUser = $this->createMock(SymfonyUserInterface::class);
         $userWrapped = new UserWrapped($originalUser, $this->apiUser);
         $this->assertSame($originalUser, $userWrapped->getWrappedUser());
 
-        $newWrappedUser = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $newWrappedUser = $this->createMock(UserInterface::class);
         $userWrapped->setWrappedUser($newWrappedUser);
         $this->assertSame($newWrappedUser, $userWrapped->getWrappedUser());
     }
@@ -84,14 +86,14 @@ class UserWrappedTest extends TestCase
 
     public function testRegularUser()
     {
-        $originalUser = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $originalUser = $this->createMock(SymfonyUserInterface::class);
         $user = new UserWrapped($originalUser, $this->apiUser);
 
         $this->assertTrue($user->isEnabled());
         $this->assertTrue($user->isAccountNonExpired());
         $this->assertTrue($user->isAccountNonLocked());
         $this->assertTrue($user->isCredentialsNonExpired());
-        $this->assertTrue($user->isEqualTo($this->getMock('Symfony\Component\Security\Core\User\UserInterface')));
+        $this->assertTrue($user->isEqualTo($this->createMock(SymfonyUserInterface::class)));
 
         $originalUser
             ->expects($this->once())
@@ -129,9 +131,9 @@ class UserWrappedTest extends TestCase
 
     public function testIsEqualTo()
     {
-        $originalUser = $this->getMock(UserEquatableInterface::class);
+        $originalUser = $this->createMock(UserEquatableInterface::class);
         $user = new UserWrapped($originalUser, $this->apiUser);
-        $otherUser = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $otherUser = $this->createMock(SymfonyUserInterface::class);
         $originalUser
             ->expects($this->once())
             ->method('isEqualTo')

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Voter/CoreVoterTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Voter/CoreVoterTest.php
@@ -8,8 +8,12 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\Voter;
 
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\MVC\Symfony\Controller\Content\ViewController;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Voter\CoreVoter;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -23,7 +27,7 @@ class CoreVoterTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->repository = $this->getMock('eZ\Publish\API\Repository\Repository');
+        $this->repository = $this->createMock(Repository::class);
     }
 
     /**
@@ -47,7 +51,7 @@ class CoreVoterTest extends TestCase
                 new Attribute(
                     'foo',
                     'bar',
-                    array('valueObject' => $this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\ValueObject'))
+                    array('valueObject' => $this->getMockForAbstractClass(ValueObject::class))
                 ),
                 false,
             ),
@@ -68,8 +72,8 @@ class CoreVoterTest extends TestCase
         return array(
             array('foo'),
             array('bar'),
-            array('eZ\Publish\API\Repository\Values\ValueObject'),
-            array('eZ\Publish\Core\MVC\Symfony\Controller\Content\ViewController'),
+            array(ValueObject::class),
+            array(ViewController::class),
         );
     }
 
@@ -82,7 +86,7 @@ class CoreVoterTest extends TestCase
         $this->assertSame(
             VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(
-                $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface'),
+                $this->createMock(TokenInterface::class),
                 new \stdClass(),
                 $attributes
             )
@@ -101,7 +105,7 @@ class CoreVoterTest extends TestCase
                     new Attribute(
                         'foo',
                         'bar',
-                        array('valueObject' => $this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\ValueObject'))
+                        array('valueObject' => $this->getMockForAbstractClass(ValueObject::class))
                     ),
                 ),
                 false,
@@ -130,7 +134,7 @@ class CoreVoterTest extends TestCase
         $this->assertSame(
             $expectedResult,
             $voter->vote(
-                $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface'),
+                $this->createMock(TokenInterface::class),
                 new \stdClass(),
                 array($attribute)
             )
@@ -165,8 +169,8 @@ class CoreVoterTest extends TestCase
                     'content',
                     'read',
                     array(
-                        'valueObject' => $this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\ValueObject'),
-                        'targets' => $this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\ValueObject'),
+                        'valueObject' => $this->getMockForAbstractClass(ValueObject::class),
+                        'targets' => $this->getMockForAbstractClass(ValueObject::class),
                     )
                 ),
                 null,
@@ -177,8 +181,8 @@ class CoreVoterTest extends TestCase
                     'content',
                     'read',
                     array(
-                        'valueObject' => $this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\ValueObject'),
-                        'targets' => array($this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\ValueObject')),
+                        'valueObject' => $this->getMockForAbstractClass(ValueObject::class),
+                        'targets' => array($this->getMockForAbstractClass(ValueObject::class)),
                     )
                 ),
                 null,
@@ -189,8 +193,8 @@ class CoreVoterTest extends TestCase
                     'content',
                     'read',
                     array(
-                        'valueObject' => $this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\ValueObject'),
-                        'targets' => $this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\ValueObject'),
+                        'valueObject' => $this->getMockForAbstractClass(ValueObject::class),
+                        'targets' => $this->getMockForAbstractClass(ValueObject::class),
                     )
                 ),
                 null,
@@ -201,8 +205,8 @@ class CoreVoterTest extends TestCase
                     'content',
                     'read',
                     array(
-                        'valueObject' => $this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\ValueObject'),
-                        'targets' => array($this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\ValueObject')),
+                        'valueObject' => $this->getMockForAbstractClass(ValueObject::class),
+                        'targets' => array($this->getMockForAbstractClass(ValueObject::class)),
                     )
                 ),
                 null,

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Voter/ValueObjectVoterTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Voter/ValueObjectVoterTest.php
@@ -8,8 +8,12 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\Voter;
 
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\MVC\Symfony\Controller\Content\ViewController;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Attribute;
 use eZ\Publish\Core\MVC\Symfony\Security\Authorization\Voter\ValueObjectVoter;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -23,7 +27,7 @@ class ValueObjectVoterTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->repository = $this->getMock('eZ\Publish\API\Repository\Repository');
+        $this->repository = $this->createMock(Repository::class);
     }
 
     /**
@@ -47,7 +51,7 @@ class ValueObjectVoterTest extends TestCase
                 new Attribute(
                     'foo',
                     'bar',
-                    array('valueObject' => $this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\ValueObject'))
+                    array('valueObject' => $this->getMockForAbstractClass(ValueObject::class))
                 ),
                 true,
             ),
@@ -68,8 +72,8 @@ class ValueObjectVoterTest extends TestCase
         return array(
             array('foo'),
             array('bar'),
-            array('eZ\Publish\API\Repository\Values\ValueObject'),
-            array('eZ\Publish\Core\MVC\Symfony\Controller\Content\ViewController'),
+            array(ValueObject::class),
+            array(ViewController::class),
         );
     }
 
@@ -82,7 +86,7 @@ class ValueObjectVoterTest extends TestCase
         $this->assertSame(
             VoterInterface::ACCESS_ABSTAIN,
             $voter->vote(
-                $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface'),
+                $this->createMock(TokenInterface::class),
                 new \stdClass(),
                 $attributes
             )
@@ -116,7 +120,7 @@ class ValueObjectVoterTest extends TestCase
         $this->assertSame(
             $expectedResult,
             $voter->vote(
-                $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface'),
+                $this->createMock(TokenInterface::class),
                 new \stdClass(),
                 array($attribute)
             )
@@ -141,8 +145,8 @@ class ValueObjectVoterTest extends TestCase
                     'content',
                     'read',
                     array(
-                        'valueObject' => $this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\ValueObject'),
-                        'targets' => $this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\ValueObject'),
+                        'valueObject' => $this->getMockForAbstractClass(ValueObject::class),
+                        'targets' => $this->getMockForAbstractClass(ValueObject::class),
                     )
                 ),
                 true,
@@ -153,8 +157,8 @@ class ValueObjectVoterTest extends TestCase
                     'content',
                     'read',
                     array(
-                        'valueObject' => $this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\ValueObject'),
-                        'targets' => array($this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\ValueObject')),
+                        'valueObject' => $this->getMockForAbstractClass(ValueObject::class),
+                        'targets' => array($this->getMockForAbstractClass(ValueObject::class)),
                     )
                 ),
                 true,
@@ -165,8 +169,8 @@ class ValueObjectVoterTest extends TestCase
                     'content',
                     'read',
                     array(
-                        'valueObject' => $this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\ValueObject'),
-                        'targets' => $this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\ValueObject'),
+                        'valueObject' => $this->getMockForAbstractClass(ValueObject::class),
+                        'targets' => $this->getMockForAbstractClass(ValueObject::class),
                     )
                 ),
                 false,
@@ -177,8 +181,8 @@ class ValueObjectVoterTest extends TestCase
                     'content',
                     'read',
                     array(
-                        'valueObject' => $this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\ValueObject'),
-                        'targets' => array($this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\ValueObject')),
+                        'valueObject' => $this->getMockForAbstractClass(ValueObject::class),
+                        'targets' => array($this->getMockForAbstractClass(ValueObject::class)),
                     )
                 ),
                 false,

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Compound/CompoundAndTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Compound/CompoundAndTest.php
@@ -9,8 +9,11 @@
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\Compound;
 
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilderInterface;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Compound\LogicalAnd;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Compound;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
 use PHPUnit\Framework\TestCase;
@@ -25,7 +28,7 @@ class CompoundAndTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->matcherBuilder = $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\MatcherBuilderInterface');
+        $this->matcherBuilder = $this->createMock(MatcherBuilderInterface::class);
     }
 
     /**
@@ -77,14 +80,14 @@ class CompoundAndTest extends TestCase
             ->matcherBuilder
             ->expects($this->any())
             ->method('buildMatcher')
-            ->will($this->returnValue($this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\Matcher')));
+            ->will($this->returnValue($this->createMock(Matcher::class)));
 
-        $compoundMatcher->setRequest($this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\Routing\\SimplifiedRequest'));
+        $compoundMatcher->setRequest($this->createMock(SimplifiedRequest::class));
         $compoundMatcher->setMatcherBuilder($this->matcherBuilder);
         $matchers = $compoundMatcher->getSubMatchers();
         $this->assertInternalType('array', $matchers);
         foreach ($matchers as $matcher) {
-            $this->assertInstanceOf('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\Matcher', $matcher);
+            $this->assertInstanceOf(Matcher::class, $matcher);
         }
     }
 
@@ -116,14 +119,14 @@ class CompoundAndTest extends TestCase
             )
         );
 
-        $matcher1 = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher');
-        $matcher2 = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher');
+        $matcher1 = $this->createMock(Matcher::class);
+        $matcher2 = $this->createMock(Matcher::class);
         $this->matcherBuilder
             ->expects($this->exactly(2))
             ->method('buildMatcher')
             ->will($this->onConsecutiveCalls($matcher1, $matcher2));
 
-        $request = $this->getMock('eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest');
+        $request = $this->createMock(SimplifiedRequest::class);
         $matcher1
             ->expects($this->once())
             ->method('setRequest')
@@ -133,7 +136,7 @@ class CompoundAndTest extends TestCase
             ->method('setRequest')
             ->with($request);
 
-        $compoundMatcher->setRequest($this->getMock('eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest'));
+        $compoundMatcher->setRequest($this->createMock(SimplifiedRequest::class));
         $compoundMatcher->setMatcherBuilder($this->matcherBuilder);
         $compoundMatcher->setRequest($request);
     }
@@ -158,16 +161,16 @@ class CompoundAndTest extends TestCase
         $this->matcherBuilder
             ->expects($this->any())
             ->method('buildMatcher')
-            ->will($this->returnValue($this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher')));
+            ->will($this->returnValue($this->createMock(VersatileMatcher::class)));
 
-        $compoundMatcher->setRequest($this->getMock('eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest'));
+        $compoundMatcher->setRequest($this->createMock(SimplifiedRequest::class));
         $compoundMatcher->setMatcherBuilder($this->matcherBuilder);
         $this->assertNull($compoundMatcher->reverseMatch('not_configured_sa'));
     }
 
     public function testReverseMatchNotVersatile()
     {
-        $request = $this->getMock('eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest');
+        $request = $this->createMock(SimplifiedRequest::class);
         $siteAccessName = 'fr_eng';
         $mapUriConfig = array('eng' => true);
         $mapHostConfig = array('fr.ezpublish.dev' => true);
@@ -184,8 +187,12 @@ class CompoundAndTest extends TestCase
         );
         $compoundMatcher->setRequest($request);
 
-        $matcher1 = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher');
-        $matcher2 = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher');
+        $matcher1 = $this->createMock(VersatileMatcher::class);
+        $matcher2 = $this->getMockBuilder(Matcher::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['reverseMatch'])
+            ->getMockForAbstractClass();
+
         $this->matcherBuilder
             ->expects($this->exactly(2))
             ->method('buildMatcher')
@@ -202,7 +209,7 @@ class CompoundAndTest extends TestCase
             ->expects($this->once())
             ->method('reverseMatch')
             ->with($siteAccessName)
-            ->will($this->returnValue($this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher')));
+            ->will($this->returnValue($this->createMock(VersatileMatcher::class)));
         $matcher2
             ->expects($this->never())
             ->method('reverseMatch');
@@ -213,7 +220,7 @@ class CompoundAndTest extends TestCase
 
     public function testReverseMatchFail()
     {
-        $request = $this->getMock('eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest');
+        $request = $this->createMock(SimplifiedRequest::class);
         $siteAccessName = 'fr_eng';
         $mapUriConfig = array('eng' => true);
         $mapHostConfig = array('fr.ezpublish.dev' => true);
@@ -230,8 +237,8 @@ class CompoundAndTest extends TestCase
         );
         $compoundMatcher->setRequest($request);
 
-        $matcher1 = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher');
-        $matcher2 = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher');
+        $matcher1 = $this->createMock(VersatileMatcher::class);
+        $matcher2 = $this->createMock(VersatileMatcher::class);
         $this->matcherBuilder
             ->expects($this->exactly(2))
             ->method('buildMatcher')
@@ -248,7 +255,7 @@ class CompoundAndTest extends TestCase
             ->expects($this->once())
             ->method('reverseMatch')
             ->with($siteAccessName)
-            ->will($this->returnValue($this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher')));
+            ->will($this->returnValue($this->createMock(VersatileMatcher::class)));
         $matcher2
             ->expects($this->once())
             ->method('reverseMatch')
@@ -261,7 +268,7 @@ class CompoundAndTest extends TestCase
 
     public function testReverseMatch()
     {
-        $request = $this->getMock('eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest');
+        $request = $this->createMock(SimplifiedRequest::class);
         $siteAccessName = 'fr_eng';
         $mapUriConfig = array('eng' => true);
         $mapHostConfig = array('fr.ezpublish.dev' => true);
@@ -278,8 +285,8 @@ class CompoundAndTest extends TestCase
         );
         $compoundMatcher->setRequest($request);
 
-        $matcher1 = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher');
-        $matcher2 = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher');
+        $matcher1 = $this->createMock(VersatileMatcher::class);
+        $matcher2 = $this->createMock(VersatileMatcher::class);
         $this->matcherBuilder
             ->expects($this->exactly(2))
             ->method('buildMatcher')
@@ -292,13 +299,13 @@ class CompoundAndTest extends TestCase
                 )
             );
 
-        $reverseMatchedMatcher1 = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher');
+        $reverseMatchedMatcher1 = $this->createMock(VersatileMatcher::class);
         $matcher1
             ->expects($this->once())
             ->method('reverseMatch')
             ->with($siteAccessName)
             ->will($this->returnValue($reverseMatchedMatcher1));
-        $reverseMatchedMatcher2 = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher');
+        $reverseMatchedMatcher2 = $this->createMock(VersatileMatcher::class);
         $matcher2
             ->expects($this->once())
             ->method('reverseMatch')
@@ -307,9 +314,9 @@ class CompoundAndTest extends TestCase
 
         $compoundMatcher->setMatcherBuilder($this->matcherBuilder);
         $result = $compoundMatcher->reverseMatch($siteAccessName);
-        $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Compound\LogicalAnd', $result);
+        $this->assertInstanceOf(LogicalAnd::class, $result);
         foreach ($result->getSubMatchers() as $subMatcher) {
-            $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher', $subMatcher);
+            $this->assertInstanceOf(VersatileMatcher::class, $subMatcher);
         }
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Compound/CompoundOrTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Compound/CompoundOrTest.php
@@ -10,8 +10,11 @@ namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\Compound;
 
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Compound\LogicalOr;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilderInterface;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Compound;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
 use PHPUnit\Framework\TestCase;
 
@@ -25,7 +28,7 @@ class CompoundOrTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->matcherBuilder = $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\MatcherBuilderInterface');
+        $this->matcherBuilder = $this->createMock(MatcherBuilderInterface::class);
     }
 
     /**
@@ -69,14 +72,14 @@ class CompoundOrTest extends TestCase
         $this->matcherBuilder
             ->expects($this->any())
             ->method('buildMatcher')
-            ->will($this->returnValue($this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\Matcher')));
+            ->will($this->returnValue($this->createMock(Matcher::class)));
 
-        $compoundMatcher->setRequest($this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\Routing\\SimplifiedRequest'));
+        $compoundMatcher->setRequest($this->createMock(SimplifiedRequest::class));
         $compoundMatcher->setMatcherBuilder($this->matcherBuilder);
         $matchers = $compoundMatcher->getSubMatchers();
         $this->assertInternalType('array', $matchers);
         foreach ($matchers as $matcher) {
-            $this->assertInstanceOf('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess\\Matcher', $matcher);
+            $this->assertInstanceOf(Matcher::class, $matcher);
         }
     }
 
@@ -115,16 +118,16 @@ class CompoundOrTest extends TestCase
         $this->matcherBuilder
             ->expects($this->any())
             ->method('buildMatcher')
-            ->will($this->returnValue($this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher')));
+            ->will($this->returnValue($this->createMock(VersatileMatcher::class)));
 
-        $compoundMatcher->setRequest($this->getMock('eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest'));
+        $compoundMatcher->setRequest($this->createMock(SimplifiedRequest::class));
         $compoundMatcher->setMatcherBuilder($this->matcherBuilder);
         $this->assertNull($compoundMatcher->reverseMatch('not_configured_sa'));
     }
 
     public function testReverseMatchNotVersatile()
     {
-        $request = $this->getMock('eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest');
+        $request = $this->createMock(SimplifiedRequest::class);
         $siteAccessName = 'fr_eng';
         $mapUriConfig = array('eng' => true);
         $mapHostConfig = array('fr.ezpublish.dev' => true);
@@ -141,8 +144,15 @@ class CompoundOrTest extends TestCase
         );
         $compoundMatcher->setRequest($request);
 
-        $matcher1 = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher');
-        $matcher2 = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher');
+        $matcher1 = $this->getMockBuilder(Matcher::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['reverseMatch'])
+            ->getMockForAbstractClass();
+        $matcher2 = $this->getMockBuilder(Matcher::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['reverseMatch'])
+            ->getMockForAbstractClass();
+
         $this->matcherBuilder
             ->expects($this->exactly(2))
             ->method('buildMatcher')
@@ -168,7 +178,7 @@ class CompoundOrTest extends TestCase
 
     public function testReverseMatchFail()
     {
-        $request = $this->getMock('eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest');
+        $request = $this->createMock(SimplifiedRequest::class);
         $siteAccessName = 'fr_eng';
         $mapUriConfig = array('eng' => true);
         $mapHostConfig = array('fr.ezpublish.dev' => true);
@@ -185,8 +195,8 @@ class CompoundOrTest extends TestCase
         );
         $compoundMatcher->setRequest($request);
 
-        $matcher1 = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher');
-        $matcher2 = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher');
+        $matcher1 = $this->createMock(VersatileMatcher::class);
+        $matcher2 = $this->createMock(VersatileMatcher::class);
         $this->matcherBuilder
             ->expects($this->exactly(2))
             ->method('buildMatcher')
@@ -216,7 +226,7 @@ class CompoundOrTest extends TestCase
 
     public function testReverseMatch1()
     {
-        $request = $this->getMock('eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest');
+        $request = $this->createMock(SimplifiedRequest::class);
         $siteAccessName = 'fr_eng';
         $mapUriConfig = array('eng' => true);
         $mapHostConfig = array('fr.ezpublish.dev' => true);
@@ -233,8 +243,8 @@ class CompoundOrTest extends TestCase
         );
         $compoundMatcher->setRequest($request);
 
-        $matcher1 = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher');
-        $matcher2 = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher');
+        $matcher1 = $this->createMock(VersatileMatcher::class);
+        $matcher2 = $this->createMock(VersatileMatcher::class);
         $this->matcherBuilder
             ->expects($this->exactly(2))
             ->method('buildMatcher')
@@ -247,7 +257,7 @@ class CompoundOrTest extends TestCase
                 )
             );
 
-        $reverseMatchedMatcher1 = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher');
+        $reverseMatchedMatcher1 = $this->createMock(VersatileMatcher::class);
         $matcher1
             ->expects($this->once())
             ->method('reverseMatch')
@@ -259,15 +269,15 @@ class CompoundOrTest extends TestCase
 
         $compoundMatcher->setMatcherBuilder($this->matcherBuilder);
         $result = $compoundMatcher->reverseMatch($siteAccessName);
-        $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Compound\LogicalOr', $result);
+        $this->assertInstanceOf(LogicalOr::class, $result);
         foreach ($result->getSubMatchers() as $subMatcher) {
-            $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher', $subMatcher);
+            $this->assertInstanceOf(VersatileMatcher::class, $subMatcher);
         }
     }
 
     public function testReverseMatch2()
     {
-        $request = $this->getMock('eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest');
+        $request = $this->createMock(SimplifiedRequest::class);
         $siteAccessName = 'fr_eng';
         $mapUriConfig = array('eng' => true);
         $mapHostConfig = array('fr.ezpublish.dev' => true);
@@ -284,8 +294,8 @@ class CompoundOrTest extends TestCase
         );
         $compoundMatcher->setRequest($request);
 
-        $matcher1 = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher');
-        $matcher2 = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher');
+        $matcher1 = $this->createMock(VersatileMatcher::class);
+        $matcher2 = $this->createMock(VersatileMatcher::class);
         $this->matcherBuilder
             ->expects($this->exactly(2))
             ->method('buildMatcher')
@@ -303,7 +313,7 @@ class CompoundOrTest extends TestCase
             ->method('reverseMatch')
             ->with($siteAccessName)
             ->will($this->returnValue(null));
-        $reverseMatchedMatcher2 = $this->getMock('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher');
+        $reverseMatchedMatcher2 = $this->createMock(VersatileMatcher::class);
         $matcher2
             ->expects($this->once())
             ->method('reverseMatch')
@@ -312,9 +322,9 @@ class CompoundOrTest extends TestCase
 
         $compoundMatcher->setMatcherBuilder($this->matcherBuilder);
         $result = $compoundMatcher->reverseMatch($siteAccessName);
-        $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Compound\LogicalOr', $result);
+        $this->assertInstanceOf(LogicalOr::class, $result);
         foreach ($result->getSubMatchers() as $subMatcher) {
-            $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\SiteAccess\VersatileMatcher', $subMatcher);
+            $this->assertInstanceOf(VersatileMatcher::class, $subMatcher);
         }
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostElementTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostElementTest.php
@@ -15,6 +15,7 @@ use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Map\Host as HostMapMatcher;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
+use Psr\Log\LoggerInterface;
 
 class RouterHostElementTest extends TestCase
 {
@@ -33,7 +34,7 @@ class RouterHostElementTest extends TestCase
     {
         return new Router(
             $this->matcherBuilder,
-            $this->getMock('Psr\\Log\\LoggerInterface'),
+            $this->createMock(LoggerInterface::class),
             'default_sa',
             array(
                 'HostElement' => array(
@@ -60,7 +61,7 @@ class RouterHostElementTest extends TestCase
     public function testMatch(SimplifiedRequest $request, $siteAccess, Router $router)
     {
         $sa = $router->match($request);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess', $sa);
+        $this->assertInstanceOf(SiteAccess::class, $sa);
         $this->assertSame($siteAccess, $sa->name);
         $router->setSiteAccess();
     }
@@ -139,7 +140,7 @@ class RouterHostElementTest extends TestCase
         $matcher = new HostElement(array($elementNumber));
         $matcher->setRequest($request);
         $result = $matcher->reverseMatch($siteAccessName);
-        $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\HostElement', $result);
+        $this->assertInstanceOf(HostElement::class, $result);
         $this->assertSame($expectedHost, $result->getRequest()->host);
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostPortURITest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostPortURITest.php
@@ -10,10 +10,12 @@ namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Map\Host;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Map\Port;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
+use Psr\Log\LoggerInterface;
 
 class RouterHostPortURITest extends TestCase
 {
@@ -32,7 +34,7 @@ class RouterHostPortURITest extends TestCase
     {
         return new Router(
             $this->matcherBuilder,
-            $this->getMock('Psr\\Log\\LoggerInterface'),
+            $this->createMock(LoggerInterface::class),
             'default_sa',
             array(
                 'Map\\Host' => array(
@@ -64,7 +66,7 @@ class RouterHostPortURITest extends TestCase
     public function testMatch(SimplifiedRequest $request, $siteAccess, Router $router)
     {
         $sa = $router->match($request);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess', $sa);
+        $this->assertInstanceOf(SiteAccess::class, $sa);
         $this->assertSame($siteAccess, $sa->name);
         $router->setSiteAccess();
     }
@@ -167,7 +169,7 @@ class RouterHostPortURITest extends TestCase
         $this->assertSame('ez.no', $matcher->getMapKey());
 
         $result = $matcher->reverseMatch('ezdemo_site');
-        $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Map\Host', $result);
+        $this->assertInstanceOf(Host::class, $result);
         $this->assertSame($request, $matcher->getRequest());
         $this->assertSame('phoenix-rises.fm', $result->getMapKey());
         $this->assertSame('phoenix-rises.fm', $result->getRequest()->host);
@@ -203,7 +205,7 @@ class RouterHostPortURITest extends TestCase
         $this->assertSame(80, $matcher->getMapKey());
 
         $result = $matcher->reverseMatch('ezdemo_site');
-        $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Map\Port', $result);
+        $this->assertInstanceOf(Port::class, $result);
         $this->assertSame($request, $matcher->getRequest());
         $this->assertSame(8000, $result->getMapKey());
         $this->assertSame(8000, $result->getRequest()->port);

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostRegexTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostRegexTest.php
@@ -10,9 +10,11 @@ namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Regex\Host as HostRegexMatcher;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
+use Psr\Log\LoggerInterface;
 
 class RouterHostRegexTest extends TestCase
 {
@@ -31,7 +33,7 @@ class RouterHostRegexTest extends TestCase
     {
         return new Router(
             $this->matcherBuilder,
-            $this->getMock('Psr\\Log\\LoggerInterface'),
+            $this->createMock(LoggerInterface::class),
             'default_sa',
             array(
                 'Regex\\Host' => array(
@@ -57,7 +59,7 @@ class RouterHostRegexTest extends TestCase
     public function testMatch($request, $siteAccess, $router)
     {
         $sa = $router->match($request);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess', $sa);
+        $this->assertInstanceOf(SiteAccess::class, $sa);
         $this->assertSame($siteAccess, $sa->name);
         $router->setSiteAccess();
     }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostTextTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostTextTest.php
@@ -10,9 +10,11 @@ namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\HostText as HostTextMatcher;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
+use Psr\Log\LoggerInterface;
 
 class RouterHostTextTest extends TestCase
 {
@@ -31,7 +33,7 @@ class RouterHostTextTest extends TestCase
     {
         return new Router(
             $this->matcherBuilder,
-            $this->getMock('Psr\\Log\\LoggerInterface'),
+            $this->createMock(LoggerInterface::class),
             'default_sa',
             array(
                 'HostText' => array(
@@ -58,7 +60,7 @@ class RouterHostTextTest extends TestCase
     public function testMatch(SimplifiedRequest $request, $siteAccess, Router $router)
     {
         $sa = $router->match($request);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess', $sa);
+        $this->assertInstanceOf(SiteAccess::class, $sa);
         $this->assertSame($siteAccess, $sa->name);
         $router->setSiteAccess();
     }
@@ -138,9 +140,9 @@ class RouterHostTextTest extends TestCase
         $matcher->setRequest(new SimplifiedRequest(array('host' => 'www.my_siteaccess.com')));
 
         $result = $matcher->reverseMatch('foobar');
-        $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\HostText', $result);
+        $this->assertInstanceOf(HostTextMatcher::class, $result);
         $request = $result->getRequest();
-        $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest', $request);
+        $this->assertInstanceOf(SimplifiedRequest::class, $request);
         $this->assertSame('www.foobar.com', $request->host);
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterMapURITest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterMapURITest.php
@@ -106,7 +106,7 @@ class RouterMapURITest extends TestCase
         $matcher->setRequest($request);
 
         $result = $matcher->reverseMatch('ezdemo_site');
-        $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Map\URI', $result);
+        $this->assertInstanceOf(URIMapMatcher::class, $result);
         $this->assertSame($request, $matcher->getRequest());
         $this->assertSame('toutouyoutou', $result->getMapKey());
         $this->assertSame('/toutouyoutou/foo', $result->getRequest()->pathinfo);

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterPortHostURITest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterPortHostURITest.php
@@ -9,9 +9,11 @@
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
 use PHPUnit\Framework\TestCase;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
+use Psr\Log\LoggerInterface;
 
 class RouterPortHostURITest extends TestCase
 {
@@ -30,7 +32,7 @@ class RouterPortHostURITest extends TestCase
     {
         return new Router(
             $this->matcherBuilder,
-            $this->getMock('Psr\\Log\\LoggerInterface'),
+            $this->createMock(LoggerInterface::class),
             'default_sa',
             array(
                 'Map\\Port' => array(
@@ -62,7 +64,7 @@ class RouterPortHostURITest extends TestCase
     public function testMatch($request, $siteAccess, $router)
     {
         $sa = $router->match($request);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess', $sa);
+        $this->assertInstanceOf(SiteAccess::class, $sa);
         $this->assertSame($siteAccess, $sa->name);
         $router->setSiteAccess();
     }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterSpecialPortsTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterSpecialPortsTest.php
@@ -10,9 +10,11 @@ namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Map\Port as PortMatcher;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
+use Psr\Log\LoggerInterface;
 
 class RouterSpecialPortsTest extends TestCase
 {
@@ -31,7 +33,7 @@ class RouterSpecialPortsTest extends TestCase
     {
         return new Router(
             $this->matcherBuilder,
-            $this->getMock('Psr\\Log\\LoggerInterface'),
+            $this->createMock(LoggerInterface::class),
             'default_sa',
             array(
                 'Map\\URI' => array(
@@ -63,7 +65,7 @@ class RouterSpecialPortsTest extends TestCase
     public function testMatch($request, $siteAccess, $router)
     {
         $sa = $router->match($request);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess', $sa);
+        $this->assertInstanceOf(SiteAccess::class, $sa);
         $this->assertSame($siteAccess, $sa->name);
         $router->setSiteAccess();
     }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElement2Test.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElement2Test.php
@@ -9,11 +9,13 @@
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIElement;
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIElement as URIElementMatcher;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
+use Psr\Log\LoggerInterface;
 
 class RouterURIElement2Test extends TestCase
 {
@@ -32,7 +34,7 @@ class RouterURIElement2Test extends TestCase
     {
         return new Router(
             $this->matcherBuilder,
-            $this->getMock('Psr\\Log\\LoggerInterface'),
+            $this->createMock(LoggerInterface::class),
             'default_sa',
             array(
                 'URIElement' => array(
@@ -58,7 +60,7 @@ class RouterURIElement2Test extends TestCase
     public function testMatch(SimplifiedRequest $request, $siteAccess, Router $router)
     {
         $sa = $router->match($request);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess', $sa);
+        $this->assertInstanceOf(SiteAccess::class, $sa);
         $this->assertSame($siteAccess, $sa->name);
         $router->setSiteAccess();
     }
@@ -190,7 +192,7 @@ class RouterURIElement2Test extends TestCase
         $matcher->setRequest(new SimplifiedRequest(array('pathinfo' => $originalPathinfo)));
 
         $result = $matcher->reverseMatch($siteAccessName);
-        $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIElement', $result);
+        $this->assertInstanceOf(URIElement::class, $result);
         $this->assertSame("/{$expectedSiteAccessPath}{$originalPathinfo}", $result->getRequest()->pathinfo);
         $this->assertSame("/$expectedSiteAccessPath/some/linked/uri", $result->analyseLink('/some/linked/uri'));
         $this->assertSame('/foo/bar/baz', $result->analyseURI("/$expectedSiteAccessPath/foo/bar/baz"));

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElementTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElementTest.php
@@ -9,11 +9,13 @@
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIElement;
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIElement as URIElementMatcher;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
+use Psr\Log\LoggerInterface;
 
 class RouterURIElementTest extends TestCase
 {
@@ -32,7 +34,7 @@ class RouterURIElementTest extends TestCase
     {
         return new Router(
             $this->matcherBuilder,
-            $this->getMock('Psr\\Log\\LoggerInterface'),
+            $this->createMock(LoggerInterface::class),
             'default_sa',
             array(
                 'URIElement' => array(
@@ -58,7 +60,7 @@ class RouterURIElementTest extends TestCase
     public function testMatch(SimplifiedRequest $request, $siteAccess, Router $router)
     {
         $sa = $router->match($request);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess', $sa);
+        $this->assertInstanceOf(SiteAccess::class, $sa);
         $this->assertSame($siteAccess, $sa->name);
         $router->setSiteAccess();
     }
@@ -166,7 +168,7 @@ class RouterURIElementTest extends TestCase
         $matcher = new URIElementMatcher(array(1));
         $matcher->setRequest(new SimplifiedRequest(array('pathinfo' => $originalPathinfo)));
         $result = $matcher->reverseMatch($siteAccessName);
-        $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIElement', $result);
+        $this->assertInstanceOf(URIElement::class, $result);
         $this->assertSame("/{$siteAccessName}{$originalPathinfo}", $result->getRequest()->pathinfo);
         $this->assertSame("/$siteAccessName/some/linked/uri", $result->analyseLink('/some/linked/uri'));
         $this->assertSame('/foo/bar/baz', $result->analyseURI("/$siteAccessName/foo/bar/baz"));

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIRegexTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIRegexTest.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Regex\URI as RegexMatcher;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
+use Psr\Log\LoggerInterface;
 
 class RouterURIRegexTest extends TestCase
 {
@@ -32,7 +33,7 @@ class RouterURIRegexTest extends TestCase
     {
         return new Router(
             $this->matcherBuilder,
-            $this->getMock('Psr\\Log\\LoggerInterface'),
+            $this->createMock(LoggerInterface::class),
             'default_sa',
             array(
                 'Regex\\URI' => array(
@@ -58,7 +59,7 @@ class RouterURIRegexTest extends TestCase
     public function testMatch($request, $siteAccess, $router)
     {
         $sa = $router->match($request);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess', $sa);
+        $this->assertInstanceOf(SiteAccess::class, $sa);
         $this->assertSame($siteAccess, $sa->name);
         $router->setSiteAccess();
     }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURITextTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURITextTest.php
@@ -8,11 +8,14 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;
 
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIText;
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIText as URITextMatcher;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder;
+use Psr\Log\LoggerInterface;
 
 class RouterURITextTest extends TestCase
 {
@@ -31,7 +34,7 @@ class RouterURITextTest extends TestCase
     {
         return new Router(
             $this->matcherBuilder,
-            $this->getMock('Psr\\Log\\LoggerInterface'),
+            $this->createMock(LoggerInterface::class),
             'default_sa',
             array(
                 'URIText' => array(
@@ -58,7 +61,7 @@ class RouterURITextTest extends TestCase
     public function testMatch(SimplifiedRequest $request, $siteAccess, Router $router)
     {
         $sa = $router->match($request);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess', $sa);
+        $this->assertInstanceOf(SiteAccess::class, $sa);
         $this->assertSame($siteAccess, $sa->name);
         $router->setSiteAccess();
     }
@@ -169,9 +172,9 @@ class RouterURITextTest extends TestCase
         $matcher->setRequest(new SimplifiedRequest(array('pathinfo' => $semanticURI)));
 
         $result = $matcher->reverseMatch('something');
-        $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIText', $result);
+        $this->assertInstanceOf(URIText::class, $result);
         $request = $result->getRequest();
-        $this->assertInstanceOf('eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest', $request);
+        $this->assertInstanceOf(SimplifiedRequest::class, $request);
         $this->assertSame("/foosomethingbar{$semanticURI}", $request->pathinfo);
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/GlobalHelperTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/GlobalHelperTest.php
@@ -8,11 +8,18 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests;
 
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\Core\Helper\TranslationHelper;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\Templating\GlobalHelper;
 use Symfony\Component\HttpFoundation\Request;
 use eZ\Publish\Core\MVC\Symfony\Routing\UrlAliasRouter;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Routing\RouterInterface;
 
 class GlobalHelperTest extends TestCase
 {
@@ -50,13 +57,11 @@ class GlobalHelperTest extends TestCase
     {
         parent::setUp();
 
-        $this->container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
-        $this->locationService = $this->getMock('eZ\\Publish\\API\\Repository\\LocationService');
-        $this->configResolver = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
-        $this->router = $this->getMock('Symfony\\Component\\Routing\\RouterInterface');
-        $this->translationHelper = $this->getMockBuilder('eZ\Publish\Core\Helper\TranslationHelper')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->container = $this->createMock(ContainerInterface::class);
+        $this->locationService = $this->createMock(LocationService::class);
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
+        $this->router = $this->createMock(RouterInterface::class);
+        $this->translationHelper = $this->createMock(TranslationHelper::class);
         $this->helper = new GlobalHelper($this->configResolver, $this->locationService, $this->router, $this->translationHelper);
     }
 
@@ -65,7 +70,7 @@ class GlobalHelperTest extends TestCase
         $request = new Request();
         $requestStack = new RequestStack();
         $requestStack->push($request);
-        $siteAccess = $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\SiteAccess');
+        $siteAccess = $this->createMock(SiteAccess::class);
         $request->attributes->set('siteaccess', $siteAccess);
         $this->helper->setRequestStack($requestStack);
 
@@ -162,7 +167,7 @@ class GlobalHelperTest extends TestCase
             ->will($this->returnValue($rootLocationId));
 
         $rootLocation = $this
-            ->getMockBuilder('eZ\\Publish\\API\\Repository\\Values\\Content\\Location')
+            ->getMockBuilder(Location::class)
             ->setConstructorArgs(array(array('id' => $rootLocationId)));
         $this->locationService
             ->expects($this->once())

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/ContentExtensionTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/ContentExtensionTest.php
@@ -8,14 +8,20 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests\Twig\Extension;
 
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\ContentExtension;
 use eZ\Publish\Core\Helper\TranslationHelper;
+use eZ\Publish\Core\Helper\FieldHelper;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Field;
+use Psr\Log\LoggerInterface;
 
 /**
  * Integration tests for ContentExtension templates.
@@ -33,8 +39,7 @@ class ContentExtensionTest extends FileSystemTwigIntegrationTestCase
 
     public function getExtensions()
     {
-        $this->fieldHelperMock = $this->getMockBuilder('eZ\\Publish\\Core\\Helper\\FieldHelper')
-            ->disableOriginalConstructor()->getMock();
+        $this->fieldHelperMock = $this->createMock(FieldHelper::class);
         $configResolver = $this->getConfigResolverMock();
 
         return array(
@@ -42,9 +47,9 @@ class ContentExtensionTest extends FileSystemTwigIntegrationTestCase
                 $this->getRepositoryMock(),
                 new TranslationHelper(
                     $configResolver,
-                    $this->getMock('eZ\\Publish\\API\\Repository\\ContentService'),
+                    $this->createMock(ContentService::class),
                     array(),
-                    $this->getMock('Psr\Log\LoggerInterface')
+                    $this->createMock(LoggerInterface::class)
                 ),
                 $this->fieldHelperMock
             ),
@@ -111,9 +116,7 @@ class ContentExtensionTest extends FileSystemTwigIntegrationTestCase
 
     private function getConfigResolverMock()
     {
-        $mock = $this->getMock(
-            'eZ\\Publish\\Core\\MVC\\ConfigResolverInterface'
-        );
+        $mock = $this->createMock(ConfigResolverInterface::class);
         // Signature: ConfigResolverInterface->getParameter( $paramName, $namespace = null, $scope = null )
         $mock->expects($this->any())
             ->method('getParameter')
@@ -150,7 +153,7 @@ class ContentExtensionTest extends FileSystemTwigIntegrationTestCase
      */
     protected function getRepositoryMock()
     {
-        $mock = $this->getMock('eZ\\Publish\\API\\Repository\\Repository');
+        $mock = $this->createMock(Repository::class);
 
         $mock->expects($this->any())
             ->method('getContentTypeService')
@@ -164,7 +167,7 @@ class ContentExtensionTest extends FileSystemTwigIntegrationTestCase
      */
     protected function getContentTypeServiceMock()
     {
-        $mock = $this->getMock('eZ\\Publish\\API\\Repository\\ContentTypeService');
+        $mock = $this->createMock(ContentTypeService::class);
 
         $mock->expects($this->any())
             ->method('loadContentType')

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FieldRenderingExtensionIntegrationTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FieldRenderingExtensionIntegrationTest.php
@@ -8,15 +8,20 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests\Twig\Extension;
 
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\Core\Helper\TranslationHelper;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\FieldRenderingExtension;
 use eZ\Publish\Core\MVC\Symfony\Templating\Twig\FieldBlockRenderer;
+use eZ\Publish\Core\MVC\Symfony\FieldType\View\ParameterProviderRegistryInterface;
 use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
+use Psr\Log\LoggerInterface;
 
 class FieldRenderingExtensionIntegrationTest extends FileSystemTwigIntegrationTestCase
 {
@@ -65,12 +70,12 @@ class FieldRenderingExtensionIntegrationTest extends FileSystemTwigIntegrationTe
             new FieldRenderingExtension(
                 $fieldBlockRenderer,
                 $this->getContentTypeServiceMock(),
-                $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\FieldType\\View\\ParameterProviderRegistryInterface'),
+                $this->createMock(ParameterProviderRegistryInterface::class),
                 new TranslationHelper(
                     $configResolver,
-                    $this->getMock('eZ\\Publish\\API\\Repository\\ContentService'),
+                    $this->createMock(ContentService::class),
                     array(),
-                    $this->getMock('Psr\Log\LoggerInterface')
+                    $this->createMock(LoggerInterface::class)
                 )
             ),
         );
@@ -152,9 +157,7 @@ class FieldRenderingExtensionIntegrationTest extends FileSystemTwigIntegrationTe
 
     private function getConfigResolverMock()
     {
-        $mock = $this->getMock(
-            'eZ\\Publish\\Core\\MVC\\ConfigResolverInterface'
-        );
+        $mock = $this->createMock(ConfigResolverInterface::class);
         // Signature: ConfigResolverInterface->getParameter( $paramName, $namespace = null, $scope = null )
         $mock->expects($this->any())
             ->method('getParameter')
@@ -179,7 +182,7 @@ class FieldRenderingExtensionIntegrationTest extends FileSystemTwigIntegrationTe
      */
     protected function getContentTypeServiceMock()
     {
-        $mock = $this->getMock('eZ\\Publish\\API\\Repository\\ContentTypeService');
+        $mock = $this->createMock(ContentTypeService::class);
 
         $mock->expects($this->any())
             ->method('loadContentType')

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FileSizeExtensionTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FileSizeExtensionTest.php
@@ -85,7 +85,7 @@ class FileSizeExtensionTest extends Twig_Test_IntegrationTestCase
      */
     protected function getConfigResolverInterfaceMock()
     {
-        $configResolverInterfaceMock = $this->getMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
+        $configResolverInterfaceMock = $this->createMock(ConfigResolverInterface::class);
         $configResolverInterfaceMock->expects($this->any())
             ->method('getParameter')
             ->with('languages')
@@ -99,7 +99,7 @@ class FileSizeExtensionTest extends Twig_Test_IntegrationTestCase
      */
     protected function getLocaleConverterInterfaceMock()
     {
-        $this->localeConverterInterfaceMock = $this->getMock('eZ\Publish\Core\MVC\Symfony\Locale\LocaleConverterInterface');
+        $this->localeConverterInterfaceMock = $this->createMock(LocaleConverterInterface::class);
         $this->localeConverterInterfaceMock->expects($this->any())
         ->method('convertToPOSIX')
         ->will(
@@ -120,7 +120,7 @@ class FileSizeExtensionTest extends Twig_Test_IntegrationTestCase
     protected function getTranslatorInterfaceMock()
     {
         $that = $this;
-        $this->translatorMock = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $this->translatorMock = $this->createMock(TranslatorInterface::class);
         $this->translatorMock
             ->expects($this->any())->method('trans')->will(
                 $this->returnCallback(

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/RoutingExtensionTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/RoutingExtensionTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests\Twig\Extension;
 
 use eZ\Publish\Core\MVC\Symfony\Routing\Generator\RouteReferenceGenerator;
 use eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\RoutingExtension;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Twig_Test_IntegrationTestCase;
@@ -31,7 +32,7 @@ class RoutingExtensionTest extends Twig_Test_IntegrationTestCase
     protected function getRouteReferenceGenerator()
     {
         $generator = new RouteReferenceGenerator(
-            $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface')
+            $this->createMock(EventDispatcherInterface::class)
         );
         $request = new Request();
         $requestStack = new RequestStack();

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/Renderer/TemplateRendererTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/Renderer/TemplateRendererTest.php
@@ -7,7 +7,10 @@ namespace eZ\Publish\Core\MVC\Symfony\View\Tests\Renderer;
 
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\View\ContentView;
+use Symfony\Component\Templating\EngineInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use eZ\Publish\Core\MVC\Symfony\View\Renderer\TemplateRenderer;
+use eZ\Publish\Core\MVC\Symfony\Event\PreContentViewEvent;
 use PHPUnit\Framework\TestCase;
 
 class TemplateRendererTest extends TestCase
@@ -29,8 +32,8 @@ class TemplateRendererTest extends TestCase
 
     public function setUp()
     {
-        $this->templateEngineMock = $this->getMock('Symfony\Component\Templating\EngineInterface');
-        $this->eventDispatcherMock = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $this->templateEngineMock = $this->createMock(EngineInterface::class);
+        $this->eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
         $this->renderer = new TemplateRenderer(
             $this->templateEngineMock,
             $this->eventDispatcherMock
@@ -47,7 +50,7 @@ class TemplateRendererTest extends TestCase
             ->method('dispatch')
             ->with(
                 MVCEvents::PRE_CONTENT_VIEW,
-                $this->isInstanceOf('\eZ\Publish\Core\MVC\Symfony\Event\PreContentViewEvent')
+                $this->isInstanceOf(PreContentViewEvent::class)
             );
 
         $this->templateEngineMock

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/ViewManagerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/ViewManagerTest.php
@@ -8,13 +8,21 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\Tests;
 
+use eZ\Publish\API\Repository\ContentService as APIContentService;
+use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\View\Manager;
 use eZ\Publish\Core\MVC\Symfony\View\View;
+use eZ\Publish\Core\MVC\Symfony\View\ViewProvider;
+use eZ\Publish\Core\MVC\Symfony\View\Configurator;
+use eZ\Publish\Core\Repository\ContentService;
 use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Templating\EngineInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @group mvc
@@ -56,13 +64,11 @@ class ViewManagerTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->templateEngineMock = $this->getMock('Symfony\\Component\\Templating\\EngineInterface');
-        $this->eventDispatcherMock = $this->getMock('Symfony\\Component\\EventDispatcher\\EventDispatcherInterface');
-        $this->repositoryMock = $this->getMockBuilder('eZ\\Publish\\Core\\Repository\\Repository')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $this->configResolverMock = $this->getMock('eZ\\Publish\\Core\\MVC\\ConfigResolverInterface');
-        $this->viewConfigurator = $this->getMock('eZ\Publish\Core\MVC\Symfony\View\Configurator');
+        $this->templateEngineMock = $this->createMock(EngineInterface::class);
+        $this->eventDispatcherMock = $this->createMock(EventDispatcherInterface::class);
+        $this->repositoryMock = $this->createMock(Repository::class);
+        $this->configResolverMock = $this->createMock(ConfigResolverInterface::class);
+        $this->viewConfigurator = $this->createMock(Configurator::class);
         $this->viewManager = new Manager(
             $this->templateEngineMock,
             $this->eventDispatcherMock,
@@ -76,7 +82,7 @@ class ViewManagerTest extends TestCase
     public function testAddContentViewProvider()
     {
         self::assertSame(array(), $this->viewManager->getAllContentViewProviders());
-        $viewProvider = $this->getMock('eZ\Publish\Core\MVC\Symfony\View\ViewProvider');
+        $viewProvider = $this->createMock(ViewProvider::class);
         $this->viewManager->addContentViewProvider($viewProvider);
         self::assertSame(array($viewProvider), $this->viewManager->getAllContentViewProviders());
     }
@@ -84,7 +90,7 @@ class ViewManagerTest extends TestCase
     public function testAddLocationViewProvider()
     {
         self::assertSame(array(), $this->viewManager->getAllLocationViewProviders());
-        $viewProvider = $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\View\\ViewProvider');
+        $viewProvider = $this->createMock(ViewProvider::class);
         $this->viewManager->addLocationViewProvider($viewProvider);
         self::assertSame(array($viewProvider), $this->viewManager->getAllLocationViewProviders());
     }
@@ -207,7 +213,7 @@ class ViewManagerTest extends TestCase
             ->with('languages')
             ->will($this->returnValue($languages));
 
-        $contentService = $this->getMock('eZ\Publish\API\Repository\ContentService');
+        $contentService = $this->createMock(APIContentService::class);
 
         $contentService->expects($this->any())
             ->method('loadContentByContentInfo')
@@ -249,9 +255,7 @@ class ViewManagerTest extends TestCase
                 )
             );
 
-        $contentService = $this->getMockBuilder('eZ\\Publish\\Core\\Repository\\ContentService')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $contentService = $this->createMock(ContentService::class);
 
         $contentService->expects($this->any())
             ->method('loadContentByContentInfo')
@@ -303,9 +307,7 @@ class ViewManagerTest extends TestCase
                 )
             );
 
-        $contentService = $this->getMockBuilder('eZ\\Publish\\Core\\Repository\\ContentService')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $contentService = $this->createMock(ContentService::class);
 
         $contentService->expects($this->any())
             ->method('loadContentByContentInfo')
@@ -340,18 +342,18 @@ class ViewManagerTest extends TestCase
     private function createContentViewProviderMocks()
     {
         return array(
-            $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\View\\ViewProvider'),
-            $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\View\\ViewProvider'),
-            $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\View\\ViewProvider'),
+            $this->createMock(ViewProvider::class),
+            $this->createMock(ViewProvider::class),
+            $this->createMock(ViewProvider::class),
         );
     }
 
     private function createLocationViewProviderMocks()
     {
         return array(
-            $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\View\\ViewProvider'),
-            $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\View\\ViewProvider'),
-            $this->getMock('eZ\\Publish\\Core\\MVC\\Symfony\\View\\ViewProvider'),
+            $this->createMock(ViewProvider::class),
+            $this->createMock(ViewProvider::class),
+            $this->createMock(ViewProvider::class),
         );
     }
 }

--- a/eZ/Publish/Core/Pagination/Tests/ContentSearchHitAdapterTest.php
+++ b/eZ/Publish/Core/Pagination/Tests/ContentSearchHitAdapterTest.php
@@ -8,8 +8,11 @@
  */
 namespace eZ\Publish\Core\Pagination\Tests;
 
+use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\Core\Pagination\Pagerfanta\ContentSearchHitAdapter;
@@ -25,7 +28,7 @@ class ContentSearchHitAdapterTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->searchService = $this->getMock('eZ\Publish\API\Repository\SearchService');
+        $this->searchService = $this->createMock(SearchService::class);
     }
 
     /**
@@ -45,9 +48,9 @@ class ContentSearchHitAdapterTest extends TestCase
     {
         $nbResults = 123;
         $query = new Query();
-        $query->query = $this->getMock('eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface');
+        $query->query = $this->createMock(CriterionInterface::class);
         $query->sortClauses = $this
-            ->getMockBuilder('eZ\Publish\API\Repository\Values\Content\Query\SortClause')
+            ->getMockBuilder(SortClause::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
@@ -75,9 +78,9 @@ class ContentSearchHitAdapterTest extends TestCase
         $nbResults = 123;
 
         $query = new Query();
-        $query->query = $this->getMock('eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface');
+        $query->query = $this->createMock(CriterionInterface::class);
         $query->sortClauses = $this
-            ->getMockBuilder('eZ\Publish\API\Repository\Values\Content\Query\SortClause')
+            ->getMockBuilder(SortClause::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
@@ -90,7 +93,7 @@ class ContentSearchHitAdapterTest extends TestCase
 
         $hits = array();
         for ($i = 0; $i < $limit; ++$i) {
-            $content = $this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\Content\Content');
+            $content = $this->getMockForAbstractClass(APIContent::class);
             $hits[] = new SearchHit(array('valueObject' => $content));
         }
         $finalResult = $this->getExpectedFinalResultFromHits($hits);

--- a/eZ/Publish/Core/Pagination/Tests/LocationSearchHitAdapterTest.php
+++ b/eZ/Publish/Core/Pagination/Tests/LocationSearchHitAdapterTest.php
@@ -8,8 +8,11 @@
  */
 namespace eZ\Publish\Core\Pagination\Tests;
 
+use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\Core\Pagination\Pagerfanta\LocationSearchHitAdapter;
@@ -25,7 +28,7 @@ class LocationSearchHitAdapterTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->searchService = $this->getMock('eZ\Publish\API\Repository\SearchService');
+        $this->searchService = $this->createMock(SearchService::class);
     }
 
     /**
@@ -45,9 +48,9 @@ class LocationSearchHitAdapterTest extends TestCase
     {
         $nbResults = 123;
         $query = new LocationQuery();
-        $query->filter = $this->getMock('eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface');
+        $query->filter = $this->createMock(CriterionInterface::class);
         $query->sortClauses = $this
-            ->getMockBuilder('eZ\Publish\API\Repository\Values\Content\Query\SortClause')
+            ->getMockBuilder(SortClause::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
@@ -75,9 +78,9 @@ class LocationSearchHitAdapterTest extends TestCase
         $nbResults = 123;
 
         $query = new LocationQuery();
-        $query->filter = $this->getMock('eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface');
+        $query->filter = $this->createMock(CriterionInterface::class);
         $query->sortClauses = $this
-            ->getMockBuilder('eZ\Publish\API\Repository\Values\Content\Query\SortClause')
+            ->getMockBuilder(SortClause::class)
             ->disableOriginalConstructor()
             ->getMockForAbstractClass();
 
@@ -90,7 +93,7 @@ class LocationSearchHitAdapterTest extends TestCase
 
         $hits = array();
         for ($i = 0; $i < $limit; ++$i) {
-            $location = $this->getMockForAbstractClass('eZ\Publish\API\Repository\Values\Content\Location');
+            $location = $this->getMockForAbstractClass(APILocation::class);
             $hits[] = new SearchHit(array('valueObject' => $location));
         }
         $finalResult = $this->getExpectedFinalResultFromHits($hits);

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
@@ -18,6 +18,9 @@ use eZ\Publish\SPI\Persistence\Content\CreateStruct;
 use eZ\Publish\SPI\Persistence\Content\UpdateStruct;
 use eZ\Publish\SPI\Persistence\Content\MetadataUpdateStruct;
 use eZ\Publish\SPI\Persistence\Content\Relation\CreateStruct as RelationCreateStruct;
+use eZ\Publish\SPI\Persistence\Content\Handler as SPIContentHandler;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as SPILocationHandler;
+use Stash\Interfaces\ItemInterface;
 
 /**
  * Test case for Persistence\Cache\ContentHandler.
@@ -63,7 +66,7 @@ class ContentHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Handler');
+        $innerHandler = $this->createMock(SPIContentHandler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentHandler')
@@ -93,7 +96,7 @@ class ContentHandlerTest extends HandlerTest
     public function testLoadCacheIsMiss()
     {
         $this->loggerMock->expects($this->once())->method('logCall');
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->createMock(ItemInterface::class);
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -110,7 +113,7 @@ class ContentHandlerTest extends HandlerTest
             ->method('isMiss')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Handler');
+        $innerHandlerMock = $this->createMock(SPIContentHandler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentHandler')
@@ -139,7 +142,7 @@ class ContentHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content'))
+            ->with($this->isInstanceOf(Content::class))
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock
@@ -157,7 +160,7 @@ class ContentHandlerTest extends HandlerTest
     public function testLoadHasCache()
     {
         $this->loggerMock->expects($this->never())->method($this->anything());
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->createMock(ItemInterface::class);
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -206,7 +209,7 @@ class ContentHandlerTest extends HandlerTest
     public function testLoadContentInfoCacheIsMiss()
     {
         $this->loggerMock->expects($this->once())->method('logCall');
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->createMock(ItemInterface::class);
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -223,7 +226,7 @@ class ContentHandlerTest extends HandlerTest
             ->method('isMiss')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Handler');
+        $innerHandlerMock = $this->createMock(SPIContentHandler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentHandler')
@@ -242,7 +245,7 @@ class ContentHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\ContentInfo'))
+            ->with($this->isInstanceOf(ContentInfo::class))
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock
@@ -260,7 +263,7 @@ class ContentHandlerTest extends HandlerTest
     public function testLoadContentInfoHasCache()
     {
         $this->loggerMock->expects($this->never())->method($this->anything());
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->createMock(ItemInterface::class);
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -300,7 +303,7 @@ class ContentHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Handler');
+        $innerHandlerMock = $this->createMock(SPIContentHandler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentHandler')
@@ -329,7 +332,7 @@ class ContentHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Handler');
+        $innerHandlerMock = $this->createMock(SPIContentHandler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentHandler')
@@ -364,7 +367,7 @@ class ContentHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Handler');
+        $innerHandlerMock = $this->createMock(SPIContentHandler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentHandler')
@@ -373,7 +376,7 @@ class ContentHandlerTest extends HandlerTest
         $innerHandlerMock
             ->expects($this->once())
             ->method('updateMetadata')
-            ->with(2, $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\MetadataUpdateStruct'))
+            ->with(2, $this->isInstanceOf(MetadataUpdateStruct::class))
             ->willReturn(new ContentInfo(array('id' => 2, 'currentVersionNo' => 3, 'remoteId' => 'o34')));
 
         $this->cacheMock
@@ -405,7 +408,7 @@ class ContentHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Handler');
+        $innerHandlerMock = $this->createMock(SPIContentHandler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentHandler')
@@ -414,7 +417,7 @@ class ContentHandlerTest extends HandlerTest
         $innerHandlerMock
             ->expects($this->once())
             ->method('updateContent')
-            ->with(2, 1, $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\UpdateStruct'))
+            ->with(2, 1, $this->isInstanceOf(UpdateStruct::class))
             ->will(
                 $this->returnValue(
                     new Content(
@@ -448,7 +451,7 @@ class ContentHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerLocationHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler');
+        $innerLocationHandlerMock = $this->createMock(SPILocationHandler::class);
         $this->persistenceHandlerMock
             ->expects($this->exactly(1))
             ->method('locationHandler')
@@ -460,7 +463,7 @@ class ContentHandlerTest extends HandlerTest
             ->with(2)
             ->willReturn([new Content\Location(array('id' => 58))]);
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Handler');
+        $innerHandlerMock = $this->createMock(SPIContentHandler::class);
         $this->persistenceHandlerMock
             ->expects($this->exactly(2))
             ->method('contentHandler')
@@ -531,7 +534,7 @@ class ContentHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Handler');
+        $innerHandlerMock = $this->createMock(SPIContentHandler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentHandler')
@@ -578,7 +581,7 @@ class ContentHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Handler');
+        $innerHandlerMock = $this->createMock(SPIContentHandler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentHandler')
@@ -587,7 +590,7 @@ class ContentHandlerTest extends HandlerTest
         $innerHandlerMock
             ->expects($this->once())
             ->method('publish')
-            ->with(2, 1, $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\MetadataUpdateStruct'))
+            ->with(2, 1, $this->isInstanceOf(MetadataUpdateStruct::class))
             ->will(
                 $this->returnValue(
                     new Content(
@@ -622,7 +625,7 @@ class ContentHandlerTest extends HandlerTest
             ->with('location', 'subtree')
             ->will($this->returnValue(true));
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->createMock(ItemInterface::class);
         $this->cacheMock
             ->expects($this->at(3))
             ->method('getItem')
@@ -632,7 +635,7 @@ class ContentHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content'))
+            ->with($this->isInstanceOf(Content::class))
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock
@@ -644,7 +647,7 @@ class ContentHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method('get');
 
-        $cacheItemMock2 = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock2 = $this->createMock(ItemInterface::class);
         $this->cacheMock
             ->expects($this->at(4))
             ->method('getItem')
@@ -654,7 +657,7 @@ class ContentHandlerTest extends HandlerTest
         $cacheItemMock2
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\ContentInfo'))
+            ->with($this->isInstanceOf(ContentInfo::class))
             ->will($this->returnValue($cacheItemMock2));
 
         $cacheItemMock2

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentLanguageHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentLanguageHandlerTest.php
@@ -10,6 +10,8 @@ namespace eZ\Publish\Core\Persistence\Cache\Tests;
 
 use eZ\Publish\SPI\Persistence\Content\Language as SPILanguage;
 use eZ\Publish\SPI\Persistence\Content\Language\CreateStruct as SPILanguageCreateStruct;
+use eZ\Publish\SPI\Persistence\Content\Language\Handler;
+use Stash\Interfaces\ItemInterface;
 
 /**
  * Test case for Persistence\Cache\ContentLanguageHandler.
@@ -22,14 +24,14 @@ class ContentLanguageHandlerTest extends HandlerTest
     public function testCreate()
     {
         $this->loggerMock->expects($this->once())->method('logCall');
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->createMock(ItemInterface::class);
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
             ->with('language', 2)
             ->will($this->returnValue($cacheItemMock));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Language\\Handler');
+        $innerHandlerMock = $this->createMock(Handler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentLanguageHandler')
@@ -38,7 +40,7 @@ class ContentLanguageHandlerTest extends HandlerTest
         $innerHandlerMock
             ->expects($this->once())
             ->method('create')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Language\\CreateStruct'))
+            ->with($this->isInstanceOf(SPILanguageCreateStruct::class))
             ->will(
                 $this->returnValue(
                     new SPILanguage(
@@ -50,7 +52,7 @@ class ContentLanguageHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Language'))
+            ->with($this->isInstanceOf(SPILanguage::class))
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock
@@ -78,7 +80,7 @@ class ContentLanguageHandlerTest extends HandlerTest
             ->with('language', 2)
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Language\\Handler');
+        $innerHandlerMock = $this->createMock(Handler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentLanguageHandler')
@@ -102,7 +104,7 @@ class ContentLanguageHandlerTest extends HandlerTest
     public function testLoadCacheIsMiss()
     {
         $this->loggerMock->expects($this->once())->method('logCall');
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->createMock(ItemInterface::class);
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -119,7 +121,7 @@ class ContentLanguageHandlerTest extends HandlerTest
             ->method('isMiss')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Language\\Handler');
+        $innerHandlerMock = $this->createMock(Handler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentLanguageHandler')
@@ -140,7 +142,7 @@ class ContentLanguageHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Language'))
+            ->with($this->isInstanceOf(SPILanguage::class))
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock
@@ -158,7 +160,7 @@ class ContentLanguageHandlerTest extends HandlerTest
     public function testLoadHasCache()
     {
         $this->loggerMock->expects($this->never())->method($this->anything());
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->createMock(ItemInterface::class);
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -203,7 +205,7 @@ class ContentLanguageHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Language\\Handler');
+        $innerHandler = $this->createMock(Handler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentLanguageHandler')
@@ -228,7 +230,7 @@ class ContentLanguageHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Language\\Handler');
+        $innerHandler = $this->createMock(Handler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentLanguageHandler')
@@ -262,7 +264,7 @@ class ContentLanguageHandlerTest extends HandlerTest
             ->with('language', 2)
             ->will($this->returnValue(true));
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Language\\Handler');
+        $innerHandler = $this->createMock(Handler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentLanguageHandler')
@@ -271,7 +273,7 @@ class ContentLanguageHandlerTest extends HandlerTest
         $innerHandler
             ->expects($this->once())
             ->method('update')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Language'))
+            ->with($this->isInstanceOf(SPILanguage::class))
             ->will(
                 $this->returnValue(
                     new SPILanguage(

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentTypeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentTypeHandlerTest.php
@@ -15,26 +15,38 @@ use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition as SPITypeFieldDefin
 use eZ\Publish\SPI\Persistence\Content\Type\Group as SPITypeGroup;
 use eZ\Publish\SPI\Persistence\Content\Type\Group\CreateStruct as SPITypeGroupCreateStruct;
 use eZ\Publish\SPI\Persistence\Content\Type\Group\UpdateStruct as SPITypeGroupUpdateStruct;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as SPIContentTypeHandler;
+use Stash\Interfaces\ItemInterface;
 
 /**
  * Test case for Persistence\Cache\ContentTypeHandler.
  */
 class ContentTypeHandlerTest extends HandlerTest
 {
+    protected function getCacheItemMock()
+    {
+        return $this->createMock(ItemInterface::class);
+    }
+
+    protected function getContentTypeHandlerMock()
+    {
+        return $this->createMock(SPIContentTypeHandler::class);
+    }
+
     /**
      * @covers \eZ\Publish\Core\Persistence\Cache\ContentTypeHandler::createGroup
      */
     public function testCreateGroup()
     {
         $this->loggerMock->expects($this->once())->method('logCall');
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
             ->with('contentTypeGroup', 55)
             ->will($this->returnValue($cacheItemMock));
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandler = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -43,13 +55,13 @@ class ContentTypeHandlerTest extends HandlerTest
         $innerHandler
             ->expects($this->once())
             ->method('createGroup')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Group\\CreateStruct'))
+            ->with($this->isInstanceOf(SPITypeGroupCreateStruct::class))
             ->will($this->returnValue(new SPITypeGroup(array('id' => 55))));
 
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Group'))
+            ->with($this->isInstanceOf(SPITypeGroup::class))
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock
@@ -71,14 +83,14 @@ class ContentTypeHandlerTest extends HandlerTest
     public function testUpdateGroup()
     {
         $this->loggerMock->expects($this->once())->method('logCall');
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
             ->with('contentTypeGroup', 55)
             ->will($this->returnValue($cacheItemMock));
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandler = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -87,13 +99,13 @@ class ContentTypeHandlerTest extends HandlerTest
         $innerHandler
             ->expects($this->once())
             ->method('updateGroup')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Group\\UpdateStruct'))
+            ->with($this->isInstanceOf(SPITypeGroupUpdateStruct::class))
             ->will($this->returnValue(new SPITypeGroup()));
 
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Group'))
+            ->with($this->isInstanceOf(SPITypeGroup::class))
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock
@@ -121,7 +133,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->with('contentTypeGroup', 55)
             ->will($this->returnValue(true));
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandler = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -143,7 +155,7 @@ class ContentTypeHandlerTest extends HandlerTest
     public function testLoadGroupIsMiss()
     {
         $this->loggerMock->expects($this->once())->method('logCall');
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -160,7 +172,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->method('isMiss')
             ->will($this->returnValue(true));
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandler = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -175,7 +187,7 @@ class ContentTypeHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Group'))
+            ->with($this->isInstanceOf(SPITypeGroup::class))
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock
@@ -193,7 +205,7 @@ class ContentTypeHandlerTest extends HandlerTest
     public function testLoadGroupHasCache()
     {
         $this->loggerMock->expects($this->never())->method($this->anything());
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -236,7 +248,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandler = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -262,7 +274,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandler = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -288,7 +300,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandler = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -314,7 +326,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandlerMock = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -342,7 +354,7 @@ class ContentTypeHandlerTest extends HandlerTest
     public function testLoadCacheIsMiss()
     {
         $this->loggerMock->expects($this->once())->method('logCall');
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -359,7 +371,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->method('isMiss')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandlerMock = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -380,7 +392,7 @@ class ContentTypeHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type'))
+            ->with($this->isInstanceOf(SPIType::class))
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock
@@ -398,7 +410,7 @@ class ContentTypeHandlerTest extends HandlerTest
     public function testLoadHasCache()
     {
         $this->loggerMock->expects($this->never())->method($this->anything());
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -439,7 +451,7 @@ class ContentTypeHandlerTest extends HandlerTest
     public function testLoadByIdentifierIsMiss()
     {
         $this->loggerMock->expects($this->once())->method('logCall');
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('getItem')
@@ -456,7 +468,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->method('isMiss')
             ->will($this->returnValue(true));
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandler = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -479,7 +491,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->method('save')
             ->with();
 
-        $cacheItemMock2 = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock2 = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(1))
             ->method('getItem')
@@ -497,7 +509,7 @@ class ContentTypeHandlerTest extends HandlerTest
         $cacheItemMock2
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type'))
+            ->with($this->isInstanceOf(SPIType::class))
             ->will($this->returnValue($cacheItemMock2));
 
         $cacheItemMock2
@@ -515,7 +527,7 @@ class ContentTypeHandlerTest extends HandlerTest
     public function testLoadByIdentifierHasCache()
     {
         $this->loggerMock->expects($this->never())->method($this->anything());
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('getItem')
@@ -541,7 +553,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->method('set');
 
         // the code reuses load():
-        $cacheItemMock2 = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock2 = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(1))
             ->method('getItem')
@@ -582,7 +594,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandler = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -604,21 +616,21 @@ class ContentTypeHandlerTest extends HandlerTest
     public function testCreate()
     {
         $this->loggerMock->expects($this->once())->method('logCall');
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('getItem')
             ->with('contentType', 55)
             ->will($this->returnValue($cacheItemMock));
 
-        $cacheItemMock2 = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock2 = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(1))
             ->method('getItem')
             ->with('contentType', 'identifier', 'forum')
             ->will($this->returnValue($cacheItemMock2));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandlerMock = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -627,7 +639,7 @@ class ContentTypeHandlerTest extends HandlerTest
         $innerHandlerMock
             ->expects($this->once())
             ->method('create')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\CreateStruct'))
+            ->with($this->isInstanceOf(SPITypeCreateStruct::class))
             ->will(
                 $this->returnValue(
                     new SPIType(
@@ -639,7 +651,7 @@ class ContentTypeHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type'))
+            ->with($this->isInstanceOf(SPIType::class))
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock
@@ -680,7 +692,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandlerMock = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -689,7 +701,7 @@ class ContentTypeHandlerTest extends HandlerTest
         $innerHandlerMock
             ->expects($this->once())
             ->method('create')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\CreateStruct'))
+            ->with($this->isInstanceOf(SPITypeCreateStruct::class))
             ->will(
                 $this->returnValue(
                     new SPIType(
@@ -708,7 +720,7 @@ class ContentTypeHandlerTest extends HandlerTest
     public function testUpdate()
     {
         $this->loggerMock->expects($this->once())->method('logCall');
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('getItem')
@@ -727,7 +739,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->with('searchableFieldMap')
             ->will($this->returnValue(true));
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandler = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -739,7 +751,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->with(
                 55,
                 SPIType::STATUS_DEFINED,
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\UpdateStruct')
+                $this->isInstanceOf(SPITypeUpdateStruct::class)
             )
             ->will(
                 $this->returnValue(
@@ -752,7 +764,7 @@ class ContentTypeHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type'))
+            ->with($this->isInstanceOf(SPIType::class))
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock
@@ -764,7 +776,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method('get');
 
-        $cacheItemMock2 = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock2 = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(3))
             ->method('getItem')
@@ -800,7 +812,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandler = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -812,7 +824,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->with(
                 55,
                 SPIType::STATUS_DRAFT,
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\UpdateStruct')
+                $this->isInstanceOf(SPITypeUpdateStruct::class)
             )
             ->will(
                 $this->returnValue(
@@ -844,7 +856,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->with('contentType', 'identifier')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandlerMock = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -872,7 +884,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandlerMock = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -900,7 +912,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandler = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -926,7 +938,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandler = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -954,7 +966,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->with('contentType', 44)
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandlerMock = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -982,7 +994,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandlerMock = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -1012,7 +1024,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->with('contentType', 44)
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandlerMock = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -1040,7 +1052,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandlerMock = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -1068,7 +1080,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandler = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -1102,7 +1114,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->with('searchableFieldMap')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandlerMock = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -1114,7 +1126,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->with(
                 44,
                 SPIType::STATUS_DEFINED,
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\FieldDefinition')
+                $this->isInstanceOf(SPITypeFieldDefinition::class)
             )
             ->will(
                 $this->returnValue(true)
@@ -1134,7 +1146,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandlerMock = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -1146,7 +1158,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->with(
                 44,
                 SPIType::STATUS_DRAFT,
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\FieldDefinition')
+                $this->isInstanceOf(SPITypeFieldDefinition::class)
             )
             ->will(
                 $this->returnValue(true)
@@ -1174,7 +1186,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->with('searchableFieldMap')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandlerMock = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -1206,7 +1218,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandlerMock = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -1246,7 +1258,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->with('searchableFieldMap')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandlerMock = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -1258,7 +1270,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->with(
                 44,
                 SPIType::STATUS_DEFINED,
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\FieldDefinition')
+                $this->isInstanceOf(SPITypeFieldDefinition::class)
             )
             ->will(
                 $this->returnValue(true)
@@ -1278,7 +1290,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandlerMock = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -1290,7 +1302,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->with(
                 44,
                 SPIType::STATUS_DRAFT,
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\FieldDefinition')
+                $this->isInstanceOf(SPITypeFieldDefinition::class)
             )
             ->will(
                 $this->returnValue(true)
@@ -1330,7 +1342,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->with('content')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandlerMock = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')
@@ -1358,7 +1370,7 @@ class ContentTypeHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler');
+        $innerHandler = $this->getContentTypeHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('contentTypeHandler')

--- a/eZ/Publish/Core/Persistence/Cache/Tests/HandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/HandlerTest.php
@@ -19,6 +19,9 @@ use eZ\Publish\Core\Persistence\Cache\TransactionHandler as CacheTransactionHand
 use eZ\Publish\Core\Persistence\Cache\TrashHandler as CacheTrashHandler;
 use eZ\Publish\Core\Persistence\Cache\UrlAliasHandler as CacheUrlAliasHandler;
 use eZ\Publish\Core\Persistence\Cache\ObjectStateHandler as CacheObjectStateHandler;
+use eZ\Publish\SPI\Persistence\Handler;
+use eZ\Publish\Core\Persistence\Cache\CacheServiceDecorator;
+use eZ\Publish\Core\Persistence\Cache\PersistenceLogger;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -63,17 +66,9 @@ abstract class HandlerTest extends TestCase
     {
         parent::setUp();
 
-        $this->persistenceHandlerMock = $this->getMock('eZ\Publish\SPI\Persistence\Handler');
-
-        $this->cacheMock = $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Cache\\CacheServiceDecorator',
-            array(),
-            array(),
-            '',
-            false
-        );
-
-        $this->loggerMock = $this->getMock('eZ\\Publish\\Core\\Persistence\\Cache\\PersistenceLogger');
+        $this->persistenceHandlerMock = $this->createMock(Handler::class);
+        $this->cacheMock = $this->createMock(CacheServiceDecorator::class);
+        $this->loggerMock = $this->createMock(PersistenceLogger::class);
 
         $this->persistenceCacheHandler = new CacheHandler(
             $this->persistenceHandlerMock,

--- a/eZ/Publish/Core/Persistence/Cache/Tests/LocationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/LocationHandlerTest.php
@@ -8,22 +8,36 @@
  */
 namespace eZ\Publish\Core\Persistence\Cache\Tests;
 
+use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
+use eZ\Publish\Core\Persistence\Cache\LocationHandler;
 use eZ\Publish\SPI\Persistence\Content\Location;
 use eZ\Publish\SPI\Persistence\Content\Location\CreateStruct;
 use eZ\Publish\SPI\Persistence\Content\Location\UpdateStruct;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as SPILocationHandler;
+use Stash\Interfaces\ItemInterface;
 
 /**
  * Test case for Persistence\Cache\LocationHandler.
  */
 class LocationHandlerTest extends HandlerTest
 {
+    protected function getCacheItemMock()
+    {
+        return $this->createMock(ItemInterface::class);
+    }
+
+    protected function getSPILocationHandlerMock()
+    {
+        return $this->createMock(SPILocationHandler::class);
+    }
+
     /**
      * @covers \eZ\Publish\Core\Persistence\Cache\LocationHandler::load
      */
     public function testLoadCacheIsMiss()
     {
         $this->loggerMock->expects($this->once())->method('logCall');
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -40,7 +54,7 @@ class LocationHandlerTest extends HandlerTest
             ->method('isMiss')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler');
+        $innerHandlerMock = $this->getSPILocationHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('locationHandler')
@@ -55,7 +69,7 @@ class LocationHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Location'))
+            ->with($this->isInstanceOf(Location::class))
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock
@@ -73,7 +87,7 @@ class LocationHandlerTest extends HandlerTest
     public function testLoadHasCache()
     {
         $this->loggerMock->expects($this->never())->method($this->anything());
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -108,7 +122,7 @@ class LocationHandlerTest extends HandlerTest
     public function testLoadLocationsByContentIsMiss()
     {
         $this->loggerMock->expects($this->once())->method('logCall');
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -125,7 +139,7 @@ class LocationHandlerTest extends HandlerTest
             ->method('isMiss')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler');
+        $innerHandlerMock = $this->getSPILocationHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('locationHandler')
@@ -163,7 +177,7 @@ class LocationHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('getItem')
@@ -185,7 +199,7 @@ class LocationHandlerTest extends HandlerTest
             ->method('set');
 
         // inline call to load()
-        $cacheItemMock2 = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock2 = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(1))
             ->method('getItem')
@@ -216,7 +230,7 @@ class LocationHandlerTest extends HandlerTest
     public function testLoadParentLocationsForDraftContentIsMiss()
     {
         $this->loggerMock->expects($this->once())->method('logCall');
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -233,7 +247,7 @@ class LocationHandlerTest extends HandlerTest
             ->method('isMiss')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler');
+        $innerHandlerMock = $this->getSPILocationHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('locationHandler')
@@ -271,7 +285,7 @@ class LocationHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('getItem')
@@ -293,7 +307,7 @@ class LocationHandlerTest extends HandlerTest
             ->method('set');
 
         // inline call to load()
-        $cacheItemMock2 = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock2 = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(1))
             ->method('getItem')
@@ -324,7 +338,7 @@ class LocationHandlerTest extends HandlerTest
     public function testLoadLocationsByContentWithRootIsMiss()
     {
         $this->loggerMock->expects($this->once())->method('logCall');
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -341,7 +355,7 @@ class LocationHandlerTest extends HandlerTest
             ->method('isMiss')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler');
+        $innerHandlerMock = $this->getSPILocationHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('locationHandler')
@@ -379,7 +393,7 @@ class LocationHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('getItem')
@@ -401,7 +415,7 @@ class LocationHandlerTest extends HandlerTest
             ->method('set');
 
         // inline call to load()
-        $cacheItemMock2 = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock2 = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(1))
             ->method('getItem')
@@ -436,7 +450,7 @@ class LocationHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler');
+        $innerHandler = $this->getSPILocationHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('locationHandler')
@@ -462,7 +476,7 @@ class LocationHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler');
+        $innerHandler = $this->getSPILocationHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('locationHandler')
@@ -502,7 +516,7 @@ class LocationHandlerTest extends HandlerTest
             ->with('content')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler');
+        $innerHandlerMock = $this->getSPILocationHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('locationHandler')
@@ -528,7 +542,7 @@ class LocationHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler');
+        $innerHandler = $this->getSPILocationHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('locationHandler')
@@ -556,7 +570,7 @@ class LocationHandlerTest extends HandlerTest
             ->with('location')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler');
+        $innerHandlerMock = $this->getSPILocationHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('locationHandler')
@@ -584,7 +598,7 @@ class LocationHandlerTest extends HandlerTest
             ->with('location')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler');
+        $innerHandlerMock = $this->getSPILocationHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('locationHandler')
@@ -660,7 +674,7 @@ class LocationHandlerTest extends HandlerTest
             ->with('content', 'info', $this->isType('integer'))
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler');
+        $innerHandlerMock = $this->getSPILocationHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('locationHandler')
@@ -672,7 +686,7 @@ class LocationHandlerTest extends HandlerTest
             ->with(33, 66)
             ->will($this->returnValue(true));
 
-        $locationMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Location');
+        $locationMock = $this->createMock(APILocation::class);
         $locationMock
             ->expects($this->any())
             ->method('__get')
@@ -681,7 +695,7 @@ class LocationHandlerTest extends HandlerTest
 
         /** @var \eZ\Publish\SPI\Persistence\Content\Location\Handler|\PHPUnit_Framework_MockObject_MockObject $handler */
         $handler = $this
-            ->getMockBuilder('eZ\\Publish\\Core\\Persistence\\Cache\\LocationHandler')
+            ->getMockBuilder(LocationHandler::class)
             ->setMethods(['load'])
             ->setConstructorArgs(
                 [
@@ -706,7 +720,7 @@ class LocationHandlerTest extends HandlerTest
     public function testUpdate()
     {
         $this->loggerMock->expects($this->once())->method('logCall');
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('clear')
@@ -717,7 +731,7 @@ class LocationHandlerTest extends HandlerTest
             ->method('clear')
             ->with('location', 'subtree');
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler');
+        $innerHandler = $this->getSPILocationHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('locationHandler')
@@ -726,7 +740,7 @@ class LocationHandlerTest extends HandlerTest
         $innerHandler
             ->expects($this->once())
             ->method('update')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\UpdateStruct'), 33)
+            ->with($this->isInstanceOf(UpdateStruct::class), 33)
             ->will($this->returnValue(new Location(array('id' => 33))));
 
         $cacheItemMock
@@ -743,14 +757,14 @@ class LocationHandlerTest extends HandlerTest
     public function testCreate()
     {
         $this->loggerMock->expects($this->once())->method('logCall');
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
             ->with('location', 33)
             ->will($this->returnValue($cacheItemMock));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler');
+        $innerHandlerMock = $this->getSPILocationHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('locationHandler')
@@ -759,13 +773,13 @@ class LocationHandlerTest extends HandlerTest
         $innerHandlerMock
             ->expects($this->once())
             ->method('create')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\CreateStruct'))
+            ->with($this->isInstanceOf(CreateStruct::class))
             ->will($this->returnValue(new Location(array('id' => 33, 'contentId' => 2))));
 
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Location'))
+            ->with($this->isInstanceOf(Location::class))
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock
@@ -841,7 +855,7 @@ class LocationHandlerTest extends HandlerTest
             ->with('user', 'role', 'assignments', 'byGroup')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler');
+        $innerHandlerMock = $this->getSPILocationHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('locationHandler')
@@ -868,7 +882,7 @@ class LocationHandlerTest extends HandlerTest
             ->method('clear')
             ->with('content');
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler');
+        $innerHandler = $this->getSPILocationHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('locationHandler')
@@ -903,7 +917,7 @@ class LocationHandlerTest extends HandlerTest
             ->with('content', 'info', 30)
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler');
+        $innerHandlerMock = $this->getSPILocationHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('locationHandler')

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ObjectStateHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ObjectStateHandlerTest.php
@@ -9,14 +9,26 @@
 namespace eZ\Publish\Core\Persistence\Cache\Tests;
 
 use eZ\Publish\SPI\Persistence\Content\ObjectState as SPIObjectState;
+use eZ\Publish\SPI\Persistence\Content\ObjectState\Handler as SPIObjectStateHandler;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\Group as SPIObjectStateGroup;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\InputStruct as SPIInputStruct;
+use Stash\Interfaces\ItemInterface;
 
 /**
  * Test case for Persistence\Cache\ObjectStateHandler.
  */
 class ObjectStateHandlerTest extends HandlerTest
 {
+    protected function getCacheItemMock()
+    {
+        return $this->createMock(ItemInterface::class);
+    }
+
+    protected function getSPIObjectStateHandler()
+    {
+        return $this->createMock(SPIObjectStateHandler::class);
+    }
+
     /**
      * @covers \eZ\Publish\Core\Persistence\Cache\ObjectStateHandler::createGroup
      */
@@ -34,7 +46,7 @@ class ObjectStateHandlerTest extends HandlerTest
         );
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Handler');
+        $innerHandler = $this->getSPIObjectStateHandler();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('objectStateHandler')
@@ -54,7 +66,7 @@ class ObjectStateHandlerTest extends HandlerTest
             ->with('objectstategroup', 'all')
             ->will($this->returnValue(null));
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -64,7 +76,7 @@ class ObjectStateHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Group'))
+            ->with($this->isInstanceOf(SPIObjectStateGroup::class))
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock
@@ -90,7 +102,7 @@ class ObjectStateHandlerTest extends HandlerTest
             )
         );
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -107,7 +119,7 @@ class ObjectStateHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Group'))
+            ->with($this->isInstanceOf(SPIObjectStateGroup::class))
             ->will($this->returnValue($cacheItemMock));
         $cacheItemMock
             ->expects($this->once())
@@ -116,7 +128,7 @@ class ObjectStateHandlerTest extends HandlerTest
 
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Handler');
+        $innerHandlerMock = $this->getSPIObjectStateHandler();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('objectStateHandler')
@@ -147,7 +159,7 @@ class ObjectStateHandlerTest extends HandlerTest
             )
         );
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -178,7 +190,7 @@ class ObjectStateHandlerTest extends HandlerTest
 
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Handler');
+        $innerHandlerMock = $this->getSPIObjectStateHandler();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('objectStateHandler')
@@ -218,7 +230,7 @@ class ObjectStateHandlerTest extends HandlerTest
     {
         $testGroups = $this->generateObjectGroupsArray();
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('getItem')
@@ -235,7 +247,7 @@ class ObjectStateHandlerTest extends HandlerTest
 
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Handler');
+        $innerHandlerMock = $this->getSPIObjectStateHandler();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('objectStateHandler')
@@ -246,6 +258,32 @@ class ObjectStateHandlerTest extends HandlerTest
             ->method('loadAllGroups')
             ->with(0, -1)
             ->will($this->returnValue($testGroups));
+
+//        foreach ($testGroups as $group) {
+//            $this->cacheMock
+//                ->expects($this->at($group->id))
+//                ->method('getItem')
+//                ->with('objectstategroup', $group->id)
+//                ->will(
+//                    $this->returnCallback(
+//                        function ($cachekey, $i) use ($group) {
+//                            $cacheItemMock = $this->getCacheItemMock();
+//                            $cacheItemMock
+//                                ->expects($this->once())
+//                                ->method('set')
+//                                ->with($group)
+//                                ->will($this->returnValue($cacheItemMock));
+//
+//                            $cacheItemMock
+//                                ->expects($this->once())
+//                                ->method('save')
+//                                ->with();
+//
+//                            return $cacheItemMock;
+//                        }
+//                    )
+//                );
+//        }
 
         $cacheItemMock
             ->expects($this->once())
@@ -272,7 +310,7 @@ class ObjectStateHandlerTest extends HandlerTest
     {
         $testGroups = $this->generateObjectGroupsArray($offset, $limit);
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('getItem')
@@ -339,7 +377,7 @@ class ObjectStateHandlerTest extends HandlerTest
             ),
         );
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('getItem')
@@ -356,7 +394,7 @@ class ObjectStateHandlerTest extends HandlerTest
 
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Handler');
+        $innerHandlerMock = $this->getSPIObjectStateHandler();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('objectStateHandler')
@@ -413,7 +451,7 @@ class ObjectStateHandlerTest extends HandlerTest
             ),
         );
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('getItem')
@@ -451,7 +489,7 @@ class ObjectStateHandlerTest extends HandlerTest
 
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Handler');
+        $innerHandlerMock = $this->getSPIObjectStateHandler();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('objectStateHandler')
@@ -463,7 +501,7 @@ class ObjectStateHandlerTest extends HandlerTest
             ->with(1, $inputStruct)
             ->will($this->returnValue($expectedGroup));
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('clear')
@@ -481,7 +519,7 @@ class ObjectStateHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Handler');
+        $innerHandlerMock = $this->getSPIObjectStateHandler();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('objectStateHandler')
@@ -492,7 +530,7 @@ class ObjectStateHandlerTest extends HandlerTest
             ->method('deleteGroup')
             ->with(1);
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('clear')
@@ -529,7 +567,7 @@ class ObjectStateHandlerTest extends HandlerTest
 
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Handler');
+        $innerHandlerMock = $this->getSPIObjectStateHandler();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('objectStateHandler')
@@ -541,7 +579,7 @@ class ObjectStateHandlerTest extends HandlerTest
             ->with(1, $inputStruct)
             ->will($this->returnValue($expectedState));
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('clear')
@@ -566,7 +604,7 @@ class ObjectStateHandlerTest extends HandlerTest
             )
         );
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -583,7 +621,7 @@ class ObjectStateHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState'))
+            ->with($this->isInstanceOf(SPIObjectState::class))
             ->will($this->returnValue($cacheItemMock));
         $cacheItemMock
             ->expects($this->once())
@@ -592,7 +630,7 @@ class ObjectStateHandlerTest extends HandlerTest
 
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Handler');
+        $innerHandlerMock = $this->getSPIObjectStateHandler();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('objectStateHandler')
@@ -624,7 +662,7 @@ class ObjectStateHandlerTest extends HandlerTest
             )
         );
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -656,7 +694,7 @@ class ObjectStateHandlerTest extends HandlerTest
 
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Handler');
+        $innerHandlerMock = $this->getSPIObjectStateHandler();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('objectStateHandler')
@@ -693,7 +731,7 @@ class ObjectStateHandlerTest extends HandlerTest
 
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Handler');
+        $innerHandlerMock = $this->getSPIObjectStateHandler();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('objectStateHandler')
@@ -705,7 +743,7 @@ class ObjectStateHandlerTest extends HandlerTest
             ->with($expectedState->id, $inputStruct)
             ->will($this->returnValue($expectedState));
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('clear')
@@ -733,7 +771,7 @@ class ObjectStateHandlerTest extends HandlerTest
 
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Handler');
+        $innerHandlerMock = $this->getSPIObjectStateHandler();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('objectStateHandler')
@@ -745,7 +783,7 @@ class ObjectStateHandlerTest extends HandlerTest
             ->with($expectedState->id, 1)
             ->will($this->returnValue($expectedState));
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('clear')
@@ -763,7 +801,7 @@ class ObjectStateHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Handler');
+        $innerHandlerMock = $this->getSPIObjectStateHandler();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('objectStateHandler')
@@ -774,7 +812,7 @@ class ObjectStateHandlerTest extends HandlerTest
             ->method('delete')
             ->with(1);
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('clear')
@@ -795,7 +833,7 @@ class ObjectStateHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Handler');
+        $innerHandlerMock = $this->getSPIObjectStateHandler();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('objectStateHandler')
@@ -806,7 +844,7 @@ class ObjectStateHandlerTest extends HandlerTest
             ->method('setContentState')
             ->with(10, 1, 2);
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('clear')
@@ -831,7 +869,7 @@ class ObjectStateHandlerTest extends HandlerTest
             )
         );
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('getItem')
@@ -857,7 +895,7 @@ class ObjectStateHandlerTest extends HandlerTest
 
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Handler');
+        $innerHandlerMock = $this->getSPIObjectStateHandler();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('objectStateHandler')
@@ -888,7 +926,7 @@ class ObjectStateHandlerTest extends HandlerTest
             )
         );
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->at(0))
             ->method('getItem')
@@ -911,7 +949,7 @@ class ObjectStateHandlerTest extends HandlerTest
             ->will(
                 $this->returnCallback(
                     function ($cachekey, $i) use ($expectedState) {
-                        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+                        $cacheItemMock = $this->getCacheItemMock();
                         $cacheItemMock
                             ->expects($this->once())
                             ->method('get')
@@ -936,7 +974,7 @@ class ObjectStateHandlerTest extends HandlerTest
 
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Handler');
+        $innerHandlerMock = $this->getSPIObjectStateHandler();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('objectStateHandler')

--- a/eZ/Publish/Core/Persistence/Cache/Tests/PersistenceHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/PersistenceHandlerTest.php
@@ -8,6 +8,9 @@
  */
 namespace eZ\Publish\Core\Persistence\Cache\Tests;
 
+use eZ\Publish\SPI\Persistence as SPIPersistence;
+use eZ\Publish\Core\Persistence\Cache;
+
 /**
  * Test case for Persistence\Cache\Handler.
  */
@@ -20,8 +23,8 @@ class PersistenceHandlerTest extends HandlerTest
      */
     public function testHandler()
     {
-        $this->assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Handler', $this->persistenceCacheHandler);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\Persistence\\Cache\\Handler', $this->persistenceCacheHandler);
+        $this->assertInstanceOf(SPIPersistence\Handler::class, $this->persistenceCacheHandler);
+        $this->assertInstanceOf(Cache\Handler::class, $this->persistenceCacheHandler);
     }
 
     /**
@@ -33,8 +36,8 @@ class PersistenceHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->never())->method($this->anything());
         $handler = $this->persistenceCacheHandler->contentHandler();
-        $this->assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Handler', $handler);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\Persistence\\Cache\\ContentHandler', $handler);
+        $this->assertInstanceOf(SPIPersistence\Content\Handler::class, $handler);
+        $this->assertInstanceOf(Cache\ContentHandler::class, $handler);
     }
 
     /**
@@ -46,8 +49,8 @@ class PersistenceHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->never())->method($this->anything());
         $handler = $this->persistenceCacheHandler->contentLanguageHandler();
-        $this->assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Language\\Handler', $handler);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\Persistence\\Cache\\ContentLanguageHandler', $handler);
+        $this->assertInstanceOf(SPIPersistence\Content\Language\Handler::class, $handler);
+        $this->assertInstanceOf(Cache\ContentLanguageHandler::class, $handler);
     }
 
     /**
@@ -59,8 +62,8 @@ class PersistenceHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->never())->method($this->anything());
         $handler = $this->persistenceCacheHandler->contentTypeHandler();
-        $this->assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler', $handler);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\Persistence\\Cache\\ContentTypeHandler', $handler);
+        $this->assertInstanceOf(SPIPersistence\Content\Type\Handler::class, $handler);
+        $this->assertInstanceOf(Cache\ContentTypeHandler::class, $handler);
     }
 
     /**
@@ -72,8 +75,8 @@ class PersistenceHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->never())->method($this->anything());
         $handler = $this->persistenceCacheHandler->locationHandler();
-        $this->assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler', $handler);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\Persistence\\Cache\\LocationHandler', $handler);
+        $this->assertInstanceOf(SPIPersistence\Content\Location\Handler::class, $handler);
+        $this->assertInstanceOf(Cache\LocationHandler::class, $handler);
     }
 
     /**
@@ -85,8 +88,8 @@ class PersistenceHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->never())->method($this->anything());
         $handler = $this->persistenceCacheHandler->trashHandler();
-        $this->assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Trash\\Handler', $handler);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\Persistence\\Cache\\TrashHandler', $handler);
+        $this->assertInstanceOf(SPIPersistence\Content\Location\Trash\Handler::class, $handler);
+        $this->assertInstanceOf(Cache\TrashHandler::class, $handler);
     }
 
     /**
@@ -98,8 +101,8 @@ class PersistenceHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->never())->method($this->anything());
         $handler = $this->persistenceCacheHandler->objectStateHandler();
-        $this->assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Handler', $handler);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\Persistence\\Cache\\ObjectStateHandler', $handler);
+        $this->assertInstanceOf(SPIPersistence\Content\ObjectState\Handler::class, $handler);
+        $this->assertInstanceOf(Cache\ObjectStateHandler::class, $handler);
     }
 
     /**
@@ -111,8 +114,8 @@ class PersistenceHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->never())->method($this->anything());
         $handler = $this->persistenceCacheHandler->sectionHandler();
-        $this->assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Section\\Handler', $handler);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\Persistence\\Cache\\SectionHandler', $handler);
+        $this->assertInstanceOf(SPIPersistence\Content\Section\Handler::class, $handler);
+        $this->assertInstanceOf(Cache\SectionHandler::class, $handler);
     }
 
     /**
@@ -124,8 +127,8 @@ class PersistenceHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->never())->method($this->anything());
         $handler = $this->persistenceCacheHandler->userHandler();
-        $this->assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\User\\Handler', $handler);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\Persistence\\Cache\\UserHandler', $handler);
+        $this->assertInstanceOf(SPIPersistence\User\Handler::class, $handler);
+        $this->assertInstanceOf(Cache\UserHandler::class, $handler);
     }
 
     /**
@@ -137,8 +140,8 @@ class PersistenceHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->never())->method($this->anything());
         $handler = $this->persistenceCacheHandler->urlAliasHandler();
-        $this->assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias\\Handler', $handler);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\Persistence\\Cache\\UrlAliasHandler', $handler);
+        $this->assertInstanceOf(SPIPersistence\Content\UrlAlias\Handler::class, $handler);
+        $this->assertInstanceOf(Cache\UrlAliasHandler::class, $handler);
     }
 
     /**
@@ -162,7 +165,7 @@ class PersistenceHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->never())->method($this->anything());
         $handler = $this->persistenceCacheHandler->transactionHandler();
-        $this->assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\TransactionHandler', $handler);
-        $this->assertInstanceOf('eZ\\Publish\\Core\\Persistence\\Cache\\TransactionHandler', $handler);
+        $this->assertInstanceOf(SPIPersistence\TransactionHandler::class, $handler);
+        $this->assertInstanceOf(Cache\TransactionHandler::class, $handler);
     }
 }

--- a/eZ/Publish/Core/Persistence/Cache/Tests/SectionHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/SectionHandlerTest.php
@@ -9,12 +9,19 @@
 namespace eZ\Publish\Core\Persistence\Cache\Tests;
 
 use eZ\Publish\SPI\Persistence\Content\Section as SPISection;
+use eZ\Publish\SPI\Persistence\Content\Section\Handler as SPISectionHandler;
+use Stash\Interfaces\ItemInterface;
 
 /**
  * Test case for Persistence\Cache\SectionHandler.
  */
 class SectionHandlerTest extends HandlerTest
 {
+    protected function getSPISectionHandlerMock()
+    {
+        return $this->createMock(SPISectionHandler::class);
+    }
+
     /**
      * @covers \eZ\Publish\Core\Persistence\Cache\SectionHandler::assign
      */
@@ -34,7 +41,7 @@ class SectionHandlerTest extends HandlerTest
             ->with('content', 'info', 44)
             ->will($this->returnValue(null));
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Section\\Handler');
+        $innerHandler = $this->getSPISectionHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('sectionHandler')
@@ -60,7 +67,7 @@ class SectionHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Section\\Handler');
+        $innerHandler = $this->getSPISectionHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('sectionHandler')
@@ -86,7 +93,7 @@ class SectionHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Section\\Handler');
+        $innerHandler = $this->getSPISectionHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('sectionHandler')
@@ -112,7 +119,7 @@ class SectionHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Section\\Handler');
+        $innerHandler = $this->getSPISectionHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('sectionHandler')
@@ -135,7 +142,7 @@ class SectionHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Section\\Handler');
+        $innerHandlerMock = $this->getSPISectionHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('sectionHandler')
@@ -153,7 +160,7 @@ class SectionHandlerTest extends HandlerTest
                 )
             );
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->createMock(ItemInterface::class);
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -163,7 +170,7 @@ class SectionHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Section'))
+            ->with($this->isInstanceOf(SPISection::class))
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock
@@ -186,7 +193,7 @@ class SectionHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Section\\Handler');
+        $innerHandlerMock = $this->getSPISectionHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('sectionHandler')
@@ -216,7 +223,7 @@ class SectionHandlerTest extends HandlerTest
     public function testLoadCacheIsMiss()
     {
         $this->loggerMock->expects($this->once())->method('logCall');
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->createMock(ItemInterface::class);
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -228,7 +235,7 @@ class SectionHandlerTest extends HandlerTest
             ->method('isMiss')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Section\\Handler');
+        $innerHandlerMock = $this->getSPISectionHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('sectionHandler')
@@ -249,7 +256,7 @@ class SectionHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Section'))
+            ->with($this->isInstanceOf(SPISection::class))
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock
@@ -272,7 +279,7 @@ class SectionHandlerTest extends HandlerTest
     public function testLoadHasCache()
     {
         $this->loggerMock->expects($this->never())->method($this->anything());
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->createMock(ItemInterface::class);
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -317,7 +324,7 @@ class SectionHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Section\\Handler');
+        $innerHandler = $this->getSPISectionHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('sectionHandler')
@@ -342,7 +349,7 @@ class SectionHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Section\\Handler');
+        $innerHandler = $this->getSPISectionHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('sectionHandler')
@@ -371,7 +378,7 @@ class SectionHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Section\\Handler');
+        $innerHandler = $this->getSPISectionHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('sectionHandler')
@@ -389,7 +396,7 @@ class SectionHandlerTest extends HandlerTest
                 )
             );
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->createMock(ItemInterface::class);
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -399,7 +406,7 @@ class SectionHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Section'))
+            ->with($this->isInstanceOf(SPISection::class))
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock

--- a/eZ/Publish/Core/Persistence/Cache/Tests/TransactionHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/TransactionHandlerTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\Core\Persistence\Cache\Tests;
 
+use eZ\Publish\SPI\Persistence\TransactionHandler;
+
 /**
  * Test case for Persistence\Cache\TransactionHandler.
  */
@@ -26,7 +28,7 @@ class TransactionHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\TransactionHandler');
+        $innerHandlerMock = $this->createMock(TransactionHandler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('transactionHandler')
@@ -53,7 +55,7 @@ class TransactionHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\TransactionHandler');
+        $innerHandlerMock = $this->createMock(TransactionHandler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('transactionHandler')
@@ -80,7 +82,7 @@ class TransactionHandlerTest extends HandlerTest
             ->expects($this->once())
             ->method('clear');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\TransactionHandler');
+        $innerHandlerMock = $this->createMock(TransactionHandler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('transactionHandler')

--- a/eZ/Publish/Core/Persistence/Cache/Tests/TrashHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/TrashHandlerTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\Persistence\Cache\Tests;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\SPI\Persistence\Content\Location\Trashed as SPITrashed;
+use eZ\Publish\SPI\Persistence\Content\Location\Trash\Handler as TrashHandler;
 
 /**
  * Test case for Persistence\Cache\SectionHandler.
@@ -26,7 +27,7 @@ class TrashHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Trash\\Handler');
+        $innerHandlerMock = $this->createMock(TrashHandler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('trashHandler')
@@ -57,7 +58,7 @@ class TrashHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Trash\\Handler');
+        $innerHandlerMock = $this->createMock(TrashHandler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('trashHandler')
@@ -104,7 +105,7 @@ class TrashHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Trash\\Handler');
+        $innerHandlerMock = $this->createMock(TrashHandler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('trashHandler')
@@ -147,7 +148,7 @@ class TrashHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Trash\\Handler');
+        $innerHandlerMock = $this->createMock(TrashHandler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('trashHandler')
@@ -178,7 +179,7 @@ class TrashHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Trash\\Handler');
+        $innerHandlerMock = $this->createMock(TrashHandler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('trashHandler')
@@ -204,7 +205,7 @@ class TrashHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Trash\\Handler');
+        $innerHandlerMock = $this->createMock(TrashHandler::class);
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('trashHandler')

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
@@ -21,7 +21,8 @@ class UrlAliasHandlerTest extends HandlerTest
     {
         return $this->createMock(ItemInterface::class);
     }
-    
+
+
     protected function getSPIUrlAliasHandlerMock()
     {
         return $this->createMock(SPIUrlAliasHandler::class);

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
@@ -22,7 +22,6 @@ class UrlAliasHandlerTest extends HandlerTest
         return $this->createMock(ItemInterface::class);
     }
 
-
     protected function getSPIUrlAliasHandlerMock()
     {
         return $this->createMock(SPIUrlAliasHandler::class);

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
@@ -113,12 +113,6 @@ class UrlAliasHandlerTest extends HandlerTest
             ->with('urlAlias')
             ->will($this->returnValue(null));
 
-        $this->cacheMock
-            ->expects($this->once())
-            ->method('getItem')
-            ->with('urlAlias', 'location', 44)
-            ->willReturn($cacheItem);
-
         $handler = $this->persistenceCacheHandler->urlAliasHandler();
         $handler->publishUrlAliasForLocation(44, 2, 'name', 'eng-GB', true);
     }
@@ -143,34 +137,6 @@ class UrlAliasHandlerTest extends HandlerTest
             ->method('publishUrlAliasForLocation')
             ->with(44, 2, 'name', 'eng-GB', true)
             ->will($this->returnValue(new UrlAlias(array('id' => 55))));
-
-        $cacheItem
-            ->expects($this->once())
-            ->method('isMiss')
-            ->willReturn(false);
-        $cacheItem
-            ->expects($this->once())
-            ->method('clear');
-        $cacheItem
-            ->expects($this->once())
-            ->method('get')
-            ->willReturn([44]);
-
-        $this->cacheMock
-            ->expects($this->once())
-            ->method('getItem')
-            ->with('urlAlias', 'location', 44)
-            ->willReturn($cacheItem);
-        $this->cacheMock
-            ->expects($this->at(1))
-            ->method('clear')
-            ->with('urlAlias', 44)
-            ->will($this->returnValue(null));
-        $this->cacheMock
-            ->expects($this->at(2))
-            ->method('clear')
-            ->with('urlAlias', 'url')
-            ->will($this->returnValue(null));
 
         $handler = $this->persistenceCacheHandler->urlAliasHandler();
         $handler->publishUrlAliasForLocation(44, 2, 'name', 'eng-GB', true);

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UserHandlerTest.php
@@ -13,13 +13,26 @@ use eZ\Publish\SPI\Persistence\User;
 use eZ\Publish\SPI\Persistence\User\Role;
 use eZ\Publish\SPI\Persistence\User\RoleAssignment;
 use eZ\Publish\SPI\Persistence\User\RoleUpdateStruct;
+use eZ\Publish\SPI\Persistence\User\RoleCreateStruct;
 use eZ\Publish\SPI\Persistence\User\Policy;
+use eZ\Publish\SPI\Persistence\User\Handler as SPIUserHandler;
+use Stash\Interfaces\ItemInterface;
 
 /**
  * Test case for Persistence\Cache\UserHandler.
  */
 class UserHandlerTest extends HandlerTest
 {
+    protected function getCacheItemMock()
+    {
+        return $this->createMock(ItemInterface::class);
+    }
+
+    protected function getSPIUserHandlerMock()
+    {
+        return $this->createMock(SPIUserHandler::class);
+    }
+
     /**
      * Commented lines represent cached functions covered by specific unit tests further down.
      *
@@ -62,7 +75,7 @@ class UserHandlerTest extends HandlerTest
             ->expects($this->never())
             ->method($this->anything());
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandler = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')
@@ -93,7 +106,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandlerMock = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')
@@ -102,7 +115,7 @@ class UserHandlerTest extends HandlerTest
         $innerHandlerMock
             ->expects($this->once())
             ->method('create')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\User'))
+            ->with($this->isInstanceOf(User::class))
             ->will(
                 $this->returnValue(true)
             );
@@ -124,7 +137,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandlerMock = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')
@@ -133,7 +146,7 @@ class UserHandlerTest extends HandlerTest
         $innerHandlerMock
             ->expects($this->once())
             ->method('update')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\User'))
+            ->with($this->isInstanceOf(User::class))
             ->will(
                 $this->returnValue(true)
             );
@@ -155,7 +168,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandlerMock = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')
@@ -198,7 +211,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -215,7 +228,7 @@ class UserHandlerTest extends HandlerTest
             ->method('isMiss')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandlerMock = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')
@@ -232,7 +245,7 @@ class UserHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\User\\Role'))
+            ->with($this->isInstanceOf(Role::class))
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock
@@ -251,7 +264,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->never())->method('logCall');
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -287,7 +300,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -304,7 +317,7 @@ class UserHandlerTest extends HandlerTest
             ->method('isMiss')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandlerMock = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')
@@ -337,7 +350,7 @@ class UserHandlerTest extends HandlerTest
         $roleAssignments = $handler->loadRoleAssignmentsByGroupId(42);
 
         $this->assertEquals(1, count($roleAssignments));
-        $this->assertInstanceOf('\\eZ\\Publish\\SPI\\Persistence\\User\\RoleAssignment', $roleAssignments[0]);
+        $this->assertInstanceOf(RoleAssignment::class, $roleAssignments[0]);
         $this->assertEquals(33, $roleAssignments[0]->roleId);
     }
 
@@ -348,7 +361,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->never())->method('logCall');
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -379,7 +392,7 @@ class UserHandlerTest extends HandlerTest
         $roleAssignments = $handler->loadRoleAssignmentsByGroupId(42);
 
         $this->assertEquals(1, count($roleAssignments));
-        $this->assertInstanceOf('\\eZ\\Publish\\SPI\\Persistence\\User\\RoleAssignment', $roleAssignments[0]);
+        $this->assertInstanceOf(RoleAssignment::class, $roleAssignments[0]);
         $this->assertEquals(33, $roleAssignments[0]->roleId);
     }
 
@@ -390,7 +403,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -407,7 +420,7 @@ class UserHandlerTest extends HandlerTest
             ->method('isMiss')
             ->will($this->returnValue(true));
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandlerMock = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')
@@ -436,7 +449,7 @@ class UserHandlerTest extends HandlerTest
         $roleAssignments = $handler->loadRoleAssignmentsByGroupId(42, true);
 
         $this->assertEquals(1, count($roleAssignments));
-        $this->assertInstanceOf('\\eZ\\Publish\\SPI\\Persistence\\User\\RoleAssignment', $roleAssignments[0]);
+        $this->assertInstanceOf(RoleAssignment::class, $roleAssignments[0]);
         $this->assertEquals(33, $roleAssignments[0]->roleId);
     }
 
@@ -447,7 +460,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->never())->method('logCall');
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -478,7 +491,7 @@ class UserHandlerTest extends HandlerTest
         $roleAssignments = $handler->loadRoleAssignmentsByGroupId(42, true);
 
         $this->assertEquals(1, count($roleAssignments));
-        $this->assertInstanceOf('\\eZ\\Publish\\SPI\\Persistence\\User\\RoleAssignment', $roleAssignments[0]);
+        $this->assertInstanceOf(RoleAssignment::class, $roleAssignments[0]);
         $this->assertEquals(33, $roleAssignments[0]->roleId);
     }
 
@@ -489,7 +502,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandlerMock = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')
@@ -498,7 +511,7 @@ class UserHandlerTest extends HandlerTest
         $innerHandlerMock
             ->expects($this->once())
             ->method('createRole')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\User\\RoleCreateStruct'))
+            ->with($this->isInstanceOf(RoleCreateStruct::class))
             ->will(
                 $this->returnValue(
                     new Role(
@@ -507,7 +520,7 @@ class UserHandlerTest extends HandlerTest
                 )
             );
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->never())
             ->method('getItem');
@@ -531,7 +544,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandlerMock = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')
@@ -549,7 +562,7 @@ class UserHandlerTest extends HandlerTest
                 )
             );
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->never())
             ->method('getItem');
@@ -574,7 +587,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandler = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')
@@ -583,7 +596,7 @@ class UserHandlerTest extends HandlerTest
         $innerHandler
             ->expects($this->once())
             ->method('updateRole')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\User\\RoleUpdateStruct'));
+            ->with($this->isInstanceOf(RoleUpdateStruct::class));
 
         $roleUpdateStruct = new RoleUpdateStruct();
         $roleUpdateStruct->id = 42;
@@ -609,7 +622,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandler = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')
@@ -618,7 +631,7 @@ class UserHandlerTest extends HandlerTest
         $innerHandler
             ->expects($this->once())
             ->method('updateRole')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\User\\RoleUpdateStruct'));
+            ->with($this->isInstanceOf(RoleUpdateStruct::class));
 
         $roleUpdateStruct = new RoleUpdateStruct();
         $roleUpdateStruct->id = 42;
@@ -644,7 +657,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandlerMock = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')
@@ -681,7 +694,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandlerMock = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')
@@ -707,7 +720,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandlerMock = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')
@@ -733,7 +746,7 @@ class UserHandlerTest extends HandlerTest
             ->with('user', 'role', 'assignments')
             ->will($this->returnValue(true));
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -743,7 +756,7 @@ class UserHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\User\\Role'))
+            ->with($this->isInstanceOf(Role::class))
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock
@@ -759,7 +772,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandlerMock = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')
@@ -793,7 +806,7 @@ class UserHandlerTest extends HandlerTest
             ->with('user', 'role', 'assignments')
             ->will($this->returnValue(true));
 
-        $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
+        $cacheItemMock = $this->getCacheItemMock();
         $this->cacheMock
             ->expects($this->once())
             ->method('getItem')
@@ -803,7 +816,7 @@ class UserHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\User\\Role'))
+            ->with($this->isInstanceOf(Role::class))
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock
@@ -822,7 +835,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandlerMock = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')
@@ -831,7 +844,7 @@ class UserHandlerTest extends HandlerTest
         $innerHandlerMock
             ->expects($this->once())
             ->method('addPolicy')
-            ->with(33, $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\User\\Policy'))
+            ->with(33, $this->isInstanceOf(Policy::class))
             ->will(
                 $this->returnValue(new Policy())
             );
@@ -853,7 +866,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandlerMock = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')
@@ -862,7 +875,7 @@ class UserHandlerTest extends HandlerTest
         $innerHandlerMock
             ->expects($this->once())
             ->method('addPolicyByRoleDraft')
-            ->with(33, $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\User\\Policy'))
+            ->with(33, $this->isInstanceOf(Policy::class))
             ->will(
                 $this->returnValue(new Policy())
             );
@@ -882,7 +895,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandlerMock = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')
@@ -891,7 +904,7 @@ class UserHandlerTest extends HandlerTest
         $innerHandlerMock
             ->expects($this->once())
             ->method('updatePolicy')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\User\\Policy'))
+            ->with($this->isInstanceOf(Policy::class))
             ->will(
                 $this->returnValue(new Policy(array('roleId' => 33)))
             );
@@ -913,7 +926,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandlerMock = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')
@@ -944,7 +957,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandlerMock = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')
@@ -987,7 +1000,7 @@ class UserHandlerTest extends HandlerTest
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->getMock('eZ\\Publish\\SPI\\Persistence\\User\\Handler');
+        $innerHandlerMock = $this->getSPIUserHandlerMock();
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method('userHandler')

--- a/eZ/Publish/Core/Persistence/Doctrine/Tests/ConnectionHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Doctrine/Tests/ConnectionHandlerTest.php
@@ -60,6 +60,6 @@ class ConnectionHandlerTest extends TestCase
     {
         $handler = ConnectionHandler::createFromDSN('sqlite://:memory:');
 
-        $this->assertInstanceOf('eZ\Publish\Core\Persistence\Doctrine\ConnectionHandler\SqliteConnectionHandler', $handler);
+        $this->assertInstanceOf(ConnectionHandler\SqliteConnectionHandler::class, $handler);
     }
 }

--- a/eZ/Publish/Core/Persistence/Doctrine/Tests/DeleteDoctrineQueryTest.php
+++ b/eZ/Publish/Core/Persistence/Doctrine/Tests/DeleteDoctrineQueryTest.php
@@ -2,6 +2,8 @@
 
 namespace eZ\Publish\Core\Persistence\Doctrine\Tests;
 
+use eZ\Publish\Core\Persistence\Database\QueryException;
+
 class DeleteDoctrineQueryTest extends TestCase
 {
     public function testGenerateDeleteQuery()
@@ -17,7 +19,7 @@ class DeleteDoctrineQueryTest extends TestCase
     {
         $deleteQuery = $this->handler->createDeleteQuery();
 
-        $this->setExpectedException('eZ\Publish\Core\Persistence\Database\QueryException');
+        $this->expectException(QueryException::class);
 
         $deleteQuery->getQuery();
     }

--- a/eZ/Publish/Core/Persistence/Doctrine/Tests/UpdateDoctrineQueryTest.php
+++ b/eZ/Publish/Core/Persistence/Doctrine/Tests/UpdateDoctrineQueryTest.php
@@ -2,6 +2,8 @@
 
 namespace eZ\Publish\Core\Persistence\Doctrine\Tests;
 
+use eZ\Publish\Core\Persistence\Database\QueryException;
+
 class UpdateDoctrineQueryTest extends TestCase
 {
     public function testGenerateUpdateQuery()
@@ -23,7 +25,7 @@ class UpdateDoctrineQueryTest extends TestCase
     {
         $updateQuery = $this->handler->createUpdateQuery();
 
-        $this->setExpectedException('eZ\Publish\Core\Persistence\Database\QueryException');
+        $this->expectException(QueryException::class);
 
         $updateQuery->getQuery();
     }
@@ -34,7 +36,7 @@ class UpdateDoctrineQueryTest extends TestCase
 
         $updateQuery->update('query_test');
 
-        $this->setExpectedException('eZ\Publish\Core\Persistence\Database\QueryException');
+        $this->expectException(QueryException::class);
 
         $updateQuery->getQuery();
     }
@@ -45,7 +47,7 @@ class UpdateDoctrineQueryTest extends TestCase
 
         $updateQuery->update('query_test')->set('val1', '?');
 
-        $this->setExpectedException('eZ\Publish\Core\Persistence\Database\QueryException');
+        $this->expectException(QueryException::class);
 
         $updateQuery->getQuery();
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldHandlerTest.php
@@ -15,9 +15,14 @@ use eZ\Publish\SPI\Persistence\Content\UpdateStruct;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
+use eZ\Publish\SPI\FieldType\FieldType;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Mapper;
+use eZ\Publish\Core\Persistence\FieldTypeRegistry;
+use eZ\Publish\Core\Persistence\Legacy\Content\Gateway;
 
 /**
  * Test case for Content Handler.
@@ -75,9 +80,9 @@ class FieldHandlerTest extends LanguageAwareTestCase
         $contentGatewayMock->expects($this->exactly(6))
             ->method('insertNewField')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content'),
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'),
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(Content::class),
+                $this->isInstanceOf(Field::class),
+                $this->isInstanceOf(StorageFieldValue::class)
             )->will($this->returnValue(42));
 
         $callNo = 0;
@@ -104,7 +109,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
                 $storageHandlerMock->expects($this->at($callNo++))
                     ->method('storeFieldData')
                     ->with(
-                        $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\VersionInfo'),
+                        $this->isInstanceOf(VersionInfo::class),
                         $this->equalTo($field)
                     )->will($this->returnValue($storageHandlerUpdatesFields));
             }
@@ -115,7 +120,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
         $storageHandlerMock->expects($this->at($callNo))
             ->method('copyFieldData')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\VersionInfo'),
+                $this->isInstanceOf(VersionInfo::class),
                 $this->equalTo($copyField),
                 $this->equalTo($originalField)
             )->will($this->returnValue($storageHandlerUpdatesFields));
@@ -133,7 +138,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
 
         $mapperMock->expects($this->exactly(6))
             ->method('convertToStorageValue')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'))
+            ->with($this->isInstanceOf(Field::class))
             ->will($this->returnValue(new StorageFieldValue()));
 
         $fieldHandler->createNewFields(
@@ -155,14 +160,14 @@ class FieldHandlerTest extends LanguageAwareTestCase
 
         $mapperMock->expects($this->exactly(12))
             ->method('convertToStorageValue')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'))
+            ->with($this->isInstanceOf(Field::class))
             ->will($this->returnValue(new StorageFieldValue()));
 
         $contentGatewayMock->expects($this->exactly(6))
             ->method('updateField')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'),
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(Field::class),
+                $this->isInstanceOf(StorageFieldValue::class)
             );
 
         $fieldHandler->createNewFields(
@@ -187,9 +192,9 @@ class FieldHandlerTest extends LanguageAwareTestCase
         $contentGatewayMock->expects($this->exactly(3))
             ->method('insertNewField')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content'),
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'),
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(Content::class),
+                $this->isInstanceOf(Field::class),
+                $this->isInstanceOf(StorageFieldValue::class)
             )->will($this->returnValue(42));
 
         $callNo = 0;
@@ -208,7 +213,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
             $storageHandlerMock->expects($this->at($callNo++))
                 ->method('storeFieldData')
                 ->with(
-                    $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\VersionInfo'),
+                    $this->isInstanceOf(VersionInfo::class),
                     $this->equalTo($field)
                 )->will($this->returnValue($storageHandlerUpdatesFields));
         }
@@ -226,7 +231,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
 
         $mapperMock->expects($this->exactly(3))
             ->method('convertToStorageValue')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'))
+            ->with($this->isInstanceOf(Field::class))
             ->will($this->returnValue(new StorageFieldValue()));
 
         $fieldHandler->createNewFields(
@@ -248,14 +253,14 @@ class FieldHandlerTest extends LanguageAwareTestCase
 
         $mapperMock->expects($this->exactly(6))
             ->method('convertToStorageValue')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'))
+            ->with($this->isInstanceOf(Field::class))
             ->will($this->returnValue(new StorageFieldValue()));
 
         $contentGatewayMock->expects($this->exactly(3))
             ->method('updateField')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'),
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(Field::class),
+                $this->isInstanceOf(StorageFieldValue::class)
             );
 
         $fieldHandler->createNewFields(
@@ -275,9 +280,9 @@ class FieldHandlerTest extends LanguageAwareTestCase
         $contentGatewayMock->expects($this->exactly(6))
             ->method('insertExistingField')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content'),
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'),
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(Content::class),
+                $this->isInstanceOf(Field::class),
+                $this->isInstanceOf(StorageFieldValue::class)
             )->will($this->returnValue(42));
 
         $callNo = 0;
@@ -298,7 +303,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
                 $storageHandlerMock->expects($this->at($callNo++))
                     ->method('copyFieldData')
                     ->with(
-                        $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\VersionInfo'),
+                        $this->isInstanceOf(VersionInfo::class),
                         $this->equalTo($field),
                         $this->equalTo($originalField)
                     )->will($this->returnValue($storageHandlerUpdatesFields));
@@ -318,7 +323,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
 
         $mapperMock->expects($this->exactly(6))
             ->method('convertToStorageValue')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'))
+            ->with($this->isInstanceOf(Field::class))
             ->will($this->returnValue(new StorageFieldValue()));
 
         $fieldHandler->createExistingFieldsInNewVersion($this->getContentFixture());
@@ -337,14 +342,14 @@ class FieldHandlerTest extends LanguageAwareTestCase
 
         $mapperMock->expects($this->exactly(12))
             ->method('convertToStorageValue')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'))
+            ->with($this->isInstanceOf(Field::class))
             ->will($this->returnValue(new StorageFieldValue()));
 
         $contentGatewayMock->expects($this->exactly(6))
             ->method('updateField')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'),
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(Field::class),
+                $this->isInstanceOf(StorageFieldValue::class)
             );
 
         $fieldHandler->createExistingFieldsInNewVersion($this->getContentFixture());
@@ -362,8 +367,8 @@ class FieldHandlerTest extends LanguageAwareTestCase
         $storageHandlerMock->expects($this->exactly(6))
             ->method('getFieldData')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\VersionInfo'),
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field')
+                $this->isInstanceOf(VersionInfo::class),
+                $this->isInstanceOf(Field::class)
             );
 
         $fieldHandler->loadExternalFieldData($this->getContentFixture());
@@ -385,9 +390,9 @@ class FieldHandlerTest extends LanguageAwareTestCase
         $contentGatewayMock->expects($this->exactly(3))
             ->method('insertNewField')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content'),
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'),
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(Content::class),
+                $this->isInstanceOf(Field::class),
+                $this->isInstanceOf(StorageFieldValue::class)
             );
 
         $callNo = 0;
@@ -413,7 +418,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
             $storageHandlerMock->expects($this->at($callNo++))
                 ->method('storeFieldData')
                 ->with(
-                    $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\VersionInfo'),
+                    $this->isInstanceOf(VersionInfo::class),
                     $this->equalTo($field)
                 )->will($this->returnValue($storageHandlerUpdatesFields));
         }
@@ -423,7 +428,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
         $storageHandlerMock->expects($this->at($callNo))
             ->method('copyFieldData')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\VersionInfo'),
+                $this->isInstanceOf(VersionInfo::class),
                 $this->equalTo($copyField),
                 $this->equalTo($originalField)
             )->will($this->returnValue($storageHandlerUpdatesFields));
@@ -441,7 +446,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
 
         $mapperMock->expects($this->exactly(3))
             ->method('convertToStorageValue')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'))
+            ->with($this->isInstanceOf(Field::class))
             ->will($this->returnValue(new StorageFieldValue()));
 
         $field = new Field(
@@ -477,14 +482,14 @@ class FieldHandlerTest extends LanguageAwareTestCase
 
         $mapperMock->expects($this->exactly(6))
             ->method('convertToStorageValue')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'))
+            ->with($this->isInstanceOf(Field::class))
             ->will($this->returnValue(new StorageFieldValue()));
 
         $contentGatewayMock->expects($this->exactly(3))
             ->method('updateField')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'),
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(Field::class),
+                $this->isInstanceOf(StorageFieldValue::class)
             );
 
         $field = new Field(
@@ -542,7 +547,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
                     $storageHandlerMock->expects($this->at($callNo++))
                         ->method('storeFieldData')
                         ->with(
-                            $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\VersionInfo'),
+                            $this->isInstanceOf(VersionInfo::class),
                             $this->equalTo($field)
                         )->will($this->returnValue($storageHandlerUpdatesFields));
                 }
@@ -553,7 +558,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
             $storageHandlerMock->expects($this->at($callNo++))
                 ->method('copyFieldData')
                 ->with(
-                    $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\VersionInfo'),
+                    $this->isInstanceOf(VersionInfo::class),
                     $this->equalTo($fieldToCopy['copy']),
                     $this->equalTo($fieldToCopy['original'])
                 )->will($this->returnValue($storageHandlerUpdatesFields));
@@ -573,14 +578,14 @@ class FieldHandlerTest extends LanguageAwareTestCase
 
         $mapperMock->expects($this->exactly(6))
             ->method('convertToStorageValue')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'))
+            ->with($this->isInstanceOf(Field::class))
             ->will($this->returnValue(new StorageFieldValue()));
 
         $contentGatewayMock->expects($this->exactly(6))
             ->method('updateField')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'),
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(Field::class),
+                $this->isInstanceOf(StorageFieldValue::class)
             );
 
         $fieldHandler->updateFields(
@@ -603,14 +608,14 @@ class FieldHandlerTest extends LanguageAwareTestCase
 
         $mapperMock->expects($this->exactly(12))
             ->method('convertToStorageValue')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'))
+            ->with($this->isInstanceOf(Field::class))
             ->will($this->returnValue(new StorageFieldValue()));
 
         $contentGatewayMock->expects($this->exactly(12))
             ->method('updateField')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'),
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(Field::class),
+                $this->isInstanceOf(StorageFieldValue::class)
             );
 
         $fieldHandler->updateFields(
@@ -655,7 +660,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
             $storageHandlerMock->expects($this->at($callNo++))
                 ->method('storeFieldData')
                 ->with(
-                    $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\VersionInfo'),
+                    $this->isInstanceOf(VersionInfo::class),
                     $this->equalTo($field)
                 )->will($this->returnValue($storageHandlerUpdatesFields));
         }
@@ -664,7 +669,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
             $storageHandlerMock->expects($this->at($callNo++))
                 ->method('copyFieldData')
                 ->with(
-                    $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\VersionInfo'),
+                    $this->isInstanceOf(VersionInfo::class),
                     $this->equalTo($fieldToCopy['copy']),
                     $this->equalTo($fieldToCopy['original'])
                 )->will($this->returnValue($storageHandlerUpdatesFields));
@@ -683,7 +688,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
 
         $mapperMock->expects($this->exactly(3))
             ->method('convertToStorageValue')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'))
+            ->with($this->isInstanceOf(Field::class))
             ->will($this->returnValue(new StorageFieldValue()));
 
         $struct = new UpdateStruct();
@@ -709,14 +714,14 @@ class FieldHandlerTest extends LanguageAwareTestCase
 
         $mapperMock->expects($this->exactly(6))
             ->method('convertToStorageValue')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'))
+            ->with($this->isInstanceOf(Field::class))
             ->will($this->returnValue(new StorageFieldValue()));
 
         $contentGatewayMock->expects($this->exactly(3))
             ->method('updateField')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'),
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(Field::class),
+                $this->isInstanceOf(StorageFieldValue::class)
             );
 
         $struct = new UpdateStruct();
@@ -749,7 +754,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
             ->method('deleteFieldData')
             ->with(
                 $this->equalTo('some-type'),
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\VersionInfo'),
+                $this->isInstanceOf(VersionInfo::class),
                 $this->equalTo(array(2, 3))
             );
 
@@ -994,13 +999,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
     protected function getStorageHandlerMock()
     {
         if (!isset($this->storageHandlerMock)) {
-            $this->storageHandlerMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageHandler',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->storageHandlerMock = $this->createMock(StorageHandler::class);
         }
 
         return $this->storageHandlerMock;
@@ -1014,13 +1013,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
     protected function getMapperMock()
     {
         if (!isset($this->mapperMock)) {
-            $this->mapperMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Mapper',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->mapperMock = $this->createMock(Mapper::class);
         }
 
         return $this->mapperMock;
@@ -1034,9 +1027,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
     protected function getContentGatewayMock()
     {
         if (!isset($this->contentGatewayMock)) {
-            $this->contentGatewayMock = $this->getMockForAbstractClass(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Gateway'
-            );
+            $this->contentGatewayMock = $this->getMockForAbstractClass(Gateway::class);
         }
 
         return $this->contentGatewayMock;
@@ -1048,13 +1039,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
     protected function getFieldTypeRegistryMock()
     {
         if (!isset($this->fieldTypeRegistryMock)) {
-            $this->fieldTypeRegistryMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\FieldTypeRegistry',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->fieldTypeRegistryMock = $this->createMock(FieldTypeRegistry::class);
 
             $this->fieldTypeRegistryMock->expects(
                 $this->any()
@@ -1076,9 +1061,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
     protected function getFieldTypeMock()
     {
         if (!isset($this->fieldTypeMock)) {
-            $this->fieldTypeMock = $this->getMock(
-                'eZ\\Publish\\SPI\\FieldType\\FieldType'
-            );
+            $this->fieldTypeMock = $this->createMock(FieldType::class);
         }
 
         return $this->fieldTypeMock;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/RelationTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/RelationTest.php
@@ -13,12 +13,12 @@ use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RelationConv
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition as PersistenceFieldDefinition;
 use eZ\Publish\SPI\Persistence\Content\FieldTypeConstraints;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test case for Relation converter in Legacy storage.
  */
-class RelationTest extends PHPUnit_Framework_TestCase
+class RelationTest extends TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RelationConverter

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValueConverterRegistryTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValueConverterRegistryTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry as Registry;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 
 /**
  * Test case for FieldValue Converter Registry.
@@ -68,8 +69,6 @@ class FieldValueConverterRegistryTest extends TestCase
      */
     protected function getFieldValueConverterMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\FieldValue\\Converter'
-        );
+        return $this->createMock(Converter::class);
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/CachingLanguageHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/CachingLanguageHandlerTest.php
@@ -10,8 +10,11 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Language;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\SPI\Persistence\Content\Language;
+use eZ\Publish\SPI\Persistence\Content\Language\CreateStruct as SPILanguageCreateStruct;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\SPI\Persistence\Content\Language\Handler as SPILanguageHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Language\CachingHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Language\Cache;
 
 /**
  * Test case for caching Language Handler.
@@ -84,7 +87,7 @@ class CachingLanguageHandlerTest extends TestCase
             ->method('create')
             ->with(
                 $this->isInstanceOf(
-                    'eZ\\Publish\\SPI\\Persistence\\Content\\Language\\CreateStruct'
+                    SPILanguageCreateStruct::class
                 )
             )->will($this->returnValue($languageFixture));
 
@@ -312,9 +315,7 @@ class CachingLanguageHandlerTest extends TestCase
     protected function getInnerLanguageHandlerMock()
     {
         if (!isset($this->innerHandlerMock)) {
-            $this->innerHandlerMock = $this->getMock(
-                'eZ\\Publish\\SPI\\Persistence\\Content\\Language\\Handler'
-            );
+            $this->innerHandlerMock = $this->createMock(SPILanguageHandler::class);
         }
 
         return $this->innerHandlerMock;
@@ -328,9 +329,7 @@ class CachingLanguageHandlerTest extends TestCase
     protected function getLanguageCacheMock()
     {
         if (!isset($this->languageCacheMock)) {
-            $this->languageCacheMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Language\\Cache'
-            );
+            $this->languageCacheMock = $this->createMock(Cache::class);
         }
 
         return $this->languageCacheMock;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/LanguageHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/LanguageHandlerTest.php
@@ -11,6 +11,9 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Language;
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\SPI\Persistence\Content\Language;
 use eZ\Publish\Core\Persistence\Legacy\Content\Language\Handler;
+use eZ\Publish\SPI\Persistence\Content\Language\CreateStruct as SPILanguageCreateStruct;
+use eZ\Publish\Core\Persistence\Legacy\Content\Language\Mapper as LanguageMapper;
+use eZ\Publish\Core\Persistence\Legacy\Content\Language\Gateway as LanguageGateway;
 
 /**
  * Test case for Language Handler.
@@ -50,7 +53,7 @@ class LanguageHandlerTest extends TestCase
             ->method('createLanguageFromCreateStruct')
             ->with(
                 $this->isInstanceOf(
-                    'eZ\\Publish\\SPI\\Persistence\\Content\\Language\\CreateStruct'
+                    SPILanguageCreateStruct::class
                 )
             )->will($this->returnValue(new Language()));
 
@@ -59,7 +62,7 @@ class LanguageHandlerTest extends TestCase
             ->method('insertLanguage')
             ->with(
                 $this->isInstanceOf(
-                    'eZ\\Publish\\SPI\\Persistence\\Content\\Language'
+                    Language::class
                 )
             )->will($this->returnValue(2));
 
@@ -68,7 +71,7 @@ class LanguageHandlerTest extends TestCase
         $result = $handler->create($createStruct);
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Language',
+            Language::class,
             $result
         );
         $this->assertEquals(
@@ -97,7 +100,7 @@ class LanguageHandlerTest extends TestCase
         $gatewayMock = $this->getGatewayMock();
         $gatewayMock->expects($this->once())
             ->method('updateLanguage')
-            ->with($this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Language'));
+            ->with($this->isInstanceOf(Language::class));
 
         $handler->update($this->getLanguageFixture());
     }
@@ -134,7 +137,7 @@ class LanguageHandlerTest extends TestCase
         $result = $handler->load(2);
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Language',
+            Language::class,
             $result
         );
     }
@@ -185,7 +188,7 @@ class LanguageHandlerTest extends TestCase
         $result = $handler->loadByLanguageCode('eng-US');
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Language',
+            Language::class,
             $result
         );
     }
@@ -303,9 +306,7 @@ class LanguageHandlerTest extends TestCase
     protected function getMapperMock()
     {
         if (!isset($this->mapperMock)) {
-            $this->mapperMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Language\\Mapper'
-            );
+            $this->mapperMock = $this->createMock(LanguageMapper::class);
         }
 
         return $this->mapperMock;
@@ -319,9 +320,7 @@ class LanguageHandlerTest extends TestCase
     protected function getGatewayMock()
     {
         if (!isset($this->gatewayMock)) {
-            $this->gatewayMock = $this->getMockForAbstractClass(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Language\\Gateway'
-            );
+            $this->gatewayMock = $this->getMockForAbstractClass(LanguageGateway::class);
         }
 
         return $this->gatewayMock;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/MaskGeneratorTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/MaskGeneratorTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Language;
 use eZ\Publish\Core\Persistence\Legacy\Tests\Content\LanguageAwareTestCase;
 use eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator;
 use eZ\Publish\SPI\Persistence\Content\Language;
+use eZ\Publish\SPI\Persistence\Content\Language\Handler as LanguageHandler;
 
 /**
  * Test case for Language MaskGenerator.
@@ -268,7 +269,7 @@ class MaskGeneratorTest extends LanguageAwareTestCase
     protected function getLanguageHandler()
     {
         if (!isset($this->languageHandler)) {
-            $this->languageHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Language\\Handler');
+            $this->languageHandler = $this->createMock(LanguageHandler::class);
             $this->languageHandler->expects($this->any())
                                   ->method('loadByLanguageCode')
                                   ->will(

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LanguageAwareTestCase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LanguageAwareTestCase.php
@@ -12,6 +12,8 @@ use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator as LanguageMaskGenerator;
 use eZ\Publish\Core\Persistence;
 use eZ\Publish\Core\Search\Legacy\Content\Mapper\FullTextMapper;
+use eZ\Publish\Core\Search\Common\FieldNameGenerator;
+use eZ\Publish\Core\Search\Common\FieldRegistry;
 
 /**
  * Test case for Language aware classes.
@@ -89,10 +91,7 @@ abstract class LanguageAwareTestCase extends TestCase
     protected function getFieldNameGeneratorMock()
     {
         if (!isset($this->fieldNameGeneratorMock)) {
-            $this->fieldNameGeneratorMock = $this
-                ->getMockBuilder('eZ\\Publish\\Core\\Search\\Common\\FieldNameGenerator')
-                ->disableOriginalConstructor()
-                ->getMock();
+            $this->fieldNameGeneratorMock = $this->createMock(FieldNameGenerator::class);
         }
 
         return $this->fieldNameGeneratorMock;
@@ -105,7 +104,7 @@ abstract class LanguageAwareTestCase extends TestCase
     protected function getFullTextMapper(Persistence\Legacy\Content\Type\Handler $contentTypeHandler)
     {
         return new FullTextMapper(
-            $this->getMock('\\eZ\\Publish\\Core\\Search\\Common\\FieldRegistry'),
+            $this->createMock(FieldRegistry::class),
             $contentTypeHandler
         );
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/MapperTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/MapperTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Location;
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper;
 use eZ\Publish\SPI\Persistence\Content\Location\Trashed;
+use eZ\Publish\SPI\Persistence\Content\Location as SPILocation;
 
 /**
  * Test case for Location\Mapper.
@@ -113,7 +114,7 @@ class MapperTest extends TestCase
         $this->assertCount(3, $locations);
         foreach ($locations as $location) {
             $this->assertInstanceOf(
-                'eZ\\Publish\\SPI\\Persistence\\Content\\Location',
+                SPILocation::class,
                 $location
             );
         }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/TrashHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/TrashHandlerTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Location;
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Trash\Handler;
 use eZ\Publish\SPI\Persistence\Content\Location\Trashed;
+use eZ\Publish\Core\Persistence\Legacy\Content as CoreContent;
 
 /**
  * Test case for TrashHandlerTest.
@@ -50,14 +51,10 @@ class TrashHandlerTest extends TestCase
         $dbHandler = $this->getDatabaseHandler();
 
         return new Handler(
-            $this->locationHandler = $this->getMockBuilder('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Handler')
-                ->disableOriginalConstructor()
-                ->getMock(),
-            $this->locationGateway = $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Gateway'),
-            $this->locationMapper = $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Mapper'),
-            $this->contentHandler = $this->getMockBuilder('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Handler')
-                ->disableOriginalConstructor()
-                ->getMock()
+            $this->locationHandler = $this->createMock(CoreContent\Location\Handler::class),
+            $this->locationGateway = $this->createMock(CoreContent\Location\Gateway::class),
+            $this->locationMapper = $this->createMock(CoreContent\Location\Mapper::class),
+            $this->contentHandler = $this->createMock(CoreContent\Handler::class)
         );
     }
 
@@ -131,7 +128,7 @@ class TrashHandlerTest extends TestCase
             ->will($this->returnValue(new Trashed(array('id' => 20))));
 
         $trashedObject = $handler->trashSubtree(20);
-        self::assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Trashed', $trashedObject);
+        self::assertInstanceOf(Trashed::class, $trashedObject);
         self::assertSame(20, $trashedObject->id);
     }
 
@@ -285,7 +282,7 @@ class TrashHandlerTest extends TestCase
             ->will($this->returnValue(new Trashed(array('id' => 20))));
 
         $trashedObject = $handler->trashSubtree(20);
-        self::assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Trashed', $trashedObject);
+        self::assertInstanceOf(Trashed::class, $trashedObject);
         self::assertSame(20, $trashedObject->id);
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationHandlerTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Handler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway;
 use eZ\Publish\SPI\Persistence\Content\Location\UpdateStruct;
 use eZ\Publish\SPI\Persistence\Content\Location\CreateStruct;
 use eZ\Publish\SPI\Persistence\Content\Location;
@@ -17,8 +18,12 @@ use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper;
+use eZ\Publish\Core\Persistence\Legacy\Content\TreeHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Handler as ContentHandler;
 use eZ\Publish\SPI\Persistence\Content\ObjectState;
+use eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Handler as ObjectStateHandler;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\Group as ObjectStateGroup;
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Handler as LocationHandler;
 
 /**
  * Test case for LocationHandlerTest.
@@ -64,10 +69,10 @@ class LocationHandlerTest extends TestCase
     {
         parent::setUp();
 
-        $this->locationGateway = $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Gateway');
-        $this->locationMapper = $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Mapper');
-        $this->treeHandler = $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\TreeHandler', array(), array(), '', false);
-        $this->contentHandler = $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Handler', array(), array(), '', false);
+        $this->locationGateway = $this->createMock(Gateway::class);
+        $this->locationMapper = $this->createMock(Mapper::class);
+        $this->treeHandler = $this->createMock(TreeHandler::class);
+        $this->contentHandler = $this->createMock(ContentHandler::class);
     }
 
     protected function getLocationHandler()
@@ -78,7 +83,7 @@ class LocationHandlerTest extends TestCase
             $this->locationGateway,
             $this->locationMapper,
             $this->contentHandler,
-            $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\ObjectState\\Handler', array(), array(), '', false),
+            $this->createMock(ObjectStateHandler::class),
             $this->treeHandler
         );
     }
@@ -583,7 +588,7 @@ class LocationHandlerTest extends TestCase
                 ->with(
                     $contentId + $offset,
                     1,
-                    $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\MetadataUpdateStruct')
+                    $this->isInstanceOf(Content\MetadataUpdateStruct::class)
                 )
                 ->will(
                     $this->returnValue(
@@ -686,16 +691,17 @@ class LocationHandlerTest extends TestCase
      */
     protected function getPartlyMockedHandler(array $methods)
     {
-        return $this->getMock(
-            '\\eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Handler',
-            $methods,
-            array(
-                $this->locationGateway = $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Gateway', array(), array(), '', false),
-                $this->locationMapper = $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Mapper', array(), array(), '', false),
-                $this->contentHandler = $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Handler', array(), array(), '', false),
-                $this->objectStateHandler = $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\ObjectState\\Handler', array(), array(), '', false),
-                $this->treeHandler = $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\TreeHandler', array(), array(), '', false),
+        return $this->getMockBuilder(LocationHandler::class)
+            ->setMethods($methods)
+            ->setConstructorArgs(
+                array(
+                    $this->locationGateway = $this->createMock(Gateway::class),
+                    $this->locationMapper = $this->createMock(Mapper::class),
+                    $this->contentHandler = $this->createMock(ContentHandler::class),
+                    $this->objectStateHandler = $this->createMock(ObjectStateHandler::class),
+                    $this->treeHandler = $this->createMock(TreeHandler::class),
+                )
             )
-        );
+            ->getMock();
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/MapperTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/MapperTest.php
@@ -10,8 +10,10 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;
 
 use eZ\Publish\Core\Persistence\Legacy\Content\Mapper;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry as Registry;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\API\Repository\Values\Content\Relation as RelationValue;
+use eZ\Publish\SPI\Persistence\Content\Relation as SPIRelation;
 use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
@@ -146,17 +148,15 @@ class MapperTest extends LanguageAwareTestCase
      */
     public function testConvertToStorageValue()
     {
-        $convMock = $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\FieldValue\\Converter'
-        );
+        $convMock = $this->createMock(Converter::class);
         $convMock->expects($this->once())
             ->method('toStorageValue')
             ->with(
                 $this->isInstanceOf(
-                    'eZ\\Publish\\SPI\\Persistence\\Content\\FieldValue'
+                    FieldValue::class
                 ),
                 $this->isInstanceOf(
-                    'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue'
+                    StorageFieldValue::class
                 )
             )->will($this->returnValue(new StorageFieldValue()));
 
@@ -170,7 +170,7 @@ class MapperTest extends LanguageAwareTestCase
         $res = $mapper->convertToStorageValue($field);
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue',
+            StorageFieldValue::class,
             $res
         );
     }
@@ -183,14 +183,12 @@ class MapperTest extends LanguageAwareTestCase
      */
     public function testExtractContentFromRows()
     {
-        $convMock = $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\FieldValue\\Converter'
-        );
+        $convMock = $this->createMock(Converter::class);
         $convMock->expects($this->exactly(13))
             ->method('toFieldValue')
             ->with(
                 $this->isInstanceOf(
-                    'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue'
+                    StorageFieldValue::class
                 )
             )->will(
                 $this->returnValue(
@@ -230,9 +228,7 @@ class MapperTest extends LanguageAwareTestCase
      */
     public function testExtractContentFromRowsMultipleVersions()
     {
-        $convMock = $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\FieldValue\\Converter'
-        );
+        $convMock = $this->createMock(Converter::class);
         $convMock->expects($this->any())
             ->method('toFieldValue')
             ->will($this->returnValue(new FieldValue()));
@@ -287,10 +283,7 @@ class MapperTest extends LanguageAwareTestCase
 
         $struct = $mapper->createCreateStructFromContent($content);
 
-        $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\CreateStruct',
-            $struct
-        );
+        $this->assertInstanceOf(CreateStruct::class, $struct);
 
         return array(
             'original' => $content,
@@ -444,7 +437,7 @@ class MapperTest extends LanguageAwareTestCase
         $mapper = $this->getMapper();
         $relation = $mapper->createRelationFromCreateStruct($struct);
 
-        self::assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Relation', $relation);
+        self::assertInstanceOf(SPIRelation::class, $relation);
         foreach ($struct as $property => $value) {
             self::assertSame($value, $relation->$property);
         }
@@ -579,11 +572,10 @@ class MapperTest extends LanguageAwareTestCase
     protected function getValueConverterRegistryMock()
     {
         if (!isset($this->valueConverterRegistryMock)) {
-            $this->valueConverterRegistryMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\FieldValue\\ConverterRegistry',
-                array(),
-                array(array())
-            );
+            $this->valueConverterRegistryMock = $this->getMockBuilder(Registry::class)
+                ->setMethods(array())
+                ->setConstructorArgs(array(array()))
+                ->getMock();
         }
 
         return $this->valueConverterRegistryMock;
@@ -632,7 +624,7 @@ class MapperTest extends LanguageAwareTestCase
         );
 
         if (!isset($this->languageHandler)) {
-            $this->languageHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\Language\\Handler');
+            $this->languageHandler = $this->createMock(Language\Handler::class);
             $this->languageHandler->expects($this->any())
                 ->method('load')
                 ->will(

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ObjectState/ObjectStateHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ObjectState/ObjectStateHandlerTest.php
@@ -10,6 +10,8 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\ObjectState;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\Content\LanguageAwareTestCase;
 use eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Handler;
+use eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Mapper;
+use eZ\Publish\Core\Persistence\Legacy\Content\ObjectState\Gateway;
 use eZ\Publish\SPI\Persistence\Content\ObjectState;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\Group;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\InputStruct;
@@ -90,7 +92,7 @@ class ObjectStateHandlerTest extends LanguageAwareTestCase
         $result = $handler->loadGroup(2);
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Group',
+            Group::class,
             $result
         );
     }
@@ -134,7 +136,7 @@ class ObjectStateHandlerTest extends LanguageAwareTestCase
         $result = $handler->loadGroupByIdentifier('ez_lock');
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Group',
+            Group::class,
             $result
         );
     }
@@ -179,7 +181,7 @@ class ObjectStateHandlerTest extends LanguageAwareTestCase
 
         foreach ($result as $resultItem) {
             $this->assertInstanceOf(
-                'eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Group',
+                Group::class,
                 $resultItem
             );
         }
@@ -208,7 +210,7 @@ class ObjectStateHandlerTest extends LanguageAwareTestCase
 
         foreach ($result as $resultItem) {
             $this->assertInstanceOf(
-                'eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState',
+                ObjectState::class,
                 $resultItem
             );
         }
@@ -245,7 +247,7 @@ class ObjectStateHandlerTest extends LanguageAwareTestCase
         $result = $handler->updateGroup(2, $this->getInputStructFixture());
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState\\Group',
+            Group::class,
             $result
         );
     }
@@ -327,7 +329,7 @@ class ObjectStateHandlerTest extends LanguageAwareTestCase
         $result = $handler->create(2, $this->getInputStructFixture());
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState',
+            ObjectState::class,
             $result
         );
     }
@@ -354,7 +356,7 @@ class ObjectStateHandlerTest extends LanguageAwareTestCase
         $result = $handler->load(1);
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState',
+            ObjectState::class,
             $result
         );
     }
@@ -398,7 +400,7 @@ class ObjectStateHandlerTest extends LanguageAwareTestCase
         $result = $handler->loadByIdentifier('not_locked', 2);
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState',
+            ObjectState::class,
             $result
         );
     }
@@ -451,7 +453,7 @@ class ObjectStateHandlerTest extends LanguageAwareTestCase
         $result = $handler->update(1, $this->getInputStructFixture());
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState',
+            ObjectState::class,
             $result
         );
     }
@@ -611,7 +613,7 @@ class ObjectStateHandlerTest extends LanguageAwareTestCase
         $result = $handler->getContentState(42, 2);
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\ObjectState',
+            ObjectState::class,
             $result
         );
     }
@@ -689,11 +691,10 @@ class ObjectStateHandlerTest extends LanguageAwareTestCase
     protected function getMapperMock()
     {
         if (!isset($this->mapperMock)) {
-            $this->mapperMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\ObjectState\\Mapper',
-                array(),
-                array($this->getLanguageHandler())
-            );
+            $this->mapperMock = $this->getMockBuilder(Mapper::class)
+                ->setConstructorArgs(array($this->getLanguageHandler()))
+                ->setMethods(array())
+                ->getMock();
         }
 
         return $this->mapperMock;
@@ -707,9 +708,7 @@ class ObjectStateHandlerTest extends LanguageAwareTestCase
     protected function getGatewayMock()
     {
         if (!isset($this->gatewayMock)) {
-            $this->gatewayMock = $this->getMockForAbstractClass(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\ObjectState\\Gateway'
-            );
+            $this->gatewayMock = $this->getMockForAbstractClass(Gateway::class);
         }
 
         return $this->gatewayMock;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Section/SectionHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Section/SectionHandlerTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Section;
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\SPI\Persistence\Content\Section;
 use eZ\Publish\Core\Persistence\Legacy\Content\Section\Handler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Section\Gateway;
 
 /**
  * Test case for Section Handler.
@@ -345,9 +346,7 @@ class SectionHandlerTest extends TestCase
     protected function getGatewayMock()
     {
         if (!isset($this->gatewayMock)) {
-            $this->gatewayMock = $this->getMockForAbstractClass(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Section\\Gateway'
-            );
+            $this->gatewayMock = $this->getMockForAbstractClass(Gateway::class);
         }
 
         return $this->gatewayMock;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/StorageHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/StorageHandlerTest.php
@@ -10,9 +10,11 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
+use eZ\Publish\SPI\FieldType\FieldStorage;
 
 /**
  * Test case for Content Handler.
@@ -58,8 +60,8 @@ class StorageHandlerTest extends TestCase
         $storageMock->expects($this->once())
             ->method('storeFieldData')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\VersionInfo'),
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'),
+                $this->isInstanceOf(VersionInfo::class),
+                $this->isInstanceOf(Field::class),
                 $this->equalTo($this->getContextMock())
             );
 
@@ -90,8 +92,8 @@ class StorageHandlerTest extends TestCase
         $storageMock->expects($this->once())
             ->method('getFieldData')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\VersionInfo'),
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Field'),
+                $this->isInstanceOf(VersionInfo::class),
+                $this->isInstanceOf(Field::class),
                 $this->equalTo($this->getContextMock())
             );
 
@@ -146,7 +148,7 @@ class StorageHandlerTest extends TestCase
         $storageMock->expects($this->once())
             ->method('deleteFieldData')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\VersionInfo'),
+                $this->isInstanceOf(VersionInfo::class),
                 $this->equalTo(array(1, 2, 3)),
                 $this->equalTo($this->getContextMock())
             );
@@ -195,11 +197,10 @@ class StorageHandlerTest extends TestCase
     protected function getStorageRegistryMock()
     {
         if (!isset($this->storageRegistryMock)) {
-            $this->storageRegistryMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageRegistry',
-                array(),
-                array(array())
-            );
+            $this->storageRegistryMock = $this->getMockBuilder(StorageRegistry::class)
+                ->setConstructorArgs(array(array()))
+                ->setMethods(array())
+                ->getMock();
         }
 
         return $this->storageRegistryMock;
@@ -213,9 +214,7 @@ class StorageHandlerTest extends TestCase
     protected function getStorageMock()
     {
         if (!isset($this->storageMock)) {
-            $this->storageMock = $this->getMock(
-                'eZ\\Publish\\SPI\\FieldType\\FieldStorage'
-            );
+            $this->storageMock = $this->createMock(FieldStorage::class);
         }
 
         return $this->storageMock;
@@ -224,9 +223,7 @@ class StorageHandlerTest extends TestCase
     protected function getVersionInfoMock()
     {
         if (!isset($this->versionInfoMock)) {
-            $this->versionInfoMock = $this->getMock(
-                'eZ\\Publish\\SPI\\Persistence\\Content\\VersionInfo'
-            );
+            $this->versionInfoMock = $this->createMock(VersionInfo::class);
         }
 
         return $this->versionInfoMock;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/StorageRegistryTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/StorageRegistryTest.php
@@ -10,6 +10,8 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageRegistry;
+use eZ\Publish\SPI\FieldType\FieldStorage;
+use eZ\Publish\Core\FieldType\NullStorage;
 
 /**
  * Test case for StorageRegistry.
@@ -57,7 +59,7 @@ class StorageRegistryTest extends TestCase
     {
         $registry = new StorageRegistry(array());
         self::assertInstanceOf(
-            'eZ\\Publish\\Core\\FieldType\\NullStorage',
+            NullStorage::class,
             $registry->getStorage('not-found')
         );
     }
@@ -69,8 +71,6 @@ class StorageRegistryTest extends TestCase
      */
     protected function getStorageMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\SPI\\FieldType\\FieldStorage'
-        );
+        return $this->createMock(FieldStorage::class);
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/TreeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/TreeHandlerTest.php
@@ -13,6 +13,11 @@ use eZ\Publish\Core\Persistence\Legacy\Content\TreeHandler;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use eZ\Publish\SPI\Persistence\Content\Location;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Mapper;
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper;
+use eZ\Publish\Core\Persistence\Legacy\Content\Gateway;
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway as LocationGateway;
 
 /**
  * Test case for Tree Handler.
@@ -368,9 +373,7 @@ class TreeHandlerTest extends TestCase
     protected function getLocationGatewayMock()
     {
         if (!isset($this->locationGatewayMock)) {
-            $this->locationGatewayMock = $this->getMockForAbstractClass(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Gateway'
-            );
+            $this->locationGatewayMock = $this->getMockForAbstractClass(LocationGateway::class);
         }
 
         return $this->locationGatewayMock;
@@ -389,13 +392,7 @@ class TreeHandlerTest extends TestCase
     protected function getLocationMapperMock()
     {
         if (!isset($this->locationMapperMock)) {
-            $this->locationMapperMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Mapper',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->locationMapperMock = $this->createMock(LocationMapper::class);
         }
 
         return $this->locationMapperMock;
@@ -414,9 +411,7 @@ class TreeHandlerTest extends TestCase
     protected function getContentGatewayMock()
     {
         if (!isset($this->contentGatewayMock)) {
-            $this->contentGatewayMock = $this->getMockForAbstractClass(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Gateway'
-            );
+            $this->contentGatewayMock = $this->getMockForAbstractClass(Gateway::class);
         }
 
         return $this->contentGatewayMock;
@@ -435,13 +430,7 @@ class TreeHandlerTest extends TestCase
     protected function getContentMapperMock()
     {
         if (!isset($this->contentMapper)) {
-            $this->contentMapper = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Mapper',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->contentMapper = $this->createMock(Mapper::class);
         }
 
         return $this->contentMapper;
@@ -460,13 +449,7 @@ class TreeHandlerTest extends TestCase
     protected function getFieldHandlerMock()
     {
         if (!isset($this->fieldHandlerMock)) {
-            $this->fieldHandlerMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\FieldHandler',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->fieldHandlerMock = $this->createMock(FieldHandler::class);
         }
 
         return $this->fieldHandlerMock;
@@ -479,17 +462,18 @@ class TreeHandlerTest extends TestCase
      */
     protected function getPartlyMockedTreeHandler(array $methods)
     {
-        return $this->getMock(
-            '\\eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\TreeHandler',
-            $methods,
-            array(
-                $this->getLocationGatewayMock(),
-                $this->getLocationMapperMock(),
-                $this->getContentGatewayMock(),
-                $this->getContentMapperMock(),
-                $this->getFieldHandlerMock(),
+        return $this->getMockBuilder(TreeHandler::class)
+            ->setMethods($methods)
+            ->setConstructorArgs(
+                array(
+                    $this->getLocationGatewayMock(),
+                    $this->getLocationMapperMock(),
+                    $this->getContentGatewayMock(),
+                    $this->getContentMapperMock(),
+                    $this->getFieldHandlerMock(),
+                )
             )
-        );
+            ->getMock();
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
@@ -17,6 +17,10 @@ use eZ\Publish\SPI\Persistence\Content\Type\Group\CreateStruct as GroupCreateStr
 use eZ\Publish\SPI\Persistence\Content\Type\Group\UpdateStruct as GroupUpdateStruct;
 use eZ\Publish\Core\Persistence\Legacy\Exception;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler;
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\Mapper;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\Update\Handler as UpdateHandler;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -81,7 +85,7 @@ class ContentTypeHandlerTest extends TestCase
             ->method('createGroupFromCreateStruct')
             ->with(
                 $this->isInstanceOf(
-                    'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Group\\CreateStruct'
+                    GroupCreateStruct::class
                 )
             )
             ->will(
@@ -93,7 +97,7 @@ class ContentTypeHandlerTest extends TestCase
             ->method('insertGroup')
             ->with(
                 $this->isInstanceOf(
-                    'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Group'
+                    Group::class
                 )
             )
             ->will($this->returnValue(23));
@@ -104,7 +108,7 @@ class ContentTypeHandlerTest extends TestCase
         );
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Group',
+            Group::class,
             $group
         );
         $this->assertEquals(
@@ -128,15 +132,15 @@ class ContentTypeHandlerTest extends TestCase
             ->method('updateGroup')
             ->with(
                 $this->isInstanceOf(
-                    'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Group\\UpdateStruct'
+                    GroupUpdateStruct::class
                 )
             );
 
-        $handlerMock = $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\Handler',
-            array('loadGroup'),
-            array($gatewayMock, $mapperMock, $this->getUpdateHandlerMock())
-        );
+        $handlerMock = $this->getMockBuilder(Handler::class)
+            ->setMethods(array('loadGroup'))
+            ->setConstructorArgs(array($gatewayMock, $mapperMock, $this->getUpdateHandlerMock()))
+            ->getMock();
+
         $handlerMock->expects($this->once())
             ->method('loadGroup')
             ->with(
@@ -150,7 +154,7 @@ class ContentTypeHandlerTest extends TestCase
         );
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Group',
+            Group::class,
             $res
         );
     }
@@ -483,7 +487,7 @@ class ContentTypeHandlerTest extends TestCase
             ->method('insertType')
             ->with(
                 $this->isInstanceOf(
-                    'eZ\\Publish\\SPI\\Persistence\\Content\\Type'
+                    Type::class
                 )
             )
             ->will($this->returnValue(23));
@@ -499,23 +503,23 @@ class ContentTypeHandlerTest extends TestCase
             ->with(
                 $this->equalTo(23),
                 $this->equalTo(1),
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\FieldDefinition'),
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldDefinition')
+                $this->isInstanceOf(FieldDefinition::class),
+                $this->isInstanceOf(StorageFieldDefinition::class)
             )
             ->will($this->returnValue(42));
 
         $mapperMock->expects($this->exactly(2))
             ->method('toStorageFieldDefinition')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type\\FieldDefinition'),
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldDefinition')
+                $this->isInstanceOf(FieldDefinition::class),
+                $this->isInstanceOf(StorageFieldDefinition::class)
             );
 
         $handler = $this->getHandler();
         $type = $handler->create($createStructFix);
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Type',
+            Type::class,
             $type,
             'Incorrect type returned from create()'
         );
@@ -555,15 +559,15 @@ class ContentTypeHandlerTest extends TestCase
                 $this->equalTo(23),
                 $this->equalTo(1),
                 $this->isInstanceOf(
-                    'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\UpdateStruct'
+                    UpdateStruct::class
                 )
             );
 
-        $handlerMock = $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\Handler',
-            array('load'),
-            array($gatewayMock, $this->getMapperMock(), $this->getUpdateHandlerMock())
-        );
+        $handlerMock = $this->getMockBuilder(Handler::class)
+            ->setMethods(array('load'))
+            ->setConstructorArgs(array($gatewayMock, $this->getMapperMock(), $this->getUpdateHandlerMock()))
+            ->getMock();
+
         $handlerMock->expects($this->once())
             ->method('load')
             ->with(
@@ -575,7 +579,7 @@ class ContentTypeHandlerTest extends TestCase
         $res = $handlerMock->update(23, 1, new UpdateStruct());
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Type',
+            Type::class,
             $res
         );
     }
@@ -647,17 +651,17 @@ class ContentTypeHandlerTest extends TestCase
             ->method('createCreateStructFromType')
             ->with(
                 $this->isInstanceOf(
-                    'eZ\\Publish\\SPI\\Persistence\\Content\\Type'
+                    Type::class
                 )
             )->will(
                 $this->returnValue(new CreateStruct())
             );
 
-        $handlerMock = $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\Handler',
-            array('load', 'internalCreate'),
-            array($gatewayMock, $mapperMock, $this->getUpdateHandlerMock())
-        );
+        $handlerMock = $this->getMockBuilder(Handler::class)
+            ->setMethods(array('load', 'internalCreate'))
+            ->setConstructorArgs(array($gatewayMock, $mapperMock, $this->getUpdateHandlerMock()))
+            ->getMock();
+
         $handlerMock->expects($this->once())
             ->method('load')
             ->with(
@@ -687,7 +691,7 @@ class ContentTypeHandlerTest extends TestCase
         $res = $handlerMock->createDraft(42, 23);
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Type',
+            Type::class,
             $res
         );
     }
@@ -703,17 +707,17 @@ class ContentTypeHandlerTest extends TestCase
             ->method('createCreateStructFromType')
             ->with(
                 $this->isInstanceOf(
-                    'eZ\\Publish\\SPI\\Persistence\\Content\\Type'
+                    Type::class
                 )
             )->will(
                 $this->returnValue(new CreateStruct(array('identifier' => 'testCopy')))
             );
 
-        $handlerMock = $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\Handler',
-            array('load', 'internalCreate', 'update'),
-            array($gatewayMock, $mapperMock, $this->getUpdateHandlerMock())
-        );
+        $handlerMock = $this->getMockBuilder(Handler::class)
+            ->setMethods(array('load', 'internalCreate', 'update'))
+            ->setConstructorArgs(array($gatewayMock, $mapperMock, $this->getUpdateHandlerMock()))
+            ->getMock();
+
         $handlerMock->expects($this->once())
             ->method('load')
             ->with(
@@ -783,7 +787,7 @@ class ContentTypeHandlerTest extends TestCase
         $res = $handlerMock->copy(42, 23, 0);
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Type',
+            Type::class,
             $res
         );
     }
@@ -893,7 +897,7 @@ class ContentTypeHandlerTest extends TestCase
         $fieldDefinition = $handler->getFieldDefinition(42, Type::STATUS_DEFINED);
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\FieldDefinition',
+            FieldDefinition::class,
             $fieldDefinition
         );
     }
@@ -910,10 +914,10 @@ class ContentTypeHandlerTest extends TestCase
             ->method('toStorageFieldDefinition')
             ->with(
                 $this->isInstanceOf(
-                    'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\FieldDefinition'
+                    FieldDefinition::class
                 ),
                 $this->isInstanceOf(
-                    'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldDefinition'
+                    StorageFieldDefinition::class
                 )
             );
 
@@ -924,10 +928,10 @@ class ContentTypeHandlerTest extends TestCase
                 $this->equalTo(23),
                 $this->equalTo(1),
                 $this->isInstanceOf(
-                    'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\FieldDefinition'
+                    FieldDefinition::class
                 ),
                 $this->isInstanceOf(
-                    'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldDefinition'
+                    StorageFieldDefinition::class
                 )
             )->will(
                 $this->returnValue(42)
@@ -998,10 +1002,10 @@ class ContentTypeHandlerTest extends TestCase
             ->method('toStorageFieldDefinition')
             ->with(
                 $this->isInstanceOf(
-                    'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\FieldDefinition'
+                    FieldDefinition::class
                 ),
                 $this->isInstanceOf(
-                    'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldDefinition'
+                    StorageFieldDefinition::class
                 )
             );
 
@@ -1012,7 +1016,7 @@ class ContentTypeHandlerTest extends TestCase
                 $this->equalTo(23),
                 $this->equalTo(1),
                 $this->isInstanceOf(
-                    'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\FieldDefinition'
+                    FieldDefinition::class
                 )
             );
 
@@ -1047,18 +1051,18 @@ class ContentTypeHandlerTest extends TestCase
         $updateHandlerMock->expects($this->once())
             ->method('updateContentObjects')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type'),
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type')
+                $this->isInstanceOf(Type::class),
+                $this->isInstanceOf(Type::class)
             );
         $updateHandlerMock->expects($this->once())
             ->method('deleteOldType')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type')
+                $this->isInstanceOf(Type::class)
             );
         $updateHandlerMock->expects($this->once())
             ->method('publishNewType')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type'),
+                $this->isInstanceOf(Type::class),
                 $this->equalTo(0)
             );
 
@@ -1098,7 +1102,7 @@ class ContentTypeHandlerTest extends TestCase
         $updateHandlerMock->expects($this->once())
             ->method('publishNewType')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\Type'),
+                $this->isInstanceOf(Type::class),
                 $this->equalTo(0)
             );
 
@@ -1128,15 +1132,16 @@ class ContentTypeHandlerTest extends TestCase
      */
     protected function getPartlyMockedHandler(array $methods)
     {
-        return $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\Handler',
-            $methods,
-            array(
-                $this->getGatewayMock(),
-                $this->getMapperMock(),
-                $this->getUpdateHandlerMock(),
+        return $this->getMockBuilder(Handler::class)
+            ->setMethods($methods)
+            ->setConstructorArgs(
+                array(
+                    $this->getGatewayMock(),
+                    $this->getMapperMock(),
+                    $this->getUpdateHandlerMock(),
+                )
             )
-        );
+            ->getMock();
     }
 
     /**
@@ -1148,7 +1153,7 @@ class ContentTypeHandlerTest extends TestCase
     {
         if (!isset($this->gatewayMock)) {
             $this->gatewayMock = $this->getMockForAbstractClass(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\Gateway'
+                Gateway::class
             );
         }
 
@@ -1165,13 +1170,10 @@ class ContentTypeHandlerTest extends TestCase
     protected function getMapperMock($methods = array())
     {
         if (!isset($this->mapperMock)) {
-            $this->mapperMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\Mapper',
-                $methods,
-                array(),
-                '',
-                false
-            );
+            $this->mapperMock = $this->getMockBuilder(Mapper::class)
+                ->disableOriginalConstructor()
+                ->setMethods($methods)
+                ->getMock();
         }
 
         return $this->mapperMock;
@@ -1185,13 +1187,10 @@ class ContentTypeHandlerTest extends TestCase
     public function getUpdateHandlerMock()
     {
         if (!isset($this->updateHandlerMock)) {
-            $this->updateHandlerMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\Update\\Handler',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->updateHandlerMock = $this->getMockBuilder(UpdateHandler::class)
+                ->disableOriginalConstructor()
+                ->setMethods(array())
+                ->getMock();
         }
 
         return $this->updateHandlerMock;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdater/Action/AddFieldTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdater/Action/AddFieldTest.php
@@ -546,6 +546,7 @@ class AddFieldTest extends TestCase
     protected function getContentGatewayMock()
     {
         if (!isset($this->contentGatewayMock)) {
+
             $this->contentGatewayMock = $this->createMock(Gateway::class);  
         }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdater/Action/AddFieldTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdater/Action/AddFieldTest.php
@@ -546,8 +546,7 @@ class AddFieldTest extends TestCase
     protected function getContentGatewayMock()
     {
         if (!isset($this->contentGatewayMock)) {
-
-            $this->contentGatewayMock = $this->createMock(Gateway::class);  
+            $this->contentGatewayMock = $this->createMock(Gateway::class);
         }
 
         return $this->contentGatewayMock;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdater/Action/AddFieldTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdater/Action/AddFieldTest.php
@@ -9,7 +9,12 @@
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Type\ContentUpdater\Action;
 
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\ContentUpdater\Action\AddField;
+use eZ\Publish\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Gateway;
 use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\SPI\Persistence\Content;
 use PHPUnit\Framework\TestCase;
 use ReflectionObject;
@@ -315,7 +320,7 @@ class AddFieldTest extends TestCase
             ->method('toStorageValue')
             ->with(
                 $value,
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(StorageFieldValue::class)
             );
 
         $this->getContentGatewayMock()
@@ -324,7 +329,7 @@ class AddFieldTest extends TestCase
             ->with(
                 $content,
                 $field,
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(StorageFieldValue::class)
             )
             ->will($this->returnValue(23));
 
@@ -364,7 +369,7 @@ class AddFieldTest extends TestCase
             ->method('toStorageValue')
             ->with(
                 $value,
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(StorageFieldValue::class)
             );
 
         $this->getContentGatewayMock()
@@ -373,7 +378,7 @@ class AddFieldTest extends TestCase
             ->with(
                 $content,
                 $field,
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(StorageFieldValue::class)
             )
             ->will($this->returnValue(23));
 
@@ -388,7 +393,7 @@ class AddFieldTest extends TestCase
             ->method('updateField')
             ->with(
                 $field,
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(StorageFieldValue::class)
             );
 
         $action = $this->getMockedAction();
@@ -419,7 +424,7 @@ class AddFieldTest extends TestCase
             ->method('toStorageValue')
             ->with(
                 $value,
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(StorageFieldValue::class)
             );
 
         $this->getContentGatewayMock()
@@ -428,7 +433,7 @@ class AddFieldTest extends TestCase
             ->with(
                 $content,
                 $field,
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(StorageFieldValue::class)
             );
 
         $this->getContentStorageHandlerMock()
@@ -467,7 +472,7 @@ class AddFieldTest extends TestCase
             ->method('toStorageValue')
             ->with(
                 $value,
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(StorageFieldValue::class)
             );
 
         $this->getContentGatewayMock()
@@ -476,7 +481,7 @@ class AddFieldTest extends TestCase
             ->with(
                 $content,
                 $field,
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(StorageFieldValue::class)
             );
 
         $this->getContentStorageHandlerMock()
@@ -490,7 +495,7 @@ class AddFieldTest extends TestCase
             ->method('updateField')
             ->with(
                 $field,
-                $this->isInstanceOf('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldValue')
+                $this->isInstanceOf(StorageFieldValue::class)
             );
 
         $action = $this->getMockedAction();
@@ -541,9 +546,7 @@ class AddFieldTest extends TestCase
     protected function getContentGatewayMock()
     {
         if (!isset($this->contentGatewayMock)) {
-            $this->contentGatewayMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Gateway'
-            );
+            $this->contentGatewayMock = $this->createMock(Gateway::class);  
         }
 
         return $this->contentGatewayMock;
@@ -557,9 +560,7 @@ class AddFieldTest extends TestCase
     protected function getFieldValueConverterMock()
     {
         if (!isset($this->fieldValueConverterMock)) {
-            $this->fieldValueConverterMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\FieldValue\\Converter'
-            );
+            $this->fieldValueConverterMock = $this->createMock(Converter::class);
         }
 
         return $this->fieldValueConverterMock;
@@ -573,13 +574,7 @@ class AddFieldTest extends TestCase
     protected function getContentStorageHandlerMock()
     {
         if (!isset($this->contentStorageHandlerMock)) {
-            $this->contentStorageHandlerMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageHandler',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->contentStorageHandlerMock = $this->createMock(StorageHandler::class);
         }
 
         return $this->contentStorageHandlerMock;
@@ -593,13 +588,7 @@ class AddFieldTest extends TestCase
     protected function getContentMapperMock()
     {
         if (!isset($this->contentMapperMock)) {
-            $this->contentMapperMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Mapper',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->contentMapperMock = $this->createMock(ContentMapper::class);
         }
 
         return $this->contentMapperMock;
@@ -652,7 +641,7 @@ class AddFieldTest extends TestCase
     protected function getMockedAction($methods = array())
     {
         return $this
-            ->getMockBuilder('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\ContentUpdater\\Action\\AddField')
+            ->getMockBuilder(AddField::class)
             ->setMethods((array)$methods)
             ->setConstructorArgs(
                 array(

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdater/Action/RemoveFieldTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdater/Action/RemoveFieldTest.php
@@ -9,7 +9,10 @@
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Type\ContentUpdater\Action;
 
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\ContentUpdater\Action\RemoveField;
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
 use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\Core\Persistence\Legacy\Content\Gateway;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -308,9 +311,7 @@ class RemoveFieldTest extends TestCase
     protected function getContentGatewayMock()
     {
         if (!isset($this->contentGatewayMock)) {
-            $this->contentGatewayMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Gateway'
-            );
+            $this->contentGatewayMock = $this->createMock(Gateway::class);
         }
 
         return $this->contentGatewayMock;
@@ -324,13 +325,7 @@ class RemoveFieldTest extends TestCase
     protected function getContentStorageHandlerMock()
     {
         if (!isset($this->contentStorageHandlerMock)) {
-            $this->contentStorageHandlerMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageHandler',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->contentStorageHandlerMock = $this->createMock(StorageHandler::class);
         }
 
         return $this->contentStorageHandlerMock;
@@ -344,13 +339,7 @@ class RemoveFieldTest extends TestCase
     protected function getContentMapperMock()
     {
         if (!isset($this->contentMapperMock)) {
-            $this->contentMapperMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Mapper',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->contentMapperMock = $this->createMock(ContentMapper::class);
         }
 
         return $this->contentMapperMock;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdaterTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdaterTest.php
@@ -9,6 +9,12 @@
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Type;
 
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\ContentUpdater;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\ContentUpdater\Action;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Mapper;
+use eZ\Publish\Core\Persistence\Legacy\Content\Gateway;
 use eZ\Publish\SPI\Persistence\Content\Type;
 use PHPUnit\Framework\TestCase;
 
@@ -91,9 +97,7 @@ class ContentUpdaterTest extends TestCase
             ->with('ezstring')
             ->will(
                 $this->returnValue(
-                    ($converterMock = $this->getMock(
-                        '\\eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\FieldValue\\Converter'
-                    ))
+                    ($converterMock = $this->createMock(Converter::class))
                 )
             );
 
@@ -126,7 +130,7 @@ class ContentUpdaterTest extends TestCase
         $updater = $this->getContentUpdater();
 
         $actionA = $this->getMockForAbstractClass(
-            '\\eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\ContentUpdater\\Action',
+            Action::class,
             array(),
             '',
             false
@@ -138,7 +142,7 @@ class ContentUpdaterTest extends TestCase
             ->method('apply')
             ->with(22);
         $actionB = $this->getMockForAbstractClass(
-            '\\eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\ContentUpdater\\Action',
+            Action::class,
             array(),
             '',
             false
@@ -215,9 +219,7 @@ class ContentUpdaterTest extends TestCase
     protected function getContentGatewayMock()
     {
         if (!isset($this->contentGatewayMock)) {
-            $this->contentGatewayMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Gateway'
-            );
+            $this->contentGatewayMock = $this->createMock(Gateway::class);
         }
 
         return $this->contentGatewayMock;
@@ -231,11 +233,7 @@ class ContentUpdaterTest extends TestCase
     protected function getConverterRegistryMock()
     {
         if (!isset($this->converterRegistryMock)) {
-            $this->converterRegistryMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\FieldValue\\ConverterRegistry',
-                array(),
-                array(array())
-            );
+            $this->converterRegistryMock = $this->createMock(ConverterRegistry::class);
         }
 
         return $this->converterRegistryMock;
@@ -249,13 +247,7 @@ class ContentUpdaterTest extends TestCase
     protected function getContentStorageHandlerMock()
     {
         if (!isset($this->contentStorageHandlerMock)) {
-            $this->contentStorageHandlerMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageHandler',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->contentStorageHandlerMock = $this->createMock(StorageHandler::class);
         }
 
         return $this->contentStorageHandlerMock;
@@ -269,13 +261,7 @@ class ContentUpdaterTest extends TestCase
     protected function getContentMapperMock()
     {
         if (!isset($this->contentMapperMock)) {
-            $this->contentMapperMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Mapper',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->contentMapperMock = $this->createMock(Mapper::class);
         }
 
         return $this->contentMapperMock;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/MapperTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/MapperTest.php
@@ -12,6 +12,7 @@ use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Mapper;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 // Needed for $sortOrder and $sortField properties
 use eZ\Publish\SPI\Persistence\Content\Location;
 use eZ\Publish\SPI\Persistence\Content\Type;
@@ -37,7 +38,7 @@ class MapperTest extends TestCase
         $group = $mapper->createGroupFromCreateStruct($createStruct);
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Group',
+            Group::class,
             $group
         );
         $this->assertPropertiesCorrect(
@@ -325,17 +326,15 @@ class MapperTest extends TestCase
      */
     public function testToStorageFieldDefinition()
     {
-        $converterMock = $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\FieldValue\\Converter'
-        );
+        $converterMock = $this->createMock(Converter::class);
         $converterMock->expects($this->once())
             ->method('toStorageFieldDefinition')
             ->with(
                 $this->isInstanceOf(
-                    'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\FieldDefinition'
+                    FieldDefinition::class
                 ),
                 $this->isInstanceOf(
-                    'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldDefinition'
+                    StorageFieldDefinition::class
                 )
             );
 
@@ -357,17 +356,15 @@ class MapperTest extends TestCase
      */
     public function testToFieldDefinition()
     {
-        $converterMock = $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\FieldValue\\Converter'
-        );
+        $converterMock = $this->createMock(Converter::class);
         $converterMock->expects($this->once())
             ->method('toFieldDefinition')
             ->with(
                 $this->isInstanceOf(
-                    'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldDefinition'
+                    StorageFieldDefinition::class
                 ),
                 $this->isInstanceOf(
-                    'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\FieldDefinition'
+                    FieldDefinition::class
                 )
             );
 
@@ -390,17 +387,17 @@ class MapperTest extends TestCase
      */
     protected function getNonConvertingMapper()
     {
-        $mapper = $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\Mapper',
-            ['toFieldDefinition'],
-            [$this->getConverterRegistryMock()]
-        );
+        $mapper = $this->getMockBuilder(Mapper::class)
+            ->setMethods(array('toFieldDefinition'))
+            ->setConstructorArgs(array($this->getConverterRegistryMock()))
+            ->getMock();
+
         // Dedicatedly tested test
         $mapper->expects($this->atLeastOnce())
             ->method('toFieldDefinition')
             ->with(
                 $this->isInstanceOf(
-                    'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\StorageFieldDefinition'
+                    StorageFieldDefinition::class
                 )
             )->will(
                 $this->returnCallback(
@@ -420,11 +417,7 @@ class MapperTest extends TestCase
      */
     protected function getConverterRegistryMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\FieldValue\\ConverterRegistry',
-            [],
-            [[]]
-        );
+        return $this->createMock(ConverterRegistry::class);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Update/Handler/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Update/Handler/DoctrineDatabaseTest.php
@@ -10,6 +10,8 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Type\UpdateHandler;
 
 use eZ\Publish\SPI\Persistence\Content\Type;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Update\Handler\DoctrineDatabase;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\ContentUpdater;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -44,10 +46,10 @@ class DoctrineDatabaseTest extends TestCase
             ->method('determineActions')
             ->with(
                 $this->isInstanceOf(
-                    'eZ\\Publish\\SPI\\Persistence\\Content\\Type'
+                    Type::class
                 ),
                 $this->isInstanceOf(
-                    'eZ\\Publish\\SPI\\Persistence\\Content\\Type'
+                    Type::class
                 )
             )->will($this->returnValue(array()));
 
@@ -144,9 +146,7 @@ class DoctrineDatabaseTest extends TestCase
     protected function getGatewayMock()
     {
         if (!isset($this->gatewayMock)) {
-            $this->gatewayMock = $this->getMockForAbstractClass(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\Gateway'
-            );
+            $this->gatewayMock = $this->getMockForAbstractClass(Gateway::class);
         }
 
         return $this->gatewayMock;
@@ -160,13 +160,7 @@ class DoctrineDatabaseTest extends TestCase
     protected function getContentUpdaterMock()
     {
         if (!isset($this->contentUpdaterMock)) {
-            $this->contentUpdaterMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\ContentUpdater',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->contentUpdaterMock = $this->createMock(ContentUpdater::class);
         }
 
         return $this->contentUpdaterMock;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/SlugConverterTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/SlugConverterTest.php
@@ -10,9 +10,11 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\UrlAlias;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\SlugConverter;
+use eZ\Publish\Core\Persistence\TransformationProcessor;
 use eZ\Publish\Core\Persistence\TransformationProcessor\PcreCompiler;
 use eZ\Publish\Core\Persistence\TransformationProcessor\PreprocessedBased;
 use eZ\Publish\Core\Persistence\Utf8Converter;
+use PHPUnit\Framework\TestSuite;
 
 /**
  * Test case for URL slug converter.
@@ -314,14 +316,15 @@ class SlugConverterTest extends TestCase
     protected function getSlugConverterMock(array $methods = array())
     {
         if (!isset($this->slugConverterMock)) {
-            $this->slugConverterMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\UrlAlias\\SlugConverter',
-                $methods,
-                array(
-                    $this->getTransformationProcessorMock(),
-                    $this->configuration,
+            $this->slugConverterMock = $this->getMockBuilder(SlugConverter::class)
+                ->setMethods($methods)
+                ->setConstructorArgs(
+                    array(
+                        $this->getTransformationProcessorMock(),
+                        $this->configuration,
+                    )
                 )
-            );
+                ->getMock();
         }
 
         return $this->slugConverterMock;
@@ -334,7 +337,7 @@ class SlugConverterTest extends TestCase
     {
         if (!isset($this->transformationProcessorMock)) {
             $this->transformationProcessorMock = $this->getMockForAbstractClass(
-                'eZ\\Publish\\Core\\Persistence\\TransformationProcessor',
+                TransformationProcessor::class,
                 array(),
                 '',
                 false,
@@ -350,10 +353,10 @@ class SlugConverterTest extends TestCase
     /**
      * Returns the test suite with all tests declared in this class.
      *
-     * @return \PHPUnit_Framework_TestSuite
+     * @return TestSuite
      */
     public static function suite()
     {
-        return new \PHPUnit_Framework_TestSuite(__CLASS__);
+        return new TestSuite(__CLASS__);
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
@@ -8,8 +8,10 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;
 
+use eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Gateway;
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Handler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway as LocationGateway;
 use eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Mapper;
 use eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Gateway\DoctrineDatabase;
 use eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\SlugConverter;
@@ -50,7 +52,7 @@ class UrlAliasHandlerTest extends TestCase
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/urlaliases_location.php');
 
         $urlAlias = $handler->lookup('jedan');
-        self::assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias', $urlAlias);
+        self::assertInstanceOf(UrlAlias::class, $urlAlias);
     }
 
     /**
@@ -354,7 +356,7 @@ class UrlAliasHandlerTest extends TestCase
 
         $urlAlias = $handler->lookup($url);
 
-        self::assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias', $urlAlias);
+        self::assertInstanceOf(UrlAlias::class, $urlAlias);
         self::assertEquals(
             new UrlAlias(
                 array(
@@ -405,7 +407,7 @@ class UrlAliasHandlerTest extends TestCase
 
         $urlAlias = $handler->lookup(strtoupper($url));
 
-        self::assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias', $urlAlias);
+        self::assertInstanceOf(UrlAlias::class, $urlAlias);
         self::assertEquals(
             new UrlAlias(
                 array(
@@ -532,7 +534,7 @@ class UrlAliasHandlerTest extends TestCase
 
         $urlAlias = $handler->lookup($url);
 
-        self::assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias', $urlAlias);
+        self::assertInstanceOf(UrlAlias::class, $urlAlias);
         self::assertEquals(
             new UrlAlias(
                 array(
@@ -714,7 +716,7 @@ class UrlAliasHandlerTest extends TestCase
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/urlaliases_location_custom.php');
 
         $urlAlias = $handler->lookup($url);
-        self::assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias', $urlAlias);
+        self::assertInstanceOf(UrlAlias::class, $urlAlias);
         self::assertEquals(
             new UrlAlias(
                 array(
@@ -758,7 +760,7 @@ class UrlAliasHandlerTest extends TestCase
 
         $urlAlias = $handler->lookup(strtoupper($url));
 
-        self::assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias', $urlAlias);
+        self::assertInstanceOf(UrlAlias::class, $urlAlias);
         self::assertEquals(
             new UrlAlias(
                 array(
@@ -885,7 +887,7 @@ class UrlAliasHandlerTest extends TestCase
 
         $urlAlias = $handler->lookup($url);
 
-        self::assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias', $urlAlias);
+        self::assertInstanceOf(UrlAlias::class, $urlAlias);
         self::assertEquals(
             new UrlAlias(
                 array(
@@ -928,7 +930,7 @@ class UrlAliasHandlerTest extends TestCase
 
         $urlAlias = $handler->lookup(strtoupper($url));
 
-        self::assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias', $urlAlias);
+        self::assertInstanceOf(UrlAlias::class, $urlAlias);
         self::assertEquals(
             new UrlAlias(
                 array(
@@ -959,12 +961,12 @@ class UrlAliasHandlerTest extends TestCase
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/urlaliases_location_iri.php');
 
         $urlAlias = $handler->lookup('ŒÄ');
-        self::assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias', $urlAlias);
+        self::assertInstanceOf(UrlAlias::class, $urlAlias);
     }
 
     protected function assertVirtualUrlAliasValid(UrlAlias $urlAlias, $id)
     {
-        self::assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias', $urlAlias);
+        self::assertInstanceOf(UrlAlias::class, $urlAlias);
         self::assertEquals($id, $urlAlias->id);
         self::assertEquals(UrlAlias::VIRTUAL, $urlAlias->type);
         /*self::assertEquals(
@@ -1206,7 +1208,7 @@ class UrlAliasHandlerTest extends TestCase
 
         $urlAlias = $handler->lookup($url);
 
-        self::assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias', $urlAlias);
+        self::assertInstanceOf(UrlAlias::class, $urlAlias);
         self::assertEquals(
             new UrlAlias(
                 array(
@@ -1555,7 +1557,7 @@ class UrlAliasHandlerTest extends TestCase
             $this->countRows()
         );
 
-        self::assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias', $publishedLocationUrlAlias);
+        self::assertInstanceOf(UrlAlias::class, $publishedLocationUrlAlias);
         self::assertEquals(
             new UrlAlias(
                 array(
@@ -1933,7 +1935,7 @@ class UrlAliasHandlerTest extends TestCase
         );
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias',
+            UrlAlias::class,
             $handlerMock->createCustomUrlAlias(1, 'path')
         );
     }
@@ -1966,7 +1968,7 @@ class UrlAliasHandlerTest extends TestCase
         );
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias',
+            UrlAlias::class,
             $handlerMock->createGlobalUrlAlias('module/module', 'path')
         );
     }
@@ -2946,7 +2948,7 @@ class UrlAliasHandlerTest extends TestCase
 
         $urlAlias = $handler->loadUrlAlias($id);
 
-        self::assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias', $urlAlias);
+        self::assertInstanceOf(UrlAlias::class, $urlAlias);
         self::assertEquals(
             new UrlAlias(
                 array(
@@ -2985,7 +2987,7 @@ class UrlAliasHandlerTest extends TestCase
 
         $urlAlias = $handler->loadUrlAlias($id);
 
-        self::assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias', $urlAlias);
+        self::assertInstanceOf(UrlAlias::class, $urlAlias);
         self::assertEquals(
             new UrlAlias(
                 array(
@@ -5025,37 +5027,18 @@ class UrlAliasHandlerTest extends TestCase
      */
     protected function getPartlyMockedHandler(array $methods)
     {
-        $mock = $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\UrlAlias\\Handler',
-            $methods,
-            array(
-                self::getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\UrlAlias\\Gateway'),
-                self::getMock(
-                    'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\UrlAlias\\Mapper',
-                    array(),
-                    array(),
-                    '',
-                    false
-                ),
-                self::getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Gateway'),
-                self::getMock(
-                    'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Language\\Handler',
-                    array(),
-                    array(),
-                    '',
-                    false
-                ),
-                self::getMock(
-                    'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\UrlAlias\\SlugConverter',
-                    array(),
-                    array(),
-                    '',
-                    false
-                ),
+        return $this->getMockBuilder(Handler::class)
+            ->setConstructorArgs(
+                array(
+                    $this->createMock(Gateway::class),
+                    $this->createMock(Mapper::class),
+                    $this->createMock(LocationGateway::class),
+                    $this->createMock(LanguageHandler::class),
+                    $this->createMock(SlugConverter::class),
+                )
             )
-        );
-
-        return $mock;
+            ->setMethods($methods)
+            ->getMock();
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/HandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/HandlerTest.php
@@ -10,6 +10,20 @@ namespace eZ\Publish\Core\Persistence\Legacy\Tests;
 
 use eZ\Publish\Core\Base\ServiceContainer;
 use eZ\Publish\Core\Persistence\Legacy\Handler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Handler as ContentHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Handler as LocationHandler;
+use eZ\Publish\Core\Persistence\Legacy\User\Handler as UserHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Section\Handler as SectionHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Handler as UrlAliasHandler;
+use eZ\Publish\Core\Persistence\Legacy\TransactionHandler;
+use eZ\Publish\SPI\Persistence\Content\Handler as SPIContentHandler;
+use eZ\Publish\SPI\Persistence\Content\Type\Handler as SPIContentTypeHandler;
+use eZ\Publish\SPI\Persistence\Content\Language\Handler as SPILanguageHandler;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as SPILocationHandler;
+use eZ\Publish\SPI\Persistence\User\Handler as SPIUserHandler;
+use eZ\Publish\SPI\Persistence\Content\Section\Handler as SPISectionHandler;
+use eZ\Publish\SPI\Persistence\Content\UrlAlias\Handler as SPIUrlAliasHandler;
+use eZ\Publish\SPI\Persistence\TransactionHandler as SPITransactionHandler;
 
 /**
  * Test case for Repository Handler.
@@ -25,11 +39,11 @@ class HandlerTest extends TestCase
         $contentHandler = $handler->contentHandler();
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Handler',
+            SPIContentHandler::class,
             $contentHandler
         );
         $this->assertInstanceOf(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Handler',
+            ContentHandler::class,
             $contentHandler
         );
     }
@@ -56,7 +70,7 @@ class HandlerTest extends TestCase
         $contentTypeHandler = $handler->contentTypeHandler();
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Type\\Handler',
+            SPIContentTypeHandler::class,
             $contentTypeHandler
         );
     }
@@ -70,7 +84,7 @@ class HandlerTest extends TestCase
         $contentLanguageHandler = $handler->contentLanguageHandler();
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Language\\Handler',
+            SPILanguageHandler::class,
             $contentLanguageHandler
         );
     }
@@ -97,11 +111,11 @@ class HandlerTest extends TestCase
         $locationHandler = $handler->locationHandler();
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Location\\Handler',
+            SPILocationHandler::class,
             $locationHandler
         );
         $this->assertInstanceOf(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Handler',
+            LocationHandler::class,
             $locationHandler
         );
     }
@@ -128,11 +142,11 @@ class HandlerTest extends TestCase
         $userHandler = $handler->userHandler();
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\User\\Handler',
+            SPIUserHandler::class,
             $userHandler
         );
         $this->assertInstanceOf(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\User\\Handler',
+            UserHandler::class,
             $userHandler
         );
     }
@@ -159,11 +173,11 @@ class HandlerTest extends TestCase
         $sectionHandler = $handler->sectionHandler();
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\Section\\Handler',
+            SPISectionHandler::class,
             $sectionHandler
         );
         $this->assertInstanceOf(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Section\\Handler',
+            SectionHandler::class,
             $sectionHandler
         );
     }
@@ -190,11 +204,11 @@ class HandlerTest extends TestCase
         $urlAliasHandler = $handler->urlAliasHandler();
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias\\Handler',
+            SPIUrlAliasHandler::class,
             $urlAliasHandler
         );
         $this->assertInstanceOf(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\UrlAlias\\Handler',
+            UrlAliasHandler::class,
             $urlAliasHandler
         );
     }
@@ -221,11 +235,11 @@ class HandlerTest extends TestCase
         $transactionHandler = $handler->transactionHandler();
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\Persistence\\TransactionHandler',
+            SPITransactionHandler::class,
             $transactionHandler
         );
         $this->assertInstanceOf(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\TransactionHandler',
+            TransactionHandler::class,
             $transactionHandler
         );
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/TransactionHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/TransactionHandlerTest.php
@@ -9,6 +9,9 @@
 namespace eZ\Publish\Core\Persistence\Legacy\Tests;
 
 use eZ\Publish\Core\Persistence\Legacy\TransactionHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Language\CachingHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\MemoryCachingHandler;
+use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use Exception;
 
 /**
@@ -191,9 +194,7 @@ class TransactionHandlerTest extends \PHPUnit\Framework\TestCase
     protected function getDatabaseHandlerMock()
     {
         if (!isset($this->dbHandlerMock)) {
-            $this->dbHandlerMock = $this->getMockForAbstractClass(
-                'eZ\\Publish\\Core\\Persistence\\Database\\DatabaseHandler'
-            );
+            $this->dbHandlerMock = $this->getMockForAbstractClass(DatabaseHandler::class);
         }
 
         return $this->dbHandlerMock;
@@ -207,13 +208,7 @@ class TransactionHandlerTest extends \PHPUnit\Framework\TestCase
     protected function getContentTypeHandlerMock()
     {
         if (!isset($this->contentTypeHandlerMock)) {
-            $this->contentTypeHandlerMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\MemoryCachingHandler',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->contentTypeHandlerMock = $this->createMock(MemoryCachingHandler::class);
         }
 
         return $this->contentTypeHandlerMock;
@@ -227,13 +222,7 @@ class TransactionHandlerTest extends \PHPUnit\Framework\TestCase
     protected function getLanguageHandlerMock()
     {
         if (!isset($this->languageHandlerMock)) {
-            $this->languageHandlerMock = $this->getMock(
-                'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Language\\CachingHandler',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->languageHandlerMock = $this->createMock(CachingHandler::class);
         }
 
         return $this->languageHandlerMock;

--- a/eZ/Publish/Core/Persistence/Tests/FieldTypeRegistryTest.php
+++ b/eZ/Publish/Core/Persistence/Tests/FieldTypeRegistryTest.php
@@ -10,6 +10,8 @@ namespace eZ\Publish\Core\Persistence\Tests;
 
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 use eZ\Publish\Core\Persistence\FieldTypeRegistry;
+use eZ\Publish\SPI\FieldType\FieldType as SPIFieldType;
+use eZ\Publish\SPI\Persistence\FieldType as SPIPersistenceFieldType;
 
 /**
  * Test case for FieldTypeRegistry.
@@ -43,7 +45,7 @@ class FieldTypeRegistryTest extends TestCase
 
         $result = $registry->getFieldType('some-type');
 
-        $this->assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\FieldType', $result);
+        $this->assertInstanceOf(SPIPersistenceFieldType::class, $result);
         $this->assertAttributeSame(
             $instance,
             'internalFieldType',
@@ -64,7 +66,7 @@ class FieldTypeRegistryTest extends TestCase
 
         $result = $registry->getFieldType('some-type');
 
-        $this->assertInstanceOf('eZ\\Publish\\SPI\\Persistence\\FieldType', $result);
+        $this->assertInstanceOf(SPIPersistenceFieldType::class, $result);
         $this->assertAttributeSame(
             $instance,
             'internalFieldType',
@@ -132,8 +134,6 @@ class FieldTypeRegistryTest extends TestCase
      */
     protected function getFieldTypeMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\SPI\\FieldType\\FieldType'
-        );
+        return $this->createMock(SPIFieldType::class);
     }
 }

--- a/eZ/Publish/Core/REST/Client/Tests/FieldTypeServiceTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/FieldTypeServiceTest.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\REST\Client\Tests;
 
 use eZ\Publish\Core\REST\Client\FieldTypeService;
+use eZ\Publish\Core\REST\Client\FieldType;
 use PHPUnit\Framework\TestCase;
 
 class FieldTypeServiceTest extends TestCase
@@ -25,13 +26,7 @@ class FieldTypeServiceTest extends TestCase
 
     public function testAddFieldType()
     {
-        $fieldTypeMock = $this->getMock(
-            'eZ\\Publish\\Core\\REST\\Client\\FieldType',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $fieldTypeMock = $this->createMock(FieldType::class);
         $fieldTypeMock->expects($this->once())
             ->method('getFieldTypeIdentifier')
             ->will($this->returnValue('my-type'));
@@ -47,13 +42,7 @@ class FieldTypeServiceTest extends TestCase
 
     public function testGetFieldType()
     {
-        $fieldTypeMock = $this->getMock(
-            'eZ\\Publish\\Core\\REST\\Client\\FieldType',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $fieldTypeMock = $this->createMock(FieldType::class);
         $fieldTypeMock->expects($this->once())
             ->method('getFieldTypeIdentifier')
             ->will($this->returnValue('my-type'));
@@ -80,24 +69,12 @@ class FieldTypeServiceTest extends TestCase
 
     public function testGetFieldTypes()
     {
-        $myFieldTypeMock = $this->getMock(
-            'eZ\\Publish\\Core\\REST\\Client\\FieldType',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $myFieldTypeMock = $this->createMock(FieldType::class);
         $myFieldTypeMock->expects($this->once())
             ->method('getFieldTypeIdentifier')
             ->will($this->returnValue('my-type'));
 
-        $yourFieldTypeMock = $this->getMock(
-            'eZ\\Publish\\Core\\REST\\Client\\FieldType',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $yourFieldTypeMock = $this->createMock(FieldType::class);
         $yourFieldTypeMock->expects($this->once())
             ->method('getFieldTypeIdentifier')
             ->will($this->returnValue('your-type'));

--- a/eZ/Publish/Core/REST/Client/Tests/HttpClient/Authentication/BasicAuthTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/HttpClient/Authentication/BasicAuthTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\REST\Client\Tests\HttpClient\Authentication;
 
 use eZ\Publish\Core\REST\Client\HttpClient\Authentication\BasicAuth;
 use eZ\Publish\Core\REST\Common\Message;
+use eZ\Publish\Core\REST\Client\HttpClient;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -100,13 +101,7 @@ class BasicAuthTest extends TestCase
     protected function getInnerHttpClientMock()
     {
         if (!isset($this->innerHttpClientMock)) {
-            $this->innerHttpClientMock = $this->getMock(
-                '\\eZ\\Publish\\Core\\REST\\Client\\HttpClient',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->innerHttpClientMock = $this->createMock(HttpClient::class);
         }
 
         return $this->innerHttpClientMock;

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/BadStateExceptionTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/BadStateExceptionTest.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\REST\Client\Tests\Input\Parser;
 
 use eZ\Publish\Core\REST\Client\Input\Parser;
+use eZ\Publish\API\Repository\Exceptions\BadStateException;
 
 class BadStateExceptionTest extends BaseTest
 {
@@ -26,7 +27,7 @@ class BadStateExceptionTest extends BaseTest
         );
 
         $exception = $parser->parse($inputArray, $this->getParsingDispatcherMock());
-        self::assertInstanceOf('eZ\Publish\API\Repository\Exceptions\BadStateException', $exception);
+        self::assertInstanceOf(BadStateException::class, $exception);
         self::assertEquals('Section with ID "23" not found.', $exception->getMessage());
     }
 

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/BaseTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/BaseTest.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\REST\Client\Tests\Input\Parser;
 
 use eZ\Publish\Core\REST\Server\Tests;
+use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 
 abstract class BaseTest extends Tests\BaseTest
 {
@@ -28,13 +29,7 @@ abstract class BaseTest extends Tests\BaseTest
     protected function getParsingDispatcherMock()
     {
         if (!isset($this->parsingDispatcherMock)) {
-            $this->parsingDispatcherMock = $this->getMock(
-                '\\eZ\\Publish\\Core\\REST\\Common\\Input\\ParsingDispatcher',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->parsingDispatcherMock = $this->createMock(ParsingDispatcher::class);
         }
 
         return $this->parsingDispatcherMock;

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/ContentTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/ContentTest.php
@@ -11,6 +11,10 @@ namespace eZ\Publish\Core\REST\Client\Tests\Input\Parser;
 
 use eZ\Publish\Core\REST\Client\Input;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
+use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
+use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
+use eZ\Publish\Core\REST\Client\Input\Parser\VersionInfo;
+use eZ\Publish\Core\REST\Client\ContentService;
 use eZ\Publish\API\Repository\Values;
 
 class ContentTest extends BaseTest
@@ -72,7 +76,7 @@ class ContentTest extends BaseTest
             ->method('parse')
             ->with(
                 $this->equalTo(array()),
-                $this->isInstanceOf('eZ\\Publish\\Core\\REST\\Common\\Input\\ParsingDispatcher')
+                $this->isInstanceOf(ParsingDispatcher::class)
             )->will($this->returnValue($versionInfoMock));
 
         $this->getFieldTypeParserMock()->expects($this->exactly(2))
@@ -157,13 +161,7 @@ class ContentTest extends BaseTest
     protected function getVersionInfoParserMock()
     {
         if (!isset($this->versionInfoParserMock)) {
-            $this->versionInfoParserMock = $this->getMock(
-                'eZ\\Publish\\Core\\REST\\Client\\Input\\Parser\\VersionInfo',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->versionInfoParserMock = $this->createMock(VersionInfo::class);
         }
 
         return $this->versionInfoParserMock;
@@ -175,13 +173,7 @@ class ContentTest extends BaseTest
     protected function getContentServiceMock()
     {
         if (!isset($this->contentServiceMock)) {
-            $this->contentServiceMock = $this->getMock(
-                'eZ\\Publish\\Core\\REST\\Client\\ContentService',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->contentServiceMock = $this->createMock(ContentService::class);
         }
 
         return $this->contentServiceMock;
@@ -193,13 +185,7 @@ class ContentTest extends BaseTest
     protected function getFieldTypeParserMock()
     {
         if (!isset($this->fieldTypeParserMock)) {
-            $this->fieldTypeParserMock = $this->getMock(
-                'eZ\\Publish\\Core\\REST\\Common\\Input\\FieldTypeParser',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->fieldTypeParserMock = $this->createMock(FieldTypeParser::class);
         }
 
         return $this->fieldTypeParserMock;

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/ContentTypeTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/ContentTypeTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\REST\Client\Tests\Input\Parser;
 
 use eZ\Publish\Core\REST\Client\Input;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
+use eZ\Publish\Core\REST\Client\ContentTypeService;
 use eZ\Publish\API\Repository\Values;
 
 class ContentTypeTest extends BaseTest
@@ -195,13 +196,7 @@ class ContentTypeTest extends BaseTest
     protected function getContentTypeServiceMock()
     {
         if (!isset($this->contentTypeServiceMock)) {
-            $this->contentTypeServiceMock = $this->getMock(
-                'eZ\\Publish\\Core\\REST\\Client\\ContentTypeService',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->contentTypeServiceMock = $this->createMock(ContentTypeService::class);
         }
 
         return $this->contentTypeServiceMock;

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/FieldDefinitionListTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/FieldDefinitionListTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\REST\Client\Tests\Input\Parser;
 
 use eZ\Publish\Core\REST\Client\Input;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
+use eZ\Publish\Core\REST\Client\ContentTypeService;
 
 class FieldDefinitionListTest extends BaseTest
 {
@@ -74,13 +75,7 @@ class FieldDefinitionListTest extends BaseTest
     protected function getContentTypeServiceMock()
     {
         if (!isset($this->contentTypeServiceMock)) {
-            $this->contentTypeServiceMock = $this->getMock(
-                'eZ\\Publish\\Core\\REST\\Client\\ContentTypeService',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->contentTypeServiceMock = $this->createMock(ContentTypeService::class);
         }
 
         return $this->contentTypeServiceMock;

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/FieldDefinitionTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/FieldDefinitionTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\REST\Client\Tests\Input\Parser;
 
 use eZ\Publish\Core\REST\Client\Input;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
+use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
 
 class FieldDefinitionTest extends BaseTest
 {
@@ -19,13 +20,7 @@ class FieldDefinitionTest extends BaseTest
     public function setUp()
     {
         parent::setUp();
-        $this->fieldTypeParserMock = $this->getMock(
-            'eZ\\Publish\\Core\\REST\\Common\\Input\\FieldTypeParser',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $this->fieldTypeParserMock = $this->createMock(FieldTypeParser::class);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/InvalidArgumentExceptionTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/InvalidArgumentExceptionTest.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\REST\Client\Tests\Input\Parser;
 
 use eZ\Publish\Core\REST\Client\Input\Parser;
+use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
 
 class InvalidArgumentExceptionTest extends BaseTest
 {
@@ -26,7 +27,7 @@ class InvalidArgumentExceptionTest extends BaseTest
         );
 
         $exception = $parser->parse($inputArray, $this->getParsingDispatcherMock());
-        self::assertInstanceOf('eZ\Publish\API\Repository\Exceptions\InvalidArgumentException', $exception);
+        self::assertInstanceOf(InvalidArgumentException::class, $exception);
         self::assertEquals('Section with ID "23" not found.', $exception->getMessage());
     }
 

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/LimitationTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/LimitationTest.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\REST\Client\Tests\Input\Parser;
 
 use eZ\Publish\Core\REST\Client\Input\Parser;
+use eZ\Publish\API\Repository\Values\User\Limitation;
 
 class LimitationTest extends BaseTest
 {
@@ -55,10 +56,7 @@ class LimitationTest extends BaseTest
      */
     public function testResultIsLimitation($result)
     {
-        $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\User\\Limitation',
-            $result
-        );
+        $this->assertInstanceOf(Limitation::class, $result);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/LocationTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/LocationTest.php
@@ -58,10 +58,7 @@ class LocationTest extends BaseTest
      */
     public function testResultIsLocation($result)
     {
-        $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\Content\\Location',
-            $result
-        );
+        $this->assertInstanceOf(Location::class, $result);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/NotFoundExceptionTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/NotFoundExceptionTest.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\REST\Client\Tests\Input\Parser;
 
 use eZ\Publish\Core\REST\Client\Input\Parser;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 
 class NotFoundExceptionTest extends BaseTest
 {
@@ -26,7 +27,7 @@ class NotFoundExceptionTest extends BaseTest
         );
 
         $exception = $parser->parse($inputArray, $this->getParsingDispatcherMock());
-        self::assertInstanceOf('eZ\Publish\API\Repository\Exceptions\NotFoundException', $exception);
+        self::assertInstanceOf(NotFoundException::class, $exception);
         self::assertEquals('Section with ID "23" not found.', $exception->getMessage());
     }
 

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/ObjectStateGroupTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/ObjectStateGroupTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\REST\Client\Tests\Input\Parser;
 
 use eZ\Publish\Core\REST\Client\Input\Parser;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
+use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
 
 class ObjectStateGroupTest extends BaseTest
 {
@@ -70,10 +71,7 @@ class ObjectStateGroupTest extends BaseTest
      */
     public function testResultIsObjectStateGroup($result)
     {
-        $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\ObjectState\\ObjectStateGroup',
-            $result
-        );
+        $this->assertInstanceOf(ObjectStateGroup::class, $result);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/ObjectStateTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/ObjectStateTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\REST\Client\Tests\Input\Parser;
 
 use eZ\Publish\Core\REST\Client\Input\Parser;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
+use eZ\Publish\API\Repository\Values\ObjectState\ObjectState;
 
 class ObjectStateTest extends BaseTest
 {
@@ -71,10 +72,7 @@ class ObjectStateTest extends BaseTest
      */
     public function testResultIsObjectState($result)
     {
-        $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\ObjectState\\ObjectState',
-            $result
-        );
+        $this->assertInstanceOf(ObjectState::class, $result);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/PolicyTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/PolicyTest.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\REST\Client\Tests\Input\Parser;
 
 use eZ\Publish\Core\REST\Client\Input\Parser;
+use eZ\Publish\API\Repository\Values\User\Policy;
 
 class PolicyTest extends BaseTest
 {
@@ -44,10 +45,7 @@ class PolicyTest extends BaseTest
      */
     public function testResultIsPolicy($result)
     {
-        $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\User\\Policy',
-            $result
-        );
+        $this->assertInstanceOf(Policy::class, $result);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/RelationTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/RelationTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\REST\Client\Tests\Input\Parser;
 
 use eZ\Publish\Core\REST\Client\Input\Parser;
 use eZ\Publish\API\Repository\Values;
+use eZ\Publish\Core\REST\Client\ContentService;
 
 class RelationTest extends BaseTest
 {
@@ -90,13 +91,7 @@ class RelationTest extends BaseTest
     protected function getContentServiceMock()
     {
         if (!isset($this->contentServiceMock)) {
-            $this->contentServiceMock = $this->getMock(
-                'eZ\\Publish\\Core\\REST\\Client\\ContentService',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->contentServiceMock = $this->createMock(ContentService::class);
         }
 
         return $this->contentServiceMock;

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/RoleAssignmentTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/RoleAssignmentTest.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\REST\Client\Tests\Input\Parser;
 
 use eZ\Publish\Core\REST\Client\Input\Parser;
+use eZ\Publish\API\Repository\Values\User\RoleAssignment;
 
 class RoleAssignmentTest extends BaseTest
 {
@@ -46,10 +47,7 @@ class RoleAssignmentTest extends BaseTest
      */
     public function testResultIsRoleAssignment($result)
     {
-        $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\User\\RoleAssignment',
-            $result
-        );
+        $this->assertInstanceOf(RoleAssignment::class, $result);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/RoleTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/RoleTest.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\REST\Client\Tests\Input\Parser;
 
 use eZ\Publish\Core\REST\Client\Input\Parser;
+use eZ\Publish\API\Repository\Values\User\Role;
 
 class RoleTest extends BaseTest
 {
@@ -43,10 +44,7 @@ class RoleTest extends BaseTest
      */
     public function testResultIsRole($result)
     {
-        $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\User\\Role',
-            $result
-        );
+        $this->assertInstanceOf(Role::class, $result);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/SectionTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/SectionTest.php
@@ -10,6 +10,7 @@
 namespace eZ\Publish\Core\REST\Client\Tests\Input\Parser;
 
 use eZ\Publish\Core\REST\Client\Input\Parser;
+use eZ\Publish\API\Repository\Values\Content\Section;
 
 class SectionTest extends BaseTest
 {
@@ -44,10 +45,7 @@ class SectionTest extends BaseTest
      */
     public function testResultIsSection($result)
     {
-        $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\Content\\Section',
-            $result
-        );
+        $this->assertInstanceOf(Section::class, $result);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Client/Tests/Input/Parser/VersionInfoTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Input/Parser/VersionInfoTest.php
@@ -13,6 +13,7 @@ use eZ\Publish\Core\REST\Client\Input;
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
 use eZ\Publish\API\Repository\Values;
 use eZ\Publish\Core\REST\Common\RequestParser;
+use eZ\Publish\Core\REST\Client\ContentService;
 
 class VersionInfoTest extends BaseTest
 {
@@ -203,13 +204,7 @@ class VersionInfoTest extends BaseTest
     protected function getContentServiceMock()
     {
         if (!isset($this->contentServiceMock)) {
-            $this->contentServiceMock = $this->getMock(
-                'eZ\\Publish\\Core\\REST\\Client\\ContentService',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->contentServiceMock = $this->createMock(ContentService::class);
         }
 
         return $this->contentServiceMock;
@@ -223,7 +218,7 @@ class VersionInfoTest extends BaseTest
         static $parser = null;
 
         if (!isset($parser)) {
-            $parser =$this->getMock('eZ\Publish\Core\REST\Common\RequestParser');
+            $parser =$this->createMock(RequestParser::class);
         }
 
         return $parser;

--- a/eZ/Publish/Core/REST/Client/Tests/Output/ValueObjectVisitor/LocationCreateStructTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Output/ValueObjectVisitor/LocationCreateStructTest.php
@@ -9,6 +9,7 @@
 
 namespace eZ\Publish\Core\REST\Client\Tests\Output\ValueObjectVisitor;
 
+use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\REST\Client\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Client\Output\ValueObjectVisitor;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
@@ -237,7 +238,7 @@ class LocationCreateStructTest extends ValueObjectVisitorBaseTest
      */
     protected function internalGetVisitor()
     {
-        $this->locationServiceMock = $this->getMock('eZ\Publish\API\Repository\LocationService');
+        $this->locationServiceMock = $this->createMock(LocationService::class);
         return new ValueObjectVisitor\LocationCreateStruct($this->locationServiceMock);
     }
 }

--- a/eZ/Publish/Core/REST/Client/Tests/Values/ContentType/ContentTypeTest.php
+++ b/eZ/Publish/Core/REST/Client/Tests/Values/ContentType/ContentTypeTest.php
@@ -11,6 +11,8 @@ namespace eZ\Publish\Core\REST\Client\Tests\Values\ContentType;
 
 use eZ\Publish\Core\REST\Client\Values\ContentType\ContentType;
 use eZ\Publish\Core\REST\Client\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\REST\Client\Values\FieldDefinitionList;
+use eZ\Publish\Core\REST\Client\ContentTypeService;
 use PHPUnit\Framework\TestCase;
 
 class ContentTypeTest extends TestCase
@@ -19,13 +21,7 @@ class ContentTypeTest extends TestCase
 
     public function setUp()
     {
-        $this->contentTypeServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\REST\\Client\\ContentTypeService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $this->contentTypeServiceMock = $this->createMock(ContentTypeService::class);
     }
 
     public function testGetName()
@@ -136,13 +132,7 @@ class ContentTypeTest extends TestCase
 
     protected function getFieldDefinitionListMock()
     {
-        $mock = $this->getMock(
-            'eZ\\Publish\\Core\\REST\\Client\\Values\\FieldDefinitionList',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $mock = $this->createMock(FieldDefinitionList::class);
         $mock->expects($this->any())
             ->method('getFieldDefinitions')
             ->will($this->returnValue($this->getFieldDefinitions()));

--- a/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/ImageProcessorTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/ImageProcessorTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\REST\Common\Tests\FieldTypeProcessor;
 
 use eZ\Publish\Core\REST\Common\FieldTypeProcessor\ImageProcessor;
 use eZ\Publish\Core\REST\Common\RequestParser;
+use Symfony\Component\Routing\RouterInterface;
 
 class ImageProcessorTest extends BinaryInputProcessorTest
 {
@@ -75,7 +76,7 @@ class ImageProcessorTest extends BinaryInputProcessorTest
     protected function getRouterMock()
     {
         if (!isset($this->requestParser)) {
-            $this->requestParser = $this->getMock('Symfony\\Component\\Routing\\RouterInterface');
+            $this->requestParser = $this->createMock(RouterInterface::class);
         }
 
         return $this->requestParser;

--- a/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/RelationListProcessorTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/RelationListProcessorTest.php
@@ -8,9 +8,11 @@
  */
 namespace eZ\Publish\Core\REST\Common\Tests\FieldTypeProcessor;
 
+use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\Core\REST\Common\FieldTypeProcessor\RelationListProcessor;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\RouterInterface;
 
 class RelationListProcessorTest extends TestCase
 {
@@ -64,7 +66,7 @@ class RelationListProcessorTest extends TestCase
     {
         $processor = $this->getProcessor();
 
-        $serviceLocationMock = $this->getMockBuilder('eZ\Publish\API\Repository\LocationService')->getMock();
+        $serviceLocationMock = $this->createMock(LocationService::class);
         $processor->setLocationService($serviceLocationMock);
 
         $serviceLocationMock
@@ -72,7 +74,7 @@ class RelationListProcessorTest extends TestCase
             ->with('42')
             ->willReturn(new Location(['path' => ['1', '25', '42']]));
 
-        $routerMock = $this->getMockBuilder('Symfony\Component\Routing\RouterInterface')->getMock();
+        $routerMock = $this->createMock(RouterInterface::class);
         $processor->setRouter($routerMock);
 
         $routerMock
@@ -98,7 +100,7 @@ class RelationListProcessorTest extends TestCase
     {
         $processor = $this->getProcessor();
 
-        $routerMock = $this->getMockBuilder('Symfony\Component\Routing\RouterInterface')->getMock();
+        $routerMock = $this->createMock(RouterInterface::class);
         $processor->setRouter($routerMock);
 
         $routerMock

--- a/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/RelationProcessorTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/RelationProcessorTest.php
@@ -8,9 +8,11 @@
  */
 namespace eZ\Publish\Core\REST\Common\Tests\FieldTypeProcessor;
 
+use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\Core\REST\Common\FieldTypeProcessor\RelationProcessor;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Routing\RouterInterface;
 
 class RelationProcessorTest extends TestCase
 {
@@ -64,7 +66,7 @@ class RelationProcessorTest extends TestCase
     {
         $processor = $this->getProcessor();
 
-        $serviceLocationMock = $this->getMockBuilder('eZ\Publish\API\Repository\LocationService')->getMock();
+        $serviceLocationMock = $this->createMock(LocationService::class);
         $processor->setLocationService($serviceLocationMock);
 
         $serviceLocationMock
@@ -72,7 +74,7 @@ class RelationProcessorTest extends TestCase
             ->with('42')
             ->willReturn(new Location(['path' => ['1', '25', '42']]));
 
-        $routerMock = $this->getMockBuilder('Symfony\Component\Routing\RouterInterface')->getMock();
+        $routerMock = $this->createMock(RouterInterface::class);
         $processor->setRouter($routerMock);
 
         $routerMock
@@ -98,7 +100,7 @@ class RelationProcessorTest extends TestCase
     {
         $processor = $this->getProcessor();
 
-        $routerMock = $this->getMockBuilder('\Symfony\Component\Routing\RouterInterface')->getMock();
+        $routerMock = $this->createMock(RouterInterface::class);
         $processor->setRouter($routerMock);
 
         $routerMock
@@ -116,7 +118,7 @@ class RelationProcessorTest extends TestCase
     {
         $processor = $this->getProcessor();
 
-        $routerMock = $this->getMockBuilder('\Symfony\Component\Routing\RouterInterface')->getMock();
+        $routerMock = $this->createMock(RouterInterface::class);
         $processor->setRouter($routerMock);
 
         $routerMock

--- a/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/RichTextProcessorTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessor/RichTextProcessorTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\REST\Common\Tests\FieldTypeProcessor;
 
 use eZ\Publish\Core\REST\Common\FieldTypeProcessor\RichTextProcessor;
+use eZ\Publish\Core\FieldType\RichText\Converter;
 use PHPUnit\Framework\TestCase;
 use DOMDocument;
 
@@ -62,7 +63,7 @@ EOT;
      */
     protected function getProcessor()
     {
-        $this->converter = $this->getMock('eZ\\Publish\\Core\\FieldType\\RichText\\Converter');
+        $this->converter = $this->createMock(Converter::class);
 
         return new RichTextProcessor($this->converter);
     }

--- a/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessorRegistryTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/FieldTypeProcessorRegistryTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\REST\Common\Tests;
 
 use eZ\Publish\Core\REST\Common\FieldTypeProcessorRegistry;
+use eZ\Publish\Core\REST\Common\FieldTypeProcessor;
 use eZ\Publish\Core\REST\Server\Tests\BaseTest;
 
 class FieldTypeProcessorRegistryTest extends BaseTest
@@ -92,12 +93,6 @@ class FieldTypeProcessorRegistryTest extends BaseTest
      */
     protected function getAProcessorMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\Core\\REST\\Common\\FieldTypeProcessor',
-            array(),
-            array(),
-            '',
-            false
-        );
+        return $this->createMock(FieldTypeProcessor::class);
     }
 }

--- a/eZ/Publish/Core/REST/Common/Tests/Input/DispatcherTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Input/DispatcherTest.php
@@ -9,6 +9,8 @@
 namespace eZ\Publish\Core\REST\Common\Tests\Input;
 
 use eZ\Publish\Core\REST\Common;
+use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
+use eZ\Publish\Core\REST\Common\Input\Handler;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,6 +18,11 @@ use PHPUnit\Framework\TestCase;
  */
 class DispatcherTest extends TestCase
 {
+    protected function getParsingDispatcherMock()
+    {
+        return $this->createMock(ParsingDispatcher::class);
+    }
+
     /**
      * @expectedException \eZ\Publish\Core\REST\Common\Exceptions\Parser
      */
@@ -23,7 +30,7 @@ class DispatcherTest extends TestCase
     {
         $message = new Common\Message();
 
-        $parsingDispatcher = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Input\\ParsingDispatcher');
+        $parsingDispatcher = $this->getParsingDispatcherMock();
         $dispatcher = new Common\Input\Dispatcher($parsingDispatcher);
 
         $dispatcher->parse($message);
@@ -40,7 +47,7 @@ class DispatcherTest extends TestCase
             )
         );
 
-        $parsingDispatcher = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Input\\ParsingDispatcher');
+        $parsingDispatcher = $this->getParsingDispatcherMock();
         $dispatcher = new Common\Input\Dispatcher($parsingDispatcher);
 
         $dispatcher->parse($message);
@@ -57,7 +64,7 @@ class DispatcherTest extends TestCase
             )
         );
 
-        $parsingDispatcher = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Input\\ParsingDispatcher');
+        $parsingDispatcher = $this->getParsingDispatcherMock();
         $dispatcher = new Common\Input\Dispatcher($parsingDispatcher);
 
         $dispatcher->parse($message);
@@ -72,14 +79,14 @@ class DispatcherTest extends TestCase
             'Hello world!'
         );
 
-        $parsingDispatcher = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Input\\ParsingDispatcher');
+        $parsingDispatcher = $this->getParsingDispatcherMock();
         $parsingDispatcher
             ->expects($this->at(0))
             ->method('parse')
             ->with(array(42), 'text/html')
             ->will($this->returnValue(23));
 
-        $handler = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Input\\Handler');
+        $handler = $this->createMock(Handler::class);
         $handler
             ->expects($this->at(0))
             ->method('convert')
@@ -108,14 +115,14 @@ class DispatcherTest extends TestCase
             'Hello world!'
         );
 
-        $parsingDispatcher = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Input\\ParsingDispatcher');
+        $parsingDispatcher = $this->getParsingDispatcherMock();
         $parsingDispatcher
             ->expects($this->at(0))
             ->method('parse')
             ->with(array('someKey' => 'someValue', '__url' => '/foo/bar'), 'text/html')
             ->will($this->returnValue(23));
 
-        $handler = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Input\\Handler');
+        $handler = $this->createMock(Handler::class);
         $handler
             ->expects($this->at(0))
             ->method('convert')
@@ -148,13 +155,13 @@ class DispatcherTest extends TestCase
             'Hello world!'
         );
 
-        $parsingDispatcher = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Input\\ParsingDispatcher');
+        $parsingDispatcher = $this->getParsingDispatcherMock();
         $parsingDispatcher
             ->expects($this->any())
             ->method('parse')
             ->with($this->anything(), 'text/html; version=1.1');
 
-        $handler = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Input\\Handler');
+        $handler = $this->createMock(Handler::class);
         $handler
             ->expects($this->any())
             ->method('convert')

--- a/eZ/Publish/Core/REST/Common/Tests/Input/FieldTypeParserTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Input/FieldTypeParserTest.php
@@ -10,7 +10,14 @@ namespace eZ\Publish\Core\REST\Common\Tests\Input;
 
 use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\Repository\ContentService;
+use eZ\Publish\Core\Repository\ContentTypeService;
+use eZ\Publish\Core\Repository\FieldTypeService;
+use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\REST\Common\FieldTypeProcessorRegistry;
+use eZ\Publish\Core\REST\Common\FieldTypeProcessor;
+use eZ\Publish\SPI\FieldType\FieldType;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -34,55 +41,13 @@ class FieldTypeParserTest extends TestCase
 
     public function setUp()
     {
-        $this->contentServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\ContentService',
-            array(),
-            array(),
-            '',
-            false
-        );
-        $this->contentTypeServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\ContentTypeService',
-            array(),
-            array(),
-            '',
-            false
-        );
-        $this->fieldTypeServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\FieldTypeService',
-            array(),
-            array(),
-            '',
-            false
-        );
-        $this->contentTypeMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\Values\\ContentType\\ContentType',
-            array(),
-            array(),
-            '',
-            false
-        );
-        $this->fieldTypeMock = $this->getMock(
-            'eZ\\Publish\\SPI\\FieldType\\FieldType',
-            array(),
-            array(),
-            '',
-            false
-        );
-        $this->fieldTypeProcessorRegistryMock = $this->getMock(
-            'eZ\\Publish\\Core\\REST\\Common\\FieldTypeProcessorRegistry',
-            array(),
-            array(),
-            '',
-            false
-        );
-        $this->fieldTypeProcessorMock = $this->getMock(
-            'eZ\\Publish\\Core\\REST\\Common\\FieldTypeProcessor',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $this->contentServiceMock = $this->createMock(ContentService::class);
+        $this->contentTypeServiceMock = $this->createMock(ContentTypeService::class);
+        $this->fieldTypeServiceMock = $this->createMock(FieldTypeService::class);
+        $this->contentTypeMock = $this->createMock(ContentType::class);
+        $this->fieldTypeMock = $this->createMock(FieldType::class);
+        $this->fieldTypeProcessorRegistryMock = $this->createMock(FieldTypeProcessorRegistry::class);
+        $this->fieldTypeProcessorMock = $this->createMock(FieldTypeProcessor::class);
     }
 
     public function testParseFieldValue()

--- a/eZ/Publish/Core/REST/Common/Tests/Input/ParserToolsTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Input/ParserToolsTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\REST\Common\Tests\Input;
 
 use eZ\Publish\Core\REST\Common\Input\ParserTools;
+use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
 use PHPUnit\Framework\TestCase;
 
 class ParserToolsTest extends TestCase
@@ -46,13 +47,7 @@ class ParserToolsTest extends TestCase
     {
         $parserTools = $this->getParserTools();
 
-        $dispatcherMock = $this->getMock(
-            'eZ\\Publish\\Core\\REST\\Common\\Input\\ParsingDispatcher',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $dispatcherMock = $this->createMock(ParsingDispatcher::class);
         $dispatcherMock->expects($this->once())
             ->method('parse')
             ->with(
@@ -76,13 +71,7 @@ class ParserToolsTest extends TestCase
     {
         $parserTools = $this->getParserTools();
 
-        $dispatcherMock = $this->getMock(
-            'eZ\\Publish\\Core\\REST\\Common\\Input\\ParsingDispatcher',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $dispatcherMock = $this->createMock(ParsingDispatcher::class);
         $dispatcherMock->expects($this->never())
             ->method('parse');
 

--- a/eZ/Publish/Core/REST/Common/Tests/Input/ParsingDispatcherTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Input/ParsingDispatcherTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\REST\Common\Tests\Input;
 
 use eZ\Publish\Core\REST\Common;
+use eZ\Publish\Core\REST\Common\Input\Parser;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -102,6 +103,6 @@ class ParsingDispatcherTest extends TestCase
      */
     private function createParserMock()
     {
-        return $this->getMock('eZ\Publish\Core\REST\Common\Input\Parser');
+        return $this->createMock(Parser::class);
     }
 }

--- a/eZ/Publish/Core/REST/Common/Tests/Output/FieldTypeSerializerTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Output/FieldTypeSerializerTest.php
@@ -8,9 +8,15 @@
  */
 namespace eZ\Publish\Core\REST\Common\Tests\Output;
 
+use eZ\Publish\API\Repository\FieldTypeService;
 use eZ\Publish\Core\REST\Common;
 use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\API\Repository\FieldType as APIFieldType;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType as APIContentType;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\REST\Common\FieldTypeProcessorRegistry;
+use eZ\Publish\Core\REST\Common\FieldTypeProcessor;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -405,13 +411,7 @@ class FieldTypeSerializerTest extends TestCase
     protected function getFieldTypeServiceMock()
     {
         if (!isset($this->fieldTypeServiceMock)) {
-            $this->fieldTypeServiceMock = $this->getMock(
-                'eZ\\Publish\\API\\Repository\\FieldTypeService',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->fieldTypeServiceMock = $this->createMock(FieldTypeService::class);
         }
 
         return $this->fieldTypeServiceMock;
@@ -420,13 +420,7 @@ class FieldTypeSerializerTest extends TestCase
     protected function getFieldTypeProcessorRegistryMock()
     {
         if (!isset($this->fieldTypeProcessorRegistryMock)) {
-            $this->fieldTypeProcessorRegistryMock = $this->getMock(
-                'eZ\\Publish\\Core\\REST\\Common\\FieldTypeProcessorRegistry',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->fieldTypeProcessorRegistryMock = $this->createMock(FieldTypeProcessorRegistry::class);
         }
 
         return $this->fieldTypeProcessorRegistryMock;
@@ -435,13 +429,7 @@ class FieldTypeSerializerTest extends TestCase
     protected function getFieldTypeProcessorMock()
     {
         if (!isset($this->fieldTypeProcessorMock)) {
-            $this->fieldTypeProcessorMock = $this->getMock(
-                'eZ\\Publish\\Core\\REST\\Common\\FieldTypeProcessor',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->fieldTypeProcessorMock = $this->createMock(FieldTypeProcessor::class);
         }
 
         return $this->fieldTypeProcessorMock;
@@ -450,13 +438,7 @@ class FieldTypeSerializerTest extends TestCase
     protected function getContentTypeMock()
     {
         if (!isset($this->contentTypeMock)) {
-            $this->contentTypeMock = $this->getMock(
-                'eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->contentTypeMock = $this->createMock(APIContentType::class);
         }
 
         return $this->contentTypeMock;
@@ -465,13 +447,7 @@ class FieldTypeSerializerTest extends TestCase
     protected function getFieldTypeMock()
     {
         if (!isset($this->fieldTypeMock)) {
-            $this->fieldTypeMock = $this->getMock(
-                'eZ\\Publish\\API\\Repository\\FieldType',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->fieldTypeMock = $this->createMock(APIFieldType::class);
         }
 
         return $this->fieldTypeMock;
@@ -480,13 +456,7 @@ class FieldTypeSerializerTest extends TestCase
     protected function getGeneratorMock()
     {
         if (!isset($this->generatorMock)) {
-            $this->generatorMock = $this->getMock(
-                'eZ\\Publish\\Core\\REST\\Common\\Output\\Generator',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->generatorMock = $this->createMock(Generator::class);
         }
 
         return $this->generatorMock;

--- a/eZ/Publish/Core/REST/Common/Tests/Output/Generator/JsonTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Output/Generator/JsonTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\REST\Common\Tests\Output\Generator;
 
 use eZ\Publish\Core\REST\Common\Tests\Output\GeneratorTest;
 use eZ\Publish\Core\REST\Common;
+use eZ\Publish\Core\REST\Common\Output\Generator\Json\FieldTypeHashGenerator;
 
 require_once __DIR__ . '/../GeneratorTest.php';
 
@@ -263,13 +264,7 @@ class JsonTest extends GeneratorTest
     {
         if (!isset($this->generator)) {
             $this->generator = new Common\Output\Generator\Json(
-                $this->getMock(
-                    'eZ\\Publish\\Core\\REST\\Common\\Output\\Generator\\Json\\FieldTypeHashGenerator',
-                    array(),
-                    array(),
-                    '',
-                    false
-                )
+                $this->createMock(FieldTypeHashGenerator::class)
             );
         }
 

--- a/eZ/Publish/Core/REST/Common/Tests/Output/Generator/XmlTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Output/Generator/XmlTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\REST\Common\Tests\Output\Generator;
 
 use eZ\Publish\Core\REST\Common\Tests\Output\GeneratorTest;
+use eZ\Publish\Core\REST\Common\Output\Generator\Xml\FieldTypeHashGenerator;
 use eZ\Publish\Core\REST\Common;
 
 require_once __DIR__ . '/../GeneratorTest.php';
@@ -232,13 +233,7 @@ class XmlTest extends GeneratorTest
     {
         if (!isset($this->generator)) {
             $this->generator = new Common\Output\Generator\Xml(
-                $this->getMock(
-                    'eZ\\Publish\\Core\\REST\\Common\\Output\\Generator\\Xml\\FieldTypeHashGenerator',
-                    array(),
-                    array(),
-                    '',
-                    false
-                )
+                $this->createMock(FieldTypeHashGenerator::class)
             );
         }
         $this->generator->setFormatOutput(true);

--- a/eZ/Publish/Core/REST/Common/Tests/Output/ValueObjectVisitorBaseTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Output/ValueObjectVisitorBaseTest.php
@@ -11,6 +11,10 @@ namespace eZ\Publish\Core\REST\Common\Tests\Output;
 use eZ\Publish\Core\REST\Common\Tests\AssertXmlTagTrait;
 use eZ\Publish\Core\REST\Server\Tests;
 use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\RequestParser as RequestParser;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouterInterface;
 
 abstract class ValueObjectVisitorBaseTest extends Tests\BaseTest
 {
@@ -59,13 +63,7 @@ abstract class ValueObjectVisitorBaseTest extends Tests\BaseTest
     protected function getVisitorMock()
     {
         if (!isset($this->visitorMock)) {
-            $this->visitorMock = $this->getMock(
-                '\\eZ\\Publish\\Core\\REST\\Common\\Output\\Visitor',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->visitorMock = $this->createMock(Visitor::class);
 
             $this->visitorMock
                 ->expects($this->any())
@@ -82,7 +80,8 @@ abstract class ValueObjectVisitorBaseTest extends Tests\BaseTest
     protected function getResponseMock()
     {
         if (!isset($this->responseMock)) {
-            $this->responseMock = $this->getMock('Symfony\Component\HttpFoundation\Response');
+            $this->responseMock = $this->getMockBuilder(Response::class)
+                ->getMock();
         }
 
         return $this->responseMock;
@@ -145,7 +144,7 @@ abstract class ValueObjectVisitorBaseTest extends Tests\BaseTest
     protected function getRequestParser()
     {
         if (!isset($this->requestParser)) {
-            $this->requestParser = $this->getMock('eZ\\Publish\\Core\\REST\\Common\\RequestParser');
+            $this->requestParser = $this->createMock(RequestParser::class);
         }
 
         return $this->requestParser;
@@ -157,7 +156,7 @@ abstract class ValueObjectVisitorBaseTest extends Tests\BaseTest
     protected function getRouterMock()
     {
         if (!isset($this->routerMock)) {
-            $this->routerMock = $this->getMock('Symfony\\Component\\Routing\\RouterInterface');
+            $this->routerMock = $this->createMock(RouterInterface::class);
         }
 
         return $this->routerMock;
@@ -197,7 +196,7 @@ abstract class ValueObjectVisitorBaseTest extends Tests\BaseTest
     protected function getTemplatedRouterMock()
     {
         if (!isset($this->templatedRouterMock)) {
-            $this->templatedRouterMock = $this->getMock('Symfony\\Component\\Routing\\RouterInterface');
+            $this->templatedRouterMock = $this->createMock(RouterInterface::class);
         }
 
         return $this->templatedRouterMock;

--- a/eZ/Publish/Core/REST/Common/Tests/Output/ValueObjectVisitorDispatcherTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Output/ValueObjectVisitorDispatcherTest.php
@@ -9,6 +9,9 @@
 namespace eZ\Publish\Core\REST\Common\Tests\Output;
 
 use eZ\Publish\Core\REST\Common;
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitor;
 use stdClass;
 use PHPUnit\Framework\TestCase;
 
@@ -81,7 +84,6 @@ class ValueObjectVisitorDispatcherTest extends TestCase
     {
         $data = new ValueObject();
 
-        $generator = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Output\\Generator');
         $valueObjectVisitor1 = $this->getValueObjectVisitorMock();
         $valueObjectVisitor2 = $this->getValueObjectVisitorMock();
 
@@ -118,7 +120,7 @@ class ValueObjectVisitorDispatcherTest extends TestCase
      */
     private function getValueObjectVisitorMock()
     {
-        return $this->getMockForAbstractClass('\\eZ\\Publish\\Core\\REST\\Common\\Output\\ValueObjectVisitor');
+        return $this->getMockForAbstractClass(ValueObjectVisitor::class);
     }
 
     /**
@@ -127,9 +129,7 @@ class ValueObjectVisitorDispatcherTest extends TestCase
     private function getOutputVisitorMock()
     {
         if (!isset($this->outputVisitorMock)) {
-            $this->outputVisitorMock = $this->getMockBuilder('\\eZ\\Publish\\Core\\REST\\Common\\Output\\Visitor')
-                ->disableOriginalConstructor()
-                ->getMock();
+            $this->outputVisitorMock = $this->createMock(Visitor::class);
         }
 
         return $this->outputVisitorMock;
@@ -141,7 +141,7 @@ class ValueObjectVisitorDispatcherTest extends TestCase
     private function getOutputGeneratorMock()
     {
         if (!isset($this->outputGeneratorMock)) {
-            $this->outputGeneratorMock = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Output\\Generator');
+            $this->outputGeneratorMock = $this->createMock(Generator::class);
         }
 
         return $this->outputGeneratorMock;

--- a/eZ/Publish/Core/REST/Common/Tests/Output/VisitorTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Output/VisitorTest.php
@@ -12,7 +12,6 @@ use eZ\Publish\Core\REST\Common;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitorDispatcher;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
-use eZ\Publish\Core\REST\Server\Input\Parser\Criterion\Visibility;
 use stdClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Response;

--- a/eZ/Publish/Core/REST/Common/Tests/Output/VisitorTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Output/VisitorTest.php
@@ -12,8 +12,8 @@ use eZ\Publish\Core\REST\Common;
 use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitorDispatcher;
 use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Output\Visitor;
-use stdClass;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use Symfony\Component\HttpFoundation\Response;
 
 /**

--- a/eZ/Publish/Core/REST/Common/Tests/Output/VisitorTest.php
+++ b/eZ/Publish/Core/REST/Common/Tests/Output/VisitorTest.php
@@ -9,6 +9,10 @@
 namespace eZ\Publish\Core\REST\Common\Tests\Output;
 
 use eZ\Publish\Core\REST\Common;
+use eZ\Publish\Core\REST\Common\Output\ValueObjectVisitorDispatcher;
+use eZ\Publish\Core\REST\Common\Output\Generator;
+use eZ\Publish\Core\REST\Common\Output\Visitor;
+use eZ\Publish\Core\REST\Server\Input\Parser\Criterion\Visibility;
 use stdClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Response;
@@ -22,7 +26,7 @@ class VisitorTest extends TestCase
     {
         $data = new stdClass();
 
-        $generator = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Output\\Generator');
+        $generator = $this->getGeneratorMock();
         $generator
             ->expects($this->at(1))
             ->method('startDocument')
@@ -39,11 +43,10 @@ class VisitorTest extends TestCase
             ->with($data)
             ->will($this->returnValue('Hello world!'));
 
-        $visitor = $this->getMock(
-            '\\eZ\\Publish\\Core\\REST\\Common\\Output\\Visitor',
-            array('visitValueObject'),
-            array($generator, $this->getValueObjectDispatcherMock())
-        );
+        $visitor = $this->getMockBuilder(Visitor::class)
+            ->setMethods(array('visitValueObject'))
+            ->setConstructorArgs(array($generator, $this->getValueObjectDispatcherMock()))
+            ->getMock();
 
         $this->assertEquals(
             new Response('Hello world!', 200, array()),
@@ -55,7 +58,7 @@ class VisitorTest extends TestCase
     {
         $data = new stdClass();
 
-        $generator = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Output\\Generator');
+        $generator = $this->getGeneratorMock();
         $generator
             ->expects($this->at(1))
             ->method('startDocument')
@@ -70,11 +73,10 @@ class VisitorTest extends TestCase
             ->expects($this->never())
             ->method('endDocument');
 
-        $visitor = $this->getMock(
-            '\\eZ\\Publish\\Core\\REST\\Common\\Output\\Visitor',
-            array('visitValueObject'),
-            array($generator, $this->getValueObjectDispatcherMock())
-        );
+        $visitor = $this->getMockBuilder(Visitor::class)
+            ->setMethods(array('visitValueObject'))
+            ->setConstructorArgs(array($generator, $this->getValueObjectDispatcherMock()))
+            ->getMock();
 
         $this->assertEquals(
             new Response(null, 200, array()),
@@ -87,7 +89,7 @@ class VisitorTest extends TestCase
         $data = new stdClass();
 
         /** @var \PHPUnit_Framework_MockObject_MockObject|Common\Output\Generator $generatorMock */
-        $generatorMock = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Output\\Generator');
+        $generatorMock = $this->getGeneratorMock();
 
         $valueObjectDispatcherMock = $this->getValueObjectDispatcherMock();
         $valueObjectDispatcherMock
@@ -103,12 +105,7 @@ class VisitorTest extends TestCase
     {
         $data = new stdClass();
 
-        $generator = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Output\\Generator');
-        $visitor = $this->getMock(
-            '\\eZ\\Publish\\Core\\REST\\Common\\Output\\Visitor',
-            array('visitValueObject'),
-            array($generator, $this->getValueObjectDispatcherMock())
-        );
+        $visitor = $this->getVisitorMock();
 
         $visitor->setHeader('Content-Type', 'text/xml');
         $this->assertEquals(
@@ -132,12 +129,7 @@ class VisitorTest extends TestCase
     {
         $data = new stdClass();
 
-        $generator = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Output\\Generator');
-        $visitor = $this->getMock(
-            '\\eZ\\Publish\\Core\\REST\\Common\\Output\\Visitor',
-            array('visitValueObject'),
-            array($generator, $this->getValueObjectDispatcherMock())
-        );
+        $visitor = $this->getVisitorMock();
 
         $visitor->setHeader('Content-Type', 'text/xml');
         $visitor->setHeader('Accept-Patch', false);
@@ -157,12 +149,7 @@ class VisitorTest extends TestCase
     {
         $data = new stdClass();
 
-        $generator = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Output\\Generator');
-        $visitor = $this->getMock(
-            '\\eZ\\Publish\\Core\\REST\\Common\\Output\\Visitor',
-            array('visitValueObject'),
-            array($generator, $this->getValueObjectDispatcherMock())
-        );
+        $visitor = $this->getVisitorMock();
 
         $visitor->setHeader('Content-Type', 'text/xml');
         $visitor->setHeader('Content-Type', 'text/html');
@@ -182,12 +169,7 @@ class VisitorTest extends TestCase
     {
         $data = new stdClass();
 
-        $generator = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Output\\Generator');
-        $visitor = $this->getMock(
-            '\\eZ\\Publish\\Core\\REST\\Common\\Output\\Visitor',
-            array('visitValueObject'),
-            array($generator, $this->getValueObjectDispatcherMock())
-        );
+        $visitor = $this->getVisitorMock();
 
         $visitor->setHeader('Content-Type', 'text/xml');
 
@@ -208,12 +190,7 @@ class VisitorTest extends TestCase
     {
         $data = new stdClass();
 
-        $generator = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Output\\Generator');
-        $visitor = $this->getMock(
-            '\\eZ\\Publish\\Core\\REST\\Common\\Output\\Visitor',
-            array('visitValueObject'),
-            array($generator, $this->getValueObjectDispatcherMock())
-        );
+        $visitor = $this->getVisitorMock();
 
         $visitor->setStatus(201);
         $this->assertEquals(
@@ -229,12 +206,7 @@ class VisitorTest extends TestCase
     {
         $data = new stdClass();
 
-        $generator = $this->getMock('\\eZ\\Publish\\Core\\REST\\Common\\Output\\Generator');
-        $visitor = $this->getMock(
-            '\\eZ\\Publish\\Core\\REST\\Common\\Output\\Visitor',
-            array('visitValueObject'),
-            array($generator, $this->getValueObjectDispatcherMock())
-        );
+        $visitor = $this->getVisitorMock();
 
         $visitor->setStatus(201);
         $visitor->setStatus(404);
@@ -253,8 +225,24 @@ class VisitorTest extends TestCase
      */
     public function getValueObjectDispatcherMock()
     {
-        return $this->getMock(
-            '\\eZ\\Publish\\Core\\REST\\Common\\Output\\ValueObjectVisitorDispatcher'
-        );
+        return $this->createMock(ValueObjectVisitorDispatcher::class);
+    }
+
+    protected function getGeneratorMock()
+    {
+        return $this->createMock(Generator::class);
+    }
+
+    protected function getVisitorMock()
+    {
+        return $this->getMockBuilder(Visitor::class)
+            ->setMethods(array('visitValueObject'))
+            ->setConstructorArgs(
+                array(
+                    $this->getGeneratorMock(),
+                    $this->getValueObjectDispatcherMock(),
+                )
+            )
+            ->getMock();
     }
 }

--- a/eZ/Publish/Core/REST/Server/Tests/Authenticator/IntegrationTestTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Authenticator/IntegrationTestTest.php
@@ -8,6 +8,9 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Authenticator;
 
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\Core\REST\Server\Tests\BaseTest;
 use eZ\Publish\Core\REST\Server\Authenticator\IntegrationTest;
 use Qafoo\RMF;
@@ -39,7 +42,7 @@ class IntegrationTestTest extends BaseTest
             ->with(23)
             ->will(
                 $this->returnValue(
-                    $user = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\User')
+                    $user = $this->createMock(User::class)
                 )
             );
 
@@ -60,13 +63,7 @@ class IntegrationTestTest extends BaseTest
     protected function getRepositoryMock()
     {
         if (!isset($this->repositoryMock)) {
-            $this->repositoryMock = $this->getMock(
-                '\\eZ\\Publish\\API\\Repository\\Repository',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->repositoryMock = $this->createMock(Repository::class);
 
             $userServiceMock = $this->getUserServiceMock();
 
@@ -90,13 +87,7 @@ class IntegrationTestTest extends BaseTest
     protected function getUserServiceMock()
     {
         if (!isset($this->userServiceMock)) {
-            $this->userServiceMock = $this->getMock(
-                '\\eZ\\Publish\\API\\Repository\\UserService',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->userServiceMock = $this->createMock(UserService::class);
         }
 
         return $this->userServiceMock;

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/BaseTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/BaseTest.php
@@ -10,6 +10,8 @@ namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
 use eZ\Publish\Core\REST\Common\Input;
 use eZ\Publish\Core\REST\Server\Tests\BaseTest as ParentBaseTest;
+use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
+use eZ\Publish\Core\REST\Common\RequestParser;
 
 /**
  * Base test for input parsers.
@@ -39,13 +41,7 @@ abstract class BaseTest extends ParentBaseTest
     protected function getParsingDispatcherMock()
     {
         if (!isset($this->parsingDispatcherMock)) {
-            $this->parsingDispatcherMock = $this->getMock(
-                '\\eZ\\Publish\\Core\\REST\\Common\\Input\\ParsingDispatcher',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->parsingDispatcherMock = $this->createMock(ParsingDispatcher::class);
         }
 
         return $this->parsingDispatcherMock;
@@ -88,7 +84,7 @@ abstract class BaseTest extends ParentBaseTest
                 return null;
             };
 
-            $this->requestParserMock = $this->getMock('eZ\\Publish\\Core\\REST\\Common\\RequestParser');
+            $this->requestParserMock = $this->createMock(RequestParser::class);
 
             $this->requestParserMock
                 ->expects($this->any())

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ContentCreateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ContentCreateTest.php
@@ -9,10 +9,15 @@
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
+use eZ\Publish\Core\Repository\ContentService;
+use eZ\Publish\Core\Repository\ContentTypeService;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\Core\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\REST\Server\Input\Parser\ContentCreate;
+use eZ\Publish\Core\REST\Server\Input\Parser\LocationCreate;
+use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
+use eZ\Publish\Core\REST\Client\FieldTypeService;
 
 class ContentCreateTest extends BaseTest
 {
@@ -519,23 +524,19 @@ class ContentCreateTest extends BaseTest
      */
     private function getFieldTypeParserMock()
     {
-        $fieldTypeParserMock = $this->getMock(
-            '\\eZ\\Publish\\Core\\REST\\Common\\Input\\FieldTypeParser',
-            array(),
-            array(
-                $this->getContentServiceMock(),
-                $this->getContentTypeServiceMock(),
-                $this->getMock(
-                    'eZ\\Publish\\Core\\REST\\Client\\FieldTypeService',
-                    array(),
-                    array(),
-                    '',
-                    false
-                ),
-            ),
-            '',
-            false
-        );
+        $fieldTypeParserMock = $this->getMockBuilder(FieldTypeParser::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array())
+            ->setConstructorArgs(
+                array(
+                    $this->getContentServiceMock(),
+                    $this->getContentTypeServiceMock(),
+                    $this->createMock(FieldTypeService::class),
+
+                )
+            )
+            ->getMock();
+
 
         $fieldTypeParserMock->expects($this->any())
             ->method('parseValue')
@@ -552,13 +553,7 @@ class ContentCreateTest extends BaseTest
      */
     private function getLocationCreateParserMock()
     {
-        $locationCreateParserMock = $this->getMock(
-            '\\eZ\\Publish\\Core\\REST\\Server\\Input\\Parser\\LocationCreate',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $locationCreateParserMock = $this->createMock(LocationCreate::class);
 
         $locationCreateParserMock->expects($this->any())
             ->method('parse')
@@ -575,13 +570,7 @@ class ContentCreateTest extends BaseTest
      */
     protected function getContentServiceMock()
     {
-        $contentServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\ContentService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $contentServiceMock = $this->createMock(ContentService::class);
 
         $contentType = $this->getContentType();
         $contentServiceMock->expects($this->any())
@@ -611,13 +600,7 @@ class ContentCreateTest extends BaseTest
      */
     protected function getContentTypeServiceMock()
     {
-        $contentTypeServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\ContentTypeService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $contentTypeServiceMock = $this->createMock(ContentTypeService::class);
 
         $contentTypeServiceMock->expects($this->any())
             ->method('loadContentType')

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ContentCreateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ContentCreateTest.php
@@ -536,7 +536,6 @@ class ContentCreateTest extends BaseTest
             )
             ->getMock();
 
-
         $fieldTypeParserMock->expects($this->any())
             ->method('parseValue')
             ->with('ezstring', array())

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ContentCreateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ContentCreateTest.php
@@ -532,7 +532,6 @@ class ContentCreateTest extends BaseTest
                     $this->getContentServiceMock(),
                     $this->getContentTypeServiceMock(),
                     $this->createMock(FieldTypeService::class),
-
                 )
             )
             ->getMock();

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ContentTypeCreateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ContentTypeCreateTest.php
@@ -10,7 +10,9 @@ namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct;
+use eZ\Publish\Core\Repository\ContentTypeService;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentTypeCreateStruct;
+use eZ\Publish\Core\REST\Server\Input\Parser\FieldDefinitionCreate;
 use eZ\Publish\Core\REST\Server\Input\Parser\ContentTypeCreate;
 
 class ContentTypeCreateTest extends BaseTest
@@ -26,7 +28,7 @@ class ContentTypeCreateTest extends BaseTest
         $result = $contentTypeCreate->parse($inputArray, $this->getParsingDispatcherMock());
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentTypeCreateStruct',
+            ContentTypeCreateStruct::class,
             $result,
             'ContentTypeCreateStruct not created correctly.'
         );
@@ -111,7 +113,7 @@ class ContentTypeCreateTest extends BaseTest
 
         foreach ($result->fieldDefinitions as $fieldDefinition) {
             $this->assertInstanceOf(
-                '\\eZ\\Publish\\API\\Repository\\Values\\ContentType\\FieldDefinitionCreateStruct',
+                FieldDefinitionCreateStruct::class,
                 $fieldDefinition,
                 'ContentTypeCreateStruct field definition not created correctly.'
             );
@@ -261,13 +263,7 @@ class ContentTypeCreateTest extends BaseTest
      */
     private function getFieldDefinitionCreateParserMock()
     {
-        $fieldDefinitionCreateParserMock = $this->getMock(
-            '\\eZ\\Publish\\Core\\REST\\Server\\Input\\Parser\\FieldDefinitionCreate',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $fieldDefinitionCreateParserMock = $this->createMock(FieldDefinitionCreate::class);
 
         $fieldDefinitionCreateParserMock->expects($this->any())
             ->method('parse')
@@ -284,13 +280,7 @@ class ContentTypeCreateTest extends BaseTest
      */
     protected function getContentTypeServiceMock()
     {
-        $contentTypeServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\ContentTypeService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $contentTypeServiceMock = $this->createMock(ContentTypeService::class);
 
         $contentTypeServiceMock->expects($this->any())
             ->method('newContentTypeCreateStruct')

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ContentTypeGroupInputTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ContentTypeGroupInputTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
+use eZ\Publish\Core\Repository\ContentTypeService;
 use eZ\Publish\Core\REST\Server\Input\Parser\ContentTypeGroupInput;
 use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroupCreateStruct;
 
@@ -30,7 +31,7 @@ class ContentTypeGroupInputTest extends BaseTest
         $result = $contentTypeGroupInput->parse($inputArray, $this->getParsingDispatcherMock());
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentTypeGroupCreateStruct',
+            ContentTypeGroupCreateStruct::class,
             $result,
             'ContentTypeGroupCreateStruct not created correctly.'
         );
@@ -92,13 +93,7 @@ class ContentTypeGroupInputTest extends BaseTest
      */
     protected function getContentTypeServiceMock()
     {
-        $contentTypeServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\ContentTypeService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $contentTypeServiceMock = $this->createMock(ContentTypeService::class);
 
         $contentTypeServiceMock->expects($this->any())
             ->method('newContentTypeGroupCreateStruct')

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ContentTypeUpdateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ContentTypeUpdateTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\ContentType\ContentTypeUpdateStruct;
+use eZ\Publish\Core\Repository\ContentTypeService;
 use eZ\Publish\Core\REST\Server\Input\Parser\ContentTypeUpdate;
 
 class ContentTypeUpdateTest extends BaseTest
@@ -25,7 +26,7 @@ class ContentTypeUpdateTest extends BaseTest
         $result = $contentTypeUpdate->parse($inputArray, $this->getParsingDispatcherMock());
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentTypeUpdateStruct',
+            ContentTypeUpdateStruct::class,
             $result,
             'ContentTypeUpdateStruct not created correctly.'
         );
@@ -174,13 +175,7 @@ class ContentTypeUpdateTest extends BaseTest
      */
     protected function getContentTypeServiceMock()
     {
-        $contentTypeServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\ContentTypeService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $contentTypeServiceMock = $this->createMock(ContentTypeService::class);
 
         $contentTypeServiceMock->expects($this->any())
             ->method('newContentTypeUpdateStruct')

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/FieldDefinitionCreateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/FieldDefinitionCreateTest.php
@@ -9,7 +9,9 @@
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct;
+use eZ\Publish\Core\Repository\ContentTypeService;
 use eZ\Publish\Core\REST\Server\Input\Parser\FieldDefinitionCreate;
+use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
 
 /**
  * @todo Test with fieldSettings and validatorConfiguration when specified
@@ -27,7 +29,7 @@ class FieldDefinitionCreateTest extends BaseTest
         $result = $fieldDefinitionCreate->parse($inputArray, $this->getParsingDispatcherMock());
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\ContentType\\FieldDefinitionCreateStruct',
+            FieldDefinitionCreateStruct::class,
             $result,
             'FieldDefinitionCreateStruct not created correctly.'
         );
@@ -197,13 +199,7 @@ class FieldDefinitionCreateTest extends BaseTest
      */
     protected function getFieldTypeParserMock()
     {
-        $fieldTypeParserMock = $this->getMock(
-            'eZ\\Publish\\Core\\REST\\Common\\Input\\FieldTypeParser',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $fieldTypeParserMock = $this->createMock(FieldTypeParser::class);
 
         $fieldTypeParserMock->expects($this->any())
             ->method('parseValue')
@@ -236,13 +232,7 @@ class FieldDefinitionCreateTest extends BaseTest
      */
     protected function getContentTypeServiceMock()
     {
-        $contentTypeServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\ContentTypeService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $contentTypeServiceMock = $this->createMock(ContentTypeService::class);
 
         $contentTypeServiceMock->expects($this->any())
             ->method('newFieldDefinitionCreateStruct')

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/FieldDefinitionUpdateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/FieldDefinitionUpdateTest.php
@@ -9,9 +9,11 @@
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionUpdateStruct;
+use eZ\Publish\Core\Repository\ContentTypeService;
 use eZ\Publish\Core\REST\Server\Input\Parser\FieldDefinitionUpdate;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
 
 /**
  * @todo Test with fieldSettings and validatorConfiguration when specified
@@ -29,7 +31,7 @@ class FieldDefinitionUpdateTest extends BaseTest
         $result = $fieldDefinitionUpdate->parse($inputArray, $this->getParsingDispatcherMock());
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\ContentType\\FieldDefinitionUpdateStruct',
+            FieldDefinitionUpdateStruct::class,
             $result,
             'FieldDefinitionUpdateStruct not created correctly.'
         );
@@ -163,13 +165,7 @@ class FieldDefinitionUpdateTest extends BaseTest
      */
     protected function getFieldTypeParserMock()
     {
-        $fieldTypeParserMock = $this->getMock(
-            'eZ\\Publish\\Core\\REST\\Common\\Input\\FieldTypeParser',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $fieldTypeParserMock = $this->createMock(FieldTypeParser::class);
 
         $fieldTypeParserMock->expects($this->any())
             ->method('parseValue')
@@ -202,13 +198,7 @@ class FieldDefinitionUpdateTest extends BaseTest
      */
     protected function getContentTypeServiceMock()
     {
-        $contentTypeServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\ContentTypeService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $contentTypeServiceMock = $this->createMock(ContentTypeService::class);
 
         $contentTypeServiceMock->expects($this->any())
             ->method('newFieldDefinitionUpdateStruct')

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/LocationCreateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/LocationCreateTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
+use eZ\Publish\Core\Repository\LocationService;
 use eZ\Publish\Core\REST\Server\Input\Parser\LocationCreate;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\Location;
@@ -34,7 +35,7 @@ class LocationCreateTest extends BaseTest
         $result = $locationCreate->parse($inputArray, $this->getParsingDispatcherMock());
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\Content\\LocationCreateStruct',
+            LocationCreateStruct::class,
             $result,
             'LocationCreateStruct not created correctly.'
         );
@@ -181,13 +182,7 @@ class LocationCreateTest extends BaseTest
      */
     protected function getLocationServiceMock()
     {
-        $locationServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\LocationService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $locationServiceMock = $this->createMock(LocationService::class);
 
         $locationServiceMock->expects($this->any())
             ->method('newLocationCreateStruct')

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/LocationUpdateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/LocationUpdateTest.php
@@ -8,9 +8,11 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
+use eZ\Publish\Core\Repository\LocationService;
 use eZ\Publish\Core\REST\Server\Input\Parser\LocationUpdate;
 use eZ\Publish\API\Repository\Values\Content\LocationUpdateStruct;
 use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\Core\REST\Server\Values\RestLocationUpdateStruct;
 
 class LocationUpdateTest extends BaseTest
 {
@@ -31,13 +33,13 @@ class LocationUpdateTest extends BaseTest
         $result = $locationUpdate->parse($inputArray, $this->getParsingDispatcherMock());
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\Core\\REST\\Server\\Values\\RestLocationUpdateStruct',
+            RestLocationUpdateStruct::class,
             $result,
             'LocationUpdateStruct not created correctly.'
         );
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\Content\\LocationUpdateStruct',
+            LocationUpdateStruct::class,
             $result->locationUpdateStruct,
             'LocationUpdateStruct not created correctly.'
         );
@@ -129,13 +131,7 @@ class LocationUpdateTest extends BaseTest
      */
     protected function getLocationServiceMock()
     {
-        $locationServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\LocationService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $locationServiceMock = $this->createMock(LocationService::class);
 
         $locationServiceMock->expects($this->any())
             ->method('newLocationUpdateStruct')

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ObjectStateCreateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ObjectStateCreateTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
+use eZ\Publish\Core\Repository\ObjectStateService;
 use eZ\Publish\Core\REST\Server\Input\Parser\ObjectStateCreate;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateCreateStruct;
 
@@ -44,7 +45,7 @@ class ObjectStateCreateTest extends BaseTest
         $result = $objectStateCreate->parse($inputArray, $this->getParsingDispatcherMock());
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\ObjectState\\ObjectStateCreateStruct',
+            ObjectStateCreateStruct::class,
             $result,
             'ObjectStateCreateStruct not created correctly.'
         );
@@ -252,13 +253,7 @@ class ObjectStateCreateTest extends BaseTest
      */
     protected function getObjectStateServiceMock()
     {
-        $objectStateServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\ObjectStateService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $objectStateServiceMock = $this->createMock(ObjectStateService::class);
 
         $objectStateServiceMock->expects($this->any())
             ->method('newObjectStateCreateStruct')

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ObjectStateGroupCreateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ObjectStateGroupCreateTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
+use eZ\Publish\Core\Repository\ObjectStateService;
 use eZ\Publish\Core\REST\Server\Input\Parser\ObjectStateGroupCreate;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroupCreateStruct;
 
@@ -43,7 +44,7 @@ class ObjectStateGroupCreateTest extends BaseTest
         $result = $objectStateGroupCreate->parse($inputArray, $this->getParsingDispatcherMock());
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\ObjectState\\ObjectStateGroupCreateStruct',
+            ObjectStateGroupCreateStruct::class,
             $result,
             'ObjectStateGroupCreateStruct not created correctly.'
         );
@@ -208,13 +209,7 @@ class ObjectStateGroupCreateTest extends BaseTest
      */
     protected function getObjectStateServiceMock()
     {
-        $objectStateServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\ObjectStateService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $objectStateServiceMock = $this->createMock(ObjectStateService::class);
 
         $objectStateServiceMock->expects($this->any())
             ->method('newObjectStateGroupCreateStruct')

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ObjectStateGroupUpdateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ObjectStateGroupUpdateTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
+use eZ\Publish\Core\Repository\ObjectStateService;
 use eZ\Publish\Core\REST\Server\Input\Parser\ObjectStateGroupUpdate;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroupUpdateStruct;
 
@@ -43,7 +44,7 @@ class ObjectStateGroupUpdateTest extends BaseTest
         $result = $objectStateGroupUpdate->parse($inputArray, $this->getParsingDispatcherMock());
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\ObjectState\\ObjectStateGroupUpdateStruct',
+            ObjectStateGroupUpdateStruct::class,
             $result,
             'ObjectStateGroupUpdateStruct not created correctly.'
         );
@@ -119,13 +120,7 @@ class ObjectStateGroupUpdateTest extends BaseTest
      */
     protected function getObjectStateServiceMock()
     {
-        $objectStateServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\ObjectStateService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $objectStateServiceMock = $this->createMock(ObjectStateService::class);
 
         $objectStateServiceMock->expects($this->any())
             ->method('newObjectStateGroupUpdateStruct')

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ObjectStateUpdateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/ObjectStateUpdateTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
+use eZ\Publish\Core\Repository\ObjectStateService;
 use eZ\Publish\Core\REST\Server\Input\Parser\ObjectStateUpdate;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateUpdateStruct;
 
@@ -43,7 +44,7 @@ class ObjectStateUpdateTest extends BaseTest
         $result = $objectStateUpdate->parse($inputArray, $this->getParsingDispatcherMock());
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\ObjectState\\ObjectStateUpdateStruct',
+            ObjectStateUpdateStruct::class,
             $result,
             'ObjectStateUpdateStruct not created correctly.'
         );
@@ -119,13 +120,7 @@ class ObjectStateUpdateTest extends BaseTest
      */
     protected function getObjectStateServiceMock()
     {
-        $objectStateServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\ObjectStateService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $objectStateServiceMock = $this->createMock(ObjectStateService::class);
 
         $objectStateServiceMock->expects($this->any())
             ->method('newObjectStateUpdateStruct')

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/PolicyCreateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/PolicyCreateTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\Core\Repository\RoleService;
 use eZ\Publish\Core\REST\Server\Input\Parser\PolicyCreate;
 use eZ\Publish\Core\Repository\Values\User\PolicyCreateStruct;
 
@@ -47,7 +49,7 @@ class PolicyCreateTest extends BaseTest
         $result = $policyCreate->parse($inputArray, $this->getParsingDispatcherMock());
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\User\\PolicyCreateStruct',
+            PolicyCreateStruct::class,
             $result,
             'PolicyCreateStruct not created correctly.'
         );
@@ -79,7 +81,7 @@ class PolicyCreateTest extends BaseTest
         );
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\User\\Limitation',
+            Limitation::class,
             $parsedLimitations['Class'],
             'Limitation not created correctly.'
         );
@@ -249,13 +251,7 @@ class PolicyCreateTest extends BaseTest
      */
     protected function getRoleServiceMock()
     {
-        $roleServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\RoleService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $roleServiceMock = $this->createMock(RoleService::class);
 
         $roleServiceMock->expects($this->any())
             ->method('newPolicyCreateStruct')

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/PolicyUpdateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/PolicyUpdateTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\Core\Repository\RoleService;
 use eZ\Publish\Core\REST\Server\Input\Parser\PolicyUpdate;
 use eZ\Publish\Core\Repository\Values\User\PolicyUpdateStruct;
 
@@ -45,7 +47,7 @@ class PolicyUpdateTest extends BaseTest
         $result = $policyUpdate->parse($inputArray, $this->getParsingDispatcherMock());
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\User\\PolicyUpdateStruct',
+            PolicyUpdateStruct::class,
             $result,
             'PolicyUpdateStruct not created correctly.'
         );
@@ -65,7 +67,7 @@ class PolicyUpdateTest extends BaseTest
         );
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\User\\Limitation',
+            Limitation::class,
             $parsedLimitations['Class'],
             'Limitation not created correctly.'
         );
@@ -159,13 +161,7 @@ class PolicyUpdateTest extends BaseTest
      */
     protected function getRoleServiceMock()
     {
-        $roleServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\RoleService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $roleServiceMock = $this->createMock(RoleService::class);
 
         $roleServiceMock->expects($this->any())
             ->method('newPolicyUpdateStruct')

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/RoleAssignInputTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/RoleAssignInputTest.php
@@ -8,8 +8,10 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
+use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation;
 use eZ\Publish\API\Repository\Values\User\Limitation\SectionLimitation;
 use eZ\Publish\Core\REST\Server\Input\Parser\RoleAssignInput;
+use eZ\Publish\Core\REST\Server\Values\RoleAssignment;
 
 class RoleAssignInputTest extends BaseTest
 {
@@ -40,7 +42,7 @@ class RoleAssignInputTest extends BaseTest
         $result = $roleAssignInput->parse($inputArray, $this->getParsingDispatcherMock());
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\Core\\REST\\Server\\Values\\RoleAssignment',
+            RoleAssignment::class,
             $result,
             'RoleAssignment not created correctly.'
         );
@@ -52,7 +54,7 @@ class RoleAssignInputTest extends BaseTest
         );
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation',
+            RoleLimitation::class,
             $result->limitation,
             'Limitation not created correctly.'
         );

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/RoleInputTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/RoleInputTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
+use eZ\Publish\Core\Repository\RoleService;
 use eZ\Publish\Core\REST\Server\Input\Parser\RoleInput;
 use eZ\Publish\Core\Repository\Values\User\RoleCreateStruct;
 
@@ -45,7 +46,7 @@ class RoleInputTest extends BaseTest
         $result = $roleInput->parse($inputArray, $this->getParsingDispatcherMock());
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\User\\RoleCreateStruct',
+            RoleCreateStruct::class,
             $result,
             'RoleCreateStruct not created correctly.'
         );
@@ -91,13 +92,7 @@ class RoleInputTest extends BaseTest
      */
     protected function getRoleServiceMock()
     {
-        $roleServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\RoleService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $roleServiceMock = $this->createMock(RoleService::class);
 
         $roleServiceMock->expects($this->any())
             ->method('newRoleCreateStruct')

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/SectionInputTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/SectionInputTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
+use eZ\Publish\Core\Repository\SectionService;
 use eZ\Publish\Core\REST\Server\Input\Parser\SectionInput;
 use eZ\Publish\API\Repository\Values\Content\SectionCreateStruct;
 
@@ -84,13 +85,7 @@ class SectionInputTest extends BaseTest
      */
     protected function getSectionServiceMock()
     {
-        $sectionServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\SectionService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $sectionServiceMock = $this->createMock(SectionService::class);
 
         $sectionServiceMock->expects($this->any())
             ->method('newSectionCreateStruct')

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/UserCreateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/UserCreateTest.php
@@ -8,10 +8,15 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
+use eZ\Publish\Core\Repository\ContentTypeService;
+use eZ\Publish\Core\Repository\UserService;
+use eZ\Publish\Core\REST\Client\ContentService;
+use eZ\Publish\Core\REST\Client\FieldTypeService;
 use eZ\Publish\Core\REST\Server\Input\Parser\UserCreate;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\Repository\Values\User\UserCreateStruct;
+use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
 
 class UserCreateTest extends BaseTest
 {
@@ -47,13 +52,13 @@ class UserCreateTest extends BaseTest
         $result = $userCreate->parse($inputArray, $this->getParsingDispatcherMock());
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\User\\UserCreateStruct',
+            UserCreateStruct::class,
             $result,
             'UserCreateStruct not created correctly.'
         );
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType',
+            ContentType::class,
             $result->contentType,
             'contentType not created correctly.'
         );
@@ -449,29 +454,17 @@ class UserCreateTest extends BaseTest
      */
     private function getFieldTypeParserMock()
     {
-        $fieldTypeParserMock = $this->getMock(
-            '\\eZ\\Publish\\Core\\REST\\Common\\Input\\FieldTypeParser',
-            array(),
-            array(
-                $this->getMock(
-                    'eZ\\Publish\\Core\\REST\\Client\\ContentService',
-                    array(),
-                    array(),
-                    '',
-                    false
-                ),
-                $this->getContentTypeServiceMock(),
-                $this->getMock(
-                    'eZ\\Publish\\Core\\REST\\Client\\FieldTypeService',
-                    array(),
-                    array(),
-                    '',
-                    false
-                ),
-            ),
-            '',
-            false
-        );
+        $fieldTypeParserMock = $this->getMockBuilder(FieldTypeParser::class)
+            ->setMethods(array())
+            ->disableOriginalConstructor()
+            ->setConstructorArgs(
+                array(
+                    $this->createMock(ContentService::class),
+                    $this->getContentTypeServiceMock(),
+                    $this->createMock(FieldTypeService::class),
+                )
+            )
+            ->getMock();
 
         $fieldTypeParserMock->expects($this->any())
             ->method('parseValue')
@@ -488,13 +481,7 @@ class UserCreateTest extends BaseTest
      */
     protected function getUserServiceMock()
     {
-        $userServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\UserService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $userServiceMock = $this->createMock(UserService::class);
 
         $contentType = $this->getContentType();
         $userServiceMock->expects($this->any())
@@ -527,13 +514,7 @@ class UserCreateTest extends BaseTest
      */
     protected function getContentTypeServiceMock()
     {
-        $contentTypeServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\ContentTypeService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $contentTypeServiceMock = $this->createMock(ContentTypeService::class);
 
         $contentTypeServiceMock->expects($this->any())
             ->method('loadContentType')

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/UserGroupCreateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/UserGroupCreateTest.php
@@ -8,10 +8,15 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
+use eZ\Publish\Core\Repository\ContentTypeService;
+use eZ\Publish\Core\Repository\UserService;
+use eZ\Publish\Core\REST\Client\ContentService;
+use eZ\Publish\Core\REST\Client\FieldTypeService;
 use eZ\Publish\Core\REST\Server\Input\Parser\UserGroupCreate;
 use eZ\Publish\Core\Repository\Values\User\UserGroupCreateStruct;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
+use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
 
 class UserGroupCreateTest extends BaseTest
 {
@@ -43,13 +48,13 @@ class UserGroupCreateTest extends BaseTest
         $result = $userGroupCreate->parse($inputArray, $this->getParsingDispatcherMock());
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\User\\UserGroupCreateStruct',
+            UserGroupCreateStruct::class,
             $result,
             'UserGroupCreateStruct not created correctly.'
         );
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType',
+            \eZ\Publish\API\Repository\Values\ContentType\ContentType::class,
             $result->contentType,
             'contentType not created correctly.'
         );
@@ -314,29 +319,17 @@ class UserGroupCreateTest extends BaseTest
      */
     private function getFieldTypeParserMock()
     {
-        $fieldTypeParserMock = $this->getMock(
-            '\\eZ\\Publish\\Core\\REST\\Common\\Input\\FieldTypeParser',
-            array(),
-            array(
-                $this->getMock(
-                    'eZ\\Publish\\Core\\REST\\Client\\ContentService',
-                    array(),
-                    array(),
-                    '',
-                    false
-                ),
-                $this->getContentTypeServiceMock(),
-                $this->getMock(
-                    'eZ\\Publish\\Core\\REST\\Client\\FieldTypeService',
-                    array(),
-                    array(),
-                    '',
-                    false
-                ),
-            ),
-            '',
-            false
-        );
+        $fieldTypeParserMock = $this->getMockBuilder(FieldTypeParser::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array())
+            ->setConstructorArgs(
+                array(
+                    $this->createMock(ContentService::class),
+                    $this->getContentTypeServiceMock(),
+                    $this->createMock(FieldTypeService::class),
+                )
+            )
+            ->getMock();
 
         $fieldTypeParserMock->expects($this->any())
             ->method('parseValue')
@@ -353,13 +346,7 @@ class UserGroupCreateTest extends BaseTest
      */
     protected function getUserServiceMock()
     {
-        $userServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\UserService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $userServiceMock = $this->createMock(UserService::class);
 
         $contentType = $this->getContentType();
         $userServiceMock->expects($this->any())
@@ -389,13 +376,7 @@ class UserGroupCreateTest extends BaseTest
      */
     protected function getContentTypeServiceMock()
     {
-        $contentTypeServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\ContentTypeService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $contentTypeServiceMock = $this->createMock(ContentTypeService::class);
 
         $contentTypeServiceMock->expects($this->any())
             ->method('loadContentType')

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/UserGroupUpdateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/UserGroupUpdateTest.php
@@ -8,12 +8,19 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
+use eZ\Publish\Core\Repository\ContentService;
+use eZ\Publish\Core\Repository\ContentTypeService;
+use eZ\Publish\Core\Repository\FieldTypeService;
+use eZ\Publish\Core\Repository\LocationService;
+use eZ\Publish\Core\Repository\UserService;
 use eZ\Publish\Core\REST\Server\Input\Parser\UserGroupUpdate;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\ContentMetadataUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\UserGroupUpdateStruct;
 use eZ\Publish\Core\Repository\Values\Content\ContentUpdateStruct;
+use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
+use eZ\Publish\Core\REST\Server\Values\RestUserGroupUpdateStruct;
 
 class UserGroupUpdateTest extends BaseTest
 {
@@ -43,19 +50,19 @@ class UserGroupUpdateTest extends BaseTest
         $result = $userGroupUpdate->parse($inputArray, $this->getParsingDispatcherMock());
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\Core\\REST\\Server\\Values\\RestUserGroupUpdateStruct',
+            RestUserGroupUpdateStruct::class,
             $result,
             'UserGroupUpdate not created correctly.'
         );
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\Content\\ContentUpdateStruct',
+            ContentUpdateStruct::class,
             $result->userGroupUpdateStruct->contentUpdateStruct,
             'UserGroupUpdate not created correctly.'
         );
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\Content\\ContentMetadataUpdateStruct',
+            ContentMetadataUpdateStruct::class,
             $result->userGroupUpdateStruct->contentMetadataUpdateStruct,
             'UserGroupUpdate not created correctly.'
         );
@@ -214,29 +221,17 @@ class UserGroupUpdateTest extends BaseTest
      */
     private function getFieldTypeParserMock()
     {
-        $fieldTypeParserMock = $this->getMock(
-            '\\eZ\\Publish\\Core\\REST\\Common\\Input\\FieldTypeParser',
-            array(),
-            array(
-                $this->getContentServiceMock(),
-                $this->getMock(
-                    'eZ\\Publish\\Core\\Repository\\ContentTypeService',
-                    array(),
-                    array(),
-                    '',
-                    false
-                ),
-                $this->getMock(
-                    'eZ\\Publish\\Core\\Repository\\FieldTypeService',
-                    array(),
-                    array(),
-                    '',
-                    false
-                ),
-            ),
-            '',
-            false
-        );
+        $fieldTypeParserMock = $this->getMockBuilder(FieldTypeParser::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array())
+            ->setConstructorArgs(
+                array(
+                    $this->getContentServiceMock(),
+                    $this->createMock(ContentTypeService::class),
+                    $this->createMock(FieldTypeService::class),
+                )
+            )
+            ->getMock();
 
         $fieldTypeParserMock->expects($this->any())
             ->method('parseFieldValue')
@@ -253,13 +248,7 @@ class UserGroupUpdateTest extends BaseTest
      */
     protected function getUserServiceMock()
     {
-        $userServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\UserService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $userServiceMock = $this->createMock(UserService::class);
 
         $userServiceMock->expects($this->any())
             ->method('newUserGroupUpdateStruct')
@@ -277,13 +266,7 @@ class UserGroupUpdateTest extends BaseTest
      */
     protected function getLocationServiceMock()
     {
-        $userServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\LocationService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $userServiceMock = $this->createMock(LocationService::class);
 
         $userServiceMock->expects($this->any())
             ->method('loadLocation')
@@ -312,13 +295,7 @@ class UserGroupUpdateTest extends BaseTest
      */
     protected function getContentServiceMock()
     {
-        $contentServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\ContentService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $contentServiceMock = $this->createMock(ContentService::class);
 
         $contentServiceMock->expects($this->any())
             ->method('newContentUpdateStruct')

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/UserUpdateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/UserUpdateTest.php
@@ -8,10 +8,16 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
+use eZ\Publish\Core\Repository\ContentService;
+use eZ\Publish\Core\Repository\UserService;
+use eZ\Publish\Core\REST\Client\ContentTypeService;
+use eZ\Publish\Core\REST\Client\FieldTypeService;
 use eZ\Publish\Core\REST\Server\Input\Parser\UserUpdate;
 use eZ\Publish\API\Repository\Values\Content\ContentMetadataUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\UserUpdateStruct;
 use eZ\Publish\Core\Repository\Values\Content\ContentUpdateStruct;
+use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
+use eZ\Publish\Core\REST\Server\Values\RestUserUpdateStruct;
 
 class UserUpdateTest extends BaseTest
 {
@@ -44,19 +50,19 @@ class UserUpdateTest extends BaseTest
         $result = $userUpdate->parse($inputArray, $this->getParsingDispatcherMock());
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\Core\\REST\\Server\\Values\\RestUserUpdateStruct',
+            RestUserUpdateStruct::class,
             $result,
             'UserUpdate not created correctly.'
         );
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\Content\\ContentUpdateStruct',
+            ContentUpdateStruct::class,
             $result->userUpdateStruct->contentUpdateStruct,
             'UserUpdate not created correctly.'
         );
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\Content\\ContentMetadataUpdateStruct',
+            ContentMetadataUpdateStruct::class,
             $result->userUpdateStruct->contentMetadataUpdateStruct,
             'UserUpdate not created correctly.'
         );
@@ -245,29 +251,17 @@ class UserUpdateTest extends BaseTest
      */
     private function getFieldTypeParserMock()
     {
-        $fieldTypeParserMock = $this->getMock(
-            '\\eZ\\Publish\\Core\\REST\\Common\\Input\\FieldTypeParser',
-            array(),
-            array(
-                $this->getContentServiceMock(),
-                $this->getMock(
-                    'eZ\\Publish\\Core\\REST\\Client\\ContentTypeService',
-                    array(),
-                    array(),
-                    '',
-                    false
-                ),
-                $this->getMock(
-                    'eZ\\Publish\\Core\\REST\\Client\\FieldTypeService',
-                    array(),
-                    array(),
-                    '',
-                    false
-                ),
-            ),
-            '',
-            false
-        );
+        $fieldTypeParserMock = $this->getMockBuilder(FieldTypeParser::class)
+            ->setMethods(array())
+            ->disableOriginalConstructor()
+            ->setConstructorArgs(
+                array(
+                    $this->getContentServiceMock(),
+                    $this->createMock(ContentTypeService::class),
+                    $this->createMock(FieldTypeService::class),
+                )
+            )
+            ->getMock();
 
         $fieldTypeParserMock->expects($this->any())
             ->method('parseFieldValue')
@@ -284,13 +278,7 @@ class UserUpdateTest extends BaseTest
      */
     protected function getUserServiceMock()
     {
-        $userServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\UserService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $userServiceMock = $this->createMock(UserService::class);
 
         $userServiceMock->expects($this->any())
             ->method('newUserUpdateStruct')
@@ -308,13 +296,7 @@ class UserUpdateTest extends BaseTest
      */
     protected function getContentServiceMock()
     {
-        $contentServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\ContentService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $contentServiceMock = $this->createMock(ContentService::class);
 
         $contentServiceMock->expects($this->any())
             ->method('newContentUpdateStruct')

--- a/eZ/Publish/Core/REST/Server/Tests/Input/Parser/VersionUpdateTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Input/Parser/VersionUpdateTest.php
@@ -8,8 +8,12 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Input\Parser;
 
+use eZ\Publish\Core\Repository\ContentService;
+use eZ\Publish\Core\REST\Client\ContentTypeService;
+use eZ\Publish\Core\REST\Client\FieldTypeService;
 use eZ\Publish\Core\REST\Server\Input\Parser\VersionUpdate;
 use eZ\Publish\Core\Repository\Values\Content\ContentUpdateStruct;
+use eZ\Publish\Core\REST\Common\Input\FieldTypeParser;
 
 class VersionUpdateTest extends BaseTest
 {
@@ -35,7 +39,7 @@ class VersionUpdateTest extends BaseTest
         $result = $VersionUpdate->parse($inputArray, $this->getParsingDispatcherMock());
 
         $this->assertInstanceOf(
-            '\\eZ\\Publish\\API\\Repository\\Values\\Content\\ContentUpdateStruct',
+            ContentUpdateStruct::class,
             $result,
             'VersionUpdate not created correctly.'
         );
@@ -141,29 +145,17 @@ class VersionUpdateTest extends BaseTest
      */
     private function getFieldTypeParserMock()
     {
-        $fieldTypeParserMock = $this->getMock(
-            '\\eZ\\Publish\\Core\\REST\\Common\\Input\\FieldTypeParser',
-            array(),
-            array(
-                $this->getContentServiceMock(),
-                $this->getMock(
-                    'eZ\\Publish\\Core\\REST\\Client\\ContentTypeService',
-                    array(),
-                    array(),
-                    '',
-                    false
-                ),
-                $this->getMock(
-                    'eZ\\Publish\\Core\\REST\\Client\\FieldTypeService',
-                    array(),
-                    array(),
-                    '',
-                    false
-                ),
-            ),
-            '',
-            false
-        );
+        $fieldTypeParserMock = $this->getMockBuilder(FieldTypeParser::class)
+            ->setMethods(array())
+            ->disableOriginalConstructor()
+            ->setConstructorArgs(
+                array(
+                    $this->getContentServiceMock(),
+                    $this->createMock(ContentTypeService::class),
+                    $this->createMock(FieldTypeService::class),
+                )
+            )
+            ->getMock();
 
         $fieldTypeParserMock->expects($this->any())
             ->method('parseFieldValue')
@@ -180,13 +172,7 @@ class VersionUpdateTest extends BaseTest
      */
     protected function getContentServiceMock()
     {
-        $contentServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\ContentService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $contentServiceMock = $this->createMock(ContentService::class);
 
         $contentServiceMock->expects($this->any())
             ->method('newContentUpdateStruct')

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/BadStateExceptionTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/BadStateExceptionTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+use eZ\Publish\API\Repository\Exceptions\BadStateException;
 
 class BadStateExceptionTest extends ExceptionTest
 {
@@ -39,7 +40,7 @@ class BadStateExceptionTest extends ExceptionTest
      */
     protected function getException()
     {
-        return $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Exceptions\\BadStateException');
+        return $this->getMockForAbstractClass(BadStateException::class);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/CachedValueTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/CachedValueTest.php
@@ -164,7 +164,7 @@ class CachedValueTest extends ValueObjectVisitorBaseTest
     {
         $options = $this->options ?: $this->defaultOptions;
 
-        $mock = $this->getMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
+        $mock = $this->createMock(ConfigResolverInterface::class);
         $mock
             ->expects($this->any())
             ->method('hasParameter')

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ContentListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ContentListTest.php
@@ -110,7 +110,7 @@ class ContentListTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->exactly(2))
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\Core\\Rest\\Server\\Values\\RestContent'));
+            ->with($this->isInstanceOf(RestContent::class));
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ContentTypeGroupListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ContentTypeGroupListTest.php
@@ -12,6 +12,7 @@ use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Server\Values\ContentTypeGroupList;
 use eZ\Publish\Core\Repository\Values\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup;
 
 class ContentTypeGroupListTest extends ValueObjectVisitorBaseTest
 {
@@ -105,7 +106,7 @@ class ContentTypeGroupListTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->exactly(2))
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentTypeGroup'));
+            ->with($this->isInstanceOf(ContentTypeGroup::class));
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ContentTypeInfoListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ContentTypeInfoListTest.php
@@ -12,6 +12,7 @@ use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Server\Values\ContentTypeInfoList;
 use eZ\Publish\Core\Repository\Values\ContentType;
+use eZ\Publish\Core\REST\Server\Values\RestContentType;
 
 class ContentTypeInfoListTest extends ValueObjectVisitorBaseTest
 {
@@ -112,7 +113,7 @@ class ContentTypeInfoListTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->exactly(2))
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\Core\\REST\\Server\\Values\\RestContentType'));
+            ->with($this->isInstanceOf(RestContentType::class));
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ContentTypeListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ContentTypeListTest.php
@@ -12,6 +12,7 @@ use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Server\Values\ContentTypeList;
 use eZ\Publish\Core\Repository\Values\ContentType;
+use eZ\Publish\Core\REST\Server\Values\RestContentType;
 
 class ContentTypeListTest extends ValueObjectVisitorBaseTest
 {
@@ -112,7 +113,7 @@ class ContentTypeListTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->exactly(2))
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\Core\\REST\\Server\\Values\\RestContentType'));
+            ->with($this->isInstanceOf(RestContentType::class));
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/FieldDefinitionListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/FieldDefinitionListTest.php
@@ -32,7 +32,7 @@ class FieldDefinitionListTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->exactly(2))
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\Core\\REST\\Server\\Values\\RestFieldDefinition'));
+            ->with($this->isInstanceOf(Server\Values\RestFieldDefinition::class));
 
         $this->addRouteExpectation(
             'ezpublish_rest_loadContentTypeFieldDefinitionList',

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/NotFoundExceptionTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/NotFoundExceptionTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 
 class NotFoundExceptionTest extends ExceptionTest
@@ -39,7 +40,7 @@ class NotFoundExceptionTest extends ExceptionTest
      */
     protected function getException()
     {
-        return $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Exceptions\\NotFoundException');
+        return $this->getMockForAbstractClass(NotFoundException::class);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ObjectStateGroupListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ObjectStateGroupListTest.php
@@ -105,7 +105,7 @@ class ObjectStateGroupListTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->exactly(2))
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\API\\Repository\\Values\\ObjectState\\ObjectStateGroup'));
+            ->with($this->isInstanceOf(\eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup::class));
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ObjectStateListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/ObjectStateListTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
+use eZ\Publish\Core\REST\Common\Values\RestObjectState;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Server\Values\ObjectStateList;
 use eZ\Publish\Core\Repository\Values\ObjectState\ObjectState;
@@ -111,7 +112,7 @@ class ObjectStateListTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->exactly(2))
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\Core\\REST\\Common\\Values\\RestObjectState'));
+            ->with($this->isInstanceOf(RestObjectState::class));
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/PolicyListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/PolicyListTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
+use eZ\Publish\API\Repository\Values\User\Policy;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Server\Values\PolicyList;
@@ -104,7 +105,7 @@ class PolicyListTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->exactly(2))
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\API\\Repository\\Values\\User\\Policy'));
+            ->with($this->isInstanceOf(Policy::class));
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RelationListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RelationListTest.php
@@ -12,6 +12,7 @@ use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Server\Values\RelationList;
 use eZ\Publish\Core\Repository\Values\Content;
+use eZ\Publish\Core\REST\Server\Values\RestRelation;
 
 class RelationListTest extends ValueObjectVisitorBaseTest
 {
@@ -114,7 +115,7 @@ class RelationListTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->exactly(2))
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\Core\\REST\\Server\\Values\\RestRelation'));
+            ->with($this->isInstanceOf(RestRelation::class));
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestContentTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestContentTest.php
@@ -8,11 +8,13 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Values\RestContent;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\Repository\Values;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\REST\Server\Values\Version;
 
 class RestContentTest extends ValueObjectVisitorBaseTest
 {
@@ -371,12 +373,12 @@ class RestContentTest extends ValueObjectVisitorBaseTest
         );
         $restContent->relations = array();
         $restContent->contentType = $this->getMockForAbstractClass(
-            'eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType'
+            ContentType::class
         );
 
         $this->getVisitorMock()->expects($this->once())
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\Core\\REST\\Server\\Values\\Version'));
+            ->with($this->isInstanceOf(Version::class));
 
         $this->addRouteExpectation(
             'ezpublish_rest_loadContent',

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestContentTypeTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestContentTypeTest.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\Repository\Values;
+use eZ\Publish\Core\REST\Server\Values\FieldDefinitionList;
 use eZ\Publish\Core\REST\Server\Values\RestContentType;
 
 /**
@@ -33,7 +34,7 @@ class RestContentTypeTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->once())
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\Core\\REST\\Server\\Values\\FieldDefinitionList'));
+            ->with($this->isInstanceOf(FieldDefinitionList::class));
 
         $this->addRouteExpectation(
             'ezpublish_rest_loadContentType',

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestExecutedViewTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestExecutedViewTest.php
@@ -8,6 +8,9 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
@@ -119,7 +122,7 @@ class RestExecutedViewTest extends ValueObjectVisitorBaseTest
      */
     public function getLocationServiceMock()
     {
-        return $this->getMock('eZ\\Publish\\API\\Repository\\LocationService');
+        return $this->createMock(LocationService::class);
     }
 
     /**
@@ -127,7 +130,7 @@ class RestExecutedViewTest extends ValueObjectVisitorBaseTest
      */
     public function getContentServiceMock()
     {
-        return $this->getMock('eZ\\Publish\\API\\Repository\\ContentService');
+        return $this->createMock(ContentService::class);
     }
 
     /**
@@ -135,7 +138,7 @@ class RestExecutedViewTest extends ValueObjectVisitorBaseTest
      */
     public function getContentTypeServiceMock()
     {
-        return $this->getMock('eZ\\Publish\\API\\Repository\\ContentTypeService');
+        return $this->createMock(ContentTypeService::class);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestFieldDefinitionTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestFieldDefinitionTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Common\Output\FieldTypeSerializer;
 use eZ\Publish\Core\REST\Server;
 use eZ\Publish\Core\Repository\Values;
 
@@ -19,13 +20,7 @@ class RestFieldDefinitionTest extends ValueObjectVisitorBaseTest
 
     public function setUp()
     {
-        $this->fieldTypeSerializerMock = $this->getMock(
-            'eZ\\Publish\\Core\\REST\\Common\\Output\\FieldTypeSerializer',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $this->fieldTypeSerializerMock = $this->createMock(FieldTypeSerializer::class);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestLocationRootNodeTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestLocationRootNodeTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Server\Values\RestContent;
 use eZ\Publish\Core\REST\Server\Values\RestLocation;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -82,7 +83,7 @@ class RestLocationRootNodeTest extends RestLocationTest
 
         $this->getVisitorMock()->expects($this->once())
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\Core\\REST\\Server\\Values\\RestContent'));
+            ->with($this->isInstanceOf(RestContent::class));
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestLocationTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestLocationTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Server\Values\RestContent;
 use eZ\Publish\Core\REST\Server\Values\RestLocation;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -89,7 +90,7 @@ class RestLocationTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->once())
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\Core\\REST\\Server\\Values\\RestContent'));
+            ->with($this->isInstanceOf(RestContent::class));
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestTrashItemTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestTrashItemTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Server\Values\RestContent;
 use eZ\Publish\Core\REST\Server\Values\RestTrashItem;
 use eZ\Publish\Core\Repository\Values\Content\TrashItem;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -80,7 +81,7 @@ class RestTrashItemTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->once())
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\Core\\REST\\Server\\Values\\RestContent'));
+            ->with($this->isInstanceOf(RestContent::class));
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestUserGroupTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestUserGroupTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Values\RestUserGroup;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
@@ -108,7 +109,7 @@ class RestUserGroupTest extends ValueObjectVisitorBaseTest
     {
         return new RestUserGroup(
             new Values\User\UserGroup(),
-            $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType'),
+            $this->getMockForAbstractClass(ContentType::class),
             new ContentInfo(
                 array(
                     'id' => 'content23',

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestUserTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RestUserTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Values\RestUser;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
@@ -103,7 +104,7 @@ class RestUserTest extends ValueObjectVisitorBaseTest
     {
         return new RestUser(
             new Values\User\User(),
-            $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType'),
+            $this->getMockForAbstractClass(ContentType::class),
             new ContentInfo(
                 array(
                     'id' => 'content23',

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RoleAssignmentListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RoleAssignmentListTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+use eZ\Publish\Core\REST\Server\Values\RestUserRoleAssignment;
 use eZ\Publish\Core\REST\Server\Values\RoleAssignmentList;
 use eZ\Publish\Core\Repository\Values\User;
 
@@ -110,7 +111,7 @@ class RoleAssignmentListTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->exactly(2))
              ->method('visitValueObject')
-             ->with($this->isInstanceOf('eZ\\Publish\\Core\\REST\\Server\\Values\\RestUserRoleAssignment'));
+             ->with($this->isInstanceOf(RestUserRoleAssignment::class));
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RoleListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/RoleListTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
+use eZ\Publish\API\Repository\Values\User\Role;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Server\Values\RoleList;
@@ -104,7 +105,7 @@ class RoleListTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->exactly(2))
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\API\\Repository\\Values\\User\\Role'));
+            ->with($this->isInstanceOf(Role::class));
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/SectionListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/SectionListTest.php
@@ -104,7 +104,7 @@ class SectionListTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->exactly(2))
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\API\\Repository\\Values\\Content\\Section'));
+            ->with($this->isInstanceOf(Content\Section::class));
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/TrashTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/TrashTest.php
@@ -113,7 +113,7 @@ class TrashTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->exactly(2))
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\Core\\REST\\Server\\Values\\RestTrashItem'));
+            ->with($this->isInstanceOf(RestTrashItem::class));
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/URLAliasListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/URLAliasListTest.php
@@ -104,7 +104,7 @@ class URLAliasListTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->exactly(2))
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\API\\Repository\\Values\\Content\\URLAlias'));
+            ->with($this->isInstanceOf(Content\URLAlias::class));
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/URLWildcardListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/URLWildcardListTest.php
@@ -109,7 +109,7 @@ class URLWildcardListTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->exactly(2))
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\API\\Repository\\Values\\Content\\URLWildcard'));
+            ->with($this->isInstanceOf(Content\URLWildcard::class));
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UnauthorizedExceptionTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UnauthorizedExceptionTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
 
 class UnauthorizedExceptionTest extends ExceptionTest
 {
@@ -39,7 +40,7 @@ class UnauthorizedExceptionTest extends ExceptionTest
      */
     protected function getException()
     {
-        return $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Exceptions\\UnauthorizedException');
+        return $this->getMockForAbstractClass(UnauthorizedException::class);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserGroupListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserGroupListTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Server\Values\UserGroupList;
@@ -105,7 +106,7 @@ class UserGroupListTest extends ValueObjectVisitorBaseTest
                             'internalFields' => array(),
                         )
                     ),
-                    $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType'),
+                    $this->getMockForAbstractClass(ContentType::class),
                     new ContentInfo(),
                     new Location(),
                     array()
@@ -116,7 +117,7 @@ class UserGroupListTest extends ValueObjectVisitorBaseTest
                             'internalFields' => array(),
                         )
                     ),
-                    $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType'),
+                    $this->getMockForAbstractClass(ContentType::class),
                     new ContentInfo(),
                     new Location(),
                     array()
@@ -127,7 +128,7 @@ class UserGroupListTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->exactly(2))
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\Core\\REST\\Server\\Values\\RestUserGroup'));
+            ->with($this->isInstanceOf(RestUserGroup::class));
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserGroupRefListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserGroupRefListTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\Repository\Values\User\UserGroup;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
@@ -34,7 +35,7 @@ class UserGroupRefListTest extends ValueObjectVisitorBaseTest
             array(
                 new RestUserGroup(
                     new UserGroup(),
-                    $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType'),
+                    $this->getMockForAbstractClass(ContentType::class),
                     new ContentInfo(),
                     new Location(
                         array(
@@ -46,7 +47,7 @@ class UserGroupRefListTest extends ValueObjectVisitorBaseTest
                 ),
                 new RestUserGroup(
                     new UserGroup(),
-                    $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType'),
+                    $this->getMockForAbstractClass(ContentType::class),
                     new ContentInfo(),
                     new Location(
                         array(

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserListTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Server\Values\UserList;
@@ -105,7 +106,7 @@ class UserListTest extends ValueObjectVisitorBaseTest
                             'internalFields' => array(),
                         )
                     ),
-                    $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType'),
+                    $this->getMockForAbstractClass(ContentType::class),
                     new ContentInfo(),
                     new Location(),
                     array()
@@ -116,7 +117,7 @@ class UserListTest extends ValueObjectVisitorBaseTest
                             'internalFields' => array(),
                         )
                     ),
-                    $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType'),
+                    $this->getMockForAbstractClass(ContentType::class),
                     new ContentInfo(),
                     new Location(),
                     array()
@@ -127,7 +128,7 @@ class UserListTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->exactly(2))
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\Core\\REST\\Server\\Values\\RestUser'));
+            ->with($this->isInstanceOf(RestUser::class));
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserRefListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserRefListTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\Repository\Values\User\User;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
@@ -34,7 +35,7 @@ class UserRefListTest extends ValueObjectVisitorBaseTest
             array(
                 new RestUser(
                     new User(),
-                    $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType'),
+                    $this->getMockForAbstractClass(ContentType::class),
                     new ContentInfo(
                         array(
                             'id' => 14,

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserSessionTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/UserSessionTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
+use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\REST\Server\Values;
@@ -176,7 +177,7 @@ class UserSessionTest extends ValueObjectVisitorBaseTest
 
     protected function getUserMock()
     {
-        $user = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
+        $user = $this->createMock(User::class);
         $user->expects($this->any())
             ->method('__get')
             ->with($this->equalTo('id'))

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/VersionListTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/VersionListTest.php
@@ -138,7 +138,7 @@ class VersionListTest extends ValueObjectVisitorBaseTest
 
         $this->getVisitorMock()->expects($this->exactly(2))
             ->method('visitValueObject')
-            ->with($this->isInstanceOf('eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo'));
+            ->with($this->isInstanceOf(\eZ\Publish\API\Repository\Values\Content\VersionInfo::class));
 
         $visitor->visit(
             $this->getVisitorMock(),

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/VersionTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/VersionTest.php
@@ -8,12 +8,15 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Output\ValueObjectVisitor;
 
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\Core\REST\Common\Output\Generator;
 use eZ\Publish\Core\REST\Common\Tests\Output\ValueObjectVisitorBaseTest;
 use eZ\Publish\Core\REST\Server\Output\ValueObjectVisitor;
 use eZ\Publish\Core\Repository\Values;
 use eZ\Publish\Core\REST\Server\Values\Version;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\Core\REST\Common\Output\FieldTypeSerializer;
 
 class VersionTest extends ValueObjectVisitorBaseTest
 {
@@ -21,13 +24,7 @@ class VersionTest extends ValueObjectVisitorBaseTest
 
     public function setUp()
     {
-        $this->fieldTypeSerializerMock = $this->getMock(
-            'eZ\\Publish\\Core\\REST\\Common\\Output\\FieldTypeSerializer',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $this->fieldTypeSerializerMock = $this->createMock(FieldTypeSerializer::class);
     }
 
     /**
@@ -74,16 +71,16 @@ class VersionTest extends ValueObjectVisitorBaseTest
                     ),
                 )
             ),
-            $this->getMockForAbstractClass('eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType'),
+            $this->getMockForAbstractClass(ContentType::class),
             array()
         );
 
         $this->fieldTypeSerializerMock->expects($this->exactly(2))
             ->method('serializeFieldValue')
             ->with(
-                $this->isInstanceOf('eZ\\Publish\\Core\\REST\\Common\\Output\\Generator'),
-                $this->isInstanceOf('eZ\\Publish\\API\\Repository\\Values\\ContentType\\ContentType'),
-                $this->isInstanceOf('eZ\\Publish\\API\\Repository\\Values\\Content\\Field')
+                $this->isInstanceOf(Generator::class),
+                $this->isInstanceOf(ContentType::class),
+                $this->isInstanceOf(Field::class)
             );
 
         $this->getVisitorMock()->expects($this->exactly(2))

--- a/eZ/Publish/Core/REST/Server/Tests/Security/RestLogoutHandlerTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Security/RestLogoutHandlerTest.php
@@ -12,12 +12,15 @@ use eZ\Publish\Core\REST\Server\Security\RestLogoutHandler;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class RestLogoutHandlerTest extends TestCase
 {
     public function testLogout()
     {
-        $session = $this->getMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
+        $session = $this->createMock(SessionInterface::class);
         $sessionId = 'eZSESSID';
         $session
             ->expects($this->once())
@@ -29,7 +32,7 @@ class RestLogoutHandlerTest extends TestCase
         $request->attributes->set('is_rest_request', true);
 
         $response = new Response();
-        $response->headers = $this->getMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
+        $response->headers = $this->createMock(ResponseHeaderBag::class);
         $response->headers
             ->expects($this->once())
             ->method('clearCookie')
@@ -39,13 +42,13 @@ class RestLogoutHandlerTest extends TestCase
         $logoutHandler->logout(
             $request,
             $response,
-            $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')
+            $this->createMock(TokenInterface::class)
         );
     }
 
     public function testLogoutNotRest()
     {
-        $session = $this->getMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
+        $session = $this->createMock(SessionInterface::class);
         $session
             ->expects($this->never())
             ->method('getName');
@@ -54,7 +57,7 @@ class RestLogoutHandlerTest extends TestCase
         $request->setSession($session);
 
         $response = new Response();
-        $response->headers = $this->getMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
+        $response->headers = $this->createMock(ResponseHeaderBag::class);
         $response->headers
             ->expects($this->never())
             ->method('clearCookie');
@@ -63,7 +66,7 @@ class RestLogoutHandlerTest extends TestCase
         $logoutHandler->logout(
             $request,
             $response,
-            $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')
+            $this->createMock(TokenInterface::class)
         );
     }
 }

--- a/eZ/Publish/Core/REST/Server/Tests/Security/RestSessionBasedAuthenticatorTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Security/RestSessionBasedAuthenticatorTest.php
@@ -8,13 +8,25 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Security;
 
+use eZ\Publish\API\Repository\Values\User\User;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\REST\Server\Security\RestAuthenticator;
 use eZ\Publish\Core\MVC\Symfony\Security\User as EzUser;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
+use Symfony\Component\Security\Http\Logout\SessionLogoutHandler;
 use Symfony\Component\Security\Http\SecurityEvents;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 
 class RestSessionBasedAuthenticatorTest extends TestCase
 {
@@ -58,12 +70,12 @@ class RestSessionBasedAuthenticatorTest extends TestCase
     protected function setUp()
     {
         parent::setUp();
-        $this->tokenStorage = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
-        $this->authenticationManager = $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface');
-        $this->eventDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $this->configResolver = $this->getMock('eZ\Publish\Core\MVC\ConfigResolverInterface');
-        $this->sessionStorage = $this->getMock('Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface');
-        $this->logger = $this->getMock('Psr\Log\LoggerInterface');
+        $this->tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $this->authenticationManager = $this->createMock(AuthenticationManagerInterface::class);
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
+        $this->sessionStorage = $this->createMock(SessionStorageInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
         $this->authenticator = new RestAuthenticator(
             $this->tokenStorage,
             $this->authenticationManager,
@@ -80,7 +92,7 @@ class RestSessionBasedAuthenticatorTest extends TestCase
         $username = 'foo_user';
         $password = 'publish';
 
-        $existingToken = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $existingToken = $this->getTokenInterfaceMock();
         $this->tokenStorage
             ->expects($this->once())
             ->method('getToken')
@@ -110,7 +122,7 @@ class RestSessionBasedAuthenticatorTest extends TestCase
         $username = 'foo_user';
         $password = 'publish';
 
-        $existingToken = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $existingToken = $this->getTokenInterfaceMock();
         $this->tokenStorage
             ->expects($this->once())
             ->method('getToken')
@@ -147,7 +159,7 @@ class RestSessionBasedAuthenticatorTest extends TestCase
         $username = 'foo_user';
         $password = 'publish';
 
-        $existingToken = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $existingToken = $this->getTokenInterfaceMock();
         $existingToken
             ->expects($this->once())
             ->method('getUsername')
@@ -158,10 +170,7 @@ class RestSessionBasedAuthenticatorTest extends TestCase
         $request->attributes->set('password', $password);
 
         $usernamePasswordToken = new UsernamePasswordToken($username, $password, self::PROVIDER_KEY);
-        $authenticatedToken = $this
-            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $authenticatedToken = $this->getUsernamePasswordTokenMock();
         $this->authenticationManager
             ->expects($this->once())
             ->method('authenticate')
@@ -207,7 +216,7 @@ class RestSessionBasedAuthenticatorTest extends TestCase
      */
     private function createUser($userId)
     {
-        $apiUser = $this->getMock('eZ\Publish\API\Repository\Values\User\User');
+        $apiUser = $this->createMock(User::class);
         $apiUser
             ->expects($this->any())
             ->method('getUserId')
@@ -225,10 +234,7 @@ class RestSessionBasedAuthenticatorTest extends TestCase
         $password = 'publish';
 
         $existingUser = $this->createUser(123);
-        $existingToken = $this
-            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $existingToken = $this->getUsernamePasswordTokenMock();
         $existingToken
             ->expects($this->once())
             ->method('getUsername')
@@ -243,10 +249,7 @@ class RestSessionBasedAuthenticatorTest extends TestCase
         $request->attributes->set('password', $password);
 
         $usernamePasswordToken = new UsernamePasswordToken($username, $password, self::PROVIDER_KEY);
-        $authenticatedToken = $this
-            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $authenticatedToken = $this->getUsernamePasswordTokenMock();
         $this->authenticationManager
             ->expects($this->once())
             ->method('authenticate')
@@ -300,10 +303,7 @@ class RestSessionBasedAuthenticatorTest extends TestCase
 
         $anonymousUserId = 10;
         $existingUser = $this->createUser($anonymousUserId);
-        $existingToken = $this
-            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $existingToken = $this->getUsernamePasswordTokenMock();
         $existingToken
             ->expects($this->once())
             ->method('getUsername')
@@ -318,10 +318,7 @@ class RestSessionBasedAuthenticatorTest extends TestCase
         $request->attributes->set('password', $password);
 
         $usernamePasswordToken = new UsernamePasswordToken($username, $password, self::PROVIDER_KEY);
-        $authenticatedToken = $this
-            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $authenticatedToken = $this->getUsernamePasswordTokenMock();
         $this->authenticationManager
             ->expects($this->once())
             ->method('authenticate')
@@ -369,7 +366,7 @@ class RestSessionBasedAuthenticatorTest extends TestCase
         $username = 'foo_user';
         $password = 'publish';
 
-        $existingToken = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $existingToken = $this->getTokenInterfaceMock();
         $existingToken
             ->expects($this->once())
             ->method('getUsername')
@@ -380,10 +377,7 @@ class RestSessionBasedAuthenticatorTest extends TestCase
         $request->attributes->set('password', $password);
 
         $usernamePasswordToken = new UsernamePasswordToken($username, $password, self::PROVIDER_KEY);
-        $authenticatedToken = $this
-            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $authenticatedToken = $this->getUsernamePasswordTokenMock();
         $this->authenticationManager
             ->expects($this->once())
             ->method('authenticate')
@@ -425,11 +419,8 @@ class RestSessionBasedAuthenticatorTest extends TestCase
         $username = 'foo_user';
         $password = 'publish';
 
-        $existingUser = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
-        $existingToken = $this
-            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $existingUser = $this->createMock(UserInterface::class);
+        $existingToken = $this->getUsernamePasswordTokenMock();
         $existingToken
             ->expects($this->once())
             ->method('getUsername')
@@ -444,10 +435,7 @@ class RestSessionBasedAuthenticatorTest extends TestCase
         $request->attributes->set('password', $password);
 
         $usernamePasswordToken = new UsernamePasswordToken($username, $password, self::PROVIDER_KEY);
-        $authenticatedToken = $this
-            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $authenticatedToken = $this->getUsernamePasswordTokenMock();
         $this->authenticationManager
             ->expects($this->once())
             ->method('authenticate')
@@ -489,7 +477,7 @@ class RestSessionBasedAuthenticatorTest extends TestCase
         $username = 'foo_user';
         $password = 'publish';
 
-        $existingToken = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $existingToken = $this->getTokenInterfaceMock();
         $existingToken
             ->expects($this->once())
             ->method('getUsername')
@@ -500,10 +488,7 @@ class RestSessionBasedAuthenticatorTest extends TestCase
         $request->attributes->set('password', $password);
 
         $usernamePasswordToken = new UsernamePasswordToken($username, $password, self::PROVIDER_KEY);
-        $authenticatedToken = $this
-            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken')
-            ->disableOriginalConstructor()
-            ->getMock();
+        $authenticatedToken = $this->getUsernamePasswordTokenMock();
         $this->authenticationManager
             ->expects($this->once())
             ->method('authenticate')
@@ -542,34 +527,34 @@ class RestSessionBasedAuthenticatorTest extends TestCase
 
     public function testLogout()
     {
-        $sessionLogoutHandler = $this->getMock('Symfony\Component\Security\Http\Logout\SessionLogoutHandler');
+        $sessionLogoutHandler = $this->createMock(SessionLogoutHandler::class);
         $sessionLogoutHandler
             ->expects($this->never())
             ->method('logout');
 
-        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token = $this->getTokenInterfaceMock();
         $this->tokenStorage
             ->expects($this->once())
             ->method('getToken')
             ->will($this->returnValue($token));
 
         $request = new Request();
-        $logoutHandler1 = $this->getMock('Symfony\Component\Security\Http\Logout\LogoutHandlerInterface');
+        $logoutHandler1 = $this->createMock(LogoutHandlerInterface::class);
         $logoutHandler1
             ->expects($this->once())
             ->method('logout')
             ->with(
                 $request,
-                $this->isInstanceOf('Symfony\Component\HttpFoundation\Response'),
+                $this->isInstanceOf(Response::class),
                 $token
             );
-        $logoutHandler2 = $this->getMock('Symfony\Component\Security\Http\Logout\LogoutHandlerInterface');
+        $logoutHandler2 = $this->createMock(LogoutHandlerInterface::class);
         $logoutHandler2
             ->expects($this->once())
             ->method('logout')
             ->with(
                 $request,
-                $this->isInstanceOf('Symfony\Component\HttpFoundation\Response'),
+                $this->isInstanceOf(Response::class),
                 $token
             );
 
@@ -578,8 +563,18 @@ class RestSessionBasedAuthenticatorTest extends TestCase
         $this->authenticator->addLogoutHandler($logoutHandler2);
 
         $this->assertInstanceOf(
-            'Symfony\Component\HttpFoundation\Response',
+            Response::class,
             $this->authenticator->logout($request)
         );
+    }
+
+    protected function getTokenInterfaceMock()
+    {
+        return $this->createMock(TokenInterface::class);
+    }
+
+    protected function getUsernamePasswordTokenMock()
+    {
+        return $this->createMock(UsernamePasswordToken::class);
     }
 }

--- a/eZ/Publish/Core/Repository/Tests/Helper/FieldTypeRegistryTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Helper/FieldTypeRegistryTest.php
@@ -8,6 +8,7 @@
 namespace eZ\Publish\Core\Repository\Tests\Helper;
 
 use eZ\Publish\Core\Repository\Helper\FieldTypeRegistry;
+use eZ\Publish\SPI\FieldType\FieldType;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -30,7 +31,7 @@ class FieldTypeRegistryTest extends TestCase
 
     protected function getFieldTypeMock()
     {
-        return $this->getMock('eZ\\Publish\\SPI\\FieldType\\FieldType');
+        return $this->createMock(FieldType::class);
     }
 
     protected function getClosure($returnValue)
@@ -51,7 +52,7 @@ class FieldTypeRegistryTest extends TestCase
         $fieldType = $registry->getFieldType('one');
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\FieldType\\FieldType',
+            FieldType::class,
             $fieldType
         );
     }
@@ -67,7 +68,7 @@ class FieldTypeRegistryTest extends TestCase
         $fieldType = $registry->getFieldType('one');
 
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\FieldType\\FieldType',
+            FieldType::class,
             $fieldType
         );
     }
@@ -127,12 +128,12 @@ class FieldTypeRegistryTest extends TestCase
         $this->assertCount(2, $fieldTypes);
         $this->assertArrayHasKey('one', $fieldTypes);
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\FieldType\\FieldType',
+            FieldType::class,
             $fieldTypes['one']
         );
         $this->assertArrayHasKey('two', $fieldTypes);
         $this->assertInstanceOf(
-            'eZ\\Publish\\SPI\\FieldType\\FieldType',
+            FieldType::class,
             $fieldTypes['two']
         );
     }

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
@@ -128,7 +128,7 @@ abstract class Base extends TestCase
     protected function getRepositoryMock()
     {
         if (!isset($this->repositoryMock)) {
-            $this->repositoryMock = self::getMock('eZ\\Publish\\API\\Repository\\Repository');
+            $this->repositoryMock = self::createMock('eZ\\Publish\\API\\Repository\\Repository');
         }
 
         return $this->repositoryMock;
@@ -142,21 +142,15 @@ abstract class Base extends TestCase
     protected function getPersistenceMock()
     {
         if (!isset($this->persistenceMock)) {
-            $this->persistenceMock = $this->getMock(
-                'eZ\\Publish\\SPI\\Persistence\\Handler',
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->persistenceMock = $this->createMock('eZ\\Publish\\SPI\\Persistence\\Handler');
 
             $this->persistenceMock->expects($this->any())
                 ->method('contentHandler')
                 ->will($this->returnValue($this->getPersistenceMockHandler('Content\\Handler')));
 
-            $this->persistenceMock->expects($this->any())
-                ->method('searchHandler')
-                ->will($this->returnValue($this->getSPIMockHandler('Search\\Handler')));
+//            $this->persistenceMock->expects($this->any())
+//                ->method('searchHandler')
+//                ->will($this->returnValue($this->getSPIMockHandler('Search\\Handler')));
 
             $this->persistenceMock->expects($this->any())
                 ->method('contentTypeHandler')
@@ -208,13 +202,11 @@ abstract class Base extends TestCase
     protected function getSPIMockHandler($handler)
     {
         if (!isset($this->spiMockHandlers[$handler])) {
-            $this->spiMockHandlers[$handler] = $this->getMock(
-                "eZ\\Publish\\SPI\\{$handler}",
-                array(),
-                array(),
-                '',
-                false
-            );
+            $this->spiMockHandlers[$handler] = $this->getMockBuilder("eZ\\Publish\\SPI\\{$handler}")
+                ->setMethods(array())
+                ->disableOriginalConstructor()
+                ->setConstructorArgs(array())
+                ->getMock();
         }
 
         return $this->spiMockHandlers[$handler];

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -22,6 +22,7 @@ use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\SPI\Persistence\Content\Location as SPILocation;
@@ -129,7 +130,7 @@ class ContentTest extends BaseServiceMockTest
         /** @var \PHPUnit_Framework_MockObject_MockObject $contentHandler */
         $contentHandler = $this->getPersistenceMock()->contentHandler();
         $domainMapperMock = $this->getDomainMapperMock();
-        $versionInfoMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo');
+        $versionInfoMock = $this->createMock(APIVersionInfo::class);
 
         $versionInfoMock->expects($this->once())
             ->method('isPublished')
@@ -216,7 +217,7 @@ class ContentTest extends BaseServiceMockTest
         /** @var \PHPUnit_Framework_MockObject_MockObject $contentHandler */
         $contentHandler = $this->getPersistenceMock()->contentHandler();
         $domainMapperMock = $this->getDomainMapperMock();
-        $versionInfoMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo');
+        $versionInfoMock = $this->createMock(APIVersionInfo::class);
 
         $versionInfoMock->expects($this->any())
             ->method('isPublished')
@@ -259,7 +260,7 @@ class ContentTest extends BaseServiceMockTest
         /** @var \PHPUnit_Framework_MockObject_MockObject $contentHandler */
         $contentHandler = $this->getPersistenceMock()->contentHandler();
         $domainMapperMock = $this->getDomainMapperMock();
-        $versionInfoMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo');
+        $versionInfoMock = $this->createMock(APIVersionInfo::class);
 
         $versionInfoMock->expects($this->once())
             ->method('isPublished')
@@ -304,7 +305,7 @@ class ContentTest extends BaseServiceMockTest
         /** @var \PHPUnit_Framework_MockObject_MockObject $contentHandler */
         $contentHandler = $this->getPersistenceMock()->contentHandler();
         $domainMapperMock = $this->getDomainMapperMock();
-        $versionInfoMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo');
+        $versionInfoMock = $this->createMock(APIVersionInfo::class);
 
         $versionInfoMock->expects($this->once())
             ->method('isPublished')
@@ -375,8 +376,8 @@ class ContentTest extends BaseServiceMockTest
     {
         $repository = $this->getRepositoryMock();
         $contentService = $this->getPartlyMockedContentService(array('internalLoadContent'));
-        $content = $this->getMock('eZ\Publish\API\Repository\Values\Content\Content');
-        $versionInfo = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo');
+        $content = $this->createMock('eZ\Publish\API\Repository\Values\Content\Content');
+        $versionInfo = $this->createMock(APIVersionInfo::class);
         $content
             ->expects($this->once())
             ->method('getVersionInfo')
@@ -405,7 +406,7 @@ class ContentTest extends BaseServiceMockTest
     {
         $repository = $this->getRepositoryMock();
         $contentService = $this->getPartlyMockedContentService(array('internalLoadContent'));
-        $content = $this->getMock('eZ\Publish\API\Repository\Values\Content\Content');
+        $content = $this->createMock('eZ\Publish\API\Repository\Values\Content\Content');
         $versionInfo = $this
             ->getMockBuilder('eZ\Publish\API\Repository\Values\Content\VersionInfo')
             ->getMockForAbstractClass();
@@ -442,7 +443,7 @@ class ContentTest extends BaseServiceMockTest
     {
         $repository = $this->getRepositoryMock();
         $contentService = $this->getPartlyMockedContentService(array('internalLoadContent'));
-        $content = $this->getMock('eZ\Publish\API\Repository\Values\Content\Content');
+        $content = $this->createMock('eZ\Publish\API\Repository\Values\Content\Content');
         $contentId = 123;
         $contentService
             ->expects($this->once())
@@ -466,7 +467,7 @@ class ContentTest extends BaseServiceMockTest
     {
         $repository = $this->getRepositoryMock();
         $contentService = $this->getPartlyMockedContentService(array('internalLoadContent'));
-        $content = $this->getMock('eZ\Publish\API\Repository\Values\Content\Content');
+        $content = $this->createMock('eZ\Publish\API\Repository\Values\Content\Content');
         $versionInfo = $this
             ->getMockBuilder('eZ\Publish\API\Repository\Values\Content\VersionInfo')
             ->getMockForAbstractClass();
@@ -539,7 +540,7 @@ class ContentTest extends BaseServiceMockTest
             ->method('load')
             ->with($realId, $realVersionNo, $languages)
             ->will($this->returnValue($spiContent));
-        $content = $this->getMock('eZ\Publish\API\Repository\Values\Content\Content');
+        $content = $this->createMock('eZ\Publish\API\Repository\Values\Content\Content');
         $this->getDomainMapperMock()
             ->expects($this->once())
             ->method('buildContentDomainObject')
@@ -590,7 +591,7 @@ class ContentTest extends BaseServiceMockTest
             ->with($id, $versionNo, $languages)
             ->will(
                 $this->throwException(
-                    $this->getMock('eZ\Publish\API\Repository\Exceptions\NotFoundException')
+                    $this->createMock('eZ\Publish\API\Repository\Exceptions\NotFoundException')
                 )
             );
 
@@ -675,7 +676,7 @@ class ContentTest extends BaseServiceMockTest
     {
         $repository = $this->getRepositoryMock();
         $contentService = $this->getPartlyMockedContentService(array('internalLoadContentInfo'));
-        $contentInfo = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
+        $contentInfo = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
 
         $contentInfo->expects($this->any())
             ->method('__get')
@@ -718,7 +719,7 @@ class ContentTest extends BaseServiceMockTest
         /** @var \PHPUnit_Framework_MockObject_MockObject $contentHandler */
         $contentHandler = $this->getPersistenceMock()->contentHandler();
 
-        $contentInfo = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
+        $contentInfo = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
 
         $contentService->expects($this->once())
             ->method('internalLoadContentInfo')
@@ -776,7 +777,7 @@ class ContentTest extends BaseServiceMockTest
         /** @var \PHPUnit_Framework_MockObject_MockObject $locationHandler */
         $locationHandler = $this->getPersistenceMock()->locationHandler();
 
-        $contentInfo = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
+        $contentInfo = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
 
         $contentService->expects($this->once())
             ->method('internalLoadContentInfo')
@@ -822,8 +823,8 @@ class ContentTest extends BaseServiceMockTest
         $contentService = $this->getPartlyMockedContentService();
         /** @var \PHPUnit_Framework_MockObject_MockObject $contentHandler */
         $contentHandler = $this->getPersistenceMock()->contentHandler();
-        $contentInfo = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
-        $versionInfo = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo');
+        $contentInfo = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
+        $versionInfo = $this->createMock(APIVersionInfo::class);
 
         $contentInfo
             ->expects($this->any())
@@ -1150,7 +1151,7 @@ class ContentTest extends BaseServiceMockTest
         $domainMapperMock = $this->getDomainMapperMock();
         $relationProcessorMock = $this->getRelationProcessorMock();
         $nameSchemaServiceMock = $this->getNameSchemaServiceMock();
-        $fieldTypeMock = $this->getMock('eZ\\Publish\\SPI\\FieldType\\FieldType');
+        $fieldTypeMock = $this->createMock('eZ\\Publish\\SPI\\FieldType\\FieldType');
         $languageCodes = $this->determineLanguageCodesForCreate($mainLanguageCode, $structFields);
         $contentType = new ContentType(
             array(
@@ -2016,7 +2017,7 @@ class ContentTest extends BaseServiceMockTest
         $contentTypeServiceMock = $this->getContentTypeServiceMock();
         $fieldTypeServiceMock = $this->getFieldTypeServiceMock();
         $domainMapperMock = $this->getDomainMapperMock();
-        $fieldTypeMock = $this->getMock('eZ\\Publish\\SPI\\FieldType\\FieldType');
+        $fieldTypeMock = $this->createMock('eZ\\Publish\\SPI\\FieldType\\FieldType');
         $contentType = new ContentType(
             array(
                 'id' => 123,
@@ -2207,7 +2208,7 @@ class ContentTest extends BaseServiceMockTest
         $fieldTypeServiceMock = $this->getFieldTypeServiceMock();
         $domainMapperMock = $this->getDomainMapperMock();
         $relationProcessorMock = $this->getRelationProcessorMock();
-        $fieldTypeMock = $this->getMock('eZ\\Publish\\SPI\\FieldType\\FieldType');
+        $fieldTypeMock = $this->createMock('eZ\\Publish\\SPI\\FieldType\\FieldType');
         $languageCodes = $this->determineLanguageCodesForCreate($mainLanguageCode, $structFields);
         $contentType = new ContentType(
             array(
@@ -3055,7 +3056,7 @@ class ContentTest extends BaseServiceMockTest
         $domainMapperMock = $this->getDomainMapperMock();
         $relationProcessorMock = $this->getRelationProcessorMock();
         $nameSchemaServiceMock = $this->getNameSchemaServiceMock();
-        $fieldTypeMock = $this->getMock('eZ\\Publish\\SPI\\FieldType\\FieldType');
+        $fieldTypeMock = $this->createMock('eZ\\Publish\\SPI\\FieldType\\FieldType');
         $existingLanguageCodes = array_map(
             function (Field $field) {
                 return $field->languageCode;
@@ -4802,7 +4803,7 @@ class ContentTest extends BaseServiceMockTest
         $languageHandlerMock = $this->getPersistenceMock()->contentLanguageHandler();
         $contentTypeServiceMock = $this->getContentTypeServiceMock();
         $fieldTypeServiceMock = $this->getFieldTypeServiceMock();
-        $fieldTypeMock = $this->getMock('eZ\\Publish\\SPI\\FieldType\\FieldType');
+        $fieldTypeMock = $this->createMock('eZ\\Publish\\SPI\\FieldType\\FieldType');
         $existingLanguageCodes = array_map(
             function (Field $field) {
                 return $field->languageCode;
@@ -5000,7 +5001,7 @@ class ContentTest extends BaseServiceMockTest
         $languageHandlerMock = $this->getPersistenceMock()->contentLanguageHandler();
         $contentTypeServiceMock = $this->getContentTypeServiceMock();
         $fieldTypeServiceMock = $this->getFieldTypeServiceMock();
-        $fieldTypeMock = $this->getMock('eZ\\Publish\\SPI\\FieldType\\FieldType');
+        $fieldTypeMock = $this->createMock('eZ\\Publish\\SPI\\FieldType\\FieldType');
         $existingLanguageCodes = array_map(
             function (Field $field) {
                 return $field->languageCode;
@@ -5241,7 +5242,7 @@ class ContentTest extends BaseServiceMockTest
     {
         $repository = $this->getRepositoryMock();
         $contentService = $this->getPartlyMockedContentService(array('internalLoadContentInfo'));
-        $contentInfo = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
+        $contentInfo = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
         $locationCreateStruct = new LocationCreateStruct();
         $location = new Location(['id' => $locationCreateStruct->parentLocationId]);
         $locationServiceMock = $this->getLocationServiceMock();
@@ -5290,7 +5291,7 @@ class ContentTest extends BaseServiceMockTest
         $repositoryMock = $this->getRepositoryMock();
         $contentService = $this->getPartlyMockedContentService(array('internalLoadContentInfo', 'internalLoadContent'));
         $locationServiceMock = $this->getLocationServiceMock();
-        $contentInfoMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
+        $contentInfoMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
         $locationCreateStruct = new LocationCreateStruct();
         $location = new Location(['id' => $locationCreateStruct->parentLocationId]);
 
@@ -5308,7 +5309,7 @@ class ContentTest extends BaseServiceMockTest
             ->method('__get')
             ->with('id')
             ->will($this->returnValue(42));
-        $versionInfoMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo');
+        $versionInfoMock = $this->createMock(APIVersionInfo::class);
 
         $versionInfoMock->expects($this->any())
             ->method('__get')
@@ -5397,7 +5398,7 @@ class ContentTest extends BaseServiceMockTest
         $repositoryMock = $this->getRepositoryMock();
         $contentService = $this->getPartlyMockedContentService(array('internalLoadContentInfo', 'internalLoadContent'));
         $locationServiceMock = $this->getLocationServiceMock();
-        $contentInfoMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
+        $contentInfoMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
         $locationCreateStruct = new LocationCreateStruct();
         $location = new Location(['id' => $locationCreateStruct->parentLocationId]);
 
@@ -5415,7 +5416,7 @@ class ContentTest extends BaseServiceMockTest
             ->method('__get')
             ->with('id')
             ->will($this->returnValue(42));
-        $versionInfoMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo');
+        $versionInfoMock = $this->createMock(APIVersionInfo::class);
 
         $versionInfoMock->expects($this->any())
             ->method('__get')
@@ -5520,7 +5521,7 @@ class ContentTest extends BaseServiceMockTest
             ->will($this->returnValue($location))
         ;
 
-        $contentInfoMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
+        $contentInfoMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
         $contentInfoMock->expects($this->any())
             ->method('__get')
             ->with('id')
@@ -5617,10 +5618,10 @@ class ContentTest extends BaseServiceMockTest
     protected function mockPublishVersion($publicationDate = null)
     {
         $domainMapperMock = $this->getDomainMapperMock();
-        $contentMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Content');
+        $contentMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Content');
         /* @var \PHPUnit_Framework_MockObject_MockObject $contentHandlerMock */
-        $versionInfoMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo');
-        $contentInfoMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
+        $versionInfoMock = $this->createMock(APIVersionInfo::class);
+        $contentInfoMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
         $contentHandlerMock = $this->getPersistenceMock()->contentHandler();
         $metadataUpdateStruct = new SPIMetadataUpdateStruct();
 
@@ -5703,7 +5704,7 @@ class ContentTest extends BaseServiceMockTest
         /** @var \PHPUnit_Framework_MockObject_MockObject $urlAliasHandlerMock */
         $urlAliasHandlerMock = $this->getPersistenceMock()->urlAliasHandler();
         $locationServiceMock = $this->getLocationServiceMock();
-        $location = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Location');
+        $location = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\Content\\Location');
 
         $location->expects($this->at(0))
             ->method('__get')
@@ -5846,19 +5847,20 @@ class ContentTest extends BaseServiceMockTest
     protected function getPartlyMockedContentService(array $methods = null)
     {
         if (!isset($this->partlyMockedContentService)) {
-            $this->partlyMockedContentService = $this->getMock(
-                'eZ\\Publish\\Core\\Repository\\ContentService',
-                $methods,
-                array(
-                    $this->getRepositoryMock(),
-                    $this->getPersistenceMock(),
-                    $this->getDomainMapperMock(),
-                    $this->getRelationProcessorMock(),
-                    $this->getNameSchemaServiceMock(),
-                    $this->getFieldTypeRegistryMock(),
-                    array(),
+            $this->partlyMockedContentService = $this->getMockBuilder('eZ\\Publish\\Core\\Repository\\ContentService')
+                ->setMethods($methods)
+                ->setConstructorArgs(
+                    array(
+                        $this->getRepositoryMock(),
+                        $this->getPersistenceMock(),
+                        $this->getDomainMapperMock(),
+                        $this->getRelationProcessorMock(),
+                        $this->getNameSchemaServiceMock(),
+                        $this->getFieldTypeRegistryMock(),
+                        array(),
+                    )
                 )
-            );
+                ->getMock();
         }
 
         return $this->partlyMockedContentService;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/NameSchemaTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/NameSchemaTest.php
@@ -381,16 +381,17 @@ class NameSchemaTest extends BaseServiceMockTest
      */
     protected function getPartlyMockedNameSchemaService(array $methods = null, array $settings = [])
     {
-        return $this->getMock(
-            NameSchemaService::class,
-            $methods,
-            [
-                $this->getPersistenceMock()->contentTypeHandler(),
-                $this->getContentTypeDomainMapperMock(),
-                $this->getNameableFieldTypeRegistryMock(),
-                $settings,
-            ]
-        );
+        return $this->getMockBuilder(NameSchemaService::class)
+            ->setMethods($methods)
+            ->setConstructorArgs(
+                [
+                    $this->getPersistenceMock()->contentTypeHandler(),
+                    $this->getContentTypeDomainMapperMock(),
+                    $this->getNameableFieldTypeRegistryMock(),
+                    $settings,
+                ]
+            )
+            ->getMock();
     }
 
     protected $contentTypeDomainMapperMock;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionTest.php
@@ -506,7 +506,7 @@ class PermissionTest extends BaseServiceMockTest
     {
         /** @var $userHandlerMock \PHPUnit_Framework_MockObject_MockObject */
         $userHandlerMock = $this->getPersistenceMock()->userHandler();
-        $limitationTypeMock = $this->getMock('eZ\\Publish\\SPI\\Limitation\\Type');
+        $limitationTypeMock = $this->createMock('eZ\\Publish\\SPI\\Limitation\\Type');
         $limitationService = $this->getLimitationServiceMock();
         $roleDomainMapper = $this->getRoleDomainMapperMock();
         $permissionResolverMock = $this->getPermissionResolverMock(['getCurrentUserReference']);
@@ -643,13 +643,12 @@ class PermissionTest extends BaseServiceMockTest
             ]
         );
 
-        $policyMock = $this->getMock(
-            'eZ\\Publish\\SPI\\Persistence\\User\\Policy',
-            array('getLimitations'),
-            array(),
-            '',
-            false
-        );
+        $policyMock = $this->getMockBuilder('eZ\\Publish\\SPI\\Persistence\\User\\Policy')
+            ->setMethods(array('getLimitations'))
+            ->setConstructorArgs(array())
+            ->disableOriginalConstructor()
+            ->getMock();
+
         $policyMock
             ->expects($this->once())
             ->method('getLimitations')
@@ -691,25 +690,23 @@ class PermissionTest extends BaseServiceMockTest
      */
     private function getPermissionSetsMock()
     {
-        $roleLimitationMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation');
+        $roleLimitationMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation');
         $roleLimitationMock
             ->expects($this->any())
             ->method('getIdentifier')
             ->will($this->returnValue('test-role-limitation-identifier'));
 
-        $policyLimitationMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation');
+        $policyLimitationMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation');
         $policyLimitationMock
             ->expects($this->any())
             ->method('getIdentifier')
             ->will($this->returnValue('test-policy-limitation-identifier'));
 
-        $policyMock = $this->getMock(
-            'eZ\\Publish\\SPI\\Persistence\\User\\Policy',
-            array('getLimitations'),
-            array(),
-            '',
-            false
-        );
+        $policyMock = $this->getMockBuilder('eZ\\Publish\\SPI\\Persistence\\User\\Policy')
+            ->setMethods(array('getLimitations'))
+            ->setConstructorArgs(array())
+            ->getMock();
+
         $policyMock
             ->expects($this->any())
             ->method('getLimitations')
@@ -816,7 +813,7 @@ class PermissionTest extends BaseServiceMockTest
     public function testCanUserComplex(array $roleLimitationEvaluations, array $policyLimitationEvaluations, $userCan)
     {
         /** @var $valueObject \eZ\Publish\API\Repository\Values\ValueObject */
-        $valueObject = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\ValueObject');
+        $valueObject = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\ValueObject');
         $limitationServiceMock = $this->getLimitationServiceMock();
         $permissionResolverMock = $this->getPermissionResolverMock(
             [
@@ -840,7 +837,7 @@ class PermissionTest extends BaseServiceMockTest
 
         $invocation = 0;
         for ($i = 0; $i < count($permissionSets); ++$i) {
-            $limitation = $this->getMock('eZ\\Publish\\SPI\\Limitation\\Type');
+            $limitation = $this->createMock('eZ\\Publish\\SPI\\Limitation\\Type');
             $limitation
                 ->expects($this->once())
                 ->method('evaluate')
@@ -862,7 +859,7 @@ class PermissionTest extends BaseServiceMockTest
                 $limitations = $policy->getLimitations();
                 for ($k = 0; $k < count($limitations); ++$k) {
                     $limitationsPass = true;
-                    $limitation = $this->getMock('eZ\\Publish\\SPI\\Limitation\\Type');
+                    $limitation = $this->createMock('eZ\\Publish\\SPI\\Limitation\\Type');
                     $limitation
                         ->expects($this->once())
                         ->method('evaluate')

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionsCriterionHandlerTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionsCriterionHandlerTest.php
@@ -312,8 +312,8 @@ class PermissionsCriterionHandlerTest extends BaseServiceMockTest
 
     protected function mockServices($criterionMock, $limitationCount, $permissionSets)
     {
-        $userMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
-        $limitationTypeMock = $this->getMock('eZ\\Publish\\SPI\\Limitation\\Type');
+        $userMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
+        $limitationTypeMock = $this->createMock('eZ\\Publish\\SPI\\Limitation\\Type');
         $limitationServiceMock = $this->getLimitationServiceMock(['getLimitationType']);
         $permissionResolverMock = $this->getPermissionResolverMock(
             [

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/RelationProcessorTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/RelationProcessorTest.php
@@ -558,7 +558,6 @@ class RelationProcessorTest extends BaseServiceMockTest
                 )
             )
             ->getMock();
-
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/RelationProcessorTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/RelationProcessorTest.php
@@ -138,7 +138,7 @@ class RelationProcessorTest extends BaseServiceMockTest
         $locationHandler = $this->getPersistenceMock()->locationHandler();
         $relationProcessor = $this->getPartlyMockedRelationProcessor();
         $fieldValueMock = $this->getMockForAbstractClass('eZ\\Publish\\Core\\FieldType\\Value');
-        $fieldTypeMock = $this->getMock('eZ\\Publish\\SPI\\FieldType\\FieldType');
+        $fieldTypeMock = $this->createMock('eZ\\Publish\\SPI\\FieldType\\FieldType');
         $locationCallCount = 0;
 
         $fieldTypeMock->expects($this->once())
@@ -206,7 +206,7 @@ class RelationProcessorTest extends BaseServiceMockTest
         $locationHandler = $this->getPersistenceMock()->locationHandler();
         $relationProcessor = $this->getPartlyMockedRelationProcessor();
         $fieldValueMock = $this->getMockForAbstractClass('eZ\\Publish\\Core\\FieldType\\Value');
-        $fieldTypeMock = $this->getMock('eZ\\Publish\\SPI\\FieldType\\FieldType');
+        $fieldTypeMock = $this->createMock('eZ\\Publish\\SPI\\FieldType\\FieldType');
 
         $fieldTypeMock->expects($this->once())
             ->method('getRelations')
@@ -550,13 +550,15 @@ class RelationProcessorTest extends BaseServiceMockTest
      */
     protected function getPartlyMockedRelationProcessor(array $methods = null)
     {
-        return $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\Helper\\RelationProcessor',
-            $methods,
-            array(
-                $this->getPersistenceMock(),
+        return $this->getMockBuilder('eZ\\Publish\\Core\\Repository\\Helper\\RelationProcessor')
+            ->setMethods($methods)
+            ->setConstructorArgs(
+                array(
+                    $this->getPersistenceMock(),
+                )
             )
-        );
+            ->getMock();
+
     }
 
     /**
@@ -564,12 +566,6 @@ class RelationProcessorTest extends BaseServiceMockTest
      */
     protected function getFieldTypeServiceMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\FieldTypeService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        return $this->createMock('eZ\\Publish\\Core\\Repository\\FieldTypeService');
     }
 }

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/RoleTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/RoleTest.php
@@ -29,8 +29,8 @@ class RoleTest extends BaseServiceMockTest
      */
     public function testCreateRoleThrowsLimitationValidationException()
     {
-        $limitationMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation');
-        $limitationTypeMock = $this->getMock('eZ\\Publish\\SPI\\Limitation\\Type');
+        $limitationMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation');
+        $limitationTypeMock = $this->createMock('eZ\\Publish\\SPI\\Limitation\\Type');
 
         $limitationMock->expects($this->any())
             ->method('getIdentifier')
@@ -53,8 +53,8 @@ class RoleTest extends BaseServiceMockTest
 
         $repository = $this->getRepositoryMock();
         /** @var \eZ\Publish\API\Repository\Values\User\RoleCreateStruct $roleCreateStructMock */
-        $roleCreateStructMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\RoleCreateStruct');
-        $policyCreateStructMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\PolicyCreateStruct');
+        $roleCreateStructMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\RoleCreateStruct');
+        $policyCreateStructMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\PolicyCreateStruct');
 
         /* @var \eZ\Publish\API\Repository\Values\User\PolicyCreateStruct $policyCreateStructMock */
         $policyCreateStructMock->module = 'mockModule';
@@ -96,8 +96,8 @@ class RoleTest extends BaseServiceMockTest
      */
     public function testAddPolicyThrowsLimitationValidationException()
     {
-        $limitationMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation');
-        $limitationTypeMock = $this->getMock('eZ\\Publish\\SPI\\Limitation\\Type');
+        $limitationMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation');
+        $limitationTypeMock = $this->createMock('eZ\\Publish\\SPI\\Limitation\\Type');
 
         $limitationTypeMock->expects($this->once())
             ->method('acceptValue')
@@ -119,8 +119,8 @@ class RoleTest extends BaseServiceMockTest
         $roleServiceMock = $this->getPartlyMockedRoleService(array('loadRole'), $settings);
 
         $repository = $this->getRepositoryMock();
-        $roleMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
-        $policyCreateStructMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\PolicyCreateStruct');
+        $roleMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
+        $policyCreateStructMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\PolicyCreateStruct');
 
         $roleMock->expects($this->any())
             ->method('__get')
@@ -162,8 +162,8 @@ class RoleTest extends BaseServiceMockTest
      */
     public function testUpdatePolicyThrowsLimitationValidationException()
     {
-        $limitationMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation');
-        $limitationTypeMock = $this->getMock('eZ\\Publish\\SPI\\Limitation\\Type');
+        $limitationMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation');
+        $limitationTypeMock = $this->createMock('eZ\\Publish\\SPI\\Limitation\\Type');
 
         $limitationTypeMock->expects($this->once())
             ->method('acceptValue')
@@ -185,8 +185,8 @@ class RoleTest extends BaseServiceMockTest
         $roleServiceMock = $this->getPartlyMockedRoleService(array('loadRole'), $settings);
 
         $repository = $this->getRepositoryMock();
-        $policyMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Policy');
-        $policyUpdateStructMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\PolicyUpdateStruct');
+        $policyMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Policy');
+        $policyUpdateStructMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\PolicyUpdateStruct');
 
         $policyMock->expects($this->any())
             ->method('__get')
@@ -233,9 +233,9 @@ class RoleTest extends BaseServiceMockTest
         $repository = $this->getRepositoryMock();
         $roleServiceMock = $this->getPartlyMockedRoleService();
         /** @var \eZ\Publish\API\Repository\Values\User\Role $roleMock */
-        $roleMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
+        $roleMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
         /** @var \eZ\Publish\API\Repository\Values\User\User $userMock */
-        $userMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
+        $userMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
 
         $repository->expects($this->once())
             ->method('canUser')
@@ -258,8 +258,8 @@ class RoleTest extends BaseServiceMockTest
      */
     public function testAssignRoleToUserThrowsLimitationValidationException()
     {
-        $limitationMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation');
-        $limitationTypeMock = $this->getMock('eZ\\Publish\\SPI\\Limitation\\Type');
+        $limitationMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation');
+        $limitationTypeMock = $this->createMock('eZ\\Publish\\SPI\\Limitation\\Type');
 
         $limitationTypeMock->expects($this->once())
             ->method('acceptValue')
@@ -281,9 +281,9 @@ class RoleTest extends BaseServiceMockTest
 
         $repository = $this->getRepositoryMock();
         /** @var \eZ\Publish\API\Repository\Values\User\Role $roleMock */
-        $roleMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
+        $roleMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
         /** @var \eZ\Publish\API\Repository\Values\User\User $userMock */
-        $userMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
+        $userMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
 
         $repository->expects($this->once())
             ->method('canUser')
@@ -310,10 +310,10 @@ class RoleTest extends BaseServiceMockTest
         $repository = $this->getRepositoryMock();
         $roleServiceMock = $this->getPartlyMockedRoleService();
         /** @var \eZ\Publish\API\Repository\Values\User\Role $roleMock */
-        $roleMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
+        $roleMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
         /** @var \eZ\Publish\API\Repository\Values\User\User $userMock */
-        $userMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
-        $limitationMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation');
+        $userMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
+        $limitationMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation');
 
         $limitationMock->expects($this->once())
             ->method('getIdentifier')
@@ -340,8 +340,8 @@ class RoleTest extends BaseServiceMockTest
      */
     public function testAssignRoleToUser()
     {
-        $limitationMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation');
-        $limitationTypeMock = $this->getMock('eZ\\Publish\\SPI\\Limitation\\Type');
+        $limitationMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation');
+        $limitationTypeMock = $this->createMock('eZ\\Publish\\SPI\\Limitation\\Type');
 
         $limitationTypeMock->expects($this->once())
             ->method('acceptValue')
@@ -362,8 +362,8 @@ class RoleTest extends BaseServiceMockTest
         $roleServiceMock = $this->getPartlyMockedRoleService(array('checkAssignmentAndFilterLimitationValues'), $settings);
 
         $repository = $this->getRepositoryMock();
-        $roleMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
-        $userMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
+        $roleMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
+        $userMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
         $userHandlerMock = $this->getPersistenceMockHandler('User\\Handler');
 
         $userMock->expects($this->any())
@@ -427,8 +427,8 @@ class RoleTest extends BaseServiceMockTest
     {
         $repository = $this->getRepositoryMock();
         $roleServiceMock = $this->getPartlyMockedRoleService(array('checkAssignmentAndFilterLimitationValues'));
-        $roleMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
-        $userMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
+        $roleMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
+        $userMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
         $userHandlerMock = $this->getPersistenceMockHandler('User\\Handler');
 
         $userMock->expects($this->any())
@@ -492,8 +492,8 @@ class RoleTest extends BaseServiceMockTest
     {
         $repository = $this->getRepositoryMock();
         $roleServiceMock = $this->getPartlyMockedRoleService(array('checkAssignmentAndFilterLimitationValues'));
-        $roleMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
-        $userMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
+        $roleMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
+        $userMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
         $userHandlerMock = $this->getPersistenceMockHandler('User\\Handler');
 
         $userMock->expects($this->any())
@@ -557,9 +557,9 @@ class RoleTest extends BaseServiceMockTest
         $repository = $this->getRepositoryMock();
         $roleServiceMock = $this->getPartlyMockedRoleService();
         /** @var \eZ\Publish\API\Repository\Values\User\Role $roleMock */
-        $roleMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
+        $roleMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
         /** @var \eZ\Publish\API\Repository\Values\User\UserGroup $userGroupMock */
-        $userGroupMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup');
+        $userGroupMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup');
 
         $repository->expects($this->once())
             ->method('canUser')
@@ -582,8 +582,8 @@ class RoleTest extends BaseServiceMockTest
      */
     public function testAssignRoleToUserGroupThrowsLimitationValidationException()
     {
-        $limitationMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation');
-        $limitationTypeMock = $this->getMock('eZ\\Publish\\SPI\\Limitation\\Type');
+        $limitationMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation');
+        $limitationTypeMock = $this->createMock('eZ\\Publish\\SPI\\Limitation\\Type');
 
         $limitationTypeMock->expects($this->once())
             ->method('acceptValue')
@@ -605,9 +605,9 @@ class RoleTest extends BaseServiceMockTest
 
         $repository = $this->getRepositoryMock();
         /** @var \eZ\Publish\API\Repository\Values\User\Role $roleMock */
-        $roleMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
+        $roleMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
         /** @var \eZ\Publish\API\Repository\Values\User\UserGroup $userGroupMock */
-        $userGroupMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup');
+        $userGroupMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup');
 
         $repository->expects($this->once())
             ->method('canUser')
@@ -634,10 +634,10 @@ class RoleTest extends BaseServiceMockTest
         $repository = $this->getRepositoryMock();
         $roleServiceMock = $this->getPartlyMockedRoleService();
         /** @var \eZ\Publish\API\Repository\Values\User\Role $roleMock */
-        $roleMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
+        $roleMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
         /** @var \eZ\Publish\API\Repository\Values\User\UserGroup $userGroupMock */
-        $userGroupMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup');
-        $limitationMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation');
+        $userGroupMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup');
+        $limitationMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation');
 
         $limitationMock->expects($this->once())
             ->method('getIdentifier')
@@ -664,8 +664,8 @@ class RoleTest extends BaseServiceMockTest
      */
     public function testAssignRoleToUserGroup()
     {
-        $limitationMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation');
-        $limitationTypeMock = $this->getMock('eZ\\Publish\\SPI\\Limitation\\Type');
+        $limitationMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Limitation\\RoleLimitation');
+        $limitationTypeMock = $this->createMock('eZ\\Publish\\SPI\\Limitation\\Type');
 
         $limitationTypeMock->expects($this->once())
             ->method('acceptValue')
@@ -686,9 +686,9 @@ class RoleTest extends BaseServiceMockTest
         $roleServiceMock = $this->getPartlyMockedRoleService(array('checkAssignmentAndFilterLimitationValues'), $settings);
 
         $repository = $this->getRepositoryMock();
-        $roleMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
-        $userGroupMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup');
-        $userServiceMock = $this->getMock('eZ\\Publish\\API\\Repository\\UserService');
+        $roleMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
+        $userGroupMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup');
+        $userServiceMock = $this->createMock('eZ\\Publish\\API\\Repository\\UserService');
         $userHandlerMock = $this->getPersistenceMockHandler('User\\Handler');
 
         $repository->expects($this->once())
@@ -755,9 +755,9 @@ class RoleTest extends BaseServiceMockTest
     {
         $repository = $this->getRepositoryMock();
         $roleServiceMock = $this->getPartlyMockedRoleService(array('checkAssignmentAndFilterLimitationValues'));
-        $roleMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
-        $userGroupMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup');
-        $userServiceMock = $this->getMock('eZ\\Publish\\API\\Repository\\UserService');
+        $roleMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
+        $userGroupMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup');
+        $userServiceMock = $this->createMock('eZ\\Publish\\API\\Repository\\UserService');
         $userHandlerMock = $this->getPersistenceMockHandler('User\\Handler');
 
         $repository->expects($this->once())
@@ -824,9 +824,9 @@ class RoleTest extends BaseServiceMockTest
     {
         $repository = $this->getRepositoryMock();
         $roleServiceMock = $this->getPartlyMockedRoleService(array('checkAssignmentAndFilterLimitationValues'));
-        $roleMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
-        $userGroupMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup');
-        $userServiceMock = $this->getMock('eZ\\Publish\\API\\Repository\\UserService');
+        $roleMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
+        $userGroupMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\UserGroup');
+        $userServiceMock = $this->createMock('eZ\\Publish\\API\\Repository\\UserService');
         $userHandlerMock = $this->getPersistenceMockHandler('User\\Handler');
 
         $repository->expects($this->once())
@@ -892,7 +892,7 @@ class RoleTest extends BaseServiceMockTest
     {
         $repository = $this->getRepositoryMock();
         $roleServiceMock = $this->getPartlyMockedRoleService();
-        $policyMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Policy');
+        $policyMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Policy');
 
         $repository->expects($this->once())
             ->method('hasAccess')
@@ -916,7 +916,7 @@ class RoleTest extends BaseServiceMockTest
     {
         $repository = $this->getRepositoryMock();
         $roleServiceMock = $this->getPartlyMockedRoleService();
-        $policyMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Policy');
+        $policyMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Policy');
 
         $policyMock->expects($this->any())
             ->method('__get')
@@ -960,7 +960,7 @@ class RoleTest extends BaseServiceMockTest
     {
         $repository = $this->getRepositoryMock();
         $roleServiceMock = $this->getPartlyMockedRoleService();
-        $policyMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Policy');
+        $policyMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Policy');
 
         $policyMock->expects($this->any())
             ->method('__get')
@@ -1005,8 +1005,8 @@ class RoleTest extends BaseServiceMockTest
     {
         $repository = $this->getRepositoryMock();
         $roleServiceMock = $this->getPartlyMockedRoleService();
-        $roleMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
-        $policyMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Policy');
+        $roleMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
+        $policyMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Policy');
 
         $repository->expects($this->once())
             ->method('hasAccess')
@@ -1030,8 +1030,8 @@ class RoleTest extends BaseServiceMockTest
     {
         $repository = $this->getRepositoryMock();
         $roleServiceMock = $this->getPartlyMockedRoleService();
-        $policyMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Policy');
-        $roleMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
+        $policyMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Policy');
+        $roleMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
 
         $roleMock->expects($this->any())
             ->method('__get')
@@ -1072,8 +1072,8 @@ class RoleTest extends BaseServiceMockTest
     {
         $repository = $this->getRepositoryMock();
         $roleServiceMock = $this->getPartlyMockedRoleService();
-        $policyMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Policy');
-        $roleMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
+        $policyMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Policy');
+        $roleMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
 
         $roleMock->expects($this->any())
             ->method('__get')
@@ -1124,8 +1124,8 @@ class RoleTest extends BaseServiceMockTest
     {
         $repository = $this->getRepositoryMock();
         $roleServiceMock = $this->getPartlyMockedRoleService(array('loadRole'));
-        $policyMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Policy');
-        $roleMock = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
+        $policyMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Policy');
+        $roleMock = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\Role');
 
         $roleMock->expects($this->any())
             ->method('__get')
@@ -1192,21 +1192,21 @@ class RoleTest extends BaseServiceMockTest
     protected function getPartlyMockedRoleService(array $methods = null, array $settings = array())
     {
         if (!isset($this->partlyMockedRoleService) || !empty($settings)) {
-            $this->partlyMockedRoleService = $this->getMock(
-                'eZ\\Publish\\Core\\Repository\\RoleService',
-                $methods,
-                array(
-                    $this->getRepositoryMock(),
-                    $this->getPersistenceMockHandler('User\\Handler'),
-                    $limitationService = $this->getPartlyMockedLimitationService($methods, $settings),
-                    $this->getMock(
-                        'eZ\\Publish\\Core\\Repository\\Helper\\RoleDomainMapper',
-                        array(),
-                        array($limitationService)
-                    ),
-                    $settings,
+            $this->partlyMockedRoleService = $this->getMockBuilder('eZ\\Publish\\Core\\Repository\\RoleService')
+                ->setMethods($methods)
+                ->setConstructorArgs(
+                    array(
+                        $this->getRepositoryMock(),
+                        $this->getPersistenceMockHandler('User\\Handler'),
+                        $limitationService = $this->getPartlyMockedLimitationService($methods, $settings),
+                        $this->getMockBuilder('eZ\\Publish\\Core\\Repository\\Helper\\RoleDomainMapper')
+                            ->setMethods(array())
+                            ->setConstructorArgs(array($limitationService))
+                            ->getMock(),
+                        $settings,
+                    )
                 )
-            );
+                ->getMock();
         }
 
         return $this->partlyMockedRoleService;
@@ -1228,13 +1228,14 @@ class RoleTest extends BaseServiceMockTest
     protected function getPartlyMockedLimitationService(array $methods = null, array $settings = array())
     {
         if (!isset($this->partlyMockedLimitationService) || !empty($settings)) {
-            $this->partlyMockedLimitationService = $this->getMock(
-                'eZ\\Publish\\Core\\Repository\\Helper\\LimitationService',
-                $methods,
-                array(
-                    $settings,
+            $this->partlyMockedLimitationService = $this->getMockBuilder('eZ\\Publish\\Core\\Repository\\Helper\\LimitationService')
+                ->setMethods($methods)
+                ->setConstructorArgs(
+                    array(
+                        $settings,
+                    )
                 )
-            );
+                ->getMock();
         }
 
         return $this->partlyMockedLimitationService;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlAliasTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlAliasTest.php
@@ -28,13 +28,7 @@ class UrlAliasTest extends BaseServiceMockTest
     public function testConstructor()
     {
         $repositoryMock = $this->getRepositoryMock();
-        $languageServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\LanguageService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $languageServiceMock = $this->createMock('eZ\\Publish\\Core\\Repository\\LanguageService');
         /** @var \eZ\Publish\SPI\Persistence\Content\UrlAlias\Handler $urlAliasHandler */
         $urlAliasHandler = $this->getPersistenceMockHandler('Content\\UrlAlias\\Handler');
         $settings = array('settings');
@@ -3459,13 +3453,7 @@ class UrlAliasTest extends BaseServiceMockTest
         $repositoryMock = $this->getRepositoryMock();
         $mockedService = $this->getPartlyMockedURLAliasServiceService(array('createUrlAlias'));
         $location = $this->getLocationStub();
-        $locationServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\LocationService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $locationServiceMock = $this->createMock('eZ\\Publish\\Core\\Repository\\LocationService');
 
         $locationServiceMock->expects(
             $this->exactly(2)
@@ -3549,13 +3537,8 @@ class UrlAliasTest extends BaseServiceMockTest
      */
     protected function getPartlyMockedURLAliasServiceService(array $methods = null)
     {
-        $languageServiceMock = $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\LanguageService',
-            array(),
-            array(),
-            '',
-            false
-        );
+        $languageServiceMock = $this->createMock('eZ\\Publish\\Core\\Repository\\LanguageService');
+
         $languageServiceMock->expects(
             $this->once()
         )->method(
@@ -3572,13 +3555,14 @@ class UrlAliasTest extends BaseServiceMockTest
             $this->returnValue($languageServiceMock)
         );
 
-        return $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\URLAliasService',
-            $methods,
-            array(
-                $this->getRepositoryMock(),
-                $this->getPersistenceMock()->urlAliasHandler(),
+        return $this->getMockBuilder('eZ\\Publish\\Core\\Repository\\URLAliasService')
+            ->setMethods($methods)
+            ->setConstructorArgs(
+                array(
+                    $this->getRepositoryMock(),
+                    $this->getPersistenceMock()->urlAliasHandler(),
+                )
             )
-        );
+            ->getMock();
     }
 }

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlWildcardTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlWildcardTest.php
@@ -790,13 +790,14 @@ class UrlWildcardTest extends BaseServiceMockTest
      */
     protected function getPartlyMockedURLWildcardService(array $methods = null)
     {
-        return $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\URLWildcardService',
-            $methods,
-            array(
-                $this->getRepositoryMock(),
-                $this->getPersistenceMock()->urlWildcardHandler(),
+        return $this->getMockBuilder('eZ\\Publish\\Core\\Repository\\URLWildcardService')
+            ->setMethods($methods)
+            ->setConstructorArgs(
+                array(
+                    $this->getRepositoryMock(),
+                    $this->getPersistenceMock()->urlWildcardHandler(),
+                )
             )
-        );
+            ->getMock();
     }
 }

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/UserTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/UserTest.php
@@ -24,13 +24,13 @@ class UserTest extends BaseServiceMockTest
     {
         $repository = $this->getRepositoryMock();
         $userService = $this->getPartlyMockedUserService(array('loadUser'));
-        $contentService = $this->getMock('eZ\\Publish\\API\\Repository\\ContentService');
+        $contentService = $this->createMock('eZ\\Publish\\API\\Repository\\ContentService');
         $userHandler = $this->getPersistenceMock()->userHandler();
 
-        $user = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
-        $loadedUser = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
-        $versionInfo = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo');
-        $contentInfo = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
+        $user = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
+        $loadedUser = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
+        $versionInfo = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo');
+        $contentInfo = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
 
         $user->expects($this->once())
             ->method('__get')
@@ -86,12 +86,12 @@ class UserTest extends BaseServiceMockTest
     {
         $repository = $this->getRepositoryMock();
         $userService = $this->getPartlyMockedUserService(array('loadUser'));
-        $contentService = $this->getMock('eZ\\Publish\\API\\Repository\\ContentService');
+        $contentService = $this->createMock('eZ\\Publish\\API\\Repository\\ContentService');
 
-        $user = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
-        $loadedUser = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
-        $versionInfo = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo');
-        $contentInfo = $this->getMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
+        $user = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
+        $loadedUser = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\User\\User');
+        $versionInfo = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\Content\\VersionInfo');
+        $contentInfo = $this->createMock('eZ\\Publish\\API\\Repository\\Values\\Content\\ContentInfo');
 
         $user->expects($this->once())
             ->method('__get')
@@ -139,13 +139,14 @@ class UserTest extends BaseServiceMockTest
      */
     protected function getPartlyMockedUserService(array $methods = null)
     {
-        return $this->getMock(
-            'eZ\\Publish\\Core\\Repository\\UserService',
-            $methods,
-            array(
-                $this->getRepositoryMock(),
-                $this->getPersistenceMock()->userHandler(),
+        return $this->getMockBuilder('eZ\\Publish\\Core\\Repository\\UserService')
+            ->setMethods($methods)
+            ->setConstructorArgs(
+                array(
+                    $this->getRepositoryMock(),
+                    $this->getPersistenceMock()->userHandler(),
+                )
             )
-        );
+            ->getMock();
     }
 }

--- a/eZ/Publish/Core/Repository/Tests/Values/Content/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/Content/ContentTest.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\Core\Repository\Tests\Values\Content;
 
 use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
-use Mockery;
 use PHPUnit\Framework\TestCase;
 
 class ContentTest extends TestCase
@@ -48,8 +47,10 @@ class ContentTest extends TestCase
     public function testGetName()
     {
         $name = 'Translated name';
-        $versionInfoMock = Mockery::mock(VersionInfo::class);
-        $versionInfoMock->shouldReceive('getName')->andReturn($name);
+        $versionInfoMock = $this->createMock(VersionInfo::class);
+        $versionInfoMock->expects($this->once())
+            ->method('getName')
+            ->willReturn($name);
 
         $object = new Content(['versionInfo' => $versionInfoMock]);
 

--- a/eZ/Publish/Core/Repository/Tests/Values/Content/VersionInfoTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/Content/VersionInfoTest.php
@@ -9,9 +9,9 @@
 namespace eZ\Publish\Core\Repository\Tests\Values\Content;
 
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class VersionInfoTest extends PHPUnit_Framework_TestCase
+class VersionInfoTest extends TestCase
 {
     public function testIsDraft()
     {

--- a/eZ/Publish/Core/Repository/Tests/Values/ObjectState/ObjectStateGroupTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/ObjectState/ObjectStateGroupTest.php
@@ -11,12 +11,12 @@ namespace eZ\Publish\Core\Repository\Tests\Values\ObjectState;
 use eZ\Publish\API\Repository\Tests\Values\ValueObjectTestTrait;
 use eZ\Publish\Core\Repository\Tests\Values\MultiLanguageTestTrait;
 use eZ\Publish\Core\Repository\Values\ObjectState\ObjectStateGroup;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test internal integrity of @see \eZ\Publish\Core\Repository\Values\ObjectState\ObjectStateGroup ValueObject.
  */
-class ObjectStateGroupTest extends PHPUnit_Framework_TestCase
+class ObjectStateGroupTest extends TestCase
 {
     use ValueObjectTestTrait;
     use MultiLanguageTestTrait;

--- a/eZ/Publish/Core/Repository/Tests/Values/ObjectState/ObjectStateTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/ObjectState/ObjectStateTest.php
@@ -11,12 +11,12 @@ namespace eZ\Publish\Core\Repository\Tests\Values\ObjectState;
 use eZ\Publish\API\Repository\Tests\Values\ValueObjectTestTrait;
 use eZ\Publish\Core\Repository\Tests\Values\MultiLanguageTestTrait;
 use eZ\Publish\Core\Repository\Values\ObjectState\ObjectState;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test internal integrity of @see \eZ\Publish\Core\Repository\Values\ObjectState\ObjectState ValueObject.
  */
-class ObjectStateTest extends PHPUnit_Framework_TestCase
+class ObjectStateTest extends TestCase
 {
     use ValueObjectTestTrait;
     use MultiLanguageTestTrait;

--- a/eZ/Publish/Core/Repository/Tests/Values/User/PolicyTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/User/PolicyTest.php
@@ -10,9 +10,9 @@ namespace eZ\Publish\Core\Repository\Tests\Values\User;
 
 use eZ\Publish\API\Repository\Tests\Values\ValueObjectTestTrait;
 use eZ\Publish\Core\Repository\Values\User\Policy;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class PolicyTest extends PHPUnit_Framework_TestCase
+class PolicyTest extends TestCase
 {
     use ValueObjectTestTrait;
 

--- a/eZ/Publish/Core/Repository/Tests/Values/User/RoleTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/User/RoleTest.php
@@ -10,9 +10,9 @@ namespace eZ\Publish\Core\Repository\Tests\Values\User;
 
 use eZ\Publish\API\Repository\Tests\Values\ValueObjectTestTrait;
 use eZ\Publish\Core\Repository\Values\User\Role;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class RoleTest extends PHPUnit_Framework_TestCase
+class RoleTest extends TestCase
 {
     use ValueObjectTestTrait;
 

--- a/eZ/Publish/Core/Repository/Tests/Values/User/UserGroupTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/User/UserGroupTest.php
@@ -12,7 +12,6 @@ use eZ\Publish\API\Repository\Tests\Values\ValueObjectTestTrait;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Repository\Values\User\UserGroup;
-use Mockery;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -48,11 +47,16 @@ class UserGroupTest extends TestCase
     public function testGetName()
     {
         $name = 'Translated name';
-        $contentMock = Mockery::mock(Content::class);
-        $versionInfoMock = Mockery::mock(VersionInfo::class);
+        $contentMock = $this->createMock(Content::class);
+        $versionInfoMock = $this->createMock(VersionInfo::class);
 
-        $contentMock->shouldReceive('getVersionInfo')->andReturn($versionInfoMock);
-        $versionInfoMock->shouldReceive('getName')->andReturn($name);
+        $contentMock->expects($this->once())
+            ->method('getVersionInfo')
+            ->willReturn($versionInfoMock);
+
+        $versionInfoMock->expects($this->once())
+            ->method('getName')
+            ->willReturn($name);
 
         $object = new UserGroup(['content' => $contentMock]);
 

--- a/eZ/Publish/Core/Repository/Tests/Values/User/UserTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/User/UserTest.php
@@ -12,7 +12,6 @@ use eZ\Publish\API\Repository\Tests\Values\ValueObjectTestTrait;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Repository\Values\User\User;
-use Mockery;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -52,11 +51,16 @@ class UserTest extends TestCase
     public function testGetName()
     {
         $name = 'Translated name';
-        $contentMock = Mockery::mock(Content::class);
-        $versionInfoMock = Mockery::mock(VersionInfo::class);
+        $contentMock = $this->createMock(Content::class);
+        $versionInfoMock = $this->createMock(VersionInfo::class);
 
-        $contentMock->shouldReceive('getVersionInfo')->andReturn($versionInfoMock);
-        $versionInfoMock->shouldReceive('getName')->andReturn($name);
+        $contentMock->expects($this->once())
+            ->method('getVersionInfo')
+            ->willReturn($versionInfoMock);
+
+        $versionInfoMock->expects($this->once())
+            ->method('getName')
+            ->willReturn($name);
 
         $object = new User(['content' => $contentMock]);
 

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentSortTest.php
@@ -19,6 +19,11 @@ use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase as ContentTypeGateway;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler as ContentTypeHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Mapper as ContentTypeMapper;
+use eZ\Publish\Core\Search\Legacy\Content\Location\Gateway as LocationGateway;
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\Update\Handler as ContentTypeUpdateHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldHandler;
 
 /**
  * Content Search test case for ContentSearchHandler.
@@ -96,7 +101,7 @@ class HandlerContentSortTest extends LanguageAwareTestCase
                 ),
                 $this->getLanguageHandler()
             ),
-            $this->getMock('eZ\\Publish\\Core\\Search\\Legacy\\Content\\Location\\Gateway'),
+            $this->createMock(LocationGateway::class),
             new Content\WordIndexer\Gateway\DoctrineDatabase(
                 $this->getDatabaseHandler(),
                 $this->getContentTypeHandler(),
@@ -105,7 +110,7 @@ class HandlerContentSortTest extends LanguageAwareTestCase
                 $this->getFullTextSearchConfiguration()
             ),
             $this->getContentMapperMock(),
-            $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Mapper'),
+            $this->createMock(LocationMapper::class),
             $this->getLanguageHandler(),
             $this->getFullTextMapper($this->getContentTypeHandler())
         );
@@ -139,7 +144,7 @@ class HandlerContentSortTest extends LanguageAwareTestCase
                         )
                     )
                 ),
-                $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\Update\\Handler')
+                $this->createMock(ContentTypeUpdateHandler::class)
             );
         }
 
@@ -153,14 +158,15 @@ class HandlerContentSortTest extends LanguageAwareTestCase
      */
     protected function getContentMapperMock()
     {
-        $mapperMock = $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Mapper',
-            array('extractContentInfoFromRows'),
-            array(
-                $this->getFieldRegistry(),
-                $this->getLanguageHandler(),
+        $mapperMock = $this->getMockBuilder(ContentMapper::class)
+            ->setConstructorArgs(
+                array(
+                    $this->getFieldRegistry(),
+                    $this->getLanguageHandler(),
+                )
             )
-        );
+            ->setMethods(array('extractContentInfoFromRows'))
+            ->getMock();
         $mapperMock->expects($this->any())
             ->method('extractContentInfoFromRows')
             ->with($this->isType('array'))
@@ -192,11 +198,10 @@ class HandlerContentSortTest extends LanguageAwareTestCase
     protected function getFieldRegistry()
     {
         if (!isset($this->fieldRegistry)) {
-            $this->fieldRegistry = $this->getMock(
-                '\\eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\FieldValue\\ConverterRegistry',
-                array(),
-                array(array())
-            );
+            $this->fieldRegistry = $this->getMockBuilder(ConverterRegistry::class)
+                ->setConstructorArgs(array())
+                ->setMethods(array())
+                ->getMock();
         }
 
         return $this->fieldRegistry;
@@ -209,13 +214,10 @@ class HandlerContentSortTest extends LanguageAwareTestCase
      */
     protected function getContentFieldHandlerMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\FieldHandler',
-            array('loadExternalFieldData'),
-            array(),
-            '',
-            false
-        );
+        return $this->getMockBuilder(FieldHandler::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('loadExternalFieldData'))
+            ->getMock();
     }
 
     public function testNoSorting()

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
@@ -20,6 +20,11 @@ use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase as ContentTypeGateway;
+use eZ\Publish\Core\Search\Legacy\Content\Location\Gateway as LocationGateway;
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\Update\Handler as ContentTypeUpdateHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldHandler;
 
 /**
  * Content Search test case for ContentSearchHandler.
@@ -215,7 +220,7 @@ class HandlerContentTest extends LanguageAwareTestCase
                 ),
                 $this->getLanguageHandler()
             ),
-            $this->getMock('eZ\\Publish\\Core\\Search\\Legacy\\Content\\Location\\Gateway'),
+            $this->createMock(LocationGateway::class),
             new Content\WordIndexer\Gateway\DoctrineDatabase(
                 $this->getDatabaseHandler(),
                 $this->getContentTypeHandler(),
@@ -224,7 +229,7 @@ class HandlerContentTest extends LanguageAwareTestCase
                 $this->getFullTextSearchConfiguration()
             ),
             $this->getContentMapperMock(),
-            $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Mapper'),
+            $this->createMock(LocationMapper::class),
             $this->getLanguageHandler(),
             $this->getFullTextMapper($this->getContentTypeHandler())
         );
@@ -241,7 +246,7 @@ class HandlerContentTest extends LanguageAwareTestCase
                     $this->getLanguageMaskGenerator()
                 ),
                 new ContentTypeMapper($this->getConverterRegistry()),
-                $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\Update\\Handler')
+                $this->createMock(ContentTypeUpdateHandler::class)
             );
         }
 
@@ -275,14 +280,15 @@ class HandlerContentTest extends LanguageAwareTestCase
      */
     protected function getContentMapperMock()
     {
-        $mapperMock = $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Mapper',
-            array('extractContentInfoFromRows'),
-            array(
-                $this->fieldRegistry,
-                $this->getLanguageHandler(),
+        $mapperMock = $this->getMockBuilder(ContentMapper::class)
+            ->setConstructorArgs(
+                array(
+                    $this->fieldRegistry,
+                    $this->getLanguageHandler(),
+                )
             )
-        );
+            ->setMethods(array('extractContentInfoFromRows'))
+            ->getMock();
         $mapperMock->expects($this->any())
             ->method('extractContentInfoFromRows')
             ->with($this->isType('array'))
@@ -313,13 +319,10 @@ class HandlerContentTest extends LanguageAwareTestCase
      */
     protected function getContentFieldHandlerMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\FieldHandler',
-            array('loadExternalFieldData'),
-            array(),
-            '',
-            false
-        );
+        return $this->getMockBuilder(FieldHandler::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('loadExternalFieldData'))
+            ->getMock();
     }
 
     /**

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
@@ -25,6 +25,10 @@ use eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler as ContentTypeHandle
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Mapper as ContentTypeMapper;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
+use eZ\Publish\Core\Search\Legacy\Content\Gateway as ContentGateway;
+use eZ\Publish\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\Update\Handler as ContentTypeUpdateHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper;
 
 /**
  * Location Search test case for ContentSearchHandler.
@@ -82,7 +86,7 @@ class HandlerLocationSortTest extends LanguageAwareTestCase
     protected function getContentSearchHandler()
     {
         return new Content\Handler(
-            $this->getMock('eZ\\Publish\\Core\\Search\\Legacy\\Content\\Gateway'),
+            $this->createMock(ContentGateway::class),
             new Content\Location\Gateway\DoctrineDatabase(
                 $this->getDatabaseHandler(),
                 new CriteriaConverter(
@@ -128,7 +132,7 @@ class HandlerLocationSortTest extends LanguageAwareTestCase
                 new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseHandler()),
                 $this->getFullTextSearchConfiguration()
             ),
-            $this->getMockBuilder('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Mapper')->disableOriginalConstructor()->getMock(),
+            $this->createMock(ContentMapper::class),
             $this->getLocationMapperMock(),
             $this->getLanguageHandler(),
             $this->getFullTextMapper($this->getContentTypeHandler())
@@ -146,7 +150,7 @@ class HandlerLocationSortTest extends LanguageAwareTestCase
                     $this->getLanguageMaskGenerator()
                 ),
                 new ContentTypeMapper($this->getConverterRegistry()),
-                $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\Update\\Handler')
+                $this->createMock(ContentTypeUpdateHandler::class)
             );
         }
 
@@ -186,10 +190,9 @@ class HandlerLocationSortTest extends LanguageAwareTestCase
      */
     protected function getLocationMapperMock()
     {
-        $mapperMock = $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Mapper',
-            array('createLocationsFromRows')
-        );
+        $mapperMock = $this->getMockBuilder(LocationMapper::class)
+            ->setMethods(array('createLocationsFromRows'))
+            ->getMock();
         $mapperMock
             ->expects($this->any())
             ->method('createLocationsFromRows')

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
@@ -26,6 +26,10 @@ use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\ConverterRegistry;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway\DoctrineDatabase as ContentTypeGateway;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Mapper as ContentTypeMapper;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler as ContentTypeHandler;
+use eZ\Publish\Core\Search\Legacy\Content\Gateway as ContentGateway;
+use eZ\Publish\Core\Persistence\Legacy\Content\Mapper as ContentMapper;
+use eZ\Publish\Core\Persistence\Legacy\Content\Type\Update\Handler as ContentTypeUpdateHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Mapper as LocationMapper;
 
 /**
  * Location Search test case for ContentSearchHandler.
@@ -107,7 +111,7 @@ class HandlerLocationTest extends LanguageAwareTestCase
         );
 
         return new Content\Handler(
-            $this->getMock('eZ\\Publish\\Core\\Search\\Legacy\\Content\\Gateway'),
+            $this->createMock(ContentGateway::class),
             new Content\Location\Gateway\DoctrineDatabase(
                 $this->getDatabaseHandler(),
                 new CriteriaConverter(
@@ -196,7 +200,7 @@ class HandlerLocationTest extends LanguageAwareTestCase
                 new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseHandler()),
                 $this->getFullTextSearchConfiguration()
             ),
-            $this->getMockBuilder('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Mapper')->disableOriginalConstructor()->getMock(),
+            $this->createMock(ContentMapper::class),
             $this->getLocationMapperMock(),
             $this->getLanguageHandler(),
             $this->getFullTextMapper($this->getContentTypeHandler())
@@ -214,7 +218,7 @@ class HandlerLocationTest extends LanguageAwareTestCase
                     $this->getLanguageMaskGenerator()
                 ),
                 new ContentTypeMapper($this->getConverterRegistry()),
-                $this->getMock('eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Type\\Update\\Handler')
+                $this->createMock(ContentTypeUpdateHandler::class)
             );
         }
 
@@ -250,10 +254,9 @@ class HandlerLocationTest extends LanguageAwareTestCase
      */
     protected function getLocationMapperMock()
     {
-        $mapperMock = $this->getMock(
-            'eZ\\Publish\\Core\\Persistence\\Legacy\\Content\\Location\\Mapper',
-            array('createLocationsFromRows')
-        );
+        $mapperMock = $this->getMockBuilder(LocationMapper::class)
+            ->setMethods(array('createLocationsFromRows'))
+            ->getMock();
         $mapperMock
             ->expects($this->any())
             ->method('createLocationsFromRows')

--- a/eZ/Publish/Core/SignalSlot/Tests/ContentServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ContentServiceTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\SignalSlot\Tests;
 
+use eZ\Publish\API\Repository\ContentService as APIContentService;
 use eZ\Publish\Core\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentMetadataUpdateStruct;
@@ -19,14 +20,13 @@ use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\SignalSlot\Signal\ContentService\RemoveTranslationSignal;
 use eZ\Publish\Core\SignalSlot\SignalDispatcher;
 use eZ\Publish\Core\SignalSlot\ContentService;
+use eZ\Publish\Core\SignalSlot\Signal\ContentService as ContentServiceSignals;
 
 class ContentServiceTest extends ServiceTest
 {
     protected function getServiceMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\API\\Repository\\ContentService'
-        );
+        return $this->createMock(APIContentService::class);
     }
 
     protected function getSignalSlotService($coreService, SignalDispatcher $dispatcher)
@@ -140,7 +140,7 @@ class ContentServiceTest extends ServiceTest
                 array($contentCreateStruct, array($locationCreateStruct)),
                 $content,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentService\CreateContentSignal',
+                ContentServiceSignals\CreateContentSignal::class,
                 array(
                     'contentId' => $contentId,
                     'versionNo' => $versionNo,
@@ -151,7 +151,7 @@ class ContentServiceTest extends ServiceTest
                 array($contentInfo, $contentMetadataUpdateStruct),
                 $content,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentService\UpdateContentMetadataSignal',
+                ContentServiceSignals\UpdateContentMetadataSignal::class,
                 array('contentId' => $contentId),
             ),
             array(
@@ -159,7 +159,7 @@ class ContentServiceTest extends ServiceTest
                 array($contentInfo),
                 $contentInfo,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteContentSignal',
+                ContentServiceSignals\DeleteContentSignal::class,
                 array('contentId' => $contentId),
             ),
             array(
@@ -167,7 +167,7 @@ class ContentServiceTest extends ServiceTest
                 array($contentInfo, $versionInfo, $user),
                 $content,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentService\CreateContentDraftSignal',
+                ContentServiceSignals\CreateContentDraftSignal::class,
                 array(
                     'contentId' => $contentId,
                     'versionNo' => $versionNo,
@@ -185,7 +185,7 @@ class ContentServiceTest extends ServiceTest
                 array($translationInfo, $translationValues, $user),
                 $content,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentService\TranslateVersionSignal',
+                ContentServiceSignals\TranslateVersionSignal::class,
                 array(
                     'contentId' => $contentId,
                     'versionNo' => $versionNo,
@@ -197,7 +197,7 @@ class ContentServiceTest extends ServiceTest
                 array($versionInfo, $contentUpdateStruct),
                 $content,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentService\UpdateContentSignal',
+                ContentServiceSignals\UpdateContentSignal::class,
                 array(
                     'contentId' => $contentId,
                     'versionNo' => $versionNo,
@@ -208,7 +208,7 @@ class ContentServiceTest extends ServiceTest
                 array($versionInfo),
                 $content,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentService\PublishVersionSignal',
+                ContentServiceSignals\PublishVersionSignal::class,
                 array(
                     'contentId' => $contentId,
                     'versionNo' => $versionNo,
@@ -219,7 +219,7 @@ class ContentServiceTest extends ServiceTest
                 array($versionInfo),
                 $versionInfo,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteVersionSignal',
+                ContentServiceSignals\DeleteVersionSignal::class,
                 array(
                     'contentId' => $contentId,
                     'versionNo' => $versionNo,
@@ -236,7 +236,7 @@ class ContentServiceTest extends ServiceTest
                 array($contentInfo, $copyLocationCreateStruct, $versionInfo),
                 $copiedContent,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentService\CopyContentSignal',
+                ContentServiceSignals\CopyContentSignal::class,
                 array(
                     'srcContentId' => $contentId,
                     'srcVersionNo' => $versionNo,
@@ -262,7 +262,7 @@ class ContentServiceTest extends ServiceTest
                 array($versionInfo, $relationDestContentInfo),
                 $newRelation,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentService\AddRelationSignal',
+                ContentServiceSignals\AddRelationSignal::class,
                 array(
                     'srcContentId' => $contentId,
                     'srcVersionNo' => $versionNo,
@@ -274,7 +274,7 @@ class ContentServiceTest extends ServiceTest
                 array($versionInfo, $relationDestContentInfo),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteRelationSignal',
+                ContentServiceSignals\DeleteRelationSignal::class,
                 array(
                     'srcContentId' => $contentId,
                     'srcVersionNo' => $versionNo,
@@ -286,7 +286,7 @@ class ContentServiceTest extends ServiceTest
                 array($translationInfo),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentService\AddTranslationInfoSignal',
+                ContentServiceSignals\AddTranslationInfoSignal::class,
                 array(),
             ),
             array(

--- a/eZ/Publish/Core/SignalSlot/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ContentTypeServiceTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\SignalSlot\Tests;
 
+use eZ\Publish\API\Repository\ContentTypeService as APIContentTypeService;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentTypeDraft;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentTypeGroup;
@@ -20,14 +21,13 @@ use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionUpdateStruct;
 use eZ\Publish\Core\SignalSlot\SignalDispatcher;
 use eZ\Publish\Core\SignalSlot\ContentTypeService;
+use eZ\Publish\Core\SignalSlot\Signal\ContentTypeService as ContentTypeServiceSignals;
 
 class ContentTypeServiceTest extends ServiceTest
 {
     protected function getServiceMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\API\\Repository\\ContentTypeService'
-        );
+        return $this->createMock(APIContentTypeService::class);
     }
 
     protected function getSignalSlotService($coreService, SignalDispatcher $dispatcher)
@@ -98,7 +98,7 @@ class ContentTypeServiceTest extends ServiceTest
                 array($contentTypeGroupCreateStruct),
                 $contentTypeGroup,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\CreateContentTypeGroupSignal',
+                ContentTypeServiceSignals\CreateContentTypeGroupSignal::class,
                 array('groupId' => $contentTypeGroupId),
             ),
             array(
@@ -124,7 +124,7 @@ class ContentTypeServiceTest extends ServiceTest
                 array($contentTypeGroup, $contentTypeGroupUpdateStruct),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\UpdateContentTypeGroupSignal',
+                ContentTypeServiceSignals\UpdateContentTypeGroupSignal::class,
                 array('contentTypeGroupId' => $contentTypeGroupId),
             ),
             array(
@@ -132,7 +132,7 @@ class ContentTypeServiceTest extends ServiceTest
                 array($contentTypeGroup),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\DeleteContentTypeGroupSignal',
+                ContentTypeServiceSignals\DeleteContentTypeGroupSignal::class,
                 array('contentTypeGroupId' => $contentTypeGroupId),
             ),
             array(
@@ -140,7 +140,7 @@ class ContentTypeServiceTest extends ServiceTest
                 array($contentTypeCreateStruct, array($contentTypeGroup)),
                 $contentType,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\CreateContentTypeSignal',
+                ContentTypeServiceSignals\CreateContentTypeSignal::class,
                 array('contentTypeId' => $contentTypeId),
             ),
             array(
@@ -178,7 +178,7 @@ class ContentTypeServiceTest extends ServiceTest
                 array($contentType),
                 $contentTypeDraft,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\CreateContentTypeDraftSignal',
+                ContentTypeServiceSignals\CreateContentTypeDraftSignal::class,
                 array('contentTypeId' => $contentTypeId),
             ),
             array(
@@ -186,7 +186,7 @@ class ContentTypeServiceTest extends ServiceTest
                 array($contentTypeDraft, $contentTypeUpdateStruct),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\UpdateContentTypeDraftSignal',
+                ContentTypeServiceSignals\UpdateContentTypeDraftSignal::class,
                 array('contentTypeDraftId' => $contentTypeId),
             ),
             array(
@@ -194,7 +194,7 @@ class ContentTypeServiceTest extends ServiceTest
                 array($contentType),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\DeleteContentTypeSignal',
+                ContentTypeServiceSignals\DeleteContentTypeSignal::class,
                 array('contentTypeId' => $contentTypeId),
             ),
             array(
@@ -202,7 +202,7 @@ class ContentTypeServiceTest extends ServiceTest
                 array($contentType, $user),
                 $copyContentType,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\CopyContentTypeSignal',
+                ContentTypeServiceSignals\CopyContentTypeSignal::class,
                 array(
                     'contentTypeId' => $contentTypeId,
                     'userId' => $userId,
@@ -213,7 +213,7 @@ class ContentTypeServiceTest extends ServiceTest
                 array($contentType, $contentTypeGroup),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\AssignContentTypeGroupSignal',
+                ContentTypeServiceSignals\AssignContentTypeGroupSignal::class,
                 array(
                     'contentTypeId' => $contentTypeId,
                     'contentTypeGroupId' => $contentTypeGroupId,
@@ -224,7 +224,7 @@ class ContentTypeServiceTest extends ServiceTest
                 array($contentType, $contentTypeGroup),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\UnassignContentTypeGroupSignal',
+                ContentTypeServiceSignals\UnassignContentTypeGroupSignal::class,
                 array(
                     'contentTypeId' => $contentTypeId,
                     'contentTypeGroupId' => $contentTypeGroupId,
@@ -235,7 +235,7 @@ class ContentTypeServiceTest extends ServiceTest
                 array($contentTypeDraft, $fieldDefinitionCreateStruct),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\AddFieldDefinitionSignal',
+                ContentTypeServiceSignals\AddFieldDefinitionSignal::class,
                 array(
                     'contentTypeDraftId' => $contentTypeId,
                 ),
@@ -245,7 +245,7 @@ class ContentTypeServiceTest extends ServiceTest
                 array($contentTypeDraft, $fieldDefinition),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\RemoveFieldDefinitionSignal',
+                ContentTypeServiceSignals\RemoveFieldDefinitionSignal::class,
                 array(
                     'contentTypeDraftId' => $contentTypeId,
                     'fieldDefinitionId' => $fieldDefinitionId,
@@ -256,7 +256,7 @@ class ContentTypeServiceTest extends ServiceTest
                 array($contentTypeDraft, $fieldDefinition, $fieldDefinitionUpdateStruct),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\UpdateFieldDefinitionSignal',
+                ContentTypeServiceSignals\UpdateFieldDefinitionSignal::class,
                 array(
                     'contentTypeDraftId' => $contentTypeId,
                     'fieldDefinitionId' => $fieldDefinitionId,
@@ -267,7 +267,7 @@ class ContentTypeServiceTest extends ServiceTest
                 array($contentTypeDraft),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ContentTypeService\PublishContentTypeDraftSignal',
+                ContentTypeServiceSignals\PublishContentTypeDraftSignal::class,
                 array(
                     'contentTypeDraftId' => $contentTypeId,
                 ),

--- a/eZ/Publish/Core/SignalSlot/Tests/FieldTypeServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/FieldTypeServiceTest.php
@@ -8,17 +8,17 @@
  */
 namespace eZ\Publish\Core\SignalSlot\Tests;
 
+use eZ\Publish\API\Repository\FieldTypeService as APIFieldTypeService;
 use eZ\Publish\Core\FieldType\TextLine\Type;
 use eZ\Publish\Core\SignalSlot\SignalDispatcher;
 use eZ\Publish\Core\SignalSlot\FieldTypeService;
+use eZ\Publish\Core\Persistence\TransformationProcessor;
 
 class FieldTypeServiceTest extends ServiceTest
 {
     protected function getServiceMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\API\\Repository\\FieldTypeService'
-        );
+        return $this->createMock(APIFieldTypeService::class);
     }
 
     protected function getSignalSlotService($coreService, SignalDispatcher $dispatcher)
@@ -29,7 +29,7 @@ class FieldTypeServiceTest extends ServiceTest
     protected function getTransformationProcessorMock()
     {
         return $this->getMockForAbstractClass(
-            'eZ\\Publish\\Core\\Persistence\\TransformationProcessor',
+            TransformationProcessor::class,
             array(),
             '',
             false,

--- a/eZ/Publish/Core/SignalSlot/Tests/LanguageServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/LanguageServiceTest.php
@@ -8,18 +8,18 @@
  */
 namespace eZ\Publish\Core\SignalSlot\Tests;
 
+use eZ\Publish\API\Repository\LanguageService as APILanguageService;
 use eZ\Publish\API\Repository\Values\Content\LanguageCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\Core\SignalSlot\SignalDispatcher;
 use eZ\Publish\Core\SignalSlot\LanguageService;
+use eZ\Publish\Core\SignalSlot\Signal\LanguageService as LanguageServiceSignals;
 
 class LanguageServiceTest extends ServiceTest
 {
     protected function getServiceMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\API\\Repository\\LanguageService'
-        );
+        return $this->createMock(APILanguageService::class);
     }
 
     protected function getSignalSlotService($coreService, SignalDispatcher $dispatcher)
@@ -52,7 +52,7 @@ class LanguageServiceTest extends ServiceTest
                 array($languageCreateStruct),
                 $language,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\LanguageService\CreateLanguageSignal',
+                LanguageServiceSignals\CreateLanguageSignal::class,
                 array('languageId' => $languageId),
             ),
             array(
@@ -60,7 +60,7 @@ class LanguageServiceTest extends ServiceTest
                 array($language, $languageNewName),
                 $language,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\LanguageService\UpdateLanguageNameSignal',
+                LanguageServiceSignals\UpdateLanguageNameSignal::class,
                 array(
                     'languageId' => $languageId,
                     'newName' => $languageNewName,
@@ -71,7 +71,7 @@ class LanguageServiceTest extends ServiceTest
                 array($language),
                 $language,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\LanguageService\EnableLanguageSignal',
+                LanguageServiceSignals\EnableLanguageSignal::class,
                 array(
                     'languageId' => $languageId,
                 ),
@@ -81,7 +81,7 @@ class LanguageServiceTest extends ServiceTest
                 array($language),
                 $language,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\LanguageService\DisableLanguageSignal',
+                LanguageServiceSignals\DisableLanguageSignal::class,
                 array(
                     'languageId' => $languageId,
                 ),
@@ -109,7 +109,7 @@ class LanguageServiceTest extends ServiceTest
                 array($language),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\LanguageService\DeleteLanguageSignal',
+                LanguageServiceSignals\DeleteLanguageSignal::class,
                 array(
                     'languageId' => $languageId,
                 ),

--- a/eZ/Publish/Core/SignalSlot/Tests/LocationServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/LocationServiceTest.php
@@ -8,20 +8,20 @@
  */
 namespace eZ\Publish\Core\SignalSlot\Tests;
 
+use eZ\Publish\API\Repository\LocationService as APILocationService;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\LocationUpdateStruct;
 use eZ\Publish\API\Repository\Values\Content\LocationList;
 use eZ\Publish\Core\SignalSlot\SignalDispatcher;
 use eZ\Publish\Core\SignalSlot\LocationService;
+use eZ\Publish\Core\SignalSlot\Signal\LocationService as LocationServiceSignals;
 
 class LocationServiceTest extends ServiceTest
 {
     protected function getServiceMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\API\\Repository\\LocationService'
-        );
+        return $this->createMock(APILocationService::class);
     }
 
     protected function getSignalSlotService($coreService, SignalDispatcher $dispatcher)
@@ -77,7 +77,7 @@ class LocationServiceTest extends ServiceTest
                 array($location, $root),
                 $location,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\LocationService\CopySubtreeSignal',
+                LocationServiceSignals\CopySubtreeSignal::class,
                 array(
                     'subtreeId' => $locationId,
                     'targetParentLocationId' => $rootId,
@@ -118,7 +118,7 @@ class LocationServiceTest extends ServiceTest
                 array($locationContentInfo, $locationCreateStruct),
                 $location,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\LocationService\CreateLocationSignal',
+                LocationServiceSignals\CreateLocationSignal::class,
                 array(
                     'contentId' => $locationContentId,
                     'locationId' => $locationId,
@@ -129,7 +129,7 @@ class LocationServiceTest extends ServiceTest
                 array($location, $locationUpdateStruct),
                 $location,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\LocationService\UpdateLocationSignal',
+                LocationServiceSignals\UpdateLocationSignal::class,
                 array(
                     'contentId' => $locationContentId,
                     'locationId' => $locationId,
@@ -140,7 +140,7 @@ class LocationServiceTest extends ServiceTest
                 array($location, $root),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\LocationService\SwapLocationSignal',
+                LocationServiceSignals\SwapLocationSignal::class,
                 array(
                     'location1Id' => $locationId,
                     'content1Id' => $locationContentId,
@@ -153,7 +153,7 @@ class LocationServiceTest extends ServiceTest
                 array($location),
                 $location,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\LocationService\HideLocationSignal',
+                LocationServiceSignals\HideLocationSignal::class,
                 array(
                     'locationId' => $locationId,
                 ),
@@ -163,7 +163,7 @@ class LocationServiceTest extends ServiceTest
                 array($location),
                 $location,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\LocationService\UnhideLocationSignal',
+                LocationServiceSignals\UnhideLocationSignal::class,
                 array(
                     'locationId' => $locationId,
                 ),
@@ -173,7 +173,7 @@ class LocationServiceTest extends ServiceTest
                 array($location, $root),
                 $location,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\LocationService\MoveSubtreeSignal',
+                LocationServiceSignals\MoveSubtreeSignal::class,
                 array(
                     'locationId' => $locationId,
                     'newParentLocationId' => $rootId,
@@ -184,7 +184,7 @@ class LocationServiceTest extends ServiceTest
                 array($location),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\LocationService\DeleteLocationSignal',
+                LocationServiceSignals\DeleteLocationSignal::class,
                 array(
                     'locationId' => $locationId,
                     'contentId' => $locationContentId,

--- a/eZ/Publish/Core/SignalSlot/Tests/ObjectStateServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ObjectStateServiceTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\SignalSlot\Tests;
 
+use eZ\Publish\API\Repository\ObjectStateService as APIObjectStateService;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateCreateStruct;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroupCreateStruct;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroupUpdateStruct;
@@ -16,14 +17,13 @@ use eZ\Publish\Core\Repository\Values\ObjectState\ObjectState;
 use eZ\Publish\Core\Repository\Values\ObjectState\ObjectStateGroup;
 use eZ\Publish\Core\SignalSlot\SignalDispatcher;
 use eZ\Publish\Core\SignalSlot\ObjectStateService;
+use eZ\Publish\Core\SignalSlot\Signal\ObjectStateService as ObjectStateServiceSignals;
 
 class ObjectStateServiceTest extends ServiceTest
 {
     protected function getServiceMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\API\\Repository\\ObjectStateService'
-        );
+        return $this->createMock(APIObjectStateService::class);
     }
 
     protected function getSignalSlotService($coreService, SignalDispatcher $dispatcher)
@@ -61,7 +61,7 @@ class ObjectStateServiceTest extends ServiceTest
                 [$objectStateGroupCreateStruct],
                 $objectStateGroup,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\CreateObjectStateGroupSignal',
+                ObjectStateServiceSignals\CreateObjectStateGroupSignal::class,
                 ['objectStateGroupId' => $objectStateGroupId],
             ],
             [
@@ -87,7 +87,7 @@ class ObjectStateServiceTest extends ServiceTest
                 [$objectStateGroup, $objectStateGroupUpdateStruct],
                 $objectStateGroup,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\UpdateObjectStateGroupSignal',
+                ObjectStateServiceSignals\UpdateObjectStateGroupSignal::class,
                 ['objectStateGroupId' => $objectStateGroupId],
             ],
             [
@@ -95,7 +95,7 @@ class ObjectStateServiceTest extends ServiceTest
                 [$objectStateGroup],
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\DeleteObjectStateGroupSignal',
+                ObjectStateServiceSignals\DeleteObjectStateGroupSignal::class,
                 ['objectStateGroupId' => $objectStateGroupId],
             ],
             [
@@ -103,7 +103,7 @@ class ObjectStateServiceTest extends ServiceTest
                 [$objectStateGroup, $objectStateCreateStruct],
                 $objectState,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\CreateObjectStateSignal',
+                ObjectStateServiceSignals\CreateObjectStateSignal::class,
                 [
                     'objectStateGroupId' => $objectStateGroupId,
                     'objectStateId' => $objectStateId,
@@ -120,7 +120,7 @@ class ObjectStateServiceTest extends ServiceTest
                 [$objectState, $objectStateUpdateStruct],
                 $objectState,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\UpdateObjectStateSignal',
+                ObjectStateServiceSignals\UpdateObjectStateSignal::class,
                 [
                     'objectStateId' => $objectStateId,
                 ],
@@ -130,7 +130,7 @@ class ObjectStateServiceTest extends ServiceTest
                 [$objectState, $priority],
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\SetPriorityOfObjectStateSignal',
+                ObjectStateServiceSignals\SetPriorityOfObjectStateSignal::class,
                 [
                     'objectStateId' => $objectStateId,
                     'priority' => $priority,
@@ -141,7 +141,7 @@ class ObjectStateServiceTest extends ServiceTest
                 [$objectState],
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\DeleteObjectStateSignal',
+                ObjectStateServiceSignals\DeleteObjectStateSignal::class,
                 [
                     'objectStateId' => $objectStateId,
                 ],
@@ -151,7 +151,7 @@ class ObjectStateServiceTest extends ServiceTest
                 [$contentInfo, $objectStateGroup, $objectState],
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\ObjectStateService\SetContentStateSignal',
+                ObjectStateServiceSignals\SetContentStateSignal::class,
                 [
                     'objectStateId' => $objectStateId,
                     'contentId' => $contentId,

--- a/eZ/Publish/Core/SignalSlot/Tests/RepositoryTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/RepositoryTest.php
@@ -36,7 +36,7 @@ class RepositoryTest extends TestCase
     public function testServiceMethod($method, $class)
     {
         $innerRepositoryMock = $this->getMockBuilder(InnerRepository::class)->disableOriginalConstructor()->getMock();
-        $signalDispatcherMock = $this->getMock(SignalDispatcher::class);
+        $signalDispatcherMock = $this->createMock(SignalDispatcher::class);
 
         $contentServiceMock = $this->getMockBuilder(ContentService::class)->disableOriginalConstructor()->getMock();
         $contentTypeServiceMock = $this->getMockBuilder(ContentTypeService::class)->disableOriginalConstructor()->getMock();
@@ -101,7 +101,7 @@ class RepositoryTest extends TestCase
     public function testAggregation($method, $parameters, $return)
     {
         $innerRepositoryMock = $this->getMockBuilder(InnerRepository::class)->disableOriginalConstructor()->getMock();
-        $signalDispatcherMock = $this->getMock(SignalDispatcher::class);
+        $signalDispatcherMock = $this->createMock(SignalDispatcher::class);
 
         $contentServiceMock = $this->getMockBuilder(ContentService::class)->disableOriginalConstructor()->getMock();
         $contentTypeServiceMock = $this->getMockBuilder(ContentTypeService::class)->disableOriginalConstructor()->getMock();

--- a/eZ/Publish/Core/SignalSlot/Tests/RoleServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/RoleServiceTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\SignalSlot\Tests;
 
+use eZ\Publish\API\Repository\RoleService as APIRoleService;
 use eZ\Publish\Core\Repository\Values\User\PolicyDraft;
 use eZ\Publish\Core\Repository\Values\User\RoleCreateStruct;
 use eZ\Publish\API\Repository\Values\User\RoleUpdateStruct;
@@ -21,14 +22,14 @@ use eZ\Publish\Core\Repository\Values\User\UserRoleAssignment;
 use eZ\Publish\Core\Repository\Values\User\UserGroupRoleAssignment;
 use eZ\Publish\Core\SignalSlot\SignalDispatcher;
 use eZ\Publish\Core\SignalSlot\RoleService;
+use eZ\Publish\SPI\Limitation\Type as LimitationType;
+use eZ\Publish\Core\SignalSlot\Signal\RoleService as RoleServiceSignals;
 
 class RoleServiceTest extends ServiceTest
 {
     protected function getServiceMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\API\\Repository\\RoleService'
-        );
+        return $this->createMock(APIRoleService::class);
     }
 
     protected function getSignalSlotService($coreService, SignalDispatcher $dispatcher)
@@ -86,7 +87,7 @@ class RoleServiceTest extends ServiceTest
                 array($roleCreateStruct),
                 $role,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\RoleService\CreateRoleSignal',
+                RoleServiceSignals\CreateRoleSignal::class,
                 array('roleId' => $roleId),
             ),
             array(
@@ -94,7 +95,7 @@ class RoleServiceTest extends ServiceTest
                 array($role),
                 $role,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\RoleService\CreateRoleDraftSignal',
+                RoleServiceSignals\CreateRoleDraftSignal::class,
                 array('roleId' => $roleId),
             ),
             array(
@@ -102,7 +103,7 @@ class RoleServiceTest extends ServiceTest
                 array($role, $roleUpdateStruct),
                 $role,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\RoleService\UpdateRoleSignal',
+                RoleServiceSignals\UpdateRoleSignal::class,
                 array('roleId' => $roleId),
             ),
             array(
@@ -110,7 +111,7 @@ class RoleServiceTest extends ServiceTest
                 array($roleDraft, $roleUpdateStruct),
                 $roleDraft,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\RoleService\UpdateRoleDraftSignal',
+                RoleServiceSignals\UpdateRoleDraftSignal::class,
                 array('roleId' => $roleId),
             ),
             array(
@@ -118,7 +119,7 @@ class RoleServiceTest extends ServiceTest
                 array($roleDraft),
                 $roleDraft,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\RoleService\PublishRoleDraftSignal',
+                RoleServiceSignals\PublishRoleDraftSignal::class,
                 array('roleId' => $roleId),
             ),
             array(
@@ -126,7 +127,7 @@ class RoleServiceTest extends ServiceTest
                 array($role, $policyCreateStruct),
                 $role,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\RoleService\AddPolicySignal',
+                RoleServiceSignals\AddPolicySignal::class,
                 array(
                     'roleId' => $roleId,
                     'policyId' => $roleId,
@@ -137,7 +138,7 @@ class RoleServiceTest extends ServiceTest
                 array($roleDraft, $policyCreateStruct),
                 $roleDraft,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\RoleService\AddPolicyByRoleDraftSignal',
+                RoleServiceSignals\AddPolicyByRoleDraftSignal::class,
                 array(
                     'roleId' => $roleId,
                     'policyId' => $roleId,
@@ -148,7 +149,7 @@ class RoleServiceTest extends ServiceTest
                 array($role, $policy),
                 $role,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\RoleService\RemovePolicySignal',
+                RoleServiceSignals\RemovePolicySignal::class,
                 array(
                     'roleId' => $roleId,
                     'policyId' => $policyId,
@@ -159,7 +160,7 @@ class RoleServiceTest extends ServiceTest
                 array($roleDraft, $policyDraft),
                 $roleDraft,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\RoleService\RemovePolicyByRoleDraftSignal',
+                RoleServiceSignals\RemovePolicyByRoleDraftSignal::class,
                 array(
                     'roleId' => $roleId,
                     'policyId' => $policyId,
@@ -170,7 +171,7 @@ class RoleServiceTest extends ServiceTest
                 array($policy),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\RoleService\RemovePolicySignal',
+                RoleServiceSignals\RemovePolicySignal::class,
                 array(
                     'roleId' => $roleId,
                     'policyId' => $policyId,
@@ -181,7 +182,7 @@ class RoleServiceTest extends ServiceTest
                 array($policy, $policyUpdateStruct),
                 $policy,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\RoleService\UpdatePolicySignal',
+                RoleServiceSignals\UpdatePolicySignal::class,
                 array('policyId' => $policyId),
             ),
             array(
@@ -213,7 +214,7 @@ class RoleServiceTest extends ServiceTest
                 array($role),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\RoleService\DeleteRoleSignal',
+                RoleServiceSignals\DeleteRoleSignal::class,
                 array('roleId' => $roleId),
             ),
             array(
@@ -221,7 +222,7 @@ class RoleServiceTest extends ServiceTest
                 array($roleDraft),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\RoleService\DeleteRoleDraftSignal',
+                RoleServiceSignals\DeleteRoleDraftSignal::class,
                 array('roleId' => $roleId),
             ),
             array(
@@ -235,7 +236,7 @@ class RoleServiceTest extends ServiceTest
                 array($role, $userGroup, $roleLimitation),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\RoleService\AssignRoleToUserGroupSignal',
+                RoleServiceSignals\AssignRoleToUserGroupSignal::class,
                 array(
                     'roleId' => $roleId,
                     'userGroupId' => $userGroupId,
@@ -247,7 +248,7 @@ class RoleServiceTest extends ServiceTest
                 array($role, $userGroup),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\RoleService\UnassignRoleFromUserGroupSignal',
+                RoleServiceSignals\UnassignRoleFromUserGroupSignal::class,
                 array(
                     'roleId' => $roleId,
                     'userGroupId' => $userGroupId,
@@ -258,7 +259,7 @@ class RoleServiceTest extends ServiceTest
                 array($role, $user, $roleLimitation),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\RoleService\AssignRoleToUserSignal',
+                RoleServiceSignals\AssignRoleToUserSignal::class,
                 array(
                     'roleId' => $roleId,
                     'userId' => $userId,
@@ -270,7 +271,7 @@ class RoleServiceTest extends ServiceTest
                 array($role, $user),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\RoleService\UnassignRoleFromUserSignal',
+                RoleServiceSignals\UnassignRoleFromUserSignal::class,
                 array(
                     'roleId' => $roleId,
                     'userId' => $userId,
@@ -321,13 +322,13 @@ class RoleServiceTest extends ServiceTest
             array(
                 'getLimitationType',
                 array('identifier'),
-                $this->getMock('eZ\\Publish\\SPI\\Limitation\\Type'),
+                $this->createMock(LimitationType::class),
                 0,
             ),
             array(
                 'getLimitationTypesByModuleFunction',
                 array('module', 'function'),
-                array($this->getMock('eZ\\Publish\\SPI\\Limitation\\Type')),
+                array($this->createMock(LimitationType::class)),
                 0,
             ),
         );

--- a/eZ/Publish/Core/SignalSlot/Tests/SearchServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/SearchServiceTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\SignalSlot\Tests;
 
+use eZ\Publish\API\Repository\SearchService as APISearchService;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
@@ -19,9 +20,7 @@ class SearchServiceTest extends ServiceTest
 {
     protected function getServiceMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\API\\Repository\\SearchService'
-        );
+        return $this->createMock(APISearchService::class);
     }
 
     protected function getSignalSlotService($coreService, SignalDispatcher $dispatcher)

--- a/eZ/Publish/Core/SignalSlot/Tests/SectionServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/SectionServiceTest.php
@@ -8,19 +8,19 @@
  */
 namespace eZ\Publish\Core\SignalSlot\Tests;
 
+use eZ\Publish\API\Repository\SectionService as APISectionService;
 use eZ\Publish\API\Repository\Values\Content\SectionCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\SectionUpdateStruct;
 use eZ\Publish\API\Repository\Values\Content\Section;
 use eZ\Publish\Core\SignalSlot\SignalDispatcher;
 use eZ\Publish\Core\SignalSlot\SectionService;
+use eZ\Publish\Core\SignalSlot\Signal\SectionService as SectionServiceSignal;
 
 class SectionServiceTest extends ServiceTest
 {
     protected function getServiceMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\API\\Repository\\SectionService'
-        );
+        return $this->createMock(APISectionService::class);
     }
 
     protected function getSignalSlotService($coreService, SignalDispatcher $dispatcher)
@@ -53,7 +53,7 @@ class SectionServiceTest extends ServiceTest
                 array($sectionCreateStruct),
                 $section,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\SectionService\CreateSectionSignal',
+                SectionServiceSignal\CreateSectionSignal::class,
                 array('sectionId' => $sectionId),
             ),
             array(
@@ -61,7 +61,7 @@ class SectionServiceTest extends ServiceTest
                 array($section, $sectionUpdateStruct),
                 $section,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\SectionService\UpdateSectionSignal',
+                SectionServiceSignal\UpdateSectionSignal::class,
                 array('sectionId' => $sectionId),
             ),
             array(
@@ -99,7 +99,7 @@ class SectionServiceTest extends ServiceTest
                 array($contentInfo, $section),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\SectionService\AssignSectionSignal',
+                SectionServiceSignal\AssignSectionSignal::class,
                 array(
                     'contentId' => $contentId,
                     'sectionId' => $sectionId,
@@ -110,7 +110,7 @@ class SectionServiceTest extends ServiceTest
                 array($section),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\SectionService\DeleteSectionSignal',
+                SectionServiceSignal\DeleteSectionSignal::class,
                 array(
                     'sectionId' => $sectionId,
                 ),

--- a/eZ/Publish/Core/SignalSlot/Tests/ServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ServiceTest.php
@@ -65,7 +65,7 @@ abstract class ServiceTest extends TestCase
                          )
                      );
 
-        $dispatcher = $this->getMock('eZ\\Publish\\Core\\SignalSlot\\SignalDispatcher');
+        $dispatcher = $this->createMock(SignalDispatcher::class);
         $that = $this;
         $d = $dispatcher->expects($this->exactly($emitNr))
                         ->method('emit');

--- a/eZ/Publish/Core/SignalSlot/Tests/SignalDispatcher/DefaultSignalDispatcherTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/SignalDispatcher/DefaultSignalDispatcherTest.php
@@ -18,7 +18,7 @@ class DefaultSignalDispatcherTest extends TestCase
 {
     public function testEmitSignalNoSlot()
     {
-        $signal = $this->getMock('\\eZ\\Publish\\Core\\SignalSlot\\Signal');
+        $signal = $this->createMock(SignalSlot\Signal::class);
 
         $dispatcher = new SignalSlot\SignalDispatcher\DefaultSignalDispatcher();
         $dispatcher->emit($signal);
@@ -26,8 +26,8 @@ class DefaultSignalDispatcherTest extends TestCase
 
     public function testEmitSignalSingleSlot()
     {
-        $signal = $this->getMock('\\eZ\\Publish\\Core\\SignalSlot\\Signal');
-        $slot = $this->getMock('\\eZ\\Publish\\Core\\SignalSlot\\Slot');
+        $signal = $this->createMock(SignalSlot\Signal::class);
+        $slot = $this->createMock(SignalSlot\Slot::class);
         $slot
             ->expects($this->once())
             ->method('receive')
@@ -41,7 +41,7 @@ class DefaultSignalDispatcherTest extends TestCase
     public function testEmitSignalSingleSlotRelative()
     {
         $signal = new SignalSlot\Signal\ContentService\PublishVersionSignal();
-        $slot = $this->getMock('\\eZ\\Publish\\Core\\SignalSlot\\Slot');
+        $slot = $this->createMock(SignalSlot\Slot::class);
         $slot
             ->expects($this->once())
             ->method('receive')
@@ -54,18 +54,18 @@ class DefaultSignalDispatcherTest extends TestCase
 
     public function testEmitSignalMultipleSlots()
     {
-        $signal = $this->getMock('\\eZ\\Publish\\Core\\SignalSlot\\Signal');
-        $slot = $this->getMock('\\eZ\\Publish\\Core\\SignalSlot\\Slot');
+        $signal = $this->createMock(SignalSlot\Signal::class);
+        $slot = $this->createMock(SignalSlot\Slot::class);
         $slot
             ->expects($this->once())
             ->method('receive')
             ->with($signal);
-        $slot2 = $this->getMock('\\eZ\\Publish\\Core\\SignalSlot\\Slot');
+        $slot2 = $this->createMock(SignalSlot\Slot::class);
         $slot2
             ->expects($this->once())
             ->method('receive')
             ->with($signal);
-        $slot3 = $this->getMock('\\eZ\\Publish\\Core\\SignalSlot\\Slot');
+        $slot3 = $this->createMock(SignalSlot\Slot::class);
         $slot3
             ->expects($this->once())
             ->method('receive')

--- a/eZ/Publish/Core/SignalSlot/Tests/SlotFactory/GeneralSlotFactoryTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/SlotFactory/GeneralSlotFactoryTest.php
@@ -24,8 +24,8 @@ class GeneralSlotFactoryTest extends TestCase
             array(array('slot1' => true, 'slot2' => true)),
             array(
                 array(
-                    'slot1' => $this->getMock('\\eZ\\Publish\\Core\\SignalSlot\\Slot'),
-                    'slot2' => $this->getMock('\\eZ\\Publish\\Core\\SignalSlot\\Slot'),
+                    'slot1' => $this->createMock(SignalSlot\Slot::class),
+                    'slot2' => $this->createMock(SignalSlot\Slot::class),
                 ),
             ),
         );

--- a/eZ/Publish/Core/SignalSlot/Tests/TrashServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/TrashServiceTest.php
@@ -8,20 +8,20 @@
  */
 namespace eZ\Publish\Core\SignalSlot\Tests;
 
+use eZ\Publish\API\Repository\TrashService as APITrashService;
 use eZ\Publish\Core\Repository\Values\Content\TrashItem;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\Core\SignalSlot\SignalDispatcher;
 use eZ\Publish\Core\SignalSlot\TrashService;
+use eZ\Publish\Core\SignalSlot\Signal\TrashService as TrashServiceSignals;
 
 class TrashServiceTest extends ServiceTest
 {
     protected function getServiceMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\API\\Repository\\TrashService'
-        );
+        return $this->createMock(APITrashService::class);
     }
 
     protected function getSignalSlotService($coreService, SignalDispatcher $dispatcher)
@@ -67,7 +67,7 @@ class TrashServiceTest extends ServiceTest
                 array($location),
                 $trashItem,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\TrashService\TrashSignal',
+                TrashServiceSignals\TrashSignal::class,
                 array('locationId' => $locationId),
             ),
             array(
@@ -75,7 +75,7 @@ class TrashServiceTest extends ServiceTest
                 array($trashItem, $root),
                 $location,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\TrashService\RecoverSignal',
+                TrashServiceSignals\RecoverSignal::class,
                 array(
                     'trashItemId' => $trashItemId,
                     'newParentLocationId' => $rootId,
@@ -87,7 +87,7 @@ class TrashServiceTest extends ServiceTest
                 array(),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\TrashService\EmptyTrashSignal',
+                TrashServiceSignals\EmptyTrashSignal::class,
                 array(),
             ),
             array(
@@ -95,7 +95,7 @@ class TrashServiceTest extends ServiceTest
                 array($trashItem),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\TrashService\DeleteTrashItemSignal',
+                TrashServiceSignals\DeleteTrashItemSignal::class,
                 array('trashItemId' => $trashItemId),
             ),
             array(

--- a/eZ/Publish/Core/SignalSlot/Tests/URLAliasServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/URLAliasServiceTest.php
@@ -8,18 +8,18 @@
  */
 namespace eZ\Publish\Core\SignalSlot\Tests;
 
+use eZ\Publish\API\Repository\URLAliasService as APIURLAliasService;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\URLAlias;
 use eZ\Publish\Core\SignalSlot\SignalDispatcher;
 use eZ\Publish\Core\SignalSlot\URLAliasService;
+use eZ\Publish\Core\SignalSlot\Signal\URLAliasService as URLAliasServiceSignals;
 
 class URLAliasServiceTest extends ServiceTest
 {
     protected function getServiceMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\API\\Repository\\URLAliasService'
-        );
+        return $this->createMock(APIURLAliasService::class);
     }
 
     protected function getSignalSlotService($coreService, SignalDispatcher $dispatcher)
@@ -85,7 +85,7 @@ class URLAliasServiceTest extends ServiceTest
                 ),
                 $locationUrlAlias,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\URLAliasService\CreateUrlAliasSignal',
+                URLAliasServiceSignals\CreateUrlAliasSignal::class,
                 array('urlAliasId' => $urlAliasId),
             ),
             array(
@@ -99,7 +99,7 @@ class URLAliasServiceTest extends ServiceTest
                 ),
                 $globalUrlAlias,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\URLAliasService\CreateGlobalUrlAliasSignal',
+                URLAliasServiceSignals\CreateGlobalUrlAliasSignal::class,
                 array('urlAliasId' => $globalUrlAliasId),
             ),
             array(
@@ -119,7 +119,7 @@ class URLAliasServiceTest extends ServiceTest
                 array($aliasList),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\URLAliasService\RemoveAliasesSignal',
+                URLAliasServiceSignals\RemoveAliasesSignal::class,
                 array(
                     'aliasList' => $aliasList,
                 ),

--- a/eZ/Publish/Core/SignalSlot/Tests/URLWildcardServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/URLWildcardServiceTest.php
@@ -8,18 +8,18 @@
  */
 namespace eZ\Publish\Core\SignalSlot\Tests;
 
+use eZ\Publish\API\Repository\URLWildcardService as APIURLWildcardService;
 use eZ\Publish\API\Repository\Values\Content\URLWildcard;
 use eZ\Publish\API\Repository\Values\Content\URLWildcardTranslationResult;
 use eZ\Publish\Core\SignalSlot\SignalDispatcher;
 use eZ\Publish\Core\SignalSlot\URLWildcardService;
+use eZ\Publish\Core\SignalSlot\Signal\URLWildcardService as URLWildcardServiceSignals;
 
 class URLWildcardServiceTest extends ServiceTest
 {
     protected function getServiceMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\API\\Repository\\URLWildcardService'
-        );
+        return $this->createMock(APIURLWildcardService::class);
     }
 
     protected function getSignalSlotService($coreService, SignalDispatcher $dispatcher)
@@ -48,7 +48,7 @@ class URLWildcardServiceTest extends ServiceTest
                 array($sourceUrl, $destinationUrl, $forward),
                 $wildcard,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\URLWildcardService\CreateSignal',
+                URLWildcardServiceSignals\CreateSignal::class,
                 array('urlWildcardId' => $wildcardId),
             ),
             array(
@@ -56,7 +56,7 @@ class URLWildcardServiceTest extends ServiceTest
                 array($wildcard),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\URLWildcardService\RemoveSignal',
+                URLWildcardServiceSignals\RemoveSignal::class,
                 array('urlWildcardId' => $wildcardId),
             ),
             array(
@@ -81,7 +81,7 @@ class URLWildcardServiceTest extends ServiceTest
                     )
                 ),
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\URLWildcardService\TranslateSignal',
+                URLWildcardServiceSignals\TranslateSignal::class,
                 array('url' => $sourceUrl),
             ),
         );

--- a/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/UserServiceTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\SignalSlot\Tests;
 
+use eZ\Publish\API\Repository\UserService as APIUserService;
 use eZ\Publish\Core\Repository\Values\User\UserGroupCreateStruct;
 use eZ\Publish\API\Repository\Values\User\UserGroupUpdateStruct;
 use eZ\Publish\Core\Repository\Values\User\UserCreateStruct;
@@ -15,14 +16,13 @@ use eZ\Publish\API\Repository\Values\User\UserUpdateStruct;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\SignalSlot\SignalDispatcher;
 use eZ\Publish\Core\SignalSlot\UserService;
+use eZ\Publish\Core\SignalSlot\Signal\UserService as UserServiceSignals;
 
 class UserServiceTest extends ServiceTest
 {
     protected function getServiceMock()
     {
-        return $this->getMock(
-            'eZ\\Publish\\API\\Repository\\UserService'
-        );
+        return $this->createMock(APIUserService::class);
     }
 
     protected function getSignalSlotService($coreService, SignalDispatcher $dispatcher)
@@ -86,7 +86,7 @@ class UserServiceTest extends ServiceTest
                 array($userGroupCreateStruct, $parentGroup),
                 $userGroup,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\UserService\CreateUserGroupSignal',
+                UserServiceSignals\CreateUserGroupSignal::class,
                 array('userGroupId' => $userGroupId),
             ),
             array(
@@ -118,7 +118,7 @@ class UserServiceTest extends ServiceTest
                 array($userGroup),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\UserService\DeleteUserGroupSignal',
+                UserServiceSignals\DeleteUserGroupSignal::class,
                 array('userGroupId' => $userGroupId),
             ),
             array(
@@ -126,7 +126,7 @@ class UserServiceTest extends ServiceTest
                 array($userGroup, $parentGroup2),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\UserService\MoveUserGroupSignal',
+                UserServiceSignals\MoveUserGroupSignal::class,
                 array(
                     'userGroupId' => $userGroupId,
                     'newParentId' => $parentGroup2Id,
@@ -137,7 +137,7 @@ class UserServiceTest extends ServiceTest
                 array($userGroup, $userGroupUpdateStruct),
                 $userGroup,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\UserService\UpdateUserGroupSignal',
+                UserServiceSignals\UpdateUserGroupSignal::class,
                 array('userGroupId' => $userGroupId),
             ),
             array(
@@ -145,7 +145,7 @@ class UserServiceTest extends ServiceTest
                 array($userCreateStruct, array($userGroup)),
                 $user,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\UserService\CreateUserSignal',
+                UserServiceSignals\CreateUserSignal::class,
                 array('userId' => $userId),
             ),
             array(
@@ -207,7 +207,7 @@ class UserServiceTest extends ServiceTest
                 array($user),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\UserService\DeleteUserSignal',
+                UserServiceSignals\DeleteUserSignal::class,
                 array('userId' => $userId),
             ),
             array(
@@ -215,7 +215,7 @@ class UserServiceTest extends ServiceTest
                 array($user, $userUpdateStruct),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\UserService\UpdateUserSignal',
+                UserServiceSignals\UpdateUserSignal::class,
                 array('userId' => $userId),
             ),
             array(
@@ -223,7 +223,7 @@ class UserServiceTest extends ServiceTest
                 array($user, $parentGroup2),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\UserService\AssignUserToUserGroupSignal',
+                UserServiceSignals\AssignUserToUserGroupSignal::class,
                 array(
                     'userId' => $userId,
                     'userGroupId' => $parentGroup2Id,
@@ -234,7 +234,7 @@ class UserServiceTest extends ServiceTest
                 array($user, $parentGroup2),
                 null,
                 1,
-                'eZ\Publish\Core\SignalSlot\Signal\UserService\UnAssignUserFromUserGroupSignal',
+                UserServiceSignals\UnAssignUserFromUserGroupSignal::class,
                 array(
                     'userId' => $userId,
                     'userGroupId' => $parentGroup2Id,

--- a/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
@@ -101,7 +101,7 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
     public function getDeprecationWarnerMock()
     {
         if (!isset($this->deprecationWarnerMock)) {
-            $this->deprecationWarnerMock = $this->getMock('eZ\Publish\Core\Base\Utils\DeprecationWarnerInterface');
+            $this->deprecationWarnerMock = $this->createMock('eZ\Publish\Core\Base\Utils\DeprecationWarnerInterface');
         }
 
         return $this->deprecationWarnerMock;
@@ -110,7 +110,7 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
     public function getAliasCleanerMock()
     {
         if (!isset($this->aliasCleanerMock)) {
-            $this->aliasCleanerMock = $this->getMock('\eZ\Publish\Core\FieldType\Image\AliasCleanerInterface');
+            $this->aliasCleanerMock = $this->createMock('\eZ\Publish\Core\FieldType\Image\AliasCleanerInterface');
         }
 
         return $this->aliasCleanerMock;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -97,7 +97,4 @@
       </exclude>
     </whitelist>
   </filter>
-  <listeners>
-    <listener class="\Mockery\Adapter\Phpunit\TestListener"></listener>
-  </listeners>
 </phpunit>


### PR DESCRIPTION
This PR resolves:
* removes deprecated `getMock` method call
* removes deprecated `setExpectedException` method call
* adds class constants
* removes dependency to Mockery introduced with https://github.com/ezsystems/ezpublish-kernel/commit/a1242292038c5e4fa21f887fa58cee11d4c9c50c (it was used in less than 10 mocks)
* removes mock for `searchHandler()` method in https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php#L157 as this method was removed in https://github.com/ezsystems/ezpublish-kernel/commit/847f4a9222d59e2ac1beac3c3f79021d46d4497e#diff-5a2488ae5862538d628850c8475f21c1 and it was generating a lot of errors (PHPUnit v4 was silently failing when you tried to mock nonexistent method)
* updated version constraint for `matthiasnoback/symfony-dependency-injection-test` to `~1.0`
* migrates test classes from `PHPUnit_Framework_TestCase` to `PHPUnit\Framework\TestCase`
* migrates `PHPUnit_Framework_Assert` to `PHPUnit\Framework\Assert`

Currently updated tests:
### API
* [x] eZ/Publish/API/Repository/Tests

### Core
* [x] eZ/Publish/Core/Base
* [x] eZ/Publish/Core/FieldType
* [x] eZ/Publish/Core/Helper
* [x] eZ/Publish/Core/IO
* [x] eZ/Publish/Core/Limitation
* [x] eZ/Publish/Core/MVC
* [x] eZ/Publish/Core/Pagination
* [x] eZ/Publish/Core/Persistence
* [x] eZ/Publish/Core/Repository
* [x] eZ/Publish/Core/REST
* [x] eZ/Publish/Core/Search
* [x] eZ/Publish/Core/SignalSlot

### SPI
* [x] eZ/Publish/SPI/Tests

### Bundles
* [x] EzPublishCoreBundle/Tests
* [x] EzPublishDebugBundle/Tests
* [x] EzPublishElasticsearchSearchEngineBundle/Tests
* [x] EzPublishIOBundle/Tests
* [x] EzPublishLegacySearchEngineBundle/Tests
* [x] EzPublishMigrationBundle/Tests
* [x] EzPublishRestBundle/Tests
* [x] EzPublishBehatBundle/Tests
* [x] EzPublishInstallerBundle/Tests