### PR TITLE
EZP-28290: Invalid cache key on url ezjscore_call_ezjscnode::subtree::2

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
@@ -53,7 +53,7 @@ class UrlAliasHandlerTest extends AbstractCacheHandlerTest
         return [
             ['listURLAliasesForLocation', [5], 'ez-urlAlias-location-list-5', [$object]],
             ['listURLAliasesForLocation', [5, true], 'ez-urlAlias-location-list-5-custom', [$object]],
-            ['lookup', ['/Home'], 'ez-urlAlias-url-_Home', $object],
+            ['lookup', ['/Home'], 'ez-urlAlias-url-_SHome', $object],
             ['loadUrlAlias', [5], 'ez-urlAlias-5', $object],
         ];
     }

--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -178,7 +178,9 @@ class UrlAliasHandler extends AbstractHandler implements UrlAliasHandlerInterfac
      */
     public function lookup($url)
     {
-        $cacheItem = $this->cache->getItem('ez-urlAlias-url-' . str_replace('/', '_', $url));
+        $cacheItem = $this->cache->getItem(
+            'ez-urlAlias-url-' . str_replace(['/', ':', '(', ')', '@'], ['_S', '_C', '_B', '_B', '_A'], $url)
+        );
         if ($cacheItem->isHit()) {
             if (($return = $cacheItem->get()) === self::NOT_FOUND) {
                 throw new NotFoundException('UrlAlias', $url);


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-28290

ping @emodric 