### PR TITLE
EZP-28886: Method eZ\Publish\Core\FieldType\Page\Value::__toString() does not always return String

### DIFF
--- a/eZ/Publish/Core/FieldType/Page/Value.php
+++ b/eZ/Publish/Core/FieldType/Page/Value.php
@@ -38,7 +38,7 @@ class Value extends BaseValue
     public function __toString()
     {
         if ($this->page instanceof Page) {
-            return $this->page->layout;
+            return (string)$this->page->layout;
         }
 
         return '';


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28886](https://jira.ez.no/browse/EZP-28886)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`/`6.13`/`7.0`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Excerpt from JIRA:
> Currently, the method eZ\Publish\Core\FieldType\Page\Value::__toString() does not always return String. It returns null if the page layout equals null. This can cause further issues because PHP throws an error if magic method __toString() returns something different then String. 
Most of the other Value classes are casting the value returned from __toString() to String, so this is what most probably should also be done in this case.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests (skipped because this function isn't tested in other Value classes. I will implement them if there is a need).
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
