### PR TITLE
EZP-28853: Add VersionInfo to persistence cache (followup for 6.13)

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -352,6 +352,7 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
             $languageCode
         );
         $this->cache->clear('content', $contentId, $versionNo);
+        $this->cache->clear('content', 'info', $contentId, 'versioninfo', $versionNo);
 
         return $content;
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28853](https://jira.ez.no/browse/EZP-28853)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.13`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This is a followup to https://github.com/ezsystems/ezpublish-kernel/pull/2254 adding a relevant cache clear to a method added between versions 6.7 and 6.13.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
