### PR TITLE
EZP-28143: getPermissionCriterion() should be cached per user

### DIFF
--- a/eZ/Publish/API/Repository/PermissionCriterionResolver.php
+++ b/eZ/Publish/API/Repository/PermissionCriterionResolver.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\API\Repository;
+
+/**
+ * This service provides methods for resolving criterion permissions.
+ *
+ * @since 6.7.7
+ */
+interface PermissionCriterionResolver
+{
+    /**
+     * Get criteria representation for a permission.
+     *
+     * Will return a criteria if current user has limited access to the given module/function,
+     * however if user has either full or no access then boolean is returned.
+     *
+     * @param string $module
+     * @param string $function
+     *
+     * @return bool|\eZ\Publish\API\Repository\Values\Content\Query\Criterion
+     */
+    public function getPermissionsCriterion($module, $function);
+}

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Repository;
 
+use eZ\Publish\API\Repository\PermissionCriterionResolver;
 use eZ\Publish\API\Repository\Values\Content\LocationUpdateStruct;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -63,9 +64,9 @@ class LocationService implements LocationServiceInterface
     protected $nameSchemaService;
 
     /**
-     * @var \eZ\Publish\Core\Repository\PermissionsCriterionHandler
+     * @var \eZ\Publish\API\Repository\PermissionCriterionResolver
      */
-    protected $permissionsCriterionHandler;
+    protected $permissionCriterionResolver;
 
     /**
      * Setups service with reference to repository object that created it & corresponding handler.
@@ -74,7 +75,7 @@ class LocationService implements LocationServiceInterface
      * @param \eZ\Publish\SPI\Persistence\Handler $handler
      * @param \eZ\Publish\Core\Repository\Helper\DomainMapper $domainMapper
      * @param \eZ\Publish\Core\Repository\Helper\NameSchemaService $nameSchemaService
-     * @param \eZ\Publish\Core\Repository\PermissionsCriterionHandler $permissionsCriterionHandler
+     * @param \eZ\Publish\API\Repository\PermissionCriterionResolver $permissionCriterionResolver
      * @param array $settings
      */
     public function __construct(
@@ -82,7 +83,7 @@ class LocationService implements LocationServiceInterface
         Handler $handler,
         Helper\DomainMapper $domainMapper,
         Helper\NameSchemaService $nameSchemaService,
-        PermissionsCriterionHandler $permissionsCriterionHandler,
+        PermissionCriterionResolver $permissionCriterionResolver,
         array $settings = array()
     ) {
         $this->repository = $repository;
@@ -93,7 +94,7 @@ class LocationService implements LocationServiceInterface
         $this->settings = $settings + array(
             //'defaultSetting' => array(),
         );
-        $this->permissionsCriterionHandler = $permissionsCriterionHandler;
+        $this->permissionCriterionResolver = $permissionCriterionResolver;
     }
 
     /**
@@ -127,7 +128,7 @@ class LocationService implements LocationServiceInterface
         /** Check read access to whole source subtree
          * @var bool|\eZ\Publish\API\Repository\Values\Content\Query\Criterion
          */
