### PR TITLE
Deprecate PHPUnit5CompatTrait

### DIFF
--- a/eZ/Publish/Core/Base/Tests/PHPUnit5CompatTrait.php
+++ b/eZ/Publish/Core/Base/Tests/PHPUnit5CompatTrait.php
@@ -9,6 +9,8 @@ namespace eZ\Publish\Core\Base\Tests;
 
 /**
  * Trait for PHPUnit 5 Forward Compatibility, for PHPUnit 4.8 use and up.
+ *
+ * @deprecated since 7.1, will be removed in 8.0. We are using PHPUnit 6, so this trait is obsolete.
  */
 trait PHPUnit5CompatTrait
 {

--- a/eZ/Publish/Core/Base/Tests/PHPUnit5CompatTrait.php
+++ b/eZ/Publish/Core/Base/Tests/PHPUnit5CompatTrait.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\Base\Tests;
  * Trait for PHPUnit 5 Forward Compatibility, for PHPUnit 4.8 use and up.
  *
  * @deprecated since 7.1, will be removed in 8.0. We are using PHPUnit 6, so this trait is obsolete.
+ * Trait was used with PHPUnit v5 and v4, so basically trait can be removed when support period for 6.7 ends.
  */
 trait PHPUnit5CompatTrait
 {


### PR DESCRIPTION
PHPUnit5CompatTrait is not required any more as now we are using PHPUnit v6.