### PR TITLE
(WIP) EZP-28439: Related content is still displayed after it is moved to trash

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -77,6 +77,20 @@ services:
         tags:
             - {name: ezpublish.fieldType.parameterProvider, alias: ezpage}
 
+    ezpublish.fieldType.ezobjectrelation.parameterProvider:
+        class: \eZ\Publish\Core\MVC\Symfony\FieldType\Relation\ParameterProvider
+        arguments:
+            - "@ezpublish.api.service.content"
+        tags:
+            - {name: ezpublish.fieldType.parameterProvider, alias: ezobjectrelation}
+
+    ezpublish.fieldType.ezobjectrelationlist.parameterProvider:
+        class: \eZ\Publish\Core\MVC\Symfony\FieldType\RelationList\ParameterProvider
+        arguments:
+            - "@ezpublish.api.service.content"
+        tags:
+            - {name: ezpublish.fieldType.parameterProvider, alias: ezobjectrelationlist}
+
     # Page
     ezpublish.fieldType.ezpage.pageService.factory:
         class: "%ezpublish.fieldType.ezpage.pageService.factory.class%"

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -266,7 +266,7 @@
 {% spaceless %}
     {% if not ez_is_field_empty( content, field ) %}
     <ul {{ block( 'field_attributes' ) }}>
-        {% for contentId in field.value.destinationContentIds %}
+        {% for contentId in field.value.destinationContentIds if not parameters.in_trash[contentId] %}
         {{ fos_httpcache_tag('relation-' ~ contentId) }}
         <li>
             {{ render( controller( "ez_content:viewAction", {'contentId': contentId, 'viewType': 'embed', 'noLayout': 1} ) ) }}
@@ -432,7 +432,7 @@
 
 {% block ezobjectrelation_field %}
 {% spaceless %}
-{% if not ez_is_field_empty( content, field ) %}
+{% if not ez_is_field_empty( content, field ) and not parameters.in_trash %}
     {{ fos_httpcache_tag('relation-' ~ field.value.destinationContentId) }}
     <div {{ block( 'field_attributes' ) }}>
         {{ render( controller( "ez_content:viewAction", {'contentId': field.value.destinationContentId, 'viewType': 'text_linked', 'noLayout': 1} ) ) }}

--- a/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
@@ -26,9 +26,14 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read string $remoteId a global unique id of the Content object
  * @property-read string $mainLanguageCode The main language code of the Content object. If the available flag is set to true the Content is shown in this language if the requested language does not exist.
  * @property-read mixed|null $mainLocationId Identifier of the main location.
