### PR TITLE
EZP-28175: Fix configresolver merge order

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/Contextualizer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/Contextualizer.php
@@ -136,19 +136,19 @@ class Contextualizer implements ContextualizerInterface
                         }
                     } else {
                         $mergedSettings[$key] = array_merge(
-                            isset($defaultSettings[$key]) ? $defaultSettings[$key] : array(),
-                            isset($groupsSettings[$key]) ? $groupsSettings[$key] : array(),
+                            isset($globalSettings[$key]) ? $globalSettings[$key] : array(),
                             isset($scopeSettings[$key]) ? $scopeSettings[$key] : array(),
-                            isset($globalSettings[$key]) ? $globalSettings[$key] : array()
+                            isset($groupsSettings[$key]) ? $groupsSettings[$key] : array(),
+                            isset($defaultSettings[$key]) ? $defaultSettings[$key] : array()
                         );
                     }
                 }
             } else {
                 $mergedSettings = array_merge(
-                    $defaultSettings,
-                    $groupsSettings,
+                    $globalSettings,
                     $scopeSettings,
-                    $globalSettings
+                    $groupsSettings,
+                    $defaultSettings
                 );
             }
 


### PR DESCRIPTION
Languages are not kept in the correct order when using config resolver.

Ensuring that when the parameters are merged that they follow the expected order.

Example:

site group has languages [eng-GB]
site has languages [fre-FR]

Languages should have the finale value [fre-FR, eng-GB] but because the merge order is reversed you get [eng-GB,eng-FR].

This makes the wrong language have precedence.
