### PR TITLE
EZP-28045: Cannot modify content after removing relation field from ContentType

### DIFF
--- a/eZ/Publish/Core/Repository/Helper/RelationProcessor.php
+++ b/eZ/Publish/Core/Repository/Helper/RelationProcessor.php
@@ -108,8 +108,10 @@ class RelationProcessor
         $mappedRelations = array();
         foreach ($existingRelations as $relation) {
             if ($relation->type === Relation::FIELD) {
-                $fieldDefinitionId = $contentType->getFieldDefinition($relation->sourceFieldDefinitionIdentifier)->id;
-                $mappedRelations[$relation->type][$fieldDefinitionId][$relation->destinationContentInfo->id] = $relation;
+                $fieldDefinition = $contentType->getFieldDefinition($relation->sourceFieldDefinitionIdentifier);
+                if ($fieldDefinition !== null) {
+                    $mappedRelations[$relation->type][$fieldDefinition->id][$relation->destinationContentInfo->id] = $relation;
+                }
             }
             // Using bitwise AND as Legacy Stack stores COMMON, LINK and EMBED relation types
             // in the same entry using bitmask

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/RelationProcessorTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/RelationProcessorTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\Core\Repository\Tests\Service\Mock\Base as BaseServiceMockTest;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\API\Repository\Values\Content\Relation;
@@ -500,6 +501,28 @@ class RelationProcessorTest extends BaseServiceMockTest
             $contentTypeMock,
             $existingRelations
         );
+    }
+
+    /**
+     * Test for the processFieldRelations() method.
+     *
+     * @covers \eZ\Publish\Core\Repository\Helper\RelationProcessor::processFieldRelations
+     */
+    public function testProcessFieldRelationsWhenRelationFieldNoLongerExists()
+    {
+        $existingRelations = [
+            $this->getStubbedRelation(2, Relation::FIELD, 43, 17),
+        ];
+
+        $contentTypeMock = $this->getMockForAbstractClass(ContentType::class);
+        $contentTypeMock
+            ->expects($this->at(0))
+            ->method('getFieldDefinition')
+            ->with($this->equalTo('identifier43'))
+            ->will($this->returnValue(null));
+
+        $relationProcessor = $this->getPartlyMockedRelationProcessor();
+        $relationProcessor->processFieldRelations([], 24, 2, $contentTypeMock, $existingRelations);
     }
 
     protected function getStubbedRelation($id, $type, $fieldDefinitionId, $contentId)


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28045

## Description 

This PR contains patch for `Trying to get property of non-object` after publishing content when previously relation field was removed from content type definition. 

## Steps to reproduce

> 1. Edit default Article ContentType
> 2. Add Single Relation or Multiple Relation field. Save and publish ContentType.
> 3. Create new Article. Set all required values and set relation to any allowed content.
> 4. Publish article.
> 5. Edit Article ContentType, remove Single Relation or Multiple Relation added previously.
> 6. Save and publish ContentType.
> 7. Go to Content, find your Article created in step 3. Edit article. You don't need to change anything. Click Publish.


