### PR TITLE
Fixed EZP-29048: Aligned Behat BuzzDriver and Functional REST tests with PSR-7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "pagerfanta/pagerfanta": "~1.0",
         "ocramius/proxy-manager": "^1.0|^2.0",
         "doctrine/doctrine-bundle": "~1.3",
-        "doctrine/dbal": "~2.6.3",
         "liip/imagine-bundle": "~1.0",
         "ircmaxell/password-compat": "^1.0",
         "oneup/flysystem-bundle": "^1.0|^2.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "ext-curl": "*",
         "symfony/symfony": "^3.4",
         "symfony-cmf/routing": "^1.1|^2.0",
-        "kriswallsmith/buzz": ">=0.9",
+        "kriswallsmith/buzz": "~0.17.0",
         "sensio/distribution-bundle": "^5.0",
         "nelmio/cors-bundle": "^1.3.3",
         "hautelook/templated-uri-bundle": "~1.0 | ~2.0",

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "pagerfanta/pagerfanta": "~1.0",
         "ocramius/proxy-manager": "^1.0|^2.0",
         "doctrine/doctrine-bundle": "~1.3",
+        "doctrine/dbal": "~2.6.3",
         "liip/imagine-bundle": "~1.0",
         "ircmaxell/password-compat": "^1.0",
         "oneup/flysystem-bundle": "^1.0|^2.0",

--- a/eZ/Bundle/EzPublishRestBundle/Features/Context/RestClient/DriverHelper.php
+++ b/eZ/Bundle/EzPublishRestBundle/Features/Context/RestClient/DriverHelper.php
@@ -16,13 +16,11 @@ trait DriverHelper
     /**
      * Make/Crypt the authentication value.
      *
-     * @param string $user
+     * @param string $username
      * @param string $password
      * @param string $type The type of authentication
      *
      * @return string Authentication value
-     *
-     * @throws \UnexpectedValueException If the $type doesn't exists
      */
     protected function makeAuthentication($username, $password, $type)
     {
@@ -31,7 +29,7 @@ trait DriverHelper
                 return 'Basic ' . base64_encode("$username:$password");
 
             default:
-                throw new \UnexpectedValueException("Authentication '$authType' invalid or not implemented yet");
+                throw new \UnexpectedValueException("Authentication '{$type}' invalid or not implemented yet");
         }
     }
 
