### PR TITLE
EZP-28110: As a developer, I want to define attributes for custom tags

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
@@ -555,6 +555,7 @@ EOT;
                                     ->end()
                                     ->arrayNode('choices')
                                         ->scalarPrototype()->end()
+                                        ->performNoDeepMerging()
                                         ->validate()
                                             ->ifEmpty()->thenUnset()
                                         ->end()

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/FieldType/RichText.php
@@ -36,93 +36,10 @@ class RichText extends AbstractFieldTypeParser
      */
     public function addFieldTypeSemanticConfig(NodeBuilder $nodeBuilder)
     {
+        // for BC setup deprecated configuration
+        $this->setupDeprecatedConfiguration($nodeBuilder);
+
         $nodeBuilder
-            ->arrayNode('output_custom_tags')
-                ->info('Custom XSL stylesheets to use for RichText transformation to HTML5. Useful for "custom tags".')
-                ->example(
-                    array(
-                        'path' => '%kernel.root_dir%/../src/Acme/TestBundle/Resources/myTag.xsl',
-                        'priority' => 10,
-                    )
-                )
-                ->prototype('array')
-                    ->children()
-                        ->scalarNode('path')
-                            ->info('Path of the XSL stylesheet to load.')
-                            ->isRequired()
-                        ->end()
-                        ->integerNode('priority')
-                            ->info('Priority in the loading order. A high value will have higher precedence in overriding XSL templates.')
-                            ->defaultValue(0)
-                        ->end()
-                    ->end()
-                ->end()
-            ->end()
-            ->arrayNode('edit_custom_tags')
-                ->info('Custom XSL stylesheets to use for RichText transformation to HTML5. Useful for "custom tags".')
-                ->example(
-                    array(
-                        'path' => '%kernel.root_dir%/../src/Acme/TestBundle/Resources/myTag.xsl',
-                        'priority' => 10,
-                    )
-                )
-                ->prototype('array')
-                    ->children()
-                        ->scalarNode('path')
-                            ->info('Path of the XSL stylesheet to load.')
-                            ->isRequired()
-                        ->end()
-                        ->integerNode('priority')
-                            ->info('Priority in the loading order. A high value will have higher precedence in overriding XSL templates.')
-                            ->defaultValue(0)
-                        ->end()
-                    ->end()
-                ->end()
-            ->end()
-            ->arrayNode('input_custom_tags')
-                ->info('Custom XSL stylesheets to use for RichText transformation to HTML5. Useful for "custom tags".')
-                ->example(
-                    array(
-                        'path' => '%kernel.root_dir%/../src/Acme/TestBundle/Resources/myTag.xsl',
-                        'priority' => 10,
-                    )
-                )
-                ->prototype('array')
-                    ->children()
-                        ->scalarNode('path')
-                            ->info('Path of the XSL stylesheet to load.')
-                            ->isRequired()
-                        ->end()
-                        ->integerNode('priority')
-                            ->info('Priority in the loading order. A high value will have higher precedence in overriding XSL templates.')
-                            ->defaultValue(0)
-                        ->end()
-                    ->end()
-                ->end()
-            ->end()
-            ->arrayNode('tags')
-                ->info('RichText template tags configuration.')
-                ->useAttributeAsKey('key')
-                ->normalizeKeys(false)
-                ->prototype('array')
-                    ->info(
-                        "Name of RichText template tag.\n" .
-                        "'default' and 'default_inline' tag names are reserved for fallback."
-                    )
-                    ->example('math_equation')
-                    ->children()
-                        ->append(
-                            $this->getTemplateNodeDefinition(
-                                'Template used for rendering RichText template tag.',
-                                'MyBundle:FieldType/RichText/tag:math_equation.html.twig'
-                            )
-                        )
-                        ->variableNode('config')
-                            ->info('Tag configuration, arbitrary configuration is allowed here.')
-                        ->end()
-                    ->end()
-                ->end()
-            ->end()
             ->arrayNode('embed')
                 ->info('RichText embed tags configuration.')
                 ->children()
@@ -306,5 +223,108 @@ class RichText extends AbstractFieldTypeParser
         $contextualizer->mapConfigArray('fieldtypes.ezrichtext.output_custom_xsl', $config);
         $contextualizer->mapConfigArray('fieldtypes.ezrichtext.edit_custom_xsl', $config);
         $contextualizer->mapConfigArray('fieldtypes.ezrichtext.input_custom_xsl', $config);
+    }
+
+    /**
+     * Add BC setup for deprecated configuration.
+     *
+     * Note: kept in separate method for readability.
+     *
+     * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $nodeBuilder
+     */
+    private function setupDeprecatedConfiguration(NodeBuilder $nodeBuilder)
+    {
+        $nodeBuilder
+            ->arrayNode('output_custom_tags')
+                ->setDeprecated('DEPRECATED. Configure custom tags using custom_tags node')
+                ->info('Custom XSL stylesheets to use for RichText transformation to HTML5. Useful for "custom tags".')
+                ->example(
+                    array(
+                        'path' => '%kernel.root_dir%/../src/Acme/TestBundle/Resources/myTag.xsl',
+                        'priority' => 10,
+                    )
+                )
+                ->prototype('array')
+                    ->children()
+                        ->scalarNode('path')
+                            ->info('Path of the XSL stylesheet to load.')
+                            ->isRequired()
+                        ->end()
+                        ->integerNode('priority')
+                            ->info('Priority in the loading order. A high value will have higher precedence in overriding XSL templates.')
+                            ->defaultValue(0)
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+            ->arrayNode('edit_custom_tags')
+                ->setDeprecated('DEPRECATED. Configure custom tags using custom_tags node')
+                ->info('Custom XSL stylesheets to use for RichText transformation to HTML5. Useful for "custom tags".')
+                ->example(
+                    array(
+                        'path' => '%kernel.root_dir%/../src/Acme/TestBundle/Resources/myTag.xsl',
+                        'priority' => 10,
+                    )
+                )
+                ->prototype('array')
+                    ->children()
+                        ->scalarNode('path')
+                            ->info('Path of the XSL stylesheet to load.')
+                            ->isRequired()
+                        ->end()
+                        ->integerNode('priority')
+                            ->info('Priority in the loading order. A high value will have higher precedence in overriding XSL templates.')
+                            ->defaultValue(0)
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+            ->arrayNode('input_custom_tags')
+                ->setDeprecated('DEPRECATED. Configure custom tags using custom_tags node')
+                ->info('Custom XSL stylesheets to use for RichText transformation to HTML5. Useful for "custom tags".')
+                ->example(
+                    array(
+                        'path' => '%kernel.root_dir%/../src/Acme/TestBundle/Resources/myTag.xsl',
+                        'priority' => 10,
+                    )
+                )
+                ->prototype('array')
+                    ->children()
+                        ->scalarNode('path')
+                            ->info('Path of the XSL stylesheet to load.')
+                            ->isRequired()
+                        ->end()
+                        ->integerNode('priority')
+                            ->info('Priority in the loading order. A high value will have higher precedence in overriding XSL templates.')
+                            ->defaultValue(0)
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+            ->arrayNode('tags')
+                ->setDeprecated('DEPRECATED. Configure custom tags using custom_tags node')
+                ->info('RichText template tags configuration.')
+                ->useAttributeAsKey('key')
+                ->normalizeKeys(false)
+                ->prototype('array')
+                    ->info(
+                        "Name of RichText template tag.\n" .
+                        "'default' and 'default_inline' tag names are reserved for fallback."
+                    )
+                    ->example('math_equation')
+                    ->children()
+                        ->append(
+                            $this->getTemplateNodeDefinition(
+                                'Template used for rendering RichText template tag.',
+                                'MyBundle:FieldType/RichText/tag:math_equation.html.twig'
+                            )
+                        )
+                        ->variableNode('config')
+                            ->info('Tag configuration, arbitrary configuration is allowed here.')
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -29,6 +29,8 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ParserInterf
 
 class EzPublishCoreExtension extends Extension implements PrependExtensionInterface
 {
+    const RICHTEXT_CUSTOM_TAGS_PARAMETER = 'ezplatform.ezrichtext.custom_tags';
+
     /**
      * @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Suggestion\Collector\SuggestionCollector
      */
@@ -113,6 +115,7 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
         $this->registerSiteAccessConfiguration($config, $container);
         $this->registerImageMagickConfiguration($config, $container);
         $this->registerPageConfiguration($config, $container);
+        $this->registerRichTextConfiguration($config, $container);
 
         // Routing
         $this->handleRouting($config, $container, $loader);
@@ -279,6 +282,22 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
             $container->setParameter(
                 'ezpublish.ezpage.enabledBlocks',
                 $config['ezpage']['enabledBlocks'] + $container->getParameter('ezpublish.ezpage.enabledBlocks')
+            );
+        }
+    }
+
+    /**
+     * Register parameters of global RichText configuration.
+     *
+     * @param array $config
+     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     */
+    private function registerRichTextConfiguration(array $config, ContainerBuilder $container)
+    {
+        if (isset($config['ezrichtext']['custom_tags'])) {
+            $container->setParameter(
+                static::RICHTEXT_CUSTOM_TAGS_PARAMETER,
+                $config['ezrichtext']['custom_tags']
             );
         }
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -20,6 +20,9 @@ parameters:
     ezplatform.default_view_templates.content.embed_image: 'EzPublishCoreBundle:default:content/embed_image.html.twig'
     ezplatform.default_view_templates.block: 'EzPublishCoreBundle:default:block/block.html.twig'
 
+    # Rich Text Custom Tags global configuration
+    ezplatform.ezrichtext.custom_tags: {}
+
     ezsettings.default.pagelayout: 'EzPublishCoreBundle::pagelayout.html.twig'
 
     # List of content type identifiers to display as image when embedded

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -22,6 +22,8 @@ parameters:
 
     # Rich Text Custom Tags global configuration
     ezplatform.ezrichtext.custom_tags: {}
+    # Rich Text Custom Tags default scope (for SiteAccess) configuration
+    ezsettings.default.fieldtypes.ezrichtext.custom_tags: []
 
     ezsettings.default.pagelayout: 'EzPublishCoreBundle::pagelayout.html.twig'
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -131,6 +131,7 @@ services:
             - "%ezpublish.fieldType.ezrichtext.tag.namespace%"
             - "%ezpublish.fieldType.ezrichtext.embed.namespace%"
             - "@?logger"
+            - "%ezplatform.ezrichtext.custom_tags%"
 
     ezpublish.fieldType.ezrichtext.converter.template:
         class: "%ezpublish.fieldType.ezrichtext.converter.template.class%"

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -266,3 +266,8 @@ services:
         class: "%ezpublish.fieldType.ezselection.nameable_field.class%"
         tags:
             - {name: ezpublish.fieldType.nameable, alias: ezselection}
+
+    # Symfony 3.4+ service definitions:
+    eZ\Publish\Core\FieldType\RichText\CustomTagsValidator:
+        public: false
+        arguments: ['%ezplatform.ezrichtext.custom_tags%']

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/FieldType/RichTextTest.php
@@ -10,6 +10,7 @@ namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
 use eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\Parser\AbstractParserTestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\FieldType\RichText as RichTextConfigParser;
 use Symfony\Component\Yaml\Yaml;
@@ -31,7 +32,7 @@ class RichTextTest extends AbstractParserTestCase
 
     protected function getMinimalConfiguration()
     {
-        return Yaml::parse(file_get_contents(__DIR__ . '/../../../Fixtures/ezpublish_minimal.yml'));
+        return Yaml::parse(file_get_contents(__DIR__ . '/../../../Fixtures/FieldType/RichText/ezrichtext.yml'));
     }
 
     public function testDefaultContentSettings()
@@ -53,6 +54,34 @@ class RichTextTest extends AbstractParserTestCase
                     'priority' => 0,
                 ),
             ),
