### PR TITLE
Implement IsFieldEmpty criterion

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/IsFieldEmpty.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/IsFieldEmpty.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
+use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
+use InvalidArgumentException;
+
+/**
+ * IsFieldEmpty criterion matches Content field based on if its value is empty or not.
+ */
+class IsFieldEmpty extends Criterion implements CriterionInterface
+{
+    /**
+     * Indicates that the field should be empty.
+     *
+     * @var mixed
+     */
+    const IS_EMPTY = 0;
+
+    /**
+     * Indicates that the field should not be empty.
+     *
+     * @var mixed
+     */
+    const IS_NOT_EMPTY = 1;
+
+    /**
+     * @param string $fieldDefinitionIdentifier
+     * @param mixed $value Field content: self::IS_EMPTY, self::IS_NOT_EMPTY
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function __construct($fieldDefinitionIdentifier, $value)
+    {
+        if ($value !== self::IS_EMPTY && $value !== self::IS_NOT_EMPTY) {
+            throw new InvalidArgumentException("Invalid field empty status value {$value}");
+        }
+
+        parent::__construct($fieldDefinitionIdentifier, null, $value);
+    }
+
+    public function getSpecifications()
+    {
+        return [
+            new Specifications(
+                Operator::EQ,
+                Specifications::FORMAT_SINGLE,
+                Specifications::TYPE_INTEGER
+            ),
+        ];
+    }
+
+    public static function createFromQueryBuilder($target, $operator, $value)
+    {
+        return new self($target, $value);
+    }
+}

--- a/eZ/Publish/Core/Persistence/FieldType.php
+++ b/eZ/Publish/Core/Persistence/FieldType.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\Persistence;
 
 use eZ\Publish\SPI\Persistence\FieldType as FieldTypeInterface;
 use eZ\Publish\SPI\FieldType\FieldType as SPIFieldType;
+use eZ\Publish\SPI\Persistence\Content\FieldValue;
 
 /**
  * This class represents a FieldType available to SPI users.
@@ -44,6 +45,13 @@ class FieldType implements FieldTypeInterface
     {
         return $this->internalFieldType->toPersistenceValue(
             $this->internalFieldType->getEmptyValue()
+        );
+    }
+
+    public function isEmptyValue(FieldValue $value)
+    {
+        return $this->internalFieldType->isEmptyValue(
+            $this->internalFieldType->fromPersistenceValue($value)
         );
     }
 }

--- a/eZ/Publish/SPI/Persistence/FieldType.php
+++ b/eZ/Publish/SPI/Persistence/FieldType.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\SPI\Persistence;
 
+use eZ\Publish\SPI\Persistence\Content\FieldValue;
+
 /**
  * The field type interface which field types available to storage engines have to implement.
  *
@@ -21,4 +23,13 @@ interface FieldType
      * @return \eZ\Publish\SPI\Persistence\Content\FieldValue
      */
     public function getEmptyValue();
+
+    /**
+     * Returns if the given $value is considered empty by the field type.
+     *
+     * @param \eZ\Publish\SPI\Persistence\Content\FieldValue $value
+     *
+     * @return bool
+     */
+    public function isEmptyValue(FieldValue $value);
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | TBD
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `6.7`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This adds `IsFieldEmpty` criterion, to match on whether Content field is empty or not.

Currently this can be implemented only with Solr Search Engine, since we need a way to store empty field value state to be able to search on it. Since indexer works with Persistence field values, Persistence FieldType is here updated with `isEmptyValue()` method.

**TODO**:
- [x] Implement field mapper and criterion visitor in Solr Search Engine
- [ ] Implement integration tests