@@ -61,10 +59,9 @@ trait DriverHelper
      */
     public function getHeader($header)
     {
-        $header = strtolower($header);
-        $headers = $this->getHeaders();
+        $response = $this->getResponse();
 
-        return empty($headers[$header]) ? null : $headers[$header];
+        return $response->hasHeader($header) ? $response->getHeader($header)[0] : null;
     }
 
     /**

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ContentTypeTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ContentTypeTest.php
@@ -23,14 +23,19 @@ class ContentTypeTest extends RESTFunctionalTestCase
   <identifier>testCreateContentTypeGroup</identifier>
 </ContentTypeGroupInput>
 XML;
-        $request = $this->createHttpRequest('POST', '/api/ezp/v2/content/typegroups', 'ContentTypeGroupInput+xml', 'ContentTypeGroup+json');
-        $request->setContent($body);
+        $request = $this->createHttpRequest(
+            'POST',
+            '/api/ezp/v2/content/typegroups',
+            'ContentTypeGroupInput+xml',
+            'ContentTypeGroup+json',
+            $body
+        );
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        $href = $response->getHeader('Location');
+        $href = $response->getHeader('Location')[0];
         $this->addCreatedElement($href);
 
         return $href;
@@ -51,8 +56,13 @@ XML;
 </ContentTypeGroupInput>
 XML;
 
-        $request = $this->createHttpRequest('PATCH', $contentTypeGroupHref, 'ContentTypeGroupInput+xml', 'ContentTypeGroup+json');
-        $request->setContent($body);
+        $request = $this->createHttpRequest(
+            'PATCH',
+            $contentTypeGroupHref,
+            'ContentTypeGroupInput+xml',
+            'ContentTypeGroup+json',
+            $body
+        );
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 200);
@@ -110,17 +120,17 @@ XML;
             'POST',
             "$contentTypeGroupHref/types?publish=true",
             'ContentTypeCreate+xml',
-            'ContentType+json'
+            'ContentType+json',
+            $body
         );
-        $request->setContent($body);
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        $this->addCreatedElement($response->getHeader('Location'));
+        $this->addCreatedElement($response->getHeader('Location')[0]);
 
-        return $response->getHeader('Location');
+        return $response->getHeader('Location')[0];
     }
 
     /**
@@ -276,7 +286,7 @@ XML;
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        $href = $response->getHeader('Location');
+        $href = $response->getHeader('Location')[0];
         $this->addCreatedElement($href);
 
         return $href;
@@ -301,16 +311,19 @@ XML;
 </ContentTypeUpdate>
 XML;
 
-        $request = $this->createHttpRequest('POST', $contentTypeHref, 'ContentTypeUpdate+xml', 'ContentTypeInfo+json');
-        $request->setContent($content);
-        $response = $this->sendHttpRequest(
-            $request
+        $request = $this->createHttpRequest(
+            'POST',
+            $contentTypeHref,
+            'ContentTypeUpdate+xml',
+            'ContentTypeInfo+json',
+            $content
         );
+        $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        $href = $response->getHeader('Location');
+        $href = $response->getHeader('Location')[0];
         $this->addCreatedElement($href);
 
         return $href;
@@ -344,11 +357,14 @@ XML;
 </ContentTypeUpdate>
 XML;
 
-        $request = $this->createHttpRequest('PATCH', $contentTypeDraftHref, 'ContentTypeUpdate+xml', 'ContentTypeInfo+json');
-        $request->setContent($content);
-        $response = $this->sendHttpRequest(
-            $request
+        $request = $this->createHttpRequest(
+            'PATCH',
+            $contentTypeDraftHref,
+            'ContentTypeUpdate+xml',
+            'ContentTypeInfo+json',
+            $content
         );
+        $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 200);
     }
@@ -383,15 +399,15 @@ XML;
             'POST',
             "$contentTypeDraftHref/fieldDefinitions",
             'FieldDefinitionCreate+xml',
-            'FieldDefinition+json'
+            'FieldDefinition+json',
+            $body
         );
-        $request->setContent($body);
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        return $response->getHeader('Location');
+        return $response->getHeader('Location')[0];
     }
 
     /**
@@ -408,7 +424,7 @@ XML;
 
         self::assertHttpResponseCodeEquals($response, 200);
 
-        $data = json_decode($response->getContent(), true);
+        $data = json_decode($response->getBody(), true);
 
         return $data['FieldDefinitions']['FieldDefinition'][0]['_href'];
     }
@@ -416,8 +432,12 @@ XML;
     /**
      * @depends testAddContentTypeDraftFieldDefinition
      * Covers GET /content/types/<contentTypeId>/fieldDefinitions/<fieldDefinitionId>
+     *
+     * @param string $fieldDefinitionHref
+     *
+     * @throws \Psr\Http\Client\ClientException
      */
-    public function testLoadContentTypeFieldDefinition($fieldDefinitionHref)
+    public function testLoadContentTypeFieldDefinition(string $fieldDefinitionHref)
     {
         $response = $this->sendHttpRequest(
             $this->createHttpRequest('GET', $fieldDefinitionHref)
@@ -449,25 +469,27 @@ XML;
             'PATCH',
             $fieldDefinitionHref,
             'FieldDefinitionUpdate+xml',
-            'FieldDefinition+json'
+            'FieldDefinition+json',
+            $body
         );
-        $request->setContent($body);
-
         $response = $this->sendHttpRequest($request);
+
         self::assertHttpResponseCodeEquals($response, 200);
     }
 
     /**
      * Covers DELETE /content/types/<contentTypeId>/draft/fieldDefinitions/<fieldDefinitionId>.
      * @depends testAddContentTypeDraftFieldDefinition
+     *
+     * @param string $fieldDefinitionHref
      */
