### PR TITLE
EZP-28185: Database update SQL missing from Kernel 6.12

### DIFF
--- a/data/update/mysql/dbupdate-6.11.0-to-6.12.0.sql
+++ b/data/update/mysql/dbupdate-6.11.0-to-6.12.0.sql
@@ -1,0 +1,5 @@
+--
+-- EZP-24744: Increase password security
+--
+
+ALTER TABLE ezuser CHANGE password_hash password_hash VARCHAR(255) default NULL;

--- a/data/update/mysql/dbupdate-6.11.0-to-6.12.0.sql
+++ b/data/update/mysql/dbupdate-6.11.0-to-6.12.0.sql
@@ -1,3 +1,7 @@
+SET default_storage_engine=InnoDB;
+-- Set storage engine schema version number
+UPDATE ezsite_data SET value='6.12.0' WHERE name='ezpublish-version';
+
 --
 -- EZP-24744: Increase password security
 --

--- a/data/update/postgres/dbupdate-6.11.0-to-6.12.0.sql
+++ b/data/update/postgres/dbupdate-6.11.0-to-6.12.0.sql
@@ -1,3 +1,6 @@
+-- Set storage engine schema version number
+UPDATE ezsite_data SET value='6.12.0' WHERE name='ezpublish-version';
+
 --
 -- EZP-24744: Increase password security
 --

--- a/data/update/postgres/dbupdate-6.11.0-to-6.12.0.sql
+++ b/data/update/postgres/dbupdate-6.11.0-to-6.12.0.sql
@@ -1,0 +1,5 @@
+--
+-- EZP-24744: Increase password security
+--
+
+ALTER TABLE ezuser ALTER COLUMN password_hash TYPE VARCHAR(255);


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-28185

eZ Platform 1.12.0 ships with ezpublish-kernel 6.12, which allows using longer hashes for passwords in the future (See https://jira.ez.no/browse/EZP-24744). This requires a change to the DB schema.

Unlike previous schema changes, this is not included in the SQL files to update the schema. This PR adds the SQL files for MySQL and PostgreSQL from [the eZ Platform upgrade instructions](https://doc.ezplatform.com/en/1.12/releases/updating_ez_platform/#__code_12) under the `data/update` directory structure:

- data/update/mysql/dbupdate-6.11.0-to-6.12.0.sql
- data/update/postgres/dbupdate-6.11.0-to-6.12.0.sql