### PR TITLE
EZP-28726: Selection edit preview fails when empty

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -166,7 +166,7 @@
             <li>{{ fieldSettings.options[selectedIndex] }}</li>
         {% endfor %}
         </ul>
-    {% elseif not fieldSettings.isMultiple %}
+    {% elseif field.value.selection|length() > 0 %}
         {% set field_value = fieldSettings.options[field.value.selection.0] %}
         {{ block( 'simple_block_field' ) }}
     {% endif %}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -160,13 +160,14 @@
 
 {% block ezselection_field %}
 {% spaceless %}
-    {% if fieldSettings.isMultiple and field.value.selection|length() > 0  %}
+    {% if field.value.selection|length() <= 0 %}
+    {% elseif fieldSettings.isMultiple %}
         <ul {{ block( 'field_attributes' ) }}>
         {% for selectedIndex in field.value.selection %}
             <li>{{ fieldSettings.options[selectedIndex] }}</li>
         {% endfor %}
         </ul>
-    {% elseif field.value.selection|length() > 0 %}
+    {% else %}
         {% set field_value = fieldSettings.options[field.value.selection.0] %}
         {{ block( 'simple_block_field' ) }}
     {% endif %}


### PR DESCRIPTION
> Fix https://jira.ez.no/browse/EZP-28726
> Sent to QA

Edit preview of single selection fails when it's empty, with HTTP 500: `Key "0" does not exist as the array is empty.`

Fix by checking array length. If it's empty there's no need to do anything, same as in the multiselect case above.