-        $contentReadCriterion = $this->permissionsCriterionHandler->getPermissionsCriterion();
+        $contentReadCriterion = $this->permissionCriterionResolver->getPermissionsCriterion();
         if ($contentReadCriterion === false) {
             throw new UnauthorizedException('content', 'read');
         } elseif ($contentReadCriterion !== true) {
@@ -590,7 +591,7 @@ class LocationService implements LocationServiceInterface
         /** Check read access to whole source subtree
          * @var bool|\eZ\Publish\API\Repository\Values\Content\Query\Criterion
          */
-        $contentReadCriterion = $this->permissionsCriterionHandler->getPermissionsCriterion();
+        $contentReadCriterion = $this->permissionCriterionResolver->getPermissionsCriterion();
         if ($contentReadCriterion === false) {
             throw new UnauthorizedException('content', 'read');
         } elseif ($contentReadCriterion !== true) {
@@ -669,7 +670,7 @@ class LocationService implements LocationServiceInterface
         /** Check remove access to descendants
          * @var bool|\eZ\Publish\API\Repository\Values\Content\Query\Criterion
          */
-        $contentReadCriterion = $this->permissionsCriterionHandler->getPermissionsCriterion('content', 'remove');
+        $contentReadCriterion = $this->permissionCriterionResolver->getPermissionsCriterion('content', 'remove');
         if ($contentReadCriterion === false) {
             throw new UnauthorizedException('content', 'remove');
         } elseif ($contentReadCriterion !== true) {

--- a/eZ/Publish/Core/Repository/Permission/CachedPermissionService.php
+++ b/eZ/Publish/Core/Repository/Permission/CachedPermissionService.php
@@ -54,7 +54,7 @@ class CachedPermissionService implements APIPermissionResolver, APIPermissionCri
      *
      * @var int
      */
-    private $permissionCriterionTimeStamp;
+    private $permissionCriterionTs;
 
     /**
      * CachedPermissionService constructor.
@@ -105,12 +105,12 @@ class CachedPermissionService implements APIPermissionResolver, APIPermissionCri
 
         if ($this->permissionCriterion !== null) {
             // If we are still within the cache TTL, then return the cached value
-            if ((time() - $this->permissionCriterionTimeStamp) < $this->cacheTTL) {
+            if ((time() - $this->permissionCriterionTs) < $this->cacheTTL) {
                 return $this->permissionCriterion;
             }
         }
 
-        $this->permissionCriterionTimeStamp = time();
+        $this->permissionCriterionTs = time();
         $this->permissionCriterion = $this->permissionCriterionResolver->getPermissionsCriterion($module, $function);
 
         return $this->permissionCriterion;

--- a/eZ/Publish/Core/Repository/Permission/CachedPermissionService.php
+++ b/eZ/Publish/Core/Repository/Permission/CachedPermissionService.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Repository\Permission;
+
+use eZ\Publish\API\Repository\PermissionResolver as APIPermissionResolver;
+use eZ\Publish\API\Repository\PermissionCriterionResolver as APIPermissionCriterionResolver;
+use eZ\Publish\API\Repository\Repository as RepositoryInterface;
+use eZ\Publish\API\Repository\Values\User\UserReference;
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+/**
+ * Cache implementation of PermissionResolver and PermissionCriterionResolver interface.
+ *
+ * Implements both interfaces as the cached permission criterion lookup needs to be
+ * expired when a different user is set as current users in the system.
+ *
+ * Cache is only done for content/read policy, as that is the one needed by search service.
+ *
+ * The logic here uses a cache TTL of a few seconds, as this is in-memory cache we are not
+ * able to know if any other concurrent user might be changing permissions.
+ */
+class CachedPermissionService implements APIPermissionResolver, APIPermissionCriterionResolver
+{
+    /**
+     * @var \eZ\Publish\API\Repository\PermissionResolver
+     */
+    private $permissionResolver;
+
+    /**
+     * @var \eZ\Publish\API\Repository\PermissionCriterionResolver
+     */
+    private $permissionCriterionResolver;
+
+    /**
+     * @var int
+     */
+    private $cacheTTL;
+
+    /**
+     * Cached value for current user's getCriterion() result.
+     *
+     * Value is null if not yet set or cleared.
+     *
+     * @var bool|\eZ\Publish\API\Repository\Values\Content\Query\Criterion
+     */
+    private $permissionCriterion;
+
+    /**
+     * Cache time stamp.
+     *
+     * @var int
+     */
+    private $permissionCriterionTimeStamp;
+
+    /**
+     * CachedPermissionService constructor.
+     *
+     * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
+     * @param \eZ\Publish\API\Repository\PermissionCriterionResolver $permissionCriterionResolver
+     * @param int $cacheTTL By default set to 5 seconds, should be low to avoid to many permission exceptions on long running requests / processes (even if tolerant search service should handle that)
+     */
+    public function __construct(
+        APIPermissionResolver $permissionResolver,
+        APIPermissionCriterionResolver $permissionCriterionResolver,
+        $cacheTTL = 5
+    ) {
+        $this->permissionResolver = $permissionResolver;
+        $this->permissionCriterionResolver = $permissionCriterionResolver;
+        $this->cacheTTL = $cacheTTL;
+    }
+
+    public function getCurrentUserReference()
+    {
+        return $this->permissionResolver->getCurrentUserReference();
+    }
+
+    public function setCurrentUserReference(UserReference $userReference)
+    {
+        $this->permissionCriterion = null;
+
+        return $this->permissionResolver->setCurrentUserReference($userReference);
+    }
+
+    public function hasAccess($module, $function, UserReference $userReference = null)
+    {
+        return $this->permissionResolver->hasAccess($module, $function, $userReference);
+    }
+
+    public function canUser($module, $function, ValueObject $object, array $targets = [])
+    {
+        return $this->permissionResolver->canUser($module, $function, $object, $targets);
+    }
+
+    public function getPermissionsCriterion($module = 'content', $function = 'read')
+    {
+        // We only cache content/read lookup as those are the once frequently done, and it's only one we can safely
+        // do that won't harm the system if it becomes stale (but user might experience permissions exceptions if it do)
+        if ($module !== 'content' || $function !== 'read') {
+            return $this->permissionCriterionResolver->getPermissionsCriterion($module, $function);
+        }
+
+        if ($this->permissionCriterion !== null) {
+            // If we are still within the cache TTL, then return the cached value
+            if ((time() - $this->permissionCriterionTimeStamp) < $this->cacheTTL) {
+                return $this->permissionCriterion;
+            }
+        }
+
+        $this->permissionCriterionTimeStamp = time();
+        $this->permissionCriterion = $this->permissionCriterionResolver->getPermissionsCriterion($module, $function);
+
+        return $this->permissionCriterion;
+    }
+
+    /**
+     * @internal For internal use only, do not depend on this method.
+     */
+    public function sudo(\Closure $callback, RepositoryInterface $outerRepository)
+    {
+        return $this->permissionResolver->sudo($callback, $outerRepository);
+    }
+}

--- a/eZ/Publish/Core/Repository/Permission/PermissionCriterionResolver.php
+++ b/eZ/Publish/Core/Repository/Permission/PermissionCriterionResolver.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Repository\Permission;
+
+use eZ\Publish\API\Repository\PermissionCriterionResolver as APIPermissionCriterionResolver;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOr;
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\API\Repository\PermissionResolver as PermissionResolverInterface;
+use eZ\Publish\Core\Repository\Helper\LimitationService;
+use RuntimeException;
+
+/**
+ * Implementation of Permissions Criterion Resolver.
+ */
+class PermissionCriterionResolver implements APIPermissionCriterionResolver
+{
+    /**
+     * @var \eZ\Publish\API\Repository\PermissionResolver
+     */
+    private $permissionResolver;
+
+    /**
+     * @var \eZ\Publish\Core\Repository\Helper\LimitationService
+     */
+    private $limitationService;
+
+    /**
+     * Constructor.
+     *
+     * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
+     * @param \eZ\Publish\Core\Repository\Helper\LimitationService $limitationService
+     */
+    public function __construct(
+        PermissionResolverInterface $permissionResolver,
+        LimitationService $limitationService
+    ) {
+        $this->permissionResolver = $permissionResolver;
+        $this->limitationService = $limitationService;
+    }
+
+    /**
+     * Get content-read Permission criteria if needed and return false if no access at all.
+     *
+     * @uses \eZ\Publish\API\Repository\PermissionResolver::getCurrentUserReference()
+     * @uses \eZ\Publish\API\Repository\PermissionResolver::hasAccess()
+     *
+     * @throws \RuntimeException If empty array of limitations are provided from hasAccess()
+     *
+     * @param string $module
+     * @param string $function
+     *
+     * @return bool|\eZ\Publish\API\Repository\Values\Content\Query\Criterion
+     */
+    public function getPermissionsCriterion($module = 'content', $function = 'read')
+    {
+        $permissionSets = $this->permissionResolver->hasAccess($module, $function);
+        if (is_bool($permissionSets)) {
+            return $permissionSets;
+        }
+
+        if (empty($permissionSets)) {
+            throw new RuntimeException("Got an empty array of limitations from hasAccess( '{$module}', '{$function}' )");
+        }
+
+        /*
+         * RoleAssignment is a OR condition, so is policy, while limitations is a AND condition
+         *
+         * If RoleAssignment has limitation then policy OR conditions are wrapped in a AND condition with the
+         * role limitation, otherwise it will be merged into RoleAssignment's OR condition.
+         */
+        $currentUserRef = $this->permissionResolver->getCurrentUserReference();
+        $roleAssignmentOrCriteria = [];
+        foreach ($permissionSets as $permissionSet) {
+            // $permissionSet is a RoleAssignment, but in the form of role limitation & role policies hash
+            $policyOrCriteria = [];
+            /**
+             * @var \eZ\Publish\API\Repository\Values\User\Policy
+             */
+            foreach ($permissionSet['policies'] as $policy) {
+                $limitations = $policy->getLimitations();
+                if ($limitations === '*' || empty($limitations)) {
+                    // Given policy gives full access, optimize away all role policies (but not role limitation if any)
+                    // This should be optimized on create/update of Roles, however we keep this here for bc with older data
+                    $policyOrCriteria = [];
+                    break;
+                }
+
+                $limitationsAndCriteria = [];
+                foreach ($limitations as $limitation) {
+                    $type = $this->limitationService->getLimitationType($limitation->getIdentifier());
+                    $limitationsAndCriteria[] = $type->getCriterion($limitation, $currentUserRef);
+                }
+
+                $policyOrCriteria[] = isset($limitationsAndCriteria[1]) ?
+                    new LogicalAnd($limitationsAndCriteria) :
+                    $limitationsAndCriteria[0];
+            }
+
+            /**
+             * Apply role limitations if there is one.
+             *
+             * @var \eZ\Publish\API\Repository\Values\User\Limitation[]
+             */
+            if ($permissionSet['limitation'] instanceof Limitation) {
+                // We need to match both the limitation AND *one* of the policies, aka; roleLimit AND policies(OR)
+                $type = $this->limitationService->getLimitationType($permissionSet['limitation']->getIdentifier());
+                if (!empty($policyOrCriteria)) {
+                    $roleAssignmentOrCriteria[] = new LogicalAnd(
+                        [
+                            $type->getCriterion($permissionSet['limitation'], $currentUserRef),
+                            isset($policyOrCriteria[1]) ? new LogicalOr($policyOrCriteria) : $policyOrCriteria[0],
+                        ]
+                    );
+                } else {
+                    $roleAssignmentOrCriteria[] = $type->getCriterion($permissionSet['limitation'], $currentUserRef);
+                }
+            } elseif (!empty($policyOrCriteria)) {
+                // Otherwise merge $policyOrCriteria into $roleAssignmentOrCriteria
+                // There is no role limitation, so any of the policies can globally match in the returned OR criteria
+                $roleAssignmentOrCriteria = empty($roleAssignmentOrCriteria) ?
+                    $policyOrCriteria :
+                    array_merge($roleAssignmentOrCriteria, $policyOrCriteria);
+            }
+        }
+
+        if (empty($roleAssignmentOrCriteria)) {
+            return false;
+        }
+
+        return isset($roleAssignmentOrCriteria[1]) ?
+            new LogicalOr($roleAssignmentOrCriteria) :
+            $roleAssignmentOrCriteria[0];
+    }
+}

--- a/eZ/Publish/Core/Repository/PermissionsCriterionHandler.php
+++ b/eZ/Publish/Core/Repository/PermissionsCriterionHandler.php
@@ -10,45 +10,19 @@ namespace eZ\Publish\Core\Repository;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
-use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOr;
-use eZ\Publish\API\Repository\Values\User\Limitation;
-use eZ\Publish\API\Repository\PermissionResolver as PermissionResolverInterface;
-use eZ\Publish\Core\Repository\Helper\LimitationService;
-use RuntimeException;
+use eZ\Publish\Core\Repository\Permission\PermissionCriterionResolver;
 
 /**
  * Handler for permissions Criterion.
+ *
+ * @deprecated 6.7.7
  */
-class PermissionsCriterionHandler
+class PermissionsCriterionHandler extends PermissionCriterionResolver
 {
-    /**
-     * @var \eZ\Publish\API\Repository\PermissionResolver
-     */
-    private $permissionResolver;
-
-    /**
-     * @var \eZ\Publish\Core\Repository\Helper\LimitationService
-     */
-    private $limitationService;
-
-    /**
-     * Constructor.
-     *
-     * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
-     * @param \eZ\Publish\Core\Repository\Helper\LimitationService $limitationService
-     */
-    public function __construct(
-        PermissionResolverInterface $permissionResolver,
-        LimitationService $limitationService
-    ) {
-        $this->permissionResolver = $permissionResolver;
-        $this->limitationService = $limitationService;
-    }
-
     /**
      * Adds content, read Permission criteria if needed and return false if no access at all.
      *
-     * @uses ::getPermissionsCriterion()
+     * @uses \eZ\Publish\Core\Repository\Permission\PermissionCriterionResolver::getPermissionsCriterion()
      *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      *
@@ -74,98 +48,5 @@ class PermissionsCriterionHandler
         }
 
         return true;
-    }
-
-    /**
-     * Get content-read Permission criteria if needed and return false if no access at all.
-     *
-     * @uses \eZ\Publish\API\Repository\PermissionResolver::hasAccess()
-     *
-     * @throws \RuntimeException If empty array of limitations are provided from hasAccess()
-     *
-     * @param string $module
-     * @param string $function
-     *
-     * @return bool|\eZ\Publish\API\Repository\Values\Content\Query\Criterion
-     */
-    public function getPermissionsCriterion($module = 'content', $function = 'read')
-    {
-        $permissionSets = $this->permissionResolver->hasAccess($module, $function);
-        if ($permissionSets === false || $permissionSets === true) {
-            return $permissionSets;
-        }
-
-        if (empty($permissionSets)) {
-            throw new RuntimeException("Got an empty array of limitations from hasAccess( '{$module}', '{$function}' )");
-        }
-
-        /*
-         * RoleAssignment is a OR condition, so is policy, while limitations is a AND condition
-         *
-         * If RoleAssignment has limitation then policy OR conditions are wrapped in a AND condition with the
-         * role limitation, otherwise it will be merged into RoleAssignment's OR condition.
-         */
-        $currentUserRef = $this->permissionResolver->getCurrentUserReference();
-        $roleAssignmentOrCriteria = array();
-        foreach ($permissionSets as $permissionSet) {
-            // $permissionSet is a RoleAssignment, but in the form of role limitation & role policies hash
-            $policyOrCriteria = array();
-            /**
-             * @var \eZ\Publish\API\Repository\Values\User\Policy
-             */
-            foreach ($permissionSet['policies'] as $policy) {
-                $limitations = $policy->getLimitations();
-                if ($limitations === '*' || empty($limitations)) {
-                    // Given policy gives full access, optimize away all role policies (but not role limitation if any)
-                    // This should be optimized on create/update of Roles, however we keep this here for bc with older data
-                    $policyOrCriteria = [];
-                    break;
-                }
-
-                $limitationsAndCriteria = array();
-                foreach ($limitations as $limitation) {
-                    $type = $this->limitationService->getLimitationType($limitation->getIdentifier());
-                    $limitationsAndCriteria[] = $type->getCriterion($limitation, $currentUserRef);
-                }
-
-                $policyOrCriteria[] = isset($limitationsAndCriteria[1]) ?
-                    new LogicalAnd($limitationsAndCriteria) :
-                    $limitationsAndCriteria[0];
-            }
-
-            /**
-             * Apply role limitations if there is one.
-             *
-             * @var \eZ\Publish\API\Repository\Values\User\Limitation[]
-             */
-            if ($permissionSet['limitation'] instanceof Limitation) {
-                // We need to match both the limitation AND *one* of the policies, aka; roleLimit AND policies(OR)
-                $type = $this->limitationService->getLimitationType($permissionSet['limitation']->getIdentifier());
-                if (!empty($policyOrCriteria)) {
-                    $roleAssignmentOrCriteria[] = new LogicalAnd(
-                        array(
-                            $type->getCriterion($permissionSet['limitation'], $currentUserRef),
-                            isset($policyOrCriteria[1]) ? new LogicalOr($policyOrCriteria) : $policyOrCriteria[0],
-                        )
-                    );
-                } else {
-                    $roleAssignmentOrCriteria[] = $type->getCriterion($permissionSet['limitation'], $currentUserRef);
-                }
-            } elseif (!empty($policyOrCriteria)) {
-                // Otherwise merge $policyOrCriteria into $roleAssignmentOrCriteria
-                // There is no role limitation, so any of the policies can globally match in the returned OR criteria
-                $roleAssignmentOrCriteria = empty($roleAssignmentOrCriteria) ?
-                    $policyOrCriteria :
-                    array_merge($roleAssignmentOrCriteria, $policyOrCriteria);
-            }
-        }
-
-        if (empty($roleAssignmentOrCriteria)) {
-            return false;
-        }
-
-        return isset($roleAssignmentOrCriteria[1]) ?
-            new LogicalOr($roleAssignmentOrCriteria) :
-            $roleAssignmentOrCriteria[0];
     }
 }

--- a/eZ/Publish/Core/Repository/SearchService.php
+++ b/eZ/Publish/Core/Repository/SearchService.php
@@ -9,7 +9,9 @@
 namespace eZ\Publish\Core\Repository;
 
 use eZ\Publish\API\Repository\SearchService as SearchServiceInterface;
+use eZ\Publish\API\Repository\PermissionCriterionResolver;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOperator;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Location as LocationCriterion;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location as LocationSortClause;
@@ -48,9 +50,9 @@ class SearchService implements SearchServiceInterface
     protected $domainMapper;
 
     /**
-     * @var \eZ\Publish\Core\Repository\PermissionsCriterionHandler
+     * @var \eZ\Publish\API\Repository\PermissionCriterionResolver
      */
-    protected $permissionsCriterionHandler;
+    protected $permissionCriterionResolver;
 
     /**
      * Setups service with reference to repository object that created it & corresponding handler.
@@ -58,14 +60,14 @@ class SearchService implements SearchServiceInterface
      * @param \eZ\Publish\API\Repository\Repository $repository
      * @param \eZ\Publish\SPI\Search\Handler $searchHandler
      * @param \eZ\Publish\Core\Repository\Helper\DomainMapper $domainMapper
-     * @param \eZ\Publish\Core\Repository\PermissionsCriterionHandler $permissionsCriterionHandler
+     * @param \eZ\Publish\API\Repository\PermissionCriterionResolver $permissionCriterionResolver
      * @param array $settings
      */
     public function __construct(
         RepositoryInterface $repository,
         Handler $searchHandler,
         Helper\DomainMapper $domainMapper,
-        PermissionsCriterionHandler $permissionsCriterionHandler,
+        PermissionCriterionResolver $permissionCriterionResolver,
         array $settings = array()
     ) {
         $this->repository = $repository;
@@ -75,7 +77,7 @@ class SearchService implements SearchServiceInterface
         $this->settings = $settings + array(
             //'defaultSetting' => array(),
         );
-        $this->permissionsCriterionHandler = $permissionsCriterionHandler;
+        $this->permissionCriterionResolver = $permissionCriterionResolver;
     }
 
     /**
@@ -177,7 +179,7 @@ class SearchService implements SearchServiceInterface
         $this->validateContentCriteria(array($query->filter), '$query');
         $this->validateContentSortClauses($query);
 
-        if ($filterOnUserPermissions && !$this->permissionsCriterionHandler->addPermissionsCriterion($query->filter)) {
+        if ($filterOnUserPermissions && !$this->addPermissionsCriterion($query->filter)) {
             return new SearchResult(array('time' => 0, 'totalCount' => 0));
         }
 
@@ -242,7 +244,7 @@ class SearchService implements SearchServiceInterface
     {
         $this->validateContentCriteria(array($filter), '$filter');
 
-        if ($filterOnUserPermissions && !$this->permissionsCriterionHandler->addPermissionsCriterion($filter)) {
+        if ($filterOnUserPermissions && !$this->addPermissionsCriterion($filter)) {
             throw new NotFoundException('Content', '*');
         }
 
@@ -303,7 +305,7 @@ class SearchService implements SearchServiceInterface
         $query = clone $query;
         $query->filter = $query->filter ?: new Criterion\MatchAll();
 
-        if ($filterOnUserPermissions && !$this->permissionsCriterionHandler->addPermissionsCriterion($query->filter)) {
+        if ($filterOnUserPermissions && !$this->addPermissionsCriterion($query->filter)) {
             return new SearchResult(array('time' => 0, 'totalCount' => 0));
         }
 
@@ -316,5 +318,36 @@ class SearchService implements SearchServiceInterface
         }
 
         return $result;
+    }
+
+    /**
+     * Adds content, read Permission criteria if needed and return false if no access at all.
+     *
+     * @uses \eZ\Publish\API\Repository\PermissionCriterionResolver::getPermissionsCriterion()
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
+     *
+     * @return bool|\eZ\Publish\API\Repository\Values\Content\Query\Criterion
+     */
+    protected function addPermissionsCriterion(Criterion &$criterion)
+    {
+        $permissionCriterion = $this->permissionCriterionResolver->getPermissionsCriterion();
+        if ($permissionCriterion === true || $permissionCriterion === false) {
+            return $permissionCriterion;
+        }
+
+        // Merge with original $criterion
+        if ($criterion instanceof LogicalAnd) {
+            $criterion->criteria[] = $permissionCriterion;
+        } else {
+            $criterion = new LogicalAnd(
+                array(
+                    $criterion,
+                    $permissionCriterion,
+                )
+            );
+        }
+
+        return true;
     }
 }

--- a/eZ/Publish/Core/Repository/Tests/Permission/CachedPermissionServiceTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Permission/CachedPermissionServiceTest.php
@@ -1,0 +1,255 @@
+<?php
+
+/**
+ * File contains: eZ\Publish\Core\Repository\Tests\Service\Mock\PermissionCriterionHandlerTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Repository\Permission;
+
+/**
+ * Avoid test failure caused by time passing between generating expected & actual object.
+ *
+ * @return int
+ */
+function time()
+{
+    static $time = 1417624981;
+
+    return ++$time;
+}
+
+namespace eZ\Publish\Core\Repository\Tests\Permission;
+
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\PermissionCriterionResolver;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\User\UserReference;
+use eZ\Publish\Core\Repository\Permission\CachedPermissionService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Mock test case for CachedPermissionService.
+ */
+class CachedPermissionServiceTest extends TestCase
+{
+    /**
+     * Test for the __construct() method.
+     */
+    public function testConstructor()
+    {
+        $permissionResolverMock = $this->getPermissionResolverMock();
+        $criterionResolverMock = $this->getPermissionCriterionResolverMock();
+        $cachedService = $this->getCachedPermissionService(10);
+
+        $this->assertAttributeSame(
+            $permissionResolverMock,
+            'permissionResolver',
+            $cachedService
+        );
+        $this->assertAttributeSame(
+            $criterionResolverMock,
+            'permissionCriterionResolver',
+            $cachedService
+        );
+        $this->assertAttributeEquals(
+            10,
+            'cacheTTL',
+            $cachedService
+        );
+        $this->assertAttributeEmpty(
+            'permissionCriterion',
+            $cachedService
+        );
+        $this->assertAttributeEmpty(
+            'permissionCriterionTs',
+            $cachedService
+        );
+    }
+
+    public function providerForTestPermissionResolverPassTrough()
+    {
+        $valueObject = $this
+            ->getMockBuilder(ValueObject::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        $userRef = $this
+            ->getMockBuilder(UserReference::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        $repository = $this
+            ->getMockBuilder(Repository::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        return [
+            ['getCurrentUserReference', [], $userRef],
+            ['setCurrentUserReference', [$userRef], null],
+            ['hasAccess', ['content', 'remove', $userRef], false],
+            ['canUser', ['content', 'remove', $valueObject, [new \stdClass()]], true],
+            ['sudo', [function () {}, $repository], null],
+        ];
+    }
+
+    /**
+     * Test for all PermissionResolver methods when they just pass true to underlying service.
+     *
+     * @dataProvider providerForTestPermissionResolverPassTrough
+     *
+     * @param $method
+     * @param array $arguments
+     * @param $return
+     */
+    public function testPermissionResolverPassTrough($method, array $arguments, $expectedReturn)
+    {
+        $this->getPermissionResolverMock([$method])
+            ->expects($this->once())
+            ->method($method)
+            ->with(...$arguments)
+            ->willReturn($expectedReturn);
+
+        $cachedService = $this->getCachedPermissionService();
+
+        $actualReturn = $cachedService->$method(...$arguments);
+        $this->assertSame($expectedReturn, $actualReturn);
+
+        // Make sure no cache properties where set
+        $this->assertAttributeEmpty('permissionCriterion', $cachedService);
+        $this->assertAttributeEmpty('permissionCriterionTs', $cachedService);
+    }
+
+    public function testGetPermissionsCriterionPassTrough()
+    {
+        $criterionMock = $this
+            ->getMockBuilder(Criterion::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        $this->getPermissionCriterionResolverMock(['getPermissionsCriterion'])
+            ->expects($this->once())
+            ->method('getPermissionsCriterion')
+            ->with('content', 'remove')
+            ->willReturn($criterionMock);
+
+        $cachedService = $this->getCachedPermissionService();
+
+        $actualReturn = $cachedService->getPermissionsCriterion('content', 'remove');
+        $this->assertSame($criterionMock, $actualReturn);
+
+        // Make sure no cache properties where set
+        $this->assertAttributeEmpty('permissionCriterion', $cachedService);
+        $this->assertAttributeEmpty('permissionCriterionTs', $cachedService);
+    }
+
+    public function testGetPermissionsCriterionCaching()
+    {
+        $criterionMock = $this
+            ->getMockBuilder(Criterion::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        $this->getPermissionCriterionResolverMock(['getPermissionsCriterion'])
+            ->expects($this->exactly(2))
+            ->method('getPermissionsCriterion')
+            ->with('content', 'read')
+            ->willReturn($criterionMock);
+
+        $cachedService = $this->getCachedPermissionService(2);
+
+        $actualReturn = $cachedService->getPermissionsCriterion('content', 'read');
+        $this->assertSame($criterionMock, $actualReturn);
+        $this->assertAttributeSame($criterionMock, 'permissionCriterion', $cachedService);
+        $this->assertAttributeEquals(1417624982, 'permissionCriterionTs', $cachedService);
+
+        // +1
+        $actualReturn = $cachedService->getPermissionsCriterion('content', 'read');
+        $this->assertSame($criterionMock, $actualReturn);
+        $this->assertAttributeSame($criterionMock, 'permissionCriterion', $cachedService);
+        $this->assertAttributeEquals(1417624982, 'permissionCriterionTs', $cachedService);
+
+        // +3, time() will be called twice and cache will be updated
+        $actualReturn = $cachedService->getPermissionsCriterion('content', 'read');
+        $this->assertSame($criterionMock, $actualReturn);
+        $this->assertAttributeSame($criterionMock, 'permissionCriterion', $cachedService);
+        $this->assertAttributeEquals(1417624985, 'permissionCriterionTs', $cachedService);
+    }
+
+    public function testSetCurrentUserReferenceCacheClear()
+    {
+        $criterionMock = $this
+            ->getMockBuilder(Criterion::class)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+
+        $this->getPermissionCriterionResolverMock(['getPermissionsCriterion'])
+            ->expects($this->once())
+            ->method('getPermissionsCriterion')
+            ->with('content', 'read')
+            ->willReturn($criterionMock);
+
+        $cachedService = $this->getCachedPermissionService(2);
+
+        $actualReturn = $cachedService->getPermissionsCriterion('content', 'read');
+        $this->assertSame($criterionMock, $actualReturn);
+        $this->assertAttributeSame($criterionMock, 'permissionCriterion', $cachedService);
+
+        $userRef = $this
+            ->getMockBuilder(UserReference::class)
+            ->getMockForAbstractClass();
+        $cachedService->setCurrentUserReference($userRef);
+        $this->assertAttributeEmpty('permissionCriterion', $cachedService);
+    }
+
+    /**
+     * Returns the CachedPermissionService to test against.
+     *
+     * @param int $ttl
+     *
+     * @return \eZ\Publish\Core\Repository\Permission\CachedPermissionService
+     */
+    protected function getCachedPermissionService($ttl = 5)
+    {
+        return new CachedPermissionService(
+            $this->getPermissionResolverMock(),
+            $this->getPermissionCriterionResolverMock(),
+            $ttl
+        );
+    }
+
+    protected $permissionResolverMock;
+
+    protected function getPermissionResolverMock($methods = [])
+    {
+        // Tests first calls here with methods set before initiating PermissionCriterionResolver with same instance.
+        if ($this->permissionResolverMock !== null) {
+            return $this->permissionResolverMock;
+        }
+
+        return $this->permissionResolverMock = $this
+            ->getMockBuilder(PermissionResolver::class)
+            ->setMethods($methods)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+    }
+
+    protected $permissionCriterionResolverMock;
+
+    protected function getPermissionCriterionResolverMock($methods = [])
+    {
+        // Tests first calls here with methods set before initiating PermissionCriterionResolver with same instance.
+        if ($this->permissionCriterionResolverMock !== null) {
+            return $this->permissionCriterionResolverMock;
+        }
+
+        return $this->permissionCriterionResolverMock = $this
+            ->getMockBuilder(PermissionCriterionResolver::class)
+            ->setMethods($methods)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+    }
+}

--- a/eZ/Publish/Core/Repository/Tests/Permission/PermissionCriterionResolverTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Permission/PermissionCriterionResolverTest.php
@@ -1,0 +1,385 @@
+<?php
+
+/**
+ * File contains: eZ\Publish\Core\Repository\Tests\Service\Mock\PermissionCriterionHandlerTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Repository\Tests\Permission;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\User\Limitation;
+use eZ\Publish\API\Repository\Values\User\User;
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\Core\Repository\Permission\PermissionCriterionResolver;
+use eZ\Publish\Core\Repository\Values\User\Policy;
+use eZ\Publish\Core\Repository\Helper\LimitationService;
+use eZ\Publish\SPI\Limitation\Type;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Mock test case for PermissionCriterionResolver.
+ */
+class PermissionCriterionResolverTest extends TestCase
+{
+    /**
+     * Test for the __construct() method.
+     */
+    public function testConstructor()
+    {
+        $permissionResolverMock = $this->getPermissionResolverMock();
+        $limitationServiceMock = $this->getLimitationServiceMock();
+        $criterionResolver = $this->getPermissionCriterionResolverMock();
+
+        $this->assertAttributeSame(
+            $permissionResolverMock,
+            'permissionResolver',
+            $criterionResolver
+        );
+        $this->assertAttributeSame(
+            $limitationServiceMock,
+            'limitationService',
+            $criterionResolver
+        );
+    }
+
+    public function providerForTestGetPermissionsCriterion()
+    {
+        $criterionMock = $this
+            ->getMockBuilder(Criterion::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $limitationMock = $this
+            ->getMockBuilder(Limitation::class)
+            ->getMockForAbstractClass();
+        $limitationMock
+            ->expects($this->any())
+            ->method('getIdentifier')
+            ->will($this->returnValue('limitationIdentifier'));
+
+        $policy1 = new Policy(['limitations' => [$limitationMock]]);
+        $policy2 = new Policy(['limitations' => [$limitationMock, $limitationMock]]);
+
+        return [
+            [
+                $criterionMock,
+                1,
+                [
+                    [
+                        'limitation' => null,
+                        'policies' => [$policy1],
+                    ],
+                ],
+                $criterionMock,
+            ],
+            [
+                $criterionMock,
+                2,
+                [
+                    [
+                        'limitation' => null,
+                        'policies' => [$policy1, $policy1],
+                    ],
+                ],
+                new Criterion\LogicalOr([$criterionMock, $criterionMock]),
+            ],
+            [
+                $criterionMock,
+                0,
+                [
+                    [
+                        'limitation' => null,
+                        'policies' => [new Policy(['limitations' => '*']), $policy1],
+                    ],
+                ],
+                false,
+            ],
+            [
+                $criterionMock,
+                0,
+                [
+                    [
+                        'limitation' => null,
+                        'policies' => [new Policy(['limitations' => []]), $policy1],
+                    ],
+                ],
+                false,
+            ],
+            [
+                $criterionMock,
+                2,
+                [
+                    [
+                        'limitation' => null,
+                        'policies' => [$policy2],
+                    ],
+                ],
+                new Criterion\LogicalAnd([$criterionMock, $criterionMock]),
+            ],
+            [
+                $criterionMock,
+                3,
+                [
+                    [
+                        'limitation' => null,
+                        'policies' => [$policy1, $policy2],
+                    ],
+                ],
+                new Criterion\LogicalOr(
+                    [
+                        $criterionMock,
+                        new Criterion\LogicalAnd([$criterionMock, $criterionMock]),
+                    ]
+                ),
+            ],
+            [
+                $criterionMock,
+                2,
+                [
+                    [
+                        'limitation' => null,
+                        'policies' => [$policy1],
+                    ],
+                    [
+                        'limitation' => null,
+                        'policies' => [$policy1],
+                    ],
+                ],
+                new Criterion\LogicalOr([$criterionMock, $criterionMock]),
+            ],
+            [
+                $criterionMock,
+                3,
+                [
+                    [
+                        'limitation' => null,
+                        'policies' => [$policy1],
+                    ],
+                    [
+                        'limitation' => null,
+                        'policies' => [$policy1, $policy1],
+                    ],
+                ],
+                new Criterion\LogicalOr([$criterionMock, $criterionMock, $criterionMock]),
+            ],
+            [
+                $criterionMock,
+                3,
+                [
+                    [
+                        'limitation' => null,
+                        'policies' => [$policy2],
+                    ],
+                    [
+                        'limitation' => null,
+                        'policies' => [$policy1],
+                    ],
+                ],
+                new Criterion\LogicalOr(
+                    [
+                        new Criterion\LogicalAnd([$criterionMock, $criterionMock]),
+                        $criterionMock,
+                    ]
+                ),
+            ],
+            [
+                $criterionMock,
+                2,
+                [
+                    [
+                        'limitation' => $limitationMock,
+                        'policies' => [$policy1],
+                    ],
+                ],
+                new Criterion\LogicalAnd([$criterionMock, $criterionMock]),
+            ],
+            [
+                $criterionMock,
+                4,
+                [
+                    [
+                        'limitation' => $limitationMock,
+                        'policies' => [$policy1],
+                    ],
+                    [
+                        'limitation' => $limitationMock,
+                        'policies' => [$policy1],
+                    ],
+                ],
+                new Criterion\LogicalOr(
+                    [
+                        new Criterion\LogicalAnd([$criterionMock, $criterionMock]),
+                        new Criterion\LogicalAnd([$criterionMock, $criterionMock]),
+                    ]
+                ),
+            ],
+            [
+                $criterionMock,
+                1,
+                [
+                    [
+                        'limitation' => $limitationMock,
+                        'policies' => [new Policy(['limitations' => '*'])],
+                    ],
+                ],
+                $criterionMock,
+            ],
+            [
+                $criterionMock,
+                2,
+                [
+                    [
+                        'limitation' => $limitationMock,
+                        'policies' => [new Policy(['limitations' => '*'])],
+                    ],
+                    [
+                        'limitation' => $limitationMock,
+                        'policies' => [new Policy(['limitations' => '*'])],
+                    ],
+                ],
+                new Criterion\LogicalOr([$criterionMock, $criterionMock]),
+            ],
+        ];
+    }
+
+    protected function mockServices($criterionMock, $limitationCount, $permissionSets)
+    {
+        $userMock = $this->getMockBuilder(User::class)->getMockForAbstractClass();
+        $limitationTypeMock = $this->getMockBuilder(Type::class)->getMockForAbstractClass();
+        $limitationServiceMock = $this->getLimitationServiceMock(['getLimitationType']);
+        $permissionResolverMock = $this->getPermissionResolverMock(
+            [
+                'hasAccess',
+                'getCurrentUserReference',
+            ]
+        );
+
+        $limitationTypeMock
+            ->expects($this->any())
+            ->method('getCriterion')
+            ->with(
+                $this->isInstanceOf(Limitation::class),
+                $this->equalTo($userMock)
+            )
+            ->will($this->returnValue($criterionMock));
+
+        $limitationServiceMock
+            ->expects($this->exactly($limitationCount))
+            ->method('getLimitationType')
+            ->with($this->equalTo('limitationIdentifier'))
+            ->will($this->returnValue($limitationTypeMock));
+
+        $permissionResolverMock
+            ->expects($this->once())
+            ->method('hasAccess')
+            ->with($this->equalTo('content'), $this->equalTo('read'))
+            ->will($this->returnValue($permissionSets));
+
+        $permissionResolverMock
+            ->expects($this->once())
+            ->method('getCurrentUserReference')
+            ->will($this->returnValue($userMock));
+    }
+
+    /**
+     * Test for the getPermissionsCriterion() method.
+     *
+     * @dataProvider providerForTestGetPermissionsCriterion
+     */
+    public function testGetPermissionsCriterion(
+        $criterionMock,
+        $limitationCount,
+        $permissionSets,
+        $expectedCriterion
+    ) {
+        $this->mockServices($criterionMock, $limitationCount, $permissionSets);
+        $criterionResolver = $this->getPermissionCriterionResolverMock(null);
+
+        $permissionsCriterion = $criterionResolver->getPermissionsCriterion();
+
+        $this->assertEquals($expectedCriterion, $permissionsCriterion);
+    }
+
+    public function providerForTestGetPermissionsCriterionBooleanPermissionSets()
+    {
+        return [
+            [true],
+            [false],
+        ];
+    }
+
+    /**
+     * Test for the getPermissionsCriterion() method.
+     *
+     * @dataProvider providerForTestGetPermissionsCriterionBooleanPermissionSets
+     */
+    public function testGetPermissionsCriterionBooleanPermissionSets($permissionSets)
+    {
+        $permissionResolverMock = $this->getPermissionResolverMock(['hasAccess']);
+        $permissionResolverMock
+            ->expects($this->once())
+            ->method('hasAccess')
+            ->with($this->equalTo('testModule'), $this->equalTo('testFunction'))
+            ->will($this->returnValue($permissionSets));
+
+        $criterionResolver = $this->getPermissionCriterionResolverMock(null);
+
+        $permissionsCriterion = $criterionResolver->getPermissionsCriterion('testModule', 'testFunction');
+
+        $this->assertEquals($permissionSets, $permissionsCriterion);
+    }
+
+    /**
+     * Returns the PermissionCriterionResolver to test with $methods mocked.
+     *
+     * @param string[]|null $methods
+     *
+     * @return \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\Core\Repository\Permission\PermissionCriterionResolver
+     */
+    protected function getPermissionCriterionResolverMock($methods = [])
+    {
+        return $this
+            ->getMockBuilder(PermissionCriterionResolver::class)
+            ->setMethods($methods)
+            ->setConstructorArgs(
+                [
+                    $this->getPermissionResolverMock(),
+                    $this->getLimitationServiceMock(),
+                ]
+            )
+            ->getMock();
+    }
+
+    protected $permissionResolverMock;
+
+    protected function getPermissionResolverMock($methods = [])
+    {
+        // Tests first calls here with methods set before initiating PermissionCriterionResolver with same instance.
+        if ($this->permissionResolverMock !== null) {
+            return $this->permissionResolverMock;
+        }
+
+        return $this->permissionResolverMock = $this
+            ->getMockBuilder(PermissionResolver::class)
+            ->setMethods($methods)
+            ->disableOriginalConstructor()
+            ->getMockForAbstractClass();
+    }
+
+    protected $limitationServiceMock;
+
+    protected function getLimitationServiceMock($methods = [])
+    {
+        // Tests first calls here with methods set before initiating PermissionCriterionResolver with same instance.
+        if ($this->limitationServiceMock !== null) {
+            return $this->limitationServiceMock;
+        }
+
+        return $this->limitationServiceMock = $this
+            ->getMockBuilder(LimitationService::class)
+            ->setMethods($methods)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionTest.php
@@ -17,6 +17,8 @@ use eZ\Publish\SPI\Persistence\User\Policy;
 
 /**
  * Mock test case for PermissionResolver.
+ *
+ * @todo Move to "Tests/Permission/"
  */
 class PermissionTest extends BaseServiceMockTest
 {
@@ -942,7 +944,7 @@ class PermissionTest extends BaseServiceMockTest
     {
         if ($this->permissionResolverMock === null) {
             $this->permissionResolverMock = $this
-                ->getMockBuilder('eZ\\Publish\\Core\\Repository\\Permission\\PermissionResolver')
+                ->getMockBuilder(PermissionResolver::class)
                 ->setMethods($methods)
                 ->setConstructorArgs(
                     [

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionsCriterionHandlerTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionsCriterionHandlerTest.php
@@ -14,6 +14,8 @@ use eZ\Publish\Core\Repository\Values\User\Policy;
 
 /**
  * Mock test case for PermissionCriterionHandler.
+ *
+ * @deprecated
  */
 class PermissionsCriterionHandlerTest extends BaseServiceMockTest
 {

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 
 use eZ\Publish\Core\Repository\Tests\Service\Mock\Base as BaseServiceMockTest;
 use eZ\Publish\Core\Repository\SearchService;
+use eZ\Publish\Core\Repository\Permission\PermissionCriterionResolver;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -30,7 +31,7 @@ class SearchTest extends BaseServiceMockTest
 
     protected $domainMapperMock;
 
-    protected $permissionsCriterionHandlerMock;
+    protected $permissionsCriterionResolverMock;
 
     /**
      * Test for the __construct() method.
@@ -43,14 +44,14 @@ class SearchTest extends BaseServiceMockTest
         /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
         $searchHandlerMock = $this->getSPIMockHandler('Search\\Handler');
         $domainMapperMock = $this->getDomainMapperMock();
-        $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
+        $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock();
         $settings = array('teh setting');
 
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
             $domainMapperMock,
-            $permissionsCriterionHandlerMock,
+            $permissionsCriterionResolverMock,
             $settings
         );
 
@@ -73,8 +74,8 @@ class SearchTest extends BaseServiceMockTest
         );
 
         $this->assertAttributeSame(
-            $permissionsCriterionHandlerMock,
-            'permissionsCriterionHandler',
+            $permissionsCriterionResolverMock,
+            'permissionCriterionResolver',
             $service
         );
 
@@ -124,13 +125,13 @@ class SearchTest extends BaseServiceMockTest
         $repositoryMock = $this->getRepositoryMock();
         /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
         $searchHandlerMock = $this->getSPIMockHandler('Search\\Handler');
-        $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
+        $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock();
 
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
             $this->getDomainMapperMock(),
-            $permissionsCriterionHandlerMock,
+            $permissionsCriterionResolverMock,
             array()
         );
 
@@ -171,12 +172,12 @@ class SearchTest extends BaseServiceMockTest
         $repositoryMock = $this->getRepositoryMock();
         /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
         $searchHandlerMock = $this->getSPIMockHandler('Search\\Handler');
-        $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
+        $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock();
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
             $this->getDomainMapperMock(),
-            $permissionsCriterionHandlerMock,
+            $permissionsCriterionResolverMock,
             array()
         );
 
@@ -193,8 +194,7 @@ class SearchTest extends BaseServiceMockTest
     /**
      * Test for the findContent() method.
      *
-     * @covers \eZ\Publish\Core\Repository\PermissionsCriterionHandler::addPermissionsCriterion
-     * @covers \eZ\Publish\Core\Repository\PermissionsCriterionHandler::getPermissionsCriterion
+     * @covers \eZ\Publish\Core\Repository\SearchService::addPermissionsCriterion
      * @covers \eZ\Publish\Core\Repository\SearchService::findContent
      * @expectedException \Exception
      * @expectedExceptionMessage Handler threw an exception
@@ -204,13 +204,13 @@ class SearchTest extends BaseServiceMockTest
         $repositoryMock = $this->getRepositoryMock();
         /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
         $searchHandlerMock = $this->getSPIMockHandler('Search\\Handler');
-        $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
+        $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock();
 
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
             $this->getDomainMapperMock(),
-            $permissionsCriterionHandlerMock,
+            $permissionsCriterionResolverMock,
             array()
         );
 
@@ -221,9 +221,9 @@ class SearchTest extends BaseServiceMockTest
             ->getMock();
         $query = new Query(array('filter' => $criterionMock));
 
-        $permissionsCriterionHandlerMock->expects($this->once())
-            ->method('addPermissionsCriterion')
-            ->with($criterionMock)
+        $permissionsCriterionResolverMock->expects($this->once())
+            ->method('getPermissionsCriterion')
+            ->with('content', 'read')
             ->will($this->throwException(new Exception('Handler threw an exception')));
 
         $service->findContent($query, array(), true);
@@ -232,8 +232,7 @@ class SearchTest extends BaseServiceMockTest
     /**
      * Test for the findContent() method.
      *
-     * @covers \eZ\Publish\Core\Repository\PermissionsCriterionHandler::addPermissionsCriterion
-     * @covers \eZ\Publish\Core\Repository\PermissionsCriterionHandler::getPermissionsCriterion
+     * @covers \eZ\Publish\Core\Repository\SearchService::addPermissionsCriterion
      * @covers \eZ\Publish\Core\Repository\SearchService::findContent
      */
     public function testFindContentNoPermissionsFilter()
@@ -242,12 +241,12 @@ class SearchTest extends BaseServiceMockTest
         /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
         $searchHandlerMock = $this->getSPIMockHandler('Search\\Handler');
         $domainMapperMock = $this->getDomainMapperMock();
-        $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
+        $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock();
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
             $domainMapperMock,
-            $permissionsCriterionHandlerMock,
+            $permissionsCriterionResolverMock,
             array()
         );
 
@@ -307,8 +306,7 @@ class SearchTest extends BaseServiceMockTest
     /**
      * Test for the findContent() method.
      *
-     * @covers \eZ\Publish\Core\Repository\PermissionsCriterionHandler::addPermissionsCriterion
-     * @covers \eZ\Publish\Core\Repository\PermissionsCriterionHandler::getPermissionsCriterion
+     * @covers \eZ\Publish\Core\Repository\SearchService::addPermissionsCriterion
      * @covers \eZ\Publish\Core\Repository\SearchService::findContent
      */
     public function testFindContentWithPermission()
@@ -317,12 +315,12 @@ class SearchTest extends BaseServiceMockTest
         /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
         $searchHandlerMock = $this->getSPIMockHandler('Search\\Handler');
         $domainMapperMock = $this->getDomainMapperMock();
-        $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
+        $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock();
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
             $domainMapperMock,
-            $permissionsCriterionHandlerMock,
+            $permissionsCriterionResolverMock,
             array()
         );
 
@@ -370,9 +368,9 @@ class SearchTest extends BaseServiceMockTest
             ->method('internalLoadContent')
             ->will($this->returnValue($contentMock));
 
-        $permissionsCriterionHandlerMock->expects($this->once())
-            ->method('addPermissionsCriterion')
-            ->with($criterionMock)
+        $permissionsCriterionResolverMock->expects($this->once())
+            ->method('getPermissionsCriterion')
+            ->with('content', 'read')
             ->will($this->returnValue(true));
 
         $result = $service->findContent($query, $languageFilter, true);
@@ -391,8 +389,7 @@ class SearchTest extends BaseServiceMockTest
     /**
      * Test for the findContent() method.
      *
-     * @covers \eZ\Publish\Core\Repository\PermissionsCriterionHandler::addPermissionsCriterion
-     * @covers \eZ\Publish\Core\Repository\PermissionsCriterionHandler::getPermissionsCriterion
+     * @covers \eZ\Publish\Core\Repository\SearchService::addPermissionsCriterion
      * @covers \eZ\Publish\Core\Repository\SearchService::findContent
      */
     public function testFindContentWithNoPermission()
@@ -400,12 +397,12 @@ class SearchTest extends BaseServiceMockTest
         $repositoryMock = $this->getRepositoryMock();
         /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
         $searchHandlerMock = $this->getSPIMockHandler('Search\\Handler');
-        $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
+        $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock();
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
             $this->getDomainMapperMock(),
-            $permissionsCriterionHandlerMock,
+            $permissionsCriterionResolverMock,
             array()
         );
 
@@ -418,9 +415,9 @@ class SearchTest extends BaseServiceMockTest
             ->getMock();
         $query = new Query(array('filter' => $criterionMock));
 
-        $permissionsCriterionHandlerMock->expects($this->once())
-            ->method('addPermissionsCriterion')
-            ->with($criterionMock)
+        $permissionsCriterionResolverMock->expects($this->once())
+            ->method('getPermissionsCriterion')
+            ->with('content', 'read')
             ->will($this->returnValue(false));
 
         $result = $service->findContent($query, array(), true);
@@ -444,7 +441,7 @@ class SearchTest extends BaseServiceMockTest
             $repositoryMock,
             $searchHandlerMock,
             $domainMapperMock,
-            $this->getPermissionsCriterionHandlerMock(),
+            $this->getPermissionCriterionResolverMock(),
             array()
         );
 
@@ -511,8 +508,7 @@ class SearchTest extends BaseServiceMockTest
     /**
      * Test for the findSingle() method.
      *
-     * @covers \eZ\Publish\Core\Repository\PermissionsCriterionHandler::addPermissionsCriterion
-     * @covers \eZ\Publish\Core\Repository\PermissionsCriterionHandler::getPermissionsCriterion
+     * @covers \eZ\Publish\Core\Repository\SearchService::addPermissionsCriterion
      * @covers \eZ\Publish\Core\Repository\SearchService::findSingle
      * @expectedException \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
@@ -525,7 +521,7 @@ class SearchTest extends BaseServiceMockTest
             $repositoryMock,
             $searchHandlerMock,
             $this->getDomainMapperMock(),
-            $this->getPermissionsCriterionHandlerMock(),
+            $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock(),
             array()
         );
 
@@ -535,14 +531,18 @@ class SearchTest extends BaseServiceMockTest
             ->disableOriginalConstructor()
             ->getMock();
 
+        $permissionsCriterionResolverMock->expects($this->once())
+            ->method('getPermissionsCriterion')
+            ->with('content', 'read')
+            ->willReturn(false);
+
         $service->findSingle($criterionMock, array(), true);
     }
 
     /**
      * Test for the findSingle() method.
      *
-     * @covers \eZ\Publish\Core\Repository\PermissionsCriterionHandler::addPermissionsCriterion
-     * @covers \eZ\Publish\Core\Repository\PermissionsCriterionHandler::getPermissionsCriterion
+     * @covers \eZ\Publish\Core\Repository\SearchService::addPermissionsCriterion
      * @covers \eZ\Publish\Core\Repository\SearchService::findSingle
      * @expectedException \Exception
      * @expectedExceptionMessage Handler threw an exception
@@ -552,12 +552,12 @@ class SearchTest extends BaseServiceMockTest
         $repositoryMock = $this->getRepositoryMock();
         /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
         $searchHandlerMock = $this->getSPIMockHandler('Search\\Handler');
-        $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
+        $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock();
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
             $this->getDomainMapperMock(),
-            $permissionsCriterionHandlerMock,
+            $permissionsCriterionResolverMock,
             array()
         );
 
@@ -567,9 +567,9 @@ class SearchTest extends BaseServiceMockTest
             ->disableOriginalConstructor()
             ->getMock();
 
-        $permissionsCriterionHandlerMock->expects($this->once())
-            ->method('addPermissionsCriterion')
-            ->with($criterionMock)
+        $permissionsCriterionResolverMock->expects($this->once())
+            ->method('getPermissionsCriterion')
+            ->with('content', 'read')
             ->will($this->throwException(new Exception('Handler threw an exception')));
 
         $service->findSingle($criterionMock, array(), true);
@@ -578,8 +578,7 @@ class SearchTest extends BaseServiceMockTest
     /**
      * Test for the findSingle() method.
      *
-     * @covers \eZ\Publish\Core\Repository\PermissionsCriterionHandler::addPermissionsCriterion
-     * @covers \eZ\Publish\Core\Repository\PermissionsCriterionHandler::getPermissionsCriterion
+     * @covers \eZ\Publish\Core\Repository\SearchService::addPermissionsCriterion
      * @covers \eZ\Publish\Core\Repository\SearchService::findSingle
      */
     public function testFindSingle()
@@ -588,12 +587,12 @@ class SearchTest extends BaseServiceMockTest
         /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
         $searchHandlerMock = $this->getSPIMockHandler('Search\\Handler');
         $domainMapperMock = $this->getDomainMapperMock();
-        $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
+        $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock();
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
             $domainMapperMock,
-            $permissionsCriterionHandlerMock,
+            $permissionsCriterionResolverMock,
             array()
         );
 
@@ -615,9 +614,9 @@ class SearchTest extends BaseServiceMockTest
             ->disableOriginalConstructor()
             ->getMock();
 
-        $permissionsCriterionHandlerMock->expects($this->once())
-            ->method('addPermissionsCriterion')
-            ->with($criterionMock)
+        $permissionsCriterionResolverMock->expects($this->once())
+            ->method('getPermissionsCriterion')
+            ->with('content', 'read')
             ->will($this->returnValue(true));
 
         $languageFilter = array();
@@ -652,12 +651,12 @@ class SearchTest extends BaseServiceMockTest
         /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
         $searchHandlerMock = $this->getSPIMockHandler('Search\\Handler');
         $domainMapperMock = $this->getDomainMapperMock();
-        $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
+        $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock();
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
             $domainMapperMock,
-            $permissionsCriterionHandlerMock,
+            $permissionsCriterionResolverMock,
             array()
         );
 
@@ -689,9 +688,9 @@ class SearchTest extends BaseServiceMockTest
             ->with($this->equalTo($spiLocation))
             ->will($this->returnValue($locationMock));
 
-        $permissionsCriterionHandlerMock->expects($this->once())
-            ->method('addPermissionsCriterion')
-            ->with($criterionMock)
+        $permissionsCriterionResolverMock->expects($this->once())
+            ->method('getPermissionsCriterion')
+            ->with('content', 'read')
             ->will($this->returnValue(true));
 
         $result = $service->findLocations($query, array(), true);
@@ -716,12 +715,12 @@ class SearchTest extends BaseServiceMockTest
         /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
         $searchHandlerMock = $this->getSPIMockHandler('Search\\Handler');
         $domainMapperMock = $this->getDomainMapperMock();
-        $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
+        $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock();
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
             $domainMapperMock,
-            $permissionsCriterionHandlerMock,
+            $permissionsCriterionResolverMock,
             array()
         );
 
@@ -776,13 +775,13 @@ class SearchTest extends BaseServiceMockTest
         $repositoryMock = $this->getRepositoryMock();
         /** @var \eZ\Publish\SPI\Search\Handler $searchHandlerMock */
         $searchHandlerMock = $this->getSPIMockHandler('Search\\Handler');
-        $permissionsCriterionHandlerMock = $this->getPermissionsCriterionHandlerMock();
+        $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock();
 
         $service = new SearchService(
             $repositoryMock,
             $searchHandlerMock,
             $this->getDomainMapperMock(),
-            $permissionsCriterionHandlerMock,
+            $permissionsCriterionResolverMock,
             array()
         );
 
@@ -793,9 +792,9 @@ class SearchTest extends BaseServiceMockTest
             ->getMock();
         $query = new LocationQuery(array('filter' => $criterionMock));
 
-        $permissionsCriterionHandlerMock->expects($this->once())
-            ->method('addPermissionsCriterion')
-            ->with($criterionMock)
+        $permissionsCriterionResolverMock->expects($this->once())
+            ->method('getPermissionsCriterion')
+            ->with('content', 'read')
             ->will($this->throwException(new Exception('Handler threw an exception')));
 
         $service->findLocations($query, array(), true);
@@ -803,10 +802,6 @@ class SearchTest extends BaseServiceMockTest
 
     /**
      * Test for the findLocations() method.
-     */
-
-    /**
-     * Test for the findContent() method.
      */
     public function testFindLocationsWithDefaultQueryValues()
     {
@@ -818,7 +813,7 @@ class SearchTest extends BaseServiceMockTest
             $repositoryMock,
             $searchHandlerMock,
             $domainMapperMock,
-            $this->getPermissionsCriterionHandlerMock(),
+            $this->getPermissionCriterionResolverMock(),
             array()
         );
 
@@ -881,17 +876,17 @@ class SearchTest extends BaseServiceMockTest
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\Core\Repository\PermissionsCriterionHandler
+     * @return \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\API\Repository\PermissionCriterionResolver
      */
-    protected function getPermissionsCriterionHandlerMock()
+    protected function getPermissionCriterionResolverMock()
     {
-        if (!isset($this->permissionsCriterionHandlerMock)) {
-            $this->permissionsCriterionHandlerMock = $this
-                ->getMockBuilder('eZ\\Publish\\Core\\Repository\\PermissionsCriterionHandler')
+        if (!isset($this->permissionsCriterionResolverMock)) {
+            $this->permissionsCriterionResolverMock = $this
+                ->getMockBuilder(PermissionCriterionResolver::class)
                 ->disableOriginalConstructor()
                 ->getMock();
         }
 
-        return $this->permissionsCriterionHandlerMock;
+        return $this->permissionsCriterionResolverMock;
     }
 }


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-28143

Cause: For non admin users, the permissions system needs to generate a query based on limitations assigned to a user. If the permissions grow complex, or the system uses a lot of object states, this will become _very_ expensive.

However if we can detect when current user changes, we can cache this permission criteria in memory as it does not change very often. For safety measure we can have a low ttl to avoid this getting stale. If it does get stale the user being served might experience seeing permission exceptions if user has lost access to something which happens to be part of search result.

Alternative would be to cache this in cache pool, however in current 5.x/6.x design that would imply moving logic down to SPI, which would imply hasAccess() should also be moved to SPI to. OR it could be accomplished in 7.0 if the cache uses right types of documented cache tags so the cache is cleared on any relevant updates to persistence.


Todo:
- [x] add unit tests for cachedPermissionService
- [x] fix failing tests 