### PR TITLE
EZP-28160: Added HTTP Cache purge after copying subtree

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/slot.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/slot.yml
@@ -2,6 +2,7 @@ parameters:
     ezpublish.http_cache.signalslot.http_cache.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\HttpCacheSlot
     ezpublish.http_cache.signalslot.assign_section.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\AssignSectionSlot
     ezpublish.http_cache.signalslot.copy_content.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\CopyContentSlot
+    ezpublish.http_cache.signalslot.copy_subtree.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\CopySubtreeSlot
     ezpublish.http_cache.signalslot.create_location.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\CreateLocationSlot
     ezpublish.http_cache.signalslot.delete_content.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\DeleteContentSlot
     ezpublish.http_cache.signalslot.delete_location.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\DeleteLocationSlot
@@ -36,6 +37,12 @@ services:
         parent: ezpublish.http_cache.signalslot.http_cache
         tags:
             - { name: ezpublish.api.slot, signal: ContentService\CopyContentSignal }
+
+    ezpublish.http_cache.signalslot.copy_subtree:
+        class: '%ezpublish.http_cache.signalslot.copy_subtree.class%'
+        parent: ezpublish.http_cache.signalslot.http_cache
+        tags:
+            - { name: ezpublish.api.slot, signal: LocationService\CopySubtreeSignal }
 
     ezpublish.http_cache.signalslot.create_location:
         class: "%ezpublish.http_cache.signalslot.create_location.class%"

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/CopySubtreeSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/CopySubtreeSlot.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling CopySubtreeSignal.
+ *
+ * @deprecated since 6.8. The platform-http-cache package defines slots for http-cache multi-tagging.
+ */
+class CopySubtreeSlot extends HttpCacheSlot
+{
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\LocationService\CopySubtreeSignal;
+    }
+
+    protected function purgeHttpCache(Signal $signal)
+    {
+        /** @var Signal\LocationService\CopySubtreeSignal $signal */
+        $this->httpCacheClearer->purge([
+            $signal->targetParentLocationId,
+        ]);
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/CopySubtreeSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/CopySubtreeSlotTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
+
+use eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\CopySubtreeSlot;
+use eZ\Publish\Core\SignalSlot\Signal\LocationService\CopySubtreeSignal;
+
+class CopySubtreeSlotTest extends AbstractSlotTest
+{
+    protected static $locationIds = [43];
+
+    /**
+     * @dataProvider getReceivedSignals
+     */
+    public function testReceivePurgesCacheForLocations($signal)
+    {
+        $this->cachePurgerMock->expects($this->once())
+            ->method('purge')
+            ->with(self::$locationIds);
+
+        $this->cachePurgerMock->expects($this->never())->method('purgeAll');
+
+        parent::receive($signal);
+    }
+
+    public static function createSignal()
+    {
+        return new CopySubtreeSignal([
+            'subtreeId' => 67,
+            'targetParentLocationId' => 43,
+            'targetNewSubtreeId' => 45,
+        ]);
+    }
+
+    public function getSlotClass()
+    {
+        return CopySubtreeSlot::class;
+    }
+
+    public static function getReceivedSignalClasses()
+    {
+        return [CopySubtreeSignal::class];
+    }
+}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28160

## Description

This PR adds a missing HTTP Cache purging after the subtree copying. Discovered while testing https://github.com/ezsystems/PlatformUIBundle/pull/893#issuecomment-340418960 

Similar to https://github.com/ezsystems/ezplatform-http-cache/pull/18

## Steps to reproduce

> 1. Create the following structure:
> a) Home/Folder A
> b) Home/Folder A/Folder B
> c) Home/Folder A/Folder B/Article
> 2. Copy subtree Folder B into Folder A
> 3. Copy subtree Folder B into Folder A again
> 4. Go to location view for Folder A
> 5. The pagination is broken (see attached screenshot) because childCount in response to GET /api/ezp/v2/content/location/X/Y is out of date.