### PR TITLE
EZP-28247: Creating an new object state does not clear the group cache

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
@@ -151,7 +151,7 @@ class ObjectStateHandler extends AbstractHandler implements ObjectStateHandlerIn
         $this->logger->logCall(__METHOD__, array('groupId' => $groupId, 'struct' => $input));
         $return = $this->persistenceHandler->objectStateHandler()->create($groupId, $input);
 
-        $this->cache->invalidateTags(['state-group-' . $groupId]);
+        $this->cache->deleteItem('ez-state-list-' . $groupId . '-by-group');
 
         return $return;
     }

--- a/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
@@ -98,7 +98,7 @@ class ObjectStateHandler extends AbstractHandler implements ObjectStateHandlerIn
      */
     public function loadObjectStates($groupId)
     {
-        $cacheItem = $this->cache->getItem('ez-state-list-' . $groupId . '-by-group');
+        $cacheItem = $this->cache->getItem('ez-state-list-by-group-' . $groupId);
         if ($cacheItem->isHit()) {
             return $cacheItem->get();
         }
@@ -151,7 +151,7 @@ class ObjectStateHandler extends AbstractHandler implements ObjectStateHandlerIn
         $this->logger->logCall(__METHOD__, array('groupId' => $groupId, 'struct' => $input));
         $return = $this->persistenceHandler->objectStateHandler()->create($groupId, $input);
 
-        $this->cache->deleteItem('ez-state-list-' . $groupId . '-by-group');
+        $this->cache->deleteItem('ez-state-list-by-group-' . $groupId);
 
         return $return;
     }

--- a/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
@@ -151,7 +151,7 @@ class ObjectStateHandler extends AbstractHandler implements ObjectStateHandlerIn
         $this->logger->logCall(__METHOD__, array('groupId' => $groupId, 'struct' => $input));
         $return = $this->persistenceHandler->objectStateHandler()->create($groupId, $input);
 
-        $this->cache->deleteItem('ez-state-list-by-group-' . $groupId);
+        $this->cache->invalidateTags(['state-group-' . $groupId]);
 
         return $return;
     }

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ObjectStateHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ObjectStateHandlerTest.php
@@ -53,7 +53,7 @@ class ObjectStateHandlerTest extends AbstractCacheHandlerTest
             ['loadGroup', [5], 'ez-state-group-5', $group],
             ['loadGroupByIdentifier', ['lock'], 'ez-state-group-lock-by-identifier', $group],
             ['loadAllGroups', [], 'ez-state-group-all', [$group]],
-            ['loadObjectStates', [5], 'ez-state-list-5-by-group', [$state]],
+            ['loadObjectStates', [5], 'ez-state-list-by-group-5', [$state]],
             ['load', [7], 'ez-state-7', $state],
             ['loadByIdentifier', ['lock', 5], 'ez-state-identifier-lock-by-group-5', $state],
             ['getContentState', [4, 5], 'ez-state-by-group-5-on-content-4', $state],


### PR DESCRIPTION
> Issue : https://jira.ez.no/browse/EZP-28247

This clears the object state group cache when a new object state is created