### PR TITLE
EZP-28860: Limit building views with view builders to string controllers

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
@@ -107,6 +107,24 @@ class ViewControllerListenerTest extends TestCase
         $this->controllerListener->getController($this->event);
     }
 
+    public function testGetControllerWithClosure()
+    {
+        $initialController = function () {};
+        $this->request->attributes->set('_controller', $initialController);
+
+        $this->viewBuilderRegistry
+            ->expects($this->once())
+            ->method('getFromRegistry')
+            ->with($initialController)
+            ->willReturn(null);
+
+        $this->event
+            ->expects($this->never())
+            ->method('setController');
+
+        $this->controllerListener->getController($this->event);
+    }
+
     public function testGetControllerMatchedView()
     {
         $id = 123;

--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/Registry/ControllerMatch.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/Registry/ControllerMatch.php
@@ -32,6 +32,10 @@ class ControllerMatch implements ViewBuilderRegistry
      */
     public function getFromRegistry($controllerString)
     {
+        if (!is_string($controllerString)) {
+            return null;
+        }
+
         foreach ($this->registry as $viewBuilder) {
             if ($viewBuilder->matches($controllerString)) {
                 return $viewBuilder;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28860](https://jira.ez.no/browse/EZP-28860)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.x`/`7.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

In Symfony, controller can be a closure, in addition to referencing the controller with 'service:method' or 'Bundle:Controller:Action'.

Using closure as a controller results in a warning that strpos cannot be used because the argument is not a string.

The error comes from the view builder system that assumes that the controller is always a string.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
