### PR TITLE
EZP-28510: ContentType list for Group is not refreshed after publishing ContentType

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
@@ -428,6 +428,17 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
 
         // Clear type cache, map cache, and content cache which contains fields.
         $this->cache->invalidateTags(['type-' . $typeId, 'type-map', 'content-fields-type-' . $typeId]);
+
+        // Clear Content Type Groups list cache
+        $contentType = $this->load($typeId, Type::STATUS_DEFINED);
+        $this->cache->deleteItems(
+            array_map(
+                function ($groupId) {
+                    return 'ez-content-type-group-' . $groupId;
+                },
+                $contentType->groupIds
+            )
+        );
     }
 
     /**


### PR DESCRIPTION
| Question | Answer |
| ------------ | ---------- |
| **Status** | Ready for a review |
| **JIRA issue** | [EZP-28510](https://jira.ez.no/browse/EZP-28510) |
| **Target version** | 7.0 |
| **BC break** | no |
| **Bug fix** | yes |

## Summary
This PR presents one possible approach to refresh list of Content Types for Content Type Group after publishing Content Type.
The reason for the failure is that when list for group is tagged, new Content Type is not published yet, so not included in tags.

## Background
We were able to reproduce this behavior only when Content Type has `ezobjectrelation` or `ezobjectrelationlist` field types, because these are the only field types that requires loading list of content types (see [`AbstractRelationFormMapper::getContentTypesHash`](https://github.com/ezsystems/repository-forms/blob/v2.0.0-beta2/lib/FieldType/Mapper/AbstractRelationFormMapper.php#L35-L45)).

What happens is that list gets loaded into Cache before published Content Type is available and this cache is never invalidated properly.

## Solution
The solution is to invalidate cache for Content Type Group after publishing, since this cache contains only published Content Types.

The approach doesn't present best practises because it performs additional load in cache layer, however this is what I've come up so far...

## Alternative approaches
1. Tag `type-map` in `loadContentTypes` (though purpose of this is for field definitions).
2. Introduce another tag for handling content types in all states in content type group.
3. Redesign SPI layer so groups for invalidation are available when publishing, see #2186
