### PR TITLE
EZP-28615: Cannot check content/create permission with ContentCreateStruct without target location

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\API\Repository\Values\User\Limitation\RoleLimitation;
 use eZ\Publish\API\Repository\Values\User\Limitation\SubtreeLimitation;
+use eZ\Publish\API\Repository\Values\User\UserGroup;
 use eZ\Publish\Core\REST\Client\Sessionable;
 use DateTime;
 use ArrayObject;
@@ -383,14 +384,18 @@ abstract class BaseTest extends TestCase
      * @param string $login
      * @param string $firstName
      * @param string $lastName
+     * @param \eZ\Publish\API\Repository\Values\User\UserGroup|null $userGroup optional user group, Editor by default
+     *
      * @return \eZ\Publish\API\Repository\Values\User\User
      */
-    protected function createUser($login, $firstName, $lastName)
+    protected function createUser($login, $firstName, $lastName, UserGroup $userGroup = null)
     {
         $repository = $this->getRepository();
 
         $userService = $repository->getUserService();
-        $userGroup = $userService->loadUserGroup(13);
+        if (null === $userGroup) {
+            $userGroup = $userService->loadUserGroup(13);
+        }
 
         // Instantiate a create struct with mandatory properties
         $userCreate = $userService->newUserCreateStruct(
@@ -464,5 +469,46 @@ abstract class BaseTest extends TestCase
         $searchHandler = $searchHandlerProperty->getValue($repository);
 
         $searchHandler->commit();
+    }
+
+    /**
+     * Create role of a given name with the given policies described by an array.
+     *
+     * @param $roleName
+     * @param array $policiesData [['module' => 'content', 'function' => 'read', 'limitations' => []]
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\Role
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\LimitationValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function createRoleWithPolicies($roleName, array $policiesData)
+    {
+        $repository = $this->getRepository(false);
+        $roleService = $repository->getRoleService();
+
+        $roleCreateStruct = $roleService->newRoleCreateStruct($roleName);
+        foreach ($policiesData as $policyData) {
+            $policyCreateStruct = $roleService->newPolicyCreateStruct(
+                $policyData['module'],
+                $policyData['function']
+            );
+
+            if (isset($policyData['limitations'])) {
+                foreach ($policyData['limitations'] as $limitation) {
+                    $policyCreateStruct->addLimitation($limitation);
+                }
+            }
+
+            $roleCreateStruct->addPolicy($policyCreateStruct);
+        }
+
+        $roleDraft = $roleService->createRole($roleCreateStruct);
+
+        $roleService->publishRoleDraft($roleDraft);
+
+        return $roleService->loadRole($roleDraft->id);
     }
 }

--- a/eZ/Publish/Core/Limitation/ParentContentTypeLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ParentContentTypeLimitationType.php
@@ -177,12 +177,14 @@ class ParentContentTypeLimitationType extends AbstractPersistenceLimitationType 
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If $targets does not contain
      *         objects of type LocationCreateStruct
      *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
      * @param array $targets
      *
      * @return bool
      */
-    protected function evaluateForContentCreateStruct(APILimitationValue $value, array $targets)
+    protected function evaluateForContentCreateStruct(APILimitationValue $value, array $targets = null)
     {
         // If targets is empty/null return false as user does not have access
         // to content w/o location with this limitation

--- a/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
@@ -170,12 +170,14 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If $targets does not contain
      *         objects of type LocationCreateStruct
      *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     *
      * @param \eZ\Publish\API\Repository\Values\User\Limitation $value
      * @param array $targets
      *
      * @return bool
      */
-    protected function evaluateForContentCreateStruct(APILimitationValue $value, array $targets)
+    protected function evaluateForContentCreateStruct(APILimitationValue $value, array $targets = null)
     {
         // If targets is empty/null return false as user does not have access
         // to content w/o location with this limitation


### PR DESCRIPTION
| Question | Answer |
| ------------- | --- |
| JIRA Issue | [EZP-28615](https://jira.ez.no/browse/EZP-28615) |
| Bug fix?      | yes |
| New feature?  | no |
| BC breaks?    | no |
| Tests pass?   | ? |
| Doc needed?   | no |

`\eZ\Publish\SPI\Limitation\Type::evaluate` accepts `null` for `$targets` instead of empty array and internally methods rely on that value, so any method using that argument has to allow `null` also, otherwise it ends up in argument type PHP error.

Actual fix: 0c562aa.

**TODO**:
- [x] Create tests.
- [x] Fix the bug.
- [x] Confirm CI tests pass.
- [x] Send for Code Review.