### PR TITLE
EZP-28337: As a Developer I want API Field Type properties to use consistent naming

### DIFF
--- a/doc/specifications/rest/REST-API-V2.rst
+++ b/doc/specifications/rest/REST-API-V2.rst
@@ -6995,7 +6995,7 @@ Version
           <xsd:element name="id" type="xsd:integer" />
           <xsd:element name="fieldDefinitionIdentifier" type="xsd:string" />
           <xsd:element name="languageCode" type="xsd:string" />
-          <xsd:element name="typeIdentifier" type="xsd:string" />
+          <xsd:element name="fieldTypeIdentifier" type="xsd:string" />
           <xsd:element name="fieldValue" type="fieldValueType" />
         </xsd:all>
       </xsd:complexType>

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/xsd/Version.xsd
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/xsd/Version.xsd
@@ -74,7 +74,7 @@
                     <xsd:element type="xsd:short" name="id"/>
                     <xsd:element type="xsd:string" name="fieldDefinitionIdentifier"/>
                     <xsd:element type="xsd:string" name="languageCode"/>
-                    <xsd:element type="xsd:string" name="typeIdentifier"/>
+                    <xsd:element type="xsd:string" name="fieldTypeIdentifier"/>
                     <xsd:element name="fieldValue">
                       <xsd:complexType mixed="true">
                         <xsd:sequence>

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -1495,7 +1495,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => true,
                     'languageCode' => 'eng-GB',
                     'fieldDefIdentifier' => 'description',
-                    'typeIdentifier' => 'ezrichtext',
+                    'fieldTypeIdentifier' => 'ezrichtext',
                 )
             ),
             new Field(
@@ -1504,7 +1504,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => true,
                     'languageCode' => 'eng-US',
                     'fieldDefIdentifier' => 'description',
-                    'typeIdentifier' => 'ezrichtext',
+                    'fieldTypeIdentifier' => 'ezrichtext',
                 )
             ),
             new Field(
@@ -1513,7 +1513,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => true,
                     'languageCode' => 'eng-GB',
                     'fieldDefIdentifier' => 'name',
-                    'typeIdentifier' => 'ezstring',
+                    'fieldTypeIdentifier' => 'ezstring',
                 )
             ),
             new Field(
@@ -1522,7 +1522,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => true,
                     'languageCode' => 'eng-US',
                     'fieldDefIdentifier' => 'name',
-                    'typeIdentifier' => 'ezstring',
+                    'fieldTypeIdentifier' => 'ezstring',
                 )
             ),
         );
@@ -2593,7 +2593,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => true,
                     'languageCode' => 'eng-US',
                     'fieldDefIdentifier' => 'description',
-                    'typeIdentifier' => 'ezrichtext',
+                    'fieldTypeIdentifier' => 'ezrichtext',
                 )
             ),
             new Field(
@@ -2602,7 +2602,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => true,
                     'languageCode' => 'eng-US',
                     'fieldDefIdentifier' => 'name',
-                    'typeIdentifier' => 'ezstring',
+                    'fieldTypeIdentifier' => 'ezstring',
                 )
             ),
         );
@@ -2628,7 +2628,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => true,
                     'languageCode' => 'eng-GB',
                     'fieldDefIdentifier' => 'description',
-                    'typeIdentifier' => 'ezrichtext',
+                    'fieldTypeIdentifier' => 'ezrichtext',
                 )
             ),
             new Field(
@@ -2637,7 +2637,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => true,
                     'languageCode' => 'eng-GB',
                     'fieldDefIdentifier' => 'name',
-                    'typeIdentifier' => 'ezstring',
+                    'fieldTypeIdentifier' => 'ezstring',
                 )
             ),
         );
@@ -2663,7 +2663,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => true,
                     'languageCode' => 'eng-US',
                     'fieldDefIdentifier' => 'description',
-                    'typeIdentifier' => 'ezrichtext',
+                    'fieldTypeIdentifier' => 'ezrichtext',
                 )
             ),
             new Field(
@@ -2672,7 +2672,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => true,
                     'languageCode' => 'eng-US',
                     'fieldDefIdentifier' => 'name',
-                    'typeIdentifier' => 'ezstring',
+                    'fieldTypeIdentifier' => 'ezstring',
                 )
             ),
         );
@@ -5759,7 +5759,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => ($field->value !== null ? true : null),
                     'languageCode' => $field->languageCode,
                     'fieldDefIdentifier' => $field->fieldDefIdentifier,
-                    'typeIdentifier' => $field->typeIdentifier,
+                    'fieldTypeIdentifier' => $field->fieldTypeIdentifier,
                 )
             );
         }
@@ -5864,7 +5864,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => 'Foo',
                     'languageCode' => 'eng-US',
                     'fieldDefIdentifier' => 'description',
