### PR TITLE
EZP-28692: Corrupt password when upgrading to eZ Platform 1.13…

### DIFF
--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -38,6 +38,7 @@ use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
 use ezcMailTools;
 use Exception;
+use Psr\Log\LoggerInterface;
 
 /**
  * This service provides methods for managing users and user groups.
@@ -60,6 +61,14 @@ class UserService implements UserServiceInterface
      * @var array
      */
     protected $settings;
+
+    /** @var \Psr\Log\LoggerInterface */
+    protected $logger;
+
+    public function setLogger(LoggerInterface $logger = null)
+    {
+        $this->logger = $logger;
+    }
 
     /**
      * Setups service with reference to repository object that created it & corresponding handler.
@@ -605,6 +614,10 @@ class UserService implements UserServiceInterface
         } else {
             // Password hash was not correctly saved, possible cause: EZP-28692
             $this->repository->rollback();
+            if (isset($this->logger)) {
+                $this->logger->error('Password hash could not be updated. Please verify that your database schema is up to date.');
+            }
+
             throw new BadStateException(
                 'user',
                 'Could not save updated password hash, reverting to previous hash. Please verify that your database schema is up to date.'

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -62,7 +62,7 @@ class UserService implements UserServiceInterface
      */
     protected $settings;
 
-    /** @var \Psr\Log\LoggerInterface */
+    /** @var \Psr\Log\LoggerInterface|null */
     protected $logger;
 
     public function setLogger(LoggerInterface $logger = null)

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -615,7 +615,7 @@ class UserService implements UserServiceInterface
             // Password hash was not correctly saved, possible cause: EZP-28692
             $this->repository->rollback();
             if (isset($this->logger)) {
-                $this->logger->error('Password hash could not be updated. Please verify that your database schema is up to date.');
+                $this->logger->critical('Password hash could not be updated. Please verify that your database schema is up to date.');
             }
 
             throw new BadStateException(

--- a/eZ/Publish/Core/settings/repository/inner.yml
+++ b/eZ/Publish/Core/settings/repository/inner.yml
@@ -79,6 +79,8 @@ services:
     ezpublish.api.service.inner_user:
         class: "%ezpublish.api.service.user.class%"
         factory: ["@ezpublish.api.inner_repository", getUserService]
+        calls:
+            - [setLogger, ["@?logger"]]
         lazy: true
 
     ezpublish.api.service.inner_search:


### PR DESCRIPTION
…from earlier versions without DB update
> Fixes https://jira.ez.no/browse/EZP-28692
> Sent to QA

RTFM error, but nice to avoid corrupted hashes and save users and admins some headaches.

- [x] Check if password was correctly saved. If not, roll back and throw, ref http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/transactions-and-concurrency.html#exception-handling
- [x] Don't catch, to force admins to deal with this issue right away.