### PR TITLE
EZP-28174: Validation of ezlocation:// and ezcontent:// links in the richtext field type

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -29,6 +29,7 @@ parameters:
     ezpublish.fieldType.ezrichtext.validator.xml.class: eZ\Publish\Core\FieldType\RichText\Validator
     ezpublish.fieldType.ezrichtext.validator.dispatcher.class: eZ\Publish\Core\FieldType\RichText\ValidatorDispatcher
     ezpublish.fieldType.ezrichtext.resources: %ezpublish.kernel.root_dir%/eZ/Publish/Core/FieldType/RichText/Resources
+    ezpublish.fieldType.ezrichtext.validator.internal_link.class: eZ\Publish\Core\FieldType\RichText\InternalLinkValidator
 
     ezpublish.fieldType.ezrichtext.converter.input.xhtml5.resources: %ezpublish.fieldType.ezrichtext.resources%/stylesheets/xhtml5/edit/docbook.xsl
     ezpublish.fieldType.ezrichtext.converter.edit.xhtml5.resources: %ezpublish.fieldType.ezrichtext.resources%/stylesheets/docbook/xhtml5/edit/xhtml5.xsl
@@ -189,6 +190,12 @@ services:
                 http://docbook.org/ns/docbook: null
                 http://ez.no/namespaces/ezpublish5/xhtml5/edit: null
                 http://ez.no/namespaces/ezpublish5/xhtml5: "@ezpublish.fieldType.ezrichtext.validator.output.ezxhtml5"
+
+    ezpublish.fieldType.ezrichtext.validator.internal_link:
+        class: '%ezpublish.fieldType.ezrichtext.validator.internal_link.class%'
+        arguments:
+            - '@ezpublish.api.service.content'
+            - '@ezpublish.api.service.location'
 
     # Image
     ezpublish.fieldType.ezimage.io_service:

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -194,8 +194,8 @@ services:
     ezpublish.fieldType.ezrichtext.validator.internal_link:
         class: '%ezpublish.fieldType.ezrichtext.validator.internal_link.class%'
         arguments:
-            - '@ezpublish.api.service.content'
-            - '@ezpublish.api.service.location'
+            - '@ezpublish.spi.persistence.cache.contentHandler'
+            - '@ezpublish.spi.persistence.cache.locationHandler'
 
     # Image
     ezpublish.fieldType.ezimage.io_service:

--- a/eZ/Publish/Core/FieldType/RichText/InternalLinkValidator.php
+++ b/eZ/Publish/Core/FieldType/RichText/InternalLinkValidator.php
@@ -8,10 +8,12 @@
  */
 namespace eZ\Publish\Core\FieldType\RichText;
 
+use DOMDocument;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
 
 /**
  * Validator for RichText internal format links.
@@ -26,6 +28,40 @@ class InternalLinkValidator
     {
         $this->contentService = $contentService;
         $this->locationService = $locationService;
+    }
+
+    /**
+     * Extracts and validate internal links.
+     *
+     * @param \DOMDocument $xml
+     * @return array
+     */
+    public function validateDocument(DOMDocument $xml)
+    {
+        $errors = [];
+
+        $xpath = new \DOMXPath($xml);
+        $xpath->registerNamespace('docbook', 'http://docbook.org/ns/docbook');
+
+        foreach (['link', 'ezlink'] as $tagName) {
+            $xpathExpression = "//docbook:{$tagName}[starts-with(@xlink:href, 'ezcontent://') or starts-with(@xlink:href, 'ezlocation://')]";
+            /** @var \DOMElement $element */
+            foreach ($xpath->query($xpathExpression) as $element) {
+                $url = $element->getAttribute('xlink:href');
+                preg_match('~^(.+)://([^#]*)?(#.*|\\s*)?$~', $url, $matches);
+                list(, $scheme, $id) = $matches;
+
+                if (empty($id)) {
+                    continue;
+                }
+
+                if (!$this->validate($scheme, $id)) {
+                    $errors[] = $this->getInvalidLinkError($scheme, $url);
+                }
+            }
+        }
+
+        return $errors;
     }
 
     /**
@@ -54,10 +90,35 @@ class InternalLinkValidator
                 default:
                     throw new InvalidArgumentException($scheme, "Given scheme '{$scheme}' is not supported.");
             }
+        } catch (UnauthorizedException $e) {
+            // Editor can link to content/location even if he doesn’t have permissions
+            return true;
         } catch (NotFoundException $e) {
             return false;
         }
 
         return true;
+    }
+
+    /**
+     * Builds error message for invalid url.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If given $scheme is not supported.
+     *
+     * @param string $scheme
+     * @param string $url
+     * @return string
+     */
+    private function getInvalidLinkError($scheme, $url)
+    {
+        switch ($scheme) {
+            case 'ezcontent':
+            case 'ezremote':
+                return sprintf('Invalid link "%s": target content cannot be found', $url);
+            case 'ezlocation':
+                return sprintf('Invalid link "%s": target location cannot be found', $url);
+            default:
+                throw new InvalidArgumentException($scheme, "Given scheme '{$scheme}' is not supported.");
+        }
     }
 }