-                    'typeIdentifier' => 'ezrichtext',
+                    'fieldTypeIdentifier' => 'ezrichtext',
                 )
             ),
             new Field(
@@ -5873,7 +5873,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => 'Bar',
                     'languageCode' => 'eng-GB',
                     'fieldDefIdentifier' => 'description',
-                    'typeIdentifier' => 'ezrichtext',
+                    'fieldTypeIdentifier' => 'ezrichtext',
                 )
             ),
             new Field(
@@ -5882,7 +5882,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => 'An awesome multi-lang forum²',
                     'languageCode' => 'eng-US',
                     'fieldDefIdentifier' => 'name',
-                    'typeIdentifier' => 'ezstring',
+                    'fieldTypeIdentifier' => 'ezstring',
                 )
             ),
             new Field(
@@ -5891,7 +5891,7 @@ class ContentServiceTest extends BaseContentServiceTest
                     'value' => 'An awesome multi-lang forum²³',
                     'languageCode' => 'eng-GB',
                     'fieldDefIdentifier' => 'name',
-                    'typeIdentifier' => 'ezstring',
+                    'fieldTypeIdentifier' => 'ezstring',
                 )
             ),
         );

--- a/eZ/Publish/API/Repository/Values/Content/Field.php
+++ b/eZ/Publish/API/Repository/Values/Content/Field.php
@@ -17,7 +17,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read string $fieldDefIdentifier the field definition identifier
  * @property-read $value the value of the field
  * @property-read string $languageCode the language code of the field
- * @property-read string $typeIdentifier field type identifier
+ * @property-read string $fieldTypeIdentifier field type identifier
  */
 class Field extends ValueObject
 {
@@ -56,5 +56,5 @@ class Field extends ValueObject
      *
      * @var string
      */
-    protected $typeIdentifier;
+    protected $fieldTypeIdentifier;
 }

--- a/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Version.php
+++ b/eZ/Publish/Core/REST/Server/Output/ValueObjectVisitor/Version.php
@@ -108,8 +108,8 @@ class Version extends ValueObjectVisitor
         $generator->startValueElement('languageCode', $field->languageCode);
         $generator->endValueElement('languageCode');
 
-        $generator->startValueElement('typeIdentifier', $field->typeIdentifier);
-        $generator->endValueElement('typeIdentifier');
+        $generator->startValueElement('fieldTypeIdentifier', $field->fieldTypeIdentifier);
+        $generator->endValueElement('fieldTypeIdentifier');
 
         $this->fieldTypeSerializer->serializeFieldValue(
             $generator,

--- a/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/VersionTest.php
+++ b/eZ/Publish/Core/REST/Server/Tests/Output/ValueObjectVisitor/VersionTest.php
@@ -59,7 +59,7 @@ class VersionTest extends ValueObjectVisitorBaseTest
                                 'id' => 1,
                                 'languageCode' => 'eng-US',
                                 'fieldDefIdentifier' => 'ezauthor',
-                                'typeIdentifier' => 'ezauthor',
+                                'fieldTypeIdentifier' => 'ezauthor',
                             )
                         ),
                         new Field(
@@ -67,7 +67,7 @@ class VersionTest extends ValueObjectVisitorBaseTest
                                 'id' => 2,
                                 'languageCode' => 'eng-US',
                                 'fieldDefIdentifier' => 'ezimage',
-                                'typeIdentifier' => 'ezauthor',
+                                'fieldTypeIdentifier' => 'ezauthor',
                             )
                         ),
                     ),

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -770,7 +770,7 @@ class ContentService implements ContentServiceInterface
                 'value' => $field->value,
                 'languageCode' => $field->languageCode,
                 'fieldDefIdentifier' => $field->fieldDefIdentifier,
-                'typeIdentifier' => $field->typeIdentifier,
+                'fieldTypeIdentifier' => $field->fieldTypeIdentifier,
             ],
             $overrides
         );

--- a/eZ/Publish/Core/Repository/Helper/DomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/DomainMapper.php
@@ -189,7 +189,7 @@ class DomainMapper
                         ->fromPersistenceValue($spiField->value),
                     'languageCode' => $spiField->languageCode,
                     'fieldDefIdentifier' => $fieldIdentifierMap[$spiField->fieldDefinitionId],
-                    'typeIdentifier' => $spiField->type,
+                    'fieldTypeIdentifier' => $spiField->type,
                 )
             );
         }


### PR DESCRIPTION
| Question | Answer |
| --- | --- |
| **Status** | Ready for a review |
| **JIRA issue** | [EZP-28337](https://jira.ez.no/browse/EZP-28337) |
| **Related to** | #2168 |
| **Alternative to** | #2175 |
| **BC break**   | no, still within the scope of `6.13` |
| **Type** | Improvement |
| **Target version** | `6.13` |

This PR aligns naming convention introduced in #2168 with other parts of the system by renaming
`eZ\Publish\API\Repository\Values\Content\Field::$typeIdentifier`
to `fieldTypeIdentifer`.

There are two major issues with my push to strictly follow DDD:
1) We have a lot of overlapping names, so distinguishing between them is good for a developer.
2) Trying to align other parts of the system with proper naming convention proved to be risky and covered too wide of a scope, see #2175.

So decision to stick with `typeIdentifier` was my mistake. This PR corrects that.

**TODO**:
- [x] Rename API Content Field `typeIdentifier` to `fieldTypeIdentifier`.
- [x] Align REST response to reflect PAPI (also new feature introduced in `6.13`) + update spec
- [x] Align unit tests
- [x] Align REST tests
- [ ] Send to QA (requires testing if it's possible to create content type and content).