### PR TITLE
[7.0] Update & Simplify install instructions

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
@@ -119,24 +119,18 @@ class ScriptHandler extends DistributionBundleScriptHandler
 <fg=cyan>Welcome to eZ Platform!</fg=cyan>
 
 <options=bold>Quick Install:</>
-(Assuming the CLI user you execute commands with below is same that extracted/installed the software)
-<comment>    $  export SYMFONY_ENV="prod"</comment>
+<comment>    $  export SYMFONY_ENV="dev"</comment>
 <comment>    $  php ${consoleDir}/console ezplatform:install <type></comment>
 <comment>    $  php ${consoleDir}/console assetic:dump</comment>
 <comment>    $  php ${consoleDir}/console server:run</comment>
 
 Note:
 - "ezplatform:install" has different installer <type>s depending on your install, see <fg=green>INSTALL.md</> or <fg=green>README.md</> for which one to use.
-- For development use you can enable full debugging by setting SYMFONY_ENV to "dev".
-- Last command will give you url to frontend of installation, add "/ez" to reach backend.
+- Instructions above assumes the CLI user you execute commands with is same that extracted/installed the software.
+- Last command will give you url to frontend of installation, add "/admin" to reach backend.
 
-Performance tips:
-- Use PHP 7.0 (or better yet PHP 7.1), and make sure opcache is enabled.
-- Dump autoload class map, even in development: <fg=green>composer dump-autoload --optimize</>
-- Follow full install instructions below to setup nginx (or Apache).
-- Further reading: https://doc.ezplatform.com/en/latest/guide/performance/
 
-For full install instructions, including setting up directory permissions, see install instructions in <fg=green>INSTALL.md</>
+For full install instructions, including setting up full web server & directory permissions, see install instructions in <fg=green>INSTALL.md</>
 or <fg=green>README.md</>.
 
 EOT

--- a/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
@@ -121,12 +121,12 @@ class ScriptHandler extends DistributionBundleScriptHandler
 <options=bold>Quick Install:</>
 <comment>    $  export SYMFONY_ENV="dev"</comment>
 <comment>    $  php ${consoleDir}/console ezplatform:install <type></comment>
-<comment>    $  php ${consoleDir}/console assetic:dump</comment>
 <comment>    $  php ${consoleDir}/console server:run</comment>
 
 Note:
-- "ezplatform:install" has different installer <type>s depending on your install, see <fg=green>INSTALL.md</> or <fg=green>README.md</> for which one to use.
-- The instructions above assume the CLI user you execute these commands with is the same one that extracted/installed the software.
+- "ezplatform:install" has different installer <type>s depending on your install, run command with <comment>--help</comment> to see your options.
+- Instructions above assume the CLI user you execute these commands with is the same one that extracted/installed the software,
+  otherwise see install instructions for directory permissions.
 - Last command will give you url to frontend of installation, add "/admin" to reach backend.
 
 

--- a/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
@@ -127,7 +127,7 @@ Note:
 - "ezplatform:install" has different installer <type>s depending on your install, run command with <comment>--help</comment> to see your options.
 - Instructions above assume the CLI user you execute these commands with is the same one that extracted/installed the software,
   otherwise see install instructions for directory permissions.
-- Last command will give you url to frontend of installation, add "/admin" to reach backend.
+- The last command will give you the url to the frontend of the installation, add "/admin" to reach backend.
 
 
 For full install instructions, including setting up full web server & directory permissions, see install instructions in <fg=green>INSTALL.md</>

--- a/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Composer/ScriptHandler.php
@@ -126,7 +126,7 @@ class ScriptHandler extends DistributionBundleScriptHandler
 
 Note:
 - "ezplatform:install" has different installer <type>s depending on your install, see <fg=green>INSTALL.md</> or <fg=green>README.md</> for which one to use.
-- Instructions above assumes the CLI user you execute commands with is same that extracted/installed the software.
+- The instructions above assume the CLI user you execute these commands with is the same one that extracted/installed the software.
 - Last command will give you url to frontend of installation, add "/admin" to reach backend.
 
 


### PR DESCRIPTION
Now that we require PHP 7.1 and have greatly improved performance of backend placing hinst on performance tuning does not need to take space here anymore.

Besides that:
- updated to use dev, with symfony 3 builtin server is only available in dev by default
- update to use `/admin` url for backend
- somewhat simplified the text a bit

Open question:
- [x] Do we need to run the assetic:dump command? As it's already ran by composer create-project which is what has been done when this is shown, **ok if we remove?**