### PR TITLE
EZEE-1866: Map\URI::analyseURI should remove siteaccess part only if is present

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/URI.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/URI.php
@@ -47,7 +47,11 @@ class URI extends Map implements URILexer
             return '/';
         }
 
-        return substr($uri, strlen($siteaccessPart));
+        if (mb_strpos($uri, $siteaccessPart) === 0) {
+            return mb_substr($uri, mb_strlen($siteaccessPart));
+        }
+
+        return $uri;
     }
 
     /**


### PR DESCRIPTION
> JIRA: https://jira.ez.no/browse/EZEE-1866

## Description

`\eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Map\URI::analyseURI` should remove siteaccess part only if is present (as in the case of `\eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\URIElement::analyseURI`)