### PR TITLE
EZP-28316: [PAPI] As a Developer I want the API to get Locations for Draft

### DIFF
--- a/eZ/Publish/API/Repository/LocationService.php
+++ b/eZ/Publish/API/Repository/LocationService.php
@@ -12,6 +12,7 @@ use eZ\Publish\API\Repository\Values\Content\LocationUpdateStruct;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 
 /**
  * Location service, used for complex subtree operations.
@@ -85,6 +86,15 @@ interface LocationService
      * @return \eZ\Publish\API\Repository\Values\Content\LocationList
      */
     public function loadLocationChildren(Location $location, $offset = 0, $limit = 25);
+
+    /**
+     * Load parent Locations for Content Draft.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Location[] List of parent Locations
+     */
+    public function loadParentLocationsForDraftContent(VersionInfo $versionInfo);
 
     /**
      * Returns the number of children which are readable by the current user of a location object.

--- a/eZ/Publish/Core/SignalSlot/LocationService.php
+++ b/eZ/Publish/Core/SignalSlot/LocationService.php
@@ -13,6 +13,7 @@ use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\LocationCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\LocationUpdateStruct;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\SignalSlot\Signal\LocationService\CopySubtreeSignal;
 use eZ\Publish\Core\SignalSlot\Signal\LocationService\CreateLocationSignal;
 use eZ\Publish\Core\SignalSlot\Signal\LocationService\UpdateLocationSignal;
@@ -146,6 +147,14 @@ class LocationService implements LocationServiceInterface
     public function loadLocationChildren(Location $location, $offset = 0, $limit = 25)
     {
         return $this->service->loadLocationChildren($location, $offset, $limit);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadParentLocationsForDraftContent(VersionInfo $versionInfo)
+    {
+        return $this->service->loadParentLocationsForDraftContent($versionInfo);
     }
 
     /**


### PR DESCRIPTION
| Question | Answer |
| ------------- | --------- |
| **JIRA issue** | [EZP-28316](https://jira.ez.no/browse/EZP-28316) |
| **Related to** | [EZP-28315](https://jira.ez.no/browse/EZP-28315) |
| **Type** | Improvement |
| **BC break**    | no |
| **Target version** | `6.13` |
| **PHP API** | `LocationService::loadParentLocationsForDraftContent` |

While working on v2 create draft, we've discovered missing feature on `LocationService` to allow loading assigned Location node(s) for newly created, not published Draft (usually to do it Content has to be published first).

There is already a method for that on Persistence Handlers layer in `eZ\Publish\SPI\Persistence\Content\Location\Handler::loadParentLocationsForDraftContent`, however it had been not exposed as `LocationService` API. This PR implements that.

**TODO**:
- [x] Implement `LocationService::loadParentLocationsForDraftContent`
- [x] Implement integration tests.
- [x] Check if Travis agrees.
- [x] Add story, or sub task of UI story
- [x] Send for review.
- [x] ~Decide if this requires QA~ *(yes, UI story does, API part must at a minimum be covered with integration tests)*