### PR TITLE
Set utf8mb4 charset and collation on mysql kernel schema and fixtures

### DIFF
--- a/data/mysql/dfs_schema.sql
+++ b/data/mysql/dfs_schema.sql
@@ -20,7 +20,7 @@ CREATE TABLE ezdfsfile (
   KEY `ezdfsfile_name_trunk` (`name_trunk`(250)),
   KEY `ezdfsfile_mtime` (`mtime`),
   KEY `ezdfsfile_expired_name` (`expired`,`name`(250))
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 

--- a/data/mysql/dfs_schema.sql
+++ b/data/mysql/dfs_schema.sql
@@ -4,7 +4,7 @@
 
 DROP TABLE IF EXISTS `ezdfsfile`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE ezdfsfile (
   `name` text NOT NULL,
   `name_trunk` text NOT NULL,
@@ -20,7 +20,7 @@ CREATE TABLE ezdfsfile (
   KEY `ezdfsfile_name_trunk` (`name_trunk`(250)),
   KEY `ezdfsfile_mtime` (`mtime`),
   KEY `ezdfsfile_expired_name` (`expired`,`name`(250))
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 

--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -1599,8 +1599,8 @@ CREATE TABLE `ezprest_authcode` (
   `id` varchar(200) NOT NULL DEFAULT '',
   `scope` varchar(200) DEFAULT NULL,
   `user_id` int(11) NOT NULL DEFAULT '0',
-  PRIMARY KEY (`id`),
-  KEY `authcode_client_id` (`client_id`)
+  PRIMARY KEY (`id` (191)),
+  KEY `authcode_client_id` (`client_id` (191))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -1640,7 +1640,7 @@ CREATE TABLE `ezprest_clients` (
   `updated` int(11) NOT NULL DEFAULT '0',
   `version` int(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `client_id_unique` (`client_id`,`version`)
+  UNIQUE KEY `client_id_unique` (`client_id` (191),`version`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -1658,8 +1658,8 @@ CREATE TABLE `ezprest_token` (
   `refresh_token` varchar(200) NOT NULL DEFAULT '',
   `scope` varchar(200) DEFAULT NULL,
   `user_id` int(11) NOT NULL DEFAULT '0',
-  PRIMARY KEY (`id`),
-  KEY `token_client_id` (`client_id`)
+  PRIMARY KEY (`id` (191)),
+  KEY `token_client_id` (`client_id` (191))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -1913,7 +1913,7 @@ CREATE TABLE `ezsearch_search_phrase` (
   `phrase_count` int(11) DEFAULT '0',
   `result_count` int(11) DEFAULT '0',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `ezsearch_search_phrase_phrase` (`phrase`),
+  UNIQUE KEY `ezsearch_search_phrase_phrase` (`phrase` (191)),
   KEY `ezsearch_search_phrase_count` (`phrase_count`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -27,7 +27,7 @@ CREATE TABLE `ezapprove_items` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `workflow_process_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -44,7 +44,7 @@ CREATE TABLE `ezbasket` (
   `session_id` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   KEY `ezbasket_session_id` (`session_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -62,7 +62,7 @@ CREATE TABLE `ezbinaryfile` (
   `original_filename` varchar(255) NOT NULL DEFAULT '',
   `version` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`contentobject_attribute_id`,`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -83,7 +83,7 @@ CREATE TABLE `ezcobj_state` (
   UNIQUE KEY `ezcobj_state_identifier` (`group_id`,`identifier`),
   KEY `ezcobj_state_lmask` (`language_mask`),
   KEY `ezcobj_state_priority` (`priority`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -101,7 +101,7 @@ CREATE TABLE `ezcobj_state_group` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `ezcobj_state_group_identifier` (`identifier`),
   KEY `ezcobj_state_group_lmask` (`language_mask`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -118,7 +118,7 @@ CREATE TABLE `ezcobj_state_group_language` (
   `name` varchar(45) NOT NULL DEFAULT '',
   `real_language_id` bigint(20) NOT NULL DEFAULT '0',
   PRIMARY KEY (`contentobject_state_group_id`,`real_language_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -134,7 +134,7 @@ CREATE TABLE `ezcobj_state_language` (
   `language_id` bigint(20) NOT NULL DEFAULT '0',
   `name` varchar(45) NOT NULL DEFAULT '',
   PRIMARY KEY (`contentobject_state_id`,`language_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -148,7 +148,7 @@ CREATE TABLE `ezcobj_state_link` (
   `contentobject_id` int(11) NOT NULL DEFAULT '0',
   `contentobject_state_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`contentobject_id`,`contentobject_state_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -172,7 +172,7 @@ CREATE TABLE `ezcollab_group` (
   PRIMARY KEY (`id`),
   KEY `ezcollab_group_depth` (`depth`),
   KEY `ezcollab_group_path` (`path_string`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -199,7 +199,7 @@ CREATE TABLE `ezcollab_item` (
   `status` int(11) NOT NULL DEFAULT '1',
   `type_identifier` varchar(40) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -219,7 +219,7 @@ CREATE TABLE `ezcollab_item_group_link` (
   `modified` int(11) NOT NULL DEFAULT '0',
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`collaboration_id`,`group_id`,`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -238,7 +238,7 @@ CREATE TABLE `ezcollab_item_message_link` (
   `modified` int(11) NOT NULL DEFAULT '0',
   `participant_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -259,7 +259,7 @@ CREATE TABLE `ezcollab_item_participant_link` (
   `participant_role` int(11) NOT NULL DEFAULT '1',
   `participant_type` int(11) NOT NULL DEFAULT '1',
   PRIMARY KEY (`collaboration_id`,`participant_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -276,7 +276,7 @@ CREATE TABLE `ezcollab_item_status` (
   `last_read` int(11) NOT NULL DEFAULT '0',
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`collaboration_id`,`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -291,7 +291,7 @@ CREATE TABLE `ezcollab_notification_rule` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -309,7 +309,7 @@ CREATE TABLE `ezcollab_profile` (
   `modified` int(11) NOT NULL DEFAULT '0',
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -335,7 +335,7 @@ CREATE TABLE `ezcollab_simple_message` (
   `message_type` varchar(40) NOT NULL DEFAULT '',
   `modified` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -364,7 +364,7 @@ CREATE TABLE `ezcomment` (
   PRIMARY KEY (`id`),
   KEY `user_id_session_key_ip` (`user_id`,`session_key`,`ip`),
   KEY `content_parentcomment` (`contentobject_id`,`language_id`,`parent_comment_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -382,7 +382,7 @@ CREATE TABLE `ezcomment_notification` (
   `status` int(11) NOT NULL DEFAULT '1',
   `comment_id` int(11) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -399,7 +399,7 @@ CREATE TABLE `ezcomment_subscriber` (
   `enabled` int(11) NOT NULL DEFAULT '1',
   `hash_string` varchar(50) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -420,7 +420,7 @@ CREATE TABLE `ezcomment_subscription` (
   `enabled` int(11) NOT NULL DEFAULT '1',
   `hash_string` varchar(50) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -437,7 +437,7 @@ CREATE TABLE `ezcontent_language` (
   `name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   KEY `ezcontent_language_name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -454,7 +454,7 @@ CREATE TABLE `ezcontentbrowsebookmark` (
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `ezcontentbrowsebookmark_user` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -472,7 +472,7 @@ CREATE TABLE `ezcontentbrowserecent` (
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `ezcontentbrowserecent_user` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -504,7 +504,7 @@ CREATE TABLE `ezcontentclass` (
   PRIMARY KEY (`id`,`version`),
   KEY `ezcontentclass_version` (`version`),
   KEY `ezcontentclass_identifier` (`identifier`,`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -544,7 +544,7 @@ CREATE TABLE `ezcontentclass_attribute` (
   `version` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`,`version`),
   KEY `ezcontentclass_attr_ccid` (`contentclass_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -560,7 +560,7 @@ CREATE TABLE `ezcontentclass_classgroup` (
   `group_id` int(11) NOT NULL DEFAULT '0',
   `group_name` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`contentclass_id`,`contentclass_version`,`group_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -577,7 +577,7 @@ CREATE TABLE `ezcontentclass_name` (
   `language_locale` varchar(20) NOT NULL DEFAULT '',
   `name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`contentclass_id`,`contentclass_version`,`language_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -595,7 +595,7 @@ CREATE TABLE `ezcontentclassgroup` (
   `modifier_id` int(11) NOT NULL DEFAULT '0',
   `name` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -626,7 +626,7 @@ CREATE TABLE `ezcontentobject` (
   KEY `ezcontentobject_owner` (`owner_id`),
   KEY `ezcontentobject_pub` (`published`),
   KEY `ezcontentobject_status` (`status`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -656,7 +656,7 @@ CREATE TABLE `ezcontentobject_attribute` (
   KEY ezcontentobject_classattr_id (contentclassattribute_id),
   KEY `sort_key_int` (`sort_key_int`),
   KEY `sort_key_string` (`sort_key_string`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -676,7 +676,7 @@ CREATE TABLE `ezcontentobject_link` (
   PRIMARY KEY (`id`),
   KEY `ezco_link_from` (`from_contentobject_id`,`from_contentobject_version`,`contentclassattribute_id`),
   KEY `ezco_link_to_co_id` (`to_contentobject_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -697,7 +697,7 @@ CREATE TABLE `ezcontentobject_name` (
   KEY `ezcontentobject_name_cov_id` (`content_version`),
   KEY `ezcontentobject_name_lang_id` (`language_id`),
   KEY `ezcontentobject_name_name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -730,7 +730,7 @@ CREATE TABLE `ezcontentobject_trash` (
   KEY `ezcobj_trash_p_node_id` (`parent_node_id`),
   KEY `ezcobj_trash_path` (`path_string`),
   KEY `ezcobj_trash_path_ident` (`path_identification_string`(50))
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -765,7 +765,7 @@ CREATE TABLE `ezcontentobject_tree` (
   KEY `ezcontentobject_tree_path` (`path_string`),
   KEY `ezcontentobject_tree_path_ident` (`path_identification_string`(50)),
   KEY `modified_subnode` (`modified_subnode`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -792,7 +792,7 @@ CREATE TABLE `ezcontentobject_version` (
   KEY `ezcobj_version_status` (`status`),
   KEY `idx_object_version_objver` (`contentobject_id`,`version`),
   KEY `ezcontobj_version_obj_status` (`contentobject_id`,`status`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -813,7 +813,7 @@ CREATE TABLE `ezcurrencydata` (
   `symbol` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   KEY `ezcurrencydata_code` (`code`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -827,7 +827,7 @@ CREATE TABLE `ezdiscountrule` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -844,7 +844,7 @@ CREATE TABLE `ezdiscountsubrule` (
   `limitation` char(1) DEFAULT NULL,
   `name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -859,7 +859,7 @@ CREATE TABLE `ezdiscountsubrule_value` (
   `issection` int(11) NOT NULL DEFAULT '0',
   `value` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`discountsubrule_id`,`value`,`issection`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -876,7 +876,7 @@ CREATE TABLE `ezenumobjectvalue` (
   `enumid` int(11) NOT NULL DEFAULT '0',
   `enumvalue` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`contentobject_attribute_id`,`contentobject_attribute_version`,`enumid`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -895,7 +895,7 @@ CREATE TABLE `ezenumvalue` (
   `placement` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`,`contentclass_attribute_id`,`contentclass_attribute_version`),
   KEY `ezenumvalue_co_cl_attr_id_co_class_att_ver` (`contentclass_attribute_id`,`contentclass_attribute_version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -912,7 +912,7 @@ CREATE TABLE `ezforgot_password` (
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `ezforgot_password_user` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -931,7 +931,7 @@ CREATE TABLE `ezgeneral_digest_user_settings` (
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `ezgeneral_digest_user_id` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -949,7 +949,7 @@ CREATE TABLE `ezgmaplocation` (
   `address` varchar(150) DEFAULT NULL,
   PRIMARY KEY (`contentobject_attribute_id`,`contentobject_version`),
   KEY `latitude_longitude_key` (`latitude`,`longitude`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -966,7 +966,7 @@ CREATE TABLE `ezimagefile` (
   PRIMARY KEY (`id`),
   KEY `ezimagefile_coid` (`contentobject_attribute_id`),
   KEY `ezimagefile_file` (`filepath`(200))
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -985,7 +985,7 @@ CREATE TABLE `ezinfocollection` (
   `user_identifier` varchar(34) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `ezinfocollection_co_id_created` (`contentobject_id`,`created`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1009,7 +1009,7 @@ CREATE TABLE `ezinfocollection_attribute` (
   KEY `ezinfocollection_attr_co_id` (`contentobject_id`),
   KEY `ezinfocollection_attr_coa_id` (`contentobject_attribute_id`),
   KEY `ezinfocollection_attr_ic_id` (`informationcollection_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1024,7 +1024,7 @@ CREATE TABLE `ezisbn_group` (
   `group_number` int(11) NOT NULL DEFAULT '0',
   `id` int(11) NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1042,7 +1042,7 @@ CREATE TABLE `ezisbn_group_range` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `to_number` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1061,7 +1061,7 @@ CREATE TABLE `ezisbn_registrant_range` (
   `registrant_to` varchar(32) NOT NULL DEFAULT '',
   `to_number` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1077,7 +1077,7 @@ CREATE TABLE `ezkeyword` (
   `keyword` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `ezkeyword_keyword` (`keyword`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1094,7 +1094,7 @@ CREATE TABLE `ezkeyword_attribute_link` (
   PRIMARY KEY (`id`),
   KEY `ezkeyword_attr_link_kid_oaid` (`keyword_id`,`objectattribute_id`),
   KEY `ezkeyword_attr_link_oaid` (`objectattribute_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1119,7 +1119,7 @@ CREATE TABLE `ezm_block` (
   PRIMARY KEY (`id`),
   KEY `ezm_block__is_removed` (`is_removed`),
   KEY `ezm_block__node_id` (`node_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1143,7 +1143,7 @@ CREATE TABLE `ezm_pool` (
   KEY `ezm_pool__block_id__ts_publication__priority` (`block_id`,`ts_publication`,`priority`),
   KEY `ezm_pool__block_id__ts_visible` (`block_id`,`ts_visible`),
   KEY `ezm_pool__block_id__ts_hidden` (`block_id`,`ts_hidden`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1168,7 +1168,7 @@ CREATE TABLE `ezmedia` (
   `version` int(11) NOT NULL DEFAULT '0',
   `width` int(11) DEFAULT NULL,
   PRIMARY KEY (`contentobject_attribute_id`,`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1188,7 +1188,7 @@ CREATE TABLE `ezmessage` (
   `send_weekday` varchar(50) NOT NULL DEFAULT '',
   `title` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1206,7 +1206,7 @@ CREATE TABLE `ezmodule_run` (
   `workflow_process_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `ezmodule_run_workflow_process_id_s` (`workflow_process_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1227,7 +1227,7 @@ CREATE TABLE `ezmultipricedata` (
   KEY `ezmultipricedata_coa_id` (`contentobject_attr_id`),
   KEY `ezmultipricedata_coa_version` (`contentobject_attr_version`),
   KEY `ezmultipricedata_currency_code` (`currency_code`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1256,7 +1256,7 @@ CREATE TABLE `eznode_assignment` (
   KEY `eznode_assignment_coid_cov` (`contentobject_id`,`contentobject_version`),
   KEY `eznode_assignment_is_main` (`is_main`),
   KEY `eznode_assignment_parent_node` (`parent_node`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1274,7 +1274,7 @@ CREATE TABLE `eznotificationcollection` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `transport` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1291,7 +1291,7 @@ CREATE TABLE `eznotificationcollection_item` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `send_date` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1314,7 +1314,7 @@ CREATE TABLE `eznotificationevent` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `status` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1332,7 +1332,7 @@ CREATE TABLE `ezoperation_memento` (
   `memento_key` varchar(32) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`,`memento_key`),
   KEY `ezoperation_memento_memento_key_main` (`memento_key`,`main`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1361,7 +1361,7 @@ CREATE TABLE `ezorder` (
   PRIMARY KEY (`id`),
   KEY `ezorder_is_archived` (`is_archived`),
   KEY `ezorder_is_tmp` (`is_temporary`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1382,7 +1382,7 @@ CREATE TABLE `ezorder_item` (
   PRIMARY KEY (`id`),
   KEY `ezorder_item_order_id` (`order_id`),
   KEY `ezorder_item_type` (`type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1395,7 +1395,7 @@ DROP TABLE IF EXISTS `ezorder_nr_incr`;
 CREATE TABLE `ezorder_nr_incr` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1414,7 +1414,7 @@ CREATE TABLE `ezorder_status` (
   KEY `ezorder_status_active` (`is_active`),
   KEY `ezorder_status_name` (`name`),
   KEY `ezorder_status_sid` (`status_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1434,7 +1434,7 @@ CREATE TABLE `ezorder_status_history` (
   KEY `ezorder_status_history_mod` (`modified`),
   KEY `ezorder_status_history_oid` (`order_id`),
   KEY `ezorder_status_history_sid` (`status_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1450,7 +1450,7 @@ CREATE TABLE `ezpackage` (
   `name` varchar(100) NOT NULL DEFAULT '',
   `version` varchar(30) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1467,7 +1467,7 @@ CREATE TABLE `ezpaymentobject` (
   `status` int(11) NOT NULL DEFAULT '0',
   `workflowprocess_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1495,7 +1495,7 @@ CREATE TABLE `ezpdf_export` (
   `title` varchar(255) DEFAULT NULL,
   `version` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`,`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1513,7 +1513,7 @@ CREATE TABLE `ezpending_actions` (
   PRIMARY KEY (`id`),
   KEY `ezpending_actions_action` (`action`),
   KEY `ezpending_actions_created` (`created`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1532,7 +1532,7 @@ CREATE TABLE `ezpolicy` (
   PRIMARY KEY (`id`),
   KEY `ezpolicy_original_id` (`original_id`),
   KEY `ezpolicy_role_id` (`role_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1548,7 +1548,7 @@ CREATE TABLE `ezpolicy_limitation` (
   `policy_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `policy_id` (`policy_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1565,7 +1565,7 @@ CREATE TABLE `ezpolicy_limitation_value` (
   PRIMARY KEY (`id`),
   KEY `ezpolicy_limitation_value_val` (`value`),
   KEY `ezpolicy_limit_value_limit_id` (`limitation_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1583,7 +1583,7 @@ CREATE TABLE `ezpreferences` (
   PRIMARY KEY (`id`),
   KEY `ezpreferences_name` (`name`),
   KEY `ezpreferences_user_id_idx` (`user_id`,`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1601,7 +1601,7 @@ CREATE TABLE `ezprest_authcode` (
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `authcode_client_id` (`client_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1618,7 +1618,7 @@ CREATE TABLE `ezprest_authorized_clients` (
   `user_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `client_user` (`rest_client_id`,`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1641,7 +1641,7 @@ CREATE TABLE `ezprest_clients` (
   `version` int(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `client_id_unique` (`client_id`,`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1660,7 +1660,7 @@ CREATE TABLE `ezprest_token` (
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `token_client_id` (`client_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1674,7 +1674,7 @@ CREATE TABLE `ezproductcategory` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1689,7 +1689,7 @@ CREATE TABLE `ezproductcollection` (
   `currency_code` varchar(4) NOT NULL DEFAULT '',
   `id` int(11) NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1712,7 +1712,7 @@ CREATE TABLE `ezproductcollection_item` (
   PRIMARY KEY (`id`),
   KEY `ezproductcollection_item_contentobject_id` (`contentobject_id`),
   KEY `ezproductcollection_item_productcollection_id` (`productcollection_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1732,7 +1732,7 @@ CREATE TABLE `ezproductcollection_item_opt` (
   `value` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   KEY `ezproductcollection_item_opt_item_id` (`item_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1750,7 +1750,7 @@ CREATE TABLE `ezpublishingqueueprocesses` (
   `started` int(11) DEFAULT NULL,
   `status` int(2) DEFAULT NULL,
   PRIMARY KEY (`ezcontentobject_version_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1767,7 +1767,7 @@ CREATE TABLE `ezrole` (
   `value` char(1) DEFAULT NULL,
   `version` int(11) DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1796,7 +1796,7 @@ CREATE TABLE `ezrss_export` (
   `title` varchar(255) DEFAULT NULL,
   `url` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`,`status`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1819,7 +1819,7 @@ CREATE TABLE `ezrss_export_item` (
   `title` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`,`status`),
   KEY `ezrss_export_rsseid` (`rssexport_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1847,7 +1847,7 @@ CREATE TABLE `ezrss_import` (
   `status` int(11) NOT NULL DEFAULT '0',
   `url` longtext,
   PRIMARY KEY (`id`,`status`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1867,7 +1867,7 @@ CREATE TABLE `ezscheduled_script` (
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `ezscheduled_script_timestamp` (`last_report_timestamp`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1897,7 +1897,7 @@ CREATE TABLE `ezsearch_object_word_link` (
   KEY `ezsearch_object_word_link_integer_value` (`integer_value`),
   KEY `ezsearch_object_word_link_object` (`contentobject_id`),
   KEY `ezsearch_object_word_link_word` (`word_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1915,7 +1915,7 @@ CREATE TABLE `ezsearch_search_phrase` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `ezsearch_search_phrase_phrase` (`phrase`),
   KEY `ezsearch_search_phrase_count` (`phrase_count`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1932,7 +1932,7 @@ CREATE TABLE `ezsearch_word` (
   PRIMARY KEY (`id`),
   KEY `ezsearch_word_obj_count` (`object_count`),
   KEY `ezsearch_word_word_i` (`word`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1949,7 +1949,7 @@ CREATE TABLE `ezsection` (
   `name` varchar(255) DEFAULT NULL,
   `navigation_part_identifier` varchar(100) DEFAULT 'ezcontentnavigationpart',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1968,7 +1968,7 @@ CREATE TABLE `ezsession` (
   PRIMARY KEY (`session_key`),
   KEY `expiration_time` (`expiration_time`),
   KEY `ezsession_user_id` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1982,7 +1982,7 @@ CREATE TABLE `ezsite_data` (
   `name` varchar(60) NOT NULL DEFAULT '',
   `value` longtext NOT NULL,
   PRIMARY KEY (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1998,7 +1998,7 @@ CREATE TABLE `ezstarrating` (
   `rating_average` float NOT NULL,
   `rating_count` int(11) NOT NULL,
   PRIMARY KEY (`contentobject_id`,`contentobject_attribute_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2019,7 +2019,7 @@ CREATE TABLE `ezstarrating_data` (
   PRIMARY KEY (`id`),
   KEY `user_id_session_key` (`user_id`,`session_key`),
   KEY `contentobject_id_contentobject_attribute_id` (`contentobject_id`,`contentobject_attribute_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2036,7 +2036,7 @@ CREATE TABLE `ezsubtree_notification_rule` (
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `ezsubtree_notification_rule_user_id` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2051,7 +2051,7 @@ CREATE TABLE `eztipafriend_counter` (
   `node_id` int(11) NOT NULL DEFAULT '0',
   `requested` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`node_id`,`requested`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2066,7 +2066,7 @@ CREATE TABLE `eztipafriend_request` (
   `email_receiver` varchar(100) NOT NULL DEFAULT '',
   KEY `eztipafriend_request_created` (`created`),
   KEY `eztipafriend_request_email_rec` (`email_receiver`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2086,7 +2086,7 @@ CREATE TABLE `eztrigger` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `eztrigger_def_id` (`module_name`(50),`function_name`(50),`connect_type`),
   KEY `eztrigger_fetch` (`name`(25),`module_name`(50),`function_name`(50))
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2106,7 +2106,7 @@ CREATE TABLE `ezurl` (
   `url` longtext,
   PRIMARY KEY (`id`),
   KEY `ezurl_url` (`url`(255))
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2123,7 +2123,7 @@ CREATE TABLE `ezurl_object_link` (
   KEY `ezurl_ol_coa_id` (`contentobject_attribute_id`),
   KEY `ezurl_ol_coa_version` (`contentobject_attribute_version`),
   KEY `ezurl_ol_url_id` (`url_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2149,7 +2149,7 @@ CREATE TABLE `ezurlalias` (
   KEY `ezurlalias_source_md5` (`source_md5`),
   KEY `ezurlalias_source_url` (`source_url`(255)),
   KEY `ezurlalias_wcard_fwd` (`is_wildcard`,`forward_to_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2179,7 +2179,7 @@ CREATE TABLE `ezurlalias_ml` (
   KEY `ezurlalias_ml_par_lnk_txt` (`parent`,`text`(32),`link`),
   KEY `ezurlalias_ml_text` (`text`(32),`id`,`link`),
   KEY `ezurlalias_ml_text_lang` (`text`(32),`lang_mask`,`parent`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2192,7 +2192,7 @@ DROP TABLE IF EXISTS `ezurlalias_ml_incr`;
 CREATE TABLE `ezurlalias_ml_incr` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2208,7 +2208,7 @@ CREATE TABLE `ezurlwildcard` (
   `source_url` longtext NOT NULL,
   `type` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2226,7 +2226,7 @@ CREATE TABLE `ezuser` (
   `password_hash_type` int(11) NOT NULL DEFAULT '1',
   PRIMARY KEY (`contentobject_id`),
   UNIQUE KEY `ezuser_login` (`login`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2243,7 +2243,7 @@ CREATE TABLE `ezuser_accountkey` (
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `hash_key` (`hash_key`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2259,7 +2259,7 @@ CREATE TABLE `ezuser_discountrule` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2278,7 +2278,7 @@ CREATE TABLE `ezuser_role` (
   PRIMARY KEY (`id`),
   KEY `ezuser_role_contentobject_id` (`contentobject_id`),
   KEY `ezuser_role_role_id` (`role_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2293,7 +2293,7 @@ CREATE TABLE `ezuser_setting` (
   `max_login` int(11) DEFAULT NULL,
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2311,7 +2311,7 @@ CREATE TABLE `ezuservisit` (
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`user_id`),
   KEY `ezuservisit_co_visit_count` (`current_visit_timestamp`,`login_count`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2326,7 +2326,7 @@ CREATE TABLE `ezvatrule` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `vat_type` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2340,7 +2340,7 @@ CREATE TABLE `ezvatrule_product_category` (
   `product_category_id` int(11) NOT NULL DEFAULT '0',
   `vatrule_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`vatrule_id`,`product_category_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2355,7 +2355,7 @@ CREATE TABLE `ezvattype` (
   `name` varchar(255) NOT NULL DEFAULT '',
   `percentage` float DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2369,7 +2369,7 @@ CREATE TABLE `ezview_counter` (
   `count` int(11) NOT NULL DEFAULT '0',
   `node_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`node_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2387,7 +2387,7 @@ CREATE TABLE `ezwaituntildatevalue` (
   `workflow_event_version` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`,`workflow_event_id`,`workflow_event_version`),
   KEY `ezwaituntildateevalue_wf_ev_id_wf_ver` (`workflow_event_id`,`workflow_event_version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2402,7 +2402,7 @@ CREATE TABLE `ezwishlist` (
   `productcollection_id` int(11) NOT NULL DEFAULT '0',
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2423,7 +2423,7 @@ CREATE TABLE `ezworkflow` (
   `version` int(11) NOT NULL DEFAULT '0',
   `workflow_type_string` varchar(50) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`,`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2440,7 +2440,7 @@ CREATE TABLE `ezworkflow_assign` (
   `node_id` int(11) NOT NULL DEFAULT '0',
   `workflow_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2468,7 +2468,7 @@ CREATE TABLE `ezworkflow_event` (
   `workflow_type_string` varchar(50) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`,`version`),
   KEY `wid_version_placement` (`workflow_id`,`version`,`placement`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2486,7 +2486,7 @@ CREATE TABLE `ezworkflow_group` (
   `modifier_id` int(11) NOT NULL DEFAULT '0',
   `name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2502,7 +2502,7 @@ CREATE TABLE `ezworkflow_group_link` (
   `workflow_id` int(11) NOT NULL DEFAULT '0',
   `workflow_version` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`workflow_id`,`group_id`,`workflow_version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2536,7 +2536,7 @@ CREATE TABLE `ezworkflow_process` (
   `workflow_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `ezworkflow_process_process_key` (`process_key`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 

--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -7,7 +7,7 @@
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+/*!40101 SET NAMES utf8mb4 */;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -21,13 +21,13 @@
 
 DROP TABLE IF EXISTS `ezapprove_items`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezapprove_items` (
   `collaboration_id` int(11) NOT NULL DEFAULT '0',
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `workflow_process_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -36,7 +36,7 @@ CREATE TABLE `ezapprove_items` (
 
 DROP TABLE IF EXISTS `ezbasket`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezbasket` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `order_id` int(11) NOT NULL DEFAULT '0',
@@ -44,7 +44,7 @@ CREATE TABLE `ezbasket` (
   `session_id` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   KEY `ezbasket_session_id` (`session_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -53,7 +53,7 @@ CREATE TABLE `ezbasket` (
 
 DROP TABLE IF EXISTS `ezbinaryfile`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezbinaryfile` (
   `contentobject_attribute_id` int(11) NOT NULL DEFAULT '0',
   `download_count` int(11) NOT NULL DEFAULT '0',
@@ -62,7 +62,7 @@ CREATE TABLE `ezbinaryfile` (
   `original_filename` varchar(255) NOT NULL DEFAULT '',
   `version` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`contentobject_attribute_id`,`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -71,7 +71,7 @@ CREATE TABLE `ezbinaryfile` (
 
 DROP TABLE IF EXISTS `ezcobj_state`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcobj_state` (
   `default_language_id` bigint(20) NOT NULL DEFAULT '0',
   `group_id` int(11) NOT NULL DEFAULT '0',
@@ -83,7 +83,7 @@ CREATE TABLE `ezcobj_state` (
   UNIQUE KEY `ezcobj_state_identifier` (`group_id`,`identifier`),
   KEY `ezcobj_state_lmask` (`language_mask`),
   KEY `ezcobj_state_priority` (`priority`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -92,7 +92,7 @@ CREATE TABLE `ezcobj_state` (
 
 DROP TABLE IF EXISTS `ezcobj_state_group`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcobj_state_group` (
   `default_language_id` bigint(20) NOT NULL DEFAULT '0',
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -101,7 +101,7 @@ CREATE TABLE `ezcobj_state_group` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `ezcobj_state_group_identifier` (`identifier`),
   KEY `ezcobj_state_group_lmask` (`language_mask`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -110,7 +110,7 @@ CREATE TABLE `ezcobj_state_group` (
 
 DROP TABLE IF EXISTS `ezcobj_state_group_language`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcobj_state_group_language` (
   `contentobject_state_group_id` int(11) NOT NULL DEFAULT '0',
   `description` longtext NOT NULL,
@@ -118,7 +118,7 @@ CREATE TABLE `ezcobj_state_group_language` (
   `name` varchar(45) NOT NULL DEFAULT '',
   `real_language_id` bigint(20) NOT NULL DEFAULT '0',
   PRIMARY KEY (`contentobject_state_group_id`,`real_language_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -127,14 +127,14 @@ CREATE TABLE `ezcobj_state_group_language` (
 
 DROP TABLE IF EXISTS `ezcobj_state_language`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcobj_state_language` (
   `contentobject_state_id` int(11) NOT NULL DEFAULT '0',
   `description` longtext NOT NULL,
   `language_id` bigint(20) NOT NULL DEFAULT '0',
   `name` varchar(45) NOT NULL DEFAULT '',
   PRIMARY KEY (`contentobject_state_id`,`language_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -143,12 +143,12 @@ CREATE TABLE `ezcobj_state_language` (
 
 DROP TABLE IF EXISTS `ezcobj_state_link`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcobj_state_link` (
   `contentobject_id` int(11) NOT NULL DEFAULT '0',
   `contentobject_state_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`contentobject_id`,`contentobject_state_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -157,7 +157,7 @@ CREATE TABLE `ezcobj_state_link` (
 
 DROP TABLE IF EXISTS `ezcollab_group`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcollab_group` (
   `created` int(11) NOT NULL DEFAULT '0',
   `depth` int(11) NOT NULL DEFAULT '0',
@@ -172,7 +172,7 @@ CREATE TABLE `ezcollab_group` (
   PRIMARY KEY (`id`),
   KEY `ezcollab_group_depth` (`depth`),
   KEY `ezcollab_group_path` (`path_string`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -181,7 +181,7 @@ CREATE TABLE `ezcollab_group` (
 
 DROP TABLE IF EXISTS `ezcollab_item`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcollab_item` (
   `created` int(11) NOT NULL DEFAULT '0',
   `creator_id` int(11) NOT NULL DEFAULT '0',
@@ -199,7 +199,7 @@ CREATE TABLE `ezcollab_item` (
   `status` int(11) NOT NULL DEFAULT '1',
   `type_identifier` varchar(40) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -208,7 +208,7 @@ CREATE TABLE `ezcollab_item` (
 
 DROP TABLE IF EXISTS `ezcollab_item_group_link`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcollab_item_group_link` (
   `collaboration_id` int(11) NOT NULL DEFAULT '0',
   `created` int(11) NOT NULL DEFAULT '0',
@@ -219,7 +219,7 @@ CREATE TABLE `ezcollab_item_group_link` (
   `modified` int(11) NOT NULL DEFAULT '0',
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`collaboration_id`,`group_id`,`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -228,7 +228,7 @@ CREATE TABLE `ezcollab_item_group_link` (
 
 DROP TABLE IF EXISTS `ezcollab_item_message_link`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcollab_item_message_link` (
   `collaboration_id` int(11) NOT NULL DEFAULT '0',
   `created` int(11) NOT NULL DEFAULT '0',
@@ -238,7 +238,7 @@ CREATE TABLE `ezcollab_item_message_link` (
   `modified` int(11) NOT NULL DEFAULT '0',
   `participant_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -247,7 +247,7 @@ CREATE TABLE `ezcollab_item_message_link` (
 
 DROP TABLE IF EXISTS `ezcollab_item_participant_link`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcollab_item_participant_link` (
   `collaboration_id` int(11) NOT NULL DEFAULT '0',
   `created` int(11) NOT NULL DEFAULT '0',
@@ -259,7 +259,7 @@ CREATE TABLE `ezcollab_item_participant_link` (
   `participant_role` int(11) NOT NULL DEFAULT '1',
   `participant_type` int(11) NOT NULL DEFAULT '1',
   PRIMARY KEY (`collaboration_id`,`participant_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -268,7 +268,7 @@ CREATE TABLE `ezcollab_item_participant_link` (
 
 DROP TABLE IF EXISTS `ezcollab_item_status`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcollab_item_status` (
   `collaboration_id` int(11) NOT NULL DEFAULT '0',
   `is_active` int(11) NOT NULL DEFAULT '1',
@@ -276,7 +276,7 @@ CREATE TABLE `ezcollab_item_status` (
   `last_read` int(11) NOT NULL DEFAULT '0',
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`collaboration_id`,`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -285,13 +285,13 @@ CREATE TABLE `ezcollab_item_status` (
 
 DROP TABLE IF EXISTS `ezcollab_notification_rule`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcollab_notification_rule` (
   `collab_identifier` varchar(255) NOT NULL DEFAULT '',
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -300,7 +300,7 @@ CREATE TABLE `ezcollab_notification_rule` (
 
 DROP TABLE IF EXISTS `ezcollab_profile`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcollab_profile` (
   `created` int(11) NOT NULL DEFAULT '0',
   `data_text1` longtext NOT NULL,
@@ -309,7 +309,7 @@ CREATE TABLE `ezcollab_profile` (
   `modified` int(11) NOT NULL DEFAULT '0',
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -318,7 +318,7 @@ CREATE TABLE `ezcollab_profile` (
 
 DROP TABLE IF EXISTS `ezcollab_simple_message`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcollab_simple_message` (
   `created` int(11) NOT NULL DEFAULT '0',
   `creator_id` int(11) NOT NULL DEFAULT '0',
@@ -335,7 +335,7 @@ CREATE TABLE `ezcollab_simple_message` (
   `message_type` varchar(40) NOT NULL DEFAULT '',
   `modified` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -344,7 +344,7 @@ CREATE TABLE `ezcollab_simple_message` (
 
 DROP TABLE IF EXISTS `ezcomment`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcomment` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `language_id` bigint(20) NOT NULL,
@@ -364,7 +364,7 @@ CREATE TABLE `ezcomment` (
   PRIMARY KEY (`id`),
   KEY `user_id_session_key_ip` (`user_id`,`session_key`,`ip`),
   KEY `content_parentcomment` (`contentobject_id`,`language_id`,`parent_comment_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -373,7 +373,7 @@ CREATE TABLE `ezcomment` (
 
 DROP TABLE IF EXISTS `ezcomment_notification`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcomment_notification` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `contentobject_id` int(11) NOT NULL,
@@ -382,7 +382,7 @@ CREATE TABLE `ezcomment_notification` (
   `status` int(11) NOT NULL DEFAULT '1',
   `comment_id` int(11) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -391,7 +391,7 @@ CREATE TABLE `ezcomment_notification` (
 
 DROP TABLE IF EXISTS `ezcomment_subscriber`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcomment_subscriber` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) NOT NULL,
@@ -399,7 +399,7 @@ CREATE TABLE `ezcomment_subscriber` (
   `enabled` int(11) NOT NULL DEFAULT '1',
   `hash_string` varchar(50) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -408,7 +408,7 @@ CREATE TABLE `ezcomment_subscriber` (
 
 DROP TABLE IF EXISTS `ezcomment_subscription`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcomment_subscription` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `user_id` int(11) NOT NULL,
@@ -420,7 +420,7 @@ CREATE TABLE `ezcomment_subscription` (
   `enabled` int(11) NOT NULL DEFAULT '1',
   `hash_string` varchar(50) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -429,7 +429,7 @@ CREATE TABLE `ezcomment_subscription` (
 
 DROP TABLE IF EXISTS `ezcontent_language`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcontent_language` (
   `disabled` int(11) NOT NULL DEFAULT '0',
   `id` bigint(20) NOT NULL DEFAULT '0',
@@ -437,7 +437,7 @@ CREATE TABLE `ezcontent_language` (
   `name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   KEY `ezcontent_language_name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -446,7 +446,7 @@ CREATE TABLE `ezcontent_language` (
 
 DROP TABLE IF EXISTS `ezcontentbrowsebookmark`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcontentbrowsebookmark` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL DEFAULT '',
@@ -454,7 +454,7 @@ CREATE TABLE `ezcontentbrowsebookmark` (
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `ezcontentbrowsebookmark_user` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -463,7 +463,7 @@ CREATE TABLE `ezcontentbrowsebookmark` (
 
 DROP TABLE IF EXISTS `ezcontentbrowserecent`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcontentbrowserecent` (
   `created` int(11) NOT NULL DEFAULT '0',
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -472,7 +472,7 @@ CREATE TABLE `ezcontentbrowserecent` (
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `ezcontentbrowserecent_user` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -481,7 +481,7 @@ CREATE TABLE `ezcontentbrowserecent` (
 
 DROP TABLE IF EXISTS `ezcontentclass`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcontentclass` (
   `always_available` int(11) NOT NULL DEFAULT '0',
   `contentobject_name` varchar(255) DEFAULT NULL,
@@ -504,7 +504,7 @@ CREATE TABLE `ezcontentclass` (
   PRIMARY KEY (`id`,`version`),
   KEY `ezcontentclass_version` (`version`),
   KEY `ezcontentclass_identifier` (`identifier`,`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -513,7 +513,7 @@ CREATE TABLE `ezcontentclass` (
 
 DROP TABLE IF EXISTS `ezcontentclass_attribute`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcontentclass_attribute` (
   `can_translate` int(11) DEFAULT '1',
   `category` varchar(25) NOT NULL DEFAULT '',
@@ -544,7 +544,7 @@ CREATE TABLE `ezcontentclass_attribute` (
   `version` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`,`version`),
   KEY `ezcontentclass_attr_ccid` (`contentclass_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -553,14 +553,14 @@ CREATE TABLE `ezcontentclass_attribute` (
 
 DROP TABLE IF EXISTS `ezcontentclass_classgroup`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcontentclass_classgroup` (
   `contentclass_id` int(11) NOT NULL DEFAULT '0',
   `contentclass_version` int(11) NOT NULL DEFAULT '0',
   `group_id` int(11) NOT NULL DEFAULT '0',
   `group_name` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`contentclass_id`,`contentclass_version`,`group_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -569,7 +569,7 @@ CREATE TABLE `ezcontentclass_classgroup` (
 
 DROP TABLE IF EXISTS `ezcontentclass_name`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcontentclass_name` (
   `contentclass_id` int(11) NOT NULL DEFAULT '0',
   `contentclass_version` int(11) NOT NULL DEFAULT '0',
@@ -577,7 +577,7 @@ CREATE TABLE `ezcontentclass_name` (
   `language_locale` varchar(20) NOT NULL DEFAULT '',
   `name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`contentclass_id`,`contentclass_version`,`language_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -586,7 +586,7 @@ CREATE TABLE `ezcontentclass_name` (
 
 DROP TABLE IF EXISTS `ezcontentclassgroup`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcontentclassgroup` (
   `created` int(11) NOT NULL DEFAULT '0',
   `creator_id` int(11) NOT NULL DEFAULT '0',
@@ -595,7 +595,7 @@ CREATE TABLE `ezcontentclassgroup` (
   `modifier_id` int(11) NOT NULL DEFAULT '0',
   `name` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -604,7 +604,7 @@ CREATE TABLE `ezcontentclassgroup` (
 
 DROP TABLE IF EXISTS `ezcontentobject`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcontentobject` (
   `contentclass_id` int(11) NOT NULL DEFAULT '0',
   `current_version` int(11) DEFAULT NULL,
@@ -626,7 +626,7 @@ CREATE TABLE `ezcontentobject` (
   KEY `ezcontentobject_owner` (`owner_id`),
   KEY `ezcontentobject_pub` (`published`),
   KEY `ezcontentobject_status` (`status`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -635,7 +635,7 @@ CREATE TABLE `ezcontentobject` (
 
 DROP TABLE IF EXISTS `ezcontentobject_attribute`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcontentobject_attribute` (
   `attribute_original_id` int(11) DEFAULT '0',
   `contentclassattribute_id` int(11) NOT NULL DEFAULT '0',
@@ -656,7 +656,7 @@ CREATE TABLE `ezcontentobject_attribute` (
   KEY ezcontentobject_classattr_id (contentclassattribute_id),
   KEY `sort_key_int` (`sort_key_int`),
   KEY `sort_key_string` (`sort_key_string`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -665,7 +665,7 @@ CREATE TABLE `ezcontentobject_attribute` (
 
 DROP TABLE IF EXISTS `ezcontentobject_link`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcontentobject_link` (
   `contentclassattribute_id` int(11) NOT NULL DEFAULT '0',
   `from_contentobject_id` int(11) NOT NULL DEFAULT '0',
@@ -676,7 +676,7 @@ CREATE TABLE `ezcontentobject_link` (
   PRIMARY KEY (`id`),
   KEY `ezco_link_from` (`from_contentobject_id`,`from_contentobject_version`,`contentclassattribute_id`),
   KEY `ezco_link_to_co_id` (`to_contentobject_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -685,7 +685,7 @@ CREATE TABLE `ezcontentobject_link` (
 
 DROP TABLE IF EXISTS `ezcontentobject_name`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcontentobject_name` (
   `content_translation` varchar(20) NOT NULL DEFAULT '',
   `content_version` int(11) NOT NULL DEFAULT '0',
@@ -697,7 +697,7 @@ CREATE TABLE `ezcontentobject_name` (
   KEY `ezcontentobject_name_cov_id` (`content_version`),
   KEY `ezcontentobject_name_lang_id` (`language_id`),
   KEY `ezcontentobject_name_name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -706,7 +706,7 @@ CREATE TABLE `ezcontentobject_name` (
 
 DROP TABLE IF EXISTS `ezcontentobject_trash`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcontentobject_trash` (
   `contentobject_id` int(11) DEFAULT NULL,
   `contentobject_version` int(11) DEFAULT NULL,
@@ -730,7 +730,7 @@ CREATE TABLE `ezcontentobject_trash` (
   KEY `ezcobj_trash_p_node_id` (`parent_node_id`),
   KEY `ezcobj_trash_path` (`path_string`),
   KEY `ezcobj_trash_path_ident` (`path_identification_string`(50))
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -739,7 +739,7 @@ CREATE TABLE `ezcontentobject_trash` (
 
 DROP TABLE IF EXISTS `ezcontentobject_tree`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcontentobject_tree` (
   `contentobject_id` int(11) DEFAULT NULL,
   `contentobject_is_published` int(11) DEFAULT NULL,
@@ -765,7 +765,7 @@ CREATE TABLE `ezcontentobject_tree` (
   KEY `ezcontentobject_tree_path` (`path_string`),
   KEY `ezcontentobject_tree_path_ident` (`path_identification_string`(50)),
   KEY `modified_subnode` (`modified_subnode`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -774,7 +774,7 @@ CREATE TABLE `ezcontentobject_tree` (
 
 DROP TABLE IF EXISTS `ezcontentobject_version`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcontentobject_version` (
   `contentobject_id` int(11) DEFAULT NULL,
   `created` int(11) NOT NULL DEFAULT '0',
@@ -792,7 +792,7 @@ CREATE TABLE `ezcontentobject_version` (
   KEY `ezcobj_version_status` (`status`),
   KEY `idx_object_version_objver` (`contentobject_id`,`version`),
   KEY `ezcontobj_version_obj_status` (`contentobject_id`,`status`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -801,7 +801,7 @@ CREATE TABLE `ezcontentobject_version` (
 
 DROP TABLE IF EXISTS `ezcurrencydata`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezcurrencydata` (
   `auto_rate_value` decimal(10,5) NOT NULL DEFAULT '0.00000',
   `code` varchar(4) NOT NULL DEFAULT '',
@@ -813,7 +813,7 @@ CREATE TABLE `ezcurrencydata` (
   `symbol` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   KEY `ezcurrencydata_code` (`code`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -822,12 +822,12 @@ CREATE TABLE `ezcurrencydata` (
 
 DROP TABLE IF EXISTS `ezdiscountrule`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezdiscountrule` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -836,7 +836,7 @@ CREATE TABLE `ezdiscountrule` (
 
 DROP TABLE IF EXISTS `ezdiscountsubrule`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezdiscountsubrule` (
   `discount_percent` float DEFAULT NULL,
   `discountrule_id` int(11) NOT NULL DEFAULT '0',
@@ -844,7 +844,7 @@ CREATE TABLE `ezdiscountsubrule` (
   `limitation` char(1) DEFAULT NULL,
   `name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -853,13 +853,13 @@ CREATE TABLE `ezdiscountsubrule` (
 
 DROP TABLE IF EXISTS `ezdiscountsubrule_value`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezdiscountsubrule_value` (
   `discountsubrule_id` int(11) NOT NULL DEFAULT '0',
   `issection` int(11) NOT NULL DEFAULT '0',
   `value` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`discountsubrule_id`,`value`,`issection`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -868,7 +868,7 @@ CREATE TABLE `ezdiscountsubrule_value` (
 
 DROP TABLE IF EXISTS `ezenumobjectvalue`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezenumobjectvalue` (
   `contentobject_attribute_id` int(11) NOT NULL DEFAULT '0',
   `contentobject_attribute_version` int(11) NOT NULL DEFAULT '0',
@@ -876,7 +876,7 @@ CREATE TABLE `ezenumobjectvalue` (
   `enumid` int(11) NOT NULL DEFAULT '0',
   `enumvalue` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`contentobject_attribute_id`,`contentobject_attribute_version`,`enumid`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -885,7 +885,7 @@ CREATE TABLE `ezenumobjectvalue` (
 
 DROP TABLE IF EXISTS `ezenumvalue`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezenumvalue` (
   `contentclass_attribute_id` int(11) NOT NULL DEFAULT '0',
   `contentclass_attribute_version` int(11) NOT NULL DEFAULT '0',
@@ -895,7 +895,7 @@ CREATE TABLE `ezenumvalue` (
   `placement` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`,`contentclass_attribute_id`,`contentclass_attribute_version`),
   KEY `ezenumvalue_co_cl_attr_id_co_class_att_ver` (`contentclass_attribute_id`,`contentclass_attribute_version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -904,7 +904,7 @@ CREATE TABLE `ezenumvalue` (
 
 DROP TABLE IF EXISTS `ezforgot_password`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezforgot_password` (
   `hash_key` varchar(32) NOT NULL DEFAULT '',
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -912,7 +912,7 @@ CREATE TABLE `ezforgot_password` (
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `ezforgot_password_user` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -921,7 +921,7 @@ CREATE TABLE `ezforgot_password` (
 
 DROP TABLE IF EXISTS `ezgeneral_digest_user_settings`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezgeneral_digest_user_settings` (
   `day` varchar(255) NOT NULL DEFAULT '',
   `digest_type` int(11) NOT NULL DEFAULT '0',
@@ -931,7 +931,7 @@ CREATE TABLE `ezgeneral_digest_user_settings` (
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `ezgeneral_digest_user_id` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -940,7 +940,7 @@ CREATE TABLE `ezgeneral_digest_user_settings` (
 
 DROP TABLE IF EXISTS `ezgmaplocation`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezgmaplocation` (
   `contentobject_attribute_id` int(11) NOT NULL DEFAULT '0',
   `contentobject_version` int(11) NOT NULL DEFAULT '0',
@@ -949,7 +949,7 @@ CREATE TABLE `ezgmaplocation` (
   `address` varchar(150) DEFAULT NULL,
   PRIMARY KEY (`contentobject_attribute_id`,`contentobject_version`),
   KEY `latitude_longitude_key` (`latitude`,`longitude`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -958,7 +958,7 @@ CREATE TABLE `ezgmaplocation` (
 
 DROP TABLE IF EXISTS `ezimagefile`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezimagefile` (
   `contentobject_attribute_id` int(11) NOT NULL DEFAULT '0',
   `filepath` longtext NOT NULL,
@@ -966,7 +966,7 @@ CREATE TABLE `ezimagefile` (
   PRIMARY KEY (`id`),
   KEY `ezimagefile_coid` (`contentobject_attribute_id`),
   KEY `ezimagefile_file` (`filepath`(200))
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -975,7 +975,7 @@ CREATE TABLE `ezimagefile` (
 
 DROP TABLE IF EXISTS `ezinfocollection`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezinfocollection` (
   `contentobject_id` int(11) NOT NULL DEFAULT '0',
   `created` int(11) NOT NULL DEFAULT '0',
@@ -985,7 +985,7 @@ CREATE TABLE `ezinfocollection` (
   `user_identifier` varchar(34) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `ezinfocollection_co_id_created` (`contentobject_id`,`created`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -994,7 +994,7 @@ CREATE TABLE `ezinfocollection` (
 
 DROP TABLE IF EXISTS `ezinfocollection_attribute`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezinfocollection_attribute` (
   `contentclass_attribute_id` int(11) NOT NULL DEFAULT '0',
   `contentobject_attribute_id` int(11) DEFAULT NULL,
@@ -1009,7 +1009,7 @@ CREATE TABLE `ezinfocollection_attribute` (
   KEY `ezinfocollection_attr_co_id` (`contentobject_id`),
   KEY `ezinfocollection_attr_coa_id` (`contentobject_attribute_id`),
   KEY `ezinfocollection_attr_ic_id` (`informationcollection_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1018,13 +1018,13 @@ CREATE TABLE `ezinfocollection_attribute` (
 
 DROP TABLE IF EXISTS `ezisbn_group`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezisbn_group` (
   `description` varchar(255) NOT NULL DEFAULT '',
   `group_number` int(11) NOT NULL DEFAULT '0',
   `id` int(11) NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1033,7 +1033,7 @@ CREATE TABLE `ezisbn_group` (
 
 DROP TABLE IF EXISTS `ezisbn_group_range`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezisbn_group_range` (
   `from_number` int(11) NOT NULL DEFAULT '0',
   `group_from` varchar(32) NOT NULL DEFAULT '',
@@ -1042,7 +1042,7 @@ CREATE TABLE `ezisbn_group_range` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `to_number` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1051,7 +1051,7 @@ CREATE TABLE `ezisbn_group_range` (
 
 DROP TABLE IF EXISTS `ezisbn_registrant_range`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezisbn_registrant_range` (
   `from_number` int(11) NOT NULL DEFAULT '0',
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -1061,7 +1061,7 @@ CREATE TABLE `ezisbn_registrant_range` (
   `registrant_to` varchar(32) NOT NULL DEFAULT '',
   `to_number` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1070,14 +1070,14 @@ CREATE TABLE `ezisbn_registrant_range` (
 
 DROP TABLE IF EXISTS `ezkeyword`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezkeyword` (
   `class_id` int(11) NOT NULL DEFAULT '0',
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `keyword` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `ezkeyword_keyword` (`keyword`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1086,7 +1086,7 @@ CREATE TABLE `ezkeyword` (
 
 DROP TABLE IF EXISTS `ezkeyword_attribute_link`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezkeyword_attribute_link` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `keyword_id` int(11) NOT NULL DEFAULT '0',
@@ -1094,7 +1094,7 @@ CREATE TABLE `ezkeyword_attribute_link` (
   PRIMARY KEY (`id`),
   KEY `ezkeyword_attr_link_kid_oaid` (`keyword_id`,`objectattribute_id`),
   KEY `ezkeyword_attr_link_oaid` (`objectattribute_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1103,7 +1103,7 @@ CREATE TABLE `ezkeyword_attribute_link` (
 
 DROP TABLE IF EXISTS `ezm_block`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezm_block` (
   `id` char(32) NOT NULL,
   `zone_id` char(32) NOT NULL,
@@ -1119,7 +1119,7 @@ CREATE TABLE `ezm_block` (
   PRIMARY KEY (`id`),
   KEY `ezm_block__is_removed` (`is_removed`),
   KEY `ezm_block__node_id` (`node_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1128,7 +1128,7 @@ CREATE TABLE `ezm_block` (
 
 DROP TABLE IF EXISTS `ezm_pool`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezm_pool` (
   `block_id` char(32) NOT NULL,
   `object_id` int(10) unsigned NOT NULL,
@@ -1143,7 +1143,7 @@ CREATE TABLE `ezm_pool` (
   KEY `ezm_pool__block_id__ts_publication__priority` (`block_id`,`ts_publication`,`priority`),
   KEY `ezm_pool__block_id__ts_visible` (`block_id`,`ts_visible`),
   KEY `ezm_pool__block_id__ts_hidden` (`block_id`,`ts_hidden`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1152,7 +1152,7 @@ CREATE TABLE `ezm_pool` (
 
 DROP TABLE IF EXISTS `ezmedia`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezmedia` (
   `contentobject_attribute_id` int(11) NOT NULL DEFAULT '0',
   `controls` varchar(50) DEFAULT NULL,
@@ -1168,7 +1168,7 @@ CREATE TABLE `ezmedia` (
   `version` int(11) NOT NULL DEFAULT '0',
   `width` int(11) DEFAULT NULL,
   PRIMARY KEY (`contentobject_attribute_id`,`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1177,7 +1177,7 @@ CREATE TABLE `ezmedia` (
 
 DROP TABLE IF EXISTS `ezmessage`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezmessage` (
   `body` longtext,
   `destination_address` varchar(50) NOT NULL DEFAULT '',
@@ -1188,7 +1188,7 @@ CREATE TABLE `ezmessage` (
   `send_weekday` varchar(50) NOT NULL DEFAULT '',
   `title` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1197,7 +1197,7 @@ CREATE TABLE `ezmessage` (
 
 DROP TABLE IF EXISTS `ezmodule_run`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezmodule_run` (
   `function_name` varchar(255) DEFAULT NULL,
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -1206,7 +1206,7 @@ CREATE TABLE `ezmodule_run` (
   `workflow_process_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `ezmodule_run_workflow_process_id_s` (`workflow_process_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1215,7 +1215,7 @@ CREATE TABLE `ezmodule_run` (
 
 DROP TABLE IF EXISTS `ezmultipricedata`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezmultipricedata` (
   `contentobject_attr_id` int(11) NOT NULL DEFAULT '0',
   `contentobject_attr_version` int(11) NOT NULL DEFAULT '0',
@@ -1227,7 +1227,7 @@ CREATE TABLE `ezmultipricedata` (
   KEY `ezmultipricedata_coa_id` (`contentobject_attr_id`),
   KEY `ezmultipricedata_coa_version` (`contentobject_attr_version`),
   KEY `ezmultipricedata_currency_code` (`currency_code`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1236,7 +1236,7 @@ CREATE TABLE `ezmultipricedata` (
 
 DROP TABLE IF EXISTS `eznode_assignment`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `eznode_assignment` (
   `contentobject_id` int(11) DEFAULT NULL,
   `contentobject_version` int(11) DEFAULT NULL,
@@ -1256,7 +1256,7 @@ CREATE TABLE `eznode_assignment` (
   KEY `eznode_assignment_coid_cov` (`contentobject_id`,`contentobject_version`),
   KEY `eznode_assignment_is_main` (`is_main`),
   KEY `eznode_assignment_parent_node` (`parent_node`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1265,7 +1265,7 @@ CREATE TABLE `eznode_assignment` (
 
 DROP TABLE IF EXISTS `eznotificationcollection`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `eznotificationcollection` (
   `data_subject` longtext NOT NULL,
   `data_text` longtext NOT NULL,
@@ -1274,7 +1274,7 @@ CREATE TABLE `eznotificationcollection` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `transport` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1283,7 +1283,7 @@ CREATE TABLE `eznotificationcollection` (
 
 DROP TABLE IF EXISTS `eznotificationcollection_item`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `eznotificationcollection_item` (
   `address` varchar(255) NOT NULL DEFAULT '',
   `collection_id` int(11) NOT NULL DEFAULT '0',
@@ -1291,7 +1291,7 @@ CREATE TABLE `eznotificationcollection_item` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `send_date` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1300,7 +1300,7 @@ CREATE TABLE `eznotificationcollection_item` (
 
 DROP TABLE IF EXISTS `eznotificationevent`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `eznotificationevent` (
   `data_int1` int(11) NOT NULL DEFAULT '0',
   `data_int2` int(11) NOT NULL DEFAULT '0',
@@ -1314,7 +1314,7 @@ CREATE TABLE `eznotificationevent` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `status` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1323,7 +1323,7 @@ CREATE TABLE `eznotificationevent` (
 
 DROP TABLE IF EXISTS `ezoperation_memento`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezoperation_memento` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `main` int(11) NOT NULL DEFAULT '0',
@@ -1332,7 +1332,7 @@ CREATE TABLE `ezoperation_memento` (
   `memento_key` varchar(32) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`,`memento_key`),
   KEY `ezoperation_memento_memento_key_main` (`memento_key`,`main`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1341,7 +1341,7 @@ CREATE TABLE `ezoperation_memento` (
 
 DROP TABLE IF EXISTS `ezorder`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezorder` (
   `account_identifier` varchar(100) NOT NULL DEFAULT 'default',
   `created` int(11) NOT NULL DEFAULT '0',
@@ -1361,7 +1361,7 @@ CREATE TABLE `ezorder` (
   PRIMARY KEY (`id`),
   KEY `ezorder_is_archived` (`is_archived`),
   KEY `ezorder_is_tmp` (`is_temporary`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1370,7 +1370,7 @@ CREATE TABLE `ezorder` (
 
 DROP TABLE IF EXISTS `ezorder_item`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezorder_item` (
   `description` varchar(255) DEFAULT NULL,
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -1382,7 +1382,7 @@ CREATE TABLE `ezorder_item` (
   PRIMARY KEY (`id`),
   KEY `ezorder_item_order_id` (`order_id`),
   KEY `ezorder_item_type` (`type`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1391,11 +1391,11 @@ CREATE TABLE `ezorder_item` (
 
 DROP TABLE IF EXISTS `ezorder_nr_incr`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezorder_nr_incr` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1404,7 +1404,7 @@ CREATE TABLE `ezorder_nr_incr` (
 
 DROP TABLE IF EXISTS `ezorder_status`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezorder_status` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `is_active` int(11) NOT NULL DEFAULT '1',
@@ -1414,7 +1414,7 @@ CREATE TABLE `ezorder_status` (
   KEY `ezorder_status_active` (`is_active`),
   KEY `ezorder_status_name` (`name`),
   KEY `ezorder_status_sid` (`status_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1423,7 +1423,7 @@ CREATE TABLE `ezorder_status` (
 
 DROP TABLE IF EXISTS `ezorder_status_history`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezorder_status_history` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `modified` int(11) NOT NULL DEFAULT '0',
@@ -1434,7 +1434,7 @@ CREATE TABLE `ezorder_status_history` (
   KEY `ezorder_status_history_mod` (`modified`),
   KEY `ezorder_status_history_oid` (`order_id`),
   KEY `ezorder_status_history_sid` (`status_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1443,14 +1443,14 @@ CREATE TABLE `ezorder_status_history` (
 
 DROP TABLE IF EXISTS `ezpackage`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezpackage` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `install_date` int(11) NOT NULL DEFAULT '0',
   `name` varchar(100) NOT NULL DEFAULT '',
   `version` varchar(30) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1459,7 +1459,7 @@ CREATE TABLE `ezpackage` (
 
 DROP TABLE IF EXISTS `ezpaymentobject`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezpaymentobject` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `order_id` int(11) NOT NULL DEFAULT '0',
@@ -1467,7 +1467,7 @@ CREATE TABLE `ezpaymentobject` (
   `status` int(11) NOT NULL DEFAULT '0',
   `workflowprocess_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1476,7 +1476,7 @@ CREATE TABLE `ezpaymentobject` (
 
 DROP TABLE IF EXISTS `ezpdf_export`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezpdf_export` (
   `created` int(11) DEFAULT NULL,
   `creator_id` int(11) DEFAULT NULL,
@@ -1495,7 +1495,7 @@ CREATE TABLE `ezpdf_export` (
   `title` varchar(255) DEFAULT NULL,
   `version` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`,`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1504,7 +1504,7 @@ CREATE TABLE `ezpdf_export` (
 
 DROP TABLE IF EXISTS `ezpending_actions`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezpending_actions` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `action` varchar(64) NOT NULL DEFAULT '',
@@ -1513,7 +1513,7 @@ CREATE TABLE `ezpending_actions` (
   PRIMARY KEY (`id`),
   KEY `ezpending_actions_action` (`action`),
   KEY `ezpending_actions_created` (`created`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1522,7 +1522,7 @@ CREATE TABLE `ezpending_actions` (
 
 DROP TABLE IF EXISTS `ezpolicy`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezpolicy` (
   `function_name` varchar(255) DEFAULT NULL,
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -1532,7 +1532,7 @@ CREATE TABLE `ezpolicy` (
   PRIMARY KEY (`id`),
   KEY `ezpolicy_original_id` (`original_id`),
   KEY `ezpolicy_role_id` (`role_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1541,14 +1541,14 @@ CREATE TABLE `ezpolicy` (
 
 DROP TABLE IF EXISTS `ezpolicy_limitation`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezpolicy_limitation` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `identifier` varchar(255) NOT NULL DEFAULT '',
   `policy_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `policy_id` (`policy_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1557,7 +1557,7 @@ CREATE TABLE `ezpolicy_limitation` (
 
 DROP TABLE IF EXISTS `ezpolicy_limitation_value`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezpolicy_limitation_value` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `limitation_id` int(11) DEFAULT NULL,
@@ -1565,7 +1565,7 @@ CREATE TABLE `ezpolicy_limitation_value` (
   PRIMARY KEY (`id`),
   KEY `ezpolicy_limitation_value_val` (`value`),
   KEY `ezpolicy_limit_value_limit_id` (`limitation_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1574,7 +1574,7 @@ CREATE TABLE `ezpolicy_limitation_value` (
 
 DROP TABLE IF EXISTS `ezpreferences`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezpreferences` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(100) DEFAULT NULL,
@@ -1583,7 +1583,7 @@ CREATE TABLE `ezpreferences` (
   PRIMARY KEY (`id`),
   KEY `ezpreferences_name` (`name`),
   KEY `ezpreferences_user_id_idx` (`user_id`,`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1592,7 +1592,7 @@ CREATE TABLE `ezpreferences` (
 
 DROP TABLE IF EXISTS `ezprest_authcode`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezprest_authcode` (
   `client_id` varchar(200) NOT NULL DEFAULT '',
   `expirytime` bigint(20) NOT NULL DEFAULT '0',
@@ -1601,7 +1601,7 @@ CREATE TABLE `ezprest_authcode` (
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `authcode_client_id` (`client_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1610,7 +1610,7 @@ CREATE TABLE `ezprest_authcode` (
 
 DROP TABLE IF EXISTS `ezprest_authorized_clients`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezprest_authorized_clients` (
   `created` int(11) DEFAULT NULL,
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -1618,7 +1618,7 @@ CREATE TABLE `ezprest_authorized_clients` (
   `user_id` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `client_user` (`rest_client_id`,`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1627,7 +1627,7 @@ CREATE TABLE `ezprest_authorized_clients` (
 
 DROP TABLE IF EXISTS `ezprest_clients`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezprest_clients` (
   `client_id` varchar(200) DEFAULT NULL,
   `client_secret` varchar(200) DEFAULT NULL,
@@ -1641,7 +1641,7 @@ CREATE TABLE `ezprest_clients` (
   `version` int(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `client_id_unique` (`client_id`,`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1650,7 +1650,7 @@ CREATE TABLE `ezprest_clients` (
 
 DROP TABLE IF EXISTS `ezprest_token`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezprest_token` (
   `client_id` varchar(200) NOT NULL DEFAULT '',
   `expirytime` bigint(20) NOT NULL DEFAULT '0',
@@ -1660,7 +1660,7 @@ CREATE TABLE `ezprest_token` (
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `token_client_id` (`client_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1669,12 +1669,12 @@ CREATE TABLE `ezprest_token` (
 
 DROP TABLE IF EXISTS `ezproductcategory`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezproductcategory` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1683,13 +1683,13 @@ CREATE TABLE `ezproductcategory` (
 
 DROP TABLE IF EXISTS `ezproductcollection`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezproductcollection` (
   `created` int(11) DEFAULT NULL,
   `currency_code` varchar(4) NOT NULL DEFAULT '',
   `id` int(11) NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1698,7 +1698,7 @@ CREATE TABLE `ezproductcollection` (
 
 DROP TABLE IF EXISTS `ezproductcollection_item`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezproductcollection_item` (
   `contentobject_id` int(11) NOT NULL DEFAULT '0',
   `discount` float DEFAULT NULL,
@@ -1712,7 +1712,7 @@ CREATE TABLE `ezproductcollection_item` (
   PRIMARY KEY (`id`),
   KEY `ezproductcollection_item_contentobject_id` (`contentobject_id`),
   KEY `ezproductcollection_item_productcollection_id` (`productcollection_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1721,7 +1721,7 @@ CREATE TABLE `ezproductcollection_item` (
 
 DROP TABLE IF EXISTS `ezproductcollection_item_opt`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezproductcollection_item_opt` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `item_id` int(11) NOT NULL DEFAULT '0',
@@ -1732,7 +1732,7 @@ CREATE TABLE `ezproductcollection_item_opt` (
   `value` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`),
   KEY `ezproductcollection_item_opt_item_id` (`item_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1741,7 +1741,7 @@ CREATE TABLE `ezproductcollection_item_opt` (
 
 DROP TABLE IF EXISTS `ezpublishingqueueprocesses`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezpublishingqueueprocesses` (
   `created` int(11) DEFAULT NULL,
   `ezcontentobject_version_id` int(11) NOT NULL DEFAULT '0',
@@ -1750,7 +1750,7 @@ CREATE TABLE `ezpublishingqueueprocesses` (
   `started` int(11) DEFAULT NULL,
   `status` int(2) DEFAULT NULL,
   PRIMARY KEY (`ezcontentobject_version_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1759,7 +1759,7 @@ CREATE TABLE `ezpublishingqueueprocesses` (
 
 DROP TABLE IF EXISTS `ezrole`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezrole` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `is_new` int(11) NOT NULL DEFAULT '0',
@@ -1767,7 +1767,7 @@ CREATE TABLE `ezrole` (
   `value` char(1) DEFAULT NULL,
   `version` int(11) DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1776,7 +1776,7 @@ CREATE TABLE `ezrole` (
 
 DROP TABLE IF EXISTS `ezrss_export`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezrss_export` (
   `access_url` varchar(255) DEFAULT NULL,
   `active` int(11) DEFAULT NULL,
@@ -1796,7 +1796,7 @@ CREATE TABLE `ezrss_export` (
   `title` varchar(255) DEFAULT NULL,
   `url` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`,`status`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1805,7 +1805,7 @@ CREATE TABLE `ezrss_export` (
 
 DROP TABLE IF EXISTS `ezrss_export_item`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezrss_export_item` (
   `category` varchar(255) DEFAULT NULL,
   `class_id` int(11) DEFAULT NULL,
@@ -1819,7 +1819,7 @@ CREATE TABLE `ezrss_export_item` (
   `title` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`,`status`),
   KEY `ezrss_export_rsseid` (`rssexport_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1828,7 +1828,7 @@ CREATE TABLE `ezrss_export_item` (
 
 DROP TABLE IF EXISTS `ezrss_import`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezrss_import` (
   `active` int(11) DEFAULT NULL,
   `class_description` varchar(255) DEFAULT NULL,
@@ -1847,7 +1847,7 @@ CREATE TABLE `ezrss_import` (
   `status` int(11) NOT NULL DEFAULT '0',
   `url` longtext,
   PRIMARY KEY (`id`,`status`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1856,7 +1856,7 @@ CREATE TABLE `ezrss_import` (
 
 DROP TABLE IF EXISTS `ezscheduled_script`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezscheduled_script` (
   `command` varchar(255) NOT NULL DEFAULT '',
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -1867,7 +1867,7 @@ CREATE TABLE `ezscheduled_script` (
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `ezscheduled_script_timestamp` (`last_report_timestamp`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1876,7 +1876,7 @@ CREATE TABLE `ezscheduled_script` (
 
 DROP TABLE IF EXISTS `ezsearch_object_word_link`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezsearch_object_word_link` (
   `contentclass_attribute_id` int(11) NOT NULL DEFAULT '0',
   `contentclass_id` int(11) NOT NULL DEFAULT '0',
@@ -1897,7 +1897,7 @@ CREATE TABLE `ezsearch_object_word_link` (
   KEY `ezsearch_object_word_link_integer_value` (`integer_value`),
   KEY `ezsearch_object_word_link_object` (`contentobject_id`),
   KEY `ezsearch_object_word_link_word` (`word_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1906,7 +1906,7 @@ CREATE TABLE `ezsearch_object_word_link` (
 
 DROP TABLE IF EXISTS `ezsearch_search_phrase`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezsearch_search_phrase` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `phrase` varchar(250) DEFAULT NULL,
@@ -1915,7 +1915,7 @@ CREATE TABLE `ezsearch_search_phrase` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `ezsearch_search_phrase_phrase` (`phrase`),
   KEY `ezsearch_search_phrase_count` (`phrase_count`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1924,7 +1924,7 @@ CREATE TABLE `ezsearch_search_phrase` (
 
 DROP TABLE IF EXISTS `ezsearch_word`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezsearch_word` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `object_count` int(11) NOT NULL DEFAULT '0',
@@ -1932,7 +1932,7 @@ CREATE TABLE `ezsearch_word` (
   PRIMARY KEY (`id`),
   KEY `ezsearch_word_obj_count` (`object_count`),
   KEY `ezsearch_word_word_i` (`word`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1941,7 +1941,7 @@ CREATE TABLE `ezsearch_word` (
 
 DROP TABLE IF EXISTS `ezsection`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezsection` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `identifier` varchar(255) DEFAULT NULL,
@@ -1949,7 +1949,7 @@ CREATE TABLE `ezsection` (
   `name` varchar(255) DEFAULT NULL,
   `navigation_part_identifier` varchar(100) DEFAULT 'ezcontentnavigationpart',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1958,7 +1958,7 @@ CREATE TABLE `ezsection` (
 
 DROP TABLE IF EXISTS `ezsession`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezsession` (
   `data` longtext NOT NULL,
   `expiration_time` int(11) NOT NULL DEFAULT '0',
@@ -1968,7 +1968,7 @@ CREATE TABLE `ezsession` (
   PRIMARY KEY (`session_key`),
   KEY `expiration_time` (`expiration_time`),
   KEY `ezsession_user_id` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1977,12 +1977,12 @@ CREATE TABLE `ezsession` (
 
 DROP TABLE IF EXISTS `ezsite_data`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezsite_data` (
   `name` varchar(60) NOT NULL DEFAULT '',
   `value` longtext NOT NULL,
   PRIMARY KEY (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1991,14 +1991,14 @@ CREATE TABLE `ezsite_data` (
 
 DROP TABLE IF EXISTS `ezstarrating`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezstarrating` (
   `contentobject_id` int(11) NOT NULL,
   `contentobject_attribute_id` int(11) NOT NULL,
   `rating_average` float NOT NULL,
   `rating_count` int(11) NOT NULL,
   PRIMARY KEY (`contentobject_id`,`contentobject_attribute_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2007,7 +2007,7 @@ CREATE TABLE `ezstarrating` (
 
 DROP TABLE IF EXISTS `ezstarrating_data`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezstarrating_data` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `created_at` int(11) NOT NULL,
@@ -2019,7 +2019,7 @@ CREATE TABLE `ezstarrating_data` (
   PRIMARY KEY (`id`),
   KEY `user_id_session_key` (`user_id`,`session_key`),
   KEY `contentobject_id_contentobject_attribute_id` (`contentobject_id`,`contentobject_attribute_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2028,7 +2028,7 @@ CREATE TABLE `ezstarrating_data` (
 
 DROP TABLE IF EXISTS `ezsubtree_notification_rule`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezsubtree_notification_rule` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `node_id` int(11) NOT NULL DEFAULT '0',
@@ -2036,7 +2036,7 @@ CREATE TABLE `ezsubtree_notification_rule` (
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `ezsubtree_notification_rule_user_id` (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2045,13 +2045,13 @@ CREATE TABLE `ezsubtree_notification_rule` (
 
 DROP TABLE IF EXISTS `eztipafriend_counter`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `eztipafriend_counter` (
   `count` int(11) NOT NULL DEFAULT '0',
   `node_id` int(11) NOT NULL DEFAULT '0',
   `requested` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`node_id`,`requested`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2060,13 +2060,13 @@ CREATE TABLE `eztipafriend_counter` (
 
 DROP TABLE IF EXISTS `eztipafriend_request`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `eztipafriend_request` (
   `created` int(11) NOT NULL DEFAULT '0',
   `email_receiver` varchar(100) NOT NULL DEFAULT '',
   KEY `eztipafriend_request_created` (`created`),
   KEY `eztipafriend_request_email_rec` (`email_receiver`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2075,7 +2075,7 @@ CREATE TABLE `eztipafriend_request` (
 
 DROP TABLE IF EXISTS `eztrigger`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `eztrigger` (
   `connect_type` char(1) NOT NULL DEFAULT '',
   `function_name` varchar(200) NOT NULL DEFAULT '',
@@ -2086,7 +2086,7 @@ CREATE TABLE `eztrigger` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `eztrigger_def_id` (`module_name`(50),`function_name`(50),`connect_type`),
   KEY `eztrigger_fetch` (`name`(25),`module_name`(50),`function_name`(50))
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2095,7 +2095,7 @@ CREATE TABLE `eztrigger` (
 
 DROP TABLE IF EXISTS `ezurl`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezurl` (
   `created` int(11) NOT NULL DEFAULT '0',
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -2106,7 +2106,7 @@ CREATE TABLE `ezurl` (
   `url` longtext,
   PRIMARY KEY (`id`),
   KEY `ezurl_url` (`url`(255))
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2115,7 +2115,7 @@ CREATE TABLE `ezurl` (
 
 DROP TABLE IF EXISTS `ezurl_object_link`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezurl_object_link` (
   `contentobject_attribute_id` int(11) NOT NULL DEFAULT '0',
   `contentobject_attribute_version` int(11) NOT NULL DEFAULT '0',
@@ -2123,7 +2123,7 @@ CREATE TABLE `ezurl_object_link` (
   KEY `ezurl_ol_coa_id` (`contentobject_attribute_id`),
   KEY `ezurl_ol_coa_version` (`contentobject_attribute_version`),
   KEY `ezurl_ol_url_id` (`url_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2132,7 +2132,7 @@ CREATE TABLE `ezurl_object_link` (
 
 DROP TABLE IF EXISTS `ezurlalias`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezurlalias` (
   `destination_url` longtext NOT NULL,
   `forward_to_id` int(11) NOT NULL DEFAULT '0',
@@ -2149,7 +2149,7 @@ CREATE TABLE `ezurlalias` (
   KEY `ezurlalias_source_md5` (`source_md5`),
   KEY `ezurlalias_source_url` (`source_url`(255)),
   KEY `ezurlalias_wcard_fwd` (`is_wildcard`,`forward_to_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2158,7 +2158,7 @@ CREATE TABLE `ezurlalias` (
 
 DROP TABLE IF EXISTS `ezurlalias_ml`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezurlalias_ml` (
   `action` longtext NOT NULL,
   `action_type` varchar(32) NOT NULL DEFAULT '',
@@ -2179,7 +2179,7 @@ CREATE TABLE `ezurlalias_ml` (
   KEY `ezurlalias_ml_par_lnk_txt` (`parent`,`text`(32),`link`),
   KEY `ezurlalias_ml_text` (`text`(32),`id`,`link`),
   KEY `ezurlalias_ml_text_lang` (`text`(32),`lang_mask`,`parent`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2188,11 +2188,11 @@ CREATE TABLE `ezurlalias_ml` (
 
 DROP TABLE IF EXISTS `ezurlalias_ml_incr`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezurlalias_ml_incr` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2201,14 +2201,14 @@ CREATE TABLE `ezurlalias_ml_incr` (
 
 DROP TABLE IF EXISTS `ezurlwildcard`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezurlwildcard` (
   `destination_url` longtext NOT NULL,
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `source_url` longtext NOT NULL,
   `type` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2217,7 +2217,7 @@ CREATE TABLE `ezurlwildcard` (
 
 DROP TABLE IF EXISTS `ezuser`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezuser` (
   `contentobject_id` int(11) NOT NULL DEFAULT '0',
   `email` varchar(150) NOT NULL DEFAULT '',
@@ -2226,7 +2226,7 @@ CREATE TABLE `ezuser` (
   `password_hash_type` int(11) NOT NULL DEFAULT '1',
   PRIMARY KEY (`contentobject_id`),
   UNIQUE KEY `ezuser_login` (`login`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2235,7 +2235,7 @@ CREATE TABLE `ezuser` (
 
 DROP TABLE IF EXISTS `ezuser_accountkey`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezuser_accountkey` (
   `hash_key` varchar(32) NOT NULL DEFAULT '',
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -2243,7 +2243,7 @@ CREATE TABLE `ezuser_accountkey` (
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `hash_key` (`hash_key`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2252,14 +2252,14 @@ CREATE TABLE `ezuser_accountkey` (
 
 DROP TABLE IF EXISTS `ezuser_discountrule`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezuser_discountrule` (
   `contentobject_id` int(11) DEFAULT NULL,
   `discountrule_id` int(11) DEFAULT NULL,
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2268,7 +2268,7 @@ CREATE TABLE `ezuser_discountrule` (
 
 DROP TABLE IF EXISTS `ezuser_role`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezuser_role` (
   `contentobject_id` int(11) DEFAULT NULL,
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -2278,7 +2278,7 @@ CREATE TABLE `ezuser_role` (
   PRIMARY KEY (`id`),
   KEY `ezuser_role_contentobject_id` (`contentobject_id`),
   KEY `ezuser_role_role_id` (`role_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2287,13 +2287,13 @@ CREATE TABLE `ezuser_role` (
 
 DROP TABLE IF EXISTS `ezuser_setting`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezuser_setting` (
   `is_enabled` int(11) NOT NULL DEFAULT '0',
   `max_login` int(11) DEFAULT NULL,
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2302,7 +2302,7 @@ CREATE TABLE `ezuser_setting` (
 
 DROP TABLE IF EXISTS `ezuservisit`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezuservisit` (
   `current_visit_timestamp` int(11) NOT NULL DEFAULT '0',
   `failed_login_attempts` int(11) NOT NULL DEFAULT '0',
@@ -2311,7 +2311,7 @@ CREATE TABLE `ezuservisit` (
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`user_id`),
   KEY `ezuservisit_co_visit_count` (`current_visit_timestamp`,`login_count`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2320,13 +2320,13 @@ CREATE TABLE `ezuservisit` (
 
 DROP TABLE IF EXISTS `ezvatrule`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezvatrule` (
   `country_code` varchar(255) NOT NULL DEFAULT '',
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `vat_type` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2335,12 +2335,12 @@ CREATE TABLE `ezvatrule` (
 
 DROP TABLE IF EXISTS `ezvatrule_product_category`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezvatrule_product_category` (
   `product_category_id` int(11) NOT NULL DEFAULT '0',
   `vatrule_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`vatrule_id`,`product_category_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2349,13 +2349,13 @@ CREATE TABLE `ezvatrule_product_category` (
 
 DROP TABLE IF EXISTS `ezvattype`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezvattype` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL DEFAULT '',
   `percentage` float DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2364,12 +2364,12 @@ CREATE TABLE `ezvattype` (
 
 DROP TABLE IF EXISTS `ezview_counter`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezview_counter` (
   `count` int(11) NOT NULL DEFAULT '0',
   `node_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`node_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2378,7 +2378,7 @@ CREATE TABLE `ezview_counter` (
 
 DROP TABLE IF EXISTS `ezwaituntildatevalue`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezwaituntildatevalue` (
   `contentclass_attribute_id` int(11) NOT NULL DEFAULT '0',
   `contentclass_id` int(11) NOT NULL DEFAULT '0',
@@ -2387,7 +2387,7 @@ CREATE TABLE `ezwaituntildatevalue` (
   `workflow_event_version` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`,`workflow_event_id`,`workflow_event_version`),
   KEY `ezwaituntildateevalue_wf_ev_id_wf_ver` (`workflow_event_id`,`workflow_event_version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2396,13 +2396,13 @@ CREATE TABLE `ezwaituntildatevalue` (
 
 DROP TABLE IF EXISTS `ezwishlist`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezwishlist` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `productcollection_id` int(11) NOT NULL DEFAULT '0',
   `user_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2411,7 +2411,7 @@ CREATE TABLE `ezwishlist` (
 
 DROP TABLE IF EXISTS `ezworkflow`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezworkflow` (
   `created` int(11) NOT NULL DEFAULT '0',
   `creator_id` int(11) NOT NULL DEFAULT '0',
@@ -2423,7 +2423,7 @@ CREATE TABLE `ezworkflow` (
   `version` int(11) NOT NULL DEFAULT '0',
   `workflow_type_string` varchar(50) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`,`version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2432,7 +2432,7 @@ CREATE TABLE `ezworkflow` (
 
 DROP TABLE IF EXISTS `ezworkflow_assign`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezworkflow_assign` (
   `access_type` int(11) NOT NULL DEFAULT '0',
   `as_tree` int(11) NOT NULL DEFAULT '0',
@@ -2440,7 +2440,7 @@ CREATE TABLE `ezworkflow_assign` (
   `node_id` int(11) NOT NULL DEFAULT '0',
   `workflow_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2449,7 +2449,7 @@ CREATE TABLE `ezworkflow_assign` (
 
 DROP TABLE IF EXISTS `ezworkflow_event`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezworkflow_event` (
   `data_int1` int(11) DEFAULT NULL,
   `data_int2` int(11) DEFAULT NULL,
@@ -2468,7 +2468,7 @@ CREATE TABLE `ezworkflow_event` (
   `workflow_type_string` varchar(50) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`,`version`),
   KEY `wid_version_placement` (`workflow_id`,`version`,`placement`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2477,7 +2477,7 @@ CREATE TABLE `ezworkflow_event` (
 
 DROP TABLE IF EXISTS `ezworkflow_group`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezworkflow_group` (
   `created` int(11) NOT NULL DEFAULT '0',
   `creator_id` int(11) NOT NULL DEFAULT '0',
@@ -2486,7 +2486,7 @@ CREATE TABLE `ezworkflow_group` (
   `modifier_id` int(11) NOT NULL DEFAULT '0',
   `name` varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2495,14 +2495,14 @@ CREATE TABLE `ezworkflow_group` (
 
 DROP TABLE IF EXISTS `ezworkflow_group_link`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezworkflow_group_link` (
   `group_id` int(11) NOT NULL DEFAULT '0',
   `group_name` varchar(255) DEFAULT NULL,
   `workflow_id` int(11) NOT NULL DEFAULT '0',
   `workflow_version` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`workflow_id`,`group_id`,`workflow_version`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -2511,7 +2511,7 @@ CREATE TABLE `ezworkflow_group_link` (
 
 DROP TABLE IF EXISTS `ezworkflow_process`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ezworkflow_process` (
   `activation_date` int(11) DEFAULT NULL,
   `content_id` int(11) NOT NULL DEFAULT '0',
@@ -2536,7 +2536,7 @@ CREATE TABLE `ezworkflow_process` (
   `workflow_id` int(11) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `ezworkflow_process_process_key` (`process_key`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
@@ -2548,4 +2548,4 @@ CREATE TABLE `ezworkflow_process` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2013-08-14 15:46:37
+-- Dump completed on 2012-08-14 15:46:37

--- a/data/update/mysql/dbupdate-6.12.0-to-7.1.0.sql
+++ b/data/update/mysql/dbupdate-6.12.0-to-7.1.0.sql
@@ -1,0 +1,25 @@
+SET default_storage_engine=InnoDB;
+-- Set storage engine schema version number
+UPDATE ezsite_data SET value='7.1.0' WHERE name='ezpublish-version';
+
+--
+-- EZP-28950: MySQL UTF8 doesn't support 4-byte chars
+--
+
+ALTER TABLE `ezprest_authcode` DROP PRIMARY KEY;
+ALTER TABLE `ezprest_authcode` ADD PRIMARY KEY (`id` (191));
+
+ALTER TABLE `ezprest_authcode` DROP KEY `authcode_client_id`;
+ALTER TABLE `ezprest_authcode` ADD KEY `authcode_client_id` (`client_id` (191));
+
+ALTER TABLE `ezprest_clients` DROP KEY `client_id_unique`;
+ALTER TABLE `ezprest_clients` ADD UNIQUE KEY `client_id_unique` (`client_id` (191),`version`);
+
+ALTER TABLE `ezprest_token` DROP PRIMARY KEY;
+ALTER TABLE `ezprest_token` ADD PRIMARY KEY (`id` (191));
+
+ALTER TABLE `ezprest_token` DROP KEY `token_client_id`;
+ALTER TABLE `ezprest_token` ADD KEY `token_client_id` (`client_id` (191));
+
+ALTER TABLE `ezsearch_search_phrase` DROP KEY `ezsearch_search_phrase_phrase`;
+ALTER TABLE `ezsearch_search_phrase` ADD UNIQUE KEY `ezsearch_search_phrase_phrase` (`phrase` (191));

--- a/data/update/mysql/dbupdate-7.1.0-to-7.2.0.sql
+++ b/data/update/mysql/dbupdate-7.1.0-to-7.2.0.sql
@@ -1,6 +1,6 @@
 SET default_storage_engine=InnoDB;
 -- Set storage engine schema version number
-UPDATE ezsite_data SET value='7.1.0' WHERE name='ezpublish-version';
+UPDATE ezsite_data SET value='7.2.0' WHERE name='ezpublish-version';
 
 --
 -- EZP-28950: MySQL UTF8 doesn't support 4-byte chars

--- a/doc/upgrade/7.2.md
+++ b/doc/upgrade/7.2.md
@@ -1,0 +1,28 @@
+# Upgrade steps from 7.1 to 7.2
+
+See `doc/bc/changes-7.2.md` for requirements changes and deprecations.
+
+## MySQL/MariaDB database tables character set change
+
+The character set for MySQL/MariaDB database tables is changed from `utf8` to `utf8mb4` to support 4-byte characters. See `data/update/mysql/dbupdate-7.1.0-to-7.2.0.sql` for the SQL upgrade statements.
+
+Beware that these upgrade statements may fail due to index collisions. This is because the indexes have been shortened, so duplicates may occur. If that happens, you must remove the duplicates manually, and then repeat the statements that failed.
+
+You should also change the character set that is specified in the application config, and in legacy if you use that.
+
+In `app/config/config.yml`, set the following:
+```yml
+doctrine:
+    dbal:
+        connections:
+            default:
+                charset: utf8mb4
+```
+Also make the corresponding change in `app/config/dfs/dfs.yml`.
+
+For legacy, in `ezpublish_legacy/settings/i18n.ini`, set the following:
+```
+[CharacterSettings]
+Charset=utf8mb4
+HTTPCharset=utf-8
+```

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
@@ -7,7 +7,7 @@ CREATE TABLE ezbinaryfile (
   original_filename varchar(255) NOT NULL DEFAULT '',
   version int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (contentobject_attribute_id,version)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezimagefile;
 CREATE TABLE ezimagefile (
@@ -17,7 +17,7 @@ CREATE TABLE ezimagefile (
   PRIMARY KEY (id),
   KEY ezimagefile_coid (contentobject_attribute_id),
   KEY ezimagefile_file (filepath(200))
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezmedia;
 CREATE TABLE ezmedia (
@@ -35,7 +35,7 @@ CREATE TABLE ezmedia (
   version int(11) NOT NULL DEFAULT 0,
   width int(11) DEFAULT NULL,
   PRIMARY KEY (contentobject_attribute_id,version)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezcobj_state;
 CREATE TABLE ezcobj_state (
@@ -49,7 +49,7 @@ CREATE TABLE ezcobj_state (
   UNIQUE KEY ezcobj_state_identifier (group_id,identifier),
   KEY ezcobj_state_lmask (language_mask),
   KEY ezcobj_state_priority (priority)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezcobj_state_group;
 CREATE TABLE ezcobj_state_group (
@@ -60,7 +60,7 @@ CREATE TABLE ezcobj_state_group (
   PRIMARY KEY (id),
   UNIQUE KEY ezcobj_state_group_identifier (identifier),
   KEY ezcobj_state_group_lmask (language_mask)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezcobj_state_group_language;
 CREATE TABLE ezcobj_state_group_language (
@@ -70,7 +70,7 @@ CREATE TABLE ezcobj_state_group_language (
   real_language_id bigint(20) NOT NULL DEFAULT 0,
   name varchar(45) NOT NULL DEFAULT '',
   PRIMARY KEY (contentobject_state_group_id,real_language_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezcobj_state_language;
 CREATE TABLE ezcobj_state_language (
@@ -79,14 +79,14 @@ CREATE TABLE ezcobj_state_language (
   language_id bigint(20) NOT NULL DEFAULT 0,
   name varchar(45) NOT NULL DEFAULT '',
   PRIMARY KEY (contentobject_state_id,language_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezcobj_state_link;
 CREATE TABLE ezcobj_state_link (
   contentobject_id int(11) NOT NULL DEFAULT 0,
   contentobject_state_id int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (contentobject_id,contentobject_state_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezcontent_language;
 CREATE TABLE ezcontent_language (
@@ -96,7 +96,7 @@ CREATE TABLE ezcontent_language (
   name varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (id),
   KEY ezcontent_language_name (name)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezcontentclass;
 CREATE TABLE ezcontentclass (
@@ -121,7 +121,7 @@ CREATE TABLE ezcontentclass (
   PRIMARY KEY (id,version),
   KEY ezcontentclass_version (version),
   KEY ezcontentclass_identifier (identifier,version)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezcontentclass_attribute;
 CREATE TABLE ezcontentclass_attribute (
@@ -154,7 +154,7 @@ CREATE TABLE ezcontentclass_attribute (
   version int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (id,version),
   KEY ezcontentclass_attr_ccid (contentclass_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezcontentclass_classgroup;
 CREATE TABLE ezcontentclass_classgroup (
@@ -163,7 +163,7 @@ CREATE TABLE ezcontentclass_classgroup (
   group_id int(11) NOT NULL DEFAULT 0,
   group_name varchar(255) DEFAULT NULL,
   PRIMARY KEY (contentclass_id,contentclass_version,group_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezcontentclass_name;
 CREATE TABLE ezcontentclass_name (
@@ -173,7 +173,7 @@ CREATE TABLE ezcontentclass_name (
   language_locale varchar(20) NOT NULL DEFAULT '',
   name varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (contentclass_id,contentclass_version,language_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezcontentclassgroup;
 CREATE TABLE ezcontentclassgroup (
@@ -184,7 +184,7 @@ CREATE TABLE ezcontentclassgroup (
   modifier_id int(11) NOT NULL DEFAULT 0,
   name varchar(255) DEFAULT NULL,
   PRIMARY KEY (id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezcontentobject;
 CREATE TABLE ezcontentobject (
@@ -208,7 +208,7 @@ CREATE TABLE ezcontentobject (
   KEY ezcontentobject_pub (published),
   UNIQUE KEY ezcontentobject_remote_id (remote_id),
   KEY ezcontentobject_status (status)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezcontentobject_attribute;
 CREATE TABLE ezcontentobject_attribute (
@@ -231,7 +231,7 @@ CREATE TABLE ezcontentobject_attribute (
   KEY ezcontentobject_classattr_id (contentclassattribute_id),
   KEY sort_key_int (sort_key_int),
   KEY sort_key_string (sort_key_string)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezcontentobject_link;
 CREATE TABLE ezcontentobject_link (
@@ -244,7 +244,7 @@ CREATE TABLE ezcontentobject_link (
   PRIMARY KEY (id),
   KEY ezco_link_from (from_contentobject_id,from_contentobject_version,contentclassattribute_id),
   KEY ezco_link_to_co_id (to_contentobject_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezcontentobject_name;
 CREATE TABLE ezcontentobject_name (
@@ -258,7 +258,7 @@ CREATE TABLE ezcontentobject_name (
   KEY ezcontentobject_name_cov_id (content_version),
   KEY ezcontentobject_name_lang_id (language_id),
   KEY ezcontentobject_name_name (name)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezcontentobject_trash;
 CREATE TABLE ezcontentobject_trash (
@@ -284,7 +284,7 @@ CREATE TABLE ezcontentobject_trash (
   KEY ezcobj_trash_p_node_id (parent_node_id),
   KEY ezcobj_trash_path (path_string),
   KEY ezcobj_trash_path_ident (path_identification_string(50))
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezcontentobject_tree;
 CREATE TABLE ezcontentobject_tree (
@@ -312,7 +312,7 @@ CREATE TABLE ezcontentobject_tree (
   KEY ezcontentobject_tree_path (path_string),
   KEY ezcontentobject_tree_path_ident (path_identification_string(50)),
   KEY modified_subnode (modified_subnode)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezcontentobject_version;
 CREATE TABLE ezcontentobject_version (
@@ -332,7 +332,7 @@ CREATE TABLE ezcontentobject_version (
   KEY ezcobj_version_status (status),
   KEY idx_object_version_objver (contentobject_id,version),
   KEY ezcontentobject_version_object_status (contentobject_id,status)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS eznode_assignment;
 CREATE TABLE eznode_assignment (
@@ -354,7 +354,7 @@ CREATE TABLE eznode_assignment (
   KEY eznode_assignment_coid_cov (contentobject_id,contentobject_version),
   KEY eznode_assignment_is_main (is_main),
   KEY eznode_assignment_parent_node (parent_node)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezpolicy;
 CREATE TABLE ezpolicy (
@@ -366,7 +366,7 @@ CREATE TABLE ezpolicy (
   PRIMARY KEY (id),
   KEY ezpolicy_original_id (original_id),
   KEY ezpolicy_role_id (role_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezpolicy_limitation;
 CREATE TABLE ezpolicy_limitation (
@@ -375,7 +375,7 @@ CREATE TABLE ezpolicy_limitation (
   policy_id int(11) DEFAULT NULL,
   PRIMARY KEY (id),
   KEY policy_id (policy_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezpolicy_limitation_value;
 CREATE TABLE ezpolicy_limitation_value (
@@ -385,7 +385,7 @@ CREATE TABLE ezpolicy_limitation_value (
   PRIMARY KEY (id),
   KEY ezpolicy_limitation_value_val (value),
   KEY ezpolicy_limitation_value_limitation_id (limitation_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezrole;
 CREATE TABLE ezrole (
@@ -395,7 +395,7 @@ CREATE TABLE ezrole (
   value char(1) DEFAULT NULL,
   version int(11) DEFAULT 0,
   PRIMARY KEY (id,version)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezurl;
 CREATE TABLE ezurl (
@@ -408,7 +408,7 @@ CREATE TABLE ezurl (
   url longtext,
   PRIMARY KEY (id),
   KEY ezurl_url (url(255))
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezurl_object_link;
 CREATE TABLE ezurl_object_link (
@@ -418,7 +418,7 @@ CREATE TABLE ezurl_object_link (
   KEY ezurl_ol_coa_id (contentobject_attribute_id),
   KEY ezurl_ol_coa_version (contentobject_attribute_version),
   KEY ezurl_ol_url_id (url_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezurlalias;
 CREATE TABLE ezurlalias (
@@ -437,7 +437,7 @@ CREATE TABLE ezurlalias (
   KEY ezurlalias_source_md5 (source_md5),
   KEY ezurlalias_source_url (source_url(255)),
   KEY ezurlalias_wcard_fwd (is_wildcard,forward_to_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezurlalias_ml;
 CREATE TABLE ezurlalias_ml (
@@ -460,13 +460,13 @@ CREATE TABLE ezurlalias_ml (
   KEY ezurlalias_ml_par_lnk_txt (parent,text(32),link),
   KEY ezurlalias_ml_text (text(32),id,link),
   KEY ezurlalias_ml_text_lang (text(32),lang_mask,parent)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezurlalias_ml_incr;
 CREATE TABLE ezurlalias_ml_incr (
   id int(11) NOT NULL auto_increment,
   PRIMARY KEY (id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezurlwildcard;
 CREATE TABLE ezurlwildcard (
@@ -475,7 +475,7 @@ CREATE TABLE ezurlwildcard (
   source_url longtext NOT NULL,
   type int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezuser;
 CREATE TABLE ezuser (
@@ -486,7 +486,7 @@ CREATE TABLE ezuser (
   password_hash_type int(11) NOT NULL DEFAULT 1,
   PRIMARY KEY (contentobject_id),
   UNIQUE KEY `ezuser_login` (`login`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezuser_role;
 CREATE TABLE ezuser_role (
@@ -498,7 +498,7 @@ CREATE TABLE ezuser_role (
   PRIMARY KEY (id),
   KEY ezuser_role_contentobject_id (contentobject_id),
   KEY ezuser_role_role_id (role_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezuser_setting;
 CREATE TABLE ezuser_setting (
@@ -506,7 +506,7 @@ CREATE TABLE ezuser_setting (
   max_login int(11) DEFAULT NULL,
   user_id int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (user_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezsearch_object_word_link;
 CREATE TABLE ezsearch_object_word_link (
@@ -529,7 +529,7 @@ CREATE TABLE ezsearch_object_word_link (
   KEY ezsearch_object_word_link_integer_value (integer_value),
   KEY ezsearch_object_word_link_object (contentobject_id),
   KEY ezsearch_object_word_link_word (word_id)
-) ENGINE=InnoDB AUTO_INCREMENT=17279 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=17279 DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezsearch_word;
 CREATE TABLE ezsearch_word (
@@ -539,7 +539,7 @@ CREATE TABLE ezsearch_word (
   PRIMARY KEY (id),
   KEY ezsearch_word_obj_count (object_count),
   KEY ezsearch_word_word_i (word)
-) ENGINE=InnoDB AUTO_INCREMENT=2523 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2523 DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezsection;
 CREATE TABLE ezsection (
@@ -549,7 +549,7 @@ CREATE TABLE ezsection (
   name varchar(255) DEFAULT NULL,
   navigation_part_identifier varchar(100) DEFAULT 'ezcontentnavigationpart',
   PRIMARY KEY (id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezuser_accountkey;
 CREATE TABLE ezuser_accountkey (
@@ -559,7 +559,7 @@ CREATE TABLE ezuser_accountkey (
   user_id int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (id),
   KEY hash_key (hash_key)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezuservisit;
 CREATE TABLE ezuservisit (
@@ -570,7 +570,7 @@ CREATE TABLE ezuservisit (
   user_id int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (user_id),
   KEY ezuservisit_co_visit_count (current_visit_timestamp,login_count)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezkeyword;
 CREATE TABLE ezkeyword (
@@ -579,7 +579,7 @@ CREATE TABLE ezkeyword (
   keyword varchar(255) DEFAULT NULL,
   PRIMARY KEY (id),
   KEY ezkeyword_keyword (keyword)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezkeyword_attribute_link;
 CREATE TABLE ezkeyword_attribute_link (
@@ -589,7 +589,7 @@ CREATE TABLE ezkeyword_attribute_link (
   PRIMARY KEY (id),
   KEY ezkeyword_attr_link_kid_oaid (keyword_id,objectattribute_id),
   KEY ezkeyword_attr_link_oaid (objectattribute_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 DROP TABLE IF EXISTS ezgmaplocation;
 CREATE TABLE ezgmaplocation (
@@ -600,4 +600,4 @@ CREATE TABLE ezgmaplocation (
   address varchar(150) DEFAULT NULL,
   PRIMARY KEY (contentobject_attribute_id,contentobject_version),
   KEY latitude_longitude_key (latitude,longitude)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
@@ -7,7 +7,7 @@ CREATE TABLE ezbinaryfile (
   original_filename varchar(255) NOT NULL DEFAULT '',
   version int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (contentobject_attribute_id,version)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezimagefile;
 CREATE TABLE ezimagefile (
@@ -17,7 +17,7 @@ CREATE TABLE ezimagefile (
   PRIMARY KEY (id),
   KEY ezimagefile_coid (contentobject_attribute_id),
   KEY ezimagefile_file (filepath(200))
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezmedia;
 CREATE TABLE ezmedia (
@@ -35,7 +35,7 @@ CREATE TABLE ezmedia (
   version int(11) NOT NULL DEFAULT 0,
   width int(11) DEFAULT NULL,
   PRIMARY KEY (contentobject_attribute_id,version)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezcobj_state;
 CREATE TABLE ezcobj_state (
@@ -49,7 +49,7 @@ CREATE TABLE ezcobj_state (
   UNIQUE KEY ezcobj_state_identifier (group_id,identifier),
   KEY ezcobj_state_lmask (language_mask),
   KEY ezcobj_state_priority (priority)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezcobj_state_group;
 CREATE TABLE ezcobj_state_group (
@@ -60,7 +60,7 @@ CREATE TABLE ezcobj_state_group (
   PRIMARY KEY (id),
   UNIQUE KEY ezcobj_state_group_identifier (identifier),
   KEY ezcobj_state_group_lmask (language_mask)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezcobj_state_group_language;
 CREATE TABLE ezcobj_state_group_language (
@@ -70,7 +70,7 @@ CREATE TABLE ezcobj_state_group_language (
   real_language_id bigint(20) NOT NULL DEFAULT 0,
   name varchar(45) NOT NULL DEFAULT '',
   PRIMARY KEY (contentobject_state_group_id,real_language_id)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezcobj_state_language;
 CREATE TABLE ezcobj_state_language (
@@ -79,14 +79,14 @@ CREATE TABLE ezcobj_state_language (
   language_id bigint(20) NOT NULL DEFAULT 0,
   name varchar(45) NOT NULL DEFAULT '',
   PRIMARY KEY (contentobject_state_id,language_id)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezcobj_state_link;
 CREATE TABLE ezcobj_state_link (
   contentobject_id int(11) NOT NULL DEFAULT 0,
   contentobject_state_id int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (contentobject_id,contentobject_state_id)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezcontent_language;
 CREATE TABLE ezcontent_language (
@@ -96,7 +96,7 @@ CREATE TABLE ezcontent_language (
   name varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (id),
   KEY ezcontent_language_name (name)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezcontentclass;
 CREATE TABLE ezcontentclass (
@@ -121,7 +121,7 @@ CREATE TABLE ezcontentclass (
   PRIMARY KEY (id,version),
   KEY ezcontentclass_version (version),
   KEY ezcontentclass_identifier (identifier,version)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezcontentclass_attribute;
 CREATE TABLE ezcontentclass_attribute (
@@ -154,7 +154,7 @@ CREATE TABLE ezcontentclass_attribute (
   version int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (id,version),
   KEY ezcontentclass_attr_ccid (contentclass_id)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezcontentclass_classgroup;
 CREATE TABLE ezcontentclass_classgroup (
@@ -163,7 +163,7 @@ CREATE TABLE ezcontentclass_classgroup (
   group_id int(11) NOT NULL DEFAULT 0,
   group_name varchar(255) DEFAULT NULL,
   PRIMARY KEY (contentclass_id,contentclass_version,group_id)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezcontentclass_name;
 CREATE TABLE ezcontentclass_name (
@@ -173,7 +173,7 @@ CREATE TABLE ezcontentclass_name (
   language_locale varchar(20) NOT NULL DEFAULT '',
   name varchar(255) NOT NULL DEFAULT '',
   PRIMARY KEY (contentclass_id,contentclass_version,language_id)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezcontentclassgroup;
 CREATE TABLE ezcontentclassgroup (
@@ -184,7 +184,7 @@ CREATE TABLE ezcontentclassgroup (
   modifier_id int(11) NOT NULL DEFAULT 0,
   name varchar(255) DEFAULT NULL,
   PRIMARY KEY (id)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezcontentobject;
 CREATE TABLE ezcontentobject (
@@ -208,7 +208,7 @@ CREATE TABLE ezcontentobject (
   KEY ezcontentobject_pub (published),
   UNIQUE KEY ezcontentobject_remote_id (remote_id),
   KEY ezcontentobject_status (status)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezcontentobject_attribute;
 CREATE TABLE ezcontentobject_attribute (
@@ -231,7 +231,7 @@ CREATE TABLE ezcontentobject_attribute (
   KEY ezcontentobject_classattr_id (contentclassattribute_id),
   KEY sort_key_int (sort_key_int),
   KEY sort_key_string (sort_key_string)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezcontentobject_link;
 CREATE TABLE ezcontentobject_link (
@@ -244,7 +244,7 @@ CREATE TABLE ezcontentobject_link (
   PRIMARY KEY (id),
   KEY ezco_link_from (from_contentobject_id,from_contentobject_version,contentclassattribute_id),
   KEY ezco_link_to_co_id (to_contentobject_id)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezcontentobject_name;
 CREATE TABLE ezcontentobject_name (
@@ -258,7 +258,7 @@ CREATE TABLE ezcontentobject_name (
   KEY ezcontentobject_name_cov_id (content_version),
   KEY ezcontentobject_name_lang_id (language_id),
   KEY ezcontentobject_name_name (name)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezcontentobject_trash;
 CREATE TABLE ezcontentobject_trash (
@@ -284,7 +284,7 @@ CREATE TABLE ezcontentobject_trash (
   KEY ezcobj_trash_p_node_id (parent_node_id),
   KEY ezcobj_trash_path (path_string),
   KEY ezcobj_trash_path_ident (path_identification_string(50))
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezcontentobject_tree;
 CREATE TABLE ezcontentobject_tree (
@@ -312,7 +312,7 @@ CREATE TABLE ezcontentobject_tree (
   KEY ezcontentobject_tree_path (path_string),
   KEY ezcontentobject_tree_path_ident (path_identification_string(50)),
   KEY modified_subnode (modified_subnode)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezcontentobject_version;
 CREATE TABLE ezcontentobject_version (
@@ -332,7 +332,7 @@ CREATE TABLE ezcontentobject_version (
   KEY ezcobj_version_status (status),
   KEY idx_object_version_objver (contentobject_id,version),
   KEY ezcontentobject_version_object_status (contentobject_id,status)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS eznode_assignment;
 CREATE TABLE eznode_assignment (
@@ -354,7 +354,7 @@ CREATE TABLE eznode_assignment (
   KEY eznode_assignment_coid_cov (contentobject_id,contentobject_version),
   KEY eznode_assignment_is_main (is_main),
   KEY eznode_assignment_parent_node (parent_node)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezpolicy;
 CREATE TABLE ezpolicy (
@@ -366,7 +366,7 @@ CREATE TABLE ezpolicy (
   PRIMARY KEY (id),
   KEY ezpolicy_original_id (original_id),
   KEY ezpolicy_role_id (role_id)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezpolicy_limitation;
 CREATE TABLE ezpolicy_limitation (
@@ -375,7 +375,7 @@ CREATE TABLE ezpolicy_limitation (
   policy_id int(11) DEFAULT NULL,
   PRIMARY KEY (id),
   KEY policy_id (policy_id)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezpolicy_limitation_value;
 CREATE TABLE ezpolicy_limitation_value (
@@ -385,7 +385,7 @@ CREATE TABLE ezpolicy_limitation_value (
   PRIMARY KEY (id),
   KEY ezpolicy_limitation_value_val (value),
   KEY ezpolicy_limitation_value_limitation_id (limitation_id)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezrole;
 CREATE TABLE ezrole (
@@ -395,7 +395,7 @@ CREATE TABLE ezrole (
   value char(1) DEFAULT NULL,
   version int(11) DEFAULT 0,
   PRIMARY KEY (id,version)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezurl;
 CREATE TABLE ezurl (
@@ -408,7 +408,7 @@ CREATE TABLE ezurl (
   url longtext,
   PRIMARY KEY (id),
   KEY ezurl_url (url(255))
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezurl_object_link;
 CREATE TABLE ezurl_object_link (
@@ -418,7 +418,7 @@ CREATE TABLE ezurl_object_link (
   KEY ezurl_ol_coa_id (contentobject_attribute_id),
   KEY ezurl_ol_coa_version (contentobject_attribute_version),
   KEY ezurl_ol_url_id (url_id)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezurlalias;
 CREATE TABLE ezurlalias (
@@ -437,7 +437,7 @@ CREATE TABLE ezurlalias (
   KEY ezurlalias_source_md5 (source_md5),
   KEY ezurlalias_source_url (source_url(255)),
   KEY ezurlalias_wcard_fwd (is_wildcard,forward_to_id)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezurlalias_ml;
 CREATE TABLE ezurlalias_ml (
@@ -460,13 +460,13 @@ CREATE TABLE ezurlalias_ml (
   KEY ezurlalias_ml_par_lnk_txt (parent,text(32),link),
   KEY ezurlalias_ml_text (text(32),id,link),
   KEY ezurlalias_ml_text_lang (text(32),lang_mask,parent)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezurlalias_ml_incr;
 CREATE TABLE ezurlalias_ml_incr (
   id int(11) NOT NULL auto_increment,
   PRIMARY KEY (id)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezurlwildcard;
 CREATE TABLE ezurlwildcard (
@@ -475,7 +475,7 @@ CREATE TABLE ezurlwildcard (
   source_url longtext NOT NULL,
   type int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (id)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezuser;
 CREATE TABLE ezuser (
@@ -486,7 +486,7 @@ CREATE TABLE ezuser (
   password_hash_type int(11) NOT NULL DEFAULT 1,
   PRIMARY KEY (contentobject_id),
   UNIQUE KEY `ezuser_login` (`login`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezuser_role;
 CREATE TABLE ezuser_role (
@@ -498,7 +498,7 @@ CREATE TABLE ezuser_role (
   PRIMARY KEY (id),
   KEY ezuser_role_contentobject_id (contentobject_id),
   KEY ezuser_role_role_id (role_id)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezuser_setting;
 CREATE TABLE ezuser_setting (
@@ -506,7 +506,7 @@ CREATE TABLE ezuser_setting (
   max_login int(11) DEFAULT NULL,
   user_id int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (user_id)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezsearch_object_word_link;
 CREATE TABLE ezsearch_object_word_link (
@@ -529,7 +529,7 @@ CREATE TABLE ezsearch_object_word_link (
   KEY ezsearch_object_word_link_integer_value (integer_value),
   KEY ezsearch_object_word_link_object (contentobject_id),
   KEY ezsearch_object_word_link_word (word_id)
-) ENGINE=InnoDB AUTO_INCREMENT=17279 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=17279 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezsearch_word;
 CREATE TABLE ezsearch_word (
@@ -539,7 +539,7 @@ CREATE TABLE ezsearch_word (
   PRIMARY KEY (id),
   KEY ezsearch_word_obj_count (object_count),
   KEY ezsearch_word_word_i (word)
-) ENGINE=InnoDB AUTO_INCREMENT=2523 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=2523 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezsection;
 CREATE TABLE ezsection (
@@ -549,7 +549,7 @@ CREATE TABLE ezsection (
   name varchar(255) DEFAULT NULL,
   navigation_part_identifier varchar(100) DEFAULT 'ezcontentnavigationpart',
   PRIMARY KEY (id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezuser_accountkey;
 CREATE TABLE ezuser_accountkey (
@@ -559,7 +559,7 @@ CREATE TABLE ezuser_accountkey (
   user_id int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (id),
   KEY hash_key (hash_key)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezuservisit;
 CREATE TABLE ezuservisit (
@@ -570,7 +570,7 @@ CREATE TABLE ezuservisit (
   user_id int(11) NOT NULL DEFAULT 0,
   PRIMARY KEY (user_id),
   KEY ezuservisit_co_visit_count (current_visit_timestamp,login_count)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezkeyword;
 CREATE TABLE ezkeyword (
@@ -579,7 +579,7 @@ CREATE TABLE ezkeyword (
   keyword varchar(255) DEFAULT NULL,
   PRIMARY KEY (id),
   KEY ezkeyword_keyword (keyword)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezkeyword_attribute_link;
 CREATE TABLE ezkeyword_attribute_link (
@@ -589,7 +589,7 @@ CREATE TABLE ezkeyword_attribute_link (
   PRIMARY KEY (id),
   KEY ezkeyword_attr_link_kid_oaid (keyword_id,objectattribute_id),
   KEY ezkeyword_attr_link_oaid (objectattribute_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 
 DROP TABLE IF EXISTS ezgmaplocation;
 CREATE TABLE ezgmaplocation (
@@ -600,4 +600,4 @@ CREATE TABLE ezgmaplocation (
   address varchar(150) DEFAULT NULL,
   PRIMARY KEY (contentobject_attribute_id,contentobject_version),
   KEY latitude_longitude_key (latitude,longitude)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28950](https://jira.ez.no/browse/EZP-28950)
| **Bug fix**        | no
| **New feature**    | kind of
| **Target version** | 7.2
| **BC breaks**      | kind of (shorter indexes)
| **Tests pass**     | yes
| **Doc needed**     | yes (for changing existing databases)

We should use the `utf8mb4` mysql charset which supports all of unicode, instead of `utf8` which does not support 4-byte characters (which includes some Chinese, emojis, and other things).

~Note that for collation I selected `utf8mb4_unicode_520_ci` instead of `utf8mb4_unicode_ci`, because the latter treats all 4-byte characters as the same. Ref https://core.trac.wordpress.org/ticket/32105#comment:3~ We will leave collation for the site admins to decide.

TODO
- [x] Go back to index length update on ezsearch_search_phrase
- [x] Add upgrade SQL
- [x] Add upgrade doc
- [x] ~Separate PRs for db charset in app/config/config.yml and legacy site.ini~ No can do, not compatible with non-mysql dbs, note in upgrade doc instead
- [x] Do this in 2.2 instead