### PR TITLE
EZP-28513: Current date populated as the default value for Date field type should be the absolute value

### DIFF
--- a/eZ/Publish/Core/FieldType/Date/Type.php
+++ b/eZ/Publish/Core/FieldType/Date/Type.php
@@ -136,7 +136,10 @@ class Type extends FieldType
     /**
      * Converts an $hash to the Value defined by the field type.
      *
-     * @param mixed $hash Null or associative array containing timestamp and optionally date in RFC850 format.
+     * @param mixed $hash Null or associative array containing one of the following (first value found in the order below is picked):
+     *                    'rfc850': Date in RFC 850 format (DateTime::RFC850)
+     *                    'timestring': Date in parseable string format supported by DateTime (e.g. 'now', '+3 days')
+     *                    'timestamp': Unix timestamp
      *
      * @return \eZ\Publish\Core\FieldType\Date\Value $value
      */
@@ -148,6 +151,10 @@ class Type extends FieldType
 
         if (isset($hash['rfc850']) && $hash['rfc850']) {
             return Value::fromString($hash['rfc850']);
+        }
+
+        if (isset($hash['timestring']) && is_string($hash['timestring'])) {
+            return Value::fromString($hash['timestring']);
         }
 
         return Value::fromTimestamp((int)$hash['timestamp']);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateConverter.php
@@ -15,7 +15,6 @@ use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 use eZ\Publish\Core\FieldType\Date\Type as DateType;
 use eZ\Publish\Core\FieldType\FieldSettings;
-use DateTime;
 
 /**
  * Date field value converter class.
@@ -93,11 +92,10 @@ class DateConverter implements Converter
         // Building default value
         switch ($fieldDef->fieldTypeConstraints->fieldSettings['defaultType']) {
             case DateType::DEFAULT_CURRENT_DATE:
-                $dateTime = new DateTime();
-                $dateTime->setTime(0, 0, 0);
                 $data = array(
-                    'timestamp' => $dateTime->getTimestamp(),
+                    'timestamp' => time(), // @deprecated timestamp is no longer used and will be removed in a future version.
                     'rfc850' => null,
+                    'timestring' => 'now',
                 );
                 break;
             default:

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/DateTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/DateTest.php
@@ -157,8 +157,7 @@ class DateTest extends TestCase
      */
     public function testToFieldDefinitionDefaultCurrentDate()
     {
-        $dateTime = new DateTime();
-        $timestamp = $dateTime->setTime(0, 0, 0)->getTimestamp();
+        $timestamp = time();
         $fieldDef = new PersistenceFieldDefinition();
         $storageDef = new StorageFieldDefinition(
             array(
@@ -168,8 +167,9 @@ class DateTest extends TestCase
 
         $this->converter->toFieldDefinition($storageDef, $fieldDef);
         self::assertInternalType('array', $fieldDef->defaultValue->data);
-        self::assertCount(2, $fieldDef->defaultValue->data);
+        self::assertCount(3, $fieldDef->defaultValue->data);
         self::assertNull($fieldDef->defaultValue->data['rfc850']);
         self::assertSame($timestamp, $fieldDef->defaultValue->data['timestamp']);
+        self::assertSame('now', $fieldDef->defaultValue->data['timestring']);
     }
 }


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28513

## Description

Current date populated as the default value for Date field type should be the absolute value (not related to the default server timezone). Otherwise, it some cases the value will be yesterday's date instead of today's date.

Patch based on DateTime field type impl.: https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php#L114 

## Steps to reproduce

> 1. Create new eZ Platform installation.
> 2. Create new Content Type with the Date Field Type. Set "Current date" as the default value for this field.
> 3. In the Platform UI, navigate to "Content structure", click "Create" button and select the Content Type created in the previous step.
> 4. Notice that the Date field will be prepopulated with yesterday's date.