### PR TITLE
[Tests] RichText RendererTest: Fixed mocks to align with PHPUnit 5.7

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/RichText/RendererTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/RichText/RendererTest.php
@@ -8,8 +8,7 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\FieldType\Tests\RichText;
 
-
-use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\Core\Repository\Repository;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/RichText/RendererTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/RichText/RendererTest.php
@@ -526,14 +526,14 @@ class RendererTest extends TestCase
         $parameters = array('parameters');
         $isInline = true;
 
-        $contentInfoMock = $this->getMock(ContentInfo::class);
+        $contentInfoMock = $this->createMock(ContentInfo::class);
         $contentInfoMock
             ->expects($this->once())
             ->method('__get')
             ->with('mainLocationId')
             ->willReturn(null);
 
-        $contentMock = $this->getMock(Content::class);
+        $contentMock = $this->createMock(Content::class);
         $contentMock
             ->expects($this->once())
             ->method('__get')


### PR DESCRIPTION
For RichText Renderer unit test we have to mock Core Repository instead of API Repository because API interface doesn't have `sudo` method which is being mocked.

I also fixed references to deprecated `getMock` along the way.

Though related to #2132 not back-porting to 6.7 as this change was introduced on merge to master due to PHPUnit 5.7 update 