### PR TITLE
EZP-28848: Add relation cache tags to default relation fields

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/content.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/content.html.twig
@@ -6,6 +6,7 @@
     {% set params = params|merge( { "linkParameters": embedParams.link } ) %}
 {% endif %}
 <div class="{% if embedParams.align is defined %}align-{{ embedParams.align }}{% endif %}{% if embedParams.class is defined %} {{ embedParams.class }}{% endif %}">
+    {{ fos_httpcache_tag('relation-' ~ embedParams.id) }}
     {{
         render(
             controller(

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/content_denied.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/content_denied.html.twig
@@ -1,3 +1,4 @@
 <div class="{% if embedParams.align is defined %}align-{{ embedParams.align }}{% endif %}{% if embedParams.class is defined %} {{ embedParams.class }}{% endif %}">
+    {{ fos_httpcache_tag('relation-' ~ embedParams.id) }}
     Content #{{ embedParams.id }}: You do not have permission to view this Content
 </div>

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/content_inline.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/content_inline.html.twig
@@ -5,6 +5,7 @@
 {% if embedParams.link is defined  %}
     {% set params = params|merge( { "linkParameters": embedParams.link } ) %}
 {% endif %}
+{{ fos_httpcache_tag('relation-' ~ embedParams.id) }}
 {{
     render(
         controller(

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/content_inline_denied.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/content_inline_denied.html.twig
@@ -1,1 +1,2 @@
+{{ fos_httpcache_tag('relation-' ~ embedParams.id) }}
 [[ Content #{{ embedParams.id }}: You do not have permission to view this Content ]]

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/location.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/location.html.twig
@@ -6,6 +6,7 @@
     {% set params = params|merge( { "linkParameters": embedParams.link } ) %}
 {% endif %}
 <div class="{% if embedParams.align is defined %}align-{{ embedParams.align }}{% endif %}{% if embedParams.class is defined %} {{ embedParams.class }}{% endif %}">
+    {{ fos_httpcache_tag('relation-location-' ~ embedParams.id) }}
     {{
         render(
             controller(

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/location_denied.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/location_denied.html.twig
@@ -1,3 +1,4 @@
 <div class="{% if embedParams.align is defined %}align-{{ embedParams.align }}{% endif %}{% if embedParams.class is defined %} {{ embedParams.class }}{% endif %}">
+    {{ fos_httpcache_tag('relation-location-' ~ embedParams.id) }}
     Location #{{ embedParams.id }}: You do not have permission to view this Location
 </div>

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/location_inline.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/location_inline.html.twig
@@ -5,6 +5,7 @@
 {% if embedParams.link is defined  %}
     {% set params = params|merge( { "linkParameters": embedParams.link } ) %}
 {% endif %}
+{{ fos_httpcache_tag('relation-location-' ~ embedParams.id) }}
 {{
     render(
         controller(

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/location_inline_denied.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/FieldType/RichText/embed/location_inline_denied.html.twig
@@ -1,1 +1,2 @@
+{{ fos_httpcache_tag('relation-location-' ~ embedParams.id) }}
 [[ Location #{{ embedParams.id }}: You do not have permission to view this Location ]]

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -265,6 +265,7 @@
     {% if not ez_is_field_empty( content, field ) %}
     <ul {{ block( 'field_attributes' ) }}>
         {% for contentId in field.value.destinationContentIds %}
+        {{ fos_httpcache_tag('relation-' ~ contentId) }}
         <li>
             {{ render( controller( "ez_content:viewAction", {'contentId': contentId, 'viewType': 'embed', 'noLayout': 1} ) ) }}
         </li>
@@ -435,6 +436,7 @@
 {% block ezobjectrelation_field %}
 {% spaceless %}
 {% if not ez_is_field_empty( content, field ) %}
+    {{ fos_httpcache_tag('relation-' ~ field.value.destinationContentId) }}
     <div {{ block( 'field_attributes' ) }}>
         {{ render( controller( "ez_content:viewAction", {'contentId': field.value.destinationContentId, 'viewType': 'text_linked', 'noLayout': 1} ) ) }}
     </div>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28848](https://jira.ez.no/browse/EZP-28848)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 6.13
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no


Testing note:
- With ezplatform-http-cache: This will only effectively work with v0.4.2 and higher, on lower versions it will not be part of xkey headers.
- Without ezplatform-http-cache: This will have no effect, and realtions cache claring is already cleared as part of the deprecated "Smart HTTP cache clearing" system, so no change there.

Review note:
- This implies a dependency on foshttpcache package until these field types are moved out to own bundles. However it will at least be version independent so we can still contain to move forward on removing http cache implematation from kernel.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
- [x] Should ideally do this on RichText to, which templates are affected?
