### PR TITLE
EZP-27996: "Remember me" doesn't retrieve the current user from Repository

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SecurityPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SecurityPass.php
@@ -20,7 +20,9 @@ class SecurityPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if (!($container->hasDefinition('security.authentication.provider.dao') && $container->hasDefinition('security.authentication.provider.anonymous'))) {
+        if (!($container->hasDefinition('security.authentication.provider.dao') &&
+              $container->hasDefinition('security.authentication.provider.rememberme') &&
+              $container->hasDefinition('security.authentication.provider.anonymous'))) {
             return;
         }
 
@@ -30,6 +32,12 @@ class SecurityPass implements CompilerPassInterface
         // We need it for checking user credentials
         $daoAuthenticationProviderDef = $container->findDefinition('security.authentication.provider.dao');
         $daoAuthenticationProviderDef->addMethodCall(
+            'setRepository',
+            array($repositoryReference)
+        );
+
+        $rememberMeAuthenticationProviderDef = $container->findDefinition('security.authentication.provider.rememberme');
+        $rememberMeAuthenticationProviderDef->addMethodCall(
             'setRepository',
             array($repositoryReference)
         );

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/security.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/security.yml
@@ -1,5 +1,6 @@
 parameters:
     security.authentication.provider.dao.class: eZ\Publish\Core\MVC\Symfony\Security\Authentication\RepositoryAuthenticationProvider
+    security.authentication.provider.rememberme.class: eZ\Publish\Core\MVC\Symfony\Security\Authentication\RememberMeRepositoryAuthenticationProvider
     security.authentication.provider.anonymous.class: eZ\Publish\Core\MVC\Symfony\Security\Authentication\AnonymousAuthenticationProvider
     security.authentication.success_handler.class: eZ\Publish\Core\MVC\Symfony\Security\Authentication\DefaultAuthenticationSuccessHandler
     ezpublish.security.user_provider.class: eZ\Publish\Core\MVC\Symfony\Security\User\Provider

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/SecurityPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/SecurityPassTest.php
@@ -20,6 +20,7 @@ class SecurityPassTest extends AbstractCompilerPassTestCase
     {
         parent::setUp();
         $this->setDefinition('security.authentication.provider.dao', new Definition());
+        $this->setDefinition('security.authentication.provider.rememberme', new Definition());
         $this->setDefinition('security.authentication.provider.anonymous', new Definition());
         $this->setDefinition('security.http_utils', new Definition());
         $this->setDefinition('security.authentication.success_handler', new Definition());
@@ -35,6 +36,11 @@ class SecurityPassTest extends AbstractCompilerPassTestCase
         $this->compile();
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'security.authentication.provider.dao',
+            'setRepository',
+            array(new Reference('ezpublish.api.repository'))
+        );
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'security.authentication.provider.rememberme',
             'setRepository',
             array(new Reference('ezpublish.api.repository'))
         );

