### PR TITLE
EZP-28439: Related content is still displayed after it is moved to trash

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -77,6 +77,20 @@ services:
         tags:
             - {name: ezpublish.fieldType.parameterProvider, alias: ezpage}
 
+    ezpublish.fieldType.ezobjectrelation.parameterProvider:
+        class: \eZ\Publish\Core\MVC\Symfony\FieldType\Relation\ParameterProvider
+        arguments:
+            - "@ezpublish.api.service.content"
+        tags:
+            - {name: ezpublish.fieldType.parameterProvider, alias: ezobjectrelation}
+
+    ezpublish.fieldType.ezobjectrelationlist.parameterProvider:
+        class: \eZ\Publish\Core\MVC\Symfony\FieldType\RelationList\ParameterProvider
+        arguments:
+            - "@ezpublish.api.service.content"
+        tags:
+            - {name: ezpublish.fieldType.parameterProvider, alias: ezobjectrelationlist}
+
     # Page
     ezpublish.fieldType.ezpage.pageService.factory:
         class: "%ezpublish.fieldType.ezpage.pageService.factory.class%"

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -264,7 +264,7 @@
 {% spaceless %}
     {% if not ez_is_field_empty( content, field ) %}
     <ul {{ block( 'field_attributes' ) }}>
-        {% for contentId in field.value.destinationContentIds %}
+        {% for contentId in field.value.destinationContentIds if parameters.available[contentId] %}
         <li>
             {{ render( controller( "ez_content:viewAction", {'contentId': contentId, 'viewType': 'embed', 'noLayout': 1} ) ) }}
         </li>
@@ -434,7 +434,7 @@
 
 {% block ezobjectrelation_field %}
 {% spaceless %}
-{% if not ez_is_field_empty( content, field ) %}
+{% if not ez_is_field_empty( content, field ) and parameters.available %}
     <div {{ block( 'field_attributes' ) }}>
         {{ render( controller( "ez_content:viewAction", {'contentId': field.value.destinationContentId, 'viewType': 'text_linked', 'noLayout': 1} ) ) }}
     </div>

--- a/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
@@ -26,9 +26,14 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read string $remoteId a global unique id of the Content object
  * @property-read string $mainLanguageCode The main language code of the Content object. If the available flag is set to true the Content is shown in this language if the requested language does not exist.
  * @property-read mixed $mainLocationId Identifier of the main location.