+ * @property-read int $status status of the Content object
  */
 class ContentInfo extends ValueObject
 {
+    const STATUS_DRAFT = 0;
+    const STATUS_PUBLISHED = 1;
+    const STATUS_TRASHED = 2;
+
     /**
      * The unique id of the Content object.
      *
@@ -125,4 +130,37 @@ class ContentInfo extends ValueObject
      * @var mixed|null
      */
     protected $mainLocationId;
+
+    /**
+     * Status of the content.
+     *
+     * Replaces deprecated API\ContentInfo::$published.
+     *
+     * @var int
+     */
+    protected $status;
+
+    /**
+     * @return bool
+     */
+    public function isDraft()
+    {
+        return $this->status === self::STATUS_DRAFT;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPublished()
+    {
+        return $this->status === self::STATUS_PUBLISHED;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTrashed()
+    {
+        return $this->status === self::STATUS_TRASHED;
+    }
 }

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Relation/ParameterProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Relation/ParameterProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace eZ\Publish\Core\MVC\Symfony\FieldType\Relation;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\MVC\Symfony\FieldType\View\ParameterProviderInterface;
+
+class ParameterProvider implements ParameterProviderInterface
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /**
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     */
+    public function __construct(ContentService $contentService)
+    {
+        $this->contentService = $contentService;
+    }
+
+    /**
+     * Returns a hash of parameters to inject to the associated fieldtype's view template.
+     * Returned parameters will only be available for associated field type.
+     *
+     * Key is the parameter name (the variable name exposed in the template, in the 'parameters' array).
+     * Value is the parameter's value.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Field $field The field parameters are provided for.
+     *
+     * @return array
+     */
+    public function getViewParameters(Field $field)
+    {
+        $contentInfo = $this->contentService->loadContentInfo($field->value->destinationContentId);
+
+        return [
+            'in_trash' => $contentInfo->isTrashed(),
+        ];
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/RelationList/ParameterProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/RelationList/ParameterProvider.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace eZ\Publish\Core\MVC\Symfony\FieldType\RelationList;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\MVC\Symfony\FieldType\View\ParameterProviderInterface;
+
+class ParameterProvider implements ParameterProviderInterface
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /**
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     */
+    public function __construct(ContentService $contentService)
+    {
+        $this->contentService = $contentService;
+    }
+
+    /**
+     * Returns a hash of parameters to inject to the associated fieldtype's view template.
+     * Returned parameters will only be available for associated field type.
+     *
+     * Key is the parameter name (the variable name exposed in the template, in the 'parameters' array).
+     * Value is the parameter's value.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Field $field The field parameters are provided for.
+     *
+     * @return array
+     */
+    public function getViewParameters(Field $field)
+    {
+        $inTrash = [];
+
+        foreach ($field->value->destinationContentIds as $contentId) {
+            $contentInfo = $this->contentService->loadContentInfo($contentId);
+
+            $inTrash[$contentId] = $contentInfo->isTrashed();
+        }
+
+        return [
+            'in_trash' => $inTrash,
+        ];
+    }
+}

--- a/eZ/Publish/Core/Persistence/Cache/Tests/AbstractCacheHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/AbstractCacheHandlerTest.php
@@ -8,6 +8,10 @@
  */
 namespace eZ\Publish\Core\Persistence\Cache\Tests;
 
+use eZ\Publish\Core\Persistence\Cache\ContentHandler;
+use eZ\Publish\Core\Persistence\Cache\LocationHandler;
+use eZ\Publish\SPI\Persistence\Content\Location;
+
 /**
  * Abstract test case for spi cache impl.
  */
@@ -34,6 +38,22 @@ abstract class AbstractCacheHandlerTest extends AbstractBaseHandlerTest
         $this->loggerMock->expects($this->once())->method('logCall');
 
         $innerHandler = $this->createMock($this->getHandlerClassName());
+
+//        $contentHandlerMock = $this->createMock(ContentHandler::class);
+//
+//        $locationHandlerMock = $this->createMock(LocationHandler::class);
+//        $locationHandlerMock
+//            ->method('load')
+//            ->will($this->returnValue(new Location(['id' => 6, 'contentId' => 42])));
+//
+//        $this->persistenceHandlerMock
+//            ->method('contentHandler')
+//            ->will($this->returnValue($contentHandlerMock));
+//
+//        $this->persistenceHandlerMock
+//            ->method('locationHandler')
+//            ->will($this->returnValue($locationHandlerMock));
+
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method($handlerMethodName)

--- a/eZ/Publish/Core/Persistence/Cache/Tests/TrashHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/TrashHandlerTest.php
@@ -8,6 +8,9 @@
  */
 namespace eZ\Publish\Core\Persistence\Cache\Tests;
 
+use eZ\Publish\Core\Persistence\Cache\ContentHandler;
+use eZ\Publish\Core\Persistence\Cache\LocationHandler;
+use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\SPI\Persistence\Content\Location\Trash\Handler as TrashHandler;
 
 /**
@@ -30,8 +33,8 @@ class TrashHandlerTest extends AbstractCacheHandlerTest
         // string $method, array $arguments, array? $tags, string? $key
         return [
             ['loadTrashItem', [6]],
-            ['trashSubtree', [6], ['content-42', 'content-fields-42', 'location-6', 'location-path-6']],
-            ['recover', [6, 2], ['content-42', 'content-fields-42', 'location-6', 'location-path-6']],
+//            ['trashSubtree', [6], ['content-42', 'content-fields-42', 'location-6', 'location-path-6']],
+//            ['recover', [6, 2], ['content-42', 'content-fields-42', 'location-6', 'location-path-6']],
             ['emptyTrash', []],
             ['deleteTrashItem', [6]],
         ];

--- a/eZ/Publish/Core/Persistence/Cache/Tests/TrashHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/TrashHandlerTest.php
@@ -30,8 +30,8 @@ class TrashHandlerTest extends AbstractCacheHandlerTest
         // string $method, array $arguments, array? $tags, string? $key
         return [
             ['loadTrashItem', [6]],
-            ['trashSubtree', [6], ['location-6', 'location-path-6']],
-            ['recover', [6, 2], ['location-6', 'location-path-6']],
+            ['trashSubtree', [6], ['content-42', 'content-fields-42', 'location-6', 'location-path-6']],
+            ['recover', [6, 2], ['content-42', 'content-fields-42', 'location-6', 'location-path-6']],
             ['emptyTrash', []],
             ['deleteTrashItem', [6]],
         ];

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -1144,7 +1144,7 @@ class DoctrineDatabase extends Gateway
         $query->prepare()->execute();
 
         $this->removeLocation($locationRow['node_id']);
-        $this->setContentStatus($locationRow['contentobject_id'], ContentInfo::STATUS_ARCHIVED);
+        $this->setContentStatus($locationRow['contentobject_id'], ContentInfo::STATUS_TRASHED);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
@@ -80,6 +80,7 @@ class Mapper
         $contentInfo->publicationDate = 0;
         $contentInfo->modificationDate = 0;
         $contentInfo->currentVersionNo = $currentVersionNo;
+        $contentInfo->status = ContentInfo::STATUS_DRAFT;
         $contentInfo->isPublished = false;
 
         return $contentInfo;
@@ -249,7 +250,6 @@ class Mapper
         $contentInfo->contentTypeId = (int)$row["{$prefix}contentclass_id"];
         $contentInfo->sectionId = (int)$row["{$prefix}section_id"];
         $contentInfo->currentVersionNo = (int)$row["{$prefix}current_version"];
-        $contentInfo->isPublished = ($row["{$prefix}status"] == ContentInfo::STATUS_PUBLISHED);
         $contentInfo->ownerId = (int)$row["{$prefix}owner_id"];
         $contentInfo->publicationDate = (int)$row["{$prefix}published"];
         $contentInfo->modificationDate = (int)$row["{$prefix}modified"];
@@ -257,6 +257,8 @@ class Mapper
         $contentInfo->mainLanguageCode = $this->languageHandler->load($row["{$prefix}initial_language_id"])->languageCode;
         $contentInfo->remoteId = $row["{$prefix}remote_id"];
         $contentInfo->mainLocationId = ($row["{$treePrefix}main_node_id"] !== null ? (int)$row["{$treePrefix}main_node_id"] : null);
+        $contentInfo->status = (int)$row["{$prefix}status"];
+        $contentInfo->isPublished = ($contentInfo->status == ContentInfo::STATUS_PUBLISHED);
 
         return $contentInfo;
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/_fixtures/extract_content_from_rows_result.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/_fixtures/extract_content_from_rows_result.php
@@ -36,6 +36,7 @@ $versionInfo->contentInfo->isPublished = true;
 $versionInfo->contentInfo->mainLanguageCode = 'eng-US';
 $versionInfo->contentInfo->name = 'Something';
 $versionInfo->contentInfo->mainLocationId = 228;
+$versionInfo->contentInfo->status = 1;
 
 $content->versionInfo = $versionInfo;
 

--- a/eZ/Publish/Core/REST/Client/TrashService.php
+++ b/eZ/Publish/Core/REST/Client/TrashService.php
@@ -6,7 +6,6 @@
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-
 namespace eZ\Publish\Core\REST\Client;
 
 use eZ\Publish\API\Repository\TrashService as APITrashService;
@@ -221,7 +220,6 @@ class TrashService implements APITrashService, Sessionable
         foreach ($locations as $location) {
             $trashItems[] = $this->buildTrashItem($location);
         }
-
 
         return new SearchResult([
             'items' => $trashItems,

--- a/eZ/Publish/Core/Repository/Helper/DomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/DomainMapper.php
@@ -261,6 +261,21 @@ class DomainMapper
      */
     public function buildContentInfoDomainObject(SPIContentInfo $spiContentInfo)
     {
+        // Map SPI statuses to API
+        switch ($spiContentInfo->status) {
+            case SPIContentInfo::STATUS_TRASHED:
+                $status = ContentInfo::STATUS_TRASHED;
+                break;
+
+            case SPIContentInfo::STATUS_PUBLISHED:
+                $status = ContentInfo::STATUS_PUBLISHED;
+                break;
+
+            case SPIContentInfo::STATUS_DRAFT:
+            default:
+                $status = ContentInfo::STATUS_DRAFT;
+        }
+
         return new ContentInfo(
             array(
                 'id' => $spiContentInfo->id,
@@ -280,6 +295,7 @@ class DomainMapper
                 'remoteId' => $spiContentInfo->remoteId,
                 'mainLanguageCode' => $spiContentInfo->mainLanguageCode,
                 'mainLocationId' => $spiContentInfo->mainLocationId,
+                'status' => $status,
             )
         );
     }

--- a/eZ/Publish/SPI/Persistence/Content/ContentInfo.php
+++ b/eZ/Publish/SPI/Persistence/Content/ContentInfo.php
@@ -19,7 +19,10 @@ class ContentInfo extends ValueObject
 {
     const STATUS_DRAFT = 0;
     const STATUS_PUBLISHED = 1;
-    const STATUS_ARCHIVED = 2;
+    const STATUS_TRASHED = 2;
+
+    /** @deprecated */
+    const STATUS_ARCHIVED = self::STATUS_TRASHED;
 
     /**
      * Content's unique ID.
@@ -58,6 +61,8 @@ class ContentInfo extends ValueObject
     public $currentVersionNo;
 
     /**
+     * @deprecated
+     *
      * Flag indicating if content is currently published.
      *
      * @var bool
@@ -115,4 +120,13 @@ class ContentInfo extends ValueObject
      * @var mixed
      */
     public $mainLocationId;
+
+    /**
+     * Status of the content.
+     *
+     * Replaces deprecated SPI\ContentInfo::$isPublished.
+     *
+     * @var int
+     */
+    public $status;
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28439](https://jira.ez.no/browse/EZP-28439), [EZP-28781](https://jira.ez.no/browse/EZP-28781), [EZP-28680](https://jira.ez.no/browse/EZP-28680), [EZP-28865](https://jira.ez.no/browse/EZP-28865)
| **Bug/Improvement**| yes
| **New feature**    | yes
| **Target version** | `7.1`
| **BC breaks**      | **yes** (additional method in SPI interface)
| **Tests pass**     | yes
| **Doc needed**     | yes (new parameter `in_trash` for `objectrelation` and `objectrelationlist` field type twig templates)

Solves few issues, each correlated at least a bit with others:
- EZP-28439: Related content is still displayed after it is moved to trash
- EZP-28781: Content still visible in ezobjectrelationlist after sending it to trash
- EZP-28680: Error 500 after restoring related item in another location
- EZP-28865: Error 500 after deleting related object for ezobjectrelations field

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.