### PR TITLE
Remove cannotBeEmpty as it is not applicable to concrete nodes in Symfony 3.4

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
@@ -115,7 +115,6 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
             ->end()
             ->arrayNode('http_cache')
                 ->info('Settings related to Http cache')
-                ->cannotBeEmpty()
                 ->children()
                     ->arrayNode('purge_servers')
                         ->info('Servers to use for Http PURGE (will NOT be used if ezpublish.http_cache.purge_type is "local").')


### PR DESCRIPTION
On Symfony 3.4, using `>cannotBeEmpty()` on concrete array nodes results in a `RuntimeException`:

```
->cannotBeEmpty() is not applicable to concrete nodes at path "ezpublish.system..http_cache"
```