### PR TITLE
EZP-28950: Show how to change table character set

### DIFF
--- a/data/update/mysql/dbupdate-7.1.0-to-7.2.0.sql
+++ b/data/update/mysql/dbupdate-7.1.0-to-7.2.0.sql
@@ -4,6 +4,8 @@ UPDATE ezsite_data SET value='7.2.0' WHERE name='ezpublish-version';
 
 --
 -- EZP-28950: MySQL UTF8 doesn't support 4-byte chars
+-- This shortens indexes so that 4-byte content can fit.
+-- After running these, convert the table character set, see doc/upgrade/7.2.md
 --
 
 ALTER TABLE `ezprest_authcode` DROP PRIMARY KEY;

--- a/doc/upgrade/7.2.md
+++ b/doc/upgrade/7.2.md
@@ -4,9 +4,18 @@ See `doc/bc/changes-7.2.md` for requirements changes and deprecations.
 
 ## MySQL/MariaDB database tables character set change
 
-The character set for MySQL/MariaDB database tables is changed from `utf8` to `utf8mb4` to support 4-byte characters. See `data/update/mysql/dbupdate-7.1.0-to-7.2.0.sql` for the SQL upgrade statements.
+The character set for MySQL/MariaDB database tables should be changed from `utf8` to `utf8mb4` to support 4-byte characters. See `data/update/mysql/dbupdate-7.1.0-to-7.2.0.sql` for the statements that shorten table indexes, these must be run first. Beware that these upgrade statements may fail due to index collisions, which may occur when indexes are shortened. If that happens, you must remove the duplicates manually, and then repeat the statements that failed.
 
-Beware that these upgrade statements may fail due to index collisions. This is because the indexes have been shortened, so duplicates may occur. If that happens, you must remove the duplicates manually, and then repeat the statements that failed.
+After successfully running those statements, change the character set of each table to `utf8mb4`. This can be done as shown below, for each of the standard tables in eZ Platform, and for any custom table you may want to convert. You may specify a collation; if you don't, the default collation for utf8mb4 will be used.
+
+To get a list of tables, enter the SQL command `show tables;`. For each of the tables you want to convert, replace `tbl_name` with the name of the table to convert:
+```sql
+-- Example using default collation
+ALTER TABLE tbl_name CONVERT TO CHARACTER SET utf8mb4;
+
+-- Example using utf8mb4_unicode_520_ci collation
+ALTER TABLE tbl_name CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci;
+```
 
 You should also change the character set that is specified in the application config, and in legacy if you use that.
 

--- a/doc/upgrade/7.2.md
+++ b/doc/upgrade/7.2.md
@@ -6,7 +6,7 @@ See `doc/bc/changes-7.2.md` for requirements changes and deprecations.
 
 The character set for MySQL/MariaDB database tables should be changed from `utf8` to `utf8mb4` to support 4-byte characters. See `data/update/mysql/dbupdate-7.1.0-to-7.2.0.sql` for the statements that shorten table indexes, these must be run first. Beware that these upgrade statements may fail due to index collisions, which may occur when indexes are shortened. If that happens, you must remove the duplicates manually, and then repeat the statements that failed.
 
-After successfully running those statements, change the character set of each table to `utf8mb4`. This can be done as shown below, for each of the standard tables in eZ Platform, and for any custom table you may want to convert. You may specify a collation; if you don't, the default collation for utf8mb4 will be used. We recommend specifying `utf8mb4_unicode_520_ci`, which supports emoji collation (the collation to use depends on your needs).
+After successfully running those statements, change the character set of each table to `utf8mb4`. This can be done as shown below, for each of the standard tables in eZ Platform, and for any custom table you may want to convert. You may specify a collation; if you don't, the default collation for utf8mb4 will be used. We recommend specifying `utf8mb4_unicode_520_ci`, which is able to tell different emojis apart, though you may have other requirements.
 
 To get a list of tables, enter the SQL command `show tables;`. For each of the tables you want to convert, replace `tbl_name` with the name of the table to convert:
 ```sql

--- a/doc/upgrade/7.2.md
+++ b/doc/upgrade/7.2.md
@@ -6,13 +6,10 @@ See `doc/bc/changes-7.2.md` for requirements changes and deprecations.
 
 The character set for MySQL/MariaDB database tables should be changed from `utf8` to `utf8mb4` to support 4-byte characters. See `data/update/mysql/dbupdate-7.1.0-to-7.2.0.sql` for the statements that shorten table indexes, these must be run first. Beware that these upgrade statements may fail due to index collisions, which may occur when indexes are shortened. If that happens, you must remove the duplicates manually, and then repeat the statements that failed.
 
-After successfully running those statements, change the character set of each table to `utf8mb4`. This can be done as shown below, for each of the standard tables in eZ Platform, and for any custom table you may want to convert. You may specify a collation; if you don't, the default collation for utf8mb4 will be used.
+After successfully running those statements, change the character set of each table to `utf8mb4`. This can be done as shown below, for each of the standard tables in eZ Platform, and for any custom table you may want to convert. You may specify a collation; if you don't, the default collation for utf8mb4 will be used. We recommend specifying `utf8mb4_unicode_520_ci`, which supports emoji collation (the collation to use depends on your needs).
 
 To get a list of tables, enter the SQL command `show tables;`. For each of the tables you want to convert, replace `tbl_name` with the name of the table to convert:
 ```sql
--- Example using default collation
-ALTER TABLE tbl_name CONVERT TO CHARACTER SET utf8mb4;
-
 -- Example using utf8mb4_unicode_520_ci collation
 ALTER TABLE tbl_name CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci;
 ```


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28950](https://jira.ez.no/browse/EZP-28950)
| **Bug/Improvement**| no
| **New feature**    | no
| **Target version** | master / 7.2
| **BC breaks**      | kind of
| **Tests pass**     | yes
| **Doc needed**     | yes

https://github.com/ezsystems/ezpublish-kernel/commit/0f82a088ebe7949970f9cf1acb687b21b42a0779 did not contain statements or info on how to change table charset on existing tables, when upgrading to 7.2.

Here I explain how to do it, rather than provide the complete set of SQL commands, because I want administrators to think carefully about which tables to convert, and which collation to use, rather than just copy a bunch of SQL commands. Also, because the number of tables varies depending on whether you use eZ Platform or Enterprise Edition, and on whether you have any additional custom tables.