### PR TITLE
Remove some deprecations on Symfony 3.4

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Languages.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Languages.php
@@ -25,7 +25,7 @@ class Languages extends AbstractParser
     {
         $nodeBuilder
             ->arrayNode('languages')
-                ->cannotBeEmpty()
+                ->requiresAtLeastOneElement()
                 ->info('Available languages, in order of precedence')
                 ->example(array('fre-FR', 'eng-GB'))
                 ->prototype('scalar')->end()

--- a/eZ/Bundle/EzPublishDebugBundle/Collector/EzPublishCoreCollector.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Collector/EzPublishCoreCollector.php
@@ -18,11 +18,7 @@ class EzPublishCoreCollector extends DataCollector
 {
     public function __construct()
     {
-        $this->data = [
-            'collectors' => [],
-            'panelTemplates' => [],
-            'toolbarTemplates' => [],
-        ];
+        $this->reset();
     }
 
     public function collect(Request $request, Response $response, \Exception $exception = null)
@@ -103,5 +99,17 @@ class EzPublishCoreCollector extends DataCollector
         }
 
         return $this->data['panelTemplates'][$collectorName];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->data = [
+            'collectors' => [],
+            'panelTemplates' => [],
+            'toolbarTemplates' => [],
+        ];
     }
 }

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/input_parsers.yml
@@ -317,7 +317,7 @@ services:
 
     ezpublish_rest.input.parser.URLWildcardCreate:
         parent: ezpublish_rest.input.parser
-        class: "%ezpublish_rest.input.parser.URLWildcardCreate.class%"
+        class: "%ezpublish_rest.input.parser.UrlWildcardCreate.class%"
         arguments:
             - "@ezpublish_rest.parser_tools"
         tags:

--- a/eZ/Publish/Core/settings/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/fieldtype_external_storages.yml
@@ -70,4 +70,4 @@ services:
             - {name: ezpublish.fieldType.externalStorageHandler, alias: ezuser}
 
     ezpublish.fieldType.metadataHandler.imagesize:
-        class: "%ezpublish.core.io.metadataHandler.imagesize.class%"
+        class: "%ezpublish.core.io.metadataHandler.imageSize.class%"


### PR DESCRIPTION
* Implements the `reset()` method in `EzPublishCoreCollector`

* Removes usage of case insensitive parameter names

* Replaces `cannotBeEmpty` with `requiresAtLeastOneElement` in `$languages$` semantic configuration.