### PR TITLE
EZP-28028: As a Developer I want API removing Translations to use consistent naming

### DIFF
--- a/doc/bc/changes-6.13.md
+++ b/doc/bc/changes-6.13.md
@@ -1,0 +1,13 @@
+# Backwards compatibility changes
+
+Changes affecting version compatibility with former or future versions.
+
+## Changes
+
+## Deprecations
+
+The `eZ\Publish\API\Repository\ContentService::removeTranslation` method is deprecated and will be removed in 7.0.
+
+Use `eZ\Publish\API\Repository\ContentService::deleteTranslation` instead.
+
+## Removed features

--- a/doc/specifications/translations/removal.md
+++ b/doc/specifications/translations/removal.md
@@ -2,17 +2,12 @@
 
 ## Removing the specific language translation from all the Content Object Versions
 
-For the cases of system maintenance involving e.g. removing a language, PHP API introduces
-the `removeTranslation` method on `ContentService` which removes the specific translation from all
-the existing Versions of a Content Object and is specified as:
+For the cases of system maintenance involving e.g. deleting a language, PHP API introduces
+the `deleteTranslation` method on `ContentService` which deletes the specific Translation from all
+the existing Versions of a Content Item and is specified as:
 
 ```php
 /**
- * Remove Content Object translation from all Versions (including archived ones) of a Content Object.
- *
- * NOTE: this operation is risky and permanent, so user interface (ideally CLI) should provide
- *       a warning before performing it.
- *
  * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the specified translation
  *         is the only one a Version has or it is the main translation of a Content Object.
  * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed
@@ -23,14 +18,14 @@ the existing Versions of a Content Object and is specified as:
  * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
  * @param string $languageCode
  */
-public function removeTranslation(ContentInfo $contentInfo, $languageCode);
+public function deleteTranslation(ContentInfo $contentInfo, $languageCode);
 ```
 
 As noted in the method doc, this operation is permanent, so user should be warned about that.
 Since it is designed for maintenance tasks and might be a long-running operation, it should be used
 by a console command, not the web interface.
 
