### PR TITLE
 EZP-28585: Added flag to URLService\UpdateUrlSignal indicating that URL address was changed

### DIFF
--- a/eZ/Publish/Core/SignalSlot/Signal/URLService/UpdateUrlSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/URLService/UpdateUrlSignal.php
@@ -19,4 +19,13 @@ class UpdateUrlSignal extends Signal
      * @var int
      */
     public $urlId;
+
+    /**
+     * If URL address was changed.
+     *
+     * @var bool
+     *
+     * @since 6.13.2
+     */
+    public $urlChanged;
 }

--- a/eZ/Publish/Core/SignalSlot/Tests/URLServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/URLServiceTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\Core\SignalSlot\Tests;
+
+use eZ\Publish\API\Repository\URLService as APIURLService;
+use eZ\Publish\API\Repository\Values\URL\SearchResult;
+use eZ\Publish\API\Repository\Values\URL\URL;
+use eZ\Publish\API\Repository\Values\URL\URLQuery;
+use eZ\Publish\API\Repository\Values\URL\URLUpdateStruct;
+use eZ\Publish\Core\SignalSlot\SignalDispatcher;
+use eZ\Publish\Core\SignalSlot\Signal\URLService\UpdateUrlSignal;
+use eZ\Publish\Core\SignalSlot\URLService;
+
+class URLServiceTest extends ServiceTest
+{
+    public function serviceProvider()
+    {
+        $url = $this->getApiUrl(12, 'http://ez.no');
+
+        return [
+            [
+                'updateUrl',
+                [
+                    $url,
+                    new URLUpdateStruct([
+                        'url' => 'http://ezplatform.com',
+                    ]),
+                ],
+                $this->getApiUrl(12, 'http://ezplatform.com', true),
+                1,
+                UpdateUrlSignal::class,
+                ['urlId' => $url->id, 'urlChanged' => true],
+            ],
+            [
+                'updateUrl',
+                [
+                    $url,
+                    new URLUpdateStruct([
+                        'isValid' => false,
+                    ]),
+                ],
+                $this->getApiUrl(12, 'http://ez.no', false),
+                1,
+                UpdateUrlSignal::class,
+                ['urlId' => $url->id, 'urlChanged' => false],
+            ],
+            [
+                'createUpdateStruct',
+                [],
+                new URLUpdateStruct(),
+                0,
+            ],
+            [
+                'findUrls',
+                [new URLQuery()],
+                new SearchResult(),
+                0,
+            ],
+            [
+                'loadById',
+                [12],
+                $url,
+                0,
+            ],
+            [
+                'loadByUrl',
+                ['http://ez.no'],
+                $url,
+                0,
+            ],
+        ];
+    }
+
+    protected function getServiceMock()
+    {
+        return $this->createMock(APIURLService::class);
+    }
+
+    protected function getSignalSlotService($innerService, SignalDispatcher $dispatcher)
+    {
+        return new URLService($innerService, $dispatcher);
+    }
+
+    private function getApiUrl($id = null, $url = null, $isValid = false)
+    {
+        return new URL([
+            'id' => $id,
+            'url' => $url,
+            'isValid' => $isValid,
+        ]);
+    }
+}

--- a/eZ/Publish/Core/SignalSlot/URLService.php
+++ b/eZ/Publish/Core/SignalSlot/URLService.php
@@ -90,6 +90,7 @@ class URLService implements URLServiceInterface
         $this->signalDispatcher->emit(
             new UpdateUrlSignal([
                 'urlId' => $returnValue->id,
+                'urlChanged' => $struct->url !== null,
             ])
         );
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28585](https://jira.ez.no/browse/EZP-28585)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `>= 6.13`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

Added flag to URLService\UpdateUrlSignal indicating that URL address was changed in . Main reason behind this change is proper HTTP Cache purge for content which contain updated URL: to avoid HTTP Cache purge if only URL status was updated. 

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement unit tests.
- [ ] Implement integration tests.
- [x] Open related PR on the `ezsystems/ezplatform-http-cache` side (https://github.com/ezsystems/ezplatform-http-cache/pull/55)
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
