### PR TITLE
EZP-28934: Incorrect variable in policy check context

### DIFF
--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -350,7 +350,7 @@ class LocationService implements LocationServiceInterface
         $content = $this->repository->getContentService()->loadContent($contentInfo->id);
         $parentLocation = $this->loadLocation($locationCreateStruct->parentLocationId);
 
-        if (!$this->repository->canUser('content', 'manage_locations', $content->contentInfo, $content)) {
+        if (!$this->repository->canUser('content', 'manage_locations', $content->contentInfo)) {
             throw new UnauthorizedException('content', 'manage_locations');
         }
 

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -350,7 +350,7 @@ class LocationService implements LocationServiceInterface
         $content = $this->repository->getContentService()->loadContent($contentInfo->id);
         $parentLocation = $this->loadLocation($locationCreateStruct->parentLocationId);
 
-        if (!$this->repository->canUser('content', 'manage_locations', $content->contentInfo, $parentLocation)) {
+        if (!$this->repository->canUser('content', 'manage_locations', $content->contentInfo, $content)) {
             throw new UnauthorizedException('content', 'manage_locations');
         }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28934](https://jira.ez.no/browse/EZP-28934)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `6.7`
| **BC breaks**      | no
| **Tests pass**     | yes/no
| **Doc needed**     | no

The previous PR (https://github.com/ezsystems/ezpublish-kernel/pull/2276) introduced `content/manage_locations` policy check, but it was based on the wrong context. This PR fixes it. The problem was discovered by QA during tests. 


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