-    public function deleteContentTypeDraftFieldDefinition($fieldDefinitionHref)
+    public function deleteContentTypeDraftFieldDefinition(string $fieldDefinitionHref)
     {
         $response = $this->sendHttpRequest(
             $this->createHttpRequest('DELETE', $fieldDefinitionHref)
         );
 
-        self::testLoadContentTypeFieldDefinition($response, 204);
+        self::assertHttpResponseCodeEquals($response, 204);
     }
 
     /**

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/LocationTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/LocationTest.php
@@ -34,16 +34,19 @@ class LocationTest extends RESTFunctionalTestCase
   <sortOrder>ASC</sortOrder>
 </LocationCreate>
 XML;
-        $request = $this->createHttpRequest('POST', "$contentHref/locations", 'LocationCreate+xml', 'Location+json');
-        $request->setContent($body);
-
+        $request = $this->createHttpRequest(
+            'POST',
+            "$contentHref/locations",
+            'LocationCreate+xml',
+            'Location+json',
+            $body
+        );
         $response = $this->sendHttpRequest($request);
+
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        $href = $response->getHeader('Location');
-
-        return $href;
+        return $response->getHeader('Location')[0];
     }
 
     /**
@@ -97,14 +100,20 @@ XML;
      */
     public function testCopySubtree($locationHref)
     {
-        $request = $this->createHttpRequest('COPY', $locationHref);
-        $request->addHeader('Destination: /api/ezp/v2/content/locations/1/43');
+        $request = $this->createHttpRequest(
+            'COPY',
+            $locationHref,
+            '',
+            '',
+            '',
+            ['Destination' => '/api/ezp/v2/content/locations/1/43']
+        );
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        return $response->getHeader('Location');
+        return $response->getHeader('Location')[0];
     }
 
     /**
@@ -113,8 +122,14 @@ XML;
      */
     public function testMoveSubtree($locationHref)
     {
-        $request = $this->createHttpRequest('MOVE', $locationHref);
-        $request->addHeader('Destination: /api/ezp/v2/content/locations/1/5');
+        $request = $this->createHttpRequest(
+            'MOVE',
+            $locationHref,
+            '',
+            '',
+            '',
+            ['Destination' => '/api/ezp/v2/content/locations/1/5']
+        );
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
@@ -174,9 +189,13 @@ XML;
 </LocationUpdate>
 XML;
 
-        $request = $this->createHttpRequest('PATCH', $locationHref, 'LocationUpdate+xml', 'Location+json');
-        $request->setContent($body);
-
+        $request = $this->createHttpRequest(
+            'PATCH',
+            $locationHref,
+            'LocationUpdate+xml',
+            'Location+json',
+            $body
+        );
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 200);

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ObjectStateTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/ObjectStateTest.php
@@ -37,16 +37,16 @@ XML;
             'POST',
             '/api/ezp/v2/content/objectstategroups',
             'ObjectStateGroupCreate+xml',
-            'ObjectStateGroup+json'
+            'ObjectStateGroup+json',
+            $body
         );
-        $request->setContent($body);
 
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        $href = $response->getHeader('Location');
+        $href = $response->getHeader('Location')[0];
         $this->addCreatedElement($href);
 
         return $href;
@@ -79,16 +79,16 @@ XML;
             'POST',
             "$objectStateGroupHref/objectstates",
             'ObjectStateCreate+xml',
-            'ObjectState+json'
+            'ObjectState+json',
+            $body
         );
-        $request->setContent($body);
 
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        $href = $response->getHeader('Location');
+        $href = $response->getHeader('Location')[0];
         $this->addCreatedElement($href);
 
         return $href;
@@ -163,8 +163,13 @@ XML;
 XML;
 
         $folderHref = $folder['_href'];
-        $request = $this->createHttpRequest('PATCH', "$folderHref/objectstates", 'ContentObjectStates+xml', 'ContentObjectStates+json');
-        $request->setContent($xml);
+        $request = $this->createHttpRequest(
+            'PATCH',
+            "$folderHref/objectstates",
+            'ContentObjectStates+xml',
+            'ContentObjectStates+json',
+            $xml
+        );
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 200);
@@ -204,9 +209,13 @@ XML;
   </descriptions>
 </ObjectStateUpdate>
 XML;
-        $request = $this->createHttpRequest('PATCH', $objectStateHref, 'ObjectStateUpdate+xml', 'ObjectState+json');
-        $request->setContent($body);
-
+        $request = $this->createHttpRequest(
+            'PATCH',
+            $objectStateHref,
+            'ObjectStateUpdate+xml',
+            'ObjectState+json',
+            $body
+        );
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 200);
@@ -231,9 +240,13 @@ XML;
   </descriptions>
 </ObjectStateGroupUpdate>
 XML;
