### PR TITLE
[7.0] EZP-28309: Fixed twig template for eztime incorrectly parsing time value

### DIFF
--- a/doc/bc/changes-7.0.md
+++ b/doc/bc/changes-7.0.md
@@ -28,6 +28,8 @@ Changes affecting version compatibility with former or future versions.
   taking into account the timezone. The reason for this change is consistency with the behavior of
   `eZ\Publish\Core\FieldType\DateAndTime\Value::fromTimestamp`.
 
+* The Twig block `eztime_field` of `eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig` is rendered using UTC timezone to avoid server timezone-related issues.
+
 ## Deprecations
 
 _7.0 is a major version, hence does not introduce deprecations but rather removes some previously deprecated features,

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -93,9 +93,9 @@
 {% spaceless %}
     {% if not ez_is_field_empty( content, field ) %}
         {% if fieldSettings.useSeconds %}
-            {% set field_value = field.value.time|localizeddate( 'none', 'medium', parameters.locale ) %}
+            {% set field_value = field.value.time|localizeddate( 'none', 'medium', parameters.locale, 'UTC' ) %}
         {% else %}
-            {% set field_value = field.value.time|localizeddate( 'none', 'short', parameters.locale ) %}
+            {% set field_value = field.value.time|localizeddate( 'none', 'short', parameters.locale, 'UTC' ) %}
         {% endif %}
         {{ block( 'simple_block_field' ) }}
     {% endif %}


### PR DESCRIPTION
Q | A
-- | --
Issue | [EZP-28309](https://jira.ez.no/browse/EZP-28309)
Type | Bug
BC break | yes
Target branch | 7.0

The root of the problem is handling **number of seconds** as a timestamp in order to use date formatter to display time. This isn't ideal because `eztime`, according to the requirements **should not be** timezone-dependent. Anyway, using date formatter is accepted as long as you force `UTC` timezone to avoid adjusting time to match server's timezone. As far as I remember the same kind of fix was used in v1 (done by the javascript though).