### PR TITLE
EZP-28070: Cleaning up temporary files created by BinaryInputProcessor::preProcessValueHash

### DIFF
--- a/eZ/Publish/Core/REST/Common/FieldTypeProcessor/BinaryInputProcessor.php
+++ b/eZ/Publish/Core/REST/Common/FieldTypeProcessor/BinaryInputProcessor.php
@@ -40,6 +40,8 @@ abstract class BinaryInputProcessor extends FieldTypeProcessor
 
             unset($incomingValueHash['data']);
             $incomingValueHash['inputUri'] = $tempFile;
+
+            register_shutdown_function('unlink', $tempFile);
         }
 
         return $incomingValueHash;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28070](https://jira.ez.no/browse/EZP-28070)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Added cleaning up for `eZ_REST_BinaryFile` temporary files created by `BinaryInputProcessor::preProcessValueHash()`

**TODO**:
- [X] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
