### PR TITLE
EZP-28214: Password hash silently defaults to MD5

### DIFF
--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -1886,12 +1886,10 @@ class UserServiceTest extends BaseTest
      * Test for the createUser() method.
      *
      * @see \eZ\Publish\API\Repository\UserService::createUser()
+     * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
     public function testCreateUserInvalidPasswordHashTypeThrowsException()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Argument 'type' is invalid: Password hash type '42424242' is not recognized");
-
         $repository = $this->getRepository();
         $signalSlotUserService = $repository->getUserService();
 
@@ -1917,6 +1915,8 @@ class UserServiceTest extends BaseTest
         try {
             $this->createUserVersion1();
         } catch (InvalidArgumentException $e) {
+            $this->assertEquals("Argument 'type' is invalid: Password hash type '42424242' is not recognized", $e->getMessage());
+
             // Reset to default settings, so we don't break other tests
             $settingsProperty->setValue($userService, $defaultUserServiceSettings);
 
@@ -1926,5 +1926,7 @@ class UserServiceTest extends BaseTest
 
         // Reset to default settings, so we don't break other tests
         $settingsProperty->setValue($userService, $defaultUserServiceSettings);
+
+        $this->fail('InvalidArgumentException was not raised.');
     }
 }

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -1887,6 +1887,7 @@ class UserServiceTest extends BaseTest
      *
      * @see \eZ\Publish\API\Repository\UserService::createUser()
      * @expectedException \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @expectedExceptionMessage Argument 'type' is invalid: Password hash type '42424242' is not recognized
      */
     public function testCreateUserInvalidPasswordHashTypeThrowsException()
     {
@@ -1915,8 +1916,6 @@ class UserServiceTest extends BaseTest
         try {
             $this->createUserVersion1();
         } catch (InvalidArgumentException $e) {
-            $this->assertEquals("Argument 'type' is invalid: Password hash type '42424242' is not recognized", $e->getMessage());
-
             // Reset to default settings, so we don't break other tests
             $settingsProperty->setValue($userService, $defaultUserServiceSettings);
 
@@ -1926,7 +1925,5 @@ class UserServiceTest extends BaseTest
 
         // Reset to default settings, so we don't break other tests
         $settingsProperty->setValue($userService, $defaultUserServiceSettings);
-
-        $this->fail('InvalidArgumentException was not raised.');
     }
 }

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -1107,6 +1107,8 @@ class UserService implements UserServiceInterface
      * @param int $type Type of password to generate
      *
      * @return string Generated password hash
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the type is not recognized
      */
     protected function createPasswordHash($login, $password, $site, $type)
     {
@@ -1124,7 +1126,7 @@ class UserService implements UserServiceInterface
                 return $password;
 
             default:
-                return md5($password);
+                throw new InvalidArgumentException('type', "Password hash type '$type' is not recognized");
         }
     }
 }


### PR DESCRIPTION
> Fix https://jira.ez.no/browse/EZP-28214 for 6.7
> Same as https://github.com/ezsystems/ezpublish-kernel/pull/2171 which was merged for 6.13 (except deprecation which is for 6.13 only)
> Sent to QA

Invalid password hash type should not be silently ignored, and we should not default to MD5.

Fix: Throw an exception if an invalid password hash type is specified.