### PR TITLE
[Installer] Removed manual cache clearing as it crashes on Sf 3.4

### DIFF
--- a/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
@@ -16,7 +16,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\PhpExecutableFinder;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
 
 class InstallPlatformCommand extends Command
@@ -29,9 +28,6 @@ class InstallPlatformCommand extends Command
 
     /** @var \Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface */
     private $cacheClearer;
-
-    /** @var \Symfony\Component\Filesystem\Filesystem */
-    private $filesystem;
 
     /** @var string */
     private $cacheDir;
@@ -52,14 +48,12 @@ class InstallPlatformCommand extends Command
         Connection $db,
         array $installers,
         CacheClearerInterface $cacheClearer,
-        Filesystem $filesystem,
         $cacheDir,
         $environment
     ) {
         $this->db = $db;
         $this->installers = $installers;
         $this->cacheClearer = $cacheClearer;
-        $this->filesystem = $filesystem;
         $this->cacheDir = $cacheDir;
         $this->environment = $environment;
         parent::__construct();
@@ -168,16 +162,7 @@ class InstallPlatformCommand extends Command
         }
 
         $output->writeln(sprintf('Clearing cache for directory <info>%s</info>', $this->cacheDir));
-        $oldCacheDir = $this->cacheDir . '_old';
-
-        if ($this->filesystem->exists($oldCacheDir)) {
-            $this->filesystem->remove($oldCacheDir);
-        }
-
         $this->cacheClearer->clear($this->cacheDir);
-
-        $this->filesystem->rename($this->cacheDir, $oldCacheDir);
-        $this->filesystem->remove($oldCacheDir);
     }
 
     /**

--- a/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
@@ -22,7 +22,6 @@ services:
             - "@database_connection"
             - []
             - "@cache_clearer"
-            - "@filesystem"
             - "%kernel.cache_dir%"
             - "%kernel.environment%"
         tags:


### PR DESCRIPTION
When trying to install eZ Platform `2.0` today I've encountered the following error:
```
PHP Warning:  Uncaught Symfony\Component\Debug\Exception\ContextErrorException: Warning: require(var/cache/dev/ContainerD7xjza8/getSwiftmailer_EmailSender_ListenerService.php): failed to open stream: No such file or directory in var/cache/dev/ContainerD7xjza8/Container.php:3923
```

I'm not 100% sure, but it seems something changed in Sf 3.4 with regards to cache clearing.

I've found out that [EZP-24158](https://jira.ez.no/browse/EZP-24158) introduced this manual cache clearing in Installer due to some dev environment problems. 
I removed it and now installer works w/o errors. Also I don't get the error described in the original issue. 
AFAICS `$this->cacheClearer->clear($this->cacheDir);` should be enough to clear cache.

I might not have the full context here, so fixing it only for `7.0`