### PR TITLE
EZP-25487: imageAlias.width and imageAlias.height fields not filled in

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGenerator.php
@@ -16,6 +16,7 @@ use eZ\Publish\SPI\Variation\Values\ImageVariation;
 use eZ\Publish\SPI\Variation\VariationHandler;
 use eZ\Publish\Core\FieldType\Value;
 use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
+use Imagine\Exception\RuntimeException;
 use Liip\ImagineBundle\Binary\BinaryInterface;
 use Liip\ImagineBundle\Binary\Loader\LoaderInterface;
 use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
@@ -23,6 +24,7 @@ use Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotResolvableException;
 use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
 use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
 use Liip\ImagineBundle\Imagine\Filter\FilterManager;
+use Imagine\Image\ImagineInterface;
 use Psr\Log\LoggerInterface;
 use InvalidArgumentException;
 use SplFileInfo;
@@ -63,17 +65,24 @@ class AliasGenerator implements VariationHandler
      */
     private $ioResolver;
 
+    /**
+     * @var \Imagine\Image\ImagineInterface;
+     */
+    private $imagine;
+
     public function __construct(
         LoaderInterface $dataLoader,
         FilterManager $filterManager,
         ResolverInterface $ioResolver,
         FilterConfiguration $filterConfiguration,
+        ImagineInterface $imagine,
         LoggerInterface $logger = null
     ) {
         $this->dataLoader = $dataLoader;
         $this->filterManager = $filterManager;
         $this->ioResolver = $ioResolver;
         $this->filterConfiguration = $filterConfiguration;
+        $this->imagine = $imagine;
         $this->logger = $logger;
     }
 
@@ -118,11 +127,16 @@ class AliasGenerator implements VariationHandler
         }
 
         try {
+            $resolvedPath = $this->ioResolver->resolve($originalPath, $variationName);
+            $image = $this->imagine->open($resolvedPath);
+            $dimensions = $image->getSize();
             $aliasInfo = new SplFileInfo(
-                $this->ioResolver->resolve($originalPath, $variationName)
+                $resolvedPath
             );
         } catch (NotResolvableException $e) {
             // If for some reason image alias cannot be resolved, throw the appropriate exception.
+            throw new InvalidVariationException($variationName, 'image', 0, $e);
+        } catch (RuntimeException $e) {
             throw new InvalidVariationException($variationName, 'image', 0, $e);
         }
 
@@ -133,6 +147,8 @@ class AliasGenerator implements VariationHandler
                 'dirPath' => $aliasInfo->getPath(),
                 'uri' => $aliasInfo->getPathname(),
                 'imageId' => $imageValue->imageId,
+                'width' => $dimensions->getWidth(),
+                'height' => $dimensions->getHeight(),
             )
         );
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -88,6 +88,7 @@ services:
             - "@liip_imagine.filter.manager"
             - "@ezpublish.image_alias.imagine.cache_resolver"
             - "@liip_imagine.filter.configuration"
+            - "@liip_imagine"
             - "@?logger"
 
     ezpublish.image_alias.imagine.alias_cleaner:

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasGeneratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasGeneratorTest.php
@@ -47,9 +47,24 @@ class AliasGeneratorTest extends TestCase
     private $logger;
 
     /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $imagine;
+
+    /**
      * @var AliasGenerator
      */
     private $aliasGenerator;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $box;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $image;
 
     protected function setUp()
     {
@@ -61,12 +76,16 @@ class AliasGeneratorTest extends TestCase
             ->getMock();
         $this->ioResolver = $this->getMock('\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface');
         $this->filterConfiguration = new FilterConfiguration();
+        $this->imagine = $this->getMock('\Imagine\Image\ImagineInterface');
         $this->logger = $this->getMock('\Psr\Log\LoggerInterface');
+        $this->box = $this->getMock('\Imagine\Image\BoxInterface');
+        $this->image = $this->getMock('\Imagine\Image\ImageInterface');
         $this->aliasGenerator = new AliasGenerator(
             $this->dataLoader,
             $this->filterManager,
             $this->ioResolver,
             $this->filterConfiguration,
+            $this->imagine,
             $this->logger
         );
     }
@@ -104,6 +123,8 @@ class AliasGeneratorTest extends TestCase
         $variationName = 'my_variation';
         $this->filterConfiguration->set($variationName, array());
         $imageId = '123-45';
+        $imageWidth = 300;
+        $imageHeight = 300;
         $imageValue = new ImageValue(array('id' => $originalPath, 'imageId' => $imageId));
         $field = new Field(array('value' => $imageValue));
         $expectedUrl = "http://localhost/foo/bar/image_$variationName.jpg";
@@ -139,6 +160,25 @@ class AliasGeneratorTest extends TestCase
             ->with($originalPath, $variationName)
             ->will($this->returnValue($expectedUrl));
 
+        $this->imagine
+            ->expects($this->once())
+            ->method('open')
+            ->with($expectedUrl)
+            ->will($this->returnValue($this->image));
+        $this->image
+            ->expects($this->once())
+            ->method('getSize')
+            ->will($this->returnValue($this->box));
+
+        $this->box
+            ->expects($this->once())
+            ->method('getWidth')
+            ->will($this->returnValue($imageWidth));
+        $this->box
+            ->expects($this->once())
+            ->method('getHeight')
+            ->will($this->returnValue($imageHeight));
+
         $expected = new ImageVariation(
             array(
                 'name' => $variationName,
@@ -146,6 +186,8 @@ class AliasGeneratorTest extends TestCase
                 'dirPath' => 'http://localhost/foo/bar',
                 'uri' => $expectedUrl,
                 'imageId' => $imageId,
+                'height' => $imageHeight,
+                'width' => $imageWidth,
             )
         );
         $this->assertEquals($expected, $this->aliasGenerator->getVariation($field, new VersionInfo(), $variationName));
