### PR TITLE
[Fix 2] EZP-28510: ContentType list for Group is not refreshed after publishing ContentType

### DIFF
--- a/doc/bc/changes-7.0.md
+++ b/doc/bc/changes-7.0.md
@@ -30,6 +30,9 @@ Changes affecting version compatibility with former or future versions.
 
 * The Twig block `eztime_field` of `eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig` is rendered using UTC timezone to avoid server timezone-related issues.
 
+* SPI Layer: The method `\eZ\Publish\SPI\Persistence\Content\Type\Handler::publish` expects now
+  `\eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft` instead of numeric Content Type Id.
+
 ## Deprecations
 
 _7.0 is a major version, hence does not introduce deprecations but rather removes some previously deprecated features,

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentTypeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentTypeHandlerTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\Core\Persistence\Cache\Tests;
 
+use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
+use eZ\Publish\Core\Repository\Values\ContentType\ContentTypeGroup;
 use eZ\Publish\SPI\Persistence\Content\Type as SPIType;
 use eZ\Publish\SPI\Persistence\Content\Type\CreateStruct as SPITypeCreateStruct;
 use eZ\Publish\SPI\Persistence\Content\Type\UpdateStruct as SPITypeUpdateStruct;
@@ -16,6 +18,7 @@ use eZ\Publish\SPI\Persistence\Content\Type\Group as SPITypeGroup;
 use eZ\Publish\SPI\Persistence\Content\Type\Group\CreateStruct as SPITypeGroupCreateStruct;
 use eZ\Publish\SPI\Persistence\Content\Type\Group\UpdateStruct as SPITypeGroupUpdateStruct;
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as SPIContentTypeHandler;
+use eZ\Publish\Core\Repository\Values\ContentType\ContentTypeDraft;
 
 /**
  * Test case for Persistence\Cache\ContentTypeHandler.
@@ -65,7 +68,7 @@ class ContentTypeHandlerTest extends AbstractCacheHandlerTest
             ['removeFieldDefinition', [5, 1, 7], null, 'ez-content-type-5-1'],
             ['updateFieldDefinition', [5, 0, new SPITypeFieldDefinition()], ['type-5', 'type-map', 'content-fields-type-5']],
             ['updateFieldDefinition', [5, 1, new SPITypeFieldDefinition()], [], 'ez-content-type-5-1'],
-            ['publish', [5], ['type-5', 'type-map', 'content-fields-type-5']],
+            ['publish', [$this->buildContentTypeDraft(5, [3, 4])], ['type-5', 'type-map', 'content-fields-type-5', 'type-group-3', 'type-group-4']],
         ];
     }
 
@@ -88,5 +91,30 @@ class ContentTypeHandlerTest extends AbstractCacheHandlerTest
             ['loadByRemoteId', ['f34tg45gf'], 'ez-content-type-f34tg45gf-by-remote', $type],
             ['getSearchableFieldMap', [], 'ez-content-type-field-map', [$type]],
         ];
+    }
+
+    /**
+     * Build proper ContentTypeDraft instance for tests.
+     *
+     * @param int $contentTypeId
+     * @param int[] $contentTypeGroupIds
+     *
+     * @return \eZ\Publish\Core\Repository\Values\ContentType\ContentTypeDraft
+     */
+    private function buildContentTypeDraft($contentTypeId, array $contentTypeGroupIds)
+    {
+        $innerContentType = new ContentType(
+            [
+                'id' => $contentTypeId,
+                'contentTypeGroups' => array_map(
+                    function ($contentTypeGroupId) {
+                        return new ContentTypeGroup(['id' => $contentTypeGroupId]);
+                    },
+                    $contentTypeGroupIds
+                ),
+            ]
+        );
+
+        return new ContentTypeDraft(['id' => 23, 'innerContentType' => $innerContentType]);
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Type;
 
+use eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft;
 use eZ\Publish\SPI\Persistence\Content\Type;
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as BaseContentTypeHandler;
 use eZ\Publish\SPI\Persistence\Content\Type\CreateStruct;
@@ -575,14 +576,14 @@ class Handler implements BaseContentTypeHandler
      *
      * Flags the content type as updated.
      *
-     * @param mixed $contentTypeId
+     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft $contentTypeDraft
      */
-    public function publish($contentTypeId)
+    public function publish(ContentTypeDraft $contentTypeDraft)
     {
-        $toType = $this->load($contentTypeId, Type::STATUS_DRAFT);
+        $toType = $this->load($contentTypeDraft->id, Type::STATUS_DRAFT);
 
         try {
-            $fromType = $this->load($contentTypeId, Type::STATUS_DEFINED);
+            $fromType = $this->load($contentTypeDraft->id, Type::STATUS_DEFINED);
             $this->updateHandler->updateContentObjects($fromType, $toType);
             $this->updateHandler->deleteOldType($fromType);
         } catch (Exception\TypeNotFound $e) {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/MemoryCachingHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/MemoryCachingHandler.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Type;
 
+use eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft;
 use eZ\Publish\SPI\Persistence\Content\Type;
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as BaseContentTypeHandler;
 use eZ\Publish\SPI\Persistence\Content\Type\CreateStruct;
@@ -451,13 +452,13 @@ class MemoryCachingHandler implements BaseContentTypeHandler
      *
      * Flags the content type as updated.
      *
-     * @param mixed $contentTypeId
+     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft $contentTypeDraft
      */
-    public function publish($contentTypeId)
+    public function publish(ContentTypeDraft $contentTypeDraft)
     {
         $this->clearCache();
 
-        return $this->innerHandler->publish($contentTypeId);
+        $this->innerHandler->publish($contentTypeDraft);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Type;
 
+use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
 use eZ\Publish\SPI\Persistence\Content\Type;
 use eZ\Publish\SPI\Persistence\Content\Type\CreateStruct;
 use eZ\Publish\SPI\Persistence\Content\Type\UpdateStruct;
@@ -21,6 +22,7 @@ use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Gateway;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Mapper;
 use eZ\Publish\Core\Persistence\Legacy\Content\Type\Update\Handler as UpdateHandler;
+use eZ\Publish\Core\Repository\Values\ContentType\ContentTypeDraft;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -1066,7 +1068,9 @@ class ContentTypeHandlerTest extends TestCase
                 $this->equalTo(0)
             );
 
-        $handler->publish(23);
+        $handler->publish(
+            new ContentTypeDraft(['innerContentType' => new ContentType(['id' => 23])])
+        );
     }
 
     /**
@@ -1106,7 +1110,9 @@ class ContentTypeHandlerTest extends TestCase
                 $this->equalTo(0)
             );
 
-        $handler->publish(23);
+        $handler->publish(
+            new ContentTypeDraft(['innerContentType' => new ContentType(['id' => 23])])
+        );
     }
 
     /**

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -1466,9 +1466,8 @@ class ContentTypeService implements ContentTypeServiceInterface
                 );
             }
 
-            $this->contentTypeHandler->publish(
-                $loadedContentTypeDraft->id
-            );
+            $this->contentTypeHandler->publish($loadedContentTypeDraft);
+
             $this->repository->commit();
         } catch (Exception $e) {
             $this->repository->rollback();

--- a/eZ/Publish/SPI/Persistence/Content/Type/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/Handler.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\SPI\Persistence\Content\Type;
 
+use eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft;
 use eZ\Publish\SPI\Persistence\Content\Type;
 use eZ\Publish\SPI\Persistence\Content\Type\Group\CreateStruct as GroupCreateStruct;
 use eZ\Publish\SPI\Persistence\Content\Type\Group\UpdateStruct as GroupUpdateStruct;
@@ -281,11 +282,11 @@ interface Handler
      *
      * Flags the content type as updated.
      *
-     * @param mixed $contentTypeId
+     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft $contentTypeDraft
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If type with $contentTypeId and Type::STATUS_DRAFT is not found
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException If the given Content Type Draft was not found
      */
-    public function publish($contentTypeId);
+    public function publish(ContentTypeDraft $contentTypeDraft);
 
     /**
      * Returns content type, field definition and field type mapping information


### PR DESCRIPTION
| Question | Answer |
| ------------ | ---------- |
| **Status** | Ready for a review |
| **Alternative to** | #2185 |
| **JIRA issue** | [EZP-28510](https://jira.ez.no/browse/EZP-28510) |
| **Target version** | 7.0 |
| **BC break** | yes, SPI |
| **Bug fix** | yes |

## Summary
The reason for the failure is that when list for group is tagged, new Content Type is not published yet, so not included in tags.

This PR presents an alternative approach to #2185 with refactored SPI layer to pass needed information on Content Type Groups without a need to load it again.

## Solution
The solution is to invalidate cache for Content Type Group after publishing, since this cache contains only published Content Types.

See 1952276 for the fix only.

**TODO**
- [ ] Decide which solution to choose
- [ ] Send to QA