### PR TITLE
EZP-28328: RichText Field Type shouldn't remove line breaks inside formatted paragraphs

### DIFF
--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl
@@ -92,6 +92,19 @@
     </xsl:call-template>
   </xsl:template>
 
+  <xsl:template match="docbook:emphasis/text()">
+    <xsl:choose>
+      <xsl:when test="ancestor::*[local-name() = 'literallayout']">
+        <xsl:call-template name="breakLine">
+          <xsl:with-param name="text" select="."/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="."/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
   <xsl:template match="docbook:emphasis">
     <xsl:choose>
       <xsl:when test="@role='strong'">

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
@@ -92,6 +92,19 @@
     </xsl:call-template>
   </xsl:template>
 
+  <xsl:template match="docbook:emphasis/text()">
+    <xsl:choose>
+      <xsl:when test="ancestor::*[local-name() = 'literallayout']">
+        <xsl:call-template name="breakLine">
+          <xsl:with-param name="text" select="."/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="."/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
   <xsl:template match="docbook:emphasis">
     <xsl:choose>
       <xsl:when test="@role='strong'">

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/xhtml5/edit/docbook.xsl
@@ -25,6 +25,27 @@
     </section>
   </xsl:template>
 
+  <xsl:template name="breakline">
+    <xsl:param name="node"/>
+    <xsl:choose>
+      <xsl:when test="descendant::ezxhtml5:br">
+        <xsl:for-each select="$node">
+          <xsl:choose>
+            <xsl:when test="local-name( current() ) = 'br'">
+              <xsl:text>&#xA;</xsl:text>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:apply-templates select="current()"/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:for-each>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
   <xsl:template match="ezxhtml5:p">
     <para>
       <xsl:if test="@class">
@@ -46,7 +67,7 @@
         </xsl:if>
       </xsl:if>
       <xsl:choose>
-        <xsl:when test="child::ezxhtml5:br">
+        <xsl:when test="descendant::ezxhtml5:br">
           <literallayout class="normal">
             <xsl:for-each select="node()">
               <xsl:choose>
@@ -80,7 +101,9 @@
           <xsl:value-of select="@class"/>
         </xsl:attribute>
       </xsl:if>
-      <xsl:apply-templates/>
+      <xsl:call-template name="breakline">
+        <xsl:with-param name="node" select="node()"/>
+      </xsl:call-template>
     </emphasis>
   </xsl:template>
 
@@ -92,21 +115,27 @@
           <xsl:value-of select="@class"/>
         </xsl:attribute>
       </xsl:if>
-      <xsl:apply-templates/>
+      <xsl:call-template name="breakline">
+        <xsl:with-param name="node" select="node()"/>
+      </xsl:call-template>
     </emphasis>
   </xsl:template>
 
   <xsl:template match="ezxhtml5:u">
     <emphasis>
       <xsl:attribute name="role">underlined</xsl:attribute>
-      <xsl:apply-templates/>
+      <xsl:call-template name="breakline">
+        <xsl:with-param name="node" select="node()"/>
+      </xsl:call-template>
     </emphasis>
   </xsl:template>
 
   <xsl:template match="ezxhtml5:del">
     <emphasis>
       <xsl:attribute name="role">strikedthrough</xsl:attribute>
-      <xsl:apply-templates/>
+      <xsl:call-template name="breakline">
+        <xsl:with-param name="node" select="node()"/>
+      </xsl:call-template>
     </emphasis>
   </xsl:template>
 

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/docbook/012-literallayout.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/docbook/012-literallayout.xml
@@ -7,6 +7,7 @@
   <title ezxhtml:level="2">This is a heading.</title>
   <para><literallayout class="normal">This is a paragraph
 with some
-extra <emphasis>CHEESE!</emphasis>
-and line breaks.</literallayout></para>
+extra <emphasis>CHEESE!
+and line breaks</emphasis>
+and more line breaks.</literallayout></para>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/ezxml/012-literallayout.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/ezxml/012-literallayout.xml
@@ -8,7 +8,8 @@
   <paragraph>
     <line>This is a paragraph</line>
     <line>with some</line>
-    <line>extra <emphasize>CHEESE!</emphasize></line>
-    <line>and line breaks.</line>
+    <line>extra <emphasize>CHEESE!
+and line breaks</emphasize></line>
+    <line>and more line breaks.</line>
   </paragraph>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/012-literallayout.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/edit/012-literallayout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5/edit">
   <h2>This is a heading.</h2>
-  <p>This is a paragraph<br/>with some<br/>extra <em>CHEESE!</em><br/>and line breaks.</p>
+  <p>This is a paragraph<br/>with some<br/>extra <em>CHEESE!<br/>and line breaks</em><br/>and more line breaks.</p>
 </section>

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/output/012-literallayout.xml
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/_fixtures/xhtml5/output/012-literallayout.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <section xmlns="http://ez.no/namespaces/ezpublish5/xhtml5">
   <h2>This is a heading.</h2>
-  <p>This is a paragraph<br/>with some<br/>extra <em>CHEESE!</em><br/>and line breaks.</p>
+  <p>This is a paragraph<br/>with some<br/>extra <em>CHEESE!<br/>and line breaks</em><br/>and more line breaks.</p>
 </section>


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28328

## Description

This PR contains patch for ignored `<br />` tags inside text formatted with bold, italic, underlined, strikedthrough, del and mix of them. 

Note to reviewers: This patch doesn't provide support for line breaks inside text formatted in `ezxml`.  

## Steps to reproduce

> 1. Create new eZ Platform installation.
> 2. Go to the Platform UI. Create new article there.
> 3. In one of the article's Rich Text fields (for example "Intro"), enter few lines of text. Lines should be inside one paragraph and separated by line breaks (Shift + Enter).
> 4. Select the entire just created paragraph and make it bold by clicking the "B" icon.
> 5. Publish the article.
> 6. Edit the article again. Notice that the line breaks are gone.

## TODO

- [x] Unit tests

  
  