### PR TITLE
EZP-29531: Do not render layout when rendering selection and relation items

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -266,7 +266,7 @@
     <ul {{ block( 'field_attributes' ) }}>
         {% for contentId in field.value.destinationContentIds if parameters.available[contentId] %}
         <li>
-            {{ render( controller( "ez_content:viewAction", {'contentId': contentId, 'viewType': 'embed', 'noLayout': 1} ) ) }}
+            {{ render( controller( "ez_content:viewAction", {'contentId': contentId, 'viewType': 'embed', 'layout': false} ) ) }}
         </li>
         {% endfor %}
     </ul>
@@ -331,7 +331,7 @@
     {% if parameters.showInfo is defined and not parameters.showInfo %}
         {% set showInfo = false %}
     {% endif %}
-    
+
     {% set draggable = defaultDraggable %}
     {% if parameters.draggable is defined and not parameters.draggable %}
         {% set draggable = 'false' %}
@@ -436,7 +436,7 @@
 {% spaceless %}
 {% if not ez_is_field_empty( content, field ) and parameters.available %}
     <div {{ block( 'field_attributes' ) }}>
-        {{ render( controller( "ez_content:viewAction", {'contentId': field.value.destinationContentId, 'viewType': 'text_linked', 'noLayout': 1} ) ) }}
+        {{ render( controller( "ez_content:viewAction", {'contentId': field.value.destinationContentId, 'viewType': 'text_linked', 'layout': false} ) ) }}
     </div>
 {% endif %}
 {% endspaceless %}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
@@ -338,7 +338,7 @@
         <div class="ez-fielddefinition-setting-name">Selection root:</div>
         <div class="ez-fielddefinition-setting-value">
         {% if rootLocationId %}
-            {{ render( controller( "ez_content:viewAction", {'locationId': rootLocationId,  'viewType': 'line'} ), {'strategy': 'esi'}) }}
+            {{ render( controller( "ez_content:viewAction", {'locationId': rootLocationId,  'viewType': 'line', 'layout': false} ), {'strategy': 'esi'}) }}
         {% else %}
             <em>No defined root</em>
         {% endif %}


### PR DESCRIPTION
> https://jira.ez.no/browse/EZP-29531

Without this fix, rendering relation and selection items in eZ Platform Admin UI v2 looks like this:

![screenshot from 2017-12-20 18-00-31](https://user-images.githubusercontent.com/362286/34218901-d1a35d04-e5af-11e7-91e9-284e1959de1d.png)

With the fix, it looks like this:

![screenshot from 2017-12-20 18-00-51](https://user-images.githubusercontent.com/362286/34218913-de320dae-e5af-11e7-8c74-9ddb35f138da.png)
