### PR TITLE
Remove mikey179/vfsStream from dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.7.1",
-        "mikey179/vfsStream": "1.1.0",
         "phpunit/phpunit": "^6.5",
         "matthiasnoback/symfony-dependency-injection-test": "~2.0",
         "symfony/assetic-bundle": "~2.3",


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | none
| **Bug fix**        | no
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Currently dev dependency `mikey179/vfsStream` is not used inside this repository, it can be removed.