### PR TITLE
Fix EZP-28046: Renaming parent leads to redirect loop when accessing child location's old URL

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
@@ -82,7 +82,6 @@ class UrlAliasHandlerTest extends HandlerTest
         $this->loggerMock->expects($this->once())->method('logCall');
 
         $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias\\Handler');
-        $cacheItem = $this->getMock('Stash\Interfaces\ItemInterface');
 
         $this->persistenceHandlerMock
             ->expects($this->once())
@@ -94,77 +93,11 @@ class UrlAliasHandlerTest extends HandlerTest
             ->method('publishUrlAliasForLocation')
             ->with(44, 2, 'name', 'eng-GB', true)
             ->will($this->returnValue(new UrlAlias(array('id' => 55))));
-
-        $cacheItem
-            ->expects($this->once())
-            ->method('isMiss')
-            ->willReturn(true);
-        $cacheItem
-            ->expects($this->never())
-            ->method('clear');
 
         $this->cacheMock
             ->expects($this->once())
             ->method('clear')
             ->with('urlAlias')
-            ->will($this->returnValue(null));
-        $this->cacheMock
-            ->expects($this->once())
-            ->method('getItem')
-            ->with('urlAlias', 'location', 44)
-            ->willReturn($cacheItem);
-
-        $handler = $this->persistenceCacheHandler->urlAliasHandler();
-        $handler->publishUrlAliasForLocation(44, 2, 'name', 'eng-GB', true);
-    }
-
-    /**
-     * @covers \eZ\Publish\Core\Persistence\Cache\UrlAliasHandler::publishUrlAliasForLocation
-     */
-    public function testPublishUrlAliasForLocationWithCachedLocation()
-    {
-        $this->loggerMock->expects($this->once())->method('logCall');
-
-        $innerHandler = $this->getMock('eZ\\Publish\\SPI\\Persistence\\Content\\UrlAlias\\Handler');
-        $cacheItem = $this->getMock('Stash\Interfaces\ItemInterface');
-
-        $this->persistenceHandlerMock
-            ->expects($this->once())
-            ->method('urlAliasHandler')
-            ->will($this->returnValue($innerHandler));
-
-        $innerHandler
-            ->expects($this->once())
-            ->method('publishUrlAliasForLocation')
-            ->with(44, 2, 'name', 'eng-GB', true)
-            ->will($this->returnValue(new UrlAlias(array('id' => 55))));
-
-        $cacheItem
-            ->expects($this->once())
-            ->method('isMiss')
-            ->willReturn(false);
-        $cacheItem
-            ->expects($this->once())
-            ->method('clear');
-        $cacheItem
-            ->expects($this->once())
-            ->method('get')
-            ->willReturn([44]);
-
-        $this->cacheMock
-            ->expects($this->once())
-            ->method('getItem')
-            ->with('urlAlias', 'location', 44)
-            ->willReturn($cacheItem);
-        $this->cacheMock
-            ->expects($this->at(1))
-            ->method('clear')
-            ->with('urlAlias', 44)
-            ->will($this->returnValue(null));
-        $this->cacheMock
-            ->expects($this->at(2))
-            ->method('clear')
-            ->with('urlAlias', 'url')
             ->will($this->returnValue(null));
 
         $handler = $this->persistenceCacheHandler->urlAliasHandler();

--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -44,7 +44,10 @@ class UrlAliasHandler extends AbstractHandler implements UrlAliasHandlerInterfac
                 'alwaysAvailable' => $alwaysAvailable,
             )
         );
-        $this->clearLocation($locationId);
+
+        // we need to clear all because we are unable to clear cache for children
+        // locations only based on the locationId
+        $this->cache->clear('urlAlias');
 
         $this->persistenceHandler->urlAliasHandler()->publishUrlAliasForLocation(
             $locationId,


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28046

## Description

When the user modifies field which is part of the content name,  the URL alias cache should be also cleared for children locations. If the cache isn't cleared for children locations then renaming parent leads to redirect loop when accessing child location's old URL

## Steps to reproduce

> 1. Create new eZ Platform installation.
> 2. Create new container object (e.g. Folder "My Folder").
> 3. Create new object inside this container (e.g. Image "My Image").
> 4. Navigate to both of them in the front office (http://example.com/My-Folder and http://example.com/My-Folder/My-Image).
> 5. Rename "My Folder" to "My Folder Modified".
> 6. Reload child's old URL in the frontoffice (e.g. http://example.com/My-Folder/My-Image).
> 7. Observe infinite redirect loop.

## TODO

- [X] Patch 
- [x] Tests 
