### PR TITLE
EZP-28846: HTTP Cache purge when UserService\{CreateUser,CreateUserGroup,UpdateUserGroup}Signal is emited

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/slot.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/slot.yml
@@ -4,6 +4,8 @@ parameters:
     ezpublish.http_cache.signalslot.copy_content.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\CopyContentSlot
     ezpublish.http_cache.signalslot.copy_subtree.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\CopySubtreeSlot
     ezpublish.http_cache.signalslot.create_location.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\CreateLocationSlot
+    ezpublish.http_cache.signalslot.create_user.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\CreateUserSlot
+    ezpublish.http_cache.signalslot.create_user_group.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\CreateUserGroupSlot
     ezpublish.http_cache.signalslot.delete_content.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\DeleteContentSlot
     ezpublish.http_cache.signalslot.delete_location.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\DeleteLocationSlot
     ezpublish.http_cache.signalslot.delete_version.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\DeleteVersionSlot
@@ -15,6 +17,7 @@ parameters:
     ezpublish.http_cache.signalslot.unhide_location.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UnhideLocationSlot
     ezpublish.http_cache.signalslot.update_location.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UpdateLocationSlot
     ezpublish.http_cache.signalslot.update_user.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UpdateUserSlot
+    ezpublish.http_cache.signalslot.update_user_group.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UpdateUserSlot
     ezpublish.http_cache.signalslot.assign_user_to_user_group.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\AssignUserToUserGroupSlot
     ezpublish.http_cache.signalslot.unassign_user_from_user_group.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UnassignUserFromUserGroupSlot
     ezpublish.http_cache.signalslot.trash.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\TrashSlot
@@ -49,6 +52,18 @@ services:
         parent: ezpublish.http_cache.signalslot.http_cache
         tags:
             - { name: ezpublish.api.slot, signal: LocationService\CreateLocationSignal }
+
+    ezpublish.http_cache.signalslot.create_user:
+        class: "%ezpublish.http_cache.signalslot.create_user.class%"
+        parent: ezpublish.http_cache.signalslot.http_cache
+        tags:
+            - { name: ezpublish.api.slot, signal: UserService\CreateUserSignal }
+
+    ezpublish.http_cache.signalslot.create_user_group:
+        class: "%ezpublish.http_cache.signalslot.create_user_group.class%"
+        parent: ezpublish.http_cache.signalslot.http_cache
+        tags:
+            - { name: ezpublish.api.slot, signal: UserService\CreateUserGroupSignal }
 
     ezpublish.http_cache.signalslot.delete_content:
         class: "%ezpublish.http_cache.signalslot.delete_content.class%"
@@ -115,6 +130,12 @@ services:
         parent: ezpublish.http_cache.signalslot.http_cache
         tags:
             - { name: ezpublish.api.slot, signal: UserService\UpdateUserSignal }
+
+    ezpublish.http_cache.signalslot.update_user_group:
+        class: "%ezpublish.http_cache.signalslot.update_user_group.class%"
+        parent: ezpublish.http_cache.signalslot.http_cache
+        tags:
+            - { name: ezpublish.api.slot, signal: UserService\UpdateUserGroupSignal }
 
     ezpublish.http_cache.signalslot.assign_user_to_user_group:
         class: "%ezpublish.http_cache.signalslot.assign_user_to_user_group.class%"

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/slot.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/slot.yml
@@ -17,7 +17,7 @@ parameters:
     ezpublish.http_cache.signalslot.unhide_location.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UnhideLocationSlot
     ezpublish.http_cache.signalslot.update_location.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UpdateLocationSlot
     ezpublish.http_cache.signalslot.update_user.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UpdateUserSlot
