### PR TITLE
EZP-28623: Display paragraph when user haven't permissions to see linked content

### DIFF
--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl
@@ -148,30 +148,37 @@
   </xsl:template>
 
   <xsl:template match="docbook:link[@xlink:href]">
-    <xsl:element name="a" namespace="{$outputNamespace}">
-      <xsl:attribute name="href">
-        <xsl:value-of select="@xlink:href"/>
-      </xsl:attribute>
-      <xsl:if test="@xlink:show = 'new'">
-        <xsl:attribute name="target">_blank</xsl:attribute>
-      </xsl:if>
-      <xsl:if test="@xml:id">
-        <xsl:attribute name="id">
-          <xsl:value-of select="@xml:id"/>
-        </xsl:attribute>
-      </xsl:if>
-      <xsl:if test="@xlink:title">
-        <xsl:attribute name="title">
-          <xsl:value-of select="@xlink:title"/>
-        </xsl:attribute>
-      </xsl:if>
-      <xsl:if test="@ezxhtml:class">
-        <xsl:attribute name="class">
-          <xsl:value-of select="@ezxhtml:class"/>
-        </xsl:attribute>
-      </xsl:if>
-      <xsl:apply-templates/>
-    </xsl:element>
+    <xsl:choose>
+      <xsl:when test="@xlink:href != '#'">
+        <xsl:element name="a" namespace="{$outputNamespace}">
+          <xsl:attribute name="href">
+            <xsl:value-of select="@xlink:href"/>
+          </xsl:attribute>
+          <xsl:if test="@xlink:show = 'new'">
+            <xsl:attribute name="target">_blank</xsl:attribute>
+          </xsl:if>
+          <xsl:if test="@xml:id">
+            <xsl:attribute name="id">
+              <xsl:value-of select="@xml:id"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:if test="@xlink:title">
+            <xsl:attribute name="title">
+              <xsl:value-of select="@xlink:title"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:if test="@ezxhtml:class">
+            <xsl:attribute name="class">
+              <xsl:value-of select="@ezxhtml:class"/>
+            </xsl:attribute>
+          </xsl:if>
+          <xsl:apply-templates/>
+        </xsl:element>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <xsl:template match="docbook:title">


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZP-28623

# Description
URL to the unaccessible linked content shouldn't be rendered as an anchor with empty `href` attribute. The whole anchor should be omitted, and only the wrapping paragraph should be rendered during the XML to HTML5 conversion.

Currently:
`<p><a href="#" target="_self">Link</a></p>`

After change:
`<p>Link</p>`