-The `removeTranslation` method and emits the `RemoveTranslationSignal` defined as:
+The `deleteTranslation` method and emits the `DeleteTranslationSignal` defined as:
 
 ```php
 namespace eZ\Publish\Core\SignalSlot\Signal\ContentService;
@@ -38,9 +33,9 @@ namespace eZ\Publish\Core\SignalSlot\Signal\ContentService;
 use eZ\Publish\Core\SignalSlot\Signal;
 
 /**
- * RemoveTranslationSignal emitted when a Content Object translation gets removed from all Versions.
+ * DeleteTranslationSignal emitted when a Content Item translation gets deleted from all Versions.
  */
-class RemoveTranslationSignal extends Signal
+class DeleteTranslationSignal extends Signal
 {
     /**
      * Content ID.

--- a/eZ/Bundle/EzPublishCoreBundle/Command/DeleteContentTranslationCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/DeleteContentTranslationCommand.php
@@ -21,9 +21,9 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Exception;
 
 /**
- * Console Command which removes a given Translation from all the Versions of a given Content Object.
+ * Console Command which deletes a given Translation from all the Versions of a given Content Item.
  */
-class RemoveContentTranslationCommand extends Command
+class DeleteContentTranslationCommand extends Command
 {
     /**
      * @var \eZ\Publish\API\Repository\Repository
@@ -62,12 +62,12 @@ class RemoveContentTranslationCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('ezplatform:remove-content-translation')
+            ->setName('ezplatform:delete-content-translation')
             ->addArgument('content-id', InputArgument::REQUIRED, 'Content Object Id')
             ->addArgument(
                 'language-code',
                 InputArgument::REQUIRED,
-                'Language code of the Translation to be removed'
+                'Language code of the Translation to be deleted'
             )
             ->addOption(
                 'user',
@@ -76,7 +76,7 @@ class RemoveContentTranslationCommand extends Command
                 'eZ Platform username (with Role containing at least Content policies: read, versionread, edit, remove, versionremove)',
                 'admin'
             )
-            ->setDescription('Remove Translation from all the Versions of a Content Object');
+            ->setDescription('Delete Translation from all the Versions of a Content Item');
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output)
@@ -115,7 +115,7 @@ class RemoveContentTranslationCommand extends Command
 
         $this->repository->beginTransaction();
         try {
-            $allLanguages = $this->removeAffectedSingularLanguageVersions(
+            $allLanguages = $this->deleteAffectedSingularLanguageVersions(
                 $contentInfo,
                 $languageCode
             );
@@ -130,7 +130,7 @@ class RemoveContentTranslationCommand extends Command
             // Confirm operation
             $contentName = "#{$contentInfo->id} ($contentInfo->name)";
             $question = new ConfirmationQuestion(
-                "Are you sure you want to remove {$languageCode} Translation from the Content {$contentName}? This operation is permanent. [y/N] ",
+                "Are you sure you want to delete {$languageCode} Translation from the Content {$contentName}? This operation is permanent. [y/N] ",
                 false
             );
             if (!$this->questionHelper->ask($this->input, $this->output, $question)) {
@@ -141,13 +141,13 @@ class RemoveContentTranslationCommand extends Command
                 return;
             }
 
-            // Remove Translation
+            // Delete Translation
             $output->writeln(
-                "<info>Removing {$languageCode} Translation of the Content {$contentName}</info>"
+                "<info>Deleting {$languageCode} Translation of the Content {$contentName}</info>"
             );
-            $this->contentService->removeTranslation($contentInfo, $languageCode);
+            $this->contentService->deleteTranslation($contentInfo, $languageCode);
 
-            $output->writeln('<info>Translation removed</info>');
+            $output->writeln('<info>Translation deleted</info>');
 
             $this->repository->commit();
         } catch (Exception $e) {
@@ -164,7 +164,7 @@ class RemoveContentTranslationCommand extends Command
      *
      * @return string[] unique Language codes across all Versions of the Content.
      */
-    private function removeAffectedSingularLanguageVersions(ContentInfo $contentInfo, $languageCode)
+    private function deleteAffectedSingularLanguageVersions(ContentInfo $contentInfo, $languageCode)
     {
         $languages = [];
         foreach ($this->contentService->loadVersions($contentInfo) as $versionInfo) {
@@ -190,7 +190,7 @@ class RemoveContentTranslationCommand extends Command
      * Interact with user to update main Language of a Content Object.
      *
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     * @param string $languageCode language code of the Translation to be removed
+     * @param string $languageCode language code of the Translation to be deleted
      * @param string[] $allLanguages all languages Content Object Versions have, w/o $languageCode
      *
      * @return \eZ\Publish\API\Repository\Values\Content\ContentInfo

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -236,8 +236,8 @@ services:
         tags:
             - {name: kernel.event_subscriber}
 
-    ezplatform.core.command.remove_content_translation:
-        class: eZ\Bundle\EzPublishCoreBundle\Command\RemoveContentTranslationCommand
+    ezplatform.core.command.delete_content_translation:
+        class: eZ\Bundle\EzPublishCoreBundle\Command\DeleteContentTranslationCommand
         arguments:
             - '@ezpublish.api.repository'
         tags:

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/slot.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/slot.yml
@@ -19,7 +19,7 @@ parameters:
     ezpublish.http_cache.signalslot.unassign_user_from_user_group.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UnassignUserFromUserGroupSlot
     ezpublish.http_cache.signalslot.trash.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\TrashSlot
     ezpublish.http_cache.signalslot.recover.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\RecoverSlot
-    ezpublish.http_cache.signalslot.remove_translation.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\RemoveTranslationSlot
+    ezpublish.http_cache.signalslot.delete_translation.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\DeleteTranslationSlot
 
 services:
     ezpublish.http_cache.signalslot.http_cache:
@@ -141,8 +141,8 @@ services:
         tags:
             - { name: ezpublish.api.slot, signal: TrashService\RecoverSignal }
 
-    ezpublish.http_cache.signalslot.remove_translation:
-        class: "%ezpublish.http_cache.signalslot.remove_translation.class%"
+    ezpublish.http_cache.signalslot.delete_translation:
+        class: "%ezpublish.http_cache.signalslot.delete_translation.class%"
         parent: ezpublish.http_cache.signalslot.http_cache
         tags:
-            - { name: ezpublish.api.slot, signal: ContentService\RemoveTranslationSignal }
+            - { name: ezpublish.api.slot, signal: ContentService\DeleteTranslationSignal }

--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -412,6 +412,8 @@ interface ContentService
      * NOTE: this operation is risky and permanent, so user interface (ideally CLI) should provide
      *       a warning before performing it.
      *
+     * @deprecated since 6.13, use {@see deleteTranslation} instead
+     *
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the specified translation
      *         is the only one a Version has or it is the main translation of a Content Object.
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed
@@ -425,6 +427,25 @@ interface ContentService
      * @since 6.11
      */
     public function removeTranslation(ContentInfo $contentInfo, $languageCode);
+
+    /**
+     * Delete Content item Translation from all Versions (including archived ones) of a Content Object.
+     *
+     * NOTE: this operation is risky and permanent, so user interface should provide a warning before performing it.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the specified translation
+     *         is the only one a Version has or it is the main translation of a Content Object.
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed
+     *         to delete the content (in one of the locations of the given Content Object).
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if languageCode argument
+     *         is invalid for the given content.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
+     * @param string $languageCode
+     *
+     * @since 6.13
+     */
+    public function deleteTranslation(ContentInfo $contentInfo, $languageCode);
 
     /**
      * Delete specified Translation from a Content Draft.

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -5157,9 +5157,9 @@ class ContentServiceTest extends BaseContentServiceTest
     /**
      * Test removal of the specific translation from all the Versions of a Content Object.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::removeTranslation
+     * @covers \eZ\Publish\Core\Repository\ContentService::deleteTranslation
      */
-    public function testRemoveTranslation()
+    public function testDeleteTranslation()
     {
         $repository = $this->getRepository();
         $contentService = $repository->getContentService();
@@ -5176,16 +5176,16 @@ class ContentServiceTest extends BaseContentServiceTest
             $contentService->publishVersion($contentDraft->versionInfo);
         }
 
-        $contentService->removeTranslation($content->contentInfo, 'eng-GB');
+        $contentService->deleteTranslation($content->contentInfo, 'eng-GB');
 
         $this->assertTranslationDoesNotExist('eng-GB', $content->id);
     }
 
     /**
-     * Test removing a translation which is initial for some Version, updates initialLanguageCode
+     * Test deleting a Translation which is initial for some Version, updates initialLanguageCode
      * with mainLanguageCode (assuming they are different).
      */
-    public function testRemoveTranslationUpdatesInitialLanguageCodeVersion()
+    public function testDeleteTranslationUpdatesInitialLanguageCodeVersion()
     {
         $repository = $this->getRepository();
         $contentService = $repository->getContentService();
@@ -5212,7 +5212,7 @@ class ContentServiceTest extends BaseContentServiceTest
         $contentMetadataUpdateStruct->mainLanguageCode = 'eng-GB';
         $content = $contentService->updateContentMetadata($publishedContent->contentInfo, $contentMetadataUpdateStruct);
 
-        $contentService->removeTranslation($content->contentInfo, 'eng-US');
+        $contentService->deleteTranslation($content->contentInfo, 'eng-US');
 
         $this->assertTranslationDoesNotExist('eng-US', $content->id);
     }
@@ -5220,9 +5220,9 @@ class ContentServiceTest extends BaseContentServiceTest
     /**
      * Test removal of the specific translation properly updates languages of the URL alias.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::removeTranslation
+     * @covers \eZ\Publish\Core\Repository\ContentService::deleteTranslation
      */
-    public function testRemoveTranslationUpdatesUrlAlias()
+    public function testDeleteTranslationUpdatesUrlAlias()
     {
         $repository = $this->getRepository();
         $contentService = $repository->getContentService();
@@ -5244,8 +5244,8 @@ class ContentServiceTest extends BaseContentServiceTest
         // create custom URL alias for Content secondary Location
         $urlAliasService->createUrlAlias($secondaryLocation, '/my-secondary-url', 'eng-GB');
 
-        // remove Translation
-        $contentService->removeTranslation($content->contentInfo, 'eng-GB');
+        // delete Translation
+        $contentService->deleteTranslation($content->contentInfo, 'eng-GB');
 
         foreach ([$mainLocation, $secondaryLocation] as $location) {
             // check auto-generated URL aliases
@@ -5263,11 +5263,11 @@ class ContentServiceTest extends BaseContentServiceTest
     /**
      * Test removal of a main translation throws BadStateException.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::removeTranslation
+     * @covers \eZ\Publish\Core\Repository\ContentService::deleteTranslation
      * @expectedException \eZ\Publish\API\Repository\Exceptions\BadStateException
      * @expectedExceptionMessage Specified translation is the main translation of the Content Object
      */
-    public function testRemoveTranslationMainLanguageThrowsBadStateException()
+    public function testDeleteTranslationMainLanguageThrowsBadStateException()
     {
         $repository = $this->getRepository();
         $contentService = $repository->getContentService();
@@ -5276,8 +5276,8 @@ class ContentServiceTest extends BaseContentServiceTest
         // delete first version which has only one translation
         $contentService->deleteVersion($contentService->loadVersionInfo($content->contentInfo, 1));
 
-        // try to remove main translation
-        $contentService->removeTranslation($content->contentInfo, $content->contentInfo->mainLanguageCode);
+        // try to delete main translation
+        $contentService->deleteTranslation($content->contentInfo, $content->contentInfo->mainLanguageCode);
     }
 
     /**
@@ -5290,11 +5290,11 @@ class ContentServiceTest extends BaseContentServiceTest
      * 4. Try to remove a translation that is the only one in the first version.
      * 5. Observe BadStateException with a message about trying to remove the last translation.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::removeTranslation
+     * @covers \eZ\Publish\Core\Repository\ContentService::deleteTranslation
      * @expectedException \eZ\Publish\API\Repository\Exceptions\BadStateException
      * @expectedExceptionMessageRegExp /The Version\(s\): \d+ of the ContentId=\d+ have only one language eng-US/
      */
-    public function testRemoveTranslationLastLanguageThrowsBadStateException()
+    public function testDeleteTranslationLastLanguageThrowsBadStateException()
     {
         $repository = $this->getRepository();
         $contentService = $repository->getContentService();
@@ -5314,18 +5314,18 @@ class ContentServiceTest extends BaseContentServiceTest
 
         $content = $contentService->updateContentMetadata($publishedContent->contentInfo, $contentMetadataUpdateStruct);
 
-        $contentService->removeTranslation($content->contentInfo, 'eng-US');
+        $contentService->deleteTranslation($content->contentInfo, 'eng-US');
     }
 
     /**
      * Test removal of the translation by the user who is not allowed to delete a content
      * throws UnauthorizedException.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::removeTranslation
+     * @covers \eZ\Publish\Core\Repository\ContentService::deleteTranslation
      * @expectedException \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      * @expectedExceptionMessage User does not have access to 'remove' 'content'
      */
-    public function testRemoveTranslationThrowsUnauthorizedException()
+    public function testDeleteTranslationThrowsUnauthorizedException()
     {
         $repository = $this->getRepository();
         $contentService = $repository->getContentService();
@@ -5346,23 +5346,23 @@ class ContentServiceTest extends BaseContentServiceTest
             'Writer'
         );
         $repository->getPermissionResolver()->setCurrentUserReference($writerUser);
-        $contentService->removeTranslation($content->contentInfo, 'eng-GB');
+        $contentService->deleteTranslation($content->contentInfo, 'eng-GB');
     }
 
     /**
      * Test removal of a non-existent translation throws InvalidArgumentException.
      *
-     * @covers \eZ\Publish\Core\Repository\ContentService::removeTranslation
+     * @covers \eZ\Publish\Core\Repository\ContentService::deleteTranslation
      * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      * @expectedExceptionMessage Argument '$languageCode' is invalid: Specified translation does not exist
      */
-    public function testRemoveTranslationThrowsInvalidArgumentException()
+    public function testDeleteTranslationThrowsInvalidArgumentException()
     {
         $repository = $this->getRepository();
         $contentService = $repository->getContentService();
         // content created by the createContentVersion1 method has eng-US translation only.
         $content = $this->createContentVersion1();
-        $contentService->removeTranslation($content->contentInfo, 'ger-DE');
+        $contentService->deleteTranslation($content->contentInfo, 'ger-DE');
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
@@ -1149,9 +1149,9 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
     /**
      * Test that removing Translation from all Versions works for data from a Field Type.
      *
-     * @covers \eZ\Publish\API\Repository\ContentService::removeTranslation
+     * @covers \eZ\Publish\API\Repository\ContentService::deleteTranslation
      */
-    public function testRemoveTranslation()
+    public function testDeleteTranslation()
     {
         $repository = $this->getRepository();
         $contentService = $repository->getContentService();
@@ -1189,7 +1189,7 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
         }
 
         // delete Translation from all available Versions
-        $contentService->removeTranslation($publishedContent->contentInfo, 'ger-DE');
+        $contentService->deleteTranslation($publishedContent->contentInfo, 'ger-DE');
 
         // check if are Versions have valid Translation
         foreach ($contentService->loadVersions($publishedContent->contentInfo) as $versionInfo) {

--- a/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
@@ -1054,7 +1054,7 @@ class SearchEngineIndexingTest extends BaseTest
     /**
      * Test search engine is updated after removal of the translation from all the Versions.
      */
-    public function testRemoveTranslation()
+    public function testDeleteTranslation()
     {
         $repository = $this->getRepository();
         $searchService = $repository->getSearchService();
@@ -1069,7 +1069,7 @@ class SearchEngineIndexingTest extends BaseTest
             false
         );
 
-        $contentService->removeTranslation($content->contentInfo, 'eng-GB');
+        $contentService->deleteTranslation($content->contentInfo, 'eng-GB');
 
         $this->refreshSearch($repository);
 

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/DeleteTranslationSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/DeleteTranslationSlot.php
@@ -11,11 +11,11 @@ namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot;
 use eZ\Publish\Core\SignalSlot\Signal;
 
 /**
- * A slot handling RemoveTranslationSignal.
+ * A slot handling DeleteTranslationSignal.
  *
  * @deprecated since 6.11. The platform-http-cache package defines slots for http-cache multi-tagging.
  */
-class RemoveTranslationSlot extends PurgeForContentHttpCacheSlot
+class DeleteTranslationSlot extends PurgeForContentHttpCacheSlot
 {
     protected function supports(Signal $signal)
     {

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/RemoveTranslationSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/RemoveTranslationSlot.php
@@ -19,6 +19,6 @@ class RemoveTranslationSlot extends PurgeForContentHttpCacheSlot
 {
     protected function supports(Signal $signal)
     {
-        return $signal instanceof Signal\ContentService\RemoveTranslationSignal;
+        return $signal instanceof Signal\ContentService\DeleteTranslationSignal;
     }
 }

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -306,6 +306,14 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
      */
     public function removeTranslationFromContent($contentId, $languageCode)
     {
+        $this->deleteTranslationFromContent($contentId, $languageCode);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteTranslationFromContent($contentId, $languageCode)
+    {
         $this->logger->logCall(
             __METHOD__,
             [
@@ -314,7 +322,7 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
             ]
         );
 
-        $this->persistenceHandler->contentHandler()->removeTranslationFromContent($contentId, $languageCode);
+        $this->persistenceHandler->contentHandler()->deleteTranslationFromContent($contentId, $languageCode);
 
         $this->cache->clear('content', $contentId);
         $this->cache->clear('content', 'info', $contentId);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
@@ -402,7 +402,7 @@ abstract class Gateway
      * @param int $contentId
      * @param string $languageCode language code of the translation
      */
-    abstract public function removeTranslationFromContent($contentId, $languageCode);
+    abstract public function deleteTranslationFromContent($contentId, $languageCode);
 
     /**
      * Delete Content fields (attributes) for the given Translation.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -1963,7 +1963,7 @@ class DoctrineDatabase extends Gateway
      * @param string $languageCode language code of the translation
      * @throws \Doctrine\DBAL\DBALException
      */
-    public function removeTranslationFromContent($contentId, $languageCode)
+    public function deleteTranslationFromContent($contentId, $languageCode)
     {
         $language = $this->languageHandler->loadByLanguageCode($languageCode);
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
@@ -739,10 +739,10 @@ class ExceptionConversion extends Gateway
      * @param int $contentId
      * @param string $languageCode language code of the translation
      */
-    public function removeTranslationFromContent($contentId, $languageCode)
+    public function deleteTranslationFromContent($contentId, $languageCode)
     {
         try {
-            return $this->innerGateway->removeTranslationFromContent($contentId, $languageCode);
+            return $this->innerGateway->deleteTranslationFromContent($contentId, $languageCode);
         } catch (DBALException $e) {
             throw new RuntimeException('Database error', 0, $e);
         } catch (PDOException $e) {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -718,6 +718,18 @@ class Handler implements BaseContentHandler
      */
     public function removeTranslationFromContent($contentId, $languageCode)
     {
+        @trigger_error(
+            __METHOD__ . ' is deprecated, use deleteTranslationFromContent instead',
+            E_USER_DEPRECATED
+        );
+        $this->deleteTranslationFromContent($contentId, $languageCode);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteTranslationFromContent($contentId, $languageCode)
+    {
         $this->fieldHandler->deleteTranslationFromContentFields(
             $contentId,
             $this->listVersions($contentId),

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -723,7 +723,7 @@ class Handler implements BaseContentHandler
             $this->listVersions($contentId),
             $languageCode
         );
-        $this->contentGateway->removeTranslationFromContent($contentId, $languageCode);
+        $this->contentGateway->deleteTranslationFromContent($contentId, $languageCode);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Client/ContentService.php
+++ b/eZ/Publish/Core/REST/Client/ContentService.php
@@ -746,26 +746,17 @@ class ContentService implements APIContentService, Sessionable
     }
 
     /**
-     * Remove Content Object translation from all Versions (including archived ones) of a Content Object.
-     *
-     * NOTE: this operation is risky and permanent, so user interface (ideally CLI) should provide
-     *       a warning before performing it.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the specified translation
-     *         is the only one a Version has or it is the main translation of a Content Object.
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed
-     *         to delete the content (in one of the locations of the given Content Object).
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if languageCode argument
-     *         is invalid for the given content.
-     *
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     * @param string $languageCode
-     *
-     * @throws \Exception
-     *
-     * @since 6.11
+     * {@inheritdoc}
      */
     public function removeTranslation(ContentInfo $contentInfo, $languageCode)
+    {
+        throw new \Exception('@todo: Implement.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteTranslation(ContentInfo $contentInfo, $languageCode)
     {
         throw new \Exception('@todo: Implement.');
     }

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1877,10 +1877,21 @@ class ContentService implements ContentServiceInterface
     }
 
     /**
-     * Remove Content Object translation from all Versions (including archived ones) of a Content Object.
+     * {@inheritdoc}
+     */
+    public function removeTranslation(ContentInfo $contentInfo, $languageCode)
+    {
+        @trigger_error(
+            __METHOD__ . ' is deprecated, use deleteTranslation instead',
+            E_USER_DEPRECATED
+        );
+        $this->deleteTranslation($contentInfo, $languageCode);
+    }
+
+    /**
+     * Delete Content item Translation from all Versions (including archived ones) of a Content Object.
      *
-     * NOTE: this operation is risky and permanent, so user interface (ideally CLI) should provide
-     *       a warning before performing it.
+     * NOTE: this operation is risky and permanent, so user interface should provide a warning before performing it.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the specified translation
      *         is the only one a Version has or it is the main translation of a Content Object.
@@ -1892,9 +1903,9 @@ class ContentService implements ContentServiceInterface
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
      * @param string $languageCode
      *
-     * @since 6.11
+     * @since 6.13
      */
-    public function removeTranslation(ContentInfo $contentInfo, $languageCode)
+    public function deleteTranslation(ContentInfo $contentInfo, $languageCode)
     {
         if ($contentInfo->mainLanguageCode === $languageCode) {
             throw new BadStateException(
@@ -1953,7 +1964,7 @@ class ContentService implements ContentServiceInterface
 
         $this->repository->beginTransaction();
         try {
-            $this->persistenceHandler->contentHandler()->removeTranslationFromContent($contentInfo->id, $languageCode);
+            $this->persistenceHandler->contentHandler()->deleteTranslationFromContent($contentInfo->id, $languageCode);
             $locationIds = array_map(
                 function (Location $location) {
                     return $location->id;

--- a/eZ/Publish/Core/Search/Common/Slot/DeleteTranslation.php
+++ b/eZ/Publish/Core/Search/Common/Slot/DeleteTranslation.php
@@ -12,9 +12,9 @@ use eZ\Publish\Core\SignalSlot\Signal;
 use eZ\Publish\Core\Search\Common\Slot;
 
 /**
- * A Search Engine slot handling RemoveTranslationSignal.
+ * A Search Engine slot handling DeleteTranslationSignal.
  */
-class RemoveTranslation extends Slot
+class DeleteTranslation extends Slot
 {
     /**
      * Receive the given $signal and react on it.

--- a/eZ/Publish/Core/Search/Common/Slot/RemoveTranslation.php
+++ b/eZ/Publish/Core/Search/Common/Slot/RemoveTranslation.php
@@ -23,7 +23,7 @@ class RemoveTranslation extends Slot
      */
     public function receive(Signal $signal)
     {
-        if (!$signal instanceof Signal\ContentService\RemoveTranslationSignal) {
+        if (!$signal instanceof Signal\ContentService\DeleteTranslationSignal) {
             return;
         }
 

--- a/eZ/Publish/Core/SignalSlot/ContentService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentService.php
@@ -633,10 +633,21 @@ class ContentService implements ContentServiceInterface
     }
 
     /**
-     * Remove Content Object translation from all Versions (including archived ones) of a Content Object.
+     * {@inheritdoc}
+     */
+    public function removeTranslation(ContentInfo $contentInfo, $languageCode)
+    {
+        @trigger_error(
+            __METHOD__ . ' is deprecated, use deleteTranslation instead',
+            E_USER_DEPRECATED
+        );
+        $this->deleteTranslation($contentInfo, $languageCode);
+    }
+
+    /**
+     * Delete Content item Translation from all Versions (including archived ones) of a Content Object.
      *
-     * NOTE: this operation is risky and permanent, so user interface (ideally CLI) should provide
-     *       a warning before performing it.
+     * NOTE: this operation is risky and permanent, so user interface should provide a warning before performing it.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the specified translation
      *         is the only one a Version has or it is the main translation of a Content Object.
@@ -648,11 +659,11 @@ class ContentService implements ContentServiceInterface
      * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
      * @param string $languageCode
      *
-     * @since 6.11
+     * @since 6.13
      */
-    public function removeTranslation(ContentInfo $contentInfo, $languageCode)
+    public function deleteTranslation(ContentInfo $contentInfo, $languageCode)
     {
-        $this->service->removeTranslation($contentInfo, $languageCode);
+        $this->service->deleteTranslation($contentInfo, $languageCode);
         $this->signalDispatcher->emit(
             new RemoveTranslationSignal(['contentId' => $contentInfo->id, 'languageCode' => $languageCode])
         );

--- a/eZ/Publish/Core/SignalSlot/ContentService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentService.php
@@ -20,6 +20,7 @@ use eZ\Publish\API\Repository\Values\Content\TranslationValues;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\Core\SignalSlot\Signal\ContentService\CreateContentSignal;
+use eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteTranslationSignal;
 use eZ\Publish\Core\SignalSlot\Signal\ContentService\RemoveTranslationSignal;
 use eZ\Publish\Core\SignalSlot\Signal\ContentService\UpdateContentMetadataSignal;
 use eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteContentSignal;
@@ -666,6 +667,9 @@ class ContentService implements ContentServiceInterface
         $this->service->deleteTranslation($contentInfo, $languageCode);
         $this->signalDispatcher->emit(
             new RemoveTranslationSignal(['contentId' => $contentInfo->id, 'languageCode' => $languageCode])
+        );
+        $this->signalDispatcher->emit(
+            new DeleteTranslationSignal(['contentId' => $contentInfo->id, 'languageCode' => $languageCode])
         );
     }
 

--- a/eZ/Publish/Core/SignalSlot/Signal/ContentService/DeleteTranslationSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/ContentService/DeleteTranslationSignal.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\SignalSlot\Signal\ContentService;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * DeleteTranslationSignal emitted when a Content Object Translation gets deleted from all Versions.
+ */
+class DeleteTranslationSignal extends Signal
+{
+    /**
+     * Content ID.
+     *
+     * @var int
+     */
+    public $contentId;
+
+    /**
+     * Language Code of the removed translation.
+     *
+     * @var string
+     */
+    public $languageCode;
+}

--- a/eZ/Publish/Core/SignalSlot/Signal/ContentService/RemoveTranslationSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/ContentService/RemoveTranslationSignal.php
@@ -8,24 +8,18 @@
  */
 namespace eZ\Publish\Core\SignalSlot\Signal\ContentService;
 
-use eZ\Publish\Core\SignalSlot\Signal;
+@trigger_error(
+    sprintf(
+        'The %s is deprecated since 6.13 and will be removed in 7.0. Use %s instead',
+        RemoveTranslationSignal::class,
+        DeleteTranslationSignal::class
+    ),
+    E_USER_DEPRECATED
+);
 
 /**
- * RemoveTranslationSignal emitted when a Content Object translation gets removed from all Versions.
+ * @deprecated since 6.13, use DeleteTranslationSignal
  */
-class RemoveTranslationSignal extends Signal
+class RemoveTranslationSignal extends DeleteTranslationSignal
 {
-    /**
-     * Content ID.
-     *
-     * @var int
-     */
-    public $contentId;
-
-    /**
-     * Language Code of the removed translation.
-     *
-     * @var string
-     */
-    public $languageCode;
 }

--- a/eZ/Publish/Core/SignalSlot/Tests/ContentServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ContentServiceTest.php
@@ -296,7 +296,7 @@ class ContentServiceTest extends ServiceTest
                 0,
             ),
             array(
-                'removeTranslation',
+                'deleteTranslation',
                 array($contentInfo, $language),
                 null,
                 1,

--- a/eZ/Publish/Core/SignalSlot/Tests/ContentServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ContentServiceTest.php
@@ -17,7 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\TranslationInfo;
 use eZ\Publish\Core\Repository\Values\Content\TranslationValues;
 use eZ\Publish\Core\Repository\Values\Content\Relation;
 use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
-use eZ\Publish\Core\SignalSlot\Signal\ContentService\RemoveTranslationSignal;
+use eZ\Publish\Core\SignalSlot\Signal\ContentService\DeleteTranslationSignal;
 use eZ\Publish\Core\SignalSlot\SignalDispatcher;
 use eZ\Publish\Core\SignalSlot\ContentService;
 use eZ\Publish\Core\SignalSlot\Signal\ContentService as ContentServiceSignals;
@@ -299,8 +299,8 @@ class ContentServiceTest extends ServiceTest
                 'deleteTranslation',
                 array($contentInfo, $language),
                 null,
-                1,
-                RemoveTranslationSignal::class,
+                2,
+                DeleteTranslationSignal::class,
                 array('contentId' => $contentId, 'languageCode' => $language),
             ),
             array(

--- a/eZ/Publish/Core/settings/search_engines/elasticsearch/slots.yml
+++ b/eZ/Publish/Core/settings/search_engines/elasticsearch/slots.yml
@@ -21,7 +21,7 @@ parameters:
     ezpublish.search.elasticsearch.slot.set_content_state.class: eZ\Publish\Core\Search\Common\Slot\SetContentState
     ezpublish.search.elasticsearch.slot.swap_location.class: eZ\Publish\Core\Search\Common\Slot\SwapLocation
     ezpublish.search.elasticsearch.slot.update_content_metadata.class: eZ\Publish\Core\Search\Common\Slot\UpdateContentMetadata
-    ezpublish.search.elasticsearch.slot.remove_translation.class: eZ\Publish\Core\Search\Common\Slot\RemoveTranslation
+    ezpublish.search.elasticsearch.slot.delete_translation.class: eZ\Publish\Core\Search\Common\Slot\DeleteTranslation
     ezpublish.search.elasticsearch.slot.assign_section.class: eZ\Publish\Core\Search\Common\Slot\AssignSection
 
 
@@ -160,11 +160,11 @@ services:
         tags:
             - {name: ezpublish.search.elasticsearch.slot, signal: ContentService\UpdateContentMetadataSignal}
 
-    ezpublish.search.elasticsearch.slot.remove_translation:
+    ezpublish.search.elasticsearch.slot.delete_translation:
         parent: ezpublish.search.elasticsearch.slot
-        class: "%ezpublish.search.elasticsearch.slot.remove_translation.class%"
+        class: "%ezpublish.search.elasticsearch.slot.delete_translation.class%"
         tags:
-            - {name: ezpublish.search.elasticsearch.slot, signal: ContentService\RemoveTranslationSignal}
+            - {name: ezpublish.search.elasticsearch.slot, signal: ContentService\DeleteTranslationSignal}
 
     ezpublish.search.elasticsearch.slot.assign_section:
         parent: ezpublish.search.elasticsearch.slot

--- a/eZ/Publish/Core/settings/search_engines/legacy/slots.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/slots.yml
@@ -8,7 +8,7 @@ parameters:
     ezpublish.search.legacy.slot.trash.class: eZ\Publish\Core\Search\Common\Slot\Trash
     ezpublish.search.legacy.slot.recover.class: eZ\Publish\Core\Search\Common\Slot\Recover
     ezpublish.search.legacy.slot.update_content_metadata.class: eZ\Publish\Core\Search\Common\Slot\UpdateContentMetadata
-    ezpublish.search.legacy.slot.remove_translation.class: eZ\Publish\Core\Search\Common\Slot\RemoveTranslation
+    ezpublish.search.legacy.slot.delete_translation.class: eZ\Publish\Core\Search\Common\Slot\DeleteTranslation
     ezpublish.search.legacy.slot.assign_section.class: eZ\Publish\Core\Search\Common\Slot\AssignSection
     ezpublish.search.legacy.slot.create_user.class: eZ\Publish\Core\Search\Common\Slot\CreateUser
     ezpublish.search.legacy.slot.delete_user.class: eZ\Publish\Core\Search\Common\Slot\DeleteUser
@@ -72,11 +72,11 @@ services:
         tags:
             - {name: ezpublish.search.legacy.slot, signal: ContentService\UpdateContentMetadataSignal}
 
-    ezpublish.search.legacy.slot.remove_translation:
+    ezpublish.search.legacy.slot.delete_translation:
         parent: ezpublish.search.legacy.slot
-        class: "%ezpublish.search.legacy.slot.remove_translation.class%"
+        class: "%ezpublish.search.legacy.slot.delete_translation.class%"
         tags:
-            - {name: ezpublish.search.legacy.slot, signal: ContentService\RemoveTranslationSignal}
+            - {name: ezpublish.search.legacy.slot, signal: ContentService\DeleteTranslationSignal}
 
     ezpublish.search.legacy.slot.assign_section:
         parent: ezpublish.search.legacy.slot

--- a/eZ/Publish/SPI/Persistence/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Handler.php
@@ -262,10 +262,20 @@ interface Handler
     /**
      * Remove the specified translation from all the Versions of a Content Object.
      *
+     * @deprecated since 6.13, use {@see deleteTranslationFromContent} instead
+     *
      * @param int $contentId
      * @param string $languageCode language code of the translation
      */
     public function removeTranslationFromContent($contentId, $languageCode);
+
+    /**
+     * Delete the specified translation from all the Versions of a Content Object.
+     *
+     * @param int $contentId
+     * @param string $languageCode language code of the translation
+     */
+    public function deleteTranslationFromContent($contentId, $languageCode);
 
     /**
      * Remove the specified Translation from the given Version Draft of a Content Object.


### PR DESCRIPTION
# Implements [EZP-28028](https://jira.ez.no/browse/EZP-28028) 

This PR deprecates `ContentService::removeTranslation`  and introduces new name `ContentService::deleteTranslation` for this method to keep consistent naming in new stack.

**TODO**:
- [x] Rebase after #2144 gets merged (and remove TMP commit)
- [x] Rebase after #2128 gets merged (and remove TMP commit)
- [x] Rename methods in Gateway layer (no need for BC).
- [x] Rename SPI Persistence Content Handler methods (keeping BC).
- [x] Add `ContentService::deleteTranslation` method and deprecate `ContentService::removeTranslation` (keeping BC).
- [x] Refactor tests to use new method.
- [x] Rename `ezplatform:remove-content-translation` command to `ezplatform:delete-content-translation` to keep consistent naming // this was introduced by eaaf6e4 which belongs to `6.12` so no need to BC right now
- [x] Deprecate `RemoveTranslationSignal` and introduce `DeleteTranslationSignal`
- [x] Update Specification ([`removal.md`](https://github.com/ezsystems/ezpublish-kernel/blob/v6.11.4/doc/specifications/translations/removal.md))
- [x] Update deprecated since tag
- [x] Add BC note.
