### PR TITLE
EZP-28148: Object States Limitations perform a lot of lookups

### DIFF
--- a/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
@@ -158,8 +158,11 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
                     );
                 }
 
-                if ($this->isStateGroupUsedForLimitation($stateGroup->id, $limitationValues)) {
-                    $objectStateIdsToVerify[] = $defaultStateId;
+                foreach ($states as $state) {
+                    // check using loose types as limitation values are strings and id's can be int
+                    if (in_array($state->id, $limitationValues)) {
+                        $objectStateIdsToVerify[] = $defaultStateId;
+                    }
                 }
             }
         } else {

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ObjectStateHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ObjectStateHandlerTest.php
@@ -397,12 +397,6 @@ class ObjectStateHandlerTest extends HandlerTest
                 )
             ),
         );
-        $testStateIds = array_map(
-            function ($state) {
-                return $state->id;
-            },
-            $testStates
-        );
 
         $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
         $this->cacheMock
@@ -436,7 +430,7 @@ class ObjectStateHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('set')
-            ->with($testStateIds)
+            ->with($testStates)
             ->will($this->returnValue($cacheItemMock));
 
         $cacheItemMock
@@ -477,12 +471,6 @@ class ObjectStateHandlerTest extends HandlerTest
                 )
             ),
         );
-        $testStateIds = array_map(
-            function ($state) {
-                return $state->id;
-            },
-            $testStates
-        );
 
         $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
         $this->cacheMock
@@ -493,32 +481,11 @@ class ObjectStateHandlerTest extends HandlerTest
         $cacheItemMock
             ->expects($this->once())
             ->method('get')
-            ->will($this->returnValue($testStateIds));
+            ->will($this->returnValue($testStates));
         $cacheItemMock
             ->expects($this->once())
             ->method('isMiss')
             ->will($this->returnValue(false));
-
-        // load()
-        foreach ($testStates as $i => $state) {
-            $this->cacheMock
-                ->expects($this->at($i + 1))
-                ->method('getItem')
-                ->with('objectstate', $state->id)
-                ->will(
-                    $this->returnCallback(
-                        function ($cachekey, $i) use ($state) {
-                            $cacheItemMock = $this->getMock('Stash\Interfaces\ItemInterface');
-                            $cacheItemMock
-                                ->expects($this->once())
-                                ->method('get')
-                                ->will($this->returnValue($state));
-
-                            return $cacheItemMock;
-                        }
-                    )
-                );
-        }
 
         $handler = $this->persistenceCacheHandler->objectStateHandler();
         $states = $handler->loadObjectStates(1);


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-28148


Cause: On installs with a lot of object states the system creates a lot of lookups for them, most notably during permission checks in Object States Limitation Type.

This takes one of the changes in SPI Cache from 7.0, changing from storing id's in cache to the full objects to avoid lookups in loops. 7.0 will be even faster thanks to Symfony Cache, however for now these two changes should hopefully help quite a bit.