--- a/eZ/Publish/Core/FieldType/RichText/InternalLinkValidator.php
+++ b/eZ/Publish/Core/FieldType/RichText/InternalLinkValidator.php
@@ -44,7 +44,7 @@ class InternalLinkValidator
         $xpath->registerNamespace('docbook', 'http://docbook.org/ns/docbook');
 
         foreach (['link', 'ezlink'] as $tagName) {
-            $xpathExpression = "//docbook:{$tagName}[starts-with(@xlink:href, 'ezcontent://') or starts-with(@xlink:href, 'ezlocation://')]";
+            $xpathExpression = $this->getXPathForLinkTag($tagName);
             /** @var \DOMElement $element */
             foreach ($xpath->query($xpathExpression) as $element) {
                 $url = $element->getAttribute('xlink:href');
@@ -120,5 +120,16 @@ class InternalLinkValidator
             default:
                 throw new InvalidArgumentException($scheme, "Given scheme '{$scheme}' is not supported.");
         }
+    }
+
+    /**
+     * Generates XPath expression for given link tag.
+     *
+     * @param string $tagName
+     * @return string
+     */
+    private function getXPathForLinkTag($tagName)
+    {
+        return "//docbook:{$tagName}[starts-with(@xlink:href, 'ezcontent://') or starts-with(@xlink:href, 'ezlocation://') or starts-with(@xlink:href, 'ezremote://')]";
     }
 }

