### PR TITLE
Allow FlySystem Bundle 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "ocramius/proxy-manager": "^1.0|^2.0",
         "doctrine/doctrine-bundle": "~1.3",
         "liip/imagine-bundle": "~1.0",
-        "oneup/flysystem-bundle": "^1.0",
+        "oneup/flysystem-bundle": "^1.0|^2.0",
         "friendsofsymfony/http-cache-bundle": "~1.2|^1.3.8",
         "sensio/framework-extra-bundle": "~3.0",
         "jms/translation-bundle": "^1.0",


### PR DESCRIPTION
It seems there are no breaking changes from 1.x to 2.x apart from bumping the PHP requirement to 7.0 (https://github.com/1up-lab/OneupFlysystemBundle/compare/1.14.0...2.0.0)

It would also allow using the version of bundle which has a same issue fixed as https://github.com/ezsystems/ezpublish-kernel/pull/2109