@@ -156,6 +198,8 @@ class AliasGeneratorTest extends TestCase
         $originalPath = 'foo/bar/image.jpg';
         $variationName = 'original';
         $imageId = '123-45';
+        $imageWidth = 300;
+        $imageHeight = 300;
         $imageValue = new ImageValue(array('id' => $originalPath, 'imageId' => $imageId));
         $field = new Field(array('value' => $imageValue));
         $expectedUrl = 'http://localhost/foo/bar/image.jpg';
@@ -176,6 +220,25 @@ class AliasGeneratorTest extends TestCase
             ->with($originalPath, $variationName)
             ->will($this->returnValue($expectedUrl));
 
+        $this->imagine
+            ->expects($this->once())
+            ->method('open')
+            ->with($expectedUrl)
+            ->will($this->returnValue($this->image));
+        $this->image
+            ->expects($this->once())
+            ->method('getSize')
+            ->will($this->returnValue($this->box));
+
+        $this->box
+            ->expects($this->once())
+            ->method('getWidth')
+            ->will($this->returnValue($imageWidth));
+        $this->box
+            ->expects($this->once())
+            ->method('getHeight')
+            ->will($this->returnValue($imageHeight));
+
         $expected = new ImageVariation(
             array(
                 'name' => $variationName,
@@ -183,6 +246,8 @@ class AliasGeneratorTest extends TestCase
                 'dirPath' => 'http://localhost/foo/bar',
                 'uri' => $expectedUrl,
                 'imageId' => $imageId,
+                'height' => $imageHeight,
+                'width' => $imageWidth,
             )
         );
         $this->assertEquals($expected, $this->aliasGenerator->getVariation($field, new VersionInfo(), $variationName));
@@ -201,6 +266,8 @@ class AliasGeneratorTest extends TestCase
         $this->filterConfiguration->set($reference1, $configReference1);
         $this->filterConfiguration->set($reference2, $configReference2);
         $imageId = '123-45';
+        $imageWidth = 300;
+        $imageHeight = 300;
         $imageValue = new ImageValue(array('id' => $originalPath, 'imageId' => $imageId));
         $field = new Field(array('value' => $imageValue));
         $expectedUrl = "http://localhost/foo/bar/image_$variationName.jpg";
@@ -249,6 +316,25 @@ class AliasGeneratorTest extends TestCase
             ->with($originalPath, $variationName)
             ->will($this->returnValue($expectedUrl));
 
+        $this->imagine
+            ->expects($this->once())
+            ->method('open')
+            ->with($expectedUrl)
+            ->will($this->returnValue($this->image));
+        $this->image
+            ->expects($this->once())
+            ->method('getSize')
+            ->will($this->returnValue($this->box));
+
+        $this->box
+            ->expects($this->once())
+            ->method('getWidth')
+            ->will($this->returnValue($imageWidth));
+        $this->box
+            ->expects($this->once())
+            ->method('getHeight')
+            ->will($this->returnValue($imageHeight));
+
         $expected = new ImageVariation(
             array(
                 'name' => $variationName,
@@ -256,6 +342,8 @@ class AliasGeneratorTest extends TestCase
                 'dirPath' => 'http://localhost/foo/bar',
                 'uri' => $expectedUrl,
                 'imageId' => $imageId,
+                'width' => $imageWidth,
+                'height' => $imageHeight,
             )
         );
         $this->assertEquals($expected, $this->aliasGenerator->getVariation($field, new VersionInfo(), $variationName));
@@ -266,6 +354,8 @@ class AliasGeneratorTest extends TestCase
         $originalPath = 'foo/bar/image.jpg';
         $variationName = 'my_variation';
         $imageId = '123-45';
+        $imageWidth = 300;
+        $imageHeight = 300;
         $imageValue = new ImageValue(array('id' => $originalPath, 'imageId' => $imageId));
         $field = new Field(array('value' => $imageValue));
         $expectedUrl = "http://localhost/foo/bar/image_$variationName.jpg";
@@ -296,6 +386,25 @@ class AliasGeneratorTest extends TestCase
             ->with($originalPath, $variationName)
             ->will($this->returnValue($expectedUrl));
 
+        $this->imagine
+            ->expects($this->once())
+            ->method('open')
+            ->with($expectedUrl)
+            ->will($this->returnValue($this->image));
+        $this->image
+            ->expects($this->once())
+            ->method('getSize')
+            ->will($this->returnValue($this->box));
+
+        $this->box
+            ->expects($this->once())
+            ->method('getWidth')
+            ->will($this->returnValue($imageWidth));
+        $this->box
+            ->expects($this->once())
+            ->method('getHeight')
+            ->will($this->returnValue($imageHeight));
+
         $expected = new ImageVariation(
             array(
                 'name' => $variationName,
@@ -303,6 +412,8 @@ class AliasGeneratorTest extends TestCase
                 'dirPath' => 'http://localhost/foo/bar',
                 'uri' => $expectedUrl,
                 'imageId' => $imageId,
+                'width' => $imageWidth,
+                'height' => $imageHeight,
             )
         );
         $this->assertEquals($expected, $this->aliasGenerator->getVariation($field, new VersionInfo(), $variationName));


### PR DESCRIPTION
Reopened for generating temporary patch for the customer. 
Not for merge.