### PR TITLE
[WiP] [PoC] [REST] Implemented Field Criterion

### DIFF
--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/Field.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/Field.php
@@ -49,7 +49,7 @@ class Field extends BaseParser
         }
 
         $fieldData = $data['Field'];
-        if (empty($fieldData['name']) || empty($fieldData['operator']) || empty($fieldData['value'])) {
+        if (empty($fieldData['name']) || empty($fieldData['operator']) || !array_key_exists('value', $fieldData)) {
             throw new Exceptions\Parser('<Field> format expects name, operator and value keys');
         }
 

--- a/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/Field.php
+++ b/eZ/Publish/Core/REST/Server/Input/Parser/Criterion/Field.php
@@ -8,14 +8,30 @@
  */
 namespace eZ\Publish\Core\REST\Server\Input\Parser\Criterion;
 
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Field as FieldCriterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
 use eZ\Publish\Core\REST\Common\Input\BaseParser;
 use eZ\Publish\Core\REST\Common\Input\ParsingDispatcher;
+use eZ\Publish\Core\REST\Common\Exceptions;
 
 /**
  * Parser for Field Criterion.
  */
 class Field extends BaseParser
 {
+    const OPERATORS = [
+        'IN' => Operator::IN,
+        'EQ' => Operator::EQ,
+        'GT' => Operator::GT,
+        'GTE' => Operator::GTE,
+        'LT' => Operator::LT,
+        'LTE' => Operator::LTE,
+        'LIKE' => Operator::LIKE,
+        'BETWEEN' => Operator::BETWEEN,
+        'CONTAINS' => Operator::CONTAINS,
+    ];
+
     /**
      * Parses input structure to a Criterion object.
      *
@@ -24,10 +40,56 @@ class Field extends BaseParser
      *
      * @throws \eZ\Publish\Core\REST\Common\Exceptions\Parser
      *
-     * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion\Field
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd
      */
     public function parse(array $data, ParsingDispatcher $parsingDispatcher)
     {
-        throw new \Exception('@todo implement');
+        if (!array_key_exists('Field', $data)) {
+            throw new Exceptions\Parser('Invalid <Field> format');
+        }
+
+        $fieldData = $data['Field'];
+        if (empty($fieldData['name']) || empty($fieldData['operator']) || empty($fieldData['value'])) {
+            throw new Exceptions\Parser('<Field> format expects name, operator and value keys');
+        }
+
+        $operator = $this->getOperator($fieldData['operator']);
+
+        $values = is_array($fieldData['value']) ? $fieldData['value'] : [$fieldData['value']];
+        $criteria = [];
+        foreach ($values as $value) {
+            $criteria[] = new FieldCriterion(
+                $fieldData['name'],
+                $operator,
+                $value
+            );
+        }
+
+        return new LogicalAnd($criteria);
+    }
+
+    /**
+     * Get operator for the given literal name.
+     *
+     * For the full list of supported operators:
+     * @see \eZ\Publish\Core\REST\Server\Input\Parser\Criterion\Field::OPERATORS
+     *
+     * @param string $operatorName operator literal operator name
+     *
+     * @return string
+     */
+    private function getOperator($operatorName)
+    {
+        $operatorName = strtoupper($operatorName);
+        if (!isset(self::OPERATORS[$operatorName])) {
+            throw new Exceptions\Parser(
+                sprintf(
+                    'Unexpected Field operator, expected one of the following: %s',
+                    implode(', ', array_keys(self::OPERATORS))
+                )
+            );
+        }
+
+        return self::OPERATORS[$operatorName];
     }
 }


### PR DESCRIPTION
# REST Search by Field Criterion
| Question | Answer |
| ------------ | ---------- |
| **Status** | Work in progress |
| **JIRA issue** | [EZP-28783](https://jira.ez.no/browse/EZP-28783) |
| **Target version** | ? |
| **BC break** | no |
| **Feature** | yes |
| **Doc PR** | TODO |

This PR is a quick **proof of concept** on missing implementation of Field Criterion for REST Search API (`POST /views`).

It allows querying by Field Definition Identifier in the same way it's achievable by PHP API.
For more information on that see usages of `eZ\Publish\API\Repository\Values\Content\Query\Criterion\Field`.

### Example
```http
POST /api/ezp/v2/views
X-CSRF-Token: {{YOUR_CSRF_TOKEN}}
Content-Type: application/vnd.ez.api.ViewInput+json; version=1.1
```
```json
{
   "ViewInput":{
      "identifier":"your-query-id",
      "public":false,
      "ContentQuery":{
         "Criteria":{

         },
         "FacetBuilders":{

         },
         "SortClauses":{

         },
         "Query":{
            "Field": {"name": "name", "operator": "CONTAINS", "value": "Welcome"}
         },
         "limit":10,
         "offset":0
      }
   }
}
```

## TODO
- [x] Implement Field Criterion
- [ ] Document.
- [ ] Write tests.