### PR TITLE
EZP-28410: Add selection limit setting to ezobjectrelationlist fieldtype

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/RelationListIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/RelationListIntegrationTest.php
@@ -120,10 +120,6 @@ class RelationListIntegrationTest extends SearchMultivaluedBaseIntegrationTest
                 'type' => 'array',
                 'default' => array(),
             ),
-            'selectionLimit' => array(
-                'type' => 'int',
-                'default' => 0,
-            ),
         );
     }
 
@@ -132,7 +128,14 @@ class RelationListIntegrationTest extends SearchMultivaluedBaseIntegrationTest
      */
     public function getValidatorSchema()
     {
-        return array();
+        return array(
+            'RelationListValueValidator' => array(
+                'selectionLimit' => array(
+                    'type' => 'int',
+                    'default' => 0,
+                ),
+            ),
+        );
     }
 
     /**
@@ -148,7 +151,6 @@ class RelationListIntegrationTest extends SearchMultivaluedBaseIntegrationTest
             'selectionMethod' => 1,
             'selectionDefaultLocation' => '2',
             'selectionContentTypes' => array('blog_post'),
-            'selectionLimit' => 1,
         );
     }
 
@@ -161,7 +163,11 @@ class RelationListIntegrationTest extends SearchMultivaluedBaseIntegrationTest
      */
     public function getValidValidatorConfiguration()
     {
-        return array();
+        return array(
+            'RelationListValueValidator' => array(
+                'selectionLimit' => 0,
+            ),
+        );
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/FieldType/RelationListIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/RelationListIntegrationTest.php
@@ -120,6 +120,10 @@ class RelationListIntegrationTest extends SearchMultivaluedBaseIntegrationTest
                 'type' => 'array',
                 'default' => array(),
             ),
+            'selectionLimit' => array(
+                'type' => 'int',
+                'default' => 0,
+            ),
         );
     }
 
@@ -144,6 +148,7 @@ class RelationListIntegrationTest extends SearchMultivaluedBaseIntegrationTest
             'selectionMethod' => 1,
             'selectionDefaultLocation' => '2',
             'selectionContentTypes' => array('blog_post'),
+            'selectionLimit' => 1,
         );
     }
 

--- a/eZ/Publish/Core/FieldType/Relation/Type.php
+++ b/eZ/Publish/Core/FieldType/Relation/Type.php
@@ -23,6 +23,8 @@ use eZ\Publish\Core\FieldType\Value as BaseValue;
  *
  * hash format ({@see fromhash()}, {@see toHash()}):
  * array( 'destinationContentId' => (int)$destinationContentId );
