### PR TITLE
EZP-28269: Fixed inconsistent creating of eztime fromTimestamp

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/TimeIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/TimeIntegrationTest.php
@@ -185,7 +185,7 @@ class TimeIntegrationTest extends SearchBaseIntegrationTest
     /**
      * Get update field externals data.
      *
-     * @return array
+     * @return TimeValue
      */
     public function getValidUpdateFieldData()
     {
@@ -206,9 +206,9 @@ class TimeIntegrationTest extends SearchBaseIntegrationTest
             $field->value
         );
 
-        $dateTime = new DateTime();
+        $dateTime = new DateTime('@12345678');
         $expectedData = array(
-            'time' => $dateTime->setTimestamp(12345678)->getTimestamp() - $dateTime->setTime(0, 0, 0)->getTimestamp(),
+            'time' => $dateTime->getTimestamp() - $dateTime->setTime(0, 0, 0)->getTimestamp(),
         );
         $this->assertPropertiesCorrect(
             $expectedData,
@@ -305,12 +305,13 @@ class TimeIntegrationTest extends SearchBaseIntegrationTest
      */
     public function provideToHashData()
     {
-        $dateTime = new DateTime();
+        $timestamp = 123456;
+        $dateTime = new DateTime("@{$timestamp}");
 
         return array(
             array(
-                TimeValue::fromTimestamp(123456),
-                $dateTime->setTimestamp(123456)->getTimestamp() - $dateTime->setTime(0, 0, 0)->getTimestamp(),
+                TimeValue::fromTimestamp($timestamp),
+                $dateTime->getTimestamp() - $dateTime->setTime(0, 0, 0)->getTimestamp(),
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/TimeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/TimeTest.php
@@ -139,44 +139,44 @@ class TimeTest extends FieldTypeTest
     public function provideValidInputForAcceptValue()
     {
         $dateTime = new DateTime();
-        $secondsInDay = 24 * 60 * 60;
+        // change timezone to UTC (+00:00) to be able to calculate proper TimeValue
+        $timestamp = $dateTime->setTimezone(new \DateTimeZone('UTC'))->getTimestamp();
 
-        return array(
-            array(
+        return [
+            [
                 null,
                 new TimeValue(),
-            ),
-            array(
+            ],
+            [
                 '2012-08-28 12:20',
                 new TimeValue(44400),
-            ),
-            array(
+            ],
+            [
                 '2012-08-28 12:20 Europe/Berlin',
                 new TimeValue(44400),
-            ),
-            array(
+            ],
+            [
                 '2012-08-28 12:20 Asia/Sakhalin',
                 new TimeValue(44400),
-            ),
-            array(
-                // Set $dateTime to proper time for correct offset
-                $dateTime->setTimestamp(1372896001)->getTimestamp(),
-                // Correct for negative offset
-                new TimeValue(($secondsInDay + $dateTime->getOffset() + 1) % $secondsInDay),
-            ),
-            array(
-                TimeValue::fromTimestamp($timestamp = 1346149200),
+            ],
+            [
+                // create new DateTime object from timestamp w/o taking into account server timezone
+                (new DateTime('@1372896001'))->getTimestamp(),
+                new TimeValue(1),
+            ],
+            [
+                TimeValue::fromTimestamp($timestamp),
                 new TimeValue(
-                    $dateTime->setTimestamp($timestamp)->getTimestamp() - $dateTime->setTime(0, 0, 0)->getTimestamp()
+                    $timestamp - $dateTime->setTime(0, 0, 0)->getTimestamp()
                 ),
-            ),
-            array(
+            ],
+            [
                 clone $dateTime,
                 new TimeValue(
                     $dateTime->getTimestamp() - $dateTime->setTime(0, 0, 0)->getTimestamp()
                 ),
-            ),
-        );
+            ],
+        ];
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/Time/Value.php
+++ b/eZ/Publish/Core/FieldType/Time/Value.php
@@ -86,8 +86,7 @@ class Value extends BaseValue
     public static function fromTimestamp($timestamp)
     {
         try {
-            $dateTime = new DateTime();
-            $dateTime->setTimestamp($timestamp);
+            $dateTime = new DateTime("@{$timestamp}");
 
             return static::fromDateTime($dateTime);
         } catch (Exception $e) {


### PR DESCRIPTION
| Q | A |
|---|---|
| **Issue** | [EZP-28269](https://jira.ez.no/browse/EZP-28269) |
| **Type** | Bug |
| **BC break** | hope not => maybe => yes |
| **Target branch** | `6.7` |

We've discovered inconsistent behavior of `Time\Value::fromTimestamp` with respect to `DateAndTime\Value::fromTimestamp`. The former one creates Time Value relying on PHP server timezone setting, while the latter - creates Value w/o timezone (or using UTC).

See [`Time::fromTimestamp`](https://github.com/ezsystems/ezpublish-kernel/blob/v6.7.6/eZ/Publish/Core/FieldType/Time/Value.php#L89-L90) and [`DateAndTime::fromTimestamp`](https://github.com/ezsystems/ezpublish-kernel/blob/v6.7.6/eZ/Publish/Core/FieldType/DateAndTime/Value.php#L71).

There is [a difference](http://php.net/manual/en/datetime.settimestamp.php#117238) in setting `\DateTime` value using constructor `"@{$timestamp}"` time string and calling `setTimezone`. The latter one takes into account server timezone.

AFAICS Time Value should be an absolute number of seconds elapsed since midnight, thus cannot be timezone-dependent. This PR provides the fix for that. If you take a look at the original [unit tests](https://github.com/ezsystems/ezpublish-kernel/blob/v6.7.6/eZ/Publish/Core/FieldType/Tests/TimeTest.php#L149-L171) there's also an inconsistency. First three tests shows that this should be timezone-independent, however the other tests provide a fix for changing timezone. I'm assuming the latter behavior is incorrect, thus fixed here, but I need some confirmation.

**TODO**:
- [ ] Get feedback on correct behavior
- [x] See if Travis agrees.
- [x] Fix `Time\Value::fromTimestamp` to be timezone-independent
- [x] Fix unit tests.
- [x] Fix integration tests.