### PR TITLE
EZP-28203: image alias removal command not removing data from "ezdfsfile" table

### DIFF
--- a/eZ/Publish/Core/IO/IOMetadataHandler/LegacyDFSCluster.php
+++ b/eZ/Publish/Core/IO/IOMetadataHandler/LegacyDFSCluster.php
@@ -239,11 +239,23 @@ SQL
         return $row['datatype'];
     }
 
+    /**
+     * Delete directory and all the content under specified directory.
+     *
+     * @param string $spiPath SPI Path, not prefixed by URL decoration
+     */
     public function deleteDirectory($spiPath)
     {
-        $stmt = $this->db->prepare('DELETE FROM ezdfsfile WHERE name LIKE ?');
-        $stmt->bindValue(1, rtrim($spiPath, '/') . '/%');
-        $stmt->execute();
+        $query = $this->db->createQueryBuilder();
+        $query
+            ->delete('ezdfsfile')
+            ->where('name LIKE :spiPath ESCAPE :esc')
+            ->setParameter(':esc', '\\')
+            ->setParameter(
+                ':spiPath',
+                addcslashes($this->addPrefix(rtrim($spiPath, '/')), '%_') . '/%'
+            );
+        $query->execute();
     }
 
     /**


### PR DESCRIPTION
This PR fix command `liip:imagine:cache:remove --filters=filter_name` not removing metadata but only binary files.

short debug story for image alias "medium":
- IOVariationPurger::purge
```
$directory = "_aliases/$aliasName";
$this->io->deleteDirectory($directory);
// $directory = '_aliases/medium'
```
- IOService::deleteDirectory
```
$prefixedUri = $this->getPrefixedUri($path);
$this->metadataHandler->deleteDirectory($prefixedUri);
// $directory = 'images/_aliases/medium'
```
- LegacyDFSCluster::deleteDirectory
```
$stmt = $this->db->prepare('DELETE FROM ezdfsfile WHERE name LIKE ?');
$stmt->bindValue(1, rtrim($spiPath, '/') . '/%');
// $spiPath = 'images/_aliases/medium'
// sql: DELETE FROM ezdfsfile WHERE name LIKE "images/_aliases/medium/%"
// name in database: var/site/images/_aliases/medium/
```