### PR TITLE
EZP-28800: Added Redis session service

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -242,3 +242,9 @@ services:
             - '@ezpublish.api.repository'
         tags:
             - { name: console.command }
+
+    ezplatform.core.session.handler.native_redis:
+        class: eZ\Bundle\EzPublishCoreBundle\Session\Handler\NativeSessionHandler
+        arguments:
+         - '%session.save_path%'
+         - 'redis'

--- a/eZ/Bundle/EzPublishCoreBundle/Session/Handler/NativeSessionHandler.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Session/Handler/NativeSessionHandler.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * File containing the NativeSessionHandler class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Session\Handler;
+
+/**
+ * Class NativeSessionHandler.
+ *
+ * This class makes it possible to configure the native PHP session handler.
+ */
+class NativeSessionHandler extends \SessionHandler
+{
+    /**
+     * @param string $savePath      Path of directory to save session files
+     *                              Default null will leave setting as defined by PHP.
+     *                              '/path', 'host:port'
+     * @param string $saveHandler   Could be any handler supported by php
+     *                              Default null will leave setting as defined by PHP.
+     *                              'redis', 'file'
+     *
+     * @see http://php.net/manual/en/session.configuration.php#ini.session.save-path for further details.
+     */
+    public function __construct($savePath = null, $saveHandler = null)
+    {
+        if (null !== $savePath) {
+            ini_set('session.save_path', $savePath);
+        }
+
+        if (null !== $saveHandler) {
+            ini_set('session.save_handler', $saveHandler);
+        }
+    }
+}


### PR DESCRIPTION
Storing session in Redis is needed on platform.sh
The [current code](https://github.com/ezsystems/ezplatform/pull/254) does [not work](https://jira.ez.no/browse/EZP-28800).

This is the kernel part of the fix for [EZP-28800](https://jira.ez.no/browse/EZP-28800)
The corresponding PR for ezplatform is [here](https://github.com/ezsystems/ezplatform/pull/262)

My idea for solving this is to create a simple redis session handler ( which just enables the PHP build in redis session handler) and then user this handler on platform.sh

Reviewers should have a look at the [jira ticket](https://jira.ez.no/browse/EZP-28800) as there are several ideas on how to solve the problem.