--- a/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RememberMeRepositoryAuthenticationProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RememberMeRepositoryAuthenticationProvider.php
@@ -11,7 +11,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Security\Authentication;
 use eZ\Publish\API\Repository\Repository;
 use Symfony\Component\Security\Core\Authentication\Provider\RememberMeAuthenticationProvider;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 class RememberMeRepositoryAuthenticationProvider extends RememberMeAuthenticationProvider
 {
@@ -32,7 +32,7 @@ class RememberMeRepositoryAuthenticationProvider extends RememberMeAuthenticatio
     {
         $authenticatedToken = parent::authenticate($token);
         if (empty($authenticatedToken)) {
-            throw new BadCredentialsException('The token is not supported by this authentication provider.');
+            throw new AuthenticationException('The token is not supported by this authentication provider.');
         }
 
         $this->repository->getPermissionResolver()->setCurrentUserReference(

--- a/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RememberMeRepositoryAuthenticationProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RememberMeRepositoryAuthenticationProvider.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * File containing the RememberMeRepositoryAuthenticationProvider class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Security\Authentication;
+
+use eZ\Publish\API\Repository\Repository;
+use Symfony\Component\Security\Core\Authentication\Provider\RememberMeAuthenticationProvider;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+class RememberMeRepositoryAuthenticationProvider extends RememberMeAuthenticationProvider
+{
+    /**
+     * @var \eZ\Publish\API\Repository\Repository
+     */
+    private $repository;
+
+    public function setRepository(Repository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function authenticate(TokenInterface $token)
+    {
+        $authenticatedToken = parent::authenticate($token);
+        if (empty($authenticatedToken)) {
+            return;
+        }
+
+        $this->repository->getPermissionResolver()->setCurrentUserReference(
+            $authenticatedToken->getUser()->getAPIUser()
+        );
+
+        return $authenticatedToken;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RememberMeRepositoryAuthenticationProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RememberMeRepositoryAuthenticationProvider.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Security\Authentication;
 use eZ\Publish\API\Repository\Repository;
 use Symfony\Component\Security\Core\Authentication\Provider\RememberMeAuthenticationProvider;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 
 class RememberMeRepositoryAuthenticationProvider extends RememberMeAuthenticationProvider
 {
@@ -31,7 +32,7 @@ class RememberMeRepositoryAuthenticationProvider extends RememberMeAuthenticatio
     {
         $authenticatedToken = parent::authenticate($token);
         if (empty($authenticatedToken)) {
-            return;
+            throw new BadCredentialsException('The token is not supported by this authentication provider.');
         }
 
         $this->repository->getPermissionResolver()->setCurrentUserReference(

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RememberMeRepositoryAuthenticationProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RememberMeRepositoryAuthenticationProviderTest.php
@@ -62,7 +62,8 @@ class RememberMeRepositoryAuthenticationProviderTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
+     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
+     * @expectedExceptionMessage The token is not supported by this authentication provider.
      */
     public function testAuthenticateWrongProviderKey()
     {

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RememberMeRepositoryAuthenticationProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RememberMeRepositoryAuthenticationProviderTest.php
@@ -8,10 +8,20 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\Authentication;
 
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\User\User as ApiUser;
+use eZ\Publish\API\Repository\Values\User\UserReference;
 use eZ\Publish\Core\MVC\Symfony\Security\Authentication\RememberMeRepositoryAuthenticationProvider;
 use eZ\Publish\Core\MVC\Symfony\Security\User;
+use eZ\Publish\Core\Repository\Helper\LimitationService;
+use eZ\Publish\Core\Repository\Helper\RoleDomainMapper;
+use eZ\Publish\Core\Repository\Permission\PermissionResolver;
+use eZ\Publish\SPI\Persistence\User\Handler as UserHandler;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 class RememberMeRepositoryAuthenticationProviderTest extends TestCase
 {
@@ -29,9 +39,9 @@ class RememberMeRepositoryAuthenticationProviderTest extends TestCase
     {
         parent::setUp();
 
-        $this->repository = $this->getMock('eZ\Publish\API\Repository\Repository');
+        $this->repository = $this->getMock(Repository::class);
         $this->authProvider = new RememberMeRepositoryAuthenticationProvider(
-            $this->getMock('Symfony\Component\Security\Core\User\UserCheckerInterface'),
+            $this->getMock(UserCheckerInterface::class),
             'my secret',
             'my provider secret'
         );
@@ -41,22 +51,22 @@ class RememberMeRepositoryAuthenticationProviderTest extends TestCase
     public function testAuthenticateUnsupportedToken()
     {
         $anonymousToken = $this
-            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken')
-            ->setConstructorArgs(['secret', $this->getMock('Symfony\Component\Security\Core\User\UserInterface')])
+            ->getMockBuilder(AnonymousToken::class)
+            ->setConstructorArgs(['secret', $this->getMock(UserInterface::class)])
             ->getMock();
         $this->assertNull($this->authProvider->authenticate($anonymousToken));
     }
 
     public function testAuthenticateWrongProviderKey()
     {
-        $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $user = $this->getMock(UserInterface::class);
         $user
             ->expects($this->any())
             ->method('getRoles')
             ->will($this->returnValue([]));
 
         $rememberMeToken = $this
-            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken')
+            ->getMockBuilder(RememberMeToken::class)
             ->setConstructorArgs([$user, 'wrong provider secret', 'my secret'])
             ->getMock();
         $rememberMeToken
@@ -72,14 +82,14 @@ class RememberMeRepositoryAuthenticationProviderTest extends TestCase
      */
     public function testAuthenticateWrongSecret()
     {
-        $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $user = $this->getMock(UserInterface::class);
         $user
             ->expects($this->any())
             ->method('getRoles')
             ->will($this->returnValue([]));
 
         $rememberMeToken = $this
-            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken')
+            ->getMockBuilder(RememberMeToken::class)
             ->setConstructorArgs([$user, 'my provider secret', 'the wrong secret'])
             ->getMock();
         $rememberMeToken
@@ -101,7 +111,7 @@ class RememberMeRepositoryAuthenticationProviderTest extends TestCase
             ->method('getPermissionResolver')
             ->will($this->returnValue($this->getPermissionResolverMock()));
 
-        $apiUser = $this->getMock('eZ\Publish\API\Repository\Values\User\User');
+        $apiUser = $this->getMock(ApiUser::class);
         $apiUser
             ->expects($this->any())
             ->method('getUserId')
@@ -123,22 +133,22 @@ class RememberMeRepositoryAuthenticationProviderTest extends TestCase
     private function getPermissionResolverMock()
     {
         return $this
-            ->getMockBuilder('eZ\Publish\Core\Repository\Permission\PermissionResolver')
+            ->getMockBuilder(PermissionResolver::class)
             ->setMethods(null)
             ->setConstructorArgs(
                 [
                     $this
-                        ->getMockBuilder('eZ\Publish\Core\Repository\Helper\RoleDomainMapper')
+                        ->getMockBuilder(RoleDomainMapper::class)
                         ->disableOriginalConstructor()
                         ->getMock(),
                     $this
-                        ->getMockBuilder('eZ\Publish\Core\Repository\Helper\LimitationService')
+                        ->getMockBuilder(LimitationService::class)
                         ->getMock(),
                     $this
-                        ->getMockBuilder('eZ\Publish\SPI\Persistence\User\Handler')
+                        ->getMockBuilder(UserHandler::class)
                         ->getMock(),
                     $this
-                        ->getMockBuilder('eZ\Publish\API\Repository\Values\User\UserReference')
+                        ->getMockBuilder(UserReference::class)
                         ->getMock(),
                 ]
             )

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RememberMeRepositoryAuthenticationProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RememberMeRepositoryAuthenticationProviderTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * File containing the RememberMeRepositoryAuthenticationProviderTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\Authentication;
+
+use eZ\Publish\Core\MVC\Symfony\Security\Authentication\RememberMeRepositoryAuthenticationProvider;
+use eZ\Publish\Core\MVC\Symfony\Security\User;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
+
+class RememberMeRepositoryAuthenticationProviderTest extends TestCase
+{
+    /**
+     * @var RememberMeRepositoryAuthenticationProvider
+     */
+    private $authProvider;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\API\Repository\Repository
+     */
+    private $repository;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->repository = $this->getMock('eZ\Publish\API\Repository\Repository');
+        $this->authProvider = new RememberMeRepositoryAuthenticationProvider(
+            $this->getMock('Symfony\Component\Security\Core\User\UserCheckerInterface'),
+            'my secret',
+            'my provider secret'
+        );
+        $this->authProvider->setRepository($this->repository);
+    }
+
+    public function testAuthenticateUnsupportedToken()
+    {
+        $anonymousToken = $this
+            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken')
+            ->setConstructorArgs(['secret', $this->getMock('Symfony\Component\Security\Core\User\UserInterface')])
+            ->getMock();
+        $this->assertNull($this->authProvider->authenticate($anonymousToken));
+    }
+
+    public function testAuthenticateWrongProviderKey()
+    {
+        $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $user
+            ->expects($this->any())
+            ->method('getRoles')
+            ->will($this->returnValue([]));
+
+        $rememberMeToken = $this
+            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken')
+            ->setConstructorArgs([$user, 'wrong provider secret', 'my secret'])
+            ->getMock();
+        $rememberMeToken
+            ->expects($this->any())
+            ->method('getProviderKey')
+            ->will($this->returnValue('wrong provider secret'));
+
+        $this->assertNull($this->authProvider->authenticate($rememberMeToken));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
+     */
+    public function testAuthenticateWrongSecret()
+    {
+        $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $user
+            ->expects($this->any())
+            ->method('getRoles')
+            ->will($this->returnValue([]));
+
+        $rememberMeToken = $this
+            ->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\RememberMeToken')
+            ->setConstructorArgs([$user, 'my provider secret', 'the wrong secret'])
+            ->getMock();
+        $rememberMeToken
+            ->expects($this->any())
+            ->method('getProviderKey')
+            ->will($this->returnValue('my provider secret'));
+        $rememberMeToken
+            ->expects($this->any())
+            ->method('getSecret')
+            ->will($this->returnValue('the wrong secret'));
+
+        $this->authProvider->authenticate($rememberMeToken);
+    }
+
+    public function testAuthenticate()
+    {
+        $this->repository
+            ->expects($this->once())
+            ->method('getPermissionResolver')
+            ->will($this->returnValue($this->getPermissionResolverMock()));
+
+        $apiUser = $this->getMock('eZ\Publish\API\Repository\Values\User\User');
+        $apiUser
+            ->expects($this->any())
+            ->method('getUserId')
+            ->will($this->returnValue(42));
+
+        $tokenUser = new User($apiUser);
+        $rememberMeToken = new RememberMeToken($tokenUser, 'my provider secret', 'my secret');
+
+        $authenticatedToken = $this->authProvider->authenticate($rememberMeToken);
+        $this->assertEquals(
+            [$rememberMeToken->getProviderKey(), $rememberMeToken->getSecret(), $rememberMeToken->getUsername()],
+            [$authenticatedToken->getProviderKey(), $authenticatedToken->getSecret(), $authenticatedToken->getUsername()]
+        );
+    }
+
+    /**
+     * @return \eZ\Publish\Core\Repository\Permission\PermissionResolver|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getPermissionResolverMock()
+    {
+        return $this
+            ->getMockBuilder('eZ\Publish\Core\Repository\Permission\PermissionResolver')
+            ->setMethods(null)
+            ->setConstructorArgs(
+                [
+                    $this
+                        ->getMockBuilder('eZ\Publish\Core\Repository\Helper\RoleDomainMapper')
+                        ->disableOriginalConstructor()
+                        ->getMock(),
+                    $this
+                        ->getMockBuilder('eZ\Publish\Core\Repository\Helper\LimitationService')
+                        ->getMock(),
+                    $this
+                        ->getMockBuilder('eZ\Publish\SPI\Persistence\User\Handler')
+                        ->getMock(),
+                    $this
+                        ->getMockBuilder('eZ\Publish\API\Repository\Values\User\UserReference')
+                        ->getMock(),
+                ]
+            )
+            ->getMock();
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RememberMeRepositoryAuthenticationProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RememberMeRepositoryAuthenticationProviderTest.php
@@ -49,7 +49,8 @@ class RememberMeRepositoryAuthenticationProviderTest extends TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
+     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
+     * @expectedExceptionMessage The token is not supported by this authentication provider.
      */
     public function testAuthenticateUnsupportedToken()
     {

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RememberMeRepositoryAuthenticationProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RememberMeRepositoryAuthenticationProviderTest.php
@@ -48,15 +48,21 @@ class RememberMeRepositoryAuthenticationProviderTest extends TestCase
         $this->authProvider->setRepository($this->repository);
     }
 
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
+     */
     public function testAuthenticateUnsupportedToken()
     {
         $anonymousToken = $this
             ->getMockBuilder(AnonymousToken::class)
             ->setConstructorArgs(['secret', $this->getMock(UserInterface::class)])
             ->getMock();
-        $this->assertNull($this->authProvider->authenticate($anonymousToken));
+        $this->authProvider->authenticate($anonymousToken);
     }
 
+    /**
+     * @expectedException \Symfony\Component\Security\Core\Exception\BadCredentialsException
+     */
     public function testAuthenticateWrongProviderKey()
     {
         $user = $this->getMock(UserInterface::class);
@@ -74,7 +80,7 @@ class RememberMeRepositoryAuthenticationProviderTest extends TestCase
             ->method('getProviderKey')
             ->will($this->returnValue('wrong provider secret'));
 
-        $this->assertNull($this->authProvider->authenticate($rememberMeToken));
+        $this->authProvider->authenticate($rememberMeToken);
     }
 
     /**


### PR DESCRIPTION
> Fix https://jira.ez.no/browse/EZP-27996
> Sent to QA

Symfony's `RememberMeAuthenticationProvider` does not set eZ's repository user (of course).
Fix: Add our own, which does.

- [x] Naming: Use `RememberMeRepositoryAuthenticationProvider` instead of `RememberMeAuthenticationProvider` to emphasise difference from the Symfony one?
- [x] Tests
- [x] Doc [already exists](https://github.com/ezsystems/ezpublish-kernel/blob/master/doc/specifications/security/authentication_symfony.md#remember-me), no more needed
- [x] Rebase when Krakow the CS fixer config changed has, because Yoda styling like we do not.