### PR TITLE
EZP-28883: Removing Translation from Draft corrupts all Url Aliases for the removed Translation

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -5414,6 +5414,11 @@ class ContentServiceTest extends BaseContentServiceTest
      * @dataProvider providerForDeleteTranslationFromDraftRemovesUrlAliasOnPublishing
      *
      * @param string[] $fieldValues translated field values
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
     public function testDeleteTranslationFromDraftRemovesUrlAliasOnPublishing(array $fieldValues)
     {
@@ -5474,6 +5479,65 @@ class ContentServiceTest extends BaseContentServiceTest
             $aliases = $urlAliasService->listLocationAliases($location, true, $languageCode);
             self::assertEmpty($aliases, 'Custom URL alias for the deleted translation still exists');
         }
+    }
+
+    /**
+     * Test that URL aliases for deleted Translations are properly archived.
+     */
+    public function testDeleteTranslationFromDraftArchivesUrlAliasOnPublishing()
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+        $urlAliasService = $repository->getURLAliasService();
+
+        $content = $contentService->publishVersion(
+            $this->createMultilingualContentDraft(
+                'folder',
+                2,
+                'eng-US',
+                [
+                    'name' => [
+                        'eng-GB' => 'BritishEnglishContent',
+                        'eng-US' => 'AmericanEnglishContent',
+                    ],
+                ]
+            )->versionInfo
+        );
+
+        $unrelatedContent = $contentService->publishVersion(
+            $this->createMultilingualContentDraft(
+                'folder',
+                2,
+                'eng-US',
+                [
+                    'name' => [
+                        'eng-GB' => 'AnotherBritishContent',
+                        'eng-US' => 'AnotherAmericanContent',
+                    ],
+                ]
+            )->versionInfo
+        );
+
+        $urlAlias = $urlAliasService->lookup('/BritishEnglishContent');
+        self::assertFalse($urlAlias->isHistory);
+        self::assertEquals($urlAlias->path, '/BritishEnglishContent');
+        self::assertEquals($urlAlias->destination, $content->contentInfo->mainLocationId);
+
+        $draft = $contentService->deleteTranslationFromDraft(
+            $contentService->createContentDraft($content->contentInfo)->versionInfo,
+            'eng-GB'
+        );
+        $content = $contentService->publishVersion($draft->versionInfo);
+
+        $urlAlias = $urlAliasService->lookup('/BritishEnglishContent');
+        self::assertTrue($urlAlias->isHistory);
+        self::assertEquals($urlAlias->path, '/BritishEnglishContent');
+        self::assertEquals($urlAlias->destination, $content->contentInfo->mainLocationId);
+
+        $unrelatedUrlAlias = $urlAliasService->lookup('/AnotherBritishContent');
+        self::assertFalse($unrelatedUrlAlias->isHistory);
+        self::assertEquals($unrelatedUrlAlias->path, '/AnotherBritishContent');
+        self::assertEquals($unrelatedUrlAlias->destination, $unrelatedContent->contentInfo->mainLocationId);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
@@ -1256,8 +1256,8 @@ class DoctrineDatabase extends Gateway
         ;
 
         $statement = $query->execute();
-        while (false !== ($row = $statement->fetch(\PDO::FETCH_ASSOC))) {
-            yield $row;
-        }
+        $rows = $statement->fetchAll(\PDO::FETCH_ASSOC);
+
+        return $rows ?: [];
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
@@ -1250,7 +1250,7 @@ class DoctrineDatabase extends Gateway
             ->from($this->table)
             ->where('action = :action')
             // fetch rows matching any of the given Languages
-            ->where('lang_mask & :languageMask <> 0')
+            ->andWhere('lang_mask & :languageMask <> 0')
             ->setParameter(':action', 'eznode:' . $locationId)
             ->setParameter(':languageMask', $languageMask)
         ;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28883](https://jira.ez.no/browse/EZP-28883)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** |  `6.13`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This little bug makes possible for admin users to delete random records from the `ezurlalias_ml` database table in multilanguage setups which breaks all url's for a language.

To reproduce:

1. Install clean ezplatform, eg a v2
2. on the admin create a new valid language
3. create a folder under the home, translate it to both language and publish; note the location id of this folder (should be 54 or around that for clean installs)
4. check db query: `SELECT * FROM ezurlalias_ml WHERE action LIKE 'eznode:54'`. Replace 54 by the folder's location id if differs. You should get 2 records with both `is_original` are `true`
5. create a new article into the previously created folder  (only in the default language) and publish it
6. edit the created article, change the short title and save it, but don't publish it
7. create a new draft for this article with the non-default language and publish it
8. find your draft which you created at point 6, and edit it and publish![ezdraft](https://user-images.githubusercontent.com/543367/36834036-c7c84a1a-1d31-11e8-97f0-8b4026744fdb.png)
9. check the query from point 4 again. You will see the results are changed and its totally messed up, only 1 record with `is_original` 1

So the problem is: you edited the article, but the folder's urlaliases are changed too and if you had more contents then they would have changed too, in a bad way.

The bug is there because `where` overrides the other `where`, so every `ezurlalias_ml` record will be deleted for a given language, not just for the affected one.