### PR TITLE
EZP-26238: eZPlatform login screen redirecting to the link the user entered initially

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SecurityPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SecurityPass.php
@@ -79,6 +79,7 @@ class SecurityPass implements CompilerPassInterface
 
         $successHandlerDef = $container->getDefinition('security.authentication.success_handler');
         $successHandlerDef->setClass(DefaultAuthenticationSuccessHandler::class);
+        $successHandlerDef->addArgument($container->getParameter('ezpublish.siteaccess.groups'));
         $successHandlerDef->addMethodCall(
             'setConfigResolver',
             array($configResolverRef)

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/SecurityPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/SecurityPassTest.php
@@ -24,6 +24,7 @@ class SecurityPassTest extends AbstractCompilerPassTestCase
         $this->setDefinition('security.authentication.provider.anonymous', new Definition());
         $this->setDefinition('security.http_utils', new Definition());
         $this->setDefinition('security.authentication.success_handler', new Definition());
+        $this->setParameter('ezpublish.siteaccess.groups', []);
     }
 
     protected function registerCompilerPass(ContainerBuilder $container)

--- a/eZ/Publish/Core/MVC/Symfony/Security/Authentication/DefaultAuthenticationSuccessHandler.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Authentication/DefaultAuthenticationSuccessHandler.php
@@ -9,10 +9,29 @@
 namespace eZ\Publish\Core\MVC\Symfony\Security\Authentication;
 
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use EzSystems\EzPlatformAdminUiBundle\EzPlatformAdminUiBundle;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler as BaseSuccessHandler;
+use Symfony\Component\Security\Http\HttpUtils;
 
 class DefaultAuthenticationSuccessHandler extends BaseSuccessHandler
 {
+    /**
+     * @var array
+     */
+    private $siteAccessGroups;
+
+    /**
+     * @param HttpUtils $httpUtils
+     * @param array $options
+     * @param array $siteAccessGroups
+     */
+    public function __construct(HttpUtils $httpUtils, array $options = array(), array $siteAccessGroups = [])
+    {
+        parent::__construct($httpUtils, $options);
+        $this->siteAccessGroups = $siteAccessGroups;
+    }
+
     /**
      * Injects the ConfigResolver to potentially override default_target_path for redirections after authentication success.
      *
@@ -24,5 +43,34 @@ class DefaultAuthenticationSuccessHandler extends BaseSuccessHandler
         if ($defaultPage !== null) {
             $this->options['default_target_path'] = $defaultPage;
         }
+    }
+
+    /**
+     * Builds the target URL according to the defined options.
+     * Overwrites default page after login for admin siteaccess.
+     * @param Request $request
+     *
+     * @return string
+     */
+    protected function determineTargetUrl(Request $request)
+    {
+        if ($this->isAdmin($request)) {
+            $this->options['default_target_path'] = 'ezplatform.dashboard';
+        }
+
+        return parent::determineTargetUrl($request);
+    }
+
+    /**
+     * Decides if used siteaccess if in admin_group.
+     * @param Request $request
+     *
+     * @return bool
+     */
+    private function isAdmin(Request $request): bool
+    {
+        $siteAccess = $request->attributes->get('siteaccess');
+
+        return in_array($siteAccess->name, $this->siteAccessGroups[EzPlatformAdminUiBundle::ADMIN_GROUP_NAME], true);
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-26238](https://jira.ez.no/browse/EZP-26238)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `master` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This solves correct redirecting for admin_sitegroups after login, without messing up frontend login redirect.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
