### PR TITLE
EZP-28775: TrashService\RecoverSignal::$newParentLocationId shouldn't be null when trash item was restored under old parent location

### DIFF
--- a/eZ/Publish/Core/SignalSlot/Tests/TrashServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/TrashServiceTest.php
@@ -40,7 +40,7 @@ class TrashServiceTest extends ServiceTest
             array(
                 'id' => $trashItemId,
                 'contentInfo' => $trashItemContentInfo,
-                'parentLocationId' => $trashItemParentLocationId
+                'parentLocationId' => $trashItemParentLocationId,
             )
         );
 
@@ -55,7 +55,7 @@ class TrashServiceTest extends ServiceTest
             array(
                 'id' => $locationId,
                 'contentInfo' => $trashItemContentInfo,
-                'parentLocationId' => $trashItemParentLocationId
+                'parentLocationId' => $trashItemParentLocationId,
             )
         );
 
@@ -63,7 +63,7 @@ class TrashServiceTest extends ServiceTest
             array(
                 'id' => $locationId,
                 'contentInfo' => $trashItemContentInfo,
-                'parentLocationId' => $newParentLocationId
+                'parentLocationId' => $newParentLocationId,
             )
         );
 

--- a/eZ/Publish/Core/SignalSlot/Tests/TrashServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/TrashServiceTest.php
@@ -31,14 +31,23 @@ class TrashServiceTest extends ServiceTest
 
     public function serviceProvider()
     {
-        $rootId = 2;
+        $newParentLocationId = 2;
         $trashItemId = $locationId = 60;
         $trashItemContentInfo = $this->getContentInfo(59, md5('trash'));
+        $trashItemParentLocationId = 17;
 
         $trashItem = new TrashItem(
             array(
                 'id' => $trashItemId,
                 'contentInfo' => $trashItemContentInfo,
+                'parentLocationId' => $trashItemParentLocationId
+            )
+        );
+
+        $newParentLocation = new Location(
+            array(
+                'id' => $newParentLocationId,
+                'contentInfo' => $this->getContentInfo(53, md5('root')),
             )
         );
 
@@ -46,12 +55,15 @@ class TrashServiceTest extends ServiceTest
             array(
                 'id' => $locationId,
                 'contentInfo' => $trashItemContentInfo,
+                'parentLocationId' => $trashItemParentLocationId
             )
         );
-        $root = new Location(
+
+        $locationWithNewParent = new Location(
             array(
-                'id' => $rootId,
-                'contentInfo' => $this->getContentInfo(53, md5('root')),
+                'id' => $locationId,
+                'contentInfo' => $trashItemContentInfo,
+                'parentLocationId' => $newParentLocationId
             )
         );
 
@@ -72,13 +84,25 @@ class TrashServiceTest extends ServiceTest
             ),
             array(
                 'recover',
-                array($trashItem, $root),
+                array($trashItem, $newParentLocation),
+                $locationWithNewParent,
+                1,
+                'eZ\Publish\Core\SignalSlot\Signal\TrashService\RecoverSignal',
+                array(
+                    'trashItemId' => $trashItemId,
+                    'newParentLocationId' => $newParentLocationId,
+                    'newLocationId' => $locationId,
+                ),
+            ),
+            array(
+                'recover',
+                array($trashItem, null),
                 $location,
                 1,
                 'eZ\Publish\Core\SignalSlot\Signal\TrashService\RecoverSignal',
                 array(
                     'trashItemId' => $trashItemId,
-                    'newParentLocationId' => $rootId,
+                    'newParentLocationId' => $trashItemParentLocationId,
                     'newLocationId' => $locationId,
                 ),
             ),

--- a/eZ/Publish/Core/SignalSlot/TrashService.php
+++ b/eZ/Publish/Core/SignalSlot/TrashService.php
@@ -117,7 +117,7 @@ class TrashService implements TrashServiceInterface
                 array(
                     'trashItemId' => $trashItem->id,
                     'contentId' => $trashItem->contentId,
-                    'newParentLocationId' => $newParentLocation !== null ? $newParentLocation->id : null,
+                    'newParentLocationId' => $newLocation->parentLocationId,
                     'newLocationId' => $newLocation->id,
                 )
             )


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZP-28775

## Description 

When the trash item is restored under old parent location, `\eZ\Publish\Core\SignalSlot\Signal\TrashService\RecoverSignal` is emitted with empty (null) value of `newParentLocationId` which prevents a HTTP cache to be purged for old parent location. 

## Steps to reproduce 

> 1. Create a new eZ Platform installation and launch it in prod environment.
> 2. Create new folder named Foobar
> 3. Create new article Foo under folder Foobar
> 4. Create new article Bar under folder Foobar
> 5. Move article Foo to trash
> 6. Restore Foo from trash
> 7. Go to Foobar folder location and notice that Sub-items pagination is broken (see attached screenshot)