+            'ezdemo_site'
+        );
+    }
+
+    /**
+     * Test Rich Text Custom Tags invalid settings, like enabling undefined Custom Tag.
+     */
+    public function testRichTextCustomTagsInvalidSettings()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Unknown RichText Custom Tag \'foo\'');
+
+        $this->load(
+            [
+                'system' => [
+                    'ezdemo_site' => [
+                        'fieldtypes' => [
+                            'ezrichtext' => [
+                                'custom_tags' => ['foo'],
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        );
+        $this->assertConfigResolverParameterValue(
+            'fieldtypes.ezrichtext.custom_tags',
+            ['foo'],
             'ezdemo_site'
         );
     }
@@ -203,6 +232,18 @@ class RichTextTest extends AbstractParserTestCase
                             ),
                         ),
                     ),
+                ),
+            ),
+            array(
+                array(
+                    'fieldtypes' => array(
+                        'ezrichtext' => array(
+                            'custom_tags' => array('video', 'equation'),
+                        ),
+                    ),
+                ),
+                array(
+                    'fieldtypes.ezrichtext.custom_tags' => array('video', 'equation'),
                 ),
             ),
             array(

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
@@ -826,4 +826,65 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
         self::assertContainerBuilderHasParameter('ezpublish.api.role.policy_map');
         self::assertEquals($expectedPolicies, $this->container->getParameter('ezpublish.api.role.policy_map'));
     }
