### PR TITLE
[WiP] EZP-28625: [E-mail fieldtype] Content item cannot be found by e-mail field value

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/EmailAddressIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/EmailAddressIntegrationTest.php
@@ -363,4 +363,14 @@ class EmailAddressIntegrationTest extends SearchBaseIntegrationTest
         // ensure case-insensitivity
         return strtoupper($this->getValidSearchValueTwo());
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getFullTextIndexedFieldData()
+    {
+        return [
+            ['holmes4', 'wyoming'],
+        ];
+    }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
@@ -218,11 +218,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
 
     public function checkFullTextSupport()
     {
-        if (ltrim(get_class($this->getSetupFactory()), '\\') === 'eZ\\Publish\\API\\Repository\\Tests\\SetupFactory\\Legacy') {
-            $this->markTestSkipped(
-                "'{$this->getTypeName()}' field type (any actually, fulltext search is missing) is not searchable with Legacy Search Engine"
-            );
-        }
+        // All supported search engines support also FullText indexing
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/EmailAddress/SearchField.php
+++ b/eZ/Publish/Core/FieldType/EmailAddress/SearchField.php
@@ -28,13 +28,18 @@ class SearchField implements Indexable
      */
     public function getIndexData(Field $field, FieldDefinition $fieldDefinition)
     {
-        return array(
+        return [
             new Search\Field(
                 'value',
                 $field->value->data,
                 new Search\FieldType\StringField()
             ),
-        );
+            new Search\Field(
+                'fulltext',
+                $field->value->data,
+                new Search\FieldType\FullTextField()
+            ),
+        ];
     }
 
     /**


### PR DESCRIPTION
| Question | Answer |
| ------------- | --- |
| **Status** | Work in progress |
| **JIRA issue** | [EZP-28625](https://jira.ez.no/browse/EZP-28625) |
| **Target version** | `6.7` |
| **Bug fix**      | yes |
| **New feature**  | no |
| **BC breaks**    | no |
| **Tests pass**  | ? |
| **Doc needed**   | no |

This PR adds missing FullText Search Field to `ezemail` Field Type.

**TODO**:
- [x] Create tests
- [x] Fix bug
- [ ] Confirm CI is passing
- [ ] Get feedback on how FullText for e-mails should work
- [ ] Send for code review