### PR TITLE
EZP-28119: SubtreeLimitationType allows set the same value twice or more

### DIFF
--- a/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
@@ -100,7 +100,7 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
      */
     public function buildValue(array $limitationValues)
     {
-        return new APISubtreeLimitation(array('limitationValues' => $limitationValues));
+        return new APISubtreeLimitation(array('limitationValues' => array_unique($limitationValues)));
     }
 
     /**

--- a/eZ/Publish/Core/Limitation/Tests/SubtreeLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/SubtreeLimitationTypeTest.php
@@ -254,6 +254,19 @@ class SubtreeLimitationTypeTest extends Base
     }
 
     /**
+     * @depends testConstruct
+     *
+     * @param \eZ\Publish\Core\Limitation\SubtreeLimitationType $limitationType
+     */
+    public function testBuildValueWithUniqueValues(SubtreeLimitationType $limitationType)
+    {
+        $limitationValues = ['/1/999/', '/1/999/', '/1/999/'];
+        $value = $limitationType->buildValue($limitationValues);
+
+        self::assertEquals(['/1/999/'], $value->limitationValues);
+    }
+
+    /**
      * @return array
      */
     public function providerForTestEvaluate()


### PR DESCRIPTION
Implements https://jira.ez.no/browse/EZP-28119

It just tries to be sure that you won't have duplicate values in SubtreeLimitation