### PR TITLE
EZP-28158: Test for EZP-28147 Updated user cannot log in

### DIFF
--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -13,10 +13,9 @@ use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
 use eZ\Publish\API\Repository\Values\User\UserGroupUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\UserUpdateStruct;
-use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
-use eZ\Publish\Core\Repository\Values\User\User;
 use eZ\Publish\Core\Repository\Values\User\UserGroup;
 use Exception;
 use ReflectionClass;
@@ -1627,7 +1626,7 @@ class UserServiceTest extends BaseTest
         $userVersion2 = $userService->updateUser($user, $userUpdate);
         /* END: Use Case */
 
-        $this->assertInstanceOf(APIUser::class, $user);
+        $this->assertInstanceOf(User::class, $user);
 
         $this->assertEquals(
             [
@@ -1683,7 +1682,7 @@ class UserServiceTest extends BaseTest
      * @see \eZ\Publish\API\Repository\UserService::updateUser()
      * @depends eZ\Publish\API\Repository\Tests\UserServiceTest::testUpdateUser
      */
-    public function testUpdateUserReturnsPublishedVersion($user)
+    public function testUpdateUserReturnsPublishedVersion(User $user)
     {
         $this->assertEquals(
             APIVersionInfo::STATUS_PUBLISHED,
@@ -1890,7 +1889,7 @@ class UserServiceTest extends BaseTest
         // This array will contain the email of the newly created "Editor" user
         $email = array();
         foreach ($userService->loadUsersOfUserGroup($group) as $user) {
-            $this->assertInstanceOf(APIUser::class, $user);
+            $this->assertInstanceOf(User::class, $user);
             $email[] = $user->email;
         }
         /* END: Use Case */

--- a/eZ/Publish/API/Repository/Values/User/User.php
+++ b/eZ/Publish/API/Repository/Values/User/User.php
@@ -23,6 +23,36 @@ use eZ\Publish\API\Repository\Values\Content\Content;
 abstract class User extends Content implements UserReference
 {
     /**
+     * @var int MD5 of password, not recommended
+     */
+    const PASSWORD_HASH_MD5_PASSWORD = 1;
+
+    /**
+     * @var int MD5 of user and password
+     */
+    const PASSWORD_HASH_MD5_USER = 2;
+
+    /**
+     * @var int MD5 of site, user and password
+     */
+    const PASSWORD_HASH_MD5_SITE = 3;
+
+    /**
+     * @var int Passwords in plaintext, should not be used for real sites
+     */
+    const PASSWORD_HASH_PLAINTEXT = 5;
+
+    /**
+     * @var int Passwords in bcrypt
+     */
+    const PASSWORD_HASH_BCRYPT = 6;
+
+    /**
+     * @var int Passwords hashed by PHPs default algorithm, which may change over time
+     */
+    const PASSWORD_HASH_PHP_DEFAULT = 7;
+
+    /**
      * User login.
      *
      * @var string

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -77,7 +77,7 @@ class UserService implements UserServiceInterface
             'defaultUserPlacement' => 12,
             'userClassID' => 4, // @todo Rename this settings to swap out "Class" for "Type"
             'userGroupClassID' => 3,
-            'hashType' => User::PASSWORD_HASH_PHP_DEFAULT,
+            'hashType' => APIUser::PASSWORD_HASH_PHP_DEFAULT,
             'siteName' => 'ez.no',
         );
     }
@@ -1125,8 +1125,8 @@ class UserService implements UserServiceInterface
     protected function verifyPassword($login, $password, $spiUser)
     {
         // In case of bcrypt let php's password functionality do it's magic
-        if ($spiUser->hashAlgorithm === User::PASSWORD_HASH_BCRYPT ||
-            $spiUser->hashAlgorithm === User::PASSWORD_HASH_PHP_DEFAULT) {
+        if ($spiUser->hashAlgorithm === APIUser::PASSWORD_HASH_BCRYPT ||
+            $spiUser->hashAlgorithm === APIUser::PASSWORD_HASH_PHP_DEFAULT) {
             return password_verify($password, $spiUser->passwordHash);
         }
 
@@ -1156,22 +1156,22 @@ class UserService implements UserServiceInterface
     protected function createPasswordHash($login, $password, $site, $type)
     {
         switch ($type) {
-            case User::PASSWORD_HASH_MD5_PASSWORD:
+            case APIUser::PASSWORD_HASH_MD5_PASSWORD:
                 return md5($password);
 
-            case User::PASSWORD_HASH_MD5_USER:
+            case APIUser::PASSWORD_HASH_MD5_USER:
                 return md5("$login\n$password");
 
-            case User::PASSWORD_HASH_MD5_SITE:
+            case APIUser::PASSWORD_HASH_MD5_SITE:
                 return md5("$login\n$password\n$site");
 
-            case User::PASSWORD_HASH_PLAINTEXT:
+            case APIUser::PASSWORD_HASH_PLAINTEXT:
                 return $password;
 
-            case User::PASSWORD_HASH_BCRYPT:
+            case APIUser::PASSWORD_HASH_BCRYPT:
                 return password_hash($password, PASSWORD_BCRYPT);
 
-            case User::PASSWORD_HASH_PHP_DEFAULT:
+            case APIUser::PASSWORD_HASH_PHP_DEFAULT:
                 return password_hash($password, PASSWORD_DEFAULT);
 
             default:

--- a/eZ/Publish/Core/Repository/Values/User/User.php
+++ b/eZ/Publish/Core/Repository/Values/User/User.php
@@ -18,36 +18,6 @@ use eZ\Publish\API\Repository\Values\User\User as APIUser;
 class User extends APIUser
 {
     /**
-     * @var int MD5 of password, not recommended
-     */
-    const PASSWORD_HASH_MD5_PASSWORD = 1;
-
-    /**
-     * @var int MD5 of user and password
-     */
-    const PASSWORD_HASH_MD5_USER = 2;
-
-    /**
-     * @var int MD5 of site, user and password
-     */
-    const PASSWORD_HASH_MD5_SITE = 3;
-
-    /**
-     * @var int Passwords in plaintext, should not be used for real sites
-     */
-    const PASSWORD_HASH_PLAINTEXT = 5;
-
-    /**
-     * @var int Passwords in bcrypt
-     */
-    const PASSWORD_HASH_BCRYPT = 6;
-
-    /**
-     * @var int Passwords hashed by PHPs default algorithm, which may change over time
-     */
-    const PASSWORD_HASH_PHP_DEFAULT = 7;
-
-    /**
      * Internal content representation.
      *
      * @var \eZ\Publish\API\Repository\Values\Content\Content


### PR DESCRIPTION
> Attempt at implementing https://jira.ez.no/browse/EZP-28158
> which is to add a test for https://jira.ez.no/browse/EZP-28147 aka. https://github.com/ezsystems/ezpublish-kernel/pull/2129
> Sent to QA

- [x] Test fails when reverting EZP-28147
- [x] Test passes when re-reverting EZP-28147