### PR TITLE
[SPI Cache] Small refactoring to make multi load abstract more solid

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -98,26 +98,17 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
 
     public function loadContentInfoList(array $contentIds)
     {
-        list($cacheMisses, $list) = $this->getMultipleCacheItems($contentIds, 'ez-content-info-');
-        if (empty($cacheMisses)) {
-            return $list;
-        }
-
-        // Load cache misses
-        $this->logger->logCall(__METHOD__, array('content' => $cacheMisses));
-        $cacheMissList = $this->persistenceHandler->contentHandler()->loadContentInfoList($cacheMisses);
-
-        // Populate cache misses with data and set final info data instead on list
-        foreach ($cacheMissList as $id => $contentInfo) {
-            $this->cache->save(
-                $list[$id]
-                    ->set($contentInfo)
-                    ->tag($this->getCacheTags($contentInfo))
-            );
-            $list[$id] = $contentInfo;
-        }
-
-        return $list;
+        return $this->getMultipleCacheItems(
+            $contentIds,
+            'ez-content-info-',
+            function(array $cacheMissIds) {
+                $this->logger->logCall(__METHOD__, ['content' => $cacheMissIds]);
+                return $this->persistenceHandler->contentHandler()->loadContentInfoList($cacheMissIds);
+            },
+            function(ContentInfo $info) {
+                return $this->getCacheTags($info);
+            }
+        );
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -103,6 +103,7 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
             'ez-content-info-',
             function (array $cacheMissIds) {
                 $this->logger->logCall(__METHOD__, ['content' => $cacheMissIds]);
+
                 return $this->persistenceHandler->contentHandler()->loadContentInfoList($cacheMissIds);
             },
             function (ContentInfo $info) {

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -101,11 +101,11 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
         return $this->getMultipleCacheItems(
             $contentIds,
             'ez-content-info-',
-            function(array $cacheMissIds) {
+            function (array $cacheMissIds) {
                 $this->logger->logCall(__METHOD__, ['content' => $cacheMissIds]);
                 return $this->persistenceHandler->contentHandler()->loadContentInfoList($cacheMissIds);
             },
-            function(ContentInfo $info) {
+            function (ContentInfo $info) {
                 return $this->getCacheTags($info);
             }
         );

--- a/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
@@ -86,26 +86,17 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
      */
     public function loadGroups(array $groupIds)
     {
-        list($cacheMissIds, $list) = $this->getMultipleCacheItems($groupIds, 'ez-content-type-group-');
-        if (empty($cacheMissIds)) {
-            return $list;
-        }
-
-        // Load cache misses
-        $this->logger->logCall(__METHOD__, array('groups' => $cacheMissIds));
-        $cacheMissList = $this->persistenceHandler->contentTypeHandler()->loadGroups($cacheMissIds);
-
-        // Populate cache misses with data and set final group data instead on list
-        foreach ($cacheMissList as $id => $group) {
-            $this->cache->save(
-                $list[$id]
-                    ->set($group)
-                    ->tag('type-group-' . $id)
-            );
-            $list[$id] = $group;
-        }
-
-        return $list;
+        return $this->getMultipleCacheItems(
+            $groupIds,
+            'ez-content-type-group-',
+            function(array $cacheMissIds) {
+                $this->logger->logCall(__METHOD__, ['groups' => $cacheMissIds]);
+                return $this->persistenceHandler->contentTypeHandler()->loadGroups($cacheMissIds);
+            },
+            function(Type\Group $group) {
+                return ['type-group-' . $group->id];
+            }
+        );
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
@@ -91,6 +91,7 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
             'ez-content-type-group-',
             function (array $cacheMissIds) {
                 $this->logger->logCall(__METHOD__, ['groups' => $cacheMissIds]);
+
                 return $this->persistenceHandler->contentTypeHandler()->loadGroups($cacheMissIds);
             },
             function (Type\Group $group) {

--- a/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
@@ -89,11 +89,11 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
         return $this->getMultipleCacheItems(
             $groupIds,
             'ez-content-type-group-',
-            function(array $cacheMissIds) {
+            function (array $cacheMissIds) {
                 $this->logger->logCall(__METHOD__, ['groups' => $cacheMissIds]);
                 return $this->persistenceHandler->contentTypeHandler()->loadGroups($cacheMissIds);
             },
-            function(Type\Group $group) {
+            function (Type\Group $group) {
                 return ['type-group-' . $group->id];
             }
         );


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | no
| **Bug fix**        | no
| **New feature**    | no
| **Target version** | master
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Small change in order to improve code for multi loading SPI Cache methods:
- Unsets cache items not found by database.
   _Found by Ramzi when search where wrongly configured to pull data from another repository
   where cache items would be returned for items not found in database. Also needed if this is ever exposed by API methods._
- Refactor to let the abstract method handle more of the logic in order to avoid even more code duplication for these methods, especially if we add more of them in the future, for future lazy properties.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
