### PR TITLE
EZP-28510: Fixed wrong cache key name used in #2185 fix

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
@@ -434,7 +434,7 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
         $this->cache->deleteItems(
             array_map(
                 function ($groupId) {
-                    return 'ez-content-type-group-' . $groupId;
+                    return 'ez-content-type-list-by-group-' . $groupId;
                 },
                 $contentType->groupIds
             )

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentTypeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentTypeHandlerTest.php
@@ -132,7 +132,7 @@ class ContentTypeHandlerTest extends AbstractCacheHandlerTest
         $this->cacheMock
             ->expects($this->once())
             ->method('deleteItems')
-            ->with(['ez-content-type-group-3', 'ez-content-type-group-4'])
+            ->with(['ez-content-type-list-by-group-3', 'ez-content-type-list-by-group-4'])
             ->willReturn(true);
 
         $handler = $this->persistenceCacheHandler->$handlerMethodName();


### PR DESCRIPTION
I missed integration test failure when checking final solution for #2185
The cache key prefix that is supposed to be used is `'ez-content-type-list-by-group-'`.

Sorry! :sob: 

// cc @andrerom @lserwatka 