### PR TITLE
EZP-28253: [REST] As a frontend developer I would like to get information about field type in the CurrentVersion object

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -6975,7 +6975,8 @@ Version
           <xsd:element name="id" type="xsd:integer" />
           <xsd:element name="fieldDefinitionIdentifier" type="xsd:string" />
           <xsd:element name="languageCode" type="xsd:string" />
-          <xsd:element name="value" type="fieldValueType" />
+          <xsd:element name="typeIdentifier" type="xsd:string" />
+          <xsd:element name="fieldValue" type="fieldValueType" />
         </xsd:all>
       </xsd:complexType>
       <xsd:complexType name="vnd.ez.api.Version">

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ContentTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ContentTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Bundle\EzPublishRestBundle\Tests\Functional;
 
+use Buzz\Message\Response;
 use eZ\Bundle\EzPublishRestBundle\Tests\Functional\TestCase as RESTFunctionalTestCase;
 
 class ContentTest extends RESTFunctionalTestCase
@@ -170,7 +171,7 @@ XML;
         );
 
         self::assertHttpResponseCodeEquals($response, 200);
-        // @todo test data
+        $this->assertVersionResponseContainsExpectedFields($response);
         // @todo test filtering (language, fields, etc)
     }
 
@@ -565,5 +566,26 @@ XML;
         }
 
         throw new \RuntimeException("Test internal error: Version with status {$status} not found");
+    }
+
+    /**
+     * Assert that Version REST Response contains proper fields.
+     *
+     * @param \Buzz\Message\Response $response
+     */
+    private function assertVersionResponseContainsExpectedFields(Response $response)
+    {
+        $contentType = $response->getHeader('Content-Type');
+        self::assertNotEmpty($contentType);
+
+        $responseBody = $response->getContent();
+
+        // check if response is of an expected Content-Type
+        self::assertEquals('Version+xml', $this->getMediaFromTypeString($contentType));
+
+        // validate by custom XSD
+        $document = new \DOMDocument();
+        $document->loadXML($responseBody);
+        $document->schemaValidate(__DIR__ . '/xsd/Version.xsd');
     }
 }

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/TestCase.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/TestCase.php
@@ -184,6 +184,18 @@ EOF;
         return "application/vnd.ez.api.$typeString";
     }
 
