### PR TITLE
Fix EZP-28740: RegenerateUrlAliasesCommand sometimes generates alias with wrong parent (0)

### DIFF
--- a/eZ/Bundle/EzPublishMigrationBundle/Command/LegacyStorage/RegenerateUrlAliasesCommand.php
+++ b/eZ/Bundle/EzPublishMigrationBundle/Command/LegacyStorage/RegenerateUrlAliasesCommand.php
@@ -259,7 +259,7 @@ EOT
             ->from('ezcontentobject_tree')
             ->where($queryBuilder->expr()->neq('node_id', 1))
             ->orderBy('depth', 'ASC')
-            ->orderBy('node_id', 'ASC');
+            ->addOrderBy('node_id', 'ASC');
 
         $this->output->writeln("Backing up custom URL alias(es) for {$totalCount} Location(s).");
 
@@ -586,7 +586,7 @@ EOT
             ->from('ezcontentobject_tree')
             ->where($queryBuilder->expr()->neq('node_id', 1))
             ->orderBy('depth', 'ASC')
-            ->orderBy('node_id', 'ASC');
+            ->addOrderBy('node_id', 'ASC');
 
         $this->output->writeln(
             "Publishing URL aliases for {$totalLocationCount} Location(s) " .


### PR DESCRIPTION
> JIRA: [EZP-28740](https://jira.ez.no/browse/EZP-28740)

Excerpt from JIRA:
> RegenerateUrlAliasesCommand sometimes tries to create aliases for child nodes before their parent alias is created. This results in "0" being written in the parent column. "0" is also an id representing the root Content, which causes malfunction.

The issue was caused by using `orderBy` because it overrides the previous setting. `addOrderBy` should be used instead (the second time).