### PR TITLE
[Composer] Added conflict with doctrine/dbal:2.7.0 due to fetch_style bug

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,9 @@
         "symfony/assetic-bundle": "~2.3",
         "ezsystems/behatbundle": "^6.1"
     },
+    "conflict": {
+        "doctrine/dbal": "2.7.0"
+    },
     "replace": {
         "ezsystems/ezpublish": "*",
         "ezsystems/ezpublish-api": "self.version",


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | N/A
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7` and higher
| **BC breaks**      | no
| **Tests pass**     | TBD
| **Doc needed**     | no

This PR adds Composer `conflict` on `doctrine/dbal:2.7.0` due to discovered PDO fetch_style regression.

**TODO**:
- [x] Add Composer conflict on `doctrine/dbal:2.7.0`.
- [x] Ask for Code Review.
