### PR TITLE
Added PermissionResolver::hasAccess BC break notice

### DIFF
--- a/doc/bc/changes-7.1.md
+++ b/doc/bc/changes-7.1.md
@@ -3,11 +3,11 @@
 Changes affecting version compatibility with former or future versions.
 
 ## Changes
-
+* The method `eZ\Publish\API\Repository\PermissionResolver::hasAccess` will now throw an `eZ\Publish\API\Repository\Exceptions\InvalidArgumentException` if module or function is invalid.
 
 ## Deprecations
 
-
+* The `eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider\RepositoryPolicyProvider` is no longer used. System policies configuration was moved to the `eZ/Publish/Core/settings/policies.yml` file.
 
 ## Removed features
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28926](https://jira.ez.no/browse/EZP-28926)
| **New feature**    | no
| **Target version** | `master` 

This PR adds missing BC break notice in docs.
