### PR TITLE
EZP-28554: Error 400 after filling Text field in URL field type

### DIFF
--- a/eZ/Publish/Core/FieldType/Url/Type.php
+++ b/eZ/Publish/Core/FieldType/Url/Type.php
@@ -82,7 +82,7 @@ class Type extends FieldType
      */
     protected function checkValueStructure(BaseValue $value)
     {
-        if (!is_string($value->link)) {
+        if (null !== $value->link && !is_string($value->link)) {
             throw new InvalidArgumentType(
                 '$value->link',
                 'string',
@@ -90,7 +90,7 @@ class Type extends FieldType
             );
         }
 
-        if (isset($value->text) && !is_string($value->text)) {
+        if (null !== $value->text && !is_string($value->text)) {
             throw new InvalidArgumentType(
                 '$value->text',
                 'string',


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28554](https://jira.ez.no/browse/EZP-28554)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Adding additional condition to if statement prevents exception to happen when link value is not provided but text is. This however only prevents 500 error to show as the fieldvalues are not saved (identical to 1.X version).


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
