### PR TITLE
EZP-28243: Purge type using service id does not work

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
@@ -327,14 +327,20 @@ EOT;
 Http cache purge type.
 
 Cache purge for content/locations is triggered when needed (e.g. on publish) and will result in one or several Http PURGE requests.
-Can be "local" or "http" or a valid service ID:
+Can be "local", "http" or a valid symfony service id:
 - If "local" is used, an Http PURGE request will be emulated when needed (e.g. when using Symfony internal reverse proxy).
-- If "http" is used, only one Http BAN request will be sent, with X-Location-Id header containing locationIds to ban.
-  X-Location-Id consists in a Regexp containing locationIds to ban.
-  Examples:
+- If "http" is used, a full HTTP PURGE/BAN is done to a real reverse proxy (Varnish, ..) depending on your config
+- If custom symfony service id is used, then check documentation on that service for how it behaves and how you need to configure your system for it.
+
+If ezplatform-http-cache package is enabled (default as of 1.12 and up), then go to documentation on this package for further
+info on how it supports multiple response tagging, purges and allow plugins for custom purge types.
+
+If that is not enabled, then the (deprecated as of 1.8) default BAN based system will be used instead.
+Where ressponses can be tagged by a single  X-Location-Id header, and for purges a single Http BAN request will be sent,
+where X-Location-Id header consists of a Regexp containing locationIds to ban.
+  BAN Examples:
    - (123|456|789) => Purge locations #123, #456, #789.
    - .* => Purge all locations.
-- If a serviceId is provided, it must be defined in the ServiceContainer and must implement eZ\Publish\Core\MVC\Symfony\Cache\PurgeClientInterface.
 EOT;
 
         $rootNode

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -365,19 +365,7 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
 
         $purgeService = null;
         if (isset($config['http_cache']['purge_type'])) {
-            switch ($config['http_cache']['purge_type']) {
-                case 'local':
-                    $purgeService = 'ezpublish.http_cache.purge_client.local';
-                    break;
-                case 'http':
-                    $purgeService = 'ezpublish.http_cache.purge_client.fos';
-                    break;
-            }
-
             $container->setParameter('ezpublish.http_cache.purge_type', $config['http_cache']['purge_type']);
-            if ($purgeService !== null) {
-                $container->setAlias('ezpublish.http_cache.purge_client', $purgeService);
-            }
         }
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -363,6 +363,7 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
     {
         $loader->load('cache.yml');
 
+        $purgeService = null;
         if (isset($config['http_cache']['purge_type'])) {
             switch ($config['http_cache']['purge_type']) {
                 case 'local':
@@ -371,15 +372,12 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
                 case 'http':
                     $purgeService = 'ezpublish.http_cache.purge_client.fos';
                     break;
-                default:
-                    if (!$container->has($config['http_cache']['purge_type'])) {
-                        throw new \InvalidArgumentException("Invalid ezpublish.http_cache.purge_type. Can be 'single', 'multiple' or a valid service identifier implementing PurgeClientInterface.");
-                    }
-
-                    $purgeService = $config['http_cache']['purge_type'];
             }
 
-            $container->setAlias('ezpublish.http_cache.purge_client', $purgeService);
+            $container->setParameter('ezpublish.http_cache.purge_type', $config['http_cache']['purge_type']);
+            if ($purgeService !== null) {
+                $container->setAlias('ezpublish.http_cache.purge_client', $purgeService);
+            }
         }
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
@@ -231,56 +231,43 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
      * @dataProvider cacheConfigurationProvider
      *
      * @param array $customCacheConfig
-     * @param string $expectedPurgeService
-     * @param int $expectedTimeout
+     * @param string $expectedPurgeType
      */
-    public function testCacheConfiguration(array $customCacheConfig, $expectedPurgeService)
+    public function testCacheConfiguration(array $customCacheConfig, $expectedPurgeType)
     {
         $this->load($customCacheConfig);
 
-        $this->assertContainerBuilderHasAlias('ezpublish.http_cache.purge_client', $expectedPurgeService);
+        $this->assertContainerBuilderHasParameter('ezpublish.http_cache.purge_type', $expectedPurgeType);
     }
 
     public function cacheConfigurationProvider()
     {
         return array(
-            array(array(), 'ezpublish.http_cache.purge_client.local', 1),
+            array(array(), 'local'),
             array(
                 array(
                     'http_cache' => array('purge_type' => 'local'),
                 ),
-                'ezpublish.http_cache.purge_client.local',
+                'local',
             ),
             array(
                 array(
                     'http_cache' => array('purge_type' => 'multiple_http'),
                 ),
-                'ezpublish.http_cache.purge_client.fos',
+                'http',
             ),
             array(
                 array(
                     'http_cache' => array('purge_type' => 'single_http'),
                 ),
-                'ezpublish.http_cache.purge_client.fos',
+                'http',
             ),
             array(
                 array(
                     'http_cache' => array('purge_type' => 'http'),
                 ),
-                'ezpublish.http_cache.purge_client.fos',
+                'http',
             ),
-        );
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testCacheConfigurationWrongPurgeType()
-    {
-        $this->load(
-            array(
-                'http_cache' => array('purge_type' => 'foobar', 'timeout' => 12),
-            )
         );
     }
 
@@ -293,6 +280,8 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                 'http_cache' => array('purge_type' => 'foobar', 'timeout' => 12),
             )
         );
+
+        $this->assertContainerBuilderHasParameter('ezpublish.http_cache.purge_type', 'foobar');
     }
 
     public function testLocaleConfiguration()


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-28243

1. Fixes so it is possible to use this setting as documented in semantic config help text.
2. Make it possible to add plugin system for ezplatform-http-cache in order to add Fasly support: https://github.com/ezsystems/ezplatform-http-cache/pull/19