### PR TITLE
EZP-28177: Tolerant and self healing Search service

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
@@ -10,6 +10,7 @@ namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\Repository\Values\User\UserReference;
+use eZ\Publish\Core\Search\Common\BackgroundIndexer;
 use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
 use eZ\Publish\SPI\Search\Handler as SearchHandler;
 use eZ\Publish\SPI\Limitation\Type as SPILimitationType;
@@ -82,16 +83,21 @@ class RepositoryFactory implements ContainerAwareInterface
      *
      * @param \eZ\Publish\SPI\Persistence\Handler $persistenceHandler
      * @param \eZ\Publish\SPI\Search\Handler $searchHandler
+     * @param \eZ\Publish\Core\Search\Common\BackgroundIndexer $backgroundIndexer
      *
      * @return \eZ\Publish\API\Repository\Repository
      */
-    public function buildRepository(PersistenceHandler $persistenceHandler, SearchHandler $searchHandler)
-    {
+    public function buildRepository(
+        PersistenceHandler $persistenceHandler,
+        SearchHandler $searchHandler,
+        BackgroundIndexer $backgroundIndexer
+    ) {
         $config = $this->container->get('ezpublish.api.repository_configuration_provider')->getRepositoryConfig();
 
         $repository = new $this->repositoryClass(
             $persistenceHandler,
             $searchHandler,
+            $backgroundIndexer,
             array(
                 'fieldType' => $this->fieldTypeCollectionFactory->getFieldTypes(),
                 'nameableFieldTypes' => $this->fieldTypeNameableCollectionFactory->getNameableFieldTypes(),

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/BackgroundIndexingTerminateListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/BackgroundIndexingTerminateListener.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\EventListener;
+
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\Core\Search\Common\BackgroundIndexer as BackgroundIndexerInterface;
+use eZ\Publish\SPI\Persistence\Content\ContentInfo;
+use eZ\Publish\SPI\Persistence\Content\Location;
+use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
+use eZ\Publish\SPI\Search\Handler as SearchHandler;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Kernel and Console terminate event based background indexer.
+ */
+class BackgroundIndexingTerminateListener implements BackgroundIndexerInterface, EventSubscriberInterface
+{
+    use LoggerAwareTrait;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Handler
+     */
+    protected $persistenceHandler;
+
+    /**
+     * @var \eZ\Publish\SPI\Search\Handler
+     */
+    protected $searchHandler;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\ContentInfo[]
+     */
+    protected $contentInfo = [];
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Location[]
+     */
+    protected $locations = [];
+
+    public function __construct(PersistenceHandler $persistenceHandler, SearchHandler $searchHandler)
+    {
+        $this->persistenceHandler = $persistenceHandler;
+        $this->searchHandler = $searchHandler;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function registerContent(ContentInfo $contentInfo)
+    {
+        $this->contentInfo[] = $contentInfo;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function registerLocation(Location $location)
+    {
+        $this->locations[] = $location;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::TERMINATE => 'reindex',
+            KernelEvents::EXCEPTION => 'reindex',
+            ConsoleEvents::TERMINATE => 'reindex',
+        ];
+    }
+
+    public function reindex()
+    {
+        $contentHandler = $this->persistenceHandler->contentHandler();
+        $contentIndexed = [];
+        $contentRemoved = [];
+        foreach ($this->contentInfo as $contentInfo) {
+            try {
+                // In case version has changed we make sure to fetch fresh ContentInfo
+                $contentInfo = $contentHandler->loadContentInfo($contentInfo->id);
+                if ($contentInfo->isPublished && empty($contentIndexed[$contentInfo->id])) {
+                    $this->searchHandler->indexContent(
+                        $contentHandler->load($contentInfo->id, $contentInfo->currentVersionNo)
+                    );
+                    $contentIndexed[$contentInfo->id] = true;
+                    continue;
+                }
+            } catch (NotFoundException $e) {
+                // Catch this so we delete the index for this content below
+            }
+
+            $this->searchHandler->deleteContent($contentInfo->id);
+            if ($contentInfo->mainLocationId) {
+                $this->searchHandler->deleteLocation($contentInfo->mainLocationId, $contentInfo->id);
+            }
+            $contentRemoved[] = $contentInfo->id;
+        }
+        $this->contentInfo = [];
+
+        foreach ($this->locations as $location) {
+            try {
+                // In case version has changed we make sure to fetch fresh ContentInfo
+                $contentInfo = $contentHandler->loadContentInfo($location->contentId);
+                if ($contentInfo->isPublished && empty($contentIndexed[$contentInfo->id])) {
+                    $this->searchHandler->indexContent(
+                        $contentHandler->load($contentInfo->id, $contentInfo->currentVersionNo)
+                    );
+                    $contentIndexed[$contentInfo->id] = true;
+                    continue;
+                }
+            } catch (NotFoundException $e) {
+                // Catch this so we delete the index for this content below
+            }
+
+            $this->searchHandler->deleteContent($location->contentId);
+            $this->searchHandler->deleteLocation($location->id, $location->contentId);
+            $contentRemoved[] = $location->contentId;
+        }
+        $this->locations = [];
+
+        if ($this->logger instanceof LoggerInterface) {
+            $this->logger->warning(
+                sprintf(
+                    'Exceptions detected on search index, content %s  was re indexed, & %s was removed from index',
+                    implode(', ', array_keys($contentIndexed)),
+                    implode(', ', $contentRemoved)
+                )
+            );
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
@@ -100,3 +100,12 @@ services:
             - "%ezpublish.signalslot.signal_dispatcher.class%"
             - "$repository$"
             - "%ezpublish.repositories%"
+
+    # Redefine background indexer to the one provided here which works on kernel/console.terminate.
+    ezpublish.search.background_indexer:
+        class: eZ\Bundle\EzPublishCoreBundle\EventListener\BackgroundIndexingTerminateListener
+        arguments:
+            - '@ezpublish.api.persistence_handler'
+            - '@ezpublish.spi.search'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -170,6 +170,14 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    ezpublish.search.background_indexer:
+        class: eZ\Bundle\EzPublishCoreBundle\EventListener\BackgroundIndexingTerminateListener
+        arguments:
+            - '@ezpublish.api.persistence_handler'
+            - '@ezpublish.spi.search'
+        tags:
+            - { name: kernel.event_subscriber }
+
     ezpublish.query_type.registry:
         class: eZ\Publish\Core\QueryType\ArrayQueryTypeRegistry
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -170,14 +170,6 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
-    ezpublish.search.background_indexer:
-        class: eZ\Bundle\EzPublishCoreBundle\EventListener\BackgroundIndexingTerminateListener
-        arguments:
-            - '@ezpublish.api.persistence_handler'
-            - '@ezpublish.spi.search'
-        tags:
-            - { name: kernel.event_subscriber }
-
     ezpublish.query_type.registry:
         class: eZ\Publish\Core\QueryType\ArrayQueryTypeRegistry
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/BackgroundIndexingTerminateListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/BackgroundIndexingTerminateListenerTest.php
@@ -1,0 +1,235 @@
+<?php
+
+/**
+ * File containing the BackgroundIndexingTerminateListenerTest class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;
+
+use eZ\Bundle\EzPublishCoreBundle\EventListener\BackgroundIndexingTerminateListener;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
+use eZ\Publish\SPI\Persistence\Content;
+use eZ\Publish\SPI\Persistence\Content\ContentInfo;
+use eZ\Publish\SPI\Persistence\Content\Location;
+use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
+use eZ\Publish\SPI\Search\Handler as SearchHandler;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class BackgroundIndexingTerminateListenerTest extends TestCase
+{
+    use PHPUnit5CompatTrait;
+
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\EventListener\BackgroundIndexingTerminateListener
+     */
+    protected $listener;
+
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Handler|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $persistenceMock;
+
+    /**
+     * @var \eZ\Publish\SPI\Search\Handler|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $searchMock;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->persistenceMock = $this->createMock(PersistenceHandler::class);
+        $this->searchMock = $this->createMock(SearchHandler::class);
+        $this->listener = new BackgroundIndexingTerminateListener(
+            $this->persistenceMock,
+            $this->searchMock
+        );
+    }
+
+    protected function tearDown()
+    {
+        unset($this->persistenceMock, $this->searchMock, $this->listener);
+        parent::tearDown();
+    }
+
+    public function testGetSubscribedEvents()
+    {
+        self::assertSame(
+            [
+                KernelEvents::TERMINATE => 'reindex',
+                KernelEvents::EXCEPTION => 'reindex',
+                ConsoleEvents::TERMINATE => 'reindex',
+            ],
+            BackgroundIndexingTerminateListener::getSubscribedEvents()
+        );
+    }
+
+    public function indexingProvider()
+    {
+        $info = new ContentInfo(['id' => 33]);
+        $location = new Location(['id' => 44, 'contentId' => 33]);
+
+        return [
+            [[$location]],
+            [[$location], $this->createMock(LoggerInterface::class)],
+            [[$info]],
+            [[$info], $this->createMock(LoggerInterface::class)],
+            [null],
+            [null, $this->createMock(LoggerInterface::class)],
+            [[$location, $info]],
+            [[$info, $location], $this->createMock(LoggerInterface::class)],
+        ];
+    }
+
+    /**
+     * @dataProvider indexingProvider
+     *
+     * @param array|null $value
+     * @param \Psr\Log\LoggerInterface|\PHPUnit_Framework_MockObject_MockObject|null $logger
+     */
+    public function testIndexing(array $values = null, $logger = null)
+    {
+        $contentHandlerMock = $this->createMock(Content\Handler::class);
+        $this->persistenceMock
+            ->expects($this->once())
+            ->method('contentHandler')
+            ->willReturn($contentHandlerMock);
+
+        if ($values) {
+            $contentHandlerMock
+                ->expects($this->once())
+                ->method('loadContentInfo')
+                ->with(33)
+                ->willReturn(new ContentInfo(['id' => 33, 'currentVersionNo' => 2, 'isPublished' => true]));
+
+            $contentHandlerMock
+                ->expects($this->once())
+                ->method('load')
+                ->with(33, 2)
+                ->willReturn(new Content());
+
+            $this->searchMock
+                ->expects($this->once())
+                ->method('indexContent')
+                ->with($this->isInstanceOf(Content::class));
+
+            $this->searchMock->expects($this->never())->method('indexLocation');
+            $this->searchMock->expects($this->never())->method('deleteContent');
+            $this->searchMock->expects($this->never())->method('deleteLocation');
+        } else {
+            $contentHandlerMock->expects($this->never())->method($this->anything());
+            $this->searchMock->expects($this->never())->method($this->anything());
+        }
+
+        foreach ((array) $values as $value) {
+            if ($value instanceof Location) {
+                $this->listener->registerLocation($value);
+            } elseif ($value instanceof ContentInfo) {
+                $this->listener->registerContent($value);
+            }
+        }
+
+        if ($logger) {
+            $this->listener->setLogger($logger);
+
+            if ($values) {
+                $logger->expects($this->once())
+                    ->method('warning')
+                    ->with($this->isType('string'));
+            } else {
+                $logger->expects($this->never())
+                    ->method('warning');
+            }
+        }
+
+        $this->listener->reindex();
+    }
+
+    public function indexDeleteProvider()
+    {
+        $location = new Location(['id' => 44, 'contentId' => 33]);
+        $info = new ContentInfo(['id' => 33, 'currentVersionNo' => 2, 'isPublished' => true]);
+
+        $infoReturn = $this->returnValue($info);
+        $infoReturnUnPublished = $this->returnValue(new ContentInfo(['id' => 33, 'currentVersionNo' => 2]));
+        $returnThrow = $this->throwException(new NotFoundException('content', '33'));
+
+        return [
+            [$location, $infoReturn, $returnThrow],
+            [$location, $returnThrow],
+            [$location, $infoReturnUnPublished],
+
+            [$info, $infoReturn, $returnThrow],
+            [$info, $returnThrow],
+            [$info, $infoReturnUnPublished],
+        ];
+    }
+
+    /**
+     * @dataProvider indexDeleteProvider
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\ContentInfo|\eZ\Publish\SPI\Persistence\Content\Location $value
+     * @param \PHPUnit_Framework_MockObject_Stub $infoReturn
+     * @param \PHPUnit_Framework_MockObject_Stub|null $contentReturn
+     */
+    public function testIndexDelete($value, $infoReturn, $contentReturn = null)
+    {
+        $contentHandlerMock = $this->createMock(Content\Handler::class);
+        $this->persistenceMock
+            ->expects($this->once())
+            ->method('contentHandler')
+            ->willReturn($contentHandlerMock);
+
+        $contentHandlerMock
+            ->expects($this->once())
+            ->method('loadContentInfo')
+            ->with(33)
+            ->will($infoReturn);
+
+        if ($contentReturn) {
+            $contentHandlerMock
+                ->expects($this->once())
+                ->method('load')
+                ->with(33, 2)
+                ->will($contentReturn);
+        } else {
+            $contentHandlerMock
+                ->expects($this->never())
+                ->method('load');
+        }
+
+        $this->searchMock->expects($this->never())->method('indexContent');
+        $this->searchMock->expects($this->never())->method('indexLocation');
+
+        if ($value instanceof Location) {
+            $contentId = $value->contentId;
+            $locationId = $value->id;
+            $this->listener->registerLocation($value);
+        } else {
+            $contentId = $value->id;
+            $locationId = $value->mainLocationId;
+            $this->listener->registerContent($value);
+        }
+
+        $this->searchMock
+            ->expects($this->once())
+            ->method('deleteContent')
+            ->with($contentId);
+
+        if ($locationId) {
+            $this->searchMock
+                ->expects($this->once())
+                ->method('deleteLocation')
+                ->with($locationId);
+        } else {
+            $this->searchMock->expects($this->never())->method('deleteLocation');
+        }
+
+        $this->listener->reindex();
+    }
+}

--- a/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\Base\Container\ApiLoader;
 
 use eZ\Publish\Core\Repository\Values\User\UserReference;
+use eZ\Publish\Core\Search\Common\BackgroundIndexer;
 use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
 use eZ\Publish\SPI\Search\Handler as SearchHandler;
 use eZ\Publish\SPI\Limitation\Type as SPILimitationType;
@@ -65,14 +66,19 @@ class RepositoryFactory implements ContainerAwareInterface
      *
      * @param \eZ\Publish\SPI\Persistence\Handler $persistenceHandler
      * @param \eZ\Publish\SPI\Search\Handler $searchHandler
+     * @param \eZ\Publish\Core\Search\Common\BackgroundIndexer $backgroundIndexer
      *
      * @return \eZ\Publish\API\Repository\Repository
      */
-    public function buildRepository(PersistenceHandler $persistenceHandler, SearchHandler $searchHandler)
-    {
+    public function buildRepository(
+        PersistenceHandler $persistenceHandler,
+        SearchHandler $searchHandler,
+        BackgroundIndexer $backgroundIndexer
+    ) {
         $repository = new $this->repositoryClass(
             $persistenceHandler,
             $searchHandler,
+            $backgroundIndexer,
             array(
                 'fieldType' => $this->fieldTypeCollectionFactory->getFieldTypes(),
                 'nameableFieldTypes' => $this->fieldTypeNameableCollectionFactory->getNameableFieldTypes(),

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -17,6 +17,7 @@ use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\Core\Repository\Permission\CachedPermissionService;
 use eZ\Publish\Core\Repository\Permission\PermissionCriterionResolver;
 use eZ\Publish\Core\Repository\Values\User\UserReference;
+use eZ\Publish\Core\Search\Common\BackgroundIndexer;
 use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
 use eZ\Publish\SPI\Search\Handler as SearchHandler;
 use Exception;
@@ -219,6 +220,11 @@ class Repository implements RepositoryInterface
     protected $permissionsHandler;
 
     /**
+     * @var \eZ\Publish\Core\Search\Common\BackgroundIndexer|null
+     */
+    protected $backgroundIndexer;
+
+    /**
      * Array of arrays of commit events indexed by the transaction count.
      *
      * @var array
@@ -248,11 +254,13 @@ class Repository implements RepositoryInterface
     public function __construct(
         PersistenceHandler $persistenceHandler,
         SearchHandler $searchHandler,
+        BackgroundIndexer $backgroundIndexer,
         array $serviceSettings = array(),
         APIUserReference $user = null
     ) {
         $this->persistenceHandler = $persistenceHandler;
         $this->searchHandler = $searchHandler;
+        $this->backgroundIndexer = $backgroundIndexer;
         $this->serviceSettings = $serviceSettings + array(
             'content' => array(),
             'contentType' => array(),
@@ -730,6 +738,7 @@ class Repository implements RepositoryInterface
             $this->searchHandler,
             $this->getDomainMapper(),
             $this->getPermissionCriterionResolver(),
+            $this->backgroundIndexer,
             $this->serviceSettings['search']
         );
 

--- a/eZ/Publish/Core/Repository/SearchService.php
+++ b/eZ/Publish/Core/Repository/SearchService.php
@@ -120,7 +120,7 @@ class SearchService implements SearchServiceInterface
                 );
             } catch (APINotFoundException $e) {
                 // Most likely stale data, so we register content for background re-indexing.
-                $this->backgroundIndexer->registerForRefresh($hit->valueObject);
+                $this->backgroundIndexer->registerContent($hit->valueObject);
                 unset($result->searchHits[$key]);
                 --$result->totalCount;
             } catch (APIUnauthorizedException $e) {
@@ -340,7 +340,7 @@ class SearchService implements SearchServiceInterface
                 );
             } catch (APINotFoundException $e) {
                 // Most likely stale data, so we register content for background re-indexing.
-                $this->backgroundIndexer->registerForRefresh($hit->valueObject);
+                $this->backgroundIndexer->registerLocation($hit->valueObject);
                 unset($result->searchHits[$key]);
                 --$result->totalCount;
             } catch (APIUnauthorizedException $e) {

--- a/eZ/Publish/Core/Repository/SearchService.php
+++ b/eZ/Publish/Core/Repository/SearchService.php
@@ -19,9 +19,12 @@ use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException as APIUnauthorizedException;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\Search\Common\BackgroundIndexer;
 use eZ\Publish\SPI\Search\Handler;
 
 /**
@@ -55,12 +58,18 @@ class SearchService implements SearchServiceInterface
     protected $permissionCriterionResolver;
 
     /**
+     * @var \eZ\Publish\Core\Search\Common\BackgroundIndexer
+     */
+    protected $backgroundIndexer;
+
+    /**
      * Setups service with reference to repository object that created it & corresponding handler.
      *
      * @param \eZ\Publish\API\Repository\Repository $repository
      * @param \eZ\Publish\SPI\Search\Handler $searchHandler
      * @param \eZ\Publish\Core\Repository\Helper\DomainMapper $domainMapper
      * @param \eZ\Publish\API\Repository\PermissionCriterionResolver $permissionCriterionResolver
+     * @param \eZ\Publish\Core\Search\Common\BackgroundIndexer $backgroundIndexer
      * @param array $settings
      */
     public function __construct(
@@ -68,6 +77,7 @@ class SearchService implements SearchServiceInterface
         Handler $searchHandler,
         Helper\DomainMapper $domainMapper,
         PermissionCriterionResolver $permissionCriterionResolver,
+        BackgroundIndexer $backgroundIndexer,
         array $settings = array()
     ) {
         $this->repository = $repository;
@@ -78,6 +88,7 @@ class SearchService implements SearchServiceInterface
             //'defaultSetting' => array(),
         );
         $this->permissionCriterionResolver = $permissionCriterionResolver;
+        $this->backgroundIndexer = $backgroundIndexer;
     }
 
     /**
@@ -97,15 +108,26 @@ class SearchService implements SearchServiceInterface
     {
         $contentService = $this->repository->getContentService();
         $result = $this->internalFindContentInfo($query, $languageFilter, $filterOnUserPermissions);
-        foreach ($result->searchHits as $hit) {
-            // As we get ContentInfo from SPI, we need to load full content (avoids getting stale content data)
-            $hit->valueObject = $contentService->internalLoadContent(
-                $hit->valueObject->id,
-                (!empty($languageFilter['languages']) ? $languageFilter['languages'] : null),
-                null,
-                false,
-                (isset($languageFilter['useAlwaysAvailable']) ? $languageFilter['useAlwaysAvailable'] : true)
-            );
+        foreach ($result->searchHits as $key => $hit) {
+            try {
+                // As we get ContentInfo from SPI, we need to load full content (avoids getting stale content data)
+                $hit->valueObject = $contentService->internalLoadContent(
+                    $hit->valueObject->id,
+                    (!empty($languageFilter['languages']) ? $languageFilter['languages'] : null),
+                    null,
+                    false,
+                    (isset($languageFilter['useAlwaysAvailable']) ? $languageFilter['useAlwaysAvailable'] : true)
+                );
+            } catch (APINotFoundException $e) {
+                // Most likely stale data, so we register content for background re-indexing.
+                $this->backgroundIndexer->registerForRefresh($hit->valueObject);
+                unset($result->searchHits[$key]);
+                --$result->totalCount;
+            } catch (APIUnauthorizedException $e) {
+                // Most likely stale cached permission criterion, as ttl is only a few seconds we don't react to this
+                unset($result->searchHits[$key]);
+                --$result->totalCount;
+            }
         }
 
         return $result;
@@ -311,10 +333,21 @@ class SearchService implements SearchServiceInterface
 
         $result = $this->searchHandler->findLocations($query, $languageFilter);
 
-        foreach ($result->searchHits as $hit) {
-            $hit->valueObject = $this->domainMapper->buildLocationDomainObject(
-                $hit->valueObject
-            );
+        foreach ($result->searchHits as $key => $hit) {
+            try {
+                $hit->valueObject = $this->domainMapper->buildLocationDomainObject(
+                    $hit->valueObject
+                );
+            } catch (APINotFoundException $e) {
+                // Most likely stale data, so we register content for background re-indexing.
+                $this->backgroundIndexer->registerForRefresh($hit->valueObject);
+                unset($result->searchHits[$key]);
+                --$result->totalCount;
+            } catch (APIUnauthorizedException $e) {
+                // Most likely stale cached permission criterion, as ttl is only a few seconds we don't react to this
+                unset($result->searchHits[$key]);
+                --$result->totalCount;
+            }
         }
 
         return $result;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 
+use eZ\Publish\Core\Search\Common\BackgroundIndexer\NullIndexer;
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\Repository\Repository;
 use eZ\Publish\Core\Repository\Values\Content\Content;
@@ -57,6 +58,7 @@ abstract class Base extends TestCase
             $repository = new Repository(
                 $this->getPersistenceMock(),
                 $this->getSPIMockHandler('Search\\Handler'),
+                new NullIndexer(),
                 $serviceSettings,
                 $this->getStubbedUser(14)
             );

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 
+use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
 use eZ\Publish\Core\Search\Common\BackgroundIndexer\NullIndexer;
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\Repository\Repository;
@@ -21,6 +22,8 @@ use eZ\Publish\Core\Repository\Values\User\User;
  */
 abstract class Base extends TestCase
 {
+    use PHPUnit5CompatTrait;
+
     /**
      * @var \eZ\Publish\API\Repository\Repository
      */

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
@@ -17,6 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use eZ\Publish\Core\Search\Common\BackgroundIndexer\NullIndexer;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo as SPIContentInfo;
 use eZ\Publish\SPI\Persistence\Content\Location as SPILocation;
 use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
@@ -52,6 +53,7 @@ class SearchTest extends BaseServiceMockTest
             $searchHandlerMock,
             $domainMapperMock,
             $permissionsCriterionResolverMock,
+            new NullIndexer(),
             $settings
         );
 
@@ -132,6 +134,7 @@ class SearchTest extends BaseServiceMockTest
             $searchHandlerMock,
             $this->getDomainMapperMock(),
             $permissionsCriterionResolverMock,
+            new NullIndexer(),
             array()
         );
 
@@ -178,6 +181,7 @@ class SearchTest extends BaseServiceMockTest
             $searchHandlerMock,
             $this->getDomainMapperMock(),
             $permissionsCriterionResolverMock,
+            new NullIndexer(),
             array()
         );
 
@@ -211,6 +215,7 @@ class SearchTest extends BaseServiceMockTest
             $searchHandlerMock,
             $this->getDomainMapperMock(),
             $permissionsCriterionResolverMock,
+            new NullIndexer(),
             array()
         );
 
@@ -247,6 +252,7 @@ class SearchTest extends BaseServiceMockTest
             $searchHandlerMock,
             $domainMapperMock,
             $permissionsCriterionResolverMock,
+            new NullIndexer(),
             array()
         );
 
@@ -321,6 +327,7 @@ class SearchTest extends BaseServiceMockTest
             $searchHandlerMock,
             $domainMapperMock,
             $permissionsCriterionResolverMock,
+            new NullIndexer(),
             array()
         );
 
@@ -403,6 +410,7 @@ class SearchTest extends BaseServiceMockTest
             $searchHandlerMock,
             $this->getDomainMapperMock(),
             $permissionsCriterionResolverMock,
+            new NullIndexer(),
             array()
         );
 
@@ -442,6 +450,7 @@ class SearchTest extends BaseServiceMockTest
             $searchHandlerMock,
             $domainMapperMock,
             $this->getPermissionCriterionResolverMock(),
+            new NullIndexer(),
             array()
         );
 
@@ -522,6 +531,7 @@ class SearchTest extends BaseServiceMockTest
             $searchHandlerMock,
             $this->getDomainMapperMock(),
             $permissionsCriterionResolverMock = $this->getPermissionCriterionResolverMock(),
+            new NullIndexer(),
             array()
         );
 
@@ -558,6 +568,7 @@ class SearchTest extends BaseServiceMockTest
             $searchHandlerMock,
             $this->getDomainMapperMock(),
             $permissionsCriterionResolverMock,
+            new NullIndexer(),
             array()
         );
 
@@ -593,6 +604,7 @@ class SearchTest extends BaseServiceMockTest
             $searchHandlerMock,
             $domainMapperMock,
             $permissionsCriterionResolverMock,
+            new NullIndexer(),
             array()
         );
 
