### PR TITLE
Fix EZP-28728: Default TTL in default scope would be set to 60 from siteaccess scope

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Content.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Content.php
@@ -28,9 +28,9 @@ class Content extends AbstractParser
             ->arrayNode('content')
                 ->info('Content related configuration')
                 ->children()
-                    ->booleanNode('view_cache')->defaultValue(true)->end()
-                    ->booleanNode('ttl_cache')->defaultValue(true)->end()
-                    ->scalarNode('default_ttl')->info('Default value for TTL cache, in seconds')->defaultValue(60)->end()
+                    ->booleanNode('view_cache')->end()
+                    ->booleanNode('ttl_cache')->end()
+                    ->scalarNode('default_ttl')->info('Default value for TTL cache, in seconds')->end()
                     ->arrayNode('tree_root')
                         ->canBeUnset()
                         ->children()
@@ -52,9 +52,17 @@ class Content extends AbstractParser
     public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
     {
         if (!empty($scopeSettings['content'])) {
-            $contextualizer->setContextualParameter('content.view_cache', $currentScope, $scopeSettings['content']['view_cache']);
-            $contextualizer->setContextualParameter('content.ttl_cache', $currentScope, $scopeSettings['content']['ttl_cache']);
-            $contextualizer->setContextualParameter('content.default_ttl', $currentScope, $scopeSettings['content']['default_ttl']);
+            if (isset($scopeSettings['content']['view_cache'])) {
+                $contextualizer->setContextualParameter('content.view_cache', $currentScope, $scopeSettings['content']['view_cache']);
+            }
+
+            if (isset($scopeSettings['content']['ttl_cache'])) {
+                $contextualizer->setContextualParameter('content.ttl_cache', $currentScope, $scopeSettings['content']['ttl_cache']);
+            }
+
+            if (isset($scopeSettings['content']['default_ttl'])) {
+                $contextualizer->setContextualParameter('content.default_ttl', $currentScope, $scopeSettings['content']['default_ttl']);
+            }
 
             if (isset($scopeSettings['content']['tree_root'])) {
                 $contextualizer->setContextualParameter(


### PR DESCRIPTION
JIRA: https://jira.ez.no/browse/EZP-28728

If set a defaultValue of an arrayNode config symfony will fill this for every siteaccess/sitaccess group:
https://github.com/symfony/symfony/blob/2.8/src/Symfony/Component/Config/Definition/ArrayNode.php#L245

I think it is enough to set it in the default_settings.yml
https://github.com/ezsystems/ezpublish-kernel/blob/6.7/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml#L87