+ * @property-read int $status status of the Content object
  */
 class ContentInfo extends ValueObject
 {
+    const STATUS_DRAFT = 0;
+    const STATUS_PUBLISHED = 1;
+    const STATUS_TRASHED = 2;
+
     /**
      * The unique id of the Content object.
      *
@@ -125,4 +130,37 @@ class ContentInfo extends ValueObject
      * @var mixed
      */
     protected $mainLocationId;
+
+    /**
+     * Status of the content.
+     *
+     * Replaces deprecated API\ContentInfo::$published.
+     *
+     * @var int
+     */
+    protected $status;
+
+    /**
+     * @return bool
+     */
+    public function isDraft()
+    {
+        return $this->status === self::STATUS_DRAFT;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPublished()
+    {
+        return $this->status === self::STATUS_PUBLISHED;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isTrashed()
+    {
+        return $this->status === self::STATUS_TRASHED;
+    }
 }

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Relation/ParameterProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Relation/ParameterProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace eZ\Publish\Core\MVC\Symfony\FieldType\Relation;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\MVC\Symfony\FieldType\View\ParameterProviderInterface;
+
+class ParameterProvider implements ParameterProviderInterface
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /**
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     */
+    public function __construct(ContentService $contentService)
+    {
+        $this->contentService = $contentService;
+    }
+
+    /**
+     * Returns a hash of parameters to inject to the associated fieldtype's view template.
+     * Returned parameters will only be available for associated field type.
+     *
+     * Key is the parameter name (the variable name exposed in the template, in the 'parameters' array).
+     * Value is the parameter's value.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Field $field The field parameters are provided for.
+     *
+     * @return array
+     */
+    public function getViewParameters(Field $field)
+    {
+        try {
+            $contentInfo = $this->contentService->loadContentInfo($field->value->destinationContentId);
+
+            return [
+                'available' => !$contentInfo->isTrashed(),
+            ];
+        } catch (NotFoundException $exception) {
+            return ['available' => false];
+        } catch (UnauthorizedException $exception) {
+            return ['available' => false];
+        }
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/RelationList/ParameterProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/RelationList/ParameterProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace eZ\Publish\Core\MVC\Symfony\FieldType\RelationList;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\MVC\Symfony\FieldType\View\ParameterProviderInterface;
+
+class ParameterProvider implements ParameterProviderInterface
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /**
+     * @param \eZ\Publish\API\Repository\ContentService $contentService
+     */
+    public function __construct(ContentService $contentService)
+    {
+        $this->contentService = $contentService;
+    }
+
+    /**
+     * Returns a hash of parameters to inject to the associated fieldtype's view template.
+     * Returned parameters will only be available for associated field type.
+     *
+     * Key is the parameter name (the variable name exposed in the template, in the 'parameters' array).
+     * Value is the parameter's value.
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Field $field The field parameters are provided for.
+     *
+     * @return array
+     */
+    public function getViewParameters(Field $field)
+    {
+        $available = [];
+
+        foreach ($field->value->destinationContentIds as $contentId) {
+            try {
+                $contentInfo = $this->contentService->loadContentInfo($contentId);
+
+                $available[$contentId] = !$contentInfo->isTrashed();
+            } catch (NotFoundException $exception) {
+                $available[$contentId] = false;
+            } catch (UnauthorizedException $exception) {
+                $available[$contentId] = false;
+            }
+        }
+
+        return [
+            'available' => $available,
+        ];
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/Relation/ParameterProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/Relation/ParameterProviderTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace eZ\Publish\Core\MVC\Symfony\FieldType\Tests\RelationList;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
+use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
+use eZ\Publish\Core\FieldType\Relation\Value;
+use eZ\Publish\Core\MVC\Symfony\FieldType\Relation\ParameterProvider;
+use PHPUnit\Framework\TestCase;
+
+class ParameterProviderTest extends TestCase
+{
+    use PHPUnit5CompatTrait;
+
+    public function providerForTestGetViewParameters()
+    {
+        return [
+            [ContentInfo::STATUS_DRAFT, ['available' => true]],
+            [ContentInfo::STATUS_PUBLISHED, ['available' => true]],
+            [ContentInfo::STATUS_TRASHED, ['available' => false]],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestGetViewParameters
+     */
+    public function testGetViewParameters($status, array $expected)
+    {
+        $contentServiceMock = $this->createMock(ContentService::class);
+        $contentServiceMock
+            ->method('loadContentInfo')
+            ->will(TestCase::returnValue(
+                new ContentInfo(['status' => $status])
+            ));
+
+        $parameterProvider = new ParameterProvider($contentServiceMock);
+        $parameters = $parameterProvider->getViewParameters(new Field([
+            'value' => new Value(123),
+        ]));
+
+        TestCase::assertSame($parameters, $expected);
+    }
+
+    public function testNotFoundGetViewParameters()
+    {
+        $contentId = 123;
+
+        $contentServiceMock = $this->createMock(ContentService::class);
+        $contentServiceMock
+            ->method('loadContentInfo')
+            ->will(TestCase::throwException(new NotFoundException('ContentInfo', $contentId)));
+
+        $parameterProvider = new ParameterProvider($contentServiceMock);
+        $parameters = $parameterProvider->getViewParameters(new Field([
+            'value' => new Value($contentId),
+        ]));
+
+        TestCase::assertSame($parameters, ['available' => false]);
+    }
+
+    public function testUnauthorizedGetViewParameters()
+    {
+        $contentId = 123;
+
+        $contentServiceMock = $this->createMock(ContentService::class);
+        $contentServiceMock
+            ->method('loadContentInfo')
+            ->will(TestCase::throwException(new UnauthorizedException('content', 'read')));
+
+        $parameterProvider = new ParameterProvider($contentServiceMock);
+        $parameters = $parameterProvider->getViewParameters(new Field([
+            'value' => new Value($contentId),
+        ]));
+
+        TestCase::assertSame($parameters, ['available' => false]);
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/RelationList/ParameterProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/RelationList/ParameterProviderTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace eZ\Publish\Core\MVC\Symfony\FieldType\Tests\Relation;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\Base\Exceptions\UnauthorizedException;
+use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
+use eZ\Publish\Core\FieldType\RelationList\Value;
+use eZ\Publish\Core\MVC\Symfony\FieldType\RelationList\ParameterProvider;
+use PHPUnit\Framework\TestCase;
+
+class ParameterProviderTest extends TestCase
+{
+    use PHPUnit5CompatTrait;
+
+    public function providerForTestGetViewParameters()
+    {
+        return [
+            [[123, 456, 789], ['available' => [123 => true, 456 => true, 789 => false]]],
+            [[123, 456], ['available' => [123 => true, 456 => true]]],
+            [[789], ['available' => [789 => false]]],
+            [[], ['available' => []]],
+        ];
+    }
+
+    /**
+     * @dataProvider providerForTestGetViewParameters
+     */
+    public function testGetViewParameters(array $desinationContentIds, array $expected)
+    {
+        $contentServiceMock = $this->createMock(ContentService::class);
+        $contentServiceMock
+            ->method('loadContentInfo')
+            ->will(TestCase::returnValueMap([
+                [123, new ContentInfo(['status' => ContentInfo::STATUS_DRAFT])],
+                [456, new ContentInfo(['status' => ContentInfo::STATUS_PUBLISHED])],
+                [789, new ContentInfo(['status' => ContentInfo::STATUS_TRASHED])],
+            ]));
+
+        $parameterProvider = new ParameterProvider($contentServiceMock);
+        $parameters = $parameterProvider->getViewParameters(new Field([
+            'value' => new Value($desinationContentIds),
+        ]));
+
+        TestCase::assertSame($parameters, $expected);
+    }
+
+    public function testNotFoundGetViewParameters()
+    {
+        $contentId = 123;
+
+        $contentServiceMock = $this->createMock(ContentService::class);
+        $contentServiceMock
+            ->method('loadContentInfo')
+            ->will(TestCase::throwException(new NotFoundException('ContentInfo', $contentId)));
+
+        $parameterProvider = new ParameterProvider($contentServiceMock);
+        $parameters = $parameterProvider->getViewParameters(new Field([
+            'value' => new Value([$contentId]),
+        ]));
+
+        TestCase::assertSame($parameters, ['available' => [$contentId => false]]);
+    }
+
+    public function testUnauthorizedGetViewParameters()
+    {
+        $contentId = 123;
+
+        $contentServiceMock = $this->createMock(ContentService::class);
+        $contentServiceMock
+            ->method('loadContentInfo')
+            ->will(TestCase::throwException(new UnauthorizedException('content', 'read')));
+
+        $parameterProvider = new ParameterProvider($contentServiceMock);
+        $parameters = $parameterProvider->getViewParameters(new Field([
+            'value' => new Value([$contentId]),
+        ]));
+
+        TestCase::assertSame($parameters, ['available' => [$contentId => false]]);
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -1144,7 +1144,7 @@ class DoctrineDatabase extends Gateway
         $query->prepare()->execute();
 
         $this->removeLocation($locationRow['node_id']);
-        $this->setContentStatus($locationRow['contentobject_id'], ContentInfo::STATUS_ARCHIVED);
+        $this->setContentStatus($locationRow['contentobject_id'], ContentInfo::STATUS_TRASHED);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
@@ -80,6 +80,7 @@ class Mapper
         $contentInfo->publicationDate = 0;
         $contentInfo->modificationDate = 0;
         $contentInfo->currentVersionNo = $currentVersionNo;
+        $contentInfo->status = ContentInfo::STATUS_DRAFT;
         $contentInfo->isPublished = false;
 
         return $contentInfo;
@@ -250,7 +251,7 @@ class Mapper
         $contentInfo->contentTypeId = (int)$row["{$prefix}contentclass_id"];
         $contentInfo->sectionId = (int)$row["{$prefix}section_id"];
         $contentInfo->currentVersionNo = (int)$row["{$prefix}current_version"];
-        $contentInfo->isPublished = (bool)($row["{$prefix}status"] == ContentInfo::STATUS_PUBLISHED);
+        $contentInfo->isPublished = ($row["{$prefix}status"] == ContentInfo::STATUS_PUBLISHED);
         $contentInfo->ownerId = (int)$row["{$prefix}owner_id"];
         $contentInfo->publicationDate = (int)$row["{$prefix}published"];
         $contentInfo->modificationDate = (int)$row["{$prefix}modified"];
@@ -258,6 +259,8 @@ class Mapper
         $contentInfo->mainLanguageCode = $this->languageHandler->load($row["{$prefix}initial_language_id"])->languageCode;
         $contentInfo->remoteId = $row["{$prefix}remote_id"];
         $contentInfo->mainLocationId = ($row["{$treePrefix}main_node_id"] !== null ? (int)$row["{$treePrefix}main_node_id"] : null);
+        $contentInfo->status = (int)$row["{$prefix}status"];
+        $contentInfo->isPublished = ($contentInfo->status == ContentInfo::STATUS_PUBLISHED);
 
         return $contentInfo;
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/_fixtures/extract_content_from_rows_result.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/_fixtures/extract_content_from_rows_result.php
@@ -36,6 +36,7 @@ $versionInfo->contentInfo->isPublished = true;
 $versionInfo->contentInfo->mainLanguageCode = 'eng-US';
 $versionInfo->contentInfo->name = 'Something';
 $versionInfo->contentInfo->mainLocationId = 228;
+$versionInfo->contentInfo->status = 1;
 
 $content->versionInfo = $versionInfo;
 

--- a/eZ/Publish/Core/Repository/Helper/DomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/DomainMapper.php
@@ -236,6 +236,21 @@ class DomainMapper
      */
     public function buildContentInfoDomainObject(SPIContentInfo $spiContentInfo)
     {
+        // Map SPI statuses to API
+        switch ($spiContentInfo->status) {
+            case SPIContentInfo::STATUS_TRASHED:
+                $status = ContentInfo::STATUS_TRASHED;
+                break;
+
+            case SPIContentInfo::STATUS_PUBLISHED:
+                $status = ContentInfo::STATUS_PUBLISHED;
+                break;
+
+            case SPIContentInfo::STATUS_DRAFT:
+            default:
+                $status = ContentInfo::STATUS_DRAFT;
+        }
+
         return new ContentInfo(
             array(
                 'id' => $spiContentInfo->id,
@@ -255,6 +270,7 @@ class DomainMapper
                 'remoteId' => $spiContentInfo->remoteId,
                 'mainLanguageCode' => $spiContentInfo->mainLanguageCode,
                 'mainLocationId' => $spiContentInfo->mainLocationId,
+                'status' => $status,
             )
         );
     }

--- a/eZ/Publish/SPI/Persistence/Content/ContentInfo.php
+++ b/eZ/Publish/SPI/Persistence/Content/ContentInfo.php
@@ -19,7 +19,10 @@ class ContentInfo extends ValueObject
 {
     const STATUS_DRAFT = 0;
     const STATUS_PUBLISHED = 1;
-    const STATUS_ARCHIVED = 2;
+    const STATUS_TRASHED = 2;
+
+    /** @deprecated Use ContentInfo::STATUS_TRASHED */
+    const STATUS_ARCHIVED = self::STATUS_TRASHED;
 
     /**
      * Content's unique ID.
@@ -58,6 +61,8 @@ class ContentInfo extends ValueObject
     public $currentVersionNo;
 
     /**
+     * @deprecated Use SPI\ContentInfo::$status (with value ContentInfo::STATUS_PUBLISHED)
+     *
      * Flag indicating if content is currently published.
      *
      * @var bool
@@ -115,4 +120,13 @@ class ContentInfo extends ValueObject
      * @var mixed
      */
     public $mainLocationId;
+
+    /**
+     * Status of the content.
+     *
+     * Replaces deprecated SPI\ContentInfo::$isPublished.
+     *
+     * @var int
+     */
+    public $status;
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28439](https://jira.ez.no/browse/EZP-28439), (also solves [EZP-28781](https://jira.ez.no/browse/EZP-28781) and [EZP-28865](https://jira.ez.no/browse/EZP-28865))
| **Bug/Improvement**| yes
| **New feature**    | no
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes (new `in_trash` variable in `objectrelation` and `objectrelationlist` filed type templates)


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.