-        $request = $this->createHttpRequest('PATCH', $objectStateGroupHref, 'ObjectStateGroupUpdate+xml', 'ObjectStateGroup+json');
-        $request->setContent($body);
-
+        $request = $this->createHttpRequest(
+            'PATCH',
+            $objectStateGroupHref,
+            'ObjectStateGroupUpdate+xml',
+            'ObjectStateGroup+json',
+            $body
+        );
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 200);

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RoleTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RoleTest.php
@@ -35,14 +35,19 @@ class RoleTest extends RESTFunctionalTestCase
   </descriptions>
 </RoleInput>
 XML;
-        $request = $this->createHttpRequest('POST', '/api/ezp/v2/user/roles', 'RoleInput+xml', 'Role+json');
-        $request->setContent($xml);
+        $request = $this->createHttpRequest(
+            'POST',
+            '/api/ezp/v2/user/roles',
+            'RoleInput+xml',
+            'Role+json',
+            $xml
+        );
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        $href = $response->getHeader('Location');
+        $href = $response->getHeader('Location')[0];
         $this->addCreatedElement($href);
 
         return $href;
@@ -74,15 +79,15 @@ XML;
             'POST',
             '/api/ezp/v2/user/roles?publish=false',
             'RoleInput+xml',
-            'RoleDraft+json'
+            'RoleDraft+json',
+            $xml
         );
-        $request->setContent($xml);
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        $href = $response->getHeader('Location');
+        $href = $response->getHeader('Location')[0];
         $this->addCreatedElement($href);
 
         return $href . '/draft';
@@ -138,15 +143,15 @@ XML;
             'POST',
             $roleHref,
             'RoleInput+xml',
-            'RoleDraft+json'
+            'RoleDraft+json',
+            $xml
         );
-        $request->setContent($xml);
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        $href = $response->getHeader('Location');
+        $href = $response->getHeader('Location')[0];
         $this->addCreatedElement($href);
 
         return $href . '/draft';
@@ -185,11 +190,9 @@ XML;
 </RoleInput>
 XML;
 
-        $request = $this->createHttpRequest('PATCH', $roleHref, 'RoleInput+xml', 'Role+json');
-        $request->setContent($xml);
+        $request = $this->createHttpRequest('PATCH', $roleHref, 'RoleInput+xml', 'Role+json', $xml);
         $response = $this->sendHttpRequest($request);
 
-        // @todo Fix failure Notice: Trying to get property of non-object in \/home\/bertrand\/www\/ezpublish-kernel\/eZ\/Publish\/Core\/Persistence\/Cache\/UserHandler.php line 174
         self::assertHttpResponseCodeEquals($response, 200);
     }
 
@@ -213,8 +216,13 @@ XML;
 </RoleInput>
 XML;
 
-        $request = $this->createHttpRequest('PATCH', $roleDraftHref, 'RoleInput+xml', 'RoleDraft+json');
-        $request->setContent($xml);
+        $request = $this->createHttpRequest(
+            'PATCH',
+            $roleDraftHref,
+            'RoleInput+xml',
+            'RoleDraft+json',
+            $xml
+        );
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 200);
@@ -243,14 +251,19 @@ XML;
   </limitations>
 </PolicyCreate>
 XML;
-        $request = $this->createHttpRequest('POST', "$roleHref/policies", 'PolicyCreate+xml', 'Policy+json');
-        $request->setContent($xml);
-
+        $request = $this->createHttpRequest(
+            'POST',
+            "$roleHref/policies",
+            'PolicyCreate+xml',
+            'Policy+json',
+            $xml
+        );
         $response = $this->sendHttpRequest($request);
+
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        $href = $response->getHeader('Location');
+        $href = $response->getHeader('Location')[0];
         $this->addCreatedElement($href);
 
         return $href;
@@ -282,15 +295,15 @@ XML;
             'POST',
             $this->roleDraftHrefToRoleHref($roleDraftHref) . '/policies',
             'PolicyCreate+xml',
-            'Policy+json'
+            'Policy+json',
+            $xml
         );
-        $request->setContent($xml);
-
         $response = $this->sendHttpRequest($request);
+
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        $href = $response->getHeader('Location');
+        $href = $response->getHeader('Location')[0];
         $this->addCreatedElement($href);
 
         return $href;