@@ -657,6 +669,7 @@ class SearchTest extends BaseServiceMockTest
             $searchHandlerMock,
             $domainMapperMock,
             $permissionsCriterionResolverMock,
+            new NullIndexer(),
             array()
         );
 
@@ -721,6 +734,7 @@ class SearchTest extends BaseServiceMockTest
             $searchHandlerMock,
             $domainMapperMock,
             $permissionsCriterionResolverMock,
+            new NullIndexer(),
             array()
         );
 
@@ -782,6 +796,7 @@ class SearchTest extends BaseServiceMockTest
             $searchHandlerMock,
             $this->getDomainMapperMock(),
             $permissionsCriterionResolverMock,
+            new NullIndexer(),
             array()
         );
 
@@ -814,6 +829,7 @@ class SearchTest extends BaseServiceMockTest
             $searchHandlerMock,
             $domainMapperMock,
             $this->getPermissionCriterionResolverMock(),
+            new NullIndexer(),
             array()
         );
 

--- a/eZ/Publish/Core/Search/Common/BackgroundIndexer.php
+++ b/eZ/Publish/Core/Search/Common/BackgroundIndexer.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Common;
+
+use eZ\Publish\SPI\Persistence\Content\ContentInfo;
+use eZ\Publish\SPI\Persistence\Content\Location;
+
+/**
+ * Interface for performing indexing in background.
+ *
+ * Example of background: After console command or request has finished execution.
+ *
+ * NOTE: This is not for use by regular indexing needs reacting to Repository signals, but rather for use inside the
+ * Search service when inconsistencies are discovered which should be re-indexed, hence operate as a self healing system.
+ */
+interface BackgroundIndexer
+{
+    /**
+     * Register a content for refreshing index in the background.
+     *
+     * If content is:
+     * - deleted (NotFoundException)
+     * - not published (draft or trashed)
+     *
+     * .. then item is removed from index, if not it is added/updated.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\ContentInfo $contentInfo
+     */
+    public function registerContent(ContentInfo $contentInfo);
+
+    /**
+     * Register a location for refreshing index in the background.
+     *
+     * If content is:
+     * - deleted (NotFoundException)
+     * - not published (draft or trashed)
+     *
+     * .. then item is removed from index, if not it is added/updated.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\Location $location
+     */
+    public function registerLocation(Location $location);
+}