+    protected function getMediaFromTypeString($typeString)
+    {
+        $prefix = 'application/vnd.ez.api.';
+        self::assertStringStartsWith(
+            $prefix,
+            $typeString,
+            "Unknown media: {$typeString}"
+        );
+
+        return substr($typeString, strlen($prefix));
+    }
+
     protected function addCreatedElement($href)
     {
         $testCase = $this;

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/xsd/Version.xsd
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/xsd/Version.xsd
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://ez.no/API/Values">
+  <xsd:element name="Version">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="VersionInfo">
+          <xsd:complexType>
+            <xsd:sequence>
+              <xsd:element type="xsd:short" name="id"/>
+              <xsd:element type="xsd:byte" name="versionNo"/>
+              <xsd:element type="xsd:string" name="status"/>
+              <xsd:element type="xsd:dateTime" name="modificationDate"/>
+              <xsd:element name="Creator">
+                <xsd:complexType>
+                  <xsd:simpleContent>
+                    <xsd:extension base="xsd:string">
+                      <xsd:attribute type="xsd:string" name="media-type"/>
+                      <xsd:attribute type="xsd:string" name="href"/>
+                    </xsd:extension>
+                  </xsd:simpleContent>
+                </xsd:complexType>
+              </xsd:element>
+              <xsd:element type="xsd:dateTime" name="creationDate"/>
+              <xsd:element type="xsd:string" name="initialLanguageCode"/>
+              <xsd:element type="xsd:string" name="languageCodes"/>
+              <xsd:element name="VersionTranslationInfo">
+                <xsd:complexType>
+                  <xsd:sequence>
+                    <xsd:element name="Language">
+                      <xsd:complexType>
+                        <xsd:sequence>
+                          <xsd:element type="xsd:string" name="languageCode"/>
+                        </xsd:sequence>
+                      </xsd:complexType>
+                    </xsd:element>
+                  </xsd:sequence>
+                  <xsd:attribute type="xsd:string" name="media-type"/>
+                </xsd:complexType>
+              </xsd:element>
+              <xsd:element name="names">
+                <xsd:complexType>
+                  <xsd:sequence>
+                    <xsd:element name="value">
+                      <xsd:complexType>
+                        <xsd:simpleContent>
+                          <xsd:extension base="xsd:string">
+                            <xsd:attribute type="xsd:string" name="languageCode"/>
+                          </xsd:extension>
+                        </xsd:simpleContent>
+                      </xsd:complexType>
+                    </xsd:element>
+                  </xsd:sequence>
+                </xsd:complexType>
+              </xsd:element>
+              <xsd:element name="Content">
+                <xsd:complexType>
+                  <xsd:simpleContent>
+                    <xsd:extension base="xsd:string">
+                      <xsd:attribute type="xsd:string" name="media-type"/>
+                      <xsd:attribute type="xsd:string" name="href"/>
+                    </xsd:extension>
+                  </xsd:simpleContent>
+                </xsd:complexType>
+              </xsd:element>
+            </xsd:sequence>
+          </xsd:complexType>
+        </xsd:element>
+        <xsd:element name="Fields">
+          <xsd:complexType>
+            <xsd:sequence>
+              <xsd:element name="field" maxOccurs="unbounded" minOccurs="0">
+                <xsd:complexType>
+                  <xsd:sequence>
+                    <xsd:element type="xsd:short" name="id"/>
+                    <xsd:element type="xsd:string" name="fieldDefinitionIdentifier"/>
+                    <xsd:element type="xsd:string" name="languageCode"/>
+                    <xsd:element type="xsd:string" name="typeIdentifier"/>
+                    <xsd:element name="fieldValue">
+                      <xsd:complexType mixed="true">
+                        <xsd:sequence>
+                          <xsd:element name="value" maxOccurs="unbounded" minOccurs="0">
+                            <xsd:complexType>
+                              <xsd:simpleContent>
+                                <xsd:extension base="xsd:string">
+                                  <xsd:attribute type="xsd:string" name="key" use="optional"/>
+                                </xsd:extension>
+                              </xsd:simpleContent>
+                            </xsd:complexType>
+                          </xsd:element>
+                        </xsd:sequence>
+                      </xsd:complexType>
+                    </xsd:element>
+                  </xsd:sequence>
+                </xsd:complexType>
+              </xsd:element>
+            </xsd:sequence>
+          </xsd:complexType>
+        </xsd:element>
+        <xsd:element name="Relations">
+          <xsd:complexType>
+            <xsd:simpleContent>
+              <xsd:extension base="xsd:string">
+                <xsd:attribute type="xsd:string" name="media-type"/>
+                <xsd:attribute type="xsd:string" name="href"/>
+              </xsd:extension>
+            </xsd:simpleContent>
+          </xsd:complexType>
+        </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute type="xsd:string" name="media-type"/>
+      <xsd:attribute type="xsd:string" name="href"/>
+    </xsd:complexType>
+  </xsd:element>
+</xsd:schema>

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -1495,6 +1495,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => true,
                     'languageCode' => 'eng-GB',
                     'fieldDefIdentifier' => 'description',
+                    'typeIdentifier' => 'ezrichtext',
                 )
             ),
             new Field(
@@ -1503,6 +1504,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => true,
                     'languageCode' => 'eng-US',
                     'fieldDefIdentifier' => 'description',
+                    'typeIdentifier' => 'ezrichtext',
                 )
             ),
             new Field(
@@ -1511,6 +1513,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => true,
                     'languageCode' => 'eng-GB',
                     'fieldDefIdentifier' => 'name',
+                    'typeIdentifier' => 'ezstring',
                 )
             ),
             new Field(
@@ -1519,6 +1522,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => true,
                     'languageCode' => 'eng-US',
                     'fieldDefIdentifier' => 'name',
+                    'typeIdentifier' => 'ezstring',
                 )
             ),
         );
@@ -2589,6 +2593,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => true,
                     'languageCode' => 'eng-US',
                     'fieldDefIdentifier' => 'description',
+                    'typeIdentifier' => 'ezrichtext',
                 )
             ),
             new Field(
@@ -2597,6 +2602,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => true,
                     'languageCode' => 'eng-US',
                     'fieldDefIdentifier' => 'name',
+                    'typeIdentifier' => 'ezstring',
                 )
             ),
         );
@@ -2622,6 +2628,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => true,
                     'languageCode' => 'eng-GB',
                     'fieldDefIdentifier' => 'description',
+                    'typeIdentifier' => 'ezrichtext',
                 )
             ),
             new Field(
@@ -2630,6 +2637,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => true,
                     'languageCode' => 'eng-GB',
                     'fieldDefIdentifier' => 'name',
+                    'typeIdentifier' => 'ezstring',
                 )
             ),
         );
@@ -2655,6 +2663,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => true,
                     'languageCode' => 'eng-US',
                     'fieldDefIdentifier' => 'description',
+                    'typeIdentifier' => 'ezrichtext',
                 )
             ),
             new Field(
@@ -2663,6 +2672,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => true,
                     'languageCode' => 'eng-US',
                     'fieldDefIdentifier' => 'name',
+                    'typeIdentifier' => 'ezstring',
                 )
             ),
         );
@@ -5756,6 +5766,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => ($field->value !== null ? true : null),
                     'languageCode' => $field->languageCode,
                     'fieldDefIdentifier' => $field->fieldDefIdentifier,
+                    'typeIdentifier' => $field->typeIdentifier,
                 )
             );
         }
