### PR TITLE
EZP-28836:  Skipping validation of non-modified fields when content is updated

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
@@ -9,6 +9,7 @@
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\Repository\Helper\RelationProcessor;
 use eZ\Publish\Core\Repository\Values\User\UserReference;
 use eZ\Publish\Core\Search\Common\BackgroundIndexer;
 use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
@@ -84,13 +85,15 @@ class RepositoryFactory implements ContainerAwareInterface
      * @param \eZ\Publish\SPI\Persistence\Handler $persistenceHandler
      * @param \eZ\Publish\SPI\Search\Handler $searchHandler
      * @param \eZ\Publish\Core\Search\Common\BackgroundIndexer $backgroundIndexer
+     * @param \eZ\Publish\Core\Repository\Helper\RelationProcessor $relationProcessor
      *
      * @return \eZ\Publish\API\Repository\Repository
      */
     public function buildRepository(
         PersistenceHandler $persistenceHandler,
         SearchHandler $searchHandler,
-        BackgroundIndexer $backgroundIndexer
+        BackgroundIndexer $backgroundIndexer,
+        RelationProcessor $relationProcessor
     ) {
         $config = $this->container->get('ezpublish.api.repository_configuration_provider')->getRepositoryConfig();
 
@@ -98,6 +101,7 @@ class RepositoryFactory implements ContainerAwareInterface
             $persistenceHandler,
             $searchHandler,
             $backgroundIndexer,
+            $relationProcessor,
             array(
                 'fieldType' => $this->fieldTypeCollectionFactory->getFieldTypes(),
                 'nameableFieldTypes' => $this->fieldTypeNameableCollectionFactory->getNameableFieldTypes(),

--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\API\Repository\Tests;
 
+use eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException;
+use eZ\Publish\API\Repository\Tests\PHPUnitConstraint\ValidationErrorOccurs as PHPUnitConstraintValidationErrorOccurs;
 use EzSystems\EzPlatformSolrSearchEngine\Tests\SetupFactory\LegacySetupFactory as LegacySolrSetupFactory;
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\API\Repository\Repository;
@@ -510,5 +512,20 @@ abstract class BaseTest extends TestCase
         $roleService->publishRoleDraft($roleDraft);
 
         return $roleService->loadRole($roleDraft->id);
+    }
+
+    /**
+     * Traverse all errors for all fields in all Translations to find expected one.
+     *
+     * @param \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException $exception
+     * @param string $expectedValidationErrorMessage
+     */
+    protected function assertValidationErrorOccurs(
+        ContentFieldValidationException $exception,
+        $expectedValidationErrorMessage
+    ) {
+        $constraint = new PHPUnitConstraintValidationErrorOccurs($expectedValidationErrorMessage);
+
+        self::assertThat($exception, $constraint);
     }
 }

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -1480,10 +1480,10 @@ class ContentServiceTest extends BaseContentServiceTest
     /**
      * Test for the updateContent() method.
      *
-     * @see \eZ\Publish\API\Repository\ContentService::updateContent()
+     * @covers \eZ\Publish\API\Repository\ContentService::updateContent()
      * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testUpdateContent
      */
