### PR TITLE
[Tests] Fixed usages of createRoleWithPolicies after EZP-28615 fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
     "extra": {
         "_ci_branch-comment_": "Keep ci branch up-to-date with master or branch if on stable. ci is never on github but convention used for ci behat testing!",
         "_ezplatform_branch_for_behat_tests_comment_": "ezplatform branch to use to run Behat tests",
-        "_ezplatform_branch_for_behat_tests": "master",
+        "_ezplatform_branch_for_behat_tests": "1.12",
         "branch-alias": {
             "dev-master": "6.12.x-dev",
             "dev-tmp_ci_branch": "6.12.x-dev"

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -5097,14 +5097,14 @@ class ContentServiceTest extends BaseContentServiceTest
         $contentService = $repository->getContentService();
 
         $this->createRoleWithPolicies('Publisher', [
-            ['content', 'read'],
-            ['content', 'create'],
-            ['content', 'publish'],
+            ['module' => 'content', 'function' => 'read'],
+            ['module' => 'content', 'function' => 'create'],
+            ['module' => 'content', 'function' => 'publish'],
         ]);
 
         $this->createRoleWithPolicies('Writer', [
-            ['content', 'read'],
-            ['content', 'create'],
+            ['module' => 'content', 'function' => 'read'],
+            ['module' => 'content', 'function' => 'create'],
         ]);
 
         $writerUser = $this->createCustomUserWithLogin(
@@ -5141,9 +5141,9 @@ class ContentServiceTest extends BaseContentServiceTest
         $repository = $this->getRepository();
 
         $this->createRoleWithPolicies('Writer', [
-            ['content', 'read'],
-            ['content', 'create'],
-            ['content', 'edit'],
+            ['module' => 'content', 'function' => 'read'],
+            ['module' => 'content', 'function' => 'create'],
+            ['module' => 'content', 'function' => 'edit'],
         ]);
         $writerUser = $this->createCustomUserWithLogin(
             'writer',
@@ -5336,10 +5336,10 @@ class ContentServiceTest extends BaseContentServiceTest
 
         // create user that can read/create/edit but cannot delete content
         $this->createRoleWithPolicies('Writer', [
-            ['content', 'read'],
-            ['content', 'versionread'],
-            ['content', 'create'],
-            ['content', 'edit'],
+            ['module' => 'content', 'function' => 'read'],
+            ['module' => 'content', 'function' => 'versionread'],
+            ['module' => 'content', 'function' => 'create'],
+            ['module' => 'content', 'function' => 'edit'],
         ]);
         $writerUser = $this->createCustomUserWithLogin(
             'writer',
@@ -5578,10 +5578,10 @@ class ContentServiceTest extends BaseContentServiceTest
 
         // create user that can read/create/delete but cannot edit or content
         $this->createRoleWithPolicies('Writer', [
-            ['content', 'read'],
-            ['content', 'versionread'],
-            ['content', 'create'],
-            ['content', 'delete'],
+            ['module' => 'content', 'function' => 'read'],
+            ['module' => 'content', 'function' => 'versionread'],
+            ['module' => 'content', 'function' => 'create'],
+            ['module' => 'content', 'function' => 'delete'],
         ]);
         $writerUser = $this->createCustomUserWithLogin(
             'user',
@@ -5632,27 +5632,6 @@ class ContentServiceTest extends BaseContentServiceTest
         foreach ($translationInfo as $propertyName => $propertyValue) {
             $this->assertNull($propertyValue, "Property '{$propertyName}' initial value should be null'");
         }
-    }
-
-    /**
-     * Simplify creating custom role with limited set of policies.
-     *
-     * @param $roleName
-     * @param array $policies e.g. [ ['content', 'create'], ['content', 'edit'], ]
-     */
-    private function createRoleWithPolicies($roleName, array $policies)
-    {
-        $repository = $this->getRepository();
-        $roleService = $repository->getRoleService();
-
-        $roleCreateStruct = $roleService->newRoleCreateStruct($roleName);
-        foreach ($policies as $policy) {
-            $policyCreateStruct = $roleService->newPolicyCreateStruct($policy[0], $policy[1]);
-            $roleCreateStruct->addPolicy($policyCreateStruct);
-        }
-
-        $roleDraft = $roleService->createRole($roleCreateStruct);
-        $roleService->publishRoleDraft($roleDraft);
     }
 
     /**


### PR DESCRIPTION
**Target branch**: 6.12
**Bug fix**: yes

This PR fixes broken integration tests after merging up EZP-28615 from `6.7`. The method `createRoleWithPolicies` was added to `BaseTest` in the mentioned fix for EZP-28615, but since `6.8` already existed in `ContentServiceTest`. My bad :(