### PR TITLE
Fixed EZP-28882: Added newly created Version no. to CreateContentDraft Signal

### DIFF
--- a/eZ/Publish/Core/SignalSlot/ContentService.php
+++ b/eZ/Publish/Core/SignalSlot/ContentService.php
@@ -325,6 +325,7 @@ class ContentService implements ContentServiceInterface
                 array(
                     'contentId' => $contentInfo->id,
                     'versionNo' => ($versionInfo !== null ? $versionInfo->versionNo : null),
+                    'newVersionNo' => $returnValue->getVersionInfo()->versionNo,
                     'userId' => ($user !== null ? $user->id : null),
                 )
             )

--- a/eZ/Publish/Core/SignalSlot/Signal/ContentService/CreateContentDraftSignal.php
+++ b/eZ/Publish/Core/SignalSlot/Signal/ContentService/CreateContentDraftSignal.php
@@ -23,7 +23,7 @@ class CreateContentDraftSignal extends Signal
     public $contentId;
 
     /**
-     * Version Number.
+     * Original Version Number.
      *
      * @var int
      */
@@ -35,4 +35,11 @@ class CreateContentDraftSignal extends Signal
      * @var mixed
      */
     public $userId;
+
+    /**
+     * Version number of newly created draft.
+     *
+     * @var int
+     */
+    public $newVersionNo;
 }

--- a/eZ/Publish/Core/SignalSlot/Tests/ContentServiceTest.php
+++ b/eZ/Publish/Core/SignalSlot/Tests/ContentServiceTest.php
@@ -163,6 +163,7 @@ class ContentServiceTest extends ServiceTest
                 array(
                     'contentId' => $contentId,
                     'versionNo' => $versionNo,
+                    'newVersionNo' => $content->getVersionInfo()->versionNo,
                     'userId' => $userId,
                 ),
             ),


### PR DESCRIPTION
CreateContentDraft signal didn't include Version number of new Draft.

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28882](https://jira.ez.no/browse/EZP-28882)
| **Bug/Improvement**| yes
| **New feature**    | yes
| **Target version** | `7.1`
| **BC breaks**      | no
| **Tests pass**     | no
| **Doc needed**     | maybe

This PR is bugfix and feature in one.
It adds `newVersionNo` property to `CreateContentDraftSignal`. For someone relying on that signal this is very useful information.

**TODO**:
- [ ] Rebase after solving failing CI issues.
- [x] Fix a bug.
- [x] Align test.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
