### PR TITLE
EZP-28306: Fixed missing namespace prefix in token id  when checking if CSRF token is stored

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-SPL": "*",
         "ext-xsl": "*",
         "zetacomponents/mail": "~1.8",
-        "symfony/symfony": "^2.8.31 | ^3.3.13",
+        "symfony/symfony": "~2.7.38 | ~2.8.31 | ^3.3.13",
         "symfony-cmf/routing": "~1.1",
         "qafoo/rmf": "1.0.*",
         "kriswallsmith/buzz": ">=0.9",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "ext-SPL": "*",
         "ext-xsl": "*",
         "zetacomponents/mail": "~1.8",
-        "symfony/symfony": "^2.7 | ^3.1",
+        "symfony/symfony": "^2.8.31 | ^3.3.13",
         "symfony-cmf/routing": "~1.1",
         "qafoo/rmf": "1.0.*",
         "kriswallsmith/buzz": ">=0.9",

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/security.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/security.yml
@@ -2,6 +2,7 @@ parameters:
     ezpublish_rest.security.authentication.listener.session.class: eZ\Publish\Core\REST\Server\Security\RestAuthenticator
     ezpublish_rest.security.authentication.logout_handler.class: eZ\Publish\Core\REST\Server\Security\RestLogoutHandler
 
+    ezpublish_rest.security.csrf.token_manager.class: eZ\Publish\Core\REST\Server\Security\CsrfTokenManager
 services:
     # Following service will be aliased at compile time to "ezpublish_rest.session_authenticator" by the Security factory.
     ezpublish_rest.security.authentication.listener.session:
@@ -20,3 +21,10 @@ services:
         class: "%ezpublish_rest.security.authentication.logout_handler.class%"
         arguments:
             - '@ezpublish.config.resolver'
+
+    ezpublish_rest.security.csrf.token_manager:
+        class: '%ezpublish_rest.security.csrf.token_manager.class%'
+        arguments:
+            - '@?security.csrf.token_generator'
+            - '@?security.csrf.token_storage'
+            - '@?request_stack'

--- a/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishRestBundle/Resources/config/services.yml
@@ -231,8 +231,7 @@ services:
         arguments:
             - "@ezpublish_rest.session_authenticator"
             - "%ezpublish_rest.csrf_token_intention%"
-            - "@?security.csrf.token_manager"
-            - "@?security.csrf.token_storage"
+            - "@?ezpublish_rest.security.csrf.token_manager"
 
     ezpublish_rest.request_listener:
         class: "%ezpublish_rest.request_listener.class%"
@@ -252,7 +251,7 @@ services:
             - "@event_dispatcher"
             - "%form.type_extension.csrf.enabled%"
             - "%ezpublish_rest.csrf_token_intention%"
-            - "@?security.csrf.token_manager"
+            - "@?ezpublish_rest.security.csrf.token_manager"
         tags:
             - { name: kernel.event_subscriber }
 

