### PR TITLE
EZP-28147: Updated user cannot log in

### DIFF
--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -741,7 +741,9 @@ class UserService implements UserServiceInterface
                                 $this->settings['hashType']
                             ) :
                             $loadedUser->passwordHash,
-                        'hashAlgorithm' => $this->settings['hashType'],
+                        'hashAlgorithm' => $userUpdateStruct->password ?
+                            $this->settings['hashType'] :
+                            $loadedUser->hashAlgorithm,
                         'isEnabled' => $userUpdateStruct->enabled !== null ? $userUpdateStruct->enabled : $loadedUser->enabled,
                         'maxLogin' => $userUpdateStruct->maxLogin !== null ? (int)$userUpdateStruct->maxLogin : $loadedUser->maxLogin,
                     )


### PR DESCRIPTION
> Fix https://jira.ez.no/browse/EZP-28147
> Work in progress
> Regression from https://github.com/ezsystems/ezpublish-kernel/pull/2095 (Well, sort of. This bug existed even before that, but since most used the default hash, it was not discovered until the default hash algorithm changed.)

`UserService::updateUser()` always sets the password hash type to the default value, regardless of whether the password is updated or not. So when editing a user whose hash type is not the default, and not updating the password, the hash and hash type will no longer match, and login will fail.

Fix by only updating the hash type when the password is updated.

TODO
- [x] ~~Make a UserService test for this particular issue~~ *Will take this in follow up as it's tricky to add tests for this*