### PR TITLE
EZP-28214: Password hash silently defaults to MD5

### DIFF
--- a/doc/bc/changes-6.13.md
+++ b/doc/bc/changes-6.13.md
@@ -10,4 +10,20 @@ The `eZ\Publish\API\Repository\ContentService::removeTranslation` method is depr
 
 Use `eZ\Publish\API\Repository\ContentService::deleteTranslation` instead.
 
+
+The following password hash types are deprecated and will be removed in a future version:
+`eZ\Publish\API\Repository\Values\User::PASSWORD_HASH_MD5_PASSWORD`
+`eZ\Publish\API\Repository\Values\User::PASSWORD_HASH_MD5_USER`
+`eZ\Publish\API\Repository\Values\User::PASSWORD_HASH_MD5_SITE`
+`eZ\Publish\API\Repository\Values\User::PASSWORD_HASH_PLAINTEXT`
+
+Use one of the following types instead:
+`eZ\Publish\API\Repository\Values\User::PASSWORD_HASH_BCRYPT`
+`eZ\Publish\API\Repository\Values\User::PASSWORD_HASH_PHP_DEFAULT`
+
+The password hashes of existing users will be updated automatically to the new default hash type
+`eZ\Publish\API\Repository\Values\User::PASSWORD_HASH_PHP_DEFAULT`
+when they login or change their passwords, unless you have specifically configured
+`eZ\Publish\Core\Repository\UserService` to use one of the deprecated types.
+
 ## Removed features

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\API\Repository\Tests;
 
+use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
@@ -2552,5 +2553,51 @@ class UserServiceTest extends BaseTest
 
         // Create a new user
         return $userService->createUser($userCreateStruct, [$group]);
+    }
+
+    /**
+     * Test for the createUser() method.
+     *
+     * @see \eZ\Publish\API\Repository\UserService::createUser()
+     */
+    public function testCreateUserInvalidPasswordHashTypeThrowsException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Argument 'type' is invalid: Password hash type '42424242' is not recognized");
+
+        $repository = $this->getRepository();
+        $signalSlotUserService = $repository->getUserService();
+
+        $signalSlotUserServiceReflection = new ReflectionClass($signalSlotUserService);
+        $userServiceProperty = $signalSlotUserServiceReflection->getProperty('service');
+        $userServiceProperty->setAccessible(true);
+        $userService = $userServiceProperty->getValue($signalSlotUserService);
+
+        $userServiceReflection = new ReflectionClass($userService);
+        $settingsProperty = $userServiceReflection->getProperty('settings');
+        $settingsProperty->setAccessible(true);
+
+        $defaultUserServiceSettings = $settingsProperty->getValue($userService);
+
+        /* BEGIN: Use Case */
+        $settingsProperty->setValue(
+            $userService,
+            [
+                'hashType' => 42424242, // Non-existing hash type
+            ] + $settingsProperty->getValue($userService)
+        );
+
+        try {
+            $this->createUserVersion1();
+        } catch (InvalidArgumentException $e) {
+            // Reset to default settings, so we don't break other tests
+            $settingsProperty->setValue($userService, $defaultUserServiceSettings);
+
+            throw $e;
+        }
+        /* END: Use Case */
+
+        // Reset to default settings, so we don't break other tests
+        $settingsProperty->setValue($userService, $defaultUserServiceSettings);
     }
 }