--- a/eZ/Publish/Core/REST/Server/Controller/SessionController.php
+++ b/eZ/Publish/Core/REST/Server/Controller/SessionController.php
@@ -157,7 +157,7 @@ class SessionController extends Controller
      */
     private function hasStoredCsrfToken()
     {
-        if (!isset($this->csrfTokenManager)) {
+        if ($this->csrfTokenManager === null) {
             return true;
         }
 

--- a/eZ/Publish/Core/REST/Server/Controller/SessionController.php
+++ b/eZ/Publish/Core/REST/Server/Controller/SessionController.php
@@ -14,7 +14,7 @@ use eZ\Publish\Core\REST\Server\Values;
 use eZ\Publish\Core\REST\Server\Exceptions;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Csrf\CsrfToken;
-use Symfony\Component\Security\Csrf\CsrfTokenManager;
+use eZ\Publish\Core\REST\Server\Security\CsrfTokenManager;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface;
@@ -27,14 +27,9 @@ class SessionController extends Controller
     private $authenticator;
 
     /**
-     * @var \Symfony\Component\Security\Csrf\CsrfTokenManager
+     * @var \eZ\Publish\Core\REST\Server\Security\CsrfTokenManager
      */
     private $csrfTokenManager;
-
-    /**
-     * @var \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface
-     */
-    private $csrfTokenStorage;
 
     /**
      * @var string
@@ -50,7 +45,6 @@ class SessionController extends Controller
         $this->authenticator = $authenticator;
         $this->csrfTokenIntention = $tokenIntention;
         $this->csrfTokenManager = $csrfTokenManager;
-        $this->csrfTokenStorage = $csrfTokenStorage;
     }
 
     /**
@@ -163,11 +157,11 @@ class SessionController extends Controller
      */
     private function hasStoredCsrfToken()
     {
-        if (!isset($this->csrfTokenStorage)) {
+        if (!isset($this->csrfTokenManager)) {
             return true;
         }
 
-        return $this->csrfTokenStorage->hasToken($this->csrfTokenIntention);
+        return $this->csrfTokenManager->hasToken($this->csrfTokenIntention);
     }
 
     /**

--- a/eZ/Publish/Core/REST/Server/Security/CsrfTokenManager.php
+++ b/eZ/Publish/Core/REST/Server/Security/CsrfTokenManager.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\REST\Server\Security;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Csrf\CsrfTokenManager as BaseCsrfTokenManager;
+use Symfony\Component\Security\Csrf\TokenGenerator\TokenGeneratorInterface;
+use Symfony\Component\Security\Csrf\TokenStorage\NativeSessionTokenStorage;
+use Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface;
+
+class CsrfTokenManager extends BaseCsrfTokenManager
+{
+    /**
+     * @var \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface
+     */
+    private $storage;
+
+    /**
+     * @var string
+     */
+    private $namespace;
+
+    public function __construct(
+        TokenGeneratorInterface $generator = null,
+        TokenStorageInterface $storage = null,
+        RequestStack $requestStack = null)
+    {
+        $this->storage = $storage ?: new NativeSessionTokenStorage();
+        $this->namespace = $this->resolveNamespace($requestStack);
+
+        parent::__construct($generator, $this->storage, $this->namespace);
+    }
+
+    /**
+     * Tests if a CSRF token is stored.
+     *
+     * @param string $tokenId
+     * @return bool
+     */
+    public function hasToken($tokenId)
+    {
+        return $this->storage->hasToken($this->namespace . $tokenId);
+    }
+
+    /**
+     * Resolves token namespace.
+     *
+     * @param RequestStack $requestStack
+     * @return string
+     */
+    private function resolveNamespace(RequestStack $requestStack = null)
+    {
+        if ($requestStack !== null && ($request = $requestStack->getMasterRequest())) {
+            return $request->isSecure() ? 'https-' : '';
+        }
+
+        return !empty($_SERVER['HTTPS']) && 'off' !== strtolower($_SERVER['HTTPS']) ? 'https-' : '';
+    }
+}

--- a/eZ/Publish/Core/REST/Server/Tests/Security/CsrfTokenManagerTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Security/CsrfTokenManagerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * File containing the RestLogoutHandlerTest class.
+ *
+ * @copyright Copyright (C) 1999-2014 eZ Systems AS. All rights reserved.
+ * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License v2
+ */
+namespace eZ\Publish\Core\REST\Server\Tests\Security;
+
+use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
+use eZ\Publish\Core\REST\Server\Security\CsrfTokenManager;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Csrf\TokenGenerator\TokenGeneratorInterface;
+use Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface;
+
+class CsrfTokenManagerTest extends TestCase
+{
+    use PHPUnit5CompatTrait;
+
+    const CSRF_TOKEN_INTENTION = 'csrf';
+
+    /** @var \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface */
+    private $tokenStorage;
+    /** @var \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\HttpFoundation\RequestStack */
+    private $requestStack;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $this->requestStack = $this->createMock(RequestStack::class);
+    }
+
+    public function testHasTokenForHttp()
+    {
+        $csrfTokenManager = $this->createCsrfTokenManager(false);
+
+        $this->tokenStorage
+            ->expects($this->once())
+            ->method('hasToken')
+            ->with(self::CSRF_TOKEN_INTENTION);
+
+        $csrfTokenManager->hasToken(self::CSRF_TOKEN_INTENTION);
+    }
+
+    public function testHasTokenForHttps()
+    {
+        $csrfTokenManager = $this->createCsrfTokenManager(true);
+
+        $this->tokenStorage
+            ->expects($this->once())
+            ->method('hasToken')
+            ->with('https-' . self::CSRF_TOKEN_INTENTION);
+
+        $csrfTokenManager->hasToken(self::CSRF_TOKEN_INTENTION);
+    }
+
+    private function createCsrfTokenManager($https = false)
+    {
+        $request = new Request();
+        if ($https) {
+            $request->server->set('HTTPS', 'ON');
+        }
+
+        $this->requestStack
+            ->expects($this->once())
+            ->method('getMasterRequest')
+            ->willReturn($request);
+
+        return new CsrfTokenManager(
+            $this->createMock(TokenGeneratorInterface::class),
+            $this->tokenStorage,
+            $this->requestStack
+        );
+    }
+}


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28306

# Description 

This patch fixes broken login to PlatformUI over https with Symfony 2.8.31. Cause of the problem was missed `namespace` prefix (introduced by https://github.com/symfony/symfony/pull/24992) in token id in  `\eZ\Publish\Core\REST\Server\Controller\SessionController::hasStoredCsrfToken`. 

# TODO:

- [X] Implementation
- [X] ~~Compatibility with <= Symfony 2.8.30 ?~~
- [x] Tests