+ *
+ * @deprecated Since 7.0 and will be removed in 8.0. Use `RelationList\Type` instead.
  */
 class Type extends FieldType
 {

--- a/eZ/Publish/Core/FieldType/Relation/Value.php
+++ b/eZ/Publish/Core/FieldType/Relation/Value.php
@@ -12,6 +12,8 @@ use eZ\Publish\Core\FieldType\Value as BaseValue;
 
 /**
  * Value for Relation field type.
+ *
+ * @deprecated Since 7.0 and will be removed in 8.0. Use `RelationList\Value` instead.
  */
 class Value extends BaseValue
 {

--- a/eZ/Publish/Core/FieldType/RelationList/Type.php
+++ b/eZ/Publish/Core/FieldType/RelationList/Type.php
@@ -45,6 +45,10 @@ class Type extends FieldType
             'type' => 'array',
             'default' => array(),
         ),
+        'selectionLimit' => array(
+            'type' => 'int',
+            'default' => 0,
+        ),
     );
 
     /**
@@ -102,6 +106,28 @@ class Type extends FieldType
                     if (!is_array($value)) {
                         $validationErrors[] = new ValidationError(
                             "Setting '%setting%' value must be of array type",
+                            null,
+                            array(
+                                '%setting%' => $name,
+                            ),
+                            "[$name]"
+                        );
+                    }
+                    break;
+                case 'selectionLimit':
+                    if (!is_int($value)) {
+                        $validationErrors[] = new ValidationError(
+                            "Setting '%setting%' value must be of integer type",
+                            null,
+                            array(
+                                '%setting%' => $name,
+                            ),
+                            "[$name]"
+                        );
+                    }
+                    if ($value < 0) {
+                        $validationErrors[] = new ValidationError(
+                            "Setting '%setting%' value cannot be lower than 0",
                             null,
                             array(
                                 '%setting%' => $name,

--- a/eZ/Publish/Core/FieldType/Tests/RelationListTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RelationListTest.php
@@ -66,6 +66,10 @@ class RelationListTest extends FieldTypeTest
                 'type' => 'array',
                 'default' => array(),
             ),
+            'selectionLimit' => array(
+                'type' => 'int',
+                'default' => 0,
+            ),
         );
     }
 
@@ -291,12 +295,14 @@ class RelationListTest extends FieldTypeTest
                 array(
                     'selectionMethod' => RelationList::SELECTION_BROWSE,
                     'selectionDefaultLocation' => 23,
+                    'selectionLimit' => 0,
                 ),
             ),
             array(
                 array(
                     'selectionMethod' => RelationList::SELECTION_DROPDOWN,
                     'selectionDefaultLocation' => 'foo',
+                    'selectionLimit' => 1,
                 ),
             ),
             array(
@@ -304,6 +310,7 @@ class RelationListTest extends FieldTypeTest
                     'selectionMethod' => RelationList::SELECTION_DROPDOWN,
                     'selectionDefaultLocation' => 'foo',
                     'selectionContentTypes' => array(1, 2, 3),
+                    'selectionLimit' => 2,
                 ),
             ),
         );
@@ -358,6 +365,14 @@ class RelationListTest extends FieldTypeTest
                     'selectionMethod' => RelationList::SELECTION_DROPDOWN,
                     'selectionDefaultLocation' => 23,
                     'selectionContentTypes' => true,
+                ),
+            ),
+            array(
+                // Invalid value for 'selectionLimit'
+                array(
+                    'selectionMethod' => RelationList::SELECTION_DROPDOWN,
+                    'selectionDefaultLocation' => 23,
+                    'selectionLimit' => 'string',
                 ),
             ),
         );

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RelationListConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RelationListConverter.php
@@ -148,6 +148,14 @@ class RelationListConverter implements Converter
         }
         $root->appendChild($selectionType);
 
+        $selectionLimit = $doc->createElement('selection_limit');
+        if (isset($fieldSettings['selectionLimit'])) {
+            $selectionLimit->setAttribute('value', (int)$fieldSettings['selectionLimit']);
+        } else {
+            $selectionLimit->setAttribute('value', 0);
+        }
+        $root->appendChild($selectionLimit);
+
         $defaultLocation = $doc->createElement('contentobject-placement');
         if (!empty($fieldSettings['selectionDefaultLocation'])) {
             $defaultLocation->setAttribute('node-id', (int)$fieldSettings['selectionDefaultLocation']);
@@ -169,6 +177,7 @@ class RelationListConverter implements Converter
      *     </constraints>
      *     <type value="2"/>
      *     <selection_type value="1"/>
+     *     <selection_limit value="5"/>
      *     <object_class value=""/>
      *     <contentobject-placement node-id="67"/>
      *   </related-objects>
@@ -193,6 +202,7 @@ class RelationListConverter implements Converter
             'selectionMethod' => 0,
             'selectionDefaultLocation' => null,
             'selectionContentTypes' => [],
+            'selectionLimit' => 0,
         ];
 
         // default value
@@ -215,6 +225,13 @@ class RelationListConverter implements Converter
             $selectionType->hasAttribute('value')
         ) {
             $fieldSettings['selectionMethod'] = (int)$selectionType->getAttribute('value');
+        }
+
+        if (
+            ($selectionLimit = $dom->getElementsByTagName('selection_limit')->item(0)) &&
+            $selectionLimit->hasAttribute('value')
+        ) {
+            $fieldSettings['selectionLimit'] = (int)$selectionLimit->getAttribute('value');
         }
 
         if (

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/RelationListTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/RelationListTest.php
@@ -207,7 +207,11 @@ EOT;
                             'selectionMethod' => Type::SELECTION_BROWSE,
                             'selectionDefaultLocation' => 12345,
                             'selectionContentTypes' => array('article', 'blog_post'),
-                            'selectionLimit' => 5,
+                        ),
+                        'validators' => array(
+                            'RelationListValueValidator' => array(
+                                'selectionLimit' => 5,
+                            ),
                         ),
                     )
                 ),
@@ -217,7 +221,7 @@ EOT;
         $expectedStorageFieldDefinition = new StorageFieldDefinition();
         $expectedStorageFieldDefinition->dataText5 = <<<EOT
 <?xml version="1.0" encoding="utf-8"?>
-<related-objects><constraints><allowed-class contentclass-identifier="article"/><allowed-class contentclass-identifier="blog_post"/></constraints><type value="2"/><object_class value=""/><selection_type value="0"/><selection_limit value="5"/><contentobject-placement node-id="12345"/></related-objects>
+<related-objects><constraints><allowed-class contentclass-identifier="article"/><allowed-class contentclass-identifier="blog_post"/></constraints><type value="2"/><object_class value=""/><selection_type value="0"/><contentobject-placement node-id="12345"/><selection_limit value="5"/></related-objects>
 
 EOT;
 
@@ -261,7 +265,11 @@ EOT;
                             'selectionMethod' => Type::SELECTION_DROPDOWN,
                             'selectionDefaultLocation' => 54321,
                             'selectionContentTypes' => array('forum', 'folder'),
-                            'selectionLimit' => 1,
+                        ),
+                        'validators' => array(
+                            'RelationListValueValidator' => array(
+                                'selectionLimit' => 1,
+                            ),
                         ),
                     )
                 ),

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/RelationListTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/RelationListTest.php
@@ -207,6 +207,7 @@ EOT;
                             'selectionMethod' => Type::SELECTION_BROWSE,
                             'selectionDefaultLocation' => 12345,
                             'selectionContentTypes' => array('article', 'blog_post'),
+                            'selectionLimit' => 5,
                         ),
                     )
                 ),
@@ -216,7 +217,7 @@ EOT;
         $expectedStorageFieldDefinition = new StorageFieldDefinition();
         $expectedStorageFieldDefinition->dataText5 = <<<EOT
 <?xml version="1.0" encoding="utf-8"?>
-<related-objects><constraints><allowed-class contentclass-identifier="article"/><allowed-class contentclass-identifier="blog_post"/></constraints><type value="2"/><object_class value=""/><selection_type value="0"/><contentobject-placement node-id="12345"/></related-objects>
+<related-objects><constraints><allowed-class contentclass-identifier="article"/><allowed-class contentclass-identifier="blog_post"/></constraints><type value="2"/><object_class value=""/><selection_type value="0"/><selection_limit value="5"/><contentobject-placement node-id="12345"/></related-objects>
 
 EOT;
 
@@ -246,6 +247,7 @@ EOT;
     </constraints><type value="2"/>
     <object_class value=""/>
     <selection_type value="1"/>
+    <selection_limit value="1"/>
     <contentobject-placement node-id="54321"/>
 </related-objects>
 
@@ -259,6 +261,7 @@ EOT;
                             'selectionMethod' => Type::SELECTION_DROPDOWN,
                             'selectionDefaultLocation' => 54321,
                             'selectionContentTypes' => array('forum', 'folder'),
+                            'selectionLimit' => 1,
                         ),
                     )
                 ),

--- a/eZ/Publish/SPI/Tests/FieldType/RelationListIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/RelationListIntegrationTest.php
@@ -77,7 +77,11 @@ class RelationListIntegrationTest extends BaseIntegrationTest
                     'selectionMethod' => 0,
                     'selectionDefaultLocation' => '',
                     'selectionContentTypes' => array(),
-                    'selectionLimit' => 0,
+                ),
+                'validators' => array(
+                    'RelationListValueValidator' => array(
+                        'selectionLimit' => 3,
+                    ),
                 ),
             )
         );
@@ -96,12 +100,20 @@ class RelationListIntegrationTest extends BaseIntegrationTest
             'selectionMethod' => 0,
             'selectionDefaultLocation' => '',
             'selectionContentTypes' => array(),
-            'selectionLimit' => 0,
+        );
+
+        $validators = array(
+            'RelationListValueValidator' => array(
+                'selectionLimit' => 3,
+            ),
         );
 
         return array(
             array('fieldType', 'ezobjectrelationlist'),
-            array('fieldTypeConstraints', new Content\FieldTypeConstraints(array('fieldSettings' => $fieldSettings))),
+            array('fieldTypeConstraints', new Content\FieldTypeConstraints(array(
+                'fieldSettings' => $fieldSettings,
+                'validators' => $validators,
+            ))),
         );
     }
 

--- a/eZ/Publish/SPI/Tests/FieldType/RelationListIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/RelationListIntegrationTest.php
@@ -77,6 +77,7 @@ class RelationListIntegrationTest extends BaseIntegrationTest
                     'selectionMethod' => 0,
                     'selectionDefaultLocation' => '',
                     'selectionContentTypes' => array(),
+                    'selectionLimit' => 0,
                 ),
             )
         );
@@ -95,6 +96,7 @@ class RelationListIntegrationTest extends BaseIntegrationTest
             'selectionMethod' => 0,
             'selectionDefaultLocation' => '',
             'selectionContentTypes' => array(),
+            'selectionLimit' => 0,
         );
 
         return array(


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28410

# Description
Adds selection limit to `ezobjectrelationlist` as there is an ongoing process od merging relation fieldtypes. This is the first step which allows to use `ezobjectrelationlist` the same way as `ezobjectrelation`.

# TODO
- [x] tests