### PR TITLE
EZP-28679: As a developer, I expect that OptionsResolverBasedQueryType implements QueryType interface

### DIFF
--- a/eZ/Publish/Core/QueryType/OptionsResolverBasedQueryType.php
+++ b/eZ/Publish/Core/QueryType/OptionsResolverBasedQueryType.php
@@ -18,7 +18,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * In addition, you must implement the `configureOptions` abstract method. It receives an OptionsResolver, and configures
  * it for the QueryType's supported parameters.
  */
-abstract class OptionsResolverBasedQueryType
+abstract class OptionsResolverBasedQueryType implements QueryType
 {
     /** @var OptionsResolver */
     private $resolver;


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28679

## Description

The `OptionsResolver Based QueryType` is designed to be the base class for  QueryTypes with parameters.  As a developer, when I extend this class I expect that `OptionsResolverBasedQueryType` already implements `QueryType` interface. 