@@ -341,8 +354,13 @@ XML;
 </PolicyUpdate>
 XML;
 
-        $request = $this->createHttpRequest('PATCH', $policyHref, 'PolicyUpdate+xml', 'Policy+json');
-        $request->setContent($xml);
+        $request = $this->createHttpRequest(
+            'PATCH',
+            $policyHref,
+            'PolicyUpdate+xml',
+            'Policy+json',
+            $xml
+        );
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 200);
@@ -367,8 +385,7 @@ XML;
 </PolicyUpdate>
 XML;
 
-        $request = $this->createHttpRequest('PATCH', $policyHref, 'PolicyUpdate+xml', 'Policy+json');
-        $request->setContent($xml);
+        $request = $this->createHttpRequest('PATCH', $policyHref, 'PolicyUpdate+xml', 'Policy+json', $xml);
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 200);
@@ -395,12 +412,12 @@ XML;
             'POST',
             '/api/ezp/v2/user/users/10/roles',
             'RoleAssignInput+xml',
-            'RoleAssignmentList+json'
+            'RoleAssignmentList+json',
+            $xml
         );
-        $request->setContent($xml);
-
         $response = $this->sendHttpRequest($request);
-        $roleAssignmentArray = json_decode($response->getContent(), true);
+
+        $roleAssignmentArray = json_decode($response->getBody(), true);
 
         self::assertHttpResponseCodeEquals($response, 200);
 
@@ -436,12 +453,12 @@ XML;
             'POST',
             '/api/ezp/v2/user/users/10/roles',
             'RoleAssignInput+xml',
-            'RoleAssignmentList+json'
+            'RoleAssignmentList+json',
+            $xml
         );
-        $request->setContent($xml);
-
         $response = $this->sendHttpRequest($request);
-        $roleAssignmentArray = json_decode($response->getContent(), true);
+
+        $roleAssignmentArray = json_decode($response->getBody(), true);
 
         self::assertHttpResponseCodeEquals($response, 200);
 
@@ -490,10 +507,6 @@ XML;
      */
     public function testAssignRoleToUserGroup($roleHref)
     {
-        self::markTestSkipped('Breaks roles, thus preventing login');
-
-        return;
-
         $xml = <<< XML
 <?xml version="1.0" encoding="UTF-8"?>
 <RoleAssignInput>
@@ -505,17 +518,17 @@ XML;
   </limitation>
 </RoleAssignInput>
 XML;
-
+        // Assign to "Guest users" group to avoid affecting other tests
         $request = $this->createHttpRequest(
             'POST',
-            '/api/ezp/v2/user/groups/1/5/44/roles',
+            '/api/ezp/v2/user/groups/1/5/12/roles',
             'RoleAssignInput+xml',
-            'RoleAssignmentList+json'
+            'RoleAssignmentList+json',
+            $xml
         );
-        $request->setContent($xml);
 
         $response = $this->sendHttpRequest($request);
-        $roleAssignmentArray = json_decode($response->getContent(), true);
+        $roleAssignmentArray = json_decode($response->getBody(), true);
 
         self::assertHttpResponseCodeEquals($response, 200);
 
@@ -710,14 +723,14 @@ XML;
             'POST',
             '/api/ezp/v2/user/roles',
             'RoleInput+xml',
-            'RoleDraft+json'
+            'RoleDraft+json',
+            $xml
         );
-        $request->setContent($xml);
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
-        $href = $response->getHeader('Location');
+        $href = $response->getHeader('Location')[0];
 
         $this->addCreatedElement($href);
 

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RootTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/RootTest.php
@@ -25,7 +25,7 @@ class RootTest extends RESTFunctionalTestCase
         );
         self::assertHttpResponseCodeEquals($response, 200);
 
