### PR TITLE
EZP-28375: As a Maintainer I want CI to run tests on behat environment of eZ Platform v2 - part 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ matrix:
     - php: 7.1
       env: TEST_CONFIG="phpunit.xml"
     - php: 7.1
-      env: REST_TEST_CONFIG="phpunit-functional-rest.xml" RUN_INSTALL=1 SYMFONY_ENV=behat SYMFONY_DEBUG=1
+      env: REST_TEST_CONFIG="phpunit-functional-rest.xml" SYMFONY_ENV=behat SYMFONY_DEBUG=1
     - php: 7.1
-      env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" RUN_INSTALL=1 SYMFONY_ENV=behat
+      env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" SYMFONY_ENV=behat
     - php: 7.1
       env: SOLR_VERSION="6.4.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml"
     - php: 7.1
@@ -61,8 +61,7 @@ before_script:
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   # Prepare system
   - if [ "$TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_unittest.sh ; fi
-  - if [ "$BEHAT_OPTS" != "" ] ; then ./bin/.travis/prepare_behat.sh ; fi
-  - if [ "$REST_TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_behat.sh ; fi
+  - if [ "$BEHAT_OPTS" != "" ] || [ "$REST_TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_behat.sh ; fi
   # Detecting timezone issues by testing on random timezone
   - TEST_TIMEZONES=("America/New_York" "Asia/Calcutta" "UTC")
   - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,10 @@ matrix:
 # 7.1
     - php: 7.1
       env: TEST_CONFIG="phpunit.xml"
-    - php: 7.1
-      env: REST_TEST_CONFIG="phpunit-functional-rest.xml" SYMFONY_ENV=behat SYMFONY_DEBUG=1 SF_CMD="ez:behat:create-language 'pol-PL' 'Polish (polski)'"
-    - php: 7.1
-      env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" SYMFONY_ENV=behat
+    #- php: 7.1
+    #  env: REST_TEST_CONFIG="phpunit-functional-rest.xml" SYMFONY_ENV=behat SYMFONY_DEBUG=1 SF_CMD="ez:behat:create-language 'pol-PL' 'Polish (polski)'"
+    #- php: 7.1
+    #  env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" SYMFONY_ENV=behat
     - php: 7.1
       env: SOLR_VERSION="6.4.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml"
     - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,8 @@ branches:
 
 # setup requirements for running unit/integration/behat tests
 before_script:
-  # Disable memory_limit for composer in PHP 5.6
-  - echo "memory_limit=-1" >> ~/.phpenv/versions/5.6/etc/conf.d/travis.ini
+  # Disable memory_limit for composer
+  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   # Prepare system
   - if [ "$TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_unittest.sh ; fi
   - if [ "$BEHAT_OPTS" != "" ] ; then ./bin/.travis/prepare_behat.sh ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ cache:
 
 env:
   global:
-    # For functional tests
-    - COMPOSE_FILE="doc/docker-compose/base-dev.yml:doc/docker-compose/selenium.yml"
+    # For functional and acceptance tests
+    - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml"
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
     - php: 7.1
       env: TEST_CONFIG="phpunit.xml"
     - php: 7.1
-      env: REST_TEST_CONFIG="phpunit-functional-rest.xml" SYMFONY_ENV=behat SYMFONY_DEBUG=1
+      env: REST_TEST_CONFIG="phpunit-functional-rest.xml" SYMFONY_ENV=behat SYMFONY_DEBUG=1 SF_CMD="ez:behat:create-language 'pol-PL' 'Polish (polski)'"
     - php: 7.1
       env: BEHAT_OPTS="--profile=rest --tags=~@broken --suite=fullJson" SYMFONY_ENV=behat
     - php: 7.1
@@ -62,6 +62,8 @@ before_script:
   # Prepare system
   - if [ "$TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_unittest.sh ; fi
   - if [ "$BEHAT_OPTS" != "" ] || [ "$REST_TEST_CONFIG" != "" ] ; then ./bin/.travis/prepare_behat.sh ; fi
+  # Execute Symfony command if specified
+  - if [ "$SF_CMD" != "" ] ; then cd "$HOME/build/ezplatform"; docker-compose exec --user www-data app sh -c "bin/console $SF_CMD" ; fi
   # Detecting timezone issues by testing on random timezone
   - TEST_TIMEZONES=("America/New_York" "Asia/Calcutta" "UTC")
   - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}

--- a/bin/.travis/prepare_behat.sh
+++ b/bin/.travis/prepare_behat.sh
@@ -9,7 +9,4 @@ echo "> Cloning ezsystems/ezplatform:${EZPLATFORM_BRANCH}"
 git clone --depth 1 --single-branch --branch "$EZPLATFORM_BRANCH" https://github.com/ezsystems/ezplatform.git ${EZPLATFORM_BUILD_DIR}
 cd ${EZPLATFORM_BUILD_DIR}
 
-# Update docker to supported version
-${EZPLATFORM_BUILD_DIR}/bin/.travis/trusty/update_docker.sh
-
 /bin/bash ./bin/.travis/trusty/setup_ezplatform.sh "${PACKAGE_BUILD_DIR}"

--- a/bin/.travis/prepare_behat.sh
+++ b/bin/.travis/prepare_behat.sh
@@ -1,27 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 
-# File for setting up system for behat testing, just like done in DemoBundle's .travis.yml
-
-# Change local git repo to be a full one as we will reuse it for composer install below
-git fetch --unshallow && git checkout -b tmp_ci_branch
-export BRANCH_BUILD_DIR=$TRAVIS_BUILD_DIR TRAVIS_BUILD_DIR="$HOME/build/ezplatform"
-
-# Checkout meta repo, use the branch indicated in composer.json under extra._ezplatform_branch_for_behat_tests
 EZPLATFORM_BRANCH=`php -r 'echo json_decode(file_get_contents("./composer.json"))->extra->_ezplatform_branch_for_behat_tests;'`
+EZPLATFORM_BRANCH="${EZPLATFORM_BRANCH:-master}"
+PACKAGE_BUILD_DIR=$PWD
+EZPLATFORM_BUILD_DIR=${HOME}/build/ezplatform
 
-cd "$HOME/build"
+echo "> Cloning ezsystems/ezplatform:${EZPLATFORM_BRANCH}"
+git clone --depth 1 --single-branch --branch "$EZPLATFORM_BRANCH" https://github.com/ezsystems/ezplatform.git ${EZPLATFORM_BUILD_DIR}
+cd ${EZPLATFORM_BUILD_DIR}
 
-git clone --depth 1 --single-branch --branch "$EZPLATFORM_BRANCH" https://github.com/ezsystems/ezplatform.git
-cd ezplatform
+# Update docker to supported version
+${EZPLATFORM_BUILD_DIR}/bin/.travis/trusty/update_docker.sh
 
-#if [ "$REST_TEST_CONFIG" != "" ] ; then
-#    echo "> Fixing security.yml for REST functional tests"
-#    sed -i "s@#        ezpublish_rest:@        ezpublish_rest:@" app/config/security.yml
-#    sed -i "s@#            pattern: ^/api/ezp/v2@            pattern: ^/api/ezp/v2@" app/config/security.yml
-#    sed -i "s@#            stateless: true@            stateless: true@" app/config/security.yml
-#    sed -i "s@#            ezpublish_http_basic:@            ezpublish_http_basic:@" app/config/security.yml
-#    sed -i "s@#                realm: eZ Publish REST API@                realm: eZ Publish REST API@" app/config/security.yml
-#fi
-
-# Install everything needed for behat testing, using our local branch of this repo
-./bin/.travis/trusty/setup_from_external_repo.sh $BRANCH_BUILD_DIR "ezsystems/ezpublish-kernel:dev-tmp_ci_branch"
+/bin/bash ./bin/.travis/trusty/setup_ezplatform.sh "${PACKAGE_BUILD_DIR}"

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     "extra": {
         "_ci_branch-comment_": "Keep ci branch up-to-date with master or branch if on stable. ci is never on github but convention used for ci behat testing!",
         "_ezplatform_branch_for_behat_tests_comment_": "ezplatform branch to use to run Behat tests",
-        "_ezplatform_branch_for_behat_tests": "ezp-28375-improve-travis-setup-script",
+        "_ezplatform_branch_for_behat_tests": "2.0",
         "branch-alias": {
             "dev-master": "7.0.x-dev",
             "dev-tmp_ci_branch": "7.0.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     "extra": {
         "_ci_branch-comment_": "Keep ci branch up-to-date with master or branch if on stable. ci is never on github but convention used for ci behat testing!",
         "_ezplatform_branch_for_behat_tests_comment_": "ezplatform branch to use to run Behat tests",
-        "_ezplatform_branch_for_behat_tests": "2.0",
+        "_ezplatform_branch_for_behat_tests": "ezp-28375-improve-travis-setup-script",
         "branch-alias": {
             "dev-master": "7.0.x-dev",
             "dev-tmp_ci_branch": "7.0.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ext-PDO": "*",
         "ext-SPL": "*",
         "ext-xsl": "*",
-        "symfony/symfony": "^3.3.13",
+        "symfony/symfony": "^3.4",
         "symfony-cmf/routing": "~1.1",
         "kriswallsmith/buzz": ">=0.9",
         "sensio/distribution-bundle": "^5.0",

--- a/doc/bc/changes-7.0.md
+++ b/doc/bc/changes-7.0.md
@@ -30,6 +30,9 @@ Changes affecting version compatibility with former or future versions.
 
 * The Twig block `eztime_field` of `eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig` is rendered using UTC timezone to avoid server timezone-related issues.
 
+* REST API no longer supports editing User Content (Content containing `ezuser` Field)
+  using Content Service. Use UserService REST API endpoints instead.
+
 ## Deprecations
 
 _7.0 is a major version, hence does not introduce deprecations but rather removes some previously deprecated features,

--- a/eZ/Bundle/EzPublishRestBundle/Features/Content/user_content.feature
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Content/user_content.feature
@@ -23,6 +23,7 @@ Feature: users can be manipulated using the Content API
          Then response status code is "204"
           And the User this Content referred to is deleted
 
+    @broken
     Scenario: Editing a User Content with the Content API works
         Given there is a User Content
          When I create a draft of this content

--- a/eZ/Publish/API/Repository/Tests/Regression/EnvTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EnvTest.php
@@ -27,7 +27,7 @@ class EnvTest extends BaseTest
 
         $this->assertInstanceOf(TagAwareAdapter::class, $pool);
 
-        $reflectionPool = new \ReflectionProperty($pool, 'itemsAdapter');
+        $reflectionPool = new \ReflectionProperty($pool, 'pool');
         $reflectionPool->setAccessible(true);
         $innerPool = $reflectionPool->getValue($pool);
 


### PR DESCRIPTION
| Question | Answer |
| ------------ | ---------- |
| **Status** | Work in progress |
| **JIRA issue** | [EZP-28375](https://jira.ez.no/browse/EZP-28375) |
| **Target version** | `7.0` |
| **BC break** | yes, for automated tests |
| **Tests pass** | [yes](https://travis-ci.org/ezsystems/ezpublish-kernel/builds/313433466) |

This PR along with its counterpart, ezsystems/ezplatform#232, enables running tests that require running eZ Platform installation using docker container (that includes behat and REST functional tests).

**TODO**
- [x] **Delete TMP commits**
- [x] **Do not merge until ezplatform counterpart ezsystems/ezplatform#232 gets merged**
- [x] Rebase after #2181 gets merged
- [x] Bump `symfony/symfony` requirement to `^3.4` and fix related broken cache pool test
- [x] Travis: Adjust .travis.yml to meta-repository changes (and simplify).
- [x] Travis: Replace hardcoded PHP version with job runtime one.
- [x] Travis: align `prepare_behat` script with meta-repository changes.
- [x] Travis: update eZ Platform Docker environment variables
- [x] Tests: Fix incorrect response code for REST login using front-end session test.
- [x] Tests: generate remoteId as md5 sum due to cache tag names limitations (forbidden characters).
- [x] Tests: added created Role to cleanup list, so tests can be run multiple times without reinstalling
- [x] Tests: Fix wrong login form action route.