### PR TITLE
EZP-27924: As a Developer I want lazy loading certain API properties

### DIFF
--- a/doc/specifications/api/README.md
+++ b/doc/specifications/api/README.md
@@ -1,6 +1,6 @@
 # API
 
-API in eZ context refers to its Public API's, this folder covering the PHP API, and specifications for
+API in eZ context refers to its Public API's. This folder covering specifically the PHP API, and specifications for
 REST API can be found in `doc/specifications/rest` folder.
 
 Common for them both is the Public API BC promise and the underlying modeling of the eZ Content Repository.
@@ -8,48 +8,10 @@ Common for them both is the Public API BC promise and the underlying modeling of
 ### PHP API
 
 PHP API _(aka papi)_ is referring to interfaces found `eZ\Publish\API`, currently
-covering all eZ Content Repository functionality, this is where you'll find it's living specification.
+covering all eZ Content Repository functionality, this is where you'll find its living specification.
 
 This folder is mainly covering concepts and features of the implementation of the API, found in:
 - `eZ\Publish\Core\Repository`: Implementation of business logic of the Repository.
 - `eZ\Publish\Core\SignalSlot`: "Signal Slot" implementation of Repository allowing to use slots (listener) for signals
   (events) on every call to api that changes data in the repository.
 
-
-### "Public API" BC promise
-Public API signifies a BC promise beyond what is provided by [Semantic Versioning](https://semver.org/)
-which is followed for interfaces and public services in all of today's eZ applications. The BC
-promise is across a major version for smaller changes, and across several major versions in
-case of major changes.
-
-Example:
-
-    For API features deprecated in 6.x series, they can earliest be removed in v8.0.0. In
-    contrast, under Semantic Versioning it could have been removed in 7.0.0.
-
-Exceptions:
-- Major releases: Taking advantage of improvements in PHP, like native type hinting. This does not need prior
-  deprecation as long as type is same or similar (e.g. array vs iterable vs generics) as previously documented.
-- As API has BC promise for consumption, and official extension point is via SPI layer:
--- Patch releases: Extending the API _implementation_ can break as implementation changes.
--- Feature releases: Implementation the API interfaces is possible, however optional arguments or new methods might be
-   added as long as it is possible to have implementation working across new and prior releases at the same time.
-- Patch releases: Smaller bug fixes, where doc and implementation has been inconsistent or wrong.
-
-
-The point of this is to secure a stable foundation for everyone to build upon for all provided Public API's.
-
-
-### SPI BC promise
-
-As of 7.0, SPI _(Service Provider Interface)_, being the official way to extend the Repository, follows the same
-extended BC rules as Symfony Framework is following:
-http://symfony.com/doc/current/contributing/code/bc.html
-
-Example:
-
-    This means when we need to add or change methods to SPI in patch or feature releases, we need to add new interfaces,
-    and in next major (if needed) deprecated the introduced interface and move over to main interface.
-
-This covers interfaces and classes in `eZ\Publish\SPI\*` namespace, and not implementation classes found in
-`eZ\Publish\Core\*` or other namespaces.

--- a/doc/specifications/api/README.md
+++ b/doc/specifications/api/README.md
@@ -1,0 +1,31 @@
+# API
+
+API in eZ context refers to its Public API's, this folder covering the PHP API, and specifications for
+REST API can be found in `doc/specifications/rest` folder.
+
+Common for them both is the Public API BC promise and the underlying modeling of the eZ Content Repository.
+
+### PHP API
+
+PHP API _(aka papi)_ is referring to interfaces found `eZ\Publish\API`, currently
+covering all eZ Content Repository functionality, this is where you'll find it's living specification.
+
+This folder is mainly covering concepts and features of the implementation of the API, found in:
+- `eZ\Publish\Core\Repository`: Implementation of business logic of the Repository.
+- `eZ\Publish\Core\SignalSlot`: "Signal Slot" implementation of Repository allowing to use slots (listener) for signals
+  (events) on every call to api that changes data in the repository.
+
+
+### "Public API" BC promise
+Public API signifies a BC promise beyond what is provided by [Semantic Versioning](https://semver.org/)
+which is followed for interfaces and public services in all of today's eZ applications. The BC
+promise is across a major version for smaller changes, and across several major versions in
+case of major changes.
+
+Example:
+
+    For API features deprecated in 6.x series, they can earliest be removed in v8.0.0. In
+    contrast, under Semantic Versioning it could have been removed in 7.0.0.
+
+
+The point of this is to secure a stable foundation for everyone to build upon for all provided Public API's.

--- a/doc/specifications/api/README.md
+++ b/doc/specifications/api/README.md
@@ -27,5 +27,29 @@ Example:
     For API features deprecated in 6.x series, they can earliest be removed in v8.0.0. In
     contrast, under Semantic Versioning it could have been removed in 7.0.0.
 
+Exceptions:
+- Major releases: Taking advantage of improvements in PHP, like native type hinting. This does not need prior
+  deprecation as long as type is same or similar (e.g. array vs iterable vs generics) as previously documented.
+- As API has BC promise for consumption, and official extension point is via SPI layer:
+-- Patch releases: Extending the API _implementation_ can break as implementation changes.
+-- Feature releases: Implementation the API interfaces is possible, however optional arguments or new methods might be
+   added as long as it is possible to have implementation working across new and prior releases at the same time.
+- Patch releases: Smaller bug fixes, where doc and implementation has been inconsistent or wrong.
+
 
 The point of this is to secure a stable foundation for everyone to build upon for all provided Public API's.
+
+
+### SPI BC promise
+
+As of 7.0, SPI _(Service Provider Interface)_, being the official way to extend the Repository, follows the same
+extended BC rules as Symfony Framework is following:
+http://symfony.com/doc/current/contributing/code/bc.html
+
+Example:
+
+    This means when we need to add or change methods to SPI in patch or feature releases, we need to add new interfaces,
+    and in next major (if needed) deprecated the introduced interface and move over to main interface.
+
+This covers interfaces and classes in `eZ\Publish\SPI\*` namespace, and not implementation classes found in
+`eZ\Publish\Core\*` or other namespaces.

--- a/doc/specifications/api/README.md
+++ b/doc/specifications/api/README.md
@@ -1,7 +1,7 @@
 # API
 
-API in eZ context refers to its Public API's. This folder covering specifically the PHP API, and specifications for
-REST API can be found in `doc/specifications/rest` folder.
+API in eZ context refers to its Public API's. This folder covers the PHP API specifically.
+Specifications for REST API can be found in `doc/specifications/rest` folder.
 
 Common for them both is the Public API BC promise and the underlying modeling of the eZ Content Repository.
 

--- a/doc/specifications/api/lazy_properties.md
+++ b/doc/specifications/api/lazy_properties.md
@@ -1,0 +1,214 @@
+# Lazy object properties
+
+
+As PHP API in eZ Platform is often used to populate templates via generic controllers, there is often a
+need to provide possibility to easily get additional info relevant directly to the domain objects involved.
+
+Prior to this feature this is only possible by:
+- Write own full fledge controller losing out on many content features by the system
+- Overriding the view controller where you can do almost anything you want, but you'll need to then maintain it yourself
+  and resort to PHP for data which in some cases are pretty basic need for the template.
+- Resort to query type which is limited to one set of objects, and mainly suitable to load for instance child objects.
+- Use of third party solutions which in varying degree diverges from the official supported API.
+
+While relevant for all domain objects, the most pressing need is for the eZ content model to get:
+- content info -> content type
+- content info -> section
+- content info -> main location _(just meta info\*)_
+- content info -> locations _(just meta info\*)_
+- location -> content
+- ...
+
+However when doing so we need to take some technical consideration into account to avoid creating more problems than we
+solve.
+
+<small>\* _see technical consideration #3_</small>
+
+### Technical consideration 1: Keep logic out of Value objects
+
+In eZ Platform the objects involved here are [DDD Value objects](https://martinfowler.com/bliki/ValueObject.html), which
+in itself contain as little logic as possible.
+
+So one technical constraint here is that we should not end up with loading logic spread across
+all value objects, and instead make sure to keep such logic in internal repository services
+which can be unit tested more cleanly and more easily refactored later.
+
+
+### Technical consideration 2: Avoid common performance pitfalls with bulk loading
+
+Avoid common performance pitfalls found in other PHP applications:
+
+#### eZ Publish legacy
+Such functionality existed in eZ Publish "legacy", however it was often the culprit of performance
+issues, as they were loading data O^n, leading to a massive amount of SQL calls to load data repeatedly.
+
+Example:
+```smarty
+{foreach $nodes as $child_node}
+      {$child_node.name} {* One raw sql call to get name(s) *}
+      {$child_node.className} {* One fetch for object and one for content class *}
+     {$child_node.object.owner.name} {* One fetch for owner (object feteched above) *}
+{/foreach}
+```
+
+Inside the loop we have at least 4 sql calls going on, which will be done on each iteration, and while it could be
+reduced to 3 per iteration by changing first line to `{$child_node.object.name}`,  many of the sql lookups could rather
+have been done in bulk while still being lazy in such cases.
+
+
+#### Doctrine ORM
+
+Doctrine provides a range of ways to let you specify how to load reference(s), [from eager, to lazy and extra lazy](http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/annotations-reference.html).
+
+However when iterating entities and accessing a reference(s) property, or [when accessing properties not pre loaded](http://www.doctrine-project.org/2009/05/29/doctrine-lazy-loading.html),
+there will be additional sql calls being made per entity just like in eZ Publish example above, with same outcome.
+
+
+### Technical consideration 3: Avoid iteration of repository
+
+Given the dynamic nature of lazy properties it's beneficial to take care when designing them to avoid ability to
+traverse whole repository _(or the whole content structure)_ using them. As this is not a feature they are meant to
+solve.
+
+Anticipating bulk loading of lazy properties across collections as mentioned in #2 can only help so much against the
+performance problems mentioned. To further avoid the situation lazy properties should also not allow traversing
+the object graph beyond the [root aggregate](https://martinfowler.com/bliki/DDD_Aggregate.html).
+
+E.g.
+- Displaying paths of a location needs own cache tagging and as such is better served by dedicated view to serve it
+  provided by the application .
+- Showing site map is a dedicated problem that at some point need dedicated solution (own service).
+- Listing children or listing content assigned to a section. This is better served using for instance query type to be
+  able to specify filters, sorting & paging.
+
+## Technical Requirements
+
+Based on the context above, our requirements can be be defined as such:
+
+- Allow to load given properties lazy.
+- Also allow to set given property's object(s) upfront in case API already happens to have the data needed.
+- Allow to load in bulk when applicable.
+
+### Non goals
+
+- Be able to iterate the whole repository
+- Exposing collections that you would typically want to filter, sort and page.
+- Cache the objects, this is responsibility of SPI Persistence Cache\*
+
+
+<small>\* _Introducing API cache would require us to refactor Core/Repository quite a bit.
+Lower hanging fruit would probably be to re-introduce a v2 SPI Persistence in-memory cache for meta data which don't
+frequently change (types, sections, states, ..). This can for instance be done in `Core/Persistence/Cache` in
+similar ttl based way as `CachedPermissionService` now does for permission lookups._</small>
+
+
+## Design
+
+As [researched in PR 2094](https://github.com/ezsystems/ezpublish-kernel/pull/2094) which was focusing on lazy loading
+collections, using lazy collections and especially using PHP's generators directly would lead to BC breaks in current API.
+
+To overcome these issues further attempts showed an opportunity to combine the following concepts:
+- Proxy objects extending API value objects for use in plain arrays, as well as in singular cases
+- Passing in vanilla Generator and id, load object on demand using `Generator->send($id)` for both bulk and singular use
+
+Example:
+```php
+trait GeneratorProxyTrait
+{
+    // (properties ...)
+
+    public function __construct(Generator $generator, mixed $id)
+    {
+        $this->generator = $generator;
+        $this->id = $id;
+    }
+
+    public function __get($name)
+    {
+        if ($name === 'id') {
+            return $this->id;
+        }
+
+        if ($this->object === null) {
+            $this->loadObject();
+        }
+
+        return $this->object->$name;
+    }
+
+    // (...)
+
+    protected function loadObject()
+    {
+        $this->object = $this->generator->send($this->id);
+        $this->generator->next();
+        unset($this->generator);
+    }
+}
+
+class ContentTypeGroupProxy extends APIContentTypeGroup
+{
+    use GeneratorProxyTrait;
+
+    /**  @var \eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup|null */
+    protected $object;
+
+    public function getNames()
+    {
+        if ($this->object === null) {
+            $this->loadObject();
+        }
+
+        return $this->object->getNames();
+    }
+
+    // (rest of methods ...)
+}
+
+class ContentTypeDomainMapper
+{
+    // (...)
+
+    public function buildContentTypeGroupProxyList(array $ids, array $prioritizedLanguages = []) : array
+    {
+        $groups = [];
+        $generator = $this->generatorForContentTypeGroupList($ids, $prioritizedLanguages);
+        foreach ($ids as $id) {
+            $groups[] = new ContentTypeGroupProxy($generator, $id);
+        }
+
+        return $groups;// to be used in for instance ContentType->contentTypeGroups
+    }
+
+    private function generatorForContentTypeGroupList(array $ids, array $prioritizedLanguages = []) : \Generator
+    {
+        $groups = $this->contentTypeHandler->loadGroups($ids);
+        while (!empty($groups)) {
+            $id = yield;
+            yield $this->buildContentTypeGroupDomainObject(
+                $groups[$id],
+                $prioritizedLanguages
+            );
+            unset($groups[$id]);
+        }
+    }
+
+    // (...)
+}
+```
+
+This allows us to:
+- use plain arrays plural object properties
+- be able to pass in bulk loading generator into proxies along with their unique id
+  - but also be able to use for singular objects without any adjustment to code
+- take advantage of PHP's built-in async on demand nature of Generators.
+- avoid putting logic in value objects, and avoid having to inject any heavy object like repository or similar.
+
+
+Downsides:
+- This is clearly misuse of Generators
+  - However given this is kept as a implementation detail this can relatively easily be refactored later once the
+    language provides other suitable features for executing code on demand.
+- Subject to issues described in https://wiki.php.net/rfc/generators#closing_a_generator
+  - However these are similar to issues you would experience with injecting repository object or similar into value
+    object, which would probably be worse as it would imply explicit circular references.

--- a/doc/specifications/api/lazy_properties.md
+++ b/doc/specifications/api/lazy_properties.md
@@ -11,11 +11,11 @@ Prior to this feature this is only possible by:
 - Resort to query type which is limited to one set of objects, and mainly suitable to load for instance child objects.
 - Use of third party solutions which in varying degree diverges from the official supported API.
 
-While relevant for all domain objects, the most pressing need is for the eZ content model to get:
+While relevant for all domain objects, the most pressing need is for the eZ content model to get _for instance_:
 - content info -> content type
 - content info -> section
-- content info -> main location _(just meta info\*)_
-- content info -> locations _(just meta info\*)_
+- content info -> main location _(just meta info\*, TBD if it should follow permission rules)_
+- content info -> locations _(just meta info\*, should be filtered by permissions like API, then what about visibility?)_
 - location -> content
 - ...
 

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -812,10 +812,7 @@ class ContentTypeService implements ContentTypeServiceInterface
             throw $e;
         }
 
-        return $this->contentTypeDomainMapper->buildContentTypeDraftDomainObject(
-            $spiContentType,
-            $this->contentTypeHandler->loadGroups($spiContentType->groupIds)
-        );
+        return $this->contentTypeDomainMapper->buildContentTypeDraftDomainObject($spiContentType);
     }
 
     /**
@@ -855,7 +852,6 @@ class ContentTypeService implements ContentTypeServiceInterface
 
         return $this->contentTypeDomainMapper->buildContentTypeDomainObject(
             $spiContentType,
-            $this->contentTypeHandler->loadGroups($spiContentType->groupIds),
             $prioritizedLanguages
         );
     }
@@ -875,7 +871,6 @@ class ContentTypeService implements ContentTypeServiceInterface
 
         return $this->contentTypeDomainMapper->buildContentTypeDomainObject(
             $spiContentType,
-            $this->contentTypeHandler->loadGroups($spiContentType->groupIds),
             $prioritizedLanguages
         );
     }
@@ -889,7 +884,6 @@ class ContentTypeService implements ContentTypeServiceInterface
 
         return $this->contentTypeDomainMapper->buildContentTypeDomainObject(
             $spiContentType,
-            $this->contentTypeHandler->loadGroups($spiContentType->groupIds),
             $prioritizedLanguages
         );
     }
@@ -916,10 +910,7 @@ class ContentTypeService implements ContentTypeServiceInterface
             throw new NotFoundException('ContentType owned by someone else', $contentTypeId);
         }
 
-        return $this->contentTypeDomainMapper->buildContentTypeDraftDomainObject(
-            $spiContentType,
-            $this->contentTypeHandler->loadGroups($spiContentType->groupIds)
-        );
+        return $this->contentTypeDomainMapper->buildContentTypeDraftDomainObject($spiContentType);
     }
 
     /**
@@ -936,7 +927,6 @@ class ContentTypeService implements ContentTypeServiceInterface
         foreach ($spiContentTypes as $spiContentType) {
             $contentTypes[] = $this->contentTypeDomainMapper->buildContentTypeDomainObject(
                 $spiContentType,
-                $this->contentTypeHandler->loadGroups($spiContentType->groupIds),
                 $prioritizedLanguages
             );
         }
@@ -987,10 +977,7 @@ class ContentTypeService implements ContentTypeServiceInterface
             }
         }
 
-        return $this->contentTypeDomainMapper->buildContentTypeDraftDomainObject(
-            $spiContentType,
-            $this->contentTypeHandler->loadGroups($spiContentType->groupIds)
-        );
+        return $this->contentTypeDomainMapper->buildContentTypeDraftDomainObject($spiContentType);
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Helper/ContentTypeDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/ContentTypeDomainMapper.php
@@ -77,7 +77,7 @@ class ContentTypeDomainMapper
     public function buildContentTypeDomainObject(
         SPIContentType $spiContentType,
         array $prioritizedLanguages = []
-    ) : APIContentType {
+    ): APIContentType {
         $mainLanguageCode = $this->contentLanguageHandler->load(
             $spiContentType->initialLanguageId
         )->languageCode;
@@ -183,7 +183,7 @@ class ContentTypeDomainMapper
      *
      * Decorates ContentType.
      */
-    public function buildContentTypeDraftDomainObject(SPIContentType $spiContentType) : APIContentTypeDraft
+    public function buildContentTypeDraftDomainObject(SPIContentType $spiContentType): APIContentTypeDraft
     {
         return new ContentTypeDraft(
             array(
@@ -195,7 +195,7 @@ class ContentTypeDomainMapper
     /**
      * Builds a ContentTypeGroup domain object from value object returned by persistence.
      */
-    public function buildContentTypeGroupDomainObject(SPIContentTypeGroup $spiGroup, array $prioritizedLanguages = []) : APIContentTypeGroup
+    public function buildContentTypeGroupDomainObject(SPIContentTypeGroup $spiGroup, array $prioritizedLanguages = []): APIContentTypeGroup
     {
         return new ContentTypeGroup(
             array(
@@ -215,7 +215,7 @@ class ContentTypeDomainMapper
     /**
      * Builds a list of ContentTypeGroup proxy objects (lazy loaded, loads all as soon as one of them loads).
      */
-    public function buildContentTypeGroupProxyList(array $ids, array $prioritizedLanguages = []) : array
+    public function buildContentTypeGroupProxyList(array $ids, array $prioritizedLanguages = []): array
     {
         $groups = [];
         $generator = $this->generatorForContentTypeGroupList($ids, $prioritizedLanguages);
@@ -226,7 +226,7 @@ class ContentTypeDomainMapper
         return $groups;
     }
 
-    private function generatorForContentTypeGroupList(array $ids, array $prioritizedLanguages = []) : \Generator
+    private function generatorForContentTypeGroupList(array $ids, array $prioritizedLanguages = []): \Generator
     {
         $groups = $this->contentTypeHandler->loadGroups($ids);
 
@@ -420,7 +420,7 @@ class ContentTypeDomainMapper
         return $spiFieldDefinition;
     }
 
-    protected function getDateTime(int $timestamp) : DateTime
+    protected function getDateTime(int $timestamp): DateTime
     {
         // Instead of using DateTime(ts) we use setTimeStamp() so timezone does not get set to UTC
         $dateTime = new DateTime();

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -890,6 +890,7 @@ class Repository implements RepositoryInterface
         }
 
         $this->contentTypeDomainMapper = new Helper\ContentTypeDomainMapper(
+            $this->persistenceHandler->contentTypeHandler(),
             $this->persistenceHandler->contentLanguageHandler(),
             $this->getFieldTypeRegistry()
         );

--- a/eZ/Publish/Core/Repository/Values/ContentType/ContentTypeGroupProxy.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/ContentTypeGroupProxy.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Repository\Values\ContentType;
+
+use eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup as APIContentTypeGroup;
+use eZ\Publish\Core\Repository\Values\GeneratorProxyTrait;
+
+/**
+ * This class represents a (lazy loaded) proxy for a content type group value.
+ *
+ * @internal Meant for internal use by Repository, type hint against API object instead.
+ */
+class ContentTypeGroupProxy extends APIContentTypeGroup
+{
+    use GeneratorProxyTrait;
+
+    /**
+     * @var \eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup|null
+     */
+    protected $object;
+
+    public function getNames()
+    {
+        if ($this->object === null) {
+            $this->loadObject();
+        }
+
+        return $this->object->getNames();
+    }
+
+    public function getName($languageCode = null)
+    {
+        if ($this->object === null) {
+            $this->loadObject();
+        }
+
+        return $this->object->getName($languageCode);
+    }
+
+    public function getDescriptions()
+    {
+        if ($this->object === null) {
+            $this->loadObject();
+        }
+
+        return $this->object->getDescriptions();
+    }
+
+    public function getDescription($languageCode = null)
+    {
+        if ($this->object === null) {
+            $this->loadObject();
+        }
+
+        return $this->object->getDescription($languageCode);
+    }
+}

--- a/eZ/Publish/Core/Repository/Values/GeneratorProxyTrait.php
+++ b/eZ/Publish/Core/Repository/Values/GeneratorProxyTrait.php
@@ -27,9 +27,11 @@ trait GeneratorProxyTrait
     protected $object;
 
     /**
+     * Needs to be protected as value objects often define this as well.
+     *
      * @var mixed
      */
-    private $id;
+    protected $id;
 
     /**
      * @var Generator|null

--- a/eZ/Publish/Core/Repository/Values/GeneratorProxyTrait.php
+++ b/eZ/Publish/Core/Repository/Values/GeneratorProxyTrait.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\Repository\Values;
+
+use Generator;
+
+/**
+ * Trait for proxies, covers all relevant magic methods and exposes private method to load object.
+ *
+ * Uses generator internally to be able to cleanly execute object load async on-demand.
+ *
+ * @internal Meant for internal use by Repository!
+ */
+trait GeneratorProxyTrait
+{
+    /**
+     * Overload this for correct type hint on object type.
+     *
+     * @var object|null
+     */
+    protected $object;
+
+    /**
+     * @var mixed
+     */
+    private $id;
+
+    /**
+     * @var Generator|null
+     */
+    private $generator;
+
+    /**
+     * GeneratorProxyTrait constructor.
+     *
+     * @param Generator $generator
+     * @param mixed $id Object id to use for loading the object on demand.
+     */
+    public function __construct(Generator $generator, $id)
+    {
+        $this->generator = $generator;
+        $this->id = $id;
+    }
+
+    public function __call($name, $arguments)
+    {
+        if ($this->object === null) {
+            $this->loadObject();
+        }
+
+        return $this->object->$name(...$arguments);
+    }
+
+    public function __invoke(...$args)
+    {
+        if ($this->object === null) {
+            $this->loadObject();
+        }
+
+        return ($this->object)(...$args);
+    }
+
+    public function __get($name)
+    {
+        if ($name === 'id') {
+            return $this->id;
+        }
+
+        if ($this->object === null) {
+            $this->loadObject();
+        }
+
+        return $this->object->$name;
+    }
+
+    public function __isset($name)
+    {
+        if ($name === 'id') {
+            return true;
+        }
+
+        if ($this->object === null) {
+            $this->loadObject();
+        }
+
+        return isset($this->object->$name);
+    }
+
+    public function __unset($name)
+    {
+        if ($this->object === null) {
+            $this->loadObject();
+        }
+
+        unset($this->object->$name);
+    }
+
+    public function __set($name, $value)
+    {
+        if ($this->object === null) {
+            $this->loadObject();
+        }
+
+        $this->object->$name = $value;
+    }
+
+    public function __toString()
+    {
+        if ($this->object === null) {
+            $this->loadObject();
+        }
+
+        return (string)$this->object;
+    }
+
+    public function __sleep()
+    {
+        if ($this->object === null) {
+            $this->loadObject();
+        }
+
+        return ['object', 'id'];
+    }
+
+    public function __debugInfo()
+    {
+        if ($this->object === null) {
+            $this->loadObject();
+        }
+
+        return [
+            'object' => $this->object,
+            'id' => $this->id,
+        ];
+    }
+
+    /**
+     * Loads the generator to object value and unset's generator.
+     *
+     * Can only be called once, so check presence of $this->object before using it.
+     *
+     * This assumes generator is made to support bulk loading of several objects, and thus takes object id as input
+     * in order to return right object at a time, and thus performs two yields per item.
+     * -> See PR that came with this trait for example generators.
+     */
+    protected function loadObject()
+    {
+        $this->object = $this->generator->send($this->id);
+        $this->generator->next();
+        unset($this->generator);
+    }
+}


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-27924
> Replaces: #2094

#### Feature
Introduces concept of lazy loaded properties in order to be able to:
- gradually expose more information on API, especially useful in templates
  - without causing additional load if not used
- with capability of bulk loading to be able to avoid O^n loading lazy properties often imply.

In this PR the concept is applied to existing `ContentType->contentTypeGroups` property as:
1. An example for how to implement lazy properties _(in this case array property, but singular once also possible and there will be followup PR for that)_
2. Performance improvment since most cases never need them when loading content types

---

#### Technical details

This is done using proxy object of (in this case) Content Type Group with takes a
Generator and object id as argument in order to load the objects
when needed. Taking advantage of possibility to `->send($id)` argument to
Generators in order to allow passing the generator into a bunch
of objects for bulk loading, meaning once one is accessed all
are loaded using one single multi get SPI call _(which is taking advantage
of multi get in SPI cache layer as well, which was introduced in 7.0)_.

Compared to injecting services into value object this:
- Makes sure to allow bulk loading across objects
- Keeps domain logic in mapper instead of spreading it around in value objects
- Continues to keep value objects "clean of logic" as they have always been

Compared to earlier [POC PR](https://github.com/ezsystems/ezpublish-kernel/pull/2094), this:
- Returns a plain php array avoiding BC break
- Avoids value objects and API consumer having to have knowledge about Generator usage, instead keeps it as an internal implementation detail in new proxy objects extending api value objects

*For further reading see doc/specifications/api/lazy_properties.md*