### PR TITLE
[POC] EZP-25487: imageAlias missing width height parameters

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGenerator.php
@@ -148,7 +148,7 @@ class AliasGenerator implements VariationHandler
                 'uri' => $aliasInfo->getPathname(),
                 'imageId' => $imageValue->imageId,
                 'width' => $dimensions->getWidth(),
-                'height' => $dimensions->getHeight()
+                'height' => $dimensions->getHeight(),
             )
         );
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGeneratorDecorator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGeneratorDecorator.php
@@ -30,7 +30,7 @@ class AliasGeneratorDecorator implements VariationHandler
         $item = $this->cache->getItem($this->getCacheKey($field, $versionInfo, $variationName));
         if ($item->isMiss()) {
             $image = $this->aliasGenerator->getVariation($field, $versionInfo, $variationName, $parameters);
-            $item->save($image);
+            $this->cache->save($item->set($image));
         }
         return $item->get();
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGeneratorDecorator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGeneratorDecorator.php
@@ -7,7 +7,7 @@ use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\SPI\Variation\VariationHandler;
 use Stash\Interfaces\PoolInterface;
 
-class AliasGeneratorDecorator
+class AliasGeneratorDecorator implements VariationHandler
 {
     /**
      * @var VariationHandler

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGeneratorDecorator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGeneratorDecorator.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine;
+
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use eZ\Publish\SPI\Variation\VariationHandler;
+use Stash\Interfaces\PoolInterface;
+
+class AliasGeneratorDecorator
+{
+    /**
+     * @var VariationHandler
+     */
+    private $aliasGenerator;
+
+    /**
+     * @var PoolInterface
+     */
+    private $cache;
+
+    public function __construct(VariationHandler $aliasGenerator, PoolInterface $cache)
+    {
+        $this->aliasGenerator = $aliasGenerator;
+        $this->cache = $cache;
+    }
+
+    public function getVariation(Field $field, VersionInfo $versionInfo, $variationName, array $parameters = array())
+    {
+        $item = $this->cache->getItem($this->getCacheKey($field, $versionInfo, $variationName));
+        if ($item->isMiss()) {
+            $image = $this->aliasGenerator->getVariation($field, $versionInfo, $variationName, $parameters);
+            $item->save($image);
+        }
+        return $item->get();
+    }
+
+    private function getCacheKey(Field $field, VersionInfo $versionInfo, $variationName)
+    {
+        return 'variation/' . $field->value . '/' . $field->id . '/' . $field->fieldDefIdentifier . '/' . $versionInfo->id . '/' . $variationName;
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -210,7 +210,8 @@ services:
 
     # Image alias generator
     ezpublish.fieldType.ezimage.variation_service:
-        alias: ezpublish.image_alias.imagine.alias_generator
+#        alias: ezpublish.image_alias.imagine.alias_generator
+        alias: ezpublish.image_alias.imagine.alias_generator_decorator
 
     ezpublish.fieldType.ezimage.io_service.published:
         parent: ezpublish.core.io.service

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -3,7 +3,7 @@ parameters:
 
     ezpublish.image_alias.imagine.binary_loader.class: eZ\Bundle\EzPublishCoreBundle\Imagine\BinaryLoader
     ezpublish.image_alias.imagine.cache_resolver.class: eZ\Bundle\EzPublishCoreBundle\Imagine\IORepositoryResolver
-    ezpublish.image_alias.imagine.alias_generator_decorator.class: eZ\Bundle\EzPublishCoreBundle\Imagine\AliasGeneratorDecorator
+    ezpublish.image_alias.imagine.alias_generator_decorator.class: eZ\Bundle\EzPublishCoreBundle\Imagine\CachedAliasGeneratorDecorator
     ezpublish.image_alias.imagine.alias_generator.class: eZ\Bundle\EzPublishCoreBundle\Imagine\AliasGenerator
     ezpublish.image_alias.imagine.alias_cleaner.class: eZ\Bundle\EzPublishCoreBundle\Imagine\AliasCleaner
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -88,6 +88,7 @@ services:
             - "@liip_imagine.filter.manager"
             - "@ezpublish.image_alias.imagine.cache_resolver"
             - "@liip_imagine.filter.configuration"
+            - "@liip_imagine"
             - "@?logger"
 
     ezpublish.image_alias.imagine.alias_cleaner:

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -3,6 +3,7 @@ parameters:
 
     ezpublish.image_alias.imagine.binary_loader.class: eZ\Bundle\EzPublishCoreBundle\Imagine\BinaryLoader
     ezpublish.image_alias.imagine.cache_resolver.class: eZ\Bundle\EzPublishCoreBundle\Imagine\IORepositoryResolver
+    ezpublish.image_alias.imagine.alias_generator_decorator.class: eZ\Bundle\EzPublishCoreBundle\Imagine\AliasGeneratorDecorator
     ezpublish.image_alias.imagine.alias_generator.class: eZ\Bundle\EzPublishCoreBundle\Imagine\AliasGenerator
     ezpublish.image_alias.imagine.alias_cleaner.class: eZ\Bundle\EzPublishCoreBundle\Imagine\AliasCleaner
 
@@ -80,6 +81,12 @@ services:
             - "@ezpublish.image_alias.variation_path_generator"
         tags:
             - { name: liip_imagine.cache.resolver, resolver: ezpublish }
+
+    ezpublish.image_alias.imagine.alias_generator_decorator:
+        class: "%ezpublish.image_alias.imagine.alias_generator_decorator.class%"
+        arguments:
+            - "@ezpublish.image_alias.imagine.alias_generator"
+            - "@ezpublish.cache_pool"
 
     ezpublish.image_alias.imagine.alias_generator:
         class: "%ezpublish.image_alias.imagine.alias_generator.class%"

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasGeneratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasGeneratorTest.php
@@ -14,7 +14,6 @@ use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
 use eZ\Publish\Core\FieldType\TextLine\Value as TextLineValue;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use eZ\Publish\SPI\Variation\Values\ImageVariation;
-use Imagine\Image\ImagineInterface;
 use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
 use Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotResolvableException;
 use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasGeneratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasGeneratorTest.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
 use eZ\Publish\Core\FieldType\TextLine\Value as TextLineValue;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use eZ\Publish\SPI\Variation\Values\ImageVariation;
+use Imagine\Image\ImagineInterface;
 use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
 use Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotResolvableException;
 use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
@@ -47,9 +48,24 @@ class AliasGeneratorTest extends TestCase
     private $logger;
 
     /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $imagine;
+
+    /**
      * @var AliasGenerator
      */
     private $aliasGenerator;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $box;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $image;
 
     protected function setUp()
     {
@@ -61,12 +77,16 @@ class AliasGeneratorTest extends TestCase
             ->getMock();
         $this->ioResolver = $this->getMock('\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface');
         $this->filterConfiguration = new FilterConfiguration();
+        $this->imagine = $this->getMock('\Imagine\Image\ImagineInterface');
         $this->logger = $this->getMock('\Psr\Log\LoggerInterface');
+        $this->box = $this->getMock('\Imagine\Image\BoxInterface');
+        $this->image = $this->getMock('\Imagine\Image\ImageInterface');
         $this->aliasGenerator = new AliasGenerator(
             $this->dataLoader,
             $this->filterManager,
             $this->ioResolver,
             $this->filterConfiguration,
+            $this->imagine,
             $this->logger
         );
     }
@@ -104,6 +124,8 @@ class AliasGeneratorTest extends TestCase
         $variationName = 'my_variation';
         $this->filterConfiguration->set($variationName, array());
         $imageId = '123-45';
+        $imageWidth = 300;
+        $imageHeight = 300;
         $imageValue = new ImageValue(array('id' => $originalPath, 'imageId' => $imageId));
         $field = new Field(array('value' => $imageValue));
         $expectedUrl = "http://localhost/foo/bar/image_$variationName.jpg";
@@ -139,6 +161,25 @@ class AliasGeneratorTest extends TestCase
             ->with($originalPath, $variationName)
             ->will($this->returnValue($expectedUrl));
 
+        $this->imagine
+            ->expects($this->once())
+            ->method('open')
+            ->with($expectedUrl)
+            ->will($this->returnValue($this->image));
+        $this->image
+            ->expects($this->once())
+            ->method('getSize')
+            ->will($this->returnValue($this->box));
+
+        $this->box
+            ->expects($this->once())
+            ->method('getWidth')
+            ->will($this->returnValue($imageWidth));
+        $this->box
+            ->expects($this->once())
+            ->method('getHeight')
+            ->will($this->returnValue($imageHeight));
+
         $expected = new ImageVariation(
             array(
                 'name' => $variationName,
@@ -146,6 +187,8 @@ class AliasGeneratorTest extends TestCase
                 'dirPath' => 'http://localhost/foo/bar',
                 'uri' => $expectedUrl,
                 'imageId' => $imageId,
+                'height' => $imageHeight,
+                'width' => $imageWidth,
             )
         );
         $this->assertEquals($expected, $this->aliasGenerator->getVariation($field, new VersionInfo(), $variationName));
@@ -156,6 +199,8 @@ class AliasGeneratorTest extends TestCase
         $originalPath = 'foo/bar/image.jpg';
         $variationName = 'original';
         $imageId = '123-45';
+        $imageWidth = 300;
+        $imageHeight = 300;
         $imageValue = new ImageValue(array('id' => $originalPath, 'imageId' => $imageId));
         $field = new Field(array('value' => $imageValue));
         $expectedUrl = 'http://localhost/foo/bar/image.jpg';
@@ -176,6 +221,25 @@ class AliasGeneratorTest extends TestCase
             ->with($originalPath, $variationName)
             ->will($this->returnValue($expectedUrl));
 
+        $this->imagine
+            ->expects($this->once())
+            ->method('open')
+            ->with($expectedUrl)
+            ->will($this->returnValue($this->image));
+        $this->image
+            ->expects($this->once())
+            ->method('getSize')
+            ->will($this->returnValue($this->box));
+
+        $this->box
+            ->expects($this->once())
+            ->method('getWidth')
+            ->will($this->returnValue($imageWidth));
+        $this->box
+            ->expects($this->once())
+            ->method('getHeight')
+            ->will($this->returnValue($imageHeight));
+
         $expected = new ImageVariation(
             array(
                 'name' => $variationName,
@@ -183,6 +247,8 @@ class AliasGeneratorTest extends TestCase
                 'dirPath' => 'http://localhost/foo/bar',
                 'uri' => $expectedUrl,
                 'imageId' => $imageId,
+                'height' => $imageHeight,
+                'width' => $imageWidth,
             )
         );
         $this->assertEquals($expected, $this->aliasGenerator->getVariation($field, new VersionInfo(), $variationName));
@@ -201,6 +267,8 @@ class AliasGeneratorTest extends TestCase
         $this->filterConfiguration->set($reference1, $configReference1);
         $this->filterConfiguration->set($reference2, $configReference2);
         $imageId = '123-45';
+        $imageWidth = 300;
+        $imageHeight = 300;
         $imageValue = new ImageValue(array('id' => $originalPath, 'imageId' => $imageId));
         $field = new Field(array('value' => $imageValue));
         $expectedUrl = "http://localhost/foo/bar/image_$variationName.jpg";
@@ -249,6 +317,25 @@ class AliasGeneratorTest extends TestCase
             ->with($originalPath, $variationName)
             ->will($this->returnValue($expectedUrl));
 
+        $this->imagine
+            ->expects($this->once())
+            ->method('open')
+            ->with($expectedUrl)
+            ->will($this->returnValue($this->image));
+        $this->image
+            ->expects($this->once())
+            ->method('getSize')
+            ->will($this->returnValue($this->box));
+
+        $this->box
+            ->expects($this->once())
+            ->method('getWidth')
+            ->will($this->returnValue($imageWidth));
+        $this->box
+            ->expects($this->once())
+            ->method('getHeight')
+            ->will($this->returnValue($imageHeight));
+
         $expected = new ImageVariation(
             array(
                 'name' => $variationName,
@@ -256,6 +343,8 @@ class AliasGeneratorTest extends TestCase
                 'dirPath' => 'http://localhost/foo/bar',
                 'uri' => $expectedUrl,
                 'imageId' => $imageId,
+                'width' => $imageWidth,
+                'height' => $imageHeight,
             )
         );
         $this->assertEquals($expected, $this->aliasGenerator->getVariation($field, new VersionInfo(), $variationName));
@@ -266,6 +355,8 @@ class AliasGeneratorTest extends TestCase
         $originalPath = 'foo/bar/image.jpg';
         $variationName = 'my_variation';
         $imageId = '123-45';
+        $imageWidth = 300;
+        $imageHeight = 300;
         $imageValue = new ImageValue(array('id' => $originalPath, 'imageId' => $imageId));
         $field = new Field(array('value' => $imageValue));
         $expectedUrl = "http://localhost/foo/bar/image_$variationName.jpg";
@@ -296,6 +387,25 @@ class AliasGeneratorTest extends TestCase
             ->with($originalPath, $variationName)
             ->will($this->returnValue($expectedUrl));
 
+        $this->imagine
+            ->expects($this->once())
+            ->method('open')
+            ->with($expectedUrl)
+            ->will($this->returnValue($this->image));
+        $this->image
+            ->expects($this->once())
+            ->method('getSize')
+            ->will($this->returnValue($this->box));
+
+        $this->box
+            ->expects($this->once())
+            ->method('getWidth')
+            ->will($this->returnValue($imageWidth));
+        $this->box
+            ->expects($this->once())
+            ->method('getHeight')
+            ->will($this->returnValue($imageHeight));
+
         $expected = new ImageVariation(
             array(
                 'name' => $variationName,
@@ -303,6 +413,8 @@ class AliasGeneratorTest extends TestCase
                 'dirPath' => 'http://localhost/foo/bar',
                 'uri' => $expectedUrl,
                 'imageId' => $imageId,
+                'width' => $imageWidth,
+                'height' => $imageHeight,
             )
         );
         $this->assertEquals($expected, $this->aliasGenerator->getVariation($field, new VersionInfo(), $variationName));


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-25487

# Description
This PR contains POC for the solution for missing imageAlias width and height parameters.

In order to obtain mentioned parameters, it is required to invoke methods `call` on `ImagineInterface` implementation and then, invoke `getDimensions()`. The idea is to use Stash Cache for caching whole `ImageVariation` object to prevent the increase of I/O operations related to additional opening and reading image file. It is required to read these values directly from the image variation file because eZ Platform generates all image variations on demand, unlike legacy which generates and then stores all variations in the database (as XML attributes stored in `data_text` column in `ezcontentobject_attribute` table). 

Not for merge, just for gather feedback.