-    public function testUpdateContentIgnoreIsRequiredOnNonUpdatedLanguages()
+    public function testUpdateContentValidatorIgnoresRequiredFieldsOfNotUpdatedLanguages()
     {
         $repository = $this->getRepository();
         /* BEGIN: Use Case */

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\API\Repository\Tests;
 
+use DOMDocument;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\Location;
@@ -1473,6 +1474,60 @@ class ContentServiceTest extends BaseContentServiceTest
         // Throws ContentFieldValidationException because the string length
         // validation of the field "short_name" fails
         $contentService->updateContent($draft->getVersionInfo(), $contentUpdate);
+        /* END: Use Case */
+    }
+
+    /**
+     * Test for the updateContent() method.
+     *
+     * @see \eZ\Publish\API\Repository\ContentService::updateContent()
+     * @depends eZ\Publish\API\Repository\Tests\ContentServiceTest::testUpdateContent
+     */
+    public function testUpdateContentIgnoreIsRequiredOnNonUpdatedLanguages()
+    {
+        $repository = $this->getRepository();
+        /* BEGIN: Use Case */
+        $contentTypeService = $repository->getContentTypeService();
+        $contentType = $contentTypeService->loadContentTypeByIdentifier('folder');
+
+        // Create multilangual content
+        $contentService = $repository->getContentService();
+        $contentCreate = $contentService->newContentCreateStruct($contentType, 'eng-US');
+        $contentCreate->setField('name', 'An awesome Sidelfingen folder', 'eng-US');
+        $contentCreate->setField('name', 'An awesome Sidelfingen folder', 'eng-GB');
+
+        $contentDraft = $contentService->createContent($contentCreate);
+
+        // 2. Update content type definition
+        $contentTypeDraft = $contentTypeService->createContentTypeDraft($contentType);
+
+        $fieldDefinition = $contentType->getFieldDefinition('description');
+        $fieldDefinitionUpdate = $contentTypeService->newFieldDefinitionUpdateStruct();
+        $fieldDefinitionUpdate->identifier = 'description';
+        $fieldDefinitionUpdate->isRequired = true;
+
+        $contentTypeService->updateFieldDefinition(
+            $contentTypeDraft,
+            $fieldDefinition,
+            $fieldDefinitionUpdate
+        );
+        $contentTypeService->publishContentTypeDraft($contentTypeDraft);
+
+        // 3. Update only eng-US translation
+        $description = new DOMDocument();
+        $description->loadXML(<<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml" xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom" version="5.0-variant ezpublish-1.0">
+    <para>Lorem ipsum dolor</para>
+</section>
+XML
+        );
+
+        $contentUpdate = $contentService->newContentUpdateStruct();
+        $contentUpdate->setField('name', 'An awesome Sidelfingen folder (updated)', 'eng-US');
+        $contentUpdate->setField('description', $description);
+
+        $contentService->updateContent($contentDraft->getVersionInfo(), $contentUpdate);
         /* END: Use Case */
     }
 

--- a/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
@@ -309,8 +309,16 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
         $repository = $this->getRepository();
         $contentTypeService = $repository->getContentTypeService();
 
+        $contentTypeIdentifier = 'test-' . $this->getTypeName();
+
+        try {
+            return $contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
+        } catch (Repository\Exceptions\NotFoundException $e) {
+            // Move on to creating Content Type
+        }
+
         $createStruct = $contentTypeService->newContentTypeCreateStruct(
-            'test-' . $this->getTypeName()
+            $contentTypeIdentifier
         );
         $createStruct->mainLanguageCode = $this->getOverride('mainLanguageCode', $typeCreateOverride, 'eng-GB');
         $createStruct->remoteId = $this->getTypeName();

