### PR TITLE
EZP-28123: Embedded content throws exception after it is moved to trash

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/FieldType/RichText/Renderer.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/RichText/Renderer.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\FieldType\RichText;
 
 use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\FieldType\RichText\RendererInterface;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
@@ -123,7 +124,24 @@ class Renderer implements RendererInterface
         $isDenied = false;
 
         try {
-            $this->checkContent($contentId);
+            /** @var \eZ\Publish\API\Repository\Values\Content\Content $content */
+            $content = $this->repository->sudo(
+                function (Repository $repository) use ($contentId) {
+                    return $repository->getContentService()->loadContent($contentId);
+                }
+            );
+
+            if (!$content->contentInfo->mainLocationId) {
+                if (isset($this->logger)) {
+                    $this->logger->error(
+                        "Could not render embedded resource: Content #{$contentId} is trashed."
+                    );
+                }
+
+                return null;
+            }
+
+            $this->checkContentPermissions($content);
         } catch (AccessDeniedException $e) {
             if (isset($this->logger)) {
                 $this->logger->error(
@@ -366,17 +384,30 @@ class Renderer implements RendererInterface
      *
      * @throws \Symfony\Component\Security\Core\Exception\AccessDeniedException
      *
-     * @param int|string $id
+     * @deprecated since 6.7
+     * @param int $contentId
      */
-    protected function checkContent($id)
+    protected function checkContent($contentId)
     {
         /** @var \eZ\Publish\API\Repository\Values\Content\Content $content */
         $content = $this->repository->sudo(
-            function (Repository $repository) use ($id) {
-                return $repository->getContentService()->loadContent($id);
+            function (Repository $repository) use ($contentId) {
+                return $repository->getContentService()->loadContent($contentId);
             }
         );
 
+        $this->checkContentPermissions($content);
+    }
+
+    /**
+     * Check embed permissions for the given Content.
+     *
+     * @throws \Symfony\Component\Security\Core\Exception\AccessDeniedException
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Content $content
+     */
+    protected function checkContentPermissions(Content $content)
+    {
         // Check both 'content/read' and 'content/view_embed'.
         if (
             !$this->authorizationChecker->isGranted(


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28123

## Description

This PR contains patch for exception `Cannot generate an UrlAlias route for content without main location` which is thrown when rendering richtext with an embedded object which is trashed. 

## Steps to reproduce

> 1. Create new eZ Platform installation.
> 2. In the back-office, create new Folder Content Type under "eZ Platform" named "Test Folder".
> 3. In the Media/Files, create new File Content Type named "Test File".
> 4. Edit the "Test Folder". In the "Description" field, embed the "Test file" using the "+" and "Embed" buttons from the Rich Text Editor. Publish "Test Folder".
> 5. In the front-office, navigate to "/Test-Folder". Confirm that the embedded Content Object "Test file" is also displayed.
> 6. In the backoffice, navigate to "Media/Files/Test file" and remove it by sending it to trash.
> 7. In the front-office, navigate to "/Test-Folder" again. If you are using "dev" environment, the above exception will be displayed.



