### PR TITLE
EZP-28176: Fix SQL error on indexing with --subtree argument

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -300,7 +300,6 @@ EOT
             ->innerJoin('c', 'ezcontentobject_tree', 't', 't.contentobject_id = c.id')
             ->where('c.status = :status')
             ->andWhere('t.path_string LIKE :path')
-            ->orderBy('t.path_string')
             ->setParameter('status', ContentInfo::STATUS_PUBLISHED, PDO::PARAM_INT)
             ->setParameter('path', $location->pathString . '%', PDO::PARAM_STR);
 


### PR DESCRIPTION
Issue caused by distinct added which does not like the order by, I guess we don't really need the order by so suggesting to remove it.
