### PR TITLE
EZP-28176: missing return on php path crashing first indexing process

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -111,7 +111,7 @@ class ReindexCommand extends ContainerAwareCommand
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Number of sub processes to spawn in parallel handling iterations, default number is number of CPU cores -1, set to 1 or 0 to disable',
-                $this->getNumberOfCPUCores() -1
+                $this->getNumberOfCPUCores() - 1
             )->setHelp(
                 <<<EOT
 The command <info>%command.name%</info> indexes current configured database in configured search engine index.

--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -257,7 +257,7 @@ EOT
                     $progress->advance(1);
 
                     if (!$process->isSuccessful()) {
-                        $this->logger->error("Child indexer process returned: " . $process->getExitCodeText());
+                        $this->logger->error('Child indexer process returned: ' . $process->getExitCodeText());
                     }
                 }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -111,7 +111,7 @@ class ReindexCommand extends ContainerAwareCommand
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Number of sub processes to spawn in parallel handling iterations, default number is number of CPU cores -1, set to 1 or 0 to disable',
-                $this->getNumberOfCPUCores()
+                $this->getNumberOfCPUCores() -1
             )->setHelp(
                 <<<EOT
 The command <info>%command.name%</info> indexes current configured database in configured search engine index.

--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -208,7 +208,7 @@ EOT
         $iterations = ceil($count / $iterationCount);
         $processCount = (int) $input->getOption('processes');
         $processCount = $processCount > $iterations ? $iterations : $processCount;
-        $processMessage = $processCount > 1 ? "using $processCount parallel processes" : 'using single process';
+        $processMessage = $processCount > 1 ? "using $processCount parallel child processes" : 'using single (current) process';
 
         if ($purge) {
             $output->writeln('Purging index...');


### PR DESCRIPTION
> issue: https://jira.ez.no/browse/EZP-28176

When _(by default when you have more than 50 items in db)_ running indexing in parallel, the first process would fail as there was a missing return on the php path function after the method was refactored during later stages of the PR work.