### PR TITLE
EZP-25636: User can't access trash if 1+ items are not readable

### DIFF
--- a/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
@@ -555,8 +555,9 @@ class TrashServiceTest extends BaseTrashServiceTest
     /**
      * Test for the findTrashItems() method.
      *
+     * @param \eZ\Publish\API\Repository\Values\User\User $user
+     *
      * @see \eZ\Publish\API\Repository\TrashService::findTrashItems()
-     * @depends eZ\Publish\API\Repository\Tests\TrashServiceTest::testTrash
      * @depends eZ\Publish\API\Repository\Tests\UserServiceTest::testCreateUser
      */
     public function testFindTrashItemsLimitedAccess(User $user)

--- a/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
@@ -555,12 +555,10 @@ class TrashServiceTest extends BaseTrashServiceTest
     /**
      * Test for the findTrashItems() method.
      *
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
-     *
      * @see \eZ\Publish\API\Repository\TrashService::findTrashItems()
-     * @depends eZ\Publish\API\Repository\Tests\UserServiceTest::testCreateUser
+     * @depends \eZ\Publish\API\Repository\Tests\TrashServiceTest::testFindTrashItems
      */
-    public function testFindTrashItemsLimitedAccess(User $user)
+    public function testFindTrashItemsLimitedAccess()
     {
         $repository = $this->getRepository();
         $trashService = $repository->getTrashService();
@@ -576,11 +574,11 @@ class TrashServiceTest extends BaseTrashServiceTest
             )
         );
 
-        // Load user service
-        $userService = $repository->getUserService();
+        // Create a user in the Editor user group.
+        $user = $this->createUserVersion1();
 
-        // Set an Editor user as current user, these users have no access to Trash by default
-        $repository->setCurrentUser($userService->loadUserByLogin($user->login));
+        // Set the Editor user as current user, these users have no access to Trash by default.
+        $repository->getPermissionResolver()->setCurrentUserReference($user);
 
         // Load all trashed locations
         $searchResult = $trashService->findTrashItems($query);

--- a/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
@@ -580,7 +580,7 @@ class TrashServiceTest extends BaseTrashServiceTest
         $userService = $repository->getUserService();
 
         // Set an Editor user as current user, these users have no access to Trash by default
-        $repository->setCurrentUser($userService->loadUser($user->getUserId()));
+        $repository->setCurrentUser($userService->loadUserByLogin($user->login));
 
         // Load all trashed locations
         $searchResult = $trashService->findTrashItems($query);

--- a/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\API\Repository\Tests;
 
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\URLAliasService;
+use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
@@ -549,6 +550,48 @@ class TrashServiceTest extends BaseTrashServiceTest
 
         // 4 trashed locations from the sub tree
         $this->assertEquals(4, $searchResult->count);
