### PR TITLE
EZP-28506: Defining a frontend template overrides the backend content view

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/LocationView.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/LocationView.php
@@ -19,9 +19,10 @@ class LocationView extends View
     public function preMap(array $config, ContextualizerInterface $contextualizer)
     {
         $scopes = array_merge(
-            [ConfigResolver::SCOPE_DEFAULT, ConfigResolver::SCOPE_GLOBAL],
+            [ConfigResolver::SCOPE_GLOBAL],
             $config['siteaccess']['list'],
-            array_keys($config['siteaccess']['groups'])
+            array_keys($config['siteaccess']['groups']),
+            [ConfigResolver::SCOPE_DEFAULT]
         );
 
         foreach ($scopes as $scope) {


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://jira.ez.no/browse/EZP-28506
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes, no, maybe
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)

Implementation is different from [documentation](https://doc.ezplatform.com/en/1.12/guide/siteaccess/#scope). Currently, for View matching `default` acts as the most important scope instead of fallback.