### PR TITLE
Removed password-compat lib from dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "ocramius/proxy-manager": "^1.0|^2.0",
         "doctrine/doctrine-bundle": "~1.3",
         "liip/imagine-bundle": "~1.0",
-        "ircmaxell/password-compat": "^1.0",
         "oneup/flysystem-bundle": "^1.0|^2.0",
         "friendsofsymfony/http-cache-bundle": "~1.2|^1.3.8",
         "sensio/framework-extra-bundle": "~3.0",


### PR DESCRIPTION
While ircmaxell/password-compat was created to provide userland implementation of password_* functions to PHP 5.3 and 5.4, do we still need this library ?