### PR TITLE
EZP-28934: LocationService doesn't check content/manage_locations policy during location create

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
@@ -1566,7 +1566,7 @@ class ContentServiceAuthorizationTest extends BaseContentServiceTest
 
         // Create and publish folders for the test case
         $folderDraft = $this->createContentDraft('folder', 2, ['name' => 'Folder1']);
-        $sourceFolder = $contentService->publishVersion($folderDraft->versionInfo);
+        $contentService->publishVersion($folderDraft->versionInfo);
         $authorizedFolderDraft = $this->createContentDraft('folder', 2, ['name' => 'AuthorizedFolder']);
         $authorizedFolder = $contentService->publishVersion($authorizedFolderDraft->versionInfo);
 
@@ -1583,9 +1583,6 @@ class ContentServiceAuthorizationTest extends BaseContentServiceTest
         $policyCreateStruct = $roleService->newPolicyCreateStruct('content', 'create');
         $policyCreateStruct->addLimitation($locationLimitation);
         $roleCreateStruct->addPolicy($policyCreateStruct);
-
-        $sourceFolderLocation = $locationService->loadLocation($sourceFolder->contentInfo->mainLocationId);
-        $authorizedFolderLocation = $locationService->loadLocation($authorizedFolder->contentInfo->mainLocationId);
 
         // check if content/publish policy is available (@since 6.8)
         $limitations = $roleService->getLimitationTypesByModuleFunction('content', 'publish');

--- a/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
@@ -1566,7 +1566,7 @@ class ContentServiceAuthorizationTest extends BaseContentServiceTest
 
         // Create and publish folders for the test case
         $folderDraft = $this->createContentDraft('folder', 2, ['name' => 'Folder1']);
-        $contentService->publishVersion($folderDraft->versionInfo);
+        $sourceFolder = $contentService->publishVersion($folderDraft->versionInfo);
         $authorizedFolderDraft = $this->createContentDraft('folder', 2, ['name' => 'AuthorizedFolder']);
         $authorizedFolder = $contentService->publishVersion($authorizedFolderDraft->versionInfo);
 
@@ -1578,10 +1578,14 @@ class ContentServiceAuthorizationTest extends BaseContentServiceTest
         );
         $roleCreateStruct->addPolicy($roleService->newPolicyCreateStruct('content', 'read'));
         $roleCreateStruct->addPolicy($roleService->newPolicyCreateStruct('content', 'versionread'));
+        $roleCreateStruct->addPolicy($roleService->newPolicyCreateStruct('content', 'manage_locations'));
 
         $policyCreateStruct = $roleService->newPolicyCreateStruct('content', 'create');
         $policyCreateStruct->addLimitation($locationLimitation);
         $roleCreateStruct->addPolicy($policyCreateStruct);
+
+        $sourceFolderLocation = $locationService->loadLocation($sourceFolder->contentInfo->mainLocationId);
+        $authorizedFolderLocation = $locationService->loadLocation($authorizedFolder->contentInfo->mainLocationId);
 
         // check if content/publish policy is available (@since 6.8)
         $limitations = $roleService->getLimitationTypesByModuleFunction('content', 'publish');

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -350,6 +350,10 @@ class LocationService implements LocationServiceInterface
         $content = $this->repository->getContentService()->loadContent($contentInfo->id);
         $parentLocation = $this->loadLocation($locationCreateStruct->parentLocationId);
 
+        if (!$this->repository->canUser('content', 'manage_locations', $contentInfo)) {
+            throw new UnauthorizedException('content', 'manage_locations');
+        }
+
         if (!$this->repository->canUser('content', 'create', $content->contentInfo, $parentLocation)) {
             throw new UnauthorizedException('content', 'create');
         }

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -350,7 +350,7 @@ class LocationService implements LocationServiceInterface
         $content = $this->repository->getContentService()->loadContent($contentInfo->id);
         $parentLocation = $this->loadLocation($locationCreateStruct->parentLocationId);
 
-        if (!$this->repository->canUser('content', 'manage_locations', $contentInfo)) {
+        if (!$this->repository->canUser('content', 'manage_locations', $content->contentInfo, $parentLocation)) {
             throw new UnauthorizedException('content', 'manage_locations');
         }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28934](https://jira.ez.no/browse/EZP-28934)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `6.7`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR adds additional permission checking on the location creating. As in legacy, `content/manage_locations` policy should be check. 

**TODO**:
- [x] Fix a bug.
- [x] Improve tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
- [x] Add integration tests