### PR TITLE
EZP-28585: SPI cache purge for related content when URL is updated

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/URLHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/URLHandler.php
@@ -31,6 +31,12 @@ class URLHandler extends AbstractHandler implements URLHandlerInterface
 
         $this->cache->invalidateTags(['url-' . $id]);
 
+        if ($struct->url !== null) {
+            $this->cache->invalidateTags(array_map(function ($id) {
+                return 'content-' . $id;
+            }, $this->persistenceHandler->urlHandler()->findUsages($id)));
+        }
+
         return $url;
     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28585](https://jira.ez.no/browse/EZP-EZP-28585)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `>= 7.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR includes clearing SPI cache for related content when URL address is update.

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