@@ -5860,6 +5871,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => 'Foo',
                     'languageCode' => 'eng-US',
                     'fieldDefIdentifier' => 'description',
+                    'typeIdentifier' => 'ezrichtext',
                 )
             ),
             new Field(
@@ -5868,6 +5880,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => 'Bar',
                     'languageCode' => 'eng-GB',
                     'fieldDefIdentifier' => 'description',
+                    'typeIdentifier' => 'ezrichtext',
                 )
             ),
             new Field(
@@ -5876,6 +5889,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => 'An awesome multi-lang forum²',
                     'languageCode' => 'eng-US',
                     'fieldDefIdentifier' => 'name',
+                    'typeIdentifier' => 'ezstring',
                 )
             ),
             new Field(
@@ -5884,6 +5898,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => 'An awesome multi-lang forum²³',
                     'languageCode' => 'eng-GB',
                     'fieldDefIdentifier' => 'name',
+                    'typeIdentifier' => 'ezstring',
                 )
             ),
         );

--- a/eZ/Publish/API/Repository/Values/Content/Field.php
+++ b/eZ/Publish/API/Repository/Values/Content/Field.php
@@ -17,6 +17,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read string $fieldDefIdentifier the field definition identifier
  * @property-read $value the value of the field
  * @property-read string $languageCode the language code of the field
+ * @property-read string $typeIdentifier field type identifier
  */
 class Field extends ValueObject
 {
@@ -49,4 +50,11 @@ class Field extends ValueObject
      * @var string
      */
     protected $languageCode;
+
+    /**
+     * Field type identifier.
+     *
+     * @var string
+     */
+    protected $typeIdentifier;
 }

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Version.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Version.php
@@ -108,6 +108,9 @@ class Version extends ValueObjectVisitor
         $generator->startValueElement('languageCode', $field->languageCode);
         $generator->endValueElement('languageCode');
 
+        $generator->startValueElement('typeIdentifier', $field->typeIdentifier);
+        $generator->endValueElement('typeIdentifier');
+
         $this->fieldTypeSerializer->serializeFieldValue(
             $generator,
             $contentType,

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/VersionTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/VersionTest.php
@@ -59,6 +59,7 @@ class VersionTest extends ValueObjectVisitorBaseTest
                                 'id' => 1,
                                 'languageCode' => 'eng-US',
                                 'fieldDefIdentifier' => 'ezauthor',
+                                'typeIdentifier' => 'ezauthor',
                             )
                         ),
                         new Field(
@@ -66,6 +67,7 @@ class VersionTest extends ValueObjectVisitorBaseTest
                                 'id' => 2,
                                 'languageCode' => 'eng-US',
                                 'fieldDefIdentifier' => 'ezimage',
+                                'typeIdentifier' => 'ezauthor',
                             )
                         ),
                     ),

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -762,15 +762,16 @@ class ContentService implements ContentServiceInterface
      *
      * @return Field
      */
-    private function cloneField(Field $field, array $overrides = array())
+    private function cloneField(Field $field, array $overrides = [])
     {
         $fieldData = array_merge(
-            array(
+            [
                 'id' => $field->id,
                 'value' => $field->value,
                 'languageCode' => $field->languageCode,
                 'fieldDefIdentifier' => $field->fieldDefIdentifier,
-            ),
+                'typeIdentifier' => $field->typeIdentifier,
+            ],
             $overrides
         );
 

--- a/eZ/Publish/Core/Repository/Helper/DomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/DomainMapper.php
@@ -189,6 +189,7 @@ class DomainMapper
                         ->fromPersistenceValue($spiField->value),
                     'languageCode' => $spiField->languageCode,
                     'fieldDefIdentifier' => $fieldIdentifierMap[$spiField->fieldDefinitionId],
+                    'typeIdentifier' => $spiField->type,
                 )
             );
         }


### PR DESCRIPTION
| Question | Answer |
| --- | --- |
| **JIRA issue** | [EZP-28253](https://jira.ez.no/browse/EZP-28253), [EZP-28276](https://jira.ez.no/browse/EZP-28276) |
| **Type** | Improvement |
| **Target version** | `6.13` |

This PR implements two related stories, introducing:
- on PHP API level, to `eZ\Publish\API\Repository\Values\Content\Field` a property `typeIdentifier` which contains Field Type identifier (`ezstring`, `ezdate`, etc.)
- on REST API level this new propery value for Version response at `//Version/VersionInfo/Fields/field/typeIdentifier`.

**TODO**:
- [x] PAPI: Add `typeIdentifier` property on `Content` `Field`.
- [x] PAPI: Update tests to account for new property.
- [x] REST: Add `typeIdentifier` to `Field` node of `Version` view
- [x] REST: Add `typeIdentifier` to REST Version `ValueObjectVisitor` test.
- [x] REST: Update functional tests to check if property exists.