### PR TITLE
EZP-28449: [Installer] Clear cache pool and not whole symfony cache on install

### DIFF
--- a/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
@@ -21,9 +21,7 @@ services:
         arguments:
             - "@database_connection"
             - []
-            - "@cache_clearer"
-            - "@filesystem"
-            - "%kernel.cache_dir%"
+            - '@ezpublish.cache_pool'
             - "%kernel.environment%"
         tags:
             - { name: console.command }


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-28449

Solves:
- incompatibility with Symfony 3.4
- having to write to app/cache on install _(if setup with redis/memcached that is uneasier)_
- Actually clearing the cache relevant for install and indexer, even when setup with redis/memcached


@emodric I did not target 6.7 here to be on the safe side, is that a problem? _(if so you'll need to report issue for 6.7)_