### PR TITLE
EZP-28048 Moving to trash shouldn't give error if you can't read items in trash

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -2046,6 +2046,8 @@ Move Subtree
 :Resource: /content/locations/<path>
 :Method: MOVE or POST with header X-HTTP-Method-Override: MOVE
 :Description: moves the location to another parent. The destination can also be /content/trash where the location is put into the trash.
+    *(NOTE: Be aware that the user might not have access to the item any longer after it has been moved,
+    for example when read access is limited by subtree)*
 :Headers:
     :Destination: A parent location resource to which the location is moved
 :Response:
@@ -2055,7 +2057,9 @@ Move Subtree
         HTTP/1.1 201 Created
         Location: /content/locations/<newPath>
 
-or if destination is /content/trash and content only has one location
+or if destination is /content/trash and content only has one location *(NOTE: Like on normal subtree
+moves, be aware that the user might not have access to the item any longer after it has been moved
+to trash)*
 
 .. code:: http
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/cache.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/cache.yml
@@ -27,7 +27,11 @@ services:
 
     ezpublish.http_cache.purger.instant:
         class: "%ezpublish.http_cache.purger.instant.class%"
-        arguments: ["@ezpublish.http_cache.purge_client", "@ezpublish.api.service.content", "@ezpublish.http_cache.event_dispatcher"]
+        arguments:
+            - '@ezpublish.http_cache.purge_client'
+            - '@ezpublish.api.service.content'
+            - '@ezpublish.http_cache.event_dispatcher'
+            - '@ezpublish.api.repository'
         tags:
             - { name: kernel.cache_clearer }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Cache/Http/InstantCachePurgerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Cache/Http/InstantCachePurgerTest.php
@@ -20,7 +20,7 @@ class InstantCachePurgerTest extends BaseTest
             ->expects($this->once())
             ->method('purgeAll');
 
-        $purger = new InstantCachePurger($this->purgeClient, $this->contentService, $this->eventDispatcher);
+        $purger = new InstantCachePurger($this->purgeClient, $this->contentService, $this->eventDispatcher, $this->repository);
         $purger->clear('cache/dir/');
     }
 }

--- a/eZ/Publish/API/Repository/TrashService.php
+++ b/eZ/Publish/API/Repository/TrashService.php
@@ -34,6 +34,7 @@ interface TrashService
     /**
      * Sends $location and all its children to trash and returns the corresponding trash item.
      *
+     * The current user may not have access to the returned trash item, check before using it.
      * Content is left untouched.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to trash the given location

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/InstantCachePurger.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/InstantCachePurger.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Cache\Http;
 
 use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\Core\MVC\Symfony\Cache\GatewayCachePurger;
 use eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface;
 use eZ\Publish\Core\MVC\Symfony\Event\ContentCacheClearEvent;
@@ -32,14 +33,21 @@ class InstantCachePurger implements GatewayCachePurger
      */
     private $eventDispatcher;
 
+    /**
+     * @var \eZ\Publish\API\Repository\Repository|\eZ\Publish\Core\Repository\Repository
+     */
+    protected $repository;
+
     public function __construct(
         PurgeClientInterface $purgeClient,
         ContentService $contentService,
-        EventDispatcherInterface $eventDispatcher
+        EventDispatcherInterface $eventDispatcher,
+        RepositoryInterface $repository
     ) {
         $this->purgeClient = $purgeClient;
         $this->contentService = $contentService;
         $this->eventDispatcher = $eventDispatcher;
+        $this->repository = $repository;
     }
 
     /**
@@ -65,7 +73,12 @@ class InstantCachePurger implements GatewayCachePurger
      */
     public function purgeForContent($contentId, $locationIds = [])
     {
-        $contentInfo = $this->contentService->loadContentInfo($contentId);
+        // Use sudo as cache clearing should happen regardless of user permissions.
+        $contentInfo = $this->repository->sudo(
+            function () use ($contentId) {
+                return $this->contentService->loadContentInfo($contentId);
+            }
+        );
 
         // Can only gather relevant locations using ContentCacheClearEvent on published content
         if ($contentInfo->published) {

--- a/eZ/Publish/Core/REST/Client/TrashService.php
+++ b/eZ/Publish/Core/REST/Client/TrashService.php
@@ -109,6 +109,7 @@ class TrashService implements APITrashService, Sessionable
     /**
      * Sends $location and all its children to trash and returns the corresponding trash item.
      *
+     * The current user may not have access to the returned trash item, check before using it.
      * Content is left untouched.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to trash the given location

--- a/eZ/Publish/Core/SignalSlot/TrashService.php
+++ b/eZ/Publish/Core/SignalSlot/TrashService.php
@@ -71,6 +71,7 @@ class TrashService implements TrashServiceInterface
     /**
      * Sends $location and all its children to trash and returns the corresponding trash item.
      *
+     * The current user may not have access to the returned trash item, check before using it.
      * Content is left untouched.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to trash the given location


### PR DESCRIPTION
> Fix https://jira.ez.no/browse/EZP-28048
> Ready for review

Editors who are allowed to trash content but don't have read access to trash, get an access denied message when trashing things (though the content is successfully trashed). Fix: Use sudo() to force it.

- [x] Use `sudo` when clearing cache
- [x] Use `sudo` when returning TrashItem after cache clear
- [x] Doc that returned TrashItem may not be readable by user