--- a/eZ/Publish/API/Repository/Tests/PHPUnitConstraint/ValidationErrorOccurs.php
+++ b/eZ/Publish/API/Repository/Tests/PHPUnitConstraint/ValidationErrorOccurs.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\API\Repository\Tests\PHPUnitConstraint;
+
+/**
+ * PHPUnit constraint checking that the given ValidationError message occurs in asserted ContentFieldValidationException.
+ *
+ * @see \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+ * @see \eZ\Publish\SPI\FieldType\ValidationError
+ */
+class ValidationErrorOccurs extends \PHPUnit_Framework_Constraint
+{
+    /**
+     * @var string
+     */
+    private $expectedValidationErrorMessage;
+
+    /**
+     * @param string $expectedValidationErrorMessage
+     */
+    public function __construct($expectedValidationErrorMessage)
+    {
+        parent::__construct();
+
+        $this->expectedValidationErrorMessage = $expectedValidationErrorMessage;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException $other
+     *
+     * @return bool
+     */
+    protected function matches($other)
+    {
+        foreach ($other->getFieldErrors() as $fieldId => $errors) {
+            foreach ($errors as $languageCode => $fieldErrors) {
+                foreach ($fieldErrors as $fieldError) {
+                    /** @var \eZ\Publish\Core\FieldType\ValidationError $fieldError */
+                    if ($fieldError->getTranslatableMessage()->message === $this->expectedValidationErrorMessage) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException $other
+     *
+     * @return string
+     */
+    protected function failureDescription($other)
+    {
+        return sprintf(
+            '%s::getFieldErrors = %s %s',
+            get_class($other),
+            var_export($other->getFieldErrors(), true),
+            $this->toString()
+        );
+    }
+
+    /**
+     * Returns a string representation of the object.
+     *
+     * @return string
+     */
+    public function toString()
+    {
+        return "contains a ValidationError with the message '{$this->expectedValidationErrorMessage}'";
+    }
+}

--- a/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Base\Container\ApiLoader;
 
+use eZ\Publish\Core\Repository\Helper\RelationProcessor;
 use eZ\Publish\Core\Repository\Values\User\UserReference;
 use eZ\Publish\Core\Search\Common\BackgroundIndexer;
 use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
@@ -73,12 +74,14 @@ class RepositoryFactory implements ContainerAwareInterface
     public function buildRepository(
         PersistenceHandler $persistenceHandler,
         SearchHandler $searchHandler,
-        BackgroundIndexer $backgroundIndexer
+        BackgroundIndexer $backgroundIndexer,
+        RelationProcessor $relationProcessor
     ) {
         $repository = new $this->repositoryClass(
             $persistenceHandler,
             $searchHandler,
             $backgroundIndexer,
+            $relationProcessor,
             array(
                 'fieldType' => $this->fieldTypeCollectionFactory->getFieldTypes(),
                 'nameableFieldTypes' => $this->fieldTypeNameableCollectionFactory->getNameableFieldTypes(),

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1358,12 +1358,8 @@ class ContentService implements ContentServiceInterface
                 continue;
             }
 
-//            dump($field->fieldDefIdentifier, $field->languageCode);
-
             $languageCodes[$field->languageCode] = true;
         }
-
-//        dump(array_keys($languageCodes));
 
         return array_keys($languageCodes);
     }

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -14,6 +14,7 @@ use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
+use eZ\Publish\Core\Repository\Helper\RelationProcessor;
 use eZ\Publish\Core\Repository\Permission\CachedPermissionService;
 use eZ\Publish\Core\Repository\Permission\PermissionCriterionResolver;
 use eZ\Publish\Core\Repository\Values\User\UserReference;
@@ -255,12 +256,14 @@ class Repository implements RepositoryInterface
         PersistenceHandler $persistenceHandler,
         SearchHandler $searchHandler,
         BackgroundIndexer $backgroundIndexer,
+        RelationProcessor $relationProcessor,
         array $serviceSettings = array(),
         APIUserReference $user = null
     ) {
         $this->persistenceHandler = $persistenceHandler;
         $this->searchHandler = $searchHandler;
         $this->backgroundIndexer = $backgroundIndexer;
+        $this->relationProcessor = $relationProcessor;
         $this->serviceSettings = $serviceSettings + array(
             'content' => array(),
             'contentType' => array(),
@@ -836,12 +839,6 @@ class Repository implements RepositoryInterface
      */
     protected function getRelationProcessor()
     {
-        if ($this->relationProcessor !== null) {
-            return $this->relationProcessor;
-        }
-
-        $this->relationProcessor = new Helper\RelationProcessor($this->persistenceHandler);
-
         return $this->relationProcessor;
     }
 

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 
 use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
+use eZ\Publish\Core\Repository\Helper\RelationProcessor;
 use eZ\Publish\Core\Search\Common\BackgroundIndexer\NullIndexer;
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\Core\Repository\Repository;
@@ -62,6 +63,7 @@ abstract class Base extends TestCase
                 $this->getPersistenceMock(),
                 $this->getSPIMockHandler('Search\\Handler'),
                 new NullIndexer(),
+                $this->getRelationProcessorMock(),
                 $serviceSettings,
                 $this->getStubbedUser(14)
             );
@@ -201,6 +203,16 @@ abstract class Base extends TestCase
         }
 
         return $this->persistenceMock;
+    }
+
+    protected function getRelationProcessorMock()
+    {
+        return $this->getMock(RelationProcessor::class,
+            array(),
+            array(),
+            '',
+            false
+        );
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -5002,7 +5002,6 @@ class ContentTest extends BaseServiceMockTest
         /** @var \PHPUnit_Framework_MockObject_MockObject $languageHandlerMock */
         $languageHandlerMock = $this->getPersistenceMock()->contentLanguageHandler();
         $contentTypeServiceMock = $this->getContentTypeServiceMock();
-        $fieldTypeServiceMock = $this->getFieldTypeServiceMock();
         $fieldTypeMock = $this->getMock('eZ\\Publish\\SPI\\FieldType\\FieldType');
         $existingLanguageCodes = array_map(
             function (Field $field) {
@@ -5083,44 +5082,32 @@ class ContentTest extends BaseServiceMockTest
             $languageCodes
         );
         $allFieldErrors = array();
-        $validateCount = 0;
         $emptyValue = self::EMPTY_FIELD_VALUE;
-        foreach ($contentType->getFieldDefinitions() as $fieldDefinition) {
-            foreach ($fieldValues[$fieldDefinition->identifier] as $languageCode => $value) {
-                $fieldTypeMock->expects($this->at($validateCount++))
-                    ->method('acceptValue')
-                    ->will(
-                        $this->returnCallback(
-                            function ($valueString) {
-                                return new ValueStub($valueString);
-                            }
-                        )
-                    );
 
-                $fieldTypeMock->expects($this->at($validateCount++))
-                    ->method('isEmptyValue')
-                    ->will(
-                        $this->returnCallback(
-                            function (ValueStub $value) use ($emptyValue) {
-                                return $emptyValue === (string)$value;
-                            }
-                        )
-                    );
+        $fieldTypeMock->expects($this->exactly(count($fieldValues) * count($languageCodes)))
+            ->method('acceptValue')
+            ->will(
+                $this->returnCallback(
+                    function ($valueString) {
+                        return new ValueStub($valueString);
+                    }
+                )
+            );
 
-                if (self::EMPTY_FIELD_VALUE === (string)$value) {
-                    continue;
-                }
+        $fieldTypeMock->expects($this->exactly(count($fieldValues) * count($languageCodes)))
+            ->method('isEmptyValue')
+            ->will(
+                $this->returnCallback(
+                    function (ValueStub $value) use ($emptyValue) {
+                        return $emptyValue === (string)$value;
+                    }
+                )
+            );
 
-                $fieldTypeMock->expects($this->at($validateCount++))
-                    ->method('validate')
-                    ->with(
-                        $this->equalTo($fieldDefinition),
-                        $this->equalTo($value)
-                    )->will($this->returnArgument(1));
-
-                $allFieldErrors[$fieldDefinition->id][$languageCode] = $value;
-            }
-        }
+        $fieldTypeMock
+            ->expects($this->any())
+            ->method('validate')
+            ->willReturnArgument(1);
 
         $this->getFieldTypeRegistryMock()->expects($this->any())
             ->method('getFieldType')
@@ -5138,7 +5125,124 @@ class ContentTest extends BaseServiceMockTest
 
     public function providerForTestUpdateContentThrowsContentFieldValidationException()
     {
-        return $this->providerForTestUpdateContentNonRedundantFieldSetComplex();
+        $allFieldErrors = [
+            [
+                'fieldDefinitionId1' => [
+                    'eng-GB' => 'newValue1-eng-GB',
+                    'eng-US' => 'newValue1-eng-GB',
+                ],
+                'fieldDefinitionId2' => [
+                    'eng-GB' => 'initialValue2',
+                ],
+                'fieldDefinitionId3' => [
+                    'eng-GB' => 'initialValue3',
+                    'eng-US' => 'initialValue3',
+                ],
+                'fieldDefinitionId4' => [
+                    'eng-GB' => 'initialValue4',
+                    'eng-US' => 'newValue4',
+                ],
+            ],
+            [
+                'fieldDefinitionId1' => [
+                    'eng-GB' => 'newValue1-eng-GB',
+                    'eng-US' => 'newValue1-eng-GB',
+                ],
+                'fieldDefinitionId2' => [
+                    'eng-GB' => 'initialValue2',
+                ],
+                'fieldDefinitionId3' => [
+                    'eng-GB' => 'initialValue3',
+                    'eng-US' => 'initialValue3',
+                ],
+                'fieldDefinitionId4' => [
+                    'eng-GB' => 'initialValue4',
+                    'eng-US' => 'newValue4',
+                ],
+            ],
+            [
+                'fieldDefinitionId1' => [
+                    'eng-GB' => 'newValue1-eng-GB',
+                    'eng-US' => 'newValue1-eng-GB',
+                ],
+                'fieldDefinitionId2' => [
+                    'eng-GB' => 'initialValue2',
+                    'eng-US' => 'newValue2',
+                ],
+                'fieldDefinitionId3' => [
+                    'eng-GB' => 'initialValue3',
+                    'eng-US' => 'initialValue3',
+                ],
+                'fieldDefinitionId4' => [
+                    'eng-GB' => 'initialValue4',
+                    'eng-US' => 'defaultValue4',
+                ],
+            ],
+            [
+                'fieldDefinitionId1' => [
+                    'eng-GB' => 'newValue1-eng-GB',
+                    'eng-US' => 'newValue1-eng-GB',
+                ],
+                'fieldDefinitionId2' => [
+                    'eng-GB' => 'initialValue2',
+                    'eng-US' => 'newValue2',
+                ],
+                'fieldDefinitionId3' => [
+                    'eng-GB' => 'initialValue3',
+                    'eng-US' => 'initialValue3',
+                ],
+                'fieldDefinitionId4' => [
+                    'eng-GB' => 'initialValue4',
+                    'eng-US' => 'defaultValue4',
+                ],
+            ],
+            [
+                'fieldDefinitionId1' => [
+                    'eng-GB' => 'newValue1-eng-GB',
+                    'ger-DE' => 'newValue1-eng-GB',
+                    'eng-US' => 'newValue1-eng-GB',
+                ],
+                'fieldDefinitionId2' => [
+                    'eng-GB' => 'initialValue2',
+                    'eng-US' => 'newValue2',
+                ],
+                'fieldDefinitionId3' => [
+                    'eng-GB' => 'initialValue3',
+                    'ger-DE' => 'initialValue3',
+                    'eng-US' => 'initialValue3',
+                ],
+                'fieldDefinitionId4' => [
+                    'eng-GB' => 'initialValue4',
+                    'eng-US' => 'defaultValue4',
+                    'ger-DE' => 'defaultValue4',
+                ],
+            ],
+            [
+                'fieldDefinitionId1' => [
+                    'eng-US' => 'newValue1-eng-GB',
+                    'ger-DE' => 'newValue1-eng-GB',
+                ],
+                'fieldDefinitionId2' => [
+                    'eng-US' => 'newValue2',
+                ],
+                'fieldDefinitionId3' => [
+                    'ger-DE' => 'initialValue3',
+                    'eng-US' => 'initialValue3',
+                ],
+                'fieldDefinitionId4' => [
+                    'ger-DE' => 'defaultValue4',
+                    'eng-US' => 'defaultValue4',
+                ],
+            ],
+        ];
+
+        $data = $this->providerForTestUpdateContentNonRedundantFieldSetComplex();
+        $count = count($data);
+        for ($i = 0; $i < $count; ++$i) {
+            $data[$i][] = $allFieldErrors[$i];
+        }
+
+        return $data;
     }
 
     /**
@@ -5151,10 +5255,10 @@ class ContentTest extends BaseServiceMockTest
      * @expectedException \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
      * @expectedExceptionMessage Content fields did not validate
      */
-    public function testUpdateContentThrowsContentFieldValidationException($initialLanguageCode, $structFields)
+    public function testUpdateContentThrowsContentFieldValidationException($initialLanguageCode, $structFields, $spiField, $allFieldErrors)
     {
         list($existingFields, $fieldDefinitions) = $this->fixturesForTestUpdateContentNonRedundantFieldSetComplex();
-        list($versionInfo, $contentUpdateStruct, $allFieldErrors) =
+        list($versionInfo, $contentUpdateStruct) =
             $this->assertForTestUpdateContentThrowsContentFieldValidationException(
                 $initialLanguageCode,
                 $structFields,

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/RelationProcessorTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/RelationProcessorTest.php
@@ -263,7 +263,7 @@ class RelationProcessorTest extends BaseServiceMockTest
         );
     }
 
-    public function testAppendFieldRelationsLogMissingLocations()
+    public function testAppendFieldRelationsLogsMissingLocations()
     {
         $fieldValueMock = $this->getMockForAbstractClass(Value::class);
         $fieldTypeMock = $this->getMock(FieldType::class);

--- a/eZ/Publish/Core/settings/repository.yml
+++ b/eZ/Publish/Core/settings/repository.yml
@@ -61,6 +61,7 @@ services:
             - '@ezpublish.api.persistence_handler'
             - '@ezpublish.spi.search'
             - '@ezpublish.search.background_indexer'
+            - '@ezpublish.repository.relation_processor'
         lazy: true
 
     ezpublish.api.service.content:
@@ -163,3 +164,10 @@ services:
 
     ezpublish.search.background_indexer:
         class: eZ\Publish\Core\Search\Common\BackgroundIndexer\NullIndexer
+
+    ezpublish.repository.relation_processor:
+        class: eZ\Publish\Core\Repository\Helper\RelationProcessor
+        arguments:
+            - '@ezpublish.api.persistence_handler'
+        calls:
+            - ['setLogger', ['@?logger']]


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28836](https://jira.ez.no/browse/EZP-28836)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR introduces skipping validation of non-modified fields when content is updated. Otherwise, an editor is unable to publish content if two or more translations contain validation error. 

**TODO**:
- [x] Rebase to 6.7 
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