--- a/eZ/Publish/API/Repository/Values/User/User.php
+++ b/eZ/Publish/API/Repository/Values/User/User.php
@@ -24,21 +24,25 @@ abstract class User extends Content implements UserReference
 {
     /**
      * @var int MD5 of password, not recommended
+     * @deprecated since 6.13
      */
     const PASSWORD_HASH_MD5_PASSWORD = 1;
 
     /**
      * @var int MD5 of user and password
+     * @deprecated since 6.13
      */
     const PASSWORD_HASH_MD5_USER = 2;
 
     /**
      * @var int MD5 of site, user and password
+     * @deprecated since 6.13
      */
     const PASSWORD_HASH_MD5_SITE = 3;
 
     /**
      * @var int Passwords in plaintext, should not be used for real sites
+     * @deprecated since 6.13
      */
     const PASSWORD_HASH_PLAINTEXT = 5;
 
@@ -51,6 +55,11 @@ abstract class User extends Content implements UserReference
      * @var int Passwords hashed by PHPs default algorithm, which may change over time
      */
     const PASSWORD_HASH_PHP_DEFAULT = 7;
+
+    /**
+     * @var int Default password hash, used when none is specified, may change over time
+     */
+    const DEFAULT_PASSWORD_HASH = self::PASSWORD_HASH_PHP_DEFAULT;
 
     /**
      * User login.

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -1152,6 +1152,8 @@ class UserService implements UserServiceInterface
      * @param int $type Type of password to generate
      *
      * @return string Generated password hash
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the type is not recognized
      */
     protected function createPasswordHash($login, $password, $site, $type)
     {
@@ -1175,7 +1177,7 @@ class UserService implements UserServiceInterface
                 return password_hash($password, PASSWORD_DEFAULT);
 
             default:
-                return md5($password);
+                throw new InvalidArgumentException('type', "Password hash type '$type' is not recognized");
         }
     }
 }

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -77,7 +77,7 @@ class UserService implements UserServiceInterface
             'defaultUserPlacement' => 12,
             'userClassID' => 4, // @todo Rename this settings to swap out "Class" for "Type"
             'userGroupClassID' => 3,
-            'hashType' => APIUser::PASSWORD_HASH_PHP_DEFAULT,
+            'hashType' => APIUser::DEFAULT_PASSWORD_HASH,
             'siteName' => 'ez.no',
         );
     }
@@ -544,6 +544,8 @@ class UserService implements UserServiceInterface
     /**
      * Loads a user for the given login and password.
      *
+     * If the password hash type differs from that configured for the service, it will be updated to the configured one.
+     *
      * {@inheritdoc}
      *
      * @param string $login
@@ -570,7 +572,25 @@ class UserService implements UserServiceInterface
             throw new NotFoundException('user', $login);
         }
 
+        $this->updatePasswordHash($login, $password, $spiUser);
+
         return $this->buildDomainUserObject($spiUser, null, $prioritizedLanguages);
+    }
+
+    /**
+     * Update password hash to the type configured for the service, if they differ.
+     *
+     * @param string $login User login
+     * @param string $password User password
+     * @param \eZ\Publish\SPI\Persistence\User $spiUser
+     */
+    private function updatePasswordHash($login, $password, SPIUser $spiUser)
+    {
+        if ($spiUser->hashAlgorithm !== $this->settings['hashType']) {
+            $spiUser->passwordHash = $this->createPasswordHash($login, $password, null, $this->settings['hashType']);
+            $spiUser->hashAlgorithm = $this->settings['hashType'];
+            $this->userHandler->update($spiUser);
+        }
     }
 
     /**
@@ -1157,17 +1177,27 @@ class UserService implements UserServiceInterface
      */
     protected function createPasswordHash($login, $password, $site, $type)
     {
+        $deprecationWarningFormat = 'Password hash type %s is deprecated since 6.13.';
+
         switch ($type) {
             case APIUser::PASSWORD_HASH_MD5_PASSWORD:
+                @trigger_error(sprintf($deprecationWarningFormat, 'PASSWORD_HASH_MD5_PASSWORD'), E_USER_DEPRECATED);
+
                 return md5($password);
 
             case APIUser::PASSWORD_HASH_MD5_USER:
+                @trigger_error(sprintf($deprecationWarningFormat, 'PASSWORD_HASH_MD5_USER'), E_USER_DEPRECATED);
+
                 return md5("$login\n$password");
 
             case APIUser::PASSWORD_HASH_MD5_SITE:
+                @trigger_error(sprintf($deprecationWarningFormat, 'PASSWORD_HASH_MD5_SITE'), E_USER_DEPRECATED);
+
                 return md5("$login\n$password\n$site");
 
             case APIUser::PASSWORD_HASH_PLAINTEXT:
+                @trigger_error(sprintf($deprecationWarningFormat, 'PASSWORD_HASH_PLAINTEXT'), E_USER_DEPRECATED);
+
                 return $password;
 
             case APIUser::PASSWORD_HASH_BCRYPT:


### PR DESCRIPTION
> Fix https://jira.ez.no/browse/EZP-28214 for new stack
> For legacy, see https://github.com/ezsystems/ezpublish-legacy/pull/1334
> Sent to QA

Invalid password hash type should not be silently ignored, and we should not default to MD5.

Fix: Throw an exception if an invalid password hash type is specified.