+
+    /**
+     * Test RichText Semantic Configuration.
+     */
+    public function testRichTextConfiguration()
+    {
+        $config = Yaml::parse(
+            file_get_contents(__DIR__ . '/Fixtures/FieldType/RichText/ezrichtext.yml')
+        );
+        $this->load($config);
+
+        // Validate Custom Tags
+        $this->assertTrue(
+            $this->container->hasParameter($this->extension::RICHTEXT_CUSTOM_TAGS_PARAMETER)
+        );
+        $expectedCustomTagsConfig = [
+            'video' => [
+                'template' => 'MyBundle:FieldType/RichText/tag:video.html.twig',
+                'icon' => '/bundles/mybundle/fieldtype/richtext/video.svg#video',
+                'attributes' => [
+                    'title' => [
+                        'type' => 'string',
+                        'required' => true,
+                        'default_value' => 'abc',
+                    ],
+                    'width' => [
+                        'type' => 'number',
+                        'required' => true,
+                        'default_value' => 360,
+                    ],
+                    'autoplay' => [
+                        'type' => 'boolean',
+                        'required' => false,
+                        'default_value' => null,
+                    ],
+                ],
+            ],
+            'equation' => [
+                'template' => 'MyBundle:FieldType/RichText/tag:equation.html.twig',
+                'icon' => '/bundles/mybundle/fieldtype/richtext/equation.svg#equation',
+                'attributes' => [
+                    'name' => [
+                        'type' => 'string',
+                        'required' => true,
+                        'default_value' => 'Equation',
+                    ],
+                    'processor' => [
+                        'type' => 'choice',
+                        'required' => true,
+                        'default_value' => 'latex',
+                        'choices' => ['latex', 'tex'],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertSame(
+            $expectedCustomTagsConfig,
+            $this->container->getParameter($this->extension::RICHTEXT_CUSTOM_TAGS_PARAMETER)
+        );
+    }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Fixtures/FieldType/RichText/ezrichtext.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Fixtures/FieldType/RichText/ezrichtext.yml
@@ -1,5 +1,17 @@
-parameters:
-    ezplatform.ezrichtext.custom_tags:
+siteaccess:
+    default_siteaccess: ezdemo_site
+    list:
+        - ezdemo_site
+    groups:
+        ezdemo_group:
+            - ezdemo_site
+    match:
+        URIElement: 1
+        Map\URI:
+            the_front: ezdemo_site
+
+ezrichtext:
+    custom_tags:
         video:
             template: 'MyBundle:FieldType/RichText/tag:video.html.twig'
             icon: '/bundles/mybundle/fieldtype/richtext/video.svg#video'
@@ -27,12 +39,3 @@ parameters:
                     required: true
                     default_value: 'latex'
                     choices: ['latex', 'tex']
-
-services:
-    logger:
-        class: Psr\Log\NullLogger
-
-    # By default use in-memory cache for tests to avoid disk IO but still make sure we tests cache clearing works
-    ezpublish.cache_pool.driver:
-        class: Symfony\Component\Cache\Adapter\ArrayAdapter
-        arguments: [120, false]

--- a/eZ/Publish/API/Repository/Tests/FieldType/_fixtures/ezrichtext/custom_tags/invalid/equation.xml
+++ b/eZ/Publish/API/Repository/Tests/FieldType/_fixtures/ezrichtext/custom_tags/invalid/equation.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+  <eztemplate name="equation">
+    <ezcontent>
+      E = mc^2
+    </ezcontent>
+    <ezconfig>
+      <ezvalue key="name">Equation</ezvalue>
+    </ezconfig>
+  </eztemplate>
+</section>

--- a/eZ/Publish/API/Repository/Tests/FieldType/_fixtures/ezrichtext/custom_tags/invalid/unknown_tag.xml
+++ b/eZ/Publish/API/Repository/Tests/FieldType/_fixtures/ezrichtext/custom_tags/invalid/unknown_tag.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+  <eztemplate name="unknown_tag">
+    <ezcontent>Undefined</ezcontent>
+    <ezconfig>
+      <ezvalue key="title">Test</ezvalue>
+    </ezconfig>
+  </eztemplate>
+</section>

--- a/eZ/Publish/API/Repository/Tests/FieldType/_fixtures/ezrichtext/custom_tags/invalid/video.xml
+++ b/eZ/Publish/API/Repository/Tests/FieldType/_fixtures/ezrichtext/custom_tags/invalid/video.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+  <eztemplate name="video">
+    <ezcontent>
+      <para>Title: Test</para>
+      <para>Width: 640</para>
+      <para>Autoplay: false</para>
+    </ezcontent>
+    <ezconfig>
+      <ezvalue key="title">Test</ezvalue>
+      <ezvalue key="width">640</ezvalue>
+      <ezvalue key="autoplay">false</ezvalue>
+      <ezvalue key="unknown_attribute">false</ezvalue>
+    </ezconfig>
+  </eztemplate>
+</section>

--- a/eZ/Publish/API/Repository/Tests/FieldType/_fixtures/ezrichtext/custom_tags/valid/equation.xml
+++ b/eZ/Publish/API/Repository/Tests/FieldType/_fixtures/ezrichtext/custom_tags/valid/equation.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+  <eztemplate name="equation">
+    <ezcontent>
+      E = mc^2
+    </ezcontent>
+    <ezconfig>
+      <ezvalue key="name">Equation</ezvalue>
+      <ezvalue key="processor">Latex</ezvalue>
+    </ezconfig>
+  </eztemplate>
+</section>

--- a/eZ/Publish/API/Repository/Tests/FieldType/_fixtures/ezrichtext/custom_tags/valid/video.xml
+++ b/eZ/Publish/API/Repository/Tests/FieldType/_fixtures/ezrichtext/custom_tags/valid/video.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+  <eztemplate name="video">
+    <ezcontent>
+      <para>Title: Test</para>
+      <para>Width: 640</para>
+      <para>Autoplay: false</para>
+    </ezcontent>
+    <ezconfig>
+      <ezvalue key="title">Test</ezvalue>
+      <ezvalue key="width">640</ezvalue>
+      <ezvalue key="autoplay">false</ezvalue>
+    </ezconfig>
+  </eztemplate>
+</section>

--- a/eZ/Publish/Core/FieldType/RichText/CustomTagsValidator.php
+++ b/eZ/Publish/Core/FieldType/RichText/CustomTagsValidator.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\RichText;
+
+use DOMDocument;
+use DOMXPath;
+
+/**
+ * Validator for Custom Tags input.
+ *
+ * The Validator checks if the given XML reflects proper Custom Tags configuration,
+ * mostly existence of specific Custom Tag and its required attributes.
+ */
+class CustomTagsValidator
+{
+    /**
+     * Custom Tags global configuration (ezpublish.ezrichtext.custom_tags Semantic Config).
+     *
+     * @var array
+     */
+    private $customTagsConfiguration;
+
+    /**
+     * @param array $customTagsConfiguration Injectable using %ezplatform.ezrichtext.custom_tags% DI Container parameter.
+     */
+    public function __construct(array $customTagsConfiguration)
+    {
+        $this->customTagsConfiguration = $customTagsConfiguration;
+    }
+
+    /**
+     * Validate Custom Tags found in the document.
+     *
+     * @param \DOMDocument $xmlDocument
+     *
+     * @return string[] an array of error messages
+     */
+    public function validateDocument(DOMDocument $xmlDocument)
+    {
+        $errors = [];
+
+        $xpath = new DOMXPath($xmlDocument);
+        $xpath->registerNamespace('docbook', 'http://docbook.org/ns/docbook');
+
+        foreach ($xpath->query('//docbook:eztemplate') as $tagElement) {
+            $tagName = $tagElement->getAttribute('name');
+            if (empty($tagName)) {
+                $errors[] = 'Missing RichText Custom Tag name';
+                continue;
+            }
+
+            if (!isset($this->customTagsConfiguration[$tagName])) {
+                $errors[] = "Unknown RichText Custom Tag '{$tagName}'";
+                continue;
+            }
+
+            $nonEmptyAttributes = [];
+            $tagAttributes = $this->customTagsConfiguration[$tagName]['attributes'];
+
+            // iterate over all attributes defined in XML document to check if their names match configuration
+            $configElements = $xpath->query('.//docbook:ezconfig/docbook:ezvalue', $tagElement);
+            foreach ($configElements as $configElement) {
+                $attributeName = $configElement->getAttribute('key');
+                if (empty($attributeName)) {
+                    $errors[] = "Missing attribute name for RichText Custom Tag '{$tagName}'";
+                    continue;
+                }
+                if (!isset($tagAttributes[$attributeName])) {
+                    $errors[] = "Unknown attribute '{$attributeName}' of RichText Custom Tag '{$tagName}'";
+                }
+
+                // collect information about non-empty attributes
+                if (!empty($configElement->textContent)) {
+                    $nonEmptyAttributes[] = $attributeName;
+                }
+            }
+
+            // check if all required attributes are present
+            foreach ($tagAttributes as $attributeName => $attributeSettings) {
+                if (empty($attributeSettings['required'])) {
+                    continue;
+                }
+
+                if (!in_array($attributeName, $nonEmptyAttributes)) {
+                    $errors[] = "The attribute '{$attributeName}' of RichText Custom Tag '{$tagName}' cannot be empty";
+                }
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/eZ/Publish/Core/FieldType/RichText/Type.php
+++ b/eZ/Publish/Core/FieldType/RichText/Type.php
@@ -51,24 +51,32 @@ class Type extends FieldType
     protected $internalLinkValidator;
 
     /**
+     * @var null|\eZ\Publish\Core\FieldType\RichText\CustomTagsValidator
+     */
+    private $customTagsValidator;
+
+    /**
      * @param \eZ\Publish\Core\FieldType\RichText\Validator $internalFormatValidator
      * @param \eZ\Publish\Core\FieldType\RichText\ConverterDispatcher $inputConverterDispatcher
      * @param null|\eZ\Publish\Core\FieldType\RichText\Normalizer $inputNormalizer
      * @param null|\eZ\Publish\Core\FieldType\RichText\ValidatorDispatcher $inputValidatorDispatcher
      * @param null|\eZ\Publish\Core\FieldType\RichText\InternalLinkValidator $internalLinkValidator
+     * @param null|\eZ\Publish\Core\FieldType\RichText\CustomTagsValidator $customTagsValidator
      */
     public function __construct(
         Validator $internalFormatValidator,
         ConverterDispatcher $inputConverterDispatcher,
         Normalizer $inputNormalizer = null,
         ValidatorDispatcher $inputValidatorDispatcher = null,
-        InternalLinkValidator $internalLinkValidator = null
+        InternalLinkValidator $internalLinkValidator = null,
+        CustomTagsValidator $customTagsValidator = null
     ) {
         $this->internalFormatValidator = $internalFormatValidator;
         $this->inputConverterDispatcher = $inputConverterDispatcher;
         $this->inputNormalizer = $inputNormalizer;
         $this->inputValidatorDispatcher = $inputValidatorDispatcher;
         $this->internalLinkValidator = $internalLinkValidator;
+        $this->customTagsValidator = $customTagsValidator;
     }
 
     /**
@@ -262,6 +270,13 @@ class Type extends FieldType
 
         if ($this->internalLinkValidator !== null) {
             $errors = $this->internalLinkValidator->validateDocument($value->xml);
+            foreach ($errors as $error) {
+                $validationErrors[] = new ValidationError($error);
+            }
+        }
+
+        if ($this->customTagsValidator !== null) {
+            $errors = $this->customTagsValidator->validateDocument($value->xml);
             foreach ($errors as $error) {
                 $validationErrors[] = new ValidationError($error);
             }

--- a/eZ/Publish/Core/FieldType/Tests/RichText/CustomTagsValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/CustomTagsValidatorTest.php
@@ -1,0 +1,228 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\FieldType\Tests\RichText;
+
+use DOMDocument;
+use eZ\Publish\Core\FieldType\RichText\CustomTagsValidator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Test RichText CustomTagsValidator.
+ *
+ * @see \eZ\Publish\Core\FieldType\RichText\CustomTagsValidator
+ */
+class CustomTagsValidatorTest extends TestCase
+{
+    /**
+     * @var CustomTagsValidator
+     */
+    private $validator;
+
+    public function setUp()
+    {
+        // reuse Custom Tags configuration from common test settings
+        $commonSettings = Yaml::parseFile(__DIR__ . '/../../../settings/tests/common.yml');
+        $customTagsConfiguration = $commonSettings['parameters']['ezplatform.ezrichtext.custom_tags'];
+
+        $this->validator = new CustomTagsValidator($customTagsConfiguration);
+    }
+
+    /**
+     * Test validating DocBook document containing Custom Tags.
+     *
+     * @covers       \CustomTagsValidator::validateDocument
+     *
+     * @dataProvider providerForTestValidateDocument
+     *
+     * @param \DOMDocument $document
+     * @param array $expectedErrors
+     */
+    public function testValidateDocument(DOMDocument $document, array $expectedErrors)
+    {
+        self::assertEquals(
+            $expectedErrors,
+            $this->validator->validateDocument($document)
+        );
+    }
+
+    /**
+     * Data provider for testValidateDocument.
+     *
+     * @see testValidateDocument
+     *
+     * @return array
+     */
+    public function providerForTestValidateDocument()
+    {
+        return [
+            [
+                $this->createDocument(
+                    <<<DOCBOOK
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+  <eztemplate name="">
+  </eztemplate>
+</section>
+DOCBOOK
+                ),
+                [
+                    'Missing RichText Custom Tag name',
+                ],
+            ],
+            [
+                $this->createDocument(
+                    <<<DOCBOOK
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+  <eztemplate name="undefined_tag">
+    <ezcontent>Undefined</ezcontent>
+    <ezconfig>
+      <ezvalue key="title">Test</ezvalue>
+    </ezconfig>
+  </eztemplate>
+</section>
+DOCBOOK
+                ),
+                [
+                    "Unknown RichText Custom Tag 'undefined_tag'",
+                ],
+            ],
+            [
+                $this->createDocument(
+                    <<<DOCBOOK
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+  <eztemplate name="video">
+    <ezcontent>Content</ezcontent>
+    <ezconfig>
+      <ezvalue key="">Test</ezvalue>
+      <ezvalue key="title">Test</ezvalue>
+      <ezvalue key="width">360</ezvalue>
+    </ezconfig>
+  </eztemplate>
+</section>
+DOCBOOK
+                ),
+                [
+                    "Missing attribute name for RichText Custom Tag 'video'",
+                ],
+            ],
+            [
+                $this->createDocument(
+                    <<<DOCBOOK
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+  <eztemplate name="video">
+    <ezcontent>Content</ezcontent>
+    <ezconfig>
+        <ezvalue key="title">Test</ezvalue>
+        <ezvalue key="unknown">Test</ezvalue>
+        <ezvalue key="width">360</ezvalue>
+    </ezconfig>
+  </eztemplate>
+</section>
+DOCBOOK
+                ),
+                [
+                    "Unknown attribute 'unknown' of RichText Custom Tag 'video'",
+                ],
+            ],
+            [
+                $this->createDocument(
+                    <<<DOCBOOK
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+  <eztemplate name="video">
+    <ezcontent>Content</ezcontent>
+    <ezconfig>
+      <ezvalue key="autoplay">false</ezvalue>
+    </ezconfig>
+  </eztemplate>
+</section>
+DOCBOOK
+                ),
+                [
+                    "The attribute 'title' of RichText Custom Tag 'video' cannot be empty",
+                    "The attribute 'width' of RichText Custom Tag 'video' cannot be empty",
+                ],
+            ],
+            [
+                $this->createDocument(
+                    <<<DOCBOOK
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+  <eztemplate name="">
+  </eztemplate>
+  <eztemplate name="undefined_tag">
+  </eztemplate>
+  <eztemplate name="video">
+    <ezcontent>Content</ezcontent>
+    <ezconfig>
+      <ezvalue key="">Test</ezvalue>
+    </ezconfig>
+  </eztemplate>
+  <eztemplate name="equation">
+    <ezcontent>Content</ezcontent>
+    <ezconfig>
+      <ezvalue key="name">Test</ezvalue>
+      <ezvalue key="unknown">Test</ezvalue>
+      <ezvalue key="processor">latex</ezvalue>
+    </ezconfig>
+  </eztemplate>
+</section>
+DOCBOOK
+                ),
+                [
+                    'Missing RichText Custom Tag name',
+                    "Unknown RichText Custom Tag 'undefined_tag'",
+                    "Missing attribute name for RichText Custom Tag 'video'",
+                    "The attribute 'title' of RichText Custom Tag 'video' cannot be empty",
+                    "The attribute 'width' of RichText Custom Tag 'video' cannot be empty",
+                    "Unknown attribute 'unknown' of RichText Custom Tag 'equation'",
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param string $source XML source
+     *
+     * @return \DOMDocument
+     */
+    protected function createDocument($source)
+    {
+        $document = new DOMDocument();
+
+        $document->preserveWhiteSpace = false;
+        $document->formatOutput = false;
+
+        $document->loadXml($source, LIBXML_NOENT);
+
+        return $document;
+    }
+}

--- a/eZ/Publish/Core/settings/fieldtype_services.yml
+++ b/eZ/Publish/Core/settings/fieldtype_services.yml
@@ -115,3 +115,8 @@ services:
         class: "%ezpublish.fieldType.ezselection.nameable_field.class%"
         tags:
             - {name: ezpublish.fieldType.nameable, alias: ezselection}
+
+    # Symfony 3.4+ service definitions:
+    eZ\Publish\Core\FieldType\RichText\CustomTagsValidator:
+        public: false
+        arguments: ['%ezplatform.ezrichtext.custom_tags%']

--- a/eZ/Publish/Core/settings/fieldtypes.yml
+++ b/eZ/Publish/Core/settings/fieldtypes.yml
@@ -413,6 +413,7 @@ services:
             - "@ezpublish.fieldType.ezrichtext.normalizer.input"
             - "@ezpublish.fieldType.ezrichtext.validator.input.dispatcher"
             - '@ezpublish.fieldType.ezrichtext.validator.internal_link'
+            - '@eZ\Publish\Core\FieldType\RichText\CustomTagsValidator'
         tags:
             - {name: ezpublish.fieldType, alias: ezrichtext}
 


### PR DESCRIPTION
| Question  | Answer
| ------------- | ---
| **Status** | Ready for testing
| **JIRA issue** | [EZP-28110](https://jira.ez.no/browse/EZP-28110)
| **Related PR** | ezsystems/ezplatform-admin-ui#320
| **Bug fix** | no
| **New feature**  | yes
| **Target version** | 7.1
| **BC breaks**    | no |
| **Tests pass**   | yes, CI failure unrelated

This PR introduces Semantic Configuration definition of RichText Custom Tags as specified in the JIRA issue.
Semantic Configuration is divided into two parts:
1. Global configuration under `ezpublish.ezrichtext.custom_tags` key containing all settings.
2. SiteAccess configuration under `ezpublish.system.<scope>.fieldtypes.ezrichtext.custom_tags` which is scalar array containing list of custom tags available for the given scope/SiteAccess. The list must contain Tags defined in the global configuration.

Configuration is validated out-of-the-box by Symfony Semantic Configuration builder, with an extra handling of `choice` type of Custom Tag attribute.
See [sample configuration](https://github.com/ezsystems/ezplatform/blob/80cfd8c2f64769882ccbfa4b0846e900b1c79cb1/app/config/my_custom_tags.yml).

Persisted user input is validated by `CustomTagsValidator` against global configuration. Inserted Custom Tag must be defined, define all required attributes, don't contain any other attributes. Correctness of DocBook XML itself is validated by already existing XSL for `eztemplate`.

**TODO**:
- [x] Define Semantic Configuration for RichText CustomTags in `eZPublishCoreBundle`
- [x] Define SiteAccess-aware RichText Custom Tags list configuration in `eZPublishCoreBundle`
- [x] Inject RichText Custom Tags configuration into RichText Renderer (for front/site rendering).
- [x] Create Custom Tags user input validator.
- [x] Deprecate old SiteAccess-aware RichText custom tags configuration.
- [x] Create unit and integration tests for the feature.