-    ezpublish.http_cache.signalslot.update_user_group.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UpdateUserSlot
+    ezpublish.http_cache.signalslot.update_user_group.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UpdateUserGroupSlot
     ezpublish.http_cache.signalslot.assign_user_to_user_group.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\AssignUserToUserGroupSlot
     ezpublish.http_cache.signalslot.unassign_user_from_user_group.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UnassignUserFromUserGroupSlot
     ezpublish.http_cache.signalslot.trash.class: eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\TrashSlot

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/CreateUserGroupSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/CreateUserGroupSlot.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling CreateUserGroupSignal.
+ */
+class CreateUserGroupSlot extends PurgeForContentHttpCacheSlot
+{
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\UserService\CreateUserGroupSignal $signal
+     */
+    protected function extractContentId(Signal $signal)
+    {
+        return $signal->userGroupId;
+    }
+
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\UserService\CreateUserGroupSignal;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/CreateUserSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/CreateUserSlot.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling CreateUserSignal.
+ */
+class CreateUserSlot extends PurgeForContentHttpCacheSlot
+{
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\UserService\CreateUserSignal $signal
+     */
+    protected function extractContentId(Signal $signal)
+    {
+        return $signal->userId;
+    }
+
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\UserService\CreateUserSignal;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/UpdateUserGroupSlot.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Http/SignalSlot/UpdateUserGroupSlot.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal;
+
+/**
+ * A slot handling UpdateUserGroupSignal.
+ */
+class UpdateUserGroupSlot extends PurgeForContentHttpCacheSlot
+{
+    /**
+     * @param \eZ\Publish\Core\SignalSlot\Signal\UserService\UpdateUserGroupSignal $signal
+     */
+    protected function extractContentId(Signal $signal)
+    {
+        return $signal->userGroupId;
+    }
+
+    protected function supports(Signal $signal)
+    {
+        return $signal instanceof Signal\UserService\UpdateUserGroupSignal;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/CreateUserGroupSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/CreateUserGroupSlotTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\UserService\CreateUserGroupSignal;
+
+class CreateUserGroupSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
+{
+    public static function createSignal()
+    {
+        return new CreateUserGroupSignal([
+            'userGroupId' => self::getContentId(),
+        ]);
+    }
+
+    public function getSlotClass()
+    {
+        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\CreateUserGroupSlot';
+    }
+
+    public static function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\UserService\CreateUserGroupSignal'];
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/CreateUserSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/CreateUserSlotTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\UserService\CreateUserSignal;
+
+class CreateUserSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
+{
+    public static function createSignal()
+    {
+        return new CreateUserSignal([
+            'userId' => self::getContentId(),
+        ]);
+    }
+
+    public function getSlotClass()
+    {
+        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\CreateUserSlot';
+    }
+
+    public static function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\UserService\CreateUserSignal'];
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/UpdateUserGroupSlotTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Cache/Tests/Http/SignalSlot/UpdateUserGroupSlotTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\MVC\Symfony\Cache\Tests\Http\SignalSlot;
+
+use eZ\Publish\Core\SignalSlot\Signal\UserService\UpdateUserGroupSignal;
+
+class UpdateUserGroupSlotTest extends AbstractPurgeForContentSlotTest implements SlotTest, PurgeForContentExpectation
+{
+    public static function createSignal()
+    {
+        return new UpdateUserGroupSignal([
+            'userGroupId' => self::getContentId(),
+        ]);
+    }
+
+    public function getSlotClass()
+    {
+        return 'eZ\Publish\Core\MVC\Symfony\Cache\Http\SignalSlot\UpdateUserGroupSlot';
+    }
+
+    public static function getReceivedSignalClasses()
+    {
+        return ['eZ\Publish\Core\SignalSlot\Signal\UserService\UpdateUserGroupSignal'];
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28846](https://jira.ez.no/browse/EZP-28846)
| **Bug fix**        | yes
| **New feature**    | no
| **Target version** | `6.7`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Follow up for https://github.com/ezsystems/ezplatform-http-cache/pull/50, regarding to built-in HTTP Cache purging. 

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