--- a/eZ/Publish/Core/Search/Common/BackgroundIndexer/NullIndexer.php
+++ b/eZ/Publish/Core/Search/Common/BackgroundIndexer/NullIndexer.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Search\Common\BackgroundIndexer;
+
+use eZ\Publish\Core\Search\Common\BackgroundIndexer as BackgroundIndexerInterface;
+use eZ\Publish\SPI\Persistence\Content\ContentInfo;
+use eZ\Publish\SPI\Persistence\Content\Location;
+
+/**
+ * Null indexer, does nothing, for default use when non has been configured.
+ */
+class NullIndexer implements BackgroundIndexerInterface
+{
+    public function registerContent(ContentInfo $contentInfo)
+    {
+    }
+
+    public function registerLocation(Location $location)
+    {
+    }
+}

--- a/eZ/Publish/Core/settings/repository.yml
+++ b/eZ/Publish/Core/settings/repository.yml
@@ -58,8 +58,9 @@ services:
         class: "%ezpublish.api.inner_repository.class%"
         factory: ["@ezpublish.api.repository.factory", buildRepository]
         arguments:
-            - "@ezpublish.api.persistence_handler"
-            - "@ezpublish.spi.search"
+            - '@ezpublish.api.persistence_handler'
+            - '@ezpublish.spi.search'
+            - '@ezpublish.search.background_indexer'
         lazy: true
 
     ezpublish.api.service.content:
@@ -159,3 +160,6 @@ services:
         arguments:
             - "%ezpublish.signalslot.signal_dispatcher.class%"
             - "legacy"
+
+    ezpublish.search.background_indexer:
+        class: eZ\Publish\Core\Search\Common\BackgroundIndexer\NullIndexer


### PR DESCRIPTION
Issue: https://jira.ez.no/browse/EZP-28177

Related:
- https://github.com/ezsystems/ezpublish-kernel/pull/2139 Parallel and selective indexing 
- https://github.com/ezsystems/ezpublish-kernel/pull/2126 getPermissionCriterion() cache

As a Developer I want a indexing command which is:
A Search service which is more tollerant of search index inconsitencies
Log of when this occures
Attempt to self heald (re- index or remove form index) in cases item is not published or removed

Todo:
- [x] UnitTests: For BackgroundIndexingTerminateListener, and mock cases logic in search service involving missing items in SearchService mock tests
- [x] Log?