### PR TITLE
EZP-28326: Improve Signals to contain affected parent locations

### DIFF
--- a/eZ/Publish/Core/SignalSlot/LocationService.php
+++ b/eZ/Publish/Core/SignalSlot/LocationService.php
@@ -181,6 +181,7 @@ class LocationService implements LocationServiceInterface
                 array(
                     'contentId' => $contentInfo->id,
                     'locationId' => $returnValue->id,
+                    'parentLocationId' => $returnValue->parentLocationId,
                 )
             )
         );
@@ -207,6 +208,7 @@ class LocationService implements LocationServiceInterface
                 array(
                     'contentId' => $location->contentId,
                     'locationId' => $location->id,
+                    'parentLocationId' => $location->parentLocationId,
                 )
             )
         );
@@ -230,8 +232,10 @@ class LocationService implements LocationServiceInterface
                 array(
                     'location1Id' => $location1->id,
                     'content1Id' => $location1->contentId,
+                    'parentLocation1Id' => $location1->parentLocationId,
                     'location2Id' => $location2->id,
                     'content2Id' => $location2->contentId,
+                    'parentLocation2Id' => $location2->parentLocationId,
                 )
             )
         );
@@ -257,6 +261,7 @@ class LocationService implements LocationServiceInterface
                     'locationId' => $location->id,
                     'contentId' => $location->contentId,
                     'currentVersionNo' => $returnValue->getContentInfo()->currentVersionNo,
+                    'parentLocationId' => $returnValue->parentLocationId,
                 )
             )
         );
@@ -285,6 +290,7 @@ class LocationService implements LocationServiceInterface
                     'locationId' => $location->id,
                     'contentId' => $location->contentId,
                     'currentVersionNo' => $returnValue->getContentInfo()->currentVersionNo,
+                    'parentLocationId' => $returnValue->parentLocationId,
                 )
             )
         );
@@ -311,6 +317,7 @@ class LocationService implements LocationServiceInterface
                 array(
                     'locationId' => $location->id,
                     'newParentLocationId' => $newParentLocation->id,
+                    'oldParentLocationId' => $location->parentLocationId,
                 )
             )
         );

--- a/eZ/Publish/Core/SignalSlot/Signal/LocationService/CreateLocationSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/LocationService/CreateLocationSignal.php
@@ -28,4 +28,13 @@ class CreateLocationSignal extends Signal
      * @var mixed
      */
     public $locationId;
+
+    /**
+     * Location ID of parent location of the created location.
+     *
+     * @since 6.7.7
+     *
+     * @var mixed
+     */
+    public $parentLocationId;
 }

--- a/eZ/Publish/Core/SignalSlot/Signal/LocationService/HideLocationSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/LocationService/HideLocationSignal.php
@@ -35,4 +35,13 @@ class HideLocationSignal extends Signal
      * @var int
      */
     public $currentVersionNo;
+
+    /**
+     * Location ID of parent location of the hidden location.
+     *
+     * @since 6.7.7
+     *
+     * @var mixed
+     */
+    public $parentLocationId;
 }

--- a/eZ/Publish/Core/SignalSlot/Signal/LocationService/MoveSubtreeSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/LocationService/MoveSubtreeSignal.php
@@ -23,6 +23,15 @@ class MoveSubtreeSignal extends Signal
     public $locationId;
 
     /**
+     * Location ID of original parent location of the moved location.
+     *
+     * @since 6.7.7
+     *
+     * @var mixed
+     */
+    public $oldParentLocationId;
+
+    /**
      * NewParentLocationId.
      *
      * @var mixed

--- a/eZ/Publish/Core/SignalSlot/Signal/LocationService/SwapLocationSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/LocationService/SwapLocationSignal.php
@@ -30,6 +30,15 @@ class SwapLocationSignal extends Signal
     public $location1Id;
 
     /**
+     * Parent Location ID of location1.
+     *
+     * @since 6.7.7
+     *
+     * @var mixed
+     */
+    public $parentLocation1Id;
+
+    /**
      * Content2 Id.
      *
      * @var mixed
@@ -42,4 +51,13 @@ class SwapLocationSignal extends Signal
      * @var mixed
      */
     public $location2Id;
