### PR TITLE
EZP-28959: Prevent publishing errors on pre-existing, undefined Custom Tags

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/RichTextIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/RichTextIntegrationTest.php
@@ -667,14 +667,7 @@ EOT;
             $invalidXmlDocument = $this->createDocument($xmlDocumentPath);
             $this->createContent(new RichTextValue($invalidXmlDocument));
         } catch (ContentFieldValidationException $e) {
-            // get first nested ValidationError
-            /** @var \eZ\Publish\SPI\FieldType\ValidationError $error */
-            $error = current(current(current($e->getFieldErrors())));
-
-            self::assertEquals(
-                $expectedValidationMessage,
-                $error->getTranslatableMessage()->message
-            );
+            $this->assertValidationErrorOccurs($e, $expectedValidationMessage);
 
             return;
         }
@@ -690,10 +683,6 @@ EOT;
     public function providerForTestCreateContentWithInvalidCustomTag()
     {
         $data = [
-            [
-                __DIR__ . '/_fixtures/ezrichtext/custom_tags/invalid/unknown_tag.xml',
-                "Unknown RichText Custom Tag 'unknown_tag'",
-            ],
             [
                 __DIR__ . '/_fixtures/ezrichtext/custom_tags/invalid/equation.xml',
                 "The attribute 'processor' of RichText Custom Tag 'equation' cannot be empty",

--- a/eZ/Publish/Core/FieldType/RichText/CustomTagsValidator.php
+++ b/eZ/Publish/Core/FieldType/RichText/CustomTagsValidator.php
@@ -41,7 +41,7 @@ class CustomTagsValidator
      *
      * @return string[] an array of error messages
      */
-    public function validateDocument(DOMDocument $xmlDocument)
+    public function validateDocument(DOMDocument $xmlDocument): array
     {
         $errors = [];
 
@@ -56,7 +56,11 @@ class CustomTagsValidator
             }
 
             if (!isset($this->customTagsConfiguration[$tagName])) {
-                $errors[] = "Unknown RichText Custom Tag '{$tagName}'";
+                @trigger_error(
+                    "Configuration for RichText Custom Tag '{$tagName}' not found. " .
+                    'Custom Tags configuration is required since 7.1, its lack will result in validation error in 8.x',
+                    E_USER_DEPRECATED
+                );
                 continue;
             }
 

--- a/eZ/Publish/Core/FieldType/Tests/RichText/CustomTagsValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/CustomTagsValidatorTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Yaml\Yaml;
 class CustomTagsValidatorTest extends TestCase
 {
     /**
-     * @var CustomTagsValidator
+     * @var \eZ\Publish\Core\FieldType\RichText\CustomTagsValidator
      */
     private $validator;
 
@@ -37,7 +37,7 @@ class CustomTagsValidatorTest extends TestCase
     /**
      * Test validating DocBook document containing Custom Tags.
      *
-     * @covers       \CustomTagsValidator::validateDocument
+     * @covers \eZ\Publish\Core\FieldType\RichText\CustomTagsValidator::validateDocument
      *
      * @dataProvider providerForTestValidateDocument
      *
@@ -77,27 +77,6 @@ DOCBOOK
                 ),
                 [
                     'Missing RichText Custom Tag name',
-                ],
-            ],
-            [
-                $this->createDocument(
-                    <<<DOCBOOK
-<?xml version="1.0" encoding="UTF-8"?>
-<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
-         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
-         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
-         version="5.0-variant ezpublish-1.0">
-  <eztemplate name="undefined_tag">
-    <ezcontent>Undefined</ezcontent>
-    <ezconfig>
-      <ezvalue key="title">Test</ezvalue>
-    </ezconfig>
-  </eztemplate>
-</section>
-DOCBOOK
-                ),
-                [
-                    "Unknown RichText Custom Tag 'undefined_tag'",
                 ],
             ],
             [
@@ -199,7 +178,6 @@ DOCBOOK
                 ),
                 [
                     'Missing RichText Custom Tag name',
-                    "Unknown RichText Custom Tag 'undefined_tag'",
                     "Missing attribute name for RichText Custom Tag 'video'",
                     "The attribute 'title' of RichText Custom Tag 'video' cannot be empty",
                     "The attribute 'width' of RichText Custom Tag 'video' cannot be empty",
@@ -207,6 +185,31 @@ DOCBOOK
                 ],
             ],
         ];
+    }
+
+    /**
+     * Test that defined but not configured yet Custom Tag doesn't cause validation error.
+     */
+    public function testValidateDocumentAcceptsLegacyTags()
+    {
+        $document = $this->createDocument(
+                <<<DOCBOOK
+<?xml version="1.0" encoding="UTF-8"?>
+<section xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ezxhtml="http://ez.no/xmlns/ezpublish/docbook/xhtml"
+         xmlns:ezcustom="http://ez.no/xmlns/ezpublish/docbook/custom"
+         version="5.0-variant ezpublish-1.0">
+  <eztemplate name="undefined_tag">
+    <ezcontent>Undefined</ezcontent>
+    <ezconfig>
+      <ezvalue key="title">Test</ezvalue>
+    </ezconfig>
+  </eztemplate>
+</section>
+DOCBOOK
+        );
+
+        self::assertEmpty($this->validator->validateDocument($document));
     }
 
     /**


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28959](https://jira.ez.no/browse/EZP-28959)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.1`
| **BC breaks**      | no, fixed
| **Tests pass**     | yes
| **Doc needed**     | no

Since RichText Custom Tags use pre-existing DocBook markup (`eztemplate` tag), due to BC policy missing configuration cannot result in validation error on publishing. 

**This PR introduces a deprecation error instead.**

**NOTE**: Initial resolution suggested making a setting that would either disable or enable that validation. Unfortunately my tests show that `@trigger_error` doesn't get logged when building Symfony container. 

Symfony provided deprecation messages appear in logs, so probably the proper context was not there yet (in `CompilerPass`) when I tried to trigger that message.

Therefore it didn't make sense to me to decorate `CustomTagsValidator` with any service, instead any undefined Custom Tag triggers deprecation notice on validation until proper per-Tag configuration is in place. I even think this solution is more flexible.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
