### PR TITLE
EZP-28375: Improved REST Functional Tests

### DIFF
--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RoleTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RoleTest.php
@@ -717,7 +717,10 @@ XML;
 
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
+        $href = $response->getHeader('Location');
 
-        return $response->getHeader('Location');
+        $this->addCreatedElement($href);
+
+        return $href;
     }
 }

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/SessionTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/SessionTest.php
@@ -98,7 +98,7 @@ class SessionTest extends TestCase
         self::assertGreaterThan(0, $csrfDomElements->length);
         $csrfTokenValue = $csrfDomElements->item(0)->nodeValue;
 
-        $loginPostRequest = new FormRequest('POST', '/login', $this->getHttpHost());
+        $loginPostRequest = new FormRequest('POST', '/login_check', $this->getHttpHost());
         $loginPostRequest->addFields([
             '_username' => $this->getLoginUsername(),
             '_password' => $this->getLoginPassword(),
@@ -115,7 +115,8 @@ class SessionTest extends TestCase
         $this->setSessionInput($request);
         $request->addHeader("Cookie: $sessionCookie");
         $response = $this->sendHttpRequest($request);
-        self::assertHttpResponseCodeEquals($response, 201);
+        // Since Session is reused, not created, expect 200 instead of 201
+        self::assertHttpResponseCodeEquals($response, 200);
     }
 
     /**

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/TestCase.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/TestCase.php
@@ -214,6 +214,7 @@ EOF;
     protected function createFolder($string, $parentLocationId)
     {
         $string = $this->addTestSuffix($string);
+        $remoteId = md5(uniqid($string, true));
         $xml = <<< XML
 <?xml version="1.0" encoding="UTF-8"?>
 <ContentCreate>
@@ -228,7 +229,7 @@ EOF;
   </LocationCreate>
   <Section href="/api/ezp/v2/content/sections/1" />
   <alwaysAvailable>true</alwaysAvailable>
-  <remoteId>{$string}</remoteId>
+  <remoteId>{$remoteId}</remoteId>
   <User href="/api/ezp/v2/user/users/14" />
   <modificationDate>2012-09-30T12:30:00</modificationDate>
   <fields>


### PR DESCRIPTION
| Question | Answer |
| ------------ | ---------- |
| **Status** | Ready for a review |
| **JIRA issue** | [EZP-28375](https://jira.ez.no/browse/EZP-28375) |
| **Related to** | #2166 |
| **Target version** | `6.7` |
| **BC break** | no |
| **Tests pass** | yes |

This PR backports REST Functional tests fixes done for #2166 to `6.7`.

**TODO**
- [x] Change remoteId to be generated as md5 to avoid issues when generating cache keys / tags.
- [x] Add created Role to list of elements for cleanup after tests finish (so tests can be re-run on the same instance without reinstalling).
- [x] Update test trying to reuse frontend session for REST actions and check if this works as expected
