### PR TITLE
[Installer] EZP-28262: Replaced hardcoded DBMS-specific SQL file paths

### DIFF
--- a/eZ/Bundle/PlatformInstallerBundle/src/Installer/CleanInstaller.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Installer/CleanInstaller.php
@@ -16,8 +16,8 @@ class CleanInstaller extends DbBasedInstaller implements Installer
 
     public function importSchema()
     {
-        $this->runQueriesFromFile('vendor/ezsystems/ezpublish-kernel/data/mysql/schema.sql');
-        $this->runQueriesFromFile('vendor/ezsystems/ezpublish-kernel/data/mysql/dfs_schema.sql');
+        $this->runQueriesFromFile($this->getKernelSQLFileForDBMS('schema.sql'));
+        $this->runQueriesFromFile($this->getKernelSQLFileForDBMS('dfs_schema.sql'));
     }
 
     public function importData()


### PR DESCRIPTION
| Q | A |
|---|---|
| **Issue** | [EZP-28262](https://jira.ez.no/browse/EZP-28262) |
| **Related to** | #2153 and [EZP-24842](https://jira.ez.no/browse/EZP-24842) |
| **BC break** | no |
| **Target branch** | `master` |

This PR is `6.x` backport of #2153. It adds a wrapper for checking and getting DBMS-specific SQL files from `/data/` directory with possibility to reuse by custom Installers and replaces hardcoded `/vendor/ezsystems/ezpublish-kernel` path.

**TODO**:
- [x] Improve Installer to simplify checking existence and getting SQL data files path.