-        return $response->getContent();
+        return $response->getBody();
     }
 
     /**
@@ -39,7 +39,7 @@ class RootTest extends RESTFunctionalTestCase
             $this->createHttpRequest('GET', '/api/ezp/v2/' . uniqid('rest'), '', 'Stuff+json')
         );
         self::assertHttpResponseCodeEquals($response, 404);
-        $responseArray = json_decode($response->getContent(), true);
+        $responseArray = json_decode($response->getBody(), true);
         self::assertArrayHasKey('ErrorMessage', $responseArray);
         self::assertEquals('No such route', $responseArray['ErrorMessage']['errorDescription']);
     }

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/SectionTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/SectionTest.php
@@ -37,14 +37,19 @@ class SectionTest extends RESTFunctionalTestCase
   <name>testCreateSection</name>
 </SectionInput>
 XML;
-        $request = $this->createHttpRequest('POST', '/api/ezp/v2/content/sections', 'SectionInput+xml', 'Section+json');
-        $request->setContent($xml);
+        $request = $this->createHttpRequest(
+            'POST',
+            '/api/ezp/v2/content/sections',
+            'SectionInput+xml',
+            'Section+json',
+            $xml
+        );
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        $href = $response->getHeader('Location');
+        $href = $response->getHeader('Location')[0];
         $this->addCreatedElement($href);
 
         return $href;
@@ -63,8 +68,13 @@ XML;
   <name>testUpdateSection</name>
 </SectionInput>
 XML;
-        $request = $this->createHttpRequest('PATCH', $sectionHref, 'SectionInput+xml', 'Section+json');
-        $request->setContent($xml);
+        $request = $this->createHttpRequest(
+            'PATCH',
+            $sectionHref,
+            'SectionInput+xml',
+            'Section+json',
+            $xml
+        );
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 200);

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/TrashTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/TrashTest.php
@@ -84,9 +84,14 @@ class TrashTest extends RESTFunctionalTestCase
     {
         $trashItemHref = $this->createTrashItem('testRestoreTrashItemWithDestination');
 
-        $request = $this->createHttpRequest('MOVE', $trashItemHref);
-        $request->addHeader('Destination: /api/ezp/v2/content/locations/1/2');
-
+        $request = $this->createHttpRequest(
+            'MOVE',
+            $trashItemHref,
+            '',
+            '',
+            '',
+            ['Destination' => '/api/ezp/v2/content/locations/1/2']
+        );
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
@@ -141,20 +146,25 @@ class TrashTest extends RESTFunctionalTestCase
     }
 
     /**
-     * @param $folderLocations
+     * @param string $contentHref
      *
-     * @return array|null|string
+     * @return string
      */
-    private function sendLocationToTrash($contentHref)
+    private function sendLocationToTrash(string $contentHref): string
     {
-        $trashRequest = $this->createHttpRequest('MOVE', $contentHref);
-        $trashRequest->addHeader('Destination: /api/ezp/v2/content/trash');
-
+        $trashRequest = $this->createHttpRequest(
+            'MOVE',
+            $contentHref,
+            '',
+            '',
+            '',
+            ['Destination' => '/api/ezp/v2/content/trash']
+        );
         $response = $this->sendHttpRequest($trashRequest);
 
         self::assertHttpResponseCodeEquals($response, 201);
 
-        $trashHref = $response->getHeader('Location');
+        $trashHref = $response->getHeader('Location')[0];
 
         return $trashHref;
     }

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/UrlAliasTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/UrlAliasTest.php
@@ -60,16 +60,16 @@ XML;
             'POST',
             '/api/ezp/v2/content/urlaliases',
             'UrlAliasCreate+xml',
-            'UrlAlias+json'
+            'UrlAlias+json',
+            $xml
         );
-        $request->setContent($xml);
 
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        $href = $response->getHeader('Location');
+        $href = $response->getHeader('Location')[0];
         $this->addCreatedElement($href);
 
         return $href;
@@ -97,16 +97,16 @@ XML;
             'POST',
             '/api/ezp/v2/content/urlaliases',
             'UrlAliasCreate+xml',
-            'UrlAlias+json'
+            'UrlAlias+json',
+            $xml
         );
-        $request->setContent($xml);
 
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        $href = $response->getHeader('Location');
+        $href = $response->getHeader('Location')[0];
         $this->addCreatedElement($href);
 
         return $href;

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/UrlWildcardTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/UrlWildcardTest.php
@@ -40,15 +40,19 @@ class UrlWildcardTest extends RESTFunctionalTestCase
 </UrlWildcardCreate>
 XML;
 