+    }
+
+    /**
+     * Test for the findTrashItems() method.
+     *
+     * @see \eZ\Publish\API\Repository\TrashService::findTrashItems()
+     * @depends eZ\Publish\API\Repository\Tests\TrashServiceTest::testTrash
+     * @depends eZ\Publish\API\Repository\Tests\UserServiceTest::testCreateUser
+     */
+    public function testFindTrashItemsLimitedAccess(User $user)
+    {
+        $repository = $this->getRepository();
+        $trashService = $repository->getTrashService();
+
+        /* BEGIN: Use Case */
+        $this->createTrashItem();
+
+        // Create a search query for all trashed items
+        $query = new Query();
+        $query->filter = new Criterion\LogicalAnd(
+            array(
+                new Criterion\Field('title', Criterion\Operator::LIKE, '*'),
+            )
+        );
+
+        // Load user service
+        $userService = $repository->getUserService();
+
+        // Set an Editor user as current user, these users have no access to Trash by default
+        $repository->setCurrentUser($userService->loadUser($user->getUserId()));
+
+        // Load all trashed locations
+        $searchResult = $trashService->findTrashItems($query);
+        /* END: Use Case */
+
+        $this->assertInstanceOf(
+            '\\eZ\\Publish\\API\\Repository\\Values\\Content\\SearchResult',
+            $searchResult
+        );
+
+        // 0 trashed locations found, though 4 exist
+        $this->assertEquals(0, $searchResult->count);
     }
 
     /**

--- a/eZ/Publish/API/Repository/TrashService.php
+++ b/eZ/Publish/API/Repository/TrashService.php
@@ -80,7 +80,7 @@ interface TrashService
     public function deleteTrashItem(TrashItem $trashItem);
 
     /**
-     * Returns a collection of Trashed locations contained in the trash.
+     * Returns a collection of Trashed locations contained in the trash, which are readable by the current user.
      *
      * $query allows to filter/sort the elements to be contained in the collection.
      *

--- a/eZ/Publish/Core/REST/Client/TrashService.php
+++ b/eZ/Publish/Core/REST/Client/TrashService.php
@@ -195,7 +195,7 @@ class TrashService implements APITrashService, Sessionable
     }
 
     /**
-     * Returns a collection of Trashed locations contained in the trash.
+     * Returns a collection of Trashed locations contained in the trash, which are readable by the current user.
      *
      * $query allows to filter/sort the elements to be contained in the collection.
      *

--- a/eZ/Publish/Core/Repository/TrashService.php
+++ b/eZ/Publish/Core/Repository/TrashService.php
@@ -314,9 +314,16 @@ class TrashService implements TrashServiceInterface
      */
     protected function buildDomainTrashItemObject(Trashed $spiTrashItem)
     {
+        // Use sudo as all trash items should be readable when viewing the trash bin
+        $contentInfo = $this->repository->sudo(
+            function () use ($spiTrashItem) {
+                return $this->repository->getContentService()->loadContentInfo($spiTrashItem->contentId);
+            }
+        );
+
         return new TrashItem(
             array(
-                'contentInfo' => $this->repository->getContentService()->loadContentInfo($spiTrashItem->contentId),
+                'contentInfo' => $contentInfo,
                 'id' => $spiTrashItem->id,
                 'priority' => $spiTrashItem->priority,
                 'hidden' => $spiTrashItem->hidden,

--- a/eZ/Publish/Core/Repository/TrashService.php
+++ b/eZ/Publish/Core/Repository/TrashService.php
@@ -314,16 +314,9 @@ class TrashService implements TrashServiceInterface
      */
     protected function buildDomainTrashItemObject(Trashed $spiTrashItem)
     {
-        // Use sudo as all trash items should be readable when viewing the trash bin
-        $contentInfo = $this->repository->sudo(
-            function () use ($spiTrashItem) {
-                return $this->repository->getContentService()->loadContentInfo($spiTrashItem->contentId);
-            }
-        );
-
         return new TrashItem(
             array(
-                'contentInfo' => $contentInfo,
+                'contentInfo' => $this->repository->getContentService()->loadContentInfo($spiTrashItem->contentId),
                 'id' => $spiTrashItem->id,
                 'priority' => $spiTrashItem->priority,
                 'hidden' => $spiTrashItem->hidden,

--- a/eZ/Publish/Core/Repository/TrashService.php
+++ b/eZ/Publish/Core/Repository/TrashService.php
@@ -251,8 +251,7 @@ class TrashService implements TrashServiceInterface
     }
 
     /**
-     * Returns a collection of Trashed locations contained in the trash.
-     * Only items that the current user has read access to are included.
+     * Returns a collection of Trashed locations contained in the trash, which are readable by the current user.
      *
      * $query allows to filter/sort the elements to be contained in the collection.
      *

--- a/eZ/Publish/Core/Repository/TrashService.php
+++ b/eZ/Publish/Core/Repository/TrashService.php
@@ -252,6 +252,7 @@ class TrashService implements TrashServiceInterface
 
     /**
      * Returns a collection of Trashed locations contained in the trash.
+     * Only items that the current user has read access to are included.
      *
      * $query allows to filter/sort the elements to be contained in the collection.
      *
@@ -294,7 +295,11 @@ class TrashService implements TrashServiceInterface
 
         $trashItems = array();
         foreach ($spiTrashItems as $spiTrashItem) {
-            $trashItems[] = $this->buildDomainTrashItemObject($spiTrashItem);
+            try {
+                $trashItems[] = $this->buildDomainTrashItemObject($spiTrashItem);
+            } catch (UnauthorizedException $e) {
+                // Do nothing, thus exclude items the current user doesn't have read access to.
+            }
         }
 
         $searchResult = new SearchResult();

--- a/eZ/Publish/Core/SignalSlot/TrashService.php
+++ b/eZ/Publish/Core/SignalSlot/TrashService.php
@@ -165,7 +165,7 @@ class TrashService implements TrashServiceInterface
     }
 
     /**
-     * Returns a collection of Trashed locations contained in the trash.
+     * Returns a collection of Trashed locations contained in the trash, which are readable by the current user.
      *
      * $query allows to filter/sort the elements to be contained in the collection.
      *


### PR DESCRIPTION
> Fix https://jira.ez.no/browse/EZP-25636
> Work in progress
> Also needs https://github.com/ezsystems/PlatformUIBundle/pull/921

- [x] Alt. A (reverted): Use sudo when loading trash items, as discussed. This leads to...
- [ ] ...when the editor views a trash item he doesn't have read access to, it is shown as "Item's ancestors are in Trash", presumably because the test is on whether the parent location can be read. ("Restore under a new parent" fails, as it should, though the message is wonky: "For the moment item's whose original location has been deleted can not be restored".) ANYWAY: We need to differentiate between "ancestor is in trash" and "ancestor is not readable".
- [x] Alt B: Exclude items the current user doesn't have read access to from the listing, by catching and discarding `UnauthorizedException`. This is IMHO a nice and simple way to go...
- [ ] ...though when we implement paging for the trash, filtering happens after the paging, so we will sometimes get fewer than the requested number of items per page.