### PR TITLE
Migrate http cache configuration

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
@@ -113,17 +113,6 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
                 ->info('The default page to show, e.g. after user login this will be used for default redirection. If provided, will override "default_target_path" from security.yml.')
                 ->example('/Getting-Started')
             ->end()
-            ->arrayNode('http_cache')
-                ->info('Settings related to Http cache')
-                ->children()
-                    ->arrayNode('purge_servers')
-                        ->info('Servers to use for Http PURGE (will NOT be used if ezpublish.http_cache.purge_type is "local").')
-                        ->example(array('http://localhost/', 'http://another.server/'))
-                        ->requiresAtLeastOneElement()
-                        ->prototype('scalar')->end()
-                    ->end()
-                ->end()
-            ->end()
             ->scalarNode('anonymous_user_id')
                 ->cannotBeEmpty()
                 ->example('10')
@@ -187,9 +176,6 @@ class Common extends AbstractParser implements SuggestionCollectorAwareInterface
             $contextualizer->setContextualParameter('session', $currentScope, $sessionOptions);
         }
 
-        if (isset($scopeSettings['http_cache']['purge_servers'])) {
-            $contextualizer->setContextualParameter('http_cache.purge_servers', $currentScope, $scopeSettings['http_cache']['purge_servers']);
-        }
         if (isset($scopeSettings['anonymous_user_id'])) {
             $contextualizer->setContextualParameter('anonymous_user_id', $currentScope, $scopeSettings['anonymous_user_id']);
         }

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/HttpCache.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/HttpCache.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractParser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+class HttpCache extends AbstractParser
+{
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    {
+        if (isset($scopeSettings['http_cache']['purge_servers'])) {
+            $contextualizer->setContextualParameter('http_cache.purge_servers', $currentScope, $scopeSettings['http_cache']['purge_servers']);
+        }
+    }
+
+    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    {
+        $nodeBuilder->arrayNode('http_cache')
+            ->info('Settings related to Http cache (this kernel defined configuration block will be removed in 7.0. Use ezplatform-http-cache for forward compatibility)')
+            ->children()
+                ->arrayNode('purge_servers')
+                    ->info('Servers to use for Http PURGE (will NOT be used if ezpublish.http_cache.purge_type is "local").')
+                    ->example(array('http://localhost/', 'http://another.server/'))
+                    ->requiresAtLeastOneElement()
+                ->prototype('scalar')->end()
+                ->end()
+            ->end()
+        ->end();
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -62,6 +62,14 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
      */
     private $siteaccessConfigurationFilters = [];
 
+    /**
+     * List of disabled ConfigParser classes.
+     * Meant to be used by external packages to turn off parts of the system that have been splitted out
+     * or deprecated.
+     * @var array
+     */
+    private $disabledConfigParsers = [];
+
     public function __construct(array $configParsers = array())
     {
         $this->configParsers = $configParsers;
@@ -159,13 +167,18 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
     private function getMainConfigParser()
     {
         if ($this->mainConfigParser === null) {
+            $parsers = [];
             foreach ($this->configParsers as $parser) {
+                if ($this->isConfigParserDisabled($parser)) {
+                    continue;
+                }
                 if ($parser instanceof SuggestionCollectorAwareInterface) {
                     $parser->setSuggestionCollector($this->suggestionCollector);
                 }
+                $parsers[] = $parser;
             }
 
-            $this->mainConfigParser = new ConfigParser($this->configParsers);
+            $this->mainConfigParser = new ConfigParser($parsers);
         }
 
         return $this->mainConfigParser;
@@ -544,5 +557,29 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
     public function addSiteAccessConfigurationFilter(SiteAccessConfigurationFilter $filter)
     {
         $this->siteaccessConfigurationFilters[] = $filter;
+    }
+
+    /**
+     * Disables a ConfigParser class.
+     * @param string $class The class the parser must be an instance of to be disabled.
+     */
+    public function disableConfigParser($class)
+    {
+        $this->disabledConfigParsers[$class] = true;
+    }
+
+    /**
+     * @param object $configParser
+     * @return bool
+     */
+    private function isConfigParserDisabled($configParser)
+    {
+        foreach (array_keys($this->disabledConfigParsers) as $disabledConfigParser) {
+            if ($configParser instanceof $disabledConfigParser) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
@@ -123,6 +123,7 @@ class EzPublishCoreBundle extends Bundle
                     new ConfigParser\FieldEditTemplates(),
                     new ConfigParser\FieldDefinitionSettingsTemplates(),
                     new ConfigParser\FieldDefinitionEditTemplates(),
+                    new ConfigParser\HttpCache(),
                     new ConfigParser\Image(),
                     new ConfigParser\Page(),
                     new ConfigParser\Languages(),


### PR DESCRIPTION
Makes it possible to disable any `ConfigParser` loaded by the `CoreExtension`. Used to allow ezsystems/ezplatform-http-cache to disable the `http_cache` semantic config.

The generic approach can be used for further extractions of features.

### TODO
- [ ] Consider targetting 6.13 instead