### PR TITLE
EZP-28972: RichText Custom Tag align attribute is not present in Tag template

### DIFF
--- a/eZ/Publish/Core/FieldType/RichText/Converter/Render/Template.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter/Render/Template.php
@@ -78,8 +78,8 @@ class Template extends Render implements Converter
             );
         }
 
-        if ($tag->hasAttribute('xlink:align')) {
-            $parameters['align'] = $tag->getAttribute('xlink:align');
+        if ($tag->hasAttribute('ezxhtml:align')) {
+            $parameters['align'] = $tag->getAttribute('ezxhtml:align');
         }
 
         $content = $this->renderer->renderTag(

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Render/TemplateTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Render/TemplateTest.php
@@ -228,6 +228,41 @@ class TemplateTest extends TestCase
                     ),
                 ),
             ),
+            array(
+                '<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml">
+  <eztemplate name="custom_tag" ezxhtml:align="right">
+    <ezcontent><para>Param: value</para></ezcontent>
+    <ezconfig>
+        <ezvalue key="param">value</ezvalue>
+    </ezconfig>
+  </eztemplate>
+</section>',
+                '<?xml version="1.0"?>
+ <section xmlns="http://docbook.org/ns/docbook" xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml">
+  <eztemplate name="custom_tag" ezxhtml:align="right">
+    <ezcontent>
+      <para>param: value</para>
+    </ezcontent>
+    <ezconfig>
+      <ezvalue key="param">value</ezvalue>
+    </ezconfig>
+    <ezpayload>custom_tag</ezpayload>
+  </eztemplate>
+</section>',
+                array(
+                    array(
+                        'name' => 'custom_tag',
+                        'is_inline' => false,
+                        'params' => array(
+                            'name' => 'custom_tag',
+                            'content' => '<para>Param: value</para>',
+                            'params' => array('param' => 'value'),
+                            'align' => 'right',
+                        ),
+                    ),
+                ),
+            ),
         );
     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28972](https://jira.ez.no/browse/EZP-28972)
| **Required by**     | ezsystems/ezplatform-demo#75
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.1`
| **BC breaks**      | no
| **Tests pass**     | TBD
| **Doc needed**     | no

The HTML5 output converter responsible for rendering RichText Custom Tag frontend template tried to get align attribute from `xlink` namespace. The correct one is `ezxhtml`.

**TODO**:
- [x] Fixed incorrect XML namespace for align attribute of RichText Custom tag template Renderer.
- [x] Identify if and what tests can be implemented for this.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
