### PR TITLE
EZEE-1851: Unable to translate own Block names in StudioUI

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/LocaleListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/LocaleListener.php
@@ -47,15 +47,17 @@ class LocaleListener extends BaseRequestListener
     public function onKernelRequest(GetResponseEvent $event)
     {
         $request = $event->getRequest();
+
         if (!$request->attributes->has('_locale')) {
+            $convertedLocales = [];
             foreach ($this->configResolver->getParameter('languages') as $locale) {
                 $convertedLocale = $this->localeConverter->convertToPOSIX($locale);
                 if ($convertedLocale !== null) {
-                    // Setting the converted locale to the _locale request attribute, so that it can be properly processed by parent listener.
-                    $request->attributes->set('_locale', $convertedLocale);
-                    break;
+                    $convertedLocales[] = $convertedLocale;
                 }
             }
+
+            $request->attributes->set('_locale', $request->getPreferredLanguage($convertedLocales));
         }
 
         parent::onKernelRequest($event);


### PR DESCRIPTION
JIRA issue: https://jira.ez.no/browse/EZEE-1851

# Description
Currently, PlatformUI chooses interface language based on `Accept-Language` header value. Despite that behaviour, kernel sets `_locale` request attribute always from the *first* language configured for admin siteaccess. Symfony's translator takes locale from the `$request->getLocale()` method. 

*Example*: SA has two configured languages like: `[eng-GB, fre-FR]`, but browser language preference is set to `fr_FR = 1; en_US = 0.9`. So, PlatformUI loads in *French*, but all interface elements translated with Symfony's translator will be in *English*. This is odd inconsistency, and what is more, it makes the user unable to render Landing Page Block name in the correct language.