### PR TITLE
[CS] Aligned code according to CS rules introduced by php-cs-fixer v2.7.1

### DIFF
--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
@@ -222,7 +222,7 @@ class DoctrineStorage extends Gateway
 
         $statement = $selectQuery->execute();
 
-        return intval($statement->fetchColumn());
+        return (int) $statement->fetchColumn();
     }
 
     /**
@@ -272,7 +272,7 @@ class DoctrineStorage extends Gateway
 
         $statement = $selectQuery->execute();
 
-        return intval($statement->fetchColumn()) === 0;
+        return (int) $statement->fetchColumn() === 0;
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway/DoctrineStorage.php
@@ -163,7 +163,7 @@ class DoctrineStorage extends Gateway
             );
         }
 
-        return intval($row['contentclass_id']);
+        return (int) $row['contentclass_id'];
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/User/UserStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/User/UserStorage/Gateway/DoctrineStorage.php
@@ -164,7 +164,7 @@ class DoctrineStorage extends Gateway
 
         $statement = $query->execute();
 
-        return intval($statement->fetchColumn());
+        return (int) $statement->fetchColumn();
     }
 
     /**


### PR DESCRIPTION
This is a follow up on #2107 which aligns new code introduced in `6.11` with new `php-cs-fixer` settings merged into `6.7`.

It includes:
- [x] Apply `modernize_types_casting` CS rule.

Note: `master` also requires such alignment for the file `eZ/Bundle/EzPublishCoreBundle/Command/RemoveContentTranslationCommand.php` present only on that branch.