--- a/eZ/Publish/Core/FieldType/RichText/Type.php
+++ b/eZ/Publish/Core/FieldType/RichText/Type.php
@@ -60,21 +60,29 @@ class Type extends FieldType
     protected $inputValidatorDispatcher;
 
     /**
+     * @var null|\eZ\Publish\Core\FieldType\RichText\InternalLinkValidator
+     */
+    protected $internalLinkValidator;
+
+    /**
      * @param \eZ\Publish\Core\FieldType\RichText\Validator $internalFormatValidator
      * @param \eZ\Publish\Core\FieldType\RichText\ConverterDispatcher $inputConverterDispatcher
      * @param null|\eZ\Publish\Core\FieldType\RichText\Normalizer $inputNormalizer
      * @param null|\eZ\Publish\Core\FieldType\RichText\ValidatorDispatcher $inputValidatorDispatcher
+     * @param null|\eZ\Publish\Core\FieldType\RichText\InternalLinkValidator $internalLinkValidator
      */
     public function __construct(
         Validator $internalFormatValidator,
         ConverterDispatcher $inputConverterDispatcher,
         Normalizer $inputNormalizer = null,
-        ValidatorDispatcher $inputValidatorDispatcher = null
+        ValidatorDispatcher $inputValidatorDispatcher = null,
+        InternalLinkValidator $internalLinkValidator = null
     ) {
         $this->internalFormatValidator = $internalFormatValidator;
         $this->inputConverterDispatcher = $inputConverterDispatcher;
         $this->inputNormalizer = $inputNormalizer;
         $this->inputValidatorDispatcher = $inputValidatorDispatcher;
+        $this->internalLinkValidator = $internalLinkValidator;
     }
 
     /**
@@ -264,6 +272,13 @@ class Type extends FieldType
             $validationErrors[] = new ValidationError(
                 "Validation of XML content failed:\n" . implode("\n", $errors)
             );
+        }
+
+        if ($this->internalLinkValidator !== null) {
+            $errors = $this->internalLinkValidator->validateDocument($value->xml);
+            foreach ($errors as $error) {
+                $validationErrors[] = new ValidationError($error);
+            }
         }
 
         return $validationErrors;

--- a/eZ/Publish/Core/FieldType/Tests/RichText/InternalLinkValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/InternalLinkValidatorTest.php
@@ -6,7 +6,6 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-
 namespace eZ\Publish\Core\FieldType\Tests\RichText;
 
 use eZ\Publish\API\Repository\ContentService;

--- a/eZ/Publish/Core/FieldType/Tests/RichText/InternalLinkValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/InternalLinkValidatorTest.php
@@ -1,0 +1,324 @@
+<?php
+
+/**
+ * File containing the InternalLinkValidatorTest.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\Tests\RichText;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
+use eZ\Publish\Core\FieldType\RichText\InternalLinkValidator;
+use PHPUnit\Framework\TestCase;
+
+class InternalLinkValidatorTest extends TestCase
+{
+    use PHPUnit5CompatTrait;
+
+    /** @var \eZ\Publish\API\Repository\ContentService|\PHPUnit_Framework_MockObject_MockObject */
+    private $contentService;
+
+    /** @var \eZ\Publish\API\Repository\LocationService|\PHPUnit_Framework_MockObject_MockObject */
+    private $locationService;
+
+    /**
+     * @before
+     */
+    public function setupInternalLinkValidator()
+    {
+        $this->contentService = $this->createMock(ContentService::class);
+        $this->locationService = $this->createMock(LocationService::class);
+    }
+
+    /**
+     * @expectedException \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException
+     * @expectedExceptionMessage Argument 'eznull' is invalid: Given scheme 'eznull' is not supported.
+     */
+    public function testValidateFailOnNotSupportedSchema()
+    {
+        $validator = $this->getInternalLinkValidator();
+        $validator->validate('eznull', 1);
+    }
+
+    public function testValidateEzContentWithExistingContentId()
+    {
+        $validator = $this->getInternalLinkValidator();
+
+        $contentId = 1;
+        $this->contentService
+            ->expects($this->once())
+            ->method('loadContentInfo')
+            ->with($contentId);
+
+        $this->assertTrue($validator->validate('ezcontent', $contentId));
+    }
+
+    public function testValidateEzContentNonExistingContentId()
+    {
+        $validator = $this->getInternalLinkValidator();
+
+        $contentId = 1;
+        $exception = $this->createMock(NotFoundException::class);
+
+        $this->contentService
+            ->expects($this->once())
+            ->method('loadContentInfo')
+            ->with($contentId)
+            ->willThrowException($exception);
+
+        $this->assertFalse($validator->validate('ezcontent', $contentId));
+    }
+
+    public function testValidateEzContentWithoutPermissions()
+    {
+        $validator = $this->getInternalLinkValidator();
+
+        $contentId = 1;
+        $exception = $this->createMock(UnauthorizedException::class);
+
+        $this->contentService
+            ->expects($this->once())
+            ->method('loadContentInfo')
+            ->with($contentId)
+            ->willThrowException($exception);
+
+        $this->assertTrue($validator->validate('ezcontent', $contentId));
+    }
+
+    public function testValidateEzLocationWithExistingLocationId()
+    {
+        $validator = $this->getInternalLinkValidator();
+
+        $locationId = 1;
+
+        $this->locationService
+            ->expects($this->once())
+            ->method('loadLocation')
+            ->with($locationId);
+
+        $this->assertTrue($validator->validate('ezlocation', $locationId));
+    }
+
+    public function testValidateEzLocationWithNonExistingLocationId()
+    {
+        $validator = $this->getInternalLinkValidator();
+
+        $locationId = 1;
+        $exception = $this->createMock(NotFoundException::class);
+
+        $this->locationService
+            ->expects($this->once())
+            ->method('loadLocation')
+            ->with($locationId)
+            ->willThrowException($exception);
+
+        $this->assertFalse($validator->validate('ezlocation', $locationId));
+    }
+
+    public function testValidateEzLocationWithoutPermissions()
+    {
+        $validator = $this->getInternalLinkValidator();
+
+        $locationId = 1;
+        $exception = $this->createMock(UnauthorizedException::class);
+
+        $this->locationService
+            ->expects($this->once())
+            ->method('loadLocation')
+            ->with($locationId)
+            ->willThrowException($exception);
+
+        $this->assertTrue($validator->validate('ezlocation', $locationId));
+    }
+
+    public function testValidateEzRemoteWithExistingRemoteId()
+    {
+        $validator = $this->getInternalLinkValidator();
+
+        $contentRemoteId = '0ba685755118cf95abb0fe25f3f6a1c8';
+
+        $this->contentService
+            ->expects($this->once())
+            ->method('loadContentByRemoteId')
+            ->with($contentRemoteId);
+
+        $this->assertTrue($validator->validate('ezremote', $contentRemoteId));
+    }
+
+    public function testValidateEzRemoteWithNonExistingRemoteId()
+    {
+        $validator = $this->getInternalLinkValidator();
+
+        $contentRemoteId = '0ba685755118cf95abb0fe25f3f6a1c8';
+        $exception = $this->createMock(NotFoundException::class);
+
+        $this->contentService
+            ->expects($this->once())
+            ->method('loadContentByRemoteId')
+            ->with($contentRemoteId)
+            ->willThrowException($exception);
+
+        $this->assertFalse($validator->validate('ezremote', $contentRemoteId));
+    }
+
+    public function testValidateEzRemoteWithoutPermissions()
+    {
+        $validator = $this->getInternalLinkValidator();
+
+        $contentRemoteId = '0ba685755118cf95abb0fe25f3f6a1c8';
+        $exception = $this->createMock(UnauthorizedException::class);
+
+        $this->contentService
+            ->expects($this->once())
+            ->method('loadContentByRemoteId')
+            ->with($contentRemoteId)
+            ->willThrowException($exception);
+
+        $this->assertTrue($validator->validate('ezremote', $contentRemoteId));
+    }
+
+    public function testValidateDocumentEzContentExistingContentId()
+    {
+        $scheme = 'ezcontent';
+        $contentId = 1;
+
+        $validator = $this->getInternalLinkValidator(['validate']);
+        $validator
+            ->expects($this->once())
+            ->method('validate')
+            ->with($scheme, $contentId)
+            ->willReturn(true);
+
+        $errors = $validator->validateDocument(
+            $this->createInputDocument($scheme, $contentId)
+        );
+
+        $this->assertEmpty($errors);
+    }
+
+    public function testValidateDocumentSkipMissingTargetId()
+    {
+        $scheme = 'ezcontent';
+        $contentId = null;
+
+        $validator = $this->getInternalLinkValidator(['validate']);
+        $validator
+            ->expects($this->never())
+            ->method('validate')
+            ->with($scheme, $contentId);
+
+        $errors = $validator->validateDocument(
+            $this->createInputDocument($scheme, $contentId)
+        );
+
+        $this->assertEmpty($errors);
+    }
+
+    public function testValidateDocumentEzContentNonExistingContentId()
+    {
+        $scheme = 'ezcontent';
+        $contentId = 1;
+
+        $validator = $this->getInternalLinkValidator(['validate']);
+        $validator
+            ->expects($this->once())
+            ->method('validate')
+            ->with($scheme, $contentId)
+            ->willReturn(false);
+
+        $errors = $validator->validateDocument(
+            $this->createInputDocument($scheme, $contentId)
+        );
+
+        $this->assertCount(1, $errors);
+        $this->assertContainsEzContentInvalidLinkError($contentId, $errors);
+    }
+
+    public function testValidateDocumentEzContentExistingLocationId()
+    {
+        $scheme = 'ezlocation';
+        $locationId = 1;
+
+        $validator = $this->getInternalLinkValidator(['validate']);
+        $validator
+            ->expects($this->once())
+            ->method('validate')
+            ->with($scheme, $locationId)
+            ->willReturn(true);
+
+        $errors = $validator->validateDocument(
+            $this->createInputDocument($scheme, $locationId)
+        );
+
+        $this->assertEmpty($errors);
+    }
+
+    public function testValidateDocumentEzContentNonExistingLocationId()
+    {
+        $scheme = 'ezlocation';
+        $locationId = 1;
+
+        $validator = $this->getInternalLinkValidator(['validate']);
+        $validator
+            ->expects($this->once())
+            ->method('validate')
+            ->with($scheme, $locationId)
+            ->willReturn(false);
+
+        $errors = $validator->validateDocument(
+            $this->createInputDocument($scheme, $locationId)
+        );
+
+        $this->assertCount(1, $errors);
+        $this->assertContainsEzLocationInvalidLinkError($locationId, $errors);
+    }
+
+    private function assertContainsEzLocationInvalidLinkError($locationId, array $errors)
+    {
+        $format = 'Invalid link "ezlocation://%d": target location cannot be found';
+
+        $this->assertContains(sprintf($format, $locationId), $errors);
+    }
+
+    private function assertContainsEzContentInvalidLinkError($contentId, array $errors)
+    {
+        $format = 'Invalid link "ezcontent://%d": target content cannot be found';
+
+        $this->assertContains(sprintf($format, $contentId), $errors);
+    }
+
+    /**
+     * @return \eZ\Publish\Core\FieldType\RichText\InternalLinkValidator|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getInternalLinkValidator(array $methods = null)
+    {
+        return $this->getMockBuilder(InternalLinkValidator::class)
+            ->setMethods($methods)
+            ->setConstructorArgs([
+                $this->contentService,
+                $this->locationService,
+            ])
+            ->getMock();
+    }
+
+    private function createInputDocument($scheme, $id)
+    {
+        $url = $scheme . '://' . $id;
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <para>
+        <link xlink:href="' . $url . '">Content link</link>
+    </para>
+</section>';
+
+        $doc = new \DOMDocument();
+        $doc->loadXML($xml);
+
+        return $doc;
+    }
+}

--- a/eZ/Publish/Core/settings/fieldtype_services.yml
+++ b/eZ/Publish/Core/settings/fieldtype_services.yml
@@ -7,6 +7,7 @@ parameters:
     ezpublish.fieldType.ezrichtext.validator.docbook.resources:
         - "%ezpublish.fieldType.ezrichtext.resources%/schemas/docbook/ezpublish.rng"
         - "%ezpublish.fieldType.ezrichtext.resources%/schemas/docbook/docbook.iso.sch.xsl"
+    ezpublish.fieldType.ezrichtext.validator.internal_link.class: eZ\Publish\Core\FieldType\RichText\InternalLinkValidator
     ezpublish.fieldType.ezpage.pageService.class: eZ\Publish\Core\FieldType\Page\PageService
     ezpublish.fieldType.ezpage.hashConverter.class: eZ\Publish\Core\FieldType\Page\HashConverter
     ezpublish.fieldType.ezimage.io_legacy.class: eZ\Publish\Core\FieldType\Image\IO\Legacy
@@ -76,6 +77,12 @@ services:
         arguments:
             -
                 http://docbook.org/ns/docbook: null
+
+    ezpublish.fieldType.ezrichtext.validator.internal_link:
+        class: '%ezpublish.fieldType.ezrichtext.validator.internal_link.class%'
+        arguments:
+            - '@ezpublish.api.service.content'
+            - '@ezpublish.api.service.location'
 
     ezpublish.fieldType.ezrichtext.normalizer.input:
         class: "%ezpublish.fieldType.ezrichtext.normalizer.aggregate.class%"

--- a/eZ/Publish/Core/settings/fieldtype_services.yml
+++ b/eZ/Publish/Core/settings/fieldtype_services.yml
@@ -81,8 +81,8 @@ services:
     ezpublish.fieldType.ezrichtext.validator.internal_link:
         class: '%ezpublish.fieldType.ezrichtext.validator.internal_link.class%'
         arguments:
-            - '@ezpublish.api.service.content'
-            - '@ezpublish.api.service.location'
+            - '@ezpublish.spi.persistence.cache.contentHandler'
+            - '@ezpublish.spi.persistence.cache.locationHandler'
 
     ezpublish.fieldType.ezrichtext.normalizer.input:
         class: "%ezpublish.fieldType.ezrichtext.normalizer.aggregate.class%"

--- a/eZ/Publish/Core/settings/fieldtypes.yml
+++ b/eZ/Publish/Core/settings/fieldtypes.yml
@@ -412,6 +412,7 @@ services:
             - "@ezpublish.fieldType.ezrichtext.converter.input.dispatcher"
             - "@ezpublish.fieldType.ezrichtext.normalizer.input"
             - "@ezpublish.fieldType.ezrichtext.validator.input.dispatcher"
+            - '@ezpublish.fieldType.ezrichtext.validator.internal_link'
         tags:
             - {name: ezpublish.fieldType, alias: ezrichtext}
 


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28174

## Description 

This PR adds validation of `ezlocation://` and `ezcontent://` links on the the richtext field type definition level. 

![zrzut ekranu 2017-11-20 o 10 55 39](https://user-images.githubusercontent.com/211967/33016964-d22a4552-cdf0-11e7-96a0-f5f9fb27cbfc.png)


Currently, if link target does not exist the `NotFound` with message `Could not find 'location' with identifier '63'` exception is thrown  (https://github.com/ezsystems/ezpublish-kernel/blob/6.7/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php#L84) when content relations are processed

## Steps to reproduce

> 1. Create new Article (or another ContentType object which has RichText filed) for e.g. Article A,
> 2. Create the second content object, for e.g. Article B. Let's assume, that this article has LocationId 63.
> 3. Edit Article A, in RichText editor, add some paragraph with text, select few words and click on add URL button. Then, click on Select content, select Article B, then Save URL and publish content.
> 4. Move Article B to trash.
> 5. Try to edit Article A. It will be impossible to save until you manually remove previously the added link. If you edit the link, you will see ezlocation://63 in Link to: field.
> 

## TODO

- [x] Validate architecture
- [x] Adjust the validation error to protocol 
- [x] `UnauthorizedException` handling in `\eZ\Publish\Core\FieldType\RichText\InternalLinkValidator::validate`
- [x] Tests
- [ ] Rebase and squash fixups before merge 