-        $request = $this->createHttpRequest('POST', '/api/ezp/v2/content/urlwildcards', 'UrlWildcardCreate+xml', 'UrlWildcard+json');
-        $request->setContent($xml);
-
+        $request = $this->createHttpRequest(
+            'POST',
+            '/api/ezp/v2/content/urlwildcards',
+            'UrlWildcardCreate+xml',
+            'UrlWildcard+json',
+            $xml
+        );
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        $href = $response->getHeader('Location');
+        $href = $response->getHeader('Location')[0];
         $this->addCreatedElement($href);
 
         return $href;

--- a/eZ/Bundle/EzPublishRestBundle/Tests/Functional/UserTest.php
+++ b/eZ/Bundle/EzPublishRestBundle/Tests/Functional/UserTest.php
@@ -55,15 +55,15 @@ XML;
             'POST',
             '/api/ezp/v2/user/groups/1/5/subgroups',
             'UserGroupCreate+xml',
-            'UserGroup+json'
+            'UserGroup+json',
+            $xml
         );
-        $request->setContent($xml);
-
         $response = $this->sendHttpRequest($request);
+
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        $href = $response->getHeader('Location');
+        $href = $response->getHeader('Location')[0];
         $this->addCreatedElement($href);
 
         return $href;
@@ -106,10 +106,9 @@ XML;
             'PATCH',
             $groupHref,
             'UserGroupUpdate+xml',
-            'UserGroup+json'
+            'UserGroup+json',
+            $xml
         );
-        $request->setContent($xml);
-
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 200);
@@ -150,15 +149,15 @@ XML;
             'POST',
             "{$userGroupHref}/users",
             'UserCreate+xml',
-            'User+json'
+            'User+json',
+            $xml
         );
-        $request->setContent($xml);
-
         $response = $this->sendHttpRequest($request);
+
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        $href = $response->getHeader('Location');
+        $href = $response->getHeader('Location')[0];
         $this->addCreatedElement($href);
 
         return $href;
@@ -201,10 +200,9 @@ XML;
             'PATCH',
             $userHref,
             'UserUpdate+xml',
-            'User+json'
+            'User+json',
+            $xml
         );
-        $request->setContent($xml);
-
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 200);
@@ -352,10 +350,16 @@ XML;
      */
     public function testMoveUserGroup($groupHref)
     {
-        $request = $this->createHttpRequest('MOVE', $groupHref);
-        $request->addHeader('Destination: /api/ezp/v2/user/groups/1/5/12');
-
+        $request = $this->createHttpRequest(
+            'MOVE',
+            $groupHref,
+            '',
+            '',
+            '',
+            ['Destination' => '/api/ezp/v2/user/groups/1/5/12']
+        );
         $response = $this->sendHttpRequest($request);
+
         self::assertHttpResponseCodeEquals($response, 201);
     }
 
@@ -381,15 +385,15 @@ XML;
             'POST',
             '/api/ezp/v2/user/sessions',
             'SessionInput+xml',
-            'Session+json'
+            'Session+json',
+            $xml
         );
-        $request->setContent($xml);
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
 
-        $href = $response->getHeader('Location');
+        $href = $response->getHeader('Location')[0];
         $this->addCreatedElement($href);
 
         return $href;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29048](https://jira.ez.no/browse/EZP-29048)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.0`, `7.1`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR fixes failing REST Behat BuzzDriver and Functional tests on `ezpublish-kernel:^7.0`.
The failure is caused by the most recent `v0.17.0` release of `kriswallsmith/buzz`. The easy way out would be to force `v0.16.1`, but new changes to the Buzz library impose best practices and use of PSR7-related namespace and conventions. It also was a good chance to fix other bugs in our REST tests.

Technical background for the changes:
- PSR7 defines specific interfaces, so naming convention changed a little bit,
- `Request` object is now immutable, so every `createHttpRequest` call needs to be fully defined when instantiating, including its body.
- `getHeader` call takes into account possibility of passing multiple values for the same header, so returns an array of header values.

This causes a little bit of trouble for Behat, which depends on state of the Context. I've refactored BuzzDriver to produce PSR-7-compliant Request after collecting and saving all required parameters.

**TODO**:
- [ ] Rebase once ezsystems/ezpublish-kernel#2299 is merged
- [x] Fix REST Functional tests.
- [x] Fix smaller bugs in REST Functional tests code
- [x] Fix Behat BuzzDriver for REST client.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
