### PR TITLE
EZP-28279: User cannot set max file size in Image field type

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
@@ -10,14 +10,10 @@ namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 
 use eZ\Publish\Core\IO\IOServiceInterface;
 use eZ\Publish\Core\IO\UrlRedecoratorInterface;
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
-use eZ\Publish\SPI\Persistence\Content\FieldTypeConstraints;
-use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
-use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 
-class ImageConverter implements Converter
+class ImageConverter extends BinaryFileConverter
 {
     /** @var \eZ\Publish\Core\IO\IOServiceInterface */
     private $imageIoService;
@@ -213,54 +209,5 @@ EOT;
         $extractedData['alternativeText'] = $ezimageTag->getAttribute('alternative_text');
 
         return $extractedData;
-    }
-
-    /**
-     * Converts field definition data in $fieldDef into $storageFieldDef.
-     *
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDef
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition $storageDef
-     */
-    public function toStorageFieldDefinition(FieldDefinition $fieldDef, StorageFieldDefinition $storageDef)
-    {
-        $storageDef->dataInt1 = (isset($fieldDef->fieldTypeConstraints->validators['FileSizeValidator']['maxFileSize'])
-            ? round($fieldDef->fieldTypeConstraints->validators['FileSizeValidator']['maxFileSize'] / 1024 / 1024)
-            : 0);
-    }
-
-    /**
-     * Converts field definition data in $storageDef into $fieldDef.
-     *
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition $storageDef
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition $fieldDef
-     */
-    public function toFieldDefinition(StorageFieldDefinition $storageDef, FieldDefinition $fieldDef)
-    {
-        $fieldDef->fieldTypeConstraints = new FieldTypeConstraints(
-            array(
-                'validators' => array(
-                    'FileSizeValidator' => array(
-                        'maxFileSize' => ($storageDef->dataInt1 != 0
-                            ? (int)$storageDef->dataInt1 * 1024 * 1024
-                            : null),
-                    ),
-                ),
-            )
-        );
-    }
-
-    /**
-     * Returns the name of the index column in the attribute table.
-     *
-     * Returns the name of the index column the datatype uses, which is either
-     * "sort_key_int" or "sort_key_string". This column is then used for
-     * filtering and sorting for this type.
-     *
-     * @return string
-     */
-    public function getIndexColumn()
-    {
-        // @todo: Correct?
-        return 'sort_key_string';
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28279](https://jira.ez.no/browse/EZP-28279)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.x`/`7.x` for bug fixes or improvements _(on existing features)_, `master` for features
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

For image fieldtype the max size input value was expecting size in bytes, then it was converted for mb for database and for frontend iw was converted back again to bytes. This unifies it across all file filedtypes.
Not sure where I should target this one. 

PR with corrected label: https://github.com/ezsystems/repository-forms/pull/226
Frontend display and validation: https://github.com/ezsystems/ezplatform-admin-ui/pull/401

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
