### PR TITLE
EZP-28271: Changed ContentService::deleteTranslation() to remove versions that only exist in that language

### DIFF
--- a/doc/specifications/translations/removal.md
+++ b/doc/specifications/translations/removal.md
@@ -8,10 +8,10 @@ the existing Versions of a Content Item and is specified as:
 
 ```php
 /**
- * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the specified translation
- *         is the only one a Version has or it is the main translation of a Content Object.
+ * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the specified Translation
+ *         is the Main Translation of a Content Item.
  * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed
- *         to delete the content (in one of the locations of the given Content Object).
+ *         to delete the content (in one of the locations of the given Content Item).
  * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if languageCode argument
  *         is invalid for the given content.
  *

--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -433,10 +433,10 @@ interface ContentService
      *
      * NOTE: this operation is risky and permanent, so user interface should provide a warning before performing it.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the specified translation
-     *         is the only one a Version has or it is the main translation of a Content Object.
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the specified Translation
+     *         is the Main Translation of a Content Item.
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed
-     *         to delete the content (in one of the locations of the given Content Object).
+     *         to delete the content (in one of the locations of the given Content Item).
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if languageCode argument
      *         is invalid for the given content.
      *

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -5281,20 +5281,11 @@ class ContentServiceTest extends BaseContentServiceTest
     }
 
     /**
-     * Test removal of the last remaining translation throws BadStateException.
-     *
-     * Note: this test case reproduces the following scenario:
-     * 1. Create the Content with a single translation.
-     * 2. Create a new Version with that translation and add to it another translation.
-     * 3. Update mainLanguageCode of the Content Object, to avoid trying to remove the main translation.
-     * 4. Try to remove a translation that is the only one in the first version.
-     * 5. Observe BadStateException with a message about trying to remove the last translation.
+     * Test removal of a Translation is possible when some archived Versions have only this Translation.
      *
      * @covers \eZ\Publish\Core\Repository\ContentService::deleteTranslation
-     * @expectedException \eZ\Publish\API\Repository\Exceptions\BadStateException
-     * @expectedExceptionMessageRegExp /The Version\(s\): \d+ of the ContentId=\d+ have only one language eng-US/
      */
-    public function testDeleteTranslationLastLanguageThrowsBadStateException()
+    public function testDeleteTranslationDeletesSingleTranslationVersions()
     {
         $repository = $this->getRepository();
         $contentService = $repository->getContentService();
@@ -5315,6 +5306,8 @@ class ContentServiceTest extends BaseContentServiceTest
         $content = $contentService->updateContentMetadata($publishedContent->contentInfo, $contentMetadataUpdateStruct);
 
         $contentService->deleteTranslation($content->contentInfo, 'eng-US');
+
+        $this->assertTranslationDoesNotExist('eng-US', $content->id);
     }
 
     /**
@@ -5354,7 +5347,7 @@ class ContentServiceTest extends BaseContentServiceTest
      *
      * @covers \eZ\Publish\Core\Repository\ContentService::deleteTranslation
      * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     * @expectedExceptionMessage Argument '$languageCode' is invalid: Specified translation does not exist
+     * @expectedExceptionMessage Argument '$languageCode' is invalid: ger-DE does not exist in the Content item
      */
     public function testDeleteTranslationThrowsInvalidArgumentException()
     {

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1893,10 +1893,10 @@ class ContentService implements ContentServiceInterface
      *
      * NOTE: this operation is risky and permanent, so user interface should provide a warning before performing it.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the specified translation
-     *         is the only one a Version has or it is the main translation of a Content Object.
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the specified Translation
+     *         is the Main Translation of a Content Item.
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed
-     *         to delete the content (in one of the locations of the given Content Object).
+     *         to delete the content (in one of the locations of the given Content Item).
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if languageCode argument
      *         is invalid for the given content.
      *

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1913,66 +1913,69 @@ class ContentService implements ContentServiceInterface
                 'Specified translation is the main translation of the Content Object'
             );
         }
-        // before actual removal, collect information on Versions
-        $versions = [];
-        $singleLangVersions = [];
-        foreach ($this->loadVersions($contentInfo) as $versionInfo) {
-            // check if user is authorized to delete Version
-            if (!$this->repository->canUser('content', 'remove', $versionInfo)) {
-                throw new UnauthorizedException(
-                    'content',
-                    'remove',
-                    [
-                        'contentId' => $contentInfo->id,
-                        'versionNo' => $versionInfo->versionNo,
-                    ]
-                );
-            }
-            // check if the specified translation exists for the Version
-            if (!in_array($languageCode, $versionInfo->languageCodes)) {
-                // if translation does not exist, simply ignore Version (see InvalidArgumentException later on)
-                continue;
-            }
-            // check if the specified translation is the only one
-            if (count($versionInfo->languageCodes) < 2) {
-                $singleLangVersions[] = $versionInfo->versionNo;
-            } else {
-                // otherwise add Version to the list of valid Versions to be processed
-                $versions[] = $versionInfo->versionNo;
-            }
-        }
 
-        if (!empty($singleLangVersions)) {
-            $verList = implode(', ', $singleLangVersions);
-            throw new BadStateException(
-                '$languageCode',
-                "The Version(s): {$verList} of the ContentId={$contentInfo->id} have only one language {$languageCode}. Remove these Version(s) before proceeding.\n" .
-                "Hint: Command 'ezplatform:remove-content-translation' handles this for you, look into it to see how this can be handled in custom code."
-            );
-        }
-
-        // if there are no Versions with the given translation, $languageCode arg is invalid
-        if (empty($versions)) {
-            throw new InvalidArgumentException(
-                '$languageCode',
-                sprintf(
-                    'Specified translation does not exist in the Content Object(id=%d)',
-                     $contentInfo->id
-                )
-            );
-        }
-
+        $translationWasFound = false;
         $this->repository->beginTransaction();
         try {
-            $this->persistenceHandler->contentHandler()->deleteTranslationFromContent($contentInfo->id, $languageCode);
+            foreach ($this->loadVersions($contentInfo) as $versionInfo) {
+                if (!$this->repository->canUser('content', 'remove', $versionInfo)) {
+                    throw new UnauthorizedException(
+                        'content',
+                        'remove',
+                        ['contentId' => $contentInfo->id, 'versionNo' => $versionInfo->versionNo]
+                    );
+                }
+
+                if (!in_array($languageCode, $versionInfo->languageCodes)) {
+                    continue;
+                }
+
+                $translationWasFound = true;
+
+                // If the translation is the version's only one, delete the version
+                if (count($versionInfo->languageCodes) < 2) {
+                    $this->persistenceHandler->contentHandler()->deleteVersion(
+                        $versionInfo->getContentInfo()->id,
+                        $versionInfo->versionNo
+                    );
+                }
+            }
+
+            if (!$translationWasFound) {
+                throw new InvalidArgumentException(
+                    '$languageCode',
+                    sprintf(
+                        '%s does not exist in the Content item(id=%d)',
+                        $languageCode,
+                        $contentInfo->id
+                    )
+                );
+            }
+
+            $this->persistenceHandler->contentHandler()->deleteTranslationFromContent(
+                $contentInfo->id,
+                $languageCode
+            );
             $locationIds = array_map(
                 function (Location $location) {
                     return $location->id;
                 },
                 $this->repository->getLocationService()->loadLocations($contentInfo)
             );
-            $this->persistenceHandler->urlAliasHandler()->translationRemoved($locationIds, $languageCode);
+            $this->persistenceHandler->urlAliasHandler()->translationRemoved(
+                $locationIds,
+                $languageCode
+            );
             $this->repository->commit();
+        } catch (InvalidArgumentException $e) {
+            $this->repository->rollback();
+            throw $e;
+        } catch (BadStateException $e) {
+            $this->repository->rollback();
+            throw $e;
+        } catch (UnauthorizedException $e) {
+            $this->repository->rollback();
+            throw $e;
         } catch (Exception $e) {
             $this->repository->rollback();
             // cover generic unexpected exception to fulfill API promise on @throws

--- a/eZ/Publish/Core/SignalSlot/ContentService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentService.php
@@ -650,10 +650,10 @@ class ContentService implements ContentServiceInterface
      *
      * NOTE: this operation is risky and permanent, so user interface should provide a warning before performing it.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the specified translation
-     *         is the only one a Version has or it is the main translation of a Content Object.
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the specified Translation
+     *         is the Main Translation of a Content Item.
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed
-     *         to delete the content (in one of the locations of the given Content Object).
+     *         to delete the content (in one of the locations of the given Content Item).
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if languageCode argument
      *         is invalid for the given content.
      *


### PR DESCRIPTION
PHP API deleteTranslation improvement on handling single-Translation Version
----
| Q | A |
|---|---|
| **Issue** | [EZP-28271](https://jira.ez.no/browse/EZP-28271) |
| **Type** | Improvement |
| **BC break** | no, deleteTranslation appeared in `6.13` |
| **Target branch** | `6.x` |

This PR improves PHP API `ContentService::deleteTranslation` to handle a case when a Translation being deleted exists as a single Translation for non-published Versions.

**TODO**:
- [x] **Rebase and squash fixups before merge**.
- [x] Align integration test with improvement
- [x] Implement deleting single-Translation Versions
- [x] Update `ezplatform:delete-content-translation` command removing unnecessary code
- [x] Update API PhpDoc