+
+    /**
+     * Parent Location ID of location2.
+     *
+     * @since 6.7.7
+     *
+     * @var mixed
+     */
+    public $parentLocation2Id;
 }

--- a/eZ/Publish/Core/SignalSlot/Signal/LocationService/UnhideLocationSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/LocationService/UnhideLocationSignal.php
@@ -35,4 +35,13 @@ class UnhideLocationSignal extends Signal
      * @var int
      */
     public $currentVersionNo;
+
+    /**
+     * Location ID of parent location of the revealed location.
+     *
+     * @since 6.7.7
+     *
+     * @var mixed
+     */
+    public $parentLocationId;
 }

--- a/eZ/Publish/Core/SignalSlot/Signal/LocationService/UpdateLocationSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/LocationService/UpdateLocationSignal.php
@@ -28,4 +28,13 @@ class UpdateLocationSignal extends Signal
      * @var mixed
      */
     public $locationId;
+
+    /**
+     * Location ID of parent location of the updated location.
+     *
+     * @since 6.7.7
+     *
+     * @var mixed
+     */
+    public $parentLocationId;
 }

--- a/eZ/Publish/Core/SignalSlot/Tests/LocationServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/LocationServiceTest.php
@@ -49,6 +49,7 @@ class LocationServiceTest extends ServiceTest
                 'path' => $rootPath,
                 'remoteId' => $rootRemoteId,
                 'contentInfo' => $rootContentInfo,
+                'parentLocationId' => 1,
             )
         );
         $locationContentInfo = $this->getContentInfo($locationContentId, $locationContentRemoteId);
@@ -58,6 +59,7 @@ class LocationServiceTest extends ServiceTest
                 'path' => $locationPath,
                 'remoteId' => $locationRemoteId,
                 'contentInfo' => $locationContentInfo,
+                'parentLocationId' => $rootId,
             )
         );
 
@@ -122,6 +124,7 @@ class LocationServiceTest extends ServiceTest
                 array(
                     'contentId' => $locationContentId,
                     'locationId' => $locationId,
+                    'parentLocationId' => $rootId,
                 ),
             ),
             array(
@@ -133,6 +136,7 @@ class LocationServiceTest extends ServiceTest
                 array(
                     'contentId' => $locationContentId,
                     'locationId' => $locationId,
+                    'parentLocationId' => $rootId,
                 ),
             ),
             array(
@@ -144,8 +148,10 @@ class LocationServiceTest extends ServiceTest
                 array(
                     'location1Id' => $locationId,
                     'content1Id' => $locationContentId,
+                    'parentLocation1Id' => $rootId,
                     'location2Id' => $rootId,
                     'content2Id' => $rootContentId,
+                    'parentLocation2Id' => 1,
                 ),
             ),
             array(
@@ -156,6 +162,7 @@ class LocationServiceTest extends ServiceTest
                 'eZ\Publish\Core\SignalSlot\Signal\LocationService\HideLocationSignal',
                 array(
                     'locationId' => $locationId,
+                    'parentLocationId' => $rootId,
                 ),
             ),
             array(
@@ -166,6 +173,7 @@ class LocationServiceTest extends ServiceTest
                 'eZ\Publish\Core\SignalSlot\Signal\LocationService\UnhideLocationSignal',
                 array(
                     'locationId' => $locationId,
+                    'parentLocationId' => $rootId,
                 ),
             ),
             array(
@@ -177,6 +185,7 @@ class LocationServiceTest extends ServiceTest
                 array(
                     'locationId' => $locationId,
                     'newParentLocationId' => $rootId,
+                    'oldParentLocationId' => $rootId,
                 ),
             ),
             array(
@@ -188,6 +197,7 @@ class LocationServiceTest extends ServiceTest
                 array(
                     'locationId' => $locationId,
                     'contentId' => $locationContentId,
+                    'parentLocationId' => $rootId,
                 ),
             ),
             array(


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-28326

Adds parent location to location based signals so cache system can use this, especially important on for instance Move where this info is lost afterwards.