### PR TITLE
EZP-28393: Can not set field settings and default value in one transaction.

### DIFF
--- a/eZ/Publish/API/Repository/FieldType.php
+++ b/eZ/Publish/API/Repository/FieldType.php
@@ -228,8 +228,9 @@ interface FieldType
      *
      * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDef The field definition of the field
      * @param \eZ\Publish\SPI\FieldType\Value $value The field value for which an action is performed
+     * @param array|null $fieldSettings Actual settings of the field
      *
      * @return \eZ\Publish\SPI\FieldType\ValidationError[]
      */
-    public function validateValue(FieldDefinition $fieldDef, Value $value);
+    public function validateValue(FieldDefinition $fieldDef, Value $value, array $fieldSettings = null);
 }

--- a/eZ/Publish/Core/FieldType/Country/Type.php
+++ b/eZ/Publish/Core/FieldType/Country/Type.php
@@ -118,14 +118,13 @@ class Type extends FieldType
      *
      * Does not use validators.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     *
      * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition The field definition of the field
-     * @param \eZ\Publish\Core\FieldType\Country\Value $fieldValue The field value for which an action is performed
+     * @param \eZ\Publish\Core\FieldType\Country\Value|\eZ\Publish\SPI\FieldType\Value $fieldValue The field value for which an action is performed
+     * @param array|null $fieldSettings Actual settings of the field
      *
      * @return \eZ\Publish\SPI\FieldType\ValidationError[]
      */
-    public function validate(FieldDefinition $fieldDefinition, SPIValue $fieldValue)
+    public function validate(FieldDefinition $fieldDefinition, SPIValue $fieldValue, array $fieldSettings = null)
     {
         $validationErrors = array();
 
@@ -133,7 +132,7 @@ class Type extends FieldType
             return $validationErrors;
         }
 
-        $fieldSettings = $fieldDefinition->getFieldSettings();
+        $fieldSettings = $fieldSettings ?? $fieldDefinition->getFieldSettings();
 
         if ((!isset($fieldSettings['isMultiple']) || $fieldSettings['isMultiple'] === false)
             && count($fieldValue->countries) > 1) {

--- a/eZ/Publish/Core/FieldType/FieldType.php
+++ b/eZ/Publish/Core/FieldType/FieldType.php
@@ -124,14 +124,13 @@ abstract class FieldType implements FieldTypeInterface
      * that no validation errors occurred. Overwrite in derived types, if
      * validation is supported.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     *
      * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition The field definition of the field
-     * @param \eZ\Publish\Core\FieldType\Value $value The field value for which an action is performed
+     * @param \eZ\Publish\Core\FieldType\Value|\eZ\Publish\SPI\FieldType\Value $value The field value for which an action is performed
+     * @param array|null $fieldSettings Actual settings of the field
      *
      * @return \eZ\Publish\SPI\FieldType\ValidationError[]
      */
-    public function validate(FieldDefinition $fieldDefinition, SPIValue $value)
+    public function validate(FieldDefinition $fieldDefinition, SPIValue $value, array $fieldSettings = null)
     {
         return array();
     }

--- a/eZ/Publish/Core/FieldType/ISBN/Type.php
+++ b/eZ/Publish/Core/FieldType/ISBN/Type.php
@@ -124,21 +124,20 @@ class Type extends FieldType
      *
      * Does not use validators.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     *
      * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition The field definition of the field
-     * @param \eZ\Publish\Core\FieldType\ISBN\Value $fieldValue The field value for which an action is performed
+     * @param \eZ\Publish\Core\FieldType\ISBN\Value|\eZ\Publish\SPI\FieldType\Value $fieldValue The field value for which an action is performed
+     * @param array|null $fieldSettings
      *
      * @return \eZ\Publish\SPI\FieldType\ValidationError[]
      */
-    public function validate(FieldDefinition $fieldDefinition, SPIValue $fieldValue)
+    public function validate(FieldDefinition $fieldDefinition, SPIValue $fieldValue, array $fieldSettings = null)
     {
         $validationErrors = array();
         if ($this->isEmptyValue($fieldValue)) {
             return $validationErrors;
         }
 
-        $fieldSettings = $fieldDefinition->getFieldSettings();
+        $fieldSettings = $fieldSettings ?? $fieldDefinition->getFieldSettings();
         $isbnTestNumber = preg_replace("/[\s|\-]/", '', trim($fieldValue->isbn));
 
         // Check if value and settings are inline

--- a/eZ/Publish/Core/REST/Client/FieldType.php
+++ b/eZ/Publish/Core/REST/Client/FieldType.php
@@ -283,11 +283,12 @@ class FieldType implements APIFieldType
      *
      * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDef The field definition of the field
      * @param \eZ\Publish\SPI\FieldType\Value $value The field value for which an action is performed
+     * @param array|null $fieldSettings Actual settings of the field
      *
      * @return \eZ\Publish\SPI\FieldType\ValidationError[]
      */
-    public function validateValue(FieldDefinition $fieldDef, Value $value)
+    public function validateValue(FieldDefinition $fieldDef, Value $value, array $fieldSettings = null)
     {
-        return $this->innerFieldType->validate($fieldDef, $value);
+        return $this->innerFieldType->validate($fieldDef, $value, $fieldSettings);
     }
 }

--- a/eZ/Publish/Core/Repository/Values/ContentType/FieldType.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/FieldType.php
@@ -289,11 +289,12 @@ class FieldType implements FieldTypeInterface
      *
      * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDef The field definition of the field
      * @param \eZ\Publish\SPI\FieldType\Value $value The field value for which an action is performed
+     * @param array|null $fieldSettings Actual settings of the field
      *
      * @return \eZ\Publish\SPI\FieldType\ValidationError[]
      */
-    public function validateValue(APIFieldDefinition $fieldDef, Value $value)
+    public function validateValue(APIFieldDefinition $fieldDef, Value $value, array $fieldSettings = null)
     {
-        return $this->internalFieldType->validate($fieldDef, $value);
+        return $this->internalFieldType->validate($fieldDef, $value, $fieldSettings);
     }
 }

--- a/eZ/Publish/SPI/FieldType/FieldType.php
+++ b/eZ/Publish/SPI/FieldType/FieldType.php
@@ -123,8 +123,6 @@ interface FieldType
     /**
      * Validates a field based on the validator configuration in the field definition.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     *
      * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDef The field definition of the field
      * @param \eZ\Publish\SPI\FieldType\Value $value The field value for which an action is performed
      *


### PR DESCRIPTION

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28393](https://jira.ez.no/browse/EZP-28393)
| **Bug/Improvement**| yes
| **New feature**    |no
| **Target version** | `7.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     |no

Currently it is not possible to set field type settings and set his default value. This PR tries to solve this by adding to validate method new optional parameter with current settings.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
