### PR TITLE
EZP-28352: After swapping the location of the content item, the main location of the content item is unassigned	

### DIFF
--- a/doc/specifications/cache/persistence/Readme.md
+++ b/doc/specifications/cache/persistence/Readme.md
@@ -30,7 +30,7 @@ List of tags and their meaning:
   _Same as above, additional tags for all parents, for operations that changes the tree itself, like move/remove/(..)._
 
 - `location-data-<location-id>` :
-  _Used on location, and invalidated when operations affect the properties on location only, e.g. swap/update._
+  _Used on location, and invalidated when operations affect the properties on location only, e.g. update._
 
 - `location-path-data-<location-id>` :
   _Same as above, but for operations affecting data in the tree, e.g. hide/unhide._

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -5618,27 +5618,6 @@ class ContentServiceTest extends BaseContentServiceTest
     }
 
     /**
-     * Simplify creating custom role with limited set of policies.
-     *
-     * @param $roleName
-     * @param array $policies e.g. [ ['content', 'create'], ['content', 'edit'], ]
-     */
-    private function createRoleWithPolicies($roleName, array $policies)
-    {
-        $repository = $this->getRepository();
-        $roleService = $repository->getRoleService();
-
-        $roleCreateStruct = $roleService->newRoleCreateStruct($roleName);
-        foreach ($policies as $policy) {
-            $policyCreateStruct = $roleService->newPolicyCreateStruct($policy[0], $policy[1]);
-            $roleCreateStruct->addPolicy($policyCreateStruct);
-        }
-
-        $roleDraft = $roleService->createRole($roleCreateStruct);
-        $roleService->publishRoleDraft($roleDraft);
-    }
-
-    /**
      * Asserts that all aliases defined in $expectedAliasProperties with the
      * given properties are available in $actualAliases and not more.
      *

--- a/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
@@ -205,7 +205,12 @@ class LocationHandler extends AbstractHandler implements LocationHandlerInterfac
 
         $return = $locationHandler->swap($locationId1, $locationId2);
 
-        $this->cache->invalidateTags(['location-data-' . $locationId1, 'location-data-' . $locationId2]);
+        $this->cache->invalidateTags(
+            [
+                'location-' . $locationId1,
+                'location-' . $locationId2,
+            ]
+        );
 
         return $return;
     }

--- a/eZ/Publish/Core/Persistence/Cache/Tests/LocationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/LocationHandlerTest.php
@@ -37,7 +37,7 @@ class LocationHandlerTest extends AbstractCacheHandlerTest
             ['markSubtreeModified', [12]],
             ['hide', [12], ['location-path-data-12']],
             ['unHide', [12], ['location-path-data-12']],
-            ['swap', [12, 45], ['location-data-12', 'location-data-45']],
+            ['swap', [12, 45], ['location-12', 'location-45']],
             ['update', [new UpdateStruct(), 12], ['location-data-12']],
             ['create', [new CreateStruct(['contentId' => 4, 'mainLocationId' => true])], ['content-4', 'role-assignment-group-list-4']],
             ['create', [new CreateStruct(['contentId' => 4, 'mainLocationId' => false])], ['content-4', 'role-assignment-group-list-4']],


### PR DESCRIPTION
| Question           | Answer |
| -----------------  | ------ |
| **JIRA issue**     | [EZP-28352](https://jira.ez.no/browse/EZP-28352) |
| **Target version** | `7.x` |
| **Bug fix**        | yes |
| **New feature**    | no |
| **BC breaks**      | no |
| **Tests pass**     | yes |
| **Doc needed**     | no |

This PR replaces invalidating `location-data-<locationId>` with `location-<locationId>` Persistence Cache Tag after Location Swap. 
It turns out that besides Location data, Content is also affected when swapping Main Location.

**TODO**:
- [x] BEFORE MERGE: rebase after #2207 gets merged up.
- [x] Create tests.
- [x] Replace invalidating of `location-data-<locationId>` with `location-<locationId>` tag.
- [x] Update Persistence Cache specification due to discovered issue.
- [x] Confirm Continuous Integration tests are passing.
- [x] Ask for Code Review.