### PR TITLE
EZP-28083: As a Developer I would need to detect capabilities of configured search engine

### DIFF
--- a/eZ/Publish/API/Repository/SearchService.php
+++ b/eZ/Publish/API/Repository/SearchService.php
@@ -182,4 +182,17 @@ interface SearchService
      * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchResult
      */
     public function findLocations(LocationQuery $query, array $languageFilter = array(), $filterOnUserPermissions = true);
+
+    /**
+     * Query for supported capability of currently configured search engine.
+     *
+     * Will return false if search engine does not implement {@see eZ\Publish\SPI\Search\Capable}.
+     *
+     * @since 6.12
+     *
+     * @param int $capabilityFlag One of CAPABILITY_* constants.
+     *
+     * @return bool
+     */
+    public function supports($capabilityFlag);
 }

--- a/eZ/Publish/Core/Repository/SearchService.php
+++ b/eZ/Publish/Core/Repository/SearchService.php
@@ -20,6 +20,7 @@ use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\SPI\Search\Capable;
 use eZ\Publish\SPI\Search\Handler;
 
 /**
@@ -316,5 +317,14 @@ class SearchService implements SearchServiceInterface
         }
 
         return $result;
+    }
+
+    public function supports($capabilityFlag)
+    {
+        if ($this->searchHandler instanceof Capable) {
+            return $this->searchHandler->supports($capabilityFlag);
+        }
+
+        return false;
     }
 }

--- a/eZ/Publish/Core/SignalSlot/SearchService.php
+++ b/eZ/Publish/Core/SignalSlot/SearchService.php
@@ -134,4 +134,9 @@ class SearchService implements SearchServiceInterface
     {
         return $this->service->findLocations($query, $languageFilter, $filterOnUserPermissions);
     }
+
+    public function supports($capabilityFlag)
+    {
+        return $this->service->supports($capabilityFlag);
+    }
 }


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-28083

Suggestion for how user might be able to detect if given search engine support advance full text capability.


Use case: eZ backend UI for knowing if it should show help text to user on the advance search features or not.

Todo:
- [x] Add method on solr _(https://github.com/ezsystems/ezplatform-solr-search-engine/commit/a770a82ef2a962bff4ca7409222c69f173ab0397 and https://github.com/ezsystems/ezplatform-solr-search-engine/commit/16f795899d7191b4a61a4b7b1ffa522634180f01 using kernel Cable interface added in 2ed71b3a0e86210bc828b4f6c7f3774446eb4bc6)_
- [x] Also back port constants to 6.7.6 so Solr code added above can use those instead of hardcoding constant values
- [x] Story