### PR TITLE
ROLE_USER is not passed with loadUserByAPIUser

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Security/User/Provider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/User/Provider.php
@@ -118,6 +118,6 @@ class Provider implements APIUserProviderInterface
      */
     public function loadUserByAPIUser(APIUser $apiUser)
     {
-        return new User($apiUser);
+        return new User($apiUser, array('ROLE_USER'));
     }
 }


### PR DESCRIPTION
> Issue: https://jira.ez.no/browse/EZP-28892


**Context**: I am using Guard to authenticate a user.
Debugging this: https://github.com/ezsystems/ezplatform-admin-ui/pull/353 I first thought I got my bug because I was using `loadUserByAPIUser` and not `loadUserByUsername`.

Through my debug, I could see the *roles* were empty with `loadUserByAPIUser` and not with `loadUserByUsername` I looked into the code and I saw that small difference.

```php
// loadUserByUsername
return new User($this->repository->getUserService()->loadUserByLogin($user), array('ROLE_USER'));
```

and
```php
// loadUserByAPIUser
 return new User($apiUser);
```
To me there is no reason to pass the role array in `loadUserByUsername` and not in `loadUserByAPIUser`.

At the end I ended up using `loadUserByUsername` to be safe on what I am doing, but I think it is good to talk about that diff ;-)
