### PR TITLE
Fix EZP-29037: PageConverter creates wrong Block Items

### DIFF
--- a/eZ/Publish/Core/FieldType/Page/Parts/Item.php
+++ b/eZ/Publish/Core/FieldType/Page/Parts/Item.php
@@ -45,7 +45,7 @@ class Item extends ValueObject
     protected $publicationDate;
 
     /**
-     * @var \DateTime
+     * @var \DateTime|null
      */
     protected $visibilityDate;
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/PageConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/PageConverter.php
@@ -283,16 +283,20 @@ class PageConverter implements Converter
                     $this->addNewNotEmptyXmlElement($dom, $itemNode, 'priority', $attrValue);
                     break;
                 case 'publicationDate':
-                    $this->addNewNotEmptyXmlElement($dom, $itemNode, 'ts_publication', $attrValue);
+                    /* @var $attrValue \DateTime */
+                    $this->addNewNotEmptyXmlElement($dom, $itemNode, 'ts_publication', $attrValue->getTimestamp());
                     break;
                 case 'visibilityDate':
-                    $this->addNewNotEmptyXmlElement($dom, $itemNode, 'ts_visible', $attrValue);
+                    /* @var $attrValue \DateTime|null */
+                    $this->addNewNotEmptyXmlElement($dom, $itemNode, 'ts_visible', $attrValue ? $attrValue->getTimestamp() : 0);
                     break;
                 case 'hiddenDate':
-                    $this->addNewNotEmptyXmlElement($dom, $itemNode, 'ts_hidden', $attrValue);
+                    /* @var $attrValue \DateTime|null */
+                    $this->addNewNotEmptyXmlElement($dom, $itemNode, 'ts_hidden', $attrValue ? $attrValue->getTimestamp() : 0);
                     break;
                 case 'rotationUntilDate':
-                    $this->addNewNotEmptyXmlElement($dom, $itemNode, 'rotation_until', $attrValue);
+                    /* @var $attrValue \DateTime|null */
+                    $this->addNewNotEmptyXmlElement($dom, $itemNode, 'rotation_until', $attrValue ? $attrValue->getTimestamp() : 0);
                     break;
                 case 'movedTo':
                     $this->addNewNotEmptyXmlElement($dom, $itemNode, 'moved_to', $attrValue);
@@ -501,7 +505,7 @@ class PageConverter implements Converter
 
             switch ($node->nodeName) {
                 case 'item':
-                    $items[] = $this->restoreItemFromXml($node);
+                    $items[] = $this->restoreItemFromXml($node, $blockId);
                     break;
                 case 'rotation':
                     if ($rotation === null) {
@@ -566,12 +570,16 @@ class PageConverter implements Converter
      * Restores value for a given Item $node.
      *
      * @param \DOMElement $node
+     * @param string $blockId
      *
      * @return \eZ\Publish\Core\FieldType\Page\Parts\Item
      */
-    protected function restoreItemFromXml(DOMElement $node)
+    protected function restoreItemFromXml(DOMElement $node, $blockId)
     {
-        $item = array('attributes' => array());
+        $item = array(
+            'blockId' => $blockId,
+            'attributes' => array(),
+        );
 
         if ($node->hasAttributes()) {
             foreach ($node->attributes as $attr) {
@@ -592,25 +600,25 @@ class PageConverter implements Converter
 
             switch ($node->nodeName) {
                 case 'object_id':
-                    $item['contentId'] = $node->nodeValue;
+                    $item['contentId'] = (int)$node->nodeValue;
                     break;
                 case 'node_id':
-                    $item['locationId'] = $node->nodeValue;
+                    $item['locationId'] = (int)$node->nodeValue;
                     break;
                 case 'priority':
-                    $item[$node->nodeName] = $node->nodeValue;
+                    $item[$node->nodeName] = (int)$node->nodeValue;
                     break;
                 case 'ts_publication':
-                    $item['publicationDate'] = $node->nodeValue;
+                    $item['publicationDate'] = new \DateTime("@{$node->nodeValue}");
                     break;
                 case 'ts_visible':
-                    $item['visibilityDate'] = $node->nodeValue;
+                    $item['visibilityDate'] = $node->nodeValue ? new \DateTime("@{$node->nodeValue}") : null;
                     break;
                 case 'ts_hidden':
-                    $item['hiddenDate'] = $node->nodeValue;
+                    $item['hiddenDate'] = $node->nodeValue ? new \DateTime("@{$node->nodeValue}") : null;
                     break;
                 case 'rotation_until':
-                    $item['rotationUntilDate'] = $node->nodeValue;
+                    $item['rotationUntilDate'] = $node->nodeValue ? new \DateTime("@{$node->nodeValue}") : null;
                     break;
                 case 'moved_to':
                     $item['movedTo'] = $node->nodeValue;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/PageTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/PageTest.php
@@ -43,7 +43,6 @@ class PageTest extends TestCase
         <rotation_until>1393607060</rotation_until>
         <moved_to>42</moved_to>
       </item>
-      <item action="add" />
     </block>
     <zone_identifier>left</zone_identifier>
   </zone>
@@ -118,17 +117,12 @@ EOT;
                                                     'contentId' => '62',
                                                     'locationId' => '64',
                                                     'priority' => '1',
-                                                    'publicationDate' => '1393607060',
-                                                    'visibilityDate' => '1393607060',
-                                                    'hiddenDate' => '1393607060',
-                                                    'rotationUntilDate' => '1393607060',
+                                                    'publicationDate' => new \DateTime('@1393607060'),
+                                                    'visibilityDate' => new \DateTime('@1393607060'),
+                                                    'hiddenDate' => new \DateTime('@1393607060'),
+                                                    'rotationUntilDate' => new \DateTime('@1393607060'),
                                                     'movedTo' => '42',
-                                                    'attributes' => array(),
-                                                )
-                                            ),
-                                            new Parts\Item(
-                                                array(
-                                                    'action' => 'add',
+                                                    'blockId' => '250bcab3ea2929edbf72ece096dcdb7a',
                                                     'attributes' => array(),
                                                 )
                                             ),
@@ -222,6 +216,16 @@ EOT;
         <unit></unit>
       </rotation>
       <zone_id>ee94402090bb170600a8dab9e1bd1c5a</zone_id>
+      <item action="add">
+        <object_id>62</object_id>
+        <node_id>64</node_id>
+        <priority>1</priority>
+        <ts_publication>1393607060</ts_publication>
+        <ts_visible>1393607060</ts_visible>
+        <ts_hidden>1393607060</ts_hidden>
+        <rotation_until>1393607060</rotation_until>
+        <moved_to>42</moved_to>
+      </item>
     </block>
     <zone_identifier>zone_1</zone_identifier>
   </zone>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29037](https://jira.ez.no/browse/EZP-29037)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

The Legacy PageConverter generates wrong Block Items.
The field render use the PageService, which makes it right.

I would like use the toHash and fromHash function of the FieldService for a migration.
There it runs in an error, because there the attributes are no DateTime objects:
https://github.com/ezsystems/ezpublish-kernel/blob/6.7/eZ/Publish/Core/FieldType/Page/HashConverter.php#L168 

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
