### PR TITLE
ezplatform:io:migrate-files command with --no-interaction should default to true

### DIFF
--- a/eZ/Bundle/EzPublishIOBundle/Command/MigrateFilesCommand.php
+++ b/eZ/Bundle/EzPublishIOBundle/Command/MigrateFilesCommand.php
@@ -159,16 +159,18 @@ EOT
             return;
         }
 
-        $helper = $this->getHelper('question');
-        $question = new ConfirmationQuestion(
-            '<question>Are you sure you want to proceed?</question> ',
-            false
-        );
+        if (!$input->getOption('no-interaction')) {
+            $helper = $this->getHelper('question');
+            $question = new ConfirmationQuestion(
+                '<question>Are you sure you want to proceed?</question> ',
+                false
+            );
 
-        if (!$helper->ask($input, $output, $question)) {
-            $output->writeln('Aborting.');
+            if (!$helper->ask($input, $output, $question)) {
+                $output->writeln('Aborting.');
 
-            return;
+                return;
+            }
         }
 
         $this->migrateFiles(


### PR DESCRIPTION
The script asks for confirmation : 

    Are you sure you want to proceed?

IMO, the script should proceed, not abort if user provides `--no-interaction`