### PR TITLE
[CI][AppVeyor] Improved PHP and Composer installation process

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,33 +12,29 @@ branches:
         - /^\d.\d+$/
 
 init:
-    - SET PATH=c:\php;%PATH%
     - SET COMPOSER_NO_INTERACTION=1
-    - SET PHP=1
     - SET ANSICON=121x90 (121x90)
     - REG ADD "HKEY_CURRENT_USER\Software\Microsoft\Command Processor" /v DelayedExpansion /t REG_DWORD /d 1 /f
 
 install:
-    - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
-    - cd c:\php
-    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/php-7.1.2-nts-Win32-VC14-x86.zip
-    - IF %PHP%==1 7z x php-7.1.2-nts-Win32-VC14-x86.zip -y >nul
-    - IF %PHP%==1 del /Q *.zip
-    - IF %PHP%==1 copy /Y php.ini-development php.ini
-    - IF %PHP%==1 echo max_execution_time=0 >> php.ini
-    - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
-    - IF %PHP%==1 echo extension=php_intl.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_xsl.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_gd2.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_pdo_sqlite.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_mbstring.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_fileinfo.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_curl.dll >> php.ini
-    - IF %PHP%==1 echo memory_limit=512M >> php.ini
-    - IF %PHP%==1 echo default_charset="utf-8" >> php.ini
-    - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
-    - IF %PHP%==1 appveyor DownloadFile https://getcomposer.org/composer.phar
+    - cinst php -y -i --version 7.1.15
+    - cinst composer -y -i
+    - refreshenv
+    - cd c:\Tools\php71
+    - copy /Y php.ini-development php.ini
+    - echo extension_dir="ext" >> php.ini
+    - echo max_execution_time=0 >> php.ini
+    - echo date.timezone="UTC" >> php.ini
+    - echo extension=php_intl.dll >> php.ini
+    - echo extension=php_xsl.dll >> php.ini
+    - echo extension=php_gd2.dll >> php.ini
+    - echo extension=php_pdo_sqlite.dll >> php.ini
+    - echo extension=php_mbstring.dll >> php.ini
+    - echo extension=php_openssl.dll >> php.ini
+    - echo extension=php_fileinfo.dll >> php.ini
+    - echo extension=php_curl.dll >> php.ini
+    - echo memory_limit=512M >> php.ini
+    - echo default_charset="utf-8" >> php.ini
     - cd c:\projects\ezpublish-kernel
     - composer install --no-suggest --no-progress --ansi
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | n/a
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

For some time now AppVeyor fails due to restrictions on windows.php.net resources.
I found another way of installing `PHP` and `Composer` packages - via [Chocolatey package manager](https://chocolatey.org/) which is already available in AppVeyor build images (`cinst` command).

**TODO**:
- [x] Install PHP and Composer using Chocolatey.
- [x] Cleanup build script.
- [x] Wait for AppVeyor to confirm.
- [x] Ask for Code Review.
