### PR TITLE
[7.0] EZP-28269: Fixed inconsistent creating of eztime fromTimestamp

### DIFF
--- a/doc/bc/changes-7.0.md
+++ b/doc/bc/changes-7.0.md
@@ -24,6 +24,9 @@ Changes affecting version compatibility with former or future versions.
 * "cache_pool_name" siteaccess setting has been removed & replaced by "cache_service_name" as the semantic is different.
   The new setting should contain the full service name of a  symfony cache service, by default app_cache.app is used.
 
+* The method `eZ\Publish\Core\FieldType\Time\Value::fromTimestamp` returns `Time\Value` without
+  taking into account the timezone. The reason for this change is consistency with the behavior of
+  `eZ\Publish\Core\FieldType\DateAndTime\Value::fromTimestamp`.
 
 ## Deprecations
 

--- a/eZ/Publish/API/Repository/Tests/FieldType/TimeIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/TimeIntegrationTest.php
@@ -185,7 +185,7 @@ class TimeIntegrationTest extends SearchBaseIntegrationTest
     /**
      * Get update field externals data.
      *
-     * @return array
+     * @return TimeValue
      */
     public function getValidUpdateFieldData()
     {
@@ -206,9 +206,9 @@ class TimeIntegrationTest extends SearchBaseIntegrationTest
             $field->value
         );
 
-        $dateTime = new DateTime();
+        $dateTime = new DateTime('@12345678');
         $expectedData = array(
-            'time' => $dateTime->setTimestamp(12345678)->getTimestamp() - $dateTime->setTime(0, 0, 0)->getTimestamp(),
+            'time' => $dateTime->getTimestamp() - $dateTime->setTime(0, 0, 0)->getTimestamp(),
         );
         $this->assertPropertiesCorrect(
             $expectedData,
@@ -305,12 +305,13 @@ class TimeIntegrationTest extends SearchBaseIntegrationTest
      */
     public function provideToHashData()
     {
-        $dateTime = new DateTime();
+        $timestamp = 123456;
+        $dateTime = new DateTime("@{$timestamp}");
 
         return array(
             array(
-                TimeValue::fromTimestamp(123456),
-                $dateTime->setTimestamp(123456)->getTimestamp() - $dateTime->setTime(0, 0, 0)->getTimestamp(),
+                TimeValue::fromTimestamp($timestamp),
+                $dateTime->getTimestamp() - $dateTime->setTime(0, 0, 0)->getTimestamp(),
             ),
         );
     }

--- a/eZ/Publish/Core/FieldType/Tests/TimeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/TimeTest.php
@@ -140,44 +140,44 @@ class TimeTest extends FieldTypeTest
     public function provideValidInputForAcceptValue()
     {
         $dateTime = new DateTime();
-        $secondsInDay = 24 * 60 * 60;
+        // change timezone to UTC (+00:00) to be able to calculate proper TimeValue
+        $timestamp = $dateTime->setTimezone(new \DateTimeZone('UTC'))->getTimestamp();
 
-        return array(
-            array(
+        return [
+            [
                 null,
                 new TimeValue(),
-            ),
-            array(
+            ],
+            [
                 '2012-08-28 12:20',
                 new TimeValue(44400),
-            ),
-            array(
+            ],
+            [
                 '2012-08-28 12:20 Europe/Berlin',
                 new TimeValue(44400),
-            ),
-            array(
+            ],
+            [
                 '2012-08-28 12:20 Asia/Sakhalin',
                 new TimeValue(44400),
-            ),
-            array(
-                // Set $dateTime to proper time for correct offset
-                $dateTime->setTimestamp(1372896001)->getTimestamp(),
-                // Correct for negative offset
-                new TimeValue(($secondsInDay + $dateTime->getOffset() + 1) % $secondsInDay),
-            ),
-            array(
-                TimeValue::fromTimestamp($timestamp = 1346149200),
+            ],
+            [
+                // create new DateTime object from timestamp w/o taking into account server timezone
+                (new DateTime('@1372896001'))->getTimestamp(),
+                new TimeValue(1),
+            ],
+            [
+                TimeValue::fromTimestamp($timestamp),
                 new TimeValue(
-                    $dateTime->setTimestamp($timestamp)->getTimestamp() - $dateTime->setTime(0, 0, 0)->getTimestamp()
+                    $timestamp - $dateTime->setTime(0, 0, 0)->getTimestamp()
                 ),
-            ),
-            array(
+            ],
+            [
                 clone $dateTime,
                 new TimeValue(
                     $dateTime->getTimestamp() - $dateTime->setTime(0, 0, 0)->getTimestamp()
                 ),
-            ),
-        );
+            ],
+        ];
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/Time/Value.php
+++ b/eZ/Publish/Core/FieldType/Time/Value.php
@@ -86,8 +86,7 @@ class Value extends BaseValue
     public static function fromTimestamp($timestamp)
     {
         try {
-            $dateTime = new DateTime();
-            $dateTime->setTimestamp($timestamp);
+            $dateTime = new DateTime("@{$timestamp}");
 
             return static::fromDateTime($dateTime);
         } catch (Exception $e) {


### PR DESCRIPTION
| Q | A |
|---|---|
| **Issue** | [EZP-28269](https://jira.ez.no/browse/EZP-28269) |
| **Related to** | #2158 |
| **Type** | Bug |
| **BC break** | yes |
| **Target branch** | `7.0` |

We've discovered inconsistent behavior of [`Time\Value::fromTimestamp`](https://github.com/ezsystems/ezpublish-kernel/blob/v6.7.6/eZ/Publish/Core/FieldType/Time/Value.php#L89-L90) with respect to [`DateAndTime\Value::fromTimestamp`](https://github.com/ezsystems/ezpublish-kernel/blob/v6.7.6/eZ/Publish/Core/FieldType/DateAndTime/Value.php#L71). The former one creates Time Value relying on PHP server timezone setting, while the latter - creates Value w/o timezone (or using UTC).

There is [a difference](http://php.net/manual/en/datetime.settimestamp.php#117238) in setting `\DateTime` value using constructor `"@{$timestamp}"` time string and calling `setTimezone`. The latter one takes into account server timezone.

**TODO**:
- [x] See if Travis agrees - errors are related to behat setup, not fix
- [x] Fix `Time\Value::fromTimestamp` to be timezone-independent
- [x] Fix unit tests.
- [x] Fix integration tests.
- [x] Add a BC note.