### PR TITLE
EZP-28210: Logout not working when session cookie domain set

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/security.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/security.yml
@@ -18,3 +18,5 @@ services:
 
     ezpublish_rest.security.authentication.logout_handler:
         class: "%ezpublish_rest.security.authentication.logout_handler.class%"
+        arguments:
+            - '@ezpublish.config.resolver'

--- a/eZ/Publish/Core/REST/Server/Security/RestLogoutHandler.php
+++ b/eZ/Publish/Core/REST/Server/Security/RestLogoutHandler.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\REST\Server\Security;
 
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -19,12 +20,41 @@ use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
  */
 class RestLogoutHandler implements LogoutHandlerInterface
 {
+    /**
+     * @var \eZ\Publish\Core\MVC\ConfigResolverInterface
+     */
+    private $configResolver;
+
+    /**
+     * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
+     */
+    public function __construct(ConfigResolverInterface $configResolver)
+    {
+        $this->configResolver = $configResolver;
+    }
+
+    /**
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @param \Symfony\Component\HttpFoundation\Response $response
+     * @param \Symfony\Component\Security\Core\Authentication\Token\TokenInterface $token
+     */
     public function logout(Request $request, Response $response, TokenInterface $token)
     {
         if (!$request->attributes->get('is_rest_request')) {
             return;
         }
 
-        $response->headers->clearCookie($request->getSession()->getName());
+        $path = '/';
+        $domain = null;
+
+        $session = $this->configResolver->getParameter('session');
+        if (array_key_exists('cookie_domain', $session)) {
+            $domain = $session['cookie_domain'];
+        }
+        if (array_key_exists('cookie_path', $session)) {
+            $path = $session['cookie_path'];
+        }
+
+        $response->headers->clearCookie($request->getSession()->getName(), $path, $domain);
     }
 }

--- a/eZ/Publish/Core/REST/Server/Tests/Security/RestLogoutHandlerTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Security/RestLogoutHandlerTest.php
@@ -8,38 +8,96 @@
  */
 namespace eZ\Publish\Core\REST\Server\Tests\Security;
 
+use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\REST\Server\Security\RestLogoutHandler;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class RestLogoutHandlerTest extends TestCase
 {
-    public function testLogout()
+    use PHPUnit5CompatTrait;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $configResolver;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $session;
+
+    protected function setUp()
     {
-        $session = $this->getMock('Symfony\Component\HttpFoundation\Session\SessionInterface');
+        parent::setUp();
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
+        $this->session = $this->createMock(SessionInterface::class);
+    }
+
+    public function testLogoutWithoutSiteaccessSessionSettings()
+    {
         $sessionId = 'eZSESSID';
-        $session
+        $this->session
             ->expects($this->once())
             ->method('getName')
             ->will($this->returnValue($sessionId));
-
         $request = new Request();
-        $request->setSession($session);
+        $request->setSession($this->session);
         $request->attributes->set('is_rest_request', true);
-
+        $this->configResolver
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with('session')
+            ->will($this->returnValue([]));
         $response = new Response();
-        $response->headers = $this->getMock('Symfony\Component\HttpFoundation\ResponseHeaderBag');
+        $response->headers = $this->createMock(ResponseHeaderBag::class);
         $response->headers
             ->expects($this->once())
             ->method('clearCookie')
             ->with($sessionId);
-
-        $logoutHandler = new RestLogoutHandler();
+        $logoutHandler = new RestLogoutHandler($this->configResolver);
         $logoutHandler->logout(
             $request,
             $response,
-            $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface')
+            $this->createMock(TokenInterface::class)
+        );
+    }
+
+    public function testLogoutWithSiteaccessSessionSettings()
+    {
+        $sessionId = 'eZSESSID';
+        $this->session
+            ->expects($this->once())
+            ->method('getName')
+            ->will($this->returnValue($sessionId));
+        $request = new Request();
+        $request->setSession($this->session);
+        $request->attributes->set('is_rest_request', true);
+        $sessionSettings = [
+            'cookie_path' => '/',
+            'cookie_domain' => 'ez.no',
+        ];
+        $this->configResolver
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with('session')
+            ->will($this->returnValue($sessionSettings));
+        $response = new Response();
+        $response->headers = $this->createMock(ResponseHeaderBag::class);
+        $response->headers
+            ->expects($this->once())
+            ->method('clearCookie')
+            ->with($sessionId, $sessionSettings['cookie_path'], $sessionSettings['cookie_domain']);
+        $logoutHandler = new RestLogoutHandler($this->configResolver);
+        $logoutHandler->logout(
+            $request,
+            $response,
+            $this->createMock(TokenInterface::class)
         );
     }
 
@@ -59,7 +117,7 @@ class RestLogoutHandlerTest extends TestCase
             ->expects($this->never())
             ->method('clearCookie');
 
-        $logoutHandler = new RestLogoutHandler();
+        $logoutHandler = new RestLogoutHandler($this->configResolver);
         $logoutHandler->logout(
             $request,
             $response,


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-28210

## Description
This PR improves `RestLogoutHandler` to make it able to remove session cookie even if `session.cookie_domain` and `session.cookie_path` is set. 