### PR TITLE
EZP-28009: Provided compatibility with external RichText package

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -182,10 +182,16 @@ class EzPublishCoreExtension extends Extension
      *
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
      * @param \Symfony\Component\DependencyInjection\Loader\FileLoader $loader
+     *
+     * @throws \Exception
      */
     private function handleDefaultSettingsLoading(ContainerBuilder $container, FileLoader $loader)
     {
         $loader->load('default_settings.yml');
+
+        if (!array_key_exists('EzPlatformRichTextBundle', $container->getParameter('kernel.bundles'))) {
+            $loader->load('ezrichtext_default_settings.yml');
+        }
 
         foreach ($this->defaultSettingsCollection as $fileLocation => $files) {
             $externalLoader = new Loader\YamlFileLoader($container, new FileLocator($fileLocation));

--- a/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
@@ -98,35 +98,36 @@ class EzPublishCoreBundle extends Bundle
         $securityExtension->addSecurityListenerFactory(new HttpBasicFactory());
         $container->addCompilerPass(new TranslationCollectorPass());
         $container->addCompilerPass(new SlugConverterConfigurationPass());
+
+        if (!$container->hasExtension('ezrichtext')) {
+            $this->getContainerExtension()->addConfigParser(new ConfigParser\FieldType\RichText());
+        }
     }
 
     public function getContainerExtension()
     {
         if (!isset($this->extension)) {
-            $this->extension = new EzPublishCoreExtension(
-                array(
-                    // LocationView config parser needs to be specified AFTER ContentView config
-                    // parser since it is used to convert location view override rules to content
-                    // view override rules. If it were specified before, ContentView provider would
-                    // just undo the conversion LocationView did.
-                    new ConfigParser\ContentView(),
-                    new ConfigParser\LocationView(),
-                    new ConfigParser\BlockView(),
-                    new ConfigParser\Common(),
-                    new ConfigParser\Content(),
-                    new ConfigParser\FieldType\RichText(),
-                    new ConfigParser\FieldType\ImageAsset(),
-                    new ConfigParser\FieldTemplates(),
-                    new ConfigParser\FieldEditTemplates(),
-                    new ConfigParser\FieldDefinitionSettingsTemplates(),
-                    new ConfigParser\FieldDefinitionEditTemplates(),
-                    new ConfigParser\Image(),
-                    new ConfigParser\Page(),
-                    new ConfigParser\Languages(),
-                    new ConfigParser\IO(new ComplexSettingParser()),
-                    new ConfigParser\UrlChecker(),
-                )
-            );
+            $this->extension = new EzPublishCoreExtension([
+                // LocationView config parser needs to be specified AFTER ContentView config
+                // parser since it is used to convert location view override rules to content
+                // view override rules. If it were specified before, ContentView provider would
+                // just undo the conversion LocationView did.
+                new ConfigParser\ContentView(),
+                new ConfigParser\LocationView(),
+                new ConfigParser\BlockView(),
+                new ConfigParser\Common(),
+                new ConfigParser\Content(),
+                new ConfigParser\FieldType\ImageAsset(),
+                new ConfigParser\FieldTemplates(),
+                new ConfigParser\FieldEditTemplates(),
+                new ConfigParser\FieldDefinitionSettingsTemplates(),
+                new ConfigParser\FieldDefinitionEditTemplates(),
+                new ConfigParser\Image(),
+                new ConfigParser\Page(),
+                new ConfigParser\Languages(),
+                new ConfigParser\IO(new ComplexSettingParser()),
+                new ConfigParser\UrlChecker(),
+            ]);
         }
 
         return $this->extension;

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -21,16 +21,6 @@ parameters:
     ezplatform.default_view_templates.content.asset_image: 'EzPublishCoreBundle:default:content/asset_image.html.twig'
     ezplatform.default_view_templates.block: 'EzPublishCoreBundle:default:block/block.html.twig'
 
-    # Rich Text Custom Tags global configuration
-    ezplatform.ezrichtext.custom_tags: {}
-    # Rich Text Custom Tags default scope (for SiteAccess) configuration
-    ezsettings.default.fieldtypes.ezrichtext.custom_tags: []
-
-    # Rich Text Custom Styles global configuration
-    ezplatform.ezrichtext.custom_styles: {}
-    # Rich Text Custom Styles default scope (for SiteAccess) configuration
-    ezsettings.default.fieldtypes.ezrichtext.custom_styles: []
-
     # Image Asset mappings
     ezsettings.default.fieldtypes.ezimageasset.mappings:
         content_type_identifier: image
@@ -113,51 +103,6 @@ parameters:
     ezsettings.default.content.field_groups.default: 'content'
 
     # FieldType settings
-    # Default XSL stylesheets for RichText rendering to HTML5.
-    # Built-in stylesheets are treated as custom for the sake of extensibility.
-    ezsettings.default.fieldtypes.ezrichtext.output_custom_xsl:
-        -
-            path: "%kernel.root_dir%/../vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl"
-            priority: 0
-
-    ezsettings.default.fieldtypes.ezrichtext.edit_custom_xsl:
-        -
-            path: "%kernel.root_dir%/../vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl"
-            priority: 0
-
-    ezsettings.default.fieldtypes.ezrichtext.input_custom_xsl: []
-
-    # RichText field type template tag settings
-    # 'default' and 'default_inline' tag identifiers are reserved for fallback
-    ezsettings.default.fieldtypes.ezrichtext.tags.default:
-        template: EzPublishCoreBundle:FieldType/RichText/tag:default.html.twig
-    ezsettings.default.fieldtypes.ezrichtext.tags.default_inline:
-        template: EzPublishCoreBundle:FieldType/RichText/tag:default_inline.html.twig
-
-    # RichText field type template style settings
-    # 'default' and 'default_inline' tag identifiers are reserved for fallback
-    ezsettings.default.fieldtypes.ezrichtext.styles.default:
-        template: EzPublishCoreBundle:FieldType/RichText/style:default.html.twig
-    ezsettings.default.fieldtypes.ezrichtext.styles.default_inline:
-        template: EzPublishCoreBundle:FieldType/RichText/style:default_inline.html.twig
-
-    # RichText field type embed settings
-    ezsettings.default.fieldtypes.ezrichtext.embed.content:
-        template: EzPublishCoreBundle:FieldType/RichText/embed:content.html.twig
-    ezsettings.default.fieldtypes.ezrichtext.embed.content_denied:
-        template: EzPublishCoreBundle:FieldType/RichText/embed:content_denied.html.twig
-    ezsettings.default.fieldtypes.ezrichtext.embed.content_inline:
-        template: EzPublishCoreBundle:FieldType/RichText/embed:content_inline.html.twig
-    ezsettings.default.fieldtypes.ezrichtext.embed.content_inline_denied:
-        template: EzPublishCoreBundle:FieldType/RichText/embed:content_inline_denied.html.twig
-    ezsettings.default.fieldtypes.ezrichtext.embed.location:
-        template: EzPublishCoreBundle:FieldType/RichText/embed:location.html.twig
-    ezsettings.default.fieldtypes.ezrichtext.embed.location_denied:
-        template: EzPublishCoreBundle:FieldType/RichText/embed:location_denied.html.twig
-    ezsettings.default.fieldtypes.ezrichtext.embed.location_inline:
-        template: EzPublishCoreBundle:FieldType/RichText/embed:location_inline.html.twig
-    ezsettings.default.fieldtypes.ezrichtext.embed.location_inline_denied:
-        template: EzPublishCoreBundle:FieldType/RichText/embed:location_inline_denied.html.twig
 
     # Cache settings
     # Server(s) URL(s) that will be used for purging HTTP cache with BAN requests.

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/ezrichtext_default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/ezrichtext_default_settings.yml
@@ -1,0 +1,56 @@
+parameters:
+    # Rich Text Custom Tags global configuration
+    ezplatform.ezrichtext.custom_tags: {}
+    # Rich Text Custom Tags default scope (for SiteAccess) configuration
+    ezsettings.default.fieldtypes.ezrichtext.custom_tags: []
+
+    # Rich Text Custom Styles global configuration
+    ezplatform.ezrichtext.custom_styles: {}
+    # Rich Text Custom Styles default scope (for SiteAccess) configuration
+    ezsettings.default.fieldtypes.ezrichtext.custom_styles: []
+
+    # Default XSL stylesheets for RichText rendering to HTML5.
+    # Built-in stylesheets are treated as custom for the sake of extensibility.
+    ezsettings.default.fieldtypes.ezrichtext.output_custom_xsl:
+        -
+            path: '%kernel.root_dir%/../vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/output/core.xsl'
+            priority: 0
+
+    ezsettings.default.fieldtypes.ezrichtext.edit_custom_xsl:
+        -
+            path: '%kernel.root_dir%/../vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/xhtml5/edit/core.xsl'
+            priority: 0
+
+    ezsettings.default.fieldtypes.ezrichtext.input_custom_xsl: []
+
+    # RichText field type template tag settings
+    # 'default' and 'default_inline' tag identifiers are reserved for fallback
+    ezsettings.default.fieldtypes.ezrichtext.tags.default:
+        template: EzPublishCoreBundle:FieldType/RichText/tag:default.html.twig
+    ezsettings.default.fieldtypes.ezrichtext.tags.default_inline:
+        template: EzPublishCoreBundle:FieldType/RichText/tag:default_inline.html.twig
+
+    # RichText field type template style settings
+    # 'default' and 'default_inline' tag identifiers are reserved for fallback
+    ezsettings.default.fieldtypes.ezrichtext.styles.default:
+        template: EzPublishCoreBundle:FieldType/RichText/style:default.html.twig
+    ezsettings.default.fieldtypes.ezrichtext.styles.default_inline:
+        template: EzPublishCoreBundle:FieldType/RichText/style:default_inline.html.twig
+
+    # RichText field type embed settings
+    ezsettings.default.fieldtypes.ezrichtext.embed.content:
+        template: EzPublishCoreBundle:FieldType/RichText/embed:content.html.twig
+    ezsettings.default.fieldtypes.ezrichtext.embed.content_denied:
+        template: EzPublishCoreBundle:FieldType/RichText/embed:content_denied.html.twig
+    ezsettings.default.fieldtypes.ezrichtext.embed.content_inline:
+        template: EzPublishCoreBundle:FieldType/RichText/embed:content_inline.html.twig
+    ezsettings.default.fieldtypes.ezrichtext.embed.content_inline_denied:
+        template: EzPublishCoreBundle:FieldType/RichText/embed:content_inline_denied.html.twig
+    ezsettings.default.fieldtypes.ezrichtext.embed.location:
+        template: EzPublishCoreBundle:FieldType/RichText/embed:location.html.twig
+    ezsettings.default.fieldtypes.ezrichtext.embed.location_denied:
+        template: EzPublishCoreBundle:FieldType/RichText/embed:location_denied.html.twig
+    ezsettings.default.fieldtypes.ezrichtext.embed.location_inline:
+        template: EzPublishCoreBundle:FieldType/RichText/embed:location_inline.html.twig
+    ezsettings.default.fieldtypes.ezrichtext.embed.location_inline_denied:
+        template: EzPublishCoreBundle:FieldType/RichText/embed:location_inline_denied.html.twig

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -11,39 +11,6 @@ parameters:
     ezpublish.fieldType.ezpage.zone.class: eZ\Publish\Core\FieldType\Page\Parts\Zone
     ezpublish.fieldType.ezpage.hashConverter.class: eZ\Publish\Core\FieldType\Page\HashConverter
 
-    # RichText
-    ezpublish.fieldType.ezrichtext.normalizer.document_type_definition.class: eZ\Publish\Core\FieldType\RichText\Normalizer\DocumentTypeDefinition
-    ezpublish.fieldType.ezrichtext.converter.xslt.class: eZ\Publish\Core\FieldType\RichText\Converter\Xslt
-    ezpublish.fieldType.ezrichtext.converter.aggregate.class: eZ\Publish\Core\FieldType\RichText\Converter\Aggregate
-    ezpublish.fieldType.ezrichtext.converter.output.html5.class: eZ\Bundle\EzPublishCoreBundle\FieldType\RichText\Converter\Html5
-    ezpublish.fieldType.ezrichtext.converter.edit.html5.class: eZ\Bundle\EzPublishCoreBundle\FieldType\RichText\Converter\Html5Edit
-    ezpublish.fieldType.ezrichtext.converter.input.html5.class: eZ\Bundle\EzPublishCoreBundle\FieldType\RichText\Converter\Html5Input
-    ezpublish.fieldType.ezrichtext.converter.programlisting.class: eZ\Publish\Core\FieldType\RichText\Converter\ProgramListing
-    ezpublish.fieldType.ezrichtext.converter.link.class: eZ\Publish\Core\FieldType\RichText\Converter\Link
-    ezpublish.fieldType.ezrichtext.converter.embed.class: eZ\Publish\Core\FieldType\RichText\Converter\Render\Embed
-    ezpublish.fieldType.ezrichtext.converter.template.class: eZ\Publish\Core\FieldType\RichText\Converter\Render\Template
-    ezpublish.fieldType.ezrichtext.embed_renderer.class: eZ\Publish\Core\MVC\Symfony\FieldType\RichText\EmbedRenderer
-    ezpublish.fieldType.ezrichtext.renderer.class: eZ\Publish\Core\MVC\Symfony\FieldType\RichText\Renderer
-    ezpublish.fieldType.ezrichtext.tag.namespace: fieldtypes.ezrichtext.tags
-    ezpublish.fieldType.ezrichtext.style.namespace: fieldtypes.ezrichtext.styles
-    ezpublish.fieldType.ezrichtext.embed.namespace: fieldtypes.ezrichtext.embed
-    ezpublish.fieldType.ezrichtext.converter.dispatcher.class: eZ\Publish\Core\FieldType\RichText\ConverterDispatcher
-    ezpublish.fieldType.ezrichtext.validator.xml.class: eZ\Publish\Core\FieldType\RichText\Validator
-    ezpublish.fieldType.ezrichtext.validator.dispatcher.class: eZ\Publish\Core\FieldType\RichText\ValidatorDispatcher
-    ezpublish.fieldType.ezrichtext.validator.internal_link.class: eZ\Publish\Core\FieldType\RichText\InternalLinkValidator
-    ezpublish.fieldType.ezrichtext.resources: "%ezpublish.kernel.root_dir%/eZ/Publish/Core/FieldType/RichText/Resources"
-
-    ezpublish.fieldType.ezrichtext.converter.input.xhtml5.resources: "%ezpublish.fieldType.ezrichtext.resources%/stylesheets/xhtml5/edit/docbook.xsl"
-    ezpublish.fieldType.ezrichtext.converter.edit.xhtml5.resources: "%ezpublish.fieldType.ezrichtext.resources%/stylesheets/docbook/xhtml5/edit/xhtml5.xsl"
-    ezpublish.fieldType.ezrichtext.converter.output.xhtml5.resources: "%ezpublish.fieldType.ezrichtext.resources%/stylesheets/docbook/xhtml5/output/xhtml5.xsl"
-    ezpublish.fieldType.ezrichtext.converter.output.xhtml5.fragment.resources: "%ezpublish.fieldType.ezrichtext.resources%/stylesheets/xhtml5/output/fragment.xsl"
-
-    ezpublish.fieldType.ezrichtext.validator.docbook.resources:
-        - "%ezpublish.fieldType.ezrichtext.resources%/schemas/docbook/ezpublish.rng"
-        - "%ezpublish.fieldType.ezrichtext.resources%/schemas/docbook/docbook.iso.sch.xsl"
-    ezpublish.fieldType.ezrichtext.validator.output.ezxhtml5.resources:
-        - "%ezpublish.fieldType.ezrichtext.resources%/schemas/ezxhtml5/output/ezxhtml5.xsd"
-
     # Image
     ezpublish.fieldType.ezimage.pathGenerator.class: eZ\Publish\Core\FieldType\Image\PathGenerator\LegacyPathGenerator
     ezpublish.fieldType.ezimage.io_service.options_provider.class: eZ\Publish\Core\FieldType\Image\IO\OptionsProvider
@@ -119,128 +86,6 @@ services:
     ezpublish.fieldType.ezpage.hashConverter:
         class: "%ezpublish.fieldType.ezpage.hashConverter.class%"
 
-    # RichText
-    ezpublish.fieldType.ezrichtext.normalizer.input:
-        class: "%ezpublish.fieldType.ezrichtext.normalizer.document_type_definition.class%"
-        arguments:
-            - "section"
-            - "http://ez.no/namespaces/ezpublish5/xhtml5/edit"
-            - "%ezpublish.kernel.root_dir%/eZ/Publish/Core/FieldType/RichText/Resources/dtd/ezxhtml5_edit_html_character_entities.dtd"
-
-    ezpublish.fieldType.ezrichtext.converter.input.xhtml5.core:
-        class: "%ezpublish.fieldType.ezrichtext.converter.input.html5.class%"
-        arguments:
-            - "%ezpublish.fieldType.ezrichtext.converter.input.xhtml5.resources%"
-            - "@ezpublish.config.resolver"
-        tags:
-            - {name: ezpublish.ezrichtext.converter.input.xhtml5, priority: 50}
-
-    # Note: should run before xsl transformation
-    ezpublish.fieldType.ezrichtext.converter.input.xhtml5.programlisting:
-        class: "%ezpublish.fieldType.ezrichtext.converter.programlisting.class%"
-        tags:
-            - {name: ezpublish.ezrichtext.converter.input.xhtml5, priority: 10}
-
-    # Aggregate converter for XHTML5 input that other converters register to
-    # through service tags.
-    ezpublish.fieldType.ezrichtext.converter.input.xhtml5:
-        class: "%ezpublish.fieldType.ezrichtext.converter.aggregate.class%"
-        lazy: true
-
-    ezpublish.fieldType.ezrichtext.converter.input.dispatcher:
-        class: "%ezpublish.fieldType.ezrichtext.converter.dispatcher.class%"
-        arguments:
-            -
-                http://docbook.org/ns/docbook: null
-                http://ez.no/namespaces/ezpublish5/xhtml5/edit: "@ezpublish.fieldType.ezrichtext.converter.input.xhtml5"
-
-    ezpublish.fieldType.ezrichtext.converter.link:
-        class: "%ezpublish.fieldType.ezrichtext.converter.link.class%"
-        arguments: ["@ezpublish.api.service.location", "@ezpublish.api.service.content", "@ezpublish.urlalias_router", "@?logger"]
-        tags:
-            - {name: ezpublish.ezrichtext.converter.output.xhtml5, priority: 0}
-
-    ezpublish.fieldType.ezrichtext.renderer:
-        class: "%ezpublish.fieldType.ezrichtext.renderer.class%"
-        arguments:
-            - "@ezpublish.api.repository"
-            - "@security.authorization_checker"
-            - "@ezpublish.config.resolver"
-            - "@templating"
-            - "%ezpublish.fieldType.ezrichtext.tag.namespace%"
-            - "%ezpublish.fieldType.ezrichtext.style.namespace%"
-            - "%ezpublish.fieldType.ezrichtext.embed.namespace%"
-            - "@?logger"
-            - "%ezplatform.ezrichtext.custom_tags%"
-            - "%ezplatform.ezrichtext.custom_styles%"
-
-    ezpublish.fieldType.ezrichtext.converter.template:
-        class: "%ezpublish.fieldType.ezrichtext.converter.template.class%"
-        arguments:
-            - "@ezpublish.fieldType.ezrichtext.renderer"
-            - "@ezpublish.fieldType.ezrichtext.converter.output.xhtml5"
-            - "@?logger"
-        tags:
-            - {name: ezpublish.ezrichtext.converter.output.xhtml5, priority: 10}
-
-    ezpublish.fieldType.ezrichtext.converter.embed:
-        class: "%ezpublish.fieldType.ezrichtext.converter.embed.class%"
-        arguments:
-            - "@ezpublish.fieldType.ezrichtext.renderer"
-            - "@?logger"
-        tags:
-            - {name: ezpublish.ezrichtext.converter.output.xhtml5, priority: 10}
-
-    ezpublish.fieldType.ezrichtext.converter.output.xhtml5.core:
-        class: "%ezpublish.fieldType.ezrichtext.converter.output.html5.class%"
-        arguments:
-            - "%ezpublish.fieldType.ezrichtext.converter.output.xhtml5.resources%"
-            - "@ezpublish.config.resolver"
-        tags:
-            - {name: ezpublish.ezrichtext.converter.output.xhtml5, priority: 50}
-
-    # Note: should typically be the last one as it produces embeddable fragment
-    ezpublish.fieldType.ezrichtext.converter.output.xhtml5.fragment:
-        class: "%ezpublish.fieldType.ezrichtext.converter.xslt.class%"
-        arguments: ["%ezpublish.fieldType.ezrichtext.converter.output.xhtml5.fragment.resources%"]
-        tags:
-            - {name: ezpublish.ezrichtext.converter.output.xhtml5, priority: 100}
-
-    # Aggregate converter for XHTML5 output that other converters register to
-    # through service tags.
-    ezpublish.fieldType.ezrichtext.converter.output.xhtml5:
-        class: "%ezpublish.fieldType.ezrichtext.converter.aggregate.class%"
-        lazy: true
-
-    ezpublish.fieldType.ezrichtext.converter.edit.xhtml5:
-        class: "%ezpublish.fieldType.ezrichtext.converter.edit.html5.class%"
-        arguments:
-            - "%ezpublish.fieldType.ezrichtext.converter.edit.xhtml5.resources%"
-            - "@ezpublish.config.resolver"
-        lazy: true
-
-    ezpublish.fieldType.ezrichtext.validator.docbook:
-        class: "%ezpublish.fieldType.ezrichtext.validator.xml.class%"
-        arguments: ["%ezpublish.fieldType.ezrichtext.validator.docbook.resources%"]
-
-    ezpublish.fieldType.ezrichtext.validator.output.ezxhtml5:
-        class: "%ezpublish.fieldType.ezrichtext.validator.xml.class%"
-        arguments: ["%ezpublish.fieldType.ezrichtext.validator.output.ezxhtml5.resources%"]
-
-    ezpublish.fieldType.ezrichtext.validator.input.dispatcher:
-        class: "%ezpublish.fieldType.ezrichtext.validator.dispatcher.class%"
-        arguments:
-            -
-                http://docbook.org/ns/docbook: null
-                http://ez.no/namespaces/ezpublish5/xhtml5/edit: null
-                http://ez.no/namespaces/ezpublish5/xhtml5: "@ezpublish.fieldType.ezrichtext.validator.output.ezxhtml5"
-
-    ezpublish.fieldType.ezrichtext.validator.internal_link:
-        class: '%ezpublish.fieldType.ezrichtext.validator.internal_link.class%'
-        arguments:
-            - '@ezpublish.spi.persistence.cache.contentHandler'
-            - '@ezpublish.spi.persistence.cache.locationHandler'
-
     # Image
     ezpublish.fieldType.ezimage.io_service:
         class: "%ezpublish.fieldType.ezimage.io_legacy.class%"
@@ -311,10 +156,6 @@ services:
             - {name: ezpublish.fieldType.nameable, alias: ezselection}
 
     # Symfony 3.4+ service definitions:
-    eZ\Publish\Core\FieldType\RichText\CustomTagsValidator:
-        public: false
-        arguments: ['%ezplatform.ezrichtext.custom_tags%']
-
     eZ\Publish\Core\FieldType\ImageAsset\NameableField:
         arguments:
             $handler: '@ezpublish.spi.persistence.cache.contentHandler'
@@ -327,4 +168,3 @@ services:
             $locationService: '@ezpublish.api.service.location'
             $contentTypeService: '@ezpublish.api.service.content_type'
             $mappings: '$fieldtypes.ezimageasset.mappings$'
-

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/richtext.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/richtext.yml
@@ -1,0 +1,3 @@
+imports:
+    - {resource: richtext/fieldtype_services.yml}
+    - {resource: richtext/templating.yml}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/richtext/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/richtext/fieldtype_services.yml
@@ -1,0 +1,160 @@
+parameters:
+    # RichText
+    ezpublish.fieldType.ezrichtext.normalizer.document_type_definition.class: eZ\Publish\Core\FieldType\RichText\Normalizer\DocumentTypeDefinition
+    ezpublish.fieldType.ezrichtext.converter.xslt.class: eZ\Publish\Core\FieldType\RichText\Converter\Xslt
+    ezpublish.fieldType.ezrichtext.converter.aggregate.class: eZ\Publish\Core\FieldType\RichText\Converter\Aggregate
+    ezpublish.fieldType.ezrichtext.converter.output.html5.class: eZ\Bundle\EzPublishCoreBundle\FieldType\RichText\Converter\Html5
+    ezpublish.fieldType.ezrichtext.converter.edit.html5.class: eZ\Bundle\EzPublishCoreBundle\FieldType\RichText\Converter\Html5Edit
+    ezpublish.fieldType.ezrichtext.converter.input.html5.class: eZ\Bundle\EzPublishCoreBundle\FieldType\RichText\Converter\Html5Input
+    ezpublish.fieldType.ezrichtext.converter.programlisting.class: eZ\Publish\Core\FieldType\RichText\Converter\ProgramListing
+    ezpublish.fieldType.ezrichtext.converter.link.class: eZ\Publish\Core\FieldType\RichText\Converter\Link
+    ezpublish.fieldType.ezrichtext.converter.embed.class: eZ\Publish\Core\FieldType\RichText\Converter\Render\Embed
+    ezpublish.fieldType.ezrichtext.converter.template.class: eZ\Publish\Core\FieldType\RichText\Converter\Render\Template
+    ezpublish.fieldType.ezrichtext.renderer.class: eZ\Publish\Core\MVC\Symfony\FieldType\RichText\Renderer
+    ezpublish.fieldType.ezrichtext.tag.namespace: fieldtypes.ezrichtext.tags
+    ezpublish.fieldType.ezrichtext.style.namespace: fieldtypes.ezrichtext.styles
+    ezpublish.fieldType.ezrichtext.embed.namespace: fieldtypes.ezrichtext.embed
+    ezpublish.fieldType.ezrichtext.converter.dispatcher.class: eZ\Publish\Core\FieldType\RichText\ConverterDispatcher
+    ezpublish.fieldType.ezrichtext.validator.xml.class: eZ\Publish\Core\FieldType\RichText\Validator
+    ezpublish.fieldType.ezrichtext.validator.dispatcher.class: eZ\Publish\Core\FieldType\RichText\ValidatorDispatcher
+    ezpublish.fieldType.ezrichtext.validator.internal_link.class: eZ\Publish\Core\FieldType\RichText\InternalLinkValidator
+    ezpublish.fieldType.ezrichtext.resources: '%ezpublish.kernel.root_dir%/eZ/Publish/Core/FieldType/RichText/Resources'
+
+    ezpublish.fieldType.ezrichtext.converter.input.xhtml5.resources: '%ezpublish.fieldType.ezrichtext.resources%/stylesheets/xhtml5/edit/docbook.xsl'
+    ezpublish.fieldType.ezrichtext.converter.edit.xhtml5.resources: '%ezpublish.fieldType.ezrichtext.resources%/stylesheets/docbook/xhtml5/edit/xhtml5.xsl'
+    ezpublish.fieldType.ezrichtext.converter.output.xhtml5.resources: '%ezpublish.fieldType.ezrichtext.resources%/stylesheets/docbook/xhtml5/output/xhtml5.xsl'
+    ezpublish.fieldType.ezrichtext.converter.output.xhtml5.fragment.resources: '%ezpublish.fieldType.ezrichtext.resources%/stylesheets/xhtml5/output/fragment.xsl'
+
+    ezpublish.fieldType.ezrichtext.validator.docbook.resources:
+        - '%ezpublish.fieldType.ezrichtext.resources%/schemas/docbook/ezpublish.rng'
+        - '%ezpublish.fieldType.ezrichtext.resources%/schemas/docbook/docbook.iso.sch.xsl'
+    ezpublish.fieldType.ezrichtext.validator.output.ezxhtml5.resources:
+        - '%ezpublish.fieldType.ezrichtext.resources%/schemas/ezxhtml5/output/ezxhtml5.xsd'
+
+services:
+    # RichText
+    ezpublish.fieldType.ezrichtext.normalizer.input:
+        class: '%ezpublish.fieldType.ezrichtext.normalizer.document_type_definition.class%'
+        arguments:
+            - 'section'
+            - 'http://ez.no/namespaces/ezpublish5/xhtml5/edit'
+            - '%ezpublish.kernel.root_dir%/eZ/Publish/Core/FieldType/RichText/Resources/dtd/ezxhtml5_edit_html_character_entities.dtd'
+
+    ezpublish.fieldType.ezrichtext.converter.input.xhtml5.core:
+        class: '%ezpublish.fieldType.ezrichtext.converter.input.html5.class%'
+        arguments:
+            - '%ezpublish.fieldType.ezrichtext.converter.input.xhtml5.resources%'
+            - '@ezpublish.config.resolver'
+        tags:
+            - {name: ezpublish.ezrichtext.converter.input.xhtml5, priority: 50}
+
+    # Note: should run before xsl transformation
+    ezpublish.fieldType.ezrichtext.converter.input.xhtml5.programlisting:
+        class: '%ezpublish.fieldType.ezrichtext.converter.programlisting.class%'
+        tags:
+            - {name: ezpublish.ezrichtext.converter.input.xhtml5, priority: 10}
+
+    # Aggregate converter for XHTML5 input that other converters register to
+    # through service tags.
+    ezpublish.fieldType.ezrichtext.converter.input.xhtml5:
+        class: '%ezpublish.fieldType.ezrichtext.converter.aggregate.class%'
+        lazy: true
+
+    ezpublish.fieldType.ezrichtext.converter.input.dispatcher:
+        class: '%ezpublish.fieldType.ezrichtext.converter.dispatcher.class%'
+        arguments:
+            -
+                http://docbook.org/ns/docbook: null
+                http://ez.no/namespaces/ezpublish5/xhtml5/edit: '@ezpublish.fieldType.ezrichtext.converter.input.xhtml5'
+
+    ezpublish.fieldType.ezrichtext.converter.link:
+        class: '%ezpublish.fieldType.ezrichtext.converter.link.class%'
+        arguments: ['@ezpublish.api.service.location', '@ezpublish.api.service.content', '@ezpublish.urlalias_router', '@?logger']
+        tags:
+            - {name: ezpublish.ezrichtext.converter.output.xhtml5, priority: 0}
+
+    ezpublish.fieldType.ezrichtext.renderer:
+        class: '%ezpublish.fieldType.ezrichtext.renderer.class%'
+        arguments:
+            - '@ezpublish.api.repository'
+            - '@security.authorization_checker'
+            - '@ezpublish.config.resolver'
+            - '@templating'
+            - '%ezpublish.fieldType.ezrichtext.tag.namespace%'
+            - '%ezpublish.fieldType.ezrichtext.style.namespace%'
+            - '%ezpublish.fieldType.ezrichtext.embed.namespace%'
+            - '@?logger'
+            - '%ezplatform.ezrichtext.custom_tags%'
+            - '%ezplatform.ezrichtext.custom_styles%'
+
+    ezpublish.fieldType.ezrichtext.converter.template:
+        class: '%ezpublish.fieldType.ezrichtext.converter.template.class%'
+        arguments:
+            - '@ezpublish.fieldType.ezrichtext.renderer'
+            - '@ezpublish.fieldType.ezrichtext.converter.output.xhtml5'
+            - '@?logger'
+        tags:
+            - {name: ezpublish.ezrichtext.converter.output.xhtml5, priority: 10}
+
+    ezpublish.fieldType.ezrichtext.converter.embed:
+        class: '%ezpublish.fieldType.ezrichtext.converter.embed.class%'
+        arguments:
+            - '@ezpublish.fieldType.ezrichtext.renderer'
+            - '@?logger'
+        tags:
+        - {name: ezpublish.ezrichtext.converter.output.xhtml5, priority: 10}
+
+    ezpublish.fieldType.ezrichtext.converter.output.xhtml5.core:
+        class: '%ezpublish.fieldType.ezrichtext.converter.output.html5.class%'
+        arguments:
+            - '%ezpublish.fieldType.ezrichtext.converter.output.xhtml5.resources%'
+            - '@ezpublish.config.resolver'
+        tags:
+            - {name: ezpublish.ezrichtext.converter.output.xhtml5, priority: 50}
+
+    # Note: should typically be the last one as it produces embeddable fragment
+    ezpublish.fieldType.ezrichtext.converter.output.xhtml5.fragment:
+        class: '%ezpublish.fieldType.ezrichtext.converter.xslt.class%'
+        arguments: ['%ezpublish.fieldType.ezrichtext.converter.output.xhtml5.fragment.resources%']
+        tags:
+            - {name: ezpublish.ezrichtext.converter.output.xhtml5, priority: 100}
+
+    # Aggregate converter for XHTML5 output that other converters register to
+    # through service tags.
+    ezpublish.fieldType.ezrichtext.converter.output.xhtml5:
+        class: '%ezpublish.fieldType.ezrichtext.converter.aggregate.class%'
+        lazy: true
+
+    ezpublish.fieldType.ezrichtext.converter.edit.xhtml5:
+        class: '%ezpublish.fieldType.ezrichtext.converter.edit.html5.class%'
+        arguments:
+            - '%ezpublish.fieldType.ezrichtext.converter.edit.xhtml5.resources%'
+            - '@ezpublish.config.resolver'
+        lazy: true
+
+    ezpublish.fieldType.ezrichtext.validator.docbook:
+        class: '%ezpublish.fieldType.ezrichtext.validator.xml.class%'
+        arguments: ['%ezpublish.fieldType.ezrichtext.validator.docbook.resources%']
+
+    ezpublish.fieldType.ezrichtext.validator.output.ezxhtml5:
+        class: '%ezpublish.fieldType.ezrichtext.validator.xml.class%'
+        arguments: ['%ezpublish.fieldType.ezrichtext.validator.output.ezxhtml5.resources%']
+
+    ezpublish.fieldType.ezrichtext.validator.input.dispatcher:
+        class: '%ezpublish.fieldType.ezrichtext.validator.dispatcher.class%'
+        arguments:
+            -
+                http://docbook.org/ns/docbook: null
+                http://ez.no/namespaces/ezpublish5/xhtml5/edit: null
+                http://ez.no/namespaces/ezpublish5/xhtml5: '@ezpublish.fieldType.ezrichtext.validator.output.ezxhtml5'
+
+    ezpublish.fieldType.ezrichtext.validator.internal_link:
+        class: '%ezpublish.fieldType.ezrichtext.validator.internal_link.class%'
+        arguments:
+            - '@ezpublish.spi.persistence.cache.contentHandler'
+            - '@ezpublish.spi.persistence.cache.locationHandler'
+
+    # Symfony 3.4+ service definitions:
+    eZ\Publish\Core\FieldType\RichText\CustomTagsValidator:
+        public: false
+        arguments: ['%ezplatform.ezrichtext.custom_tags%']

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/richtext/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/richtext/templating.yml
@@ -1,0 +1,11 @@
+parameters:
+    ezpublish.twig.extension.rich_text.class: eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\RichTextExtension
+
+services:
+    ezpublish.twig.extension.rich_text:
+        class: "%ezpublish.twig.extension.rich_text.class%"
+        arguments:
+            - "@ezpublish.fieldType.ezrichtext.converter.output.xhtml5"
+            - "@ezpublish.fieldType.ezrichtext.converter.edit.xhtml5"
+        tags:
+            - { name: twig.extension }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -21,7 +21,6 @@ parameters:
     ezpublish.templating.field_block_renderer.twig.class: eZ\Publish\Core\MVC\Symfony\Templating\Twig\FieldBlockRenderer
     ezpublish.twig.extension.field_rendering.class: eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\FieldRenderingExtension
     ezpublish.twig.extension.image.class: eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\ImageExtension
-    ezpublish.twig.extension.rich_text.class: eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\RichTextExtension
 
     ezpublish.view.cache_response_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\CacheViewResponseListener
     ezpublish.view.block_cache_response_listener.class: eZ\Bundle\EzPublishCoreBundle\EventListener\BlockCacheResponseListener
@@ -193,15 +192,6 @@ services:
             - '@eZ\Publish\Core\FieldType\ImageAsset\AssetMapper'
         tags:
             - { name: twig.extension }
-
-    ezpublish.twig.extension.rich_text:
-        class: "%ezpublish.twig.extension.rich_text.class%"
-        arguments:
-            - "@ezpublish.fieldType.ezrichtext.converter.output.xhtml5"
-            - "@ezpublish.fieldType.ezrichtext.converter.edit.xhtml5"
-        tags:
-            - { name: twig.extension }
-
 
     ezpublish.view.custom_location_controller_checker:
         class: "%ezpublish.view.custom_location_controller_checker.class%"

--- a/eZ/Publish/Core/settings/containerBuilder.php
+++ b/eZ/Publish/Core/settings/containerBuilder.php
@@ -47,6 +47,7 @@ $loader->load('settings.yml');
 $loader->load('utils.yml');
 $loader->load('tests/common.yml');
 $loader->load('policies.yml');
+$loader->load('richtext.yml');
 
 // Cache settings (takes same env variables as ezplatform does, only supports "singleredis" setup)
 if (getenv('CUSTOM_CACHE_POOL') === 'singleredis') {

--- a/eZ/Publish/Core/settings/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/fieldtype_external_storages.yml
@@ -6,7 +6,6 @@ parameters:
     ezpublish.fieldType.ezurl.externalStorage.class: eZ\Publish\Core\FieldType\Url\UrlStorage
     ezpublish.fieldType.ezgmaplocation.externalStorage.class: eZ\Publish\Core\FieldType\MapLocation\MapLocationStorage
     ezpublish.fieldType.ezuser.externalStorage.class: eZ\Publish\Core\FieldType\User\UserStorage
-    ezpublish.fieldType.ezrichtext.externalStorage.class: eZ\Publish\Core\FieldType\RichText\RichTextStorage
 
 services:
     ezpublish.fieldType.ezbinaryfile.externalStorage:
@@ -54,12 +53,6 @@ services:
             - "@?logger"
         tags:
             - {name: ezpublish.fieldType.externalStorageHandler, alias: ezurl}
-
-    ezpublish.fieldType.ezrichtext.externalStorage:
-        class: "%ezpublish.fieldType.ezrichtext.externalStorage.class%"
-        arguments: ["@ezpublish.fieldType.ezrichtext.storage_gateway"]
-        tags:
-            - {name: ezpublish.fieldType.externalStorageHandler, alias: ezrichtext}
 
     ezpublish.fieldType.ezgmaplocation.externalStorage:
         class: "%ezpublish.fieldType.ezgmaplocation.externalStorage.class%"

--- a/eZ/Publish/Core/settings/fieldtype_services.yml
+++ b/eZ/Publish/Core/settings/fieldtype_services.yml
@@ -1,13 +1,4 @@
 parameters:
-    ezpublish.fieldType.ezrichtext.normalizer.aggregate.class: eZ\Publish\Core\FieldType\RichText\Normalizer\Aggregate
-    ezpublish.fieldType.ezrichtext.validator.dispatcher.class: eZ\Publish\Core\FieldType\RichText\ValidatorDispatcher
-    ezpublish.fieldType.ezrichtext.converter.dispatcher.class: eZ\Publish\Core\FieldType\RichText\ConverterDispatcher
-    ezpublish.fieldType.ezrichtext.validator.xml.class: eZ\Publish\Core\FieldType\RichText\Validator
-    ezpublish.fieldType.ezrichtext.resources: "%ezpublish.kernel.root_dir%/eZ/Publish/Core/FieldType/RichText/Resources"
-    ezpublish.fieldType.ezrichtext.validator.docbook.resources:
-        - "%ezpublish.fieldType.ezrichtext.resources%/schemas/docbook/ezpublish.rng"
-        - "%ezpublish.fieldType.ezrichtext.resources%/schemas/docbook/docbook.iso.sch.xsl"
-    ezpublish.fieldType.ezrichtext.validator.internal_link.class: eZ\Publish\Core\FieldType\RichText\InternalLinkValidator
     ezpublish.fieldType.ezpage.pageService.class: eZ\Publish\Core\FieldType\Page\PageService
     ezpublish.fieldType.ezpage.hashConverter.class: eZ\Publish\Core\FieldType\Page\HashConverter
     ezpublish.fieldType.ezimage.io_legacy.class: eZ\Publish\Core\FieldType\Image\IO\Legacy
@@ -61,32 +52,6 @@ services:
     ezpublish.fieldType.ezbinaryfile.pathGenerator:
         class: "%ezpublish.fieldType.ezbinaryfile.pathGenerator.class%"
 
-    # RichText
-    ezpublish.fieldType.ezrichtext.converter.input.dispatcher:
-        class: "%ezpublish.fieldType.ezrichtext.converter.dispatcher.class%"
-        arguments:
-            -
-                http://docbook.org/ns/docbook: null
-
-    ezpublish.fieldType.ezrichtext.validator.docbook:
-        class: "%ezpublish.fieldType.ezrichtext.validator.xml.class%"
-        arguments: ["%ezpublish.fieldType.ezrichtext.validator.docbook.resources%"]
-
-    ezpublish.fieldType.ezrichtext.validator.input.dispatcher:
-        class: "%ezpublish.fieldType.ezrichtext.validator.dispatcher.class%"
-        arguments:
-            -
-                http://docbook.org/ns/docbook: null
-
-    ezpublish.fieldType.ezrichtext.validator.internal_link:
-        class: '%ezpublish.fieldType.ezrichtext.validator.internal_link.class%'
-        arguments:
-            - '@ezpublish.spi.persistence.cache.contentHandler'
-            - '@ezpublish.spi.persistence.cache.locationHandler'
-
-    ezpublish.fieldType.ezrichtext.normalizer.input:
-        class: "%ezpublish.fieldType.ezrichtext.normalizer.aggregate.class%"
-
     # Page
     ezpublish.fieldType.ezpage.pageService:
         class: "%ezpublish.fieldType.ezpage.pageService.class%"
@@ -117,10 +82,6 @@ services:
             - {name: ezpublish.fieldType.nameable, alias: ezselection}
 
     # Symfony 3.4+ service definitions:
-    eZ\Publish\Core\FieldType\RichText\CustomTagsValidator:
-        public: false
-        arguments: ['%ezplatform.ezrichtext.custom_tags%']
-
     eZ\Publish\Core\FieldType\ImageAsset\NameableField:
         public: false
         arguments:

--- a/eZ/Publish/Core/settings/fieldtypes.yml
+++ b/eZ/Publish/Core/settings/fieldtypes.yml
@@ -272,7 +272,6 @@ parameters:
         ZM: {Name: "Zambia", Alpha2: "ZM", Alpha3: "ZMB", IDC: "260"}
         ZW: {Name: "Zimbabwe", Alpha2: "ZW", Alpha3: "ZWE", IDC: "263"}
     ezpublish.fieldType.eznull.class: eZ\Publish\Core\FieldType\Null\Type
-    ezpublish.fieldType.ezrichtext.class: eZ\Publish\Core\FieldType\RichText\Type
 
 services:
     ezpublish.fieldType:
@@ -403,19 +402,6 @@ services:
         parent: ezpublish.fieldType
         tags:
             - {name: ezpublish.fieldType, alias: ezurl}
-
-    ezpublish.fieldType.ezrichtext:
-        class: "%ezpublish.fieldType.ezrichtext.class%"
-        parent: ezpublish.fieldType
-        arguments:
-            - "@ezpublish.fieldType.ezrichtext.validator.docbook"
-            - "@ezpublish.fieldType.ezrichtext.converter.input.dispatcher"
-            - "@ezpublish.fieldType.ezrichtext.normalizer.input"
-            - "@ezpublish.fieldType.ezrichtext.validator.input.dispatcher"
-            - '@ezpublish.fieldType.ezrichtext.validator.internal_link'
-            - '@eZ\Publish\Core\FieldType\RichText\CustomTagsValidator'
-        tags:
-            - {name: ezpublish.fieldType, alias: ezrichtext}
 
     ezpublish.fieldType.ezpage:
         class: "%ezpublish.fieldType.ezpage.class%"

--- a/eZ/Publish/Core/settings/indexable_fieldtypes.yml
+++ b/eZ/Publish/Core/settings/indexable_fieldtypes.yml
@@ -2,7 +2,6 @@ parameters:
     ezpublish.fieldType.indexable.ezkeyword.class: eZ\Publish\Core\FieldType\Keyword\SearchField
     ezpublish.fieldType.indexable.ezauthor.class: eZ\Publish\Core\FieldType\Author\SearchField
     ezpublish.fieldType.indexable.ezstring.class: eZ\Publish\Core\FieldType\TextLine\SearchField
-    ezpublish.fieldType.indexable.ezrichtext.class: eZ\Publish\Core\FieldType\RichText\SearchField
     ezpublish.fieldType.indexable.eztext.class: eZ\Publish\Core\FieldType\TextBlock\SearchField
     ezpublish.fieldType.indexable.ezisbn.class: eZ\Publish\Core\FieldType\ISBN\SearchField
     ezpublish.fieldType.indexable.ezboolean.class: eZ\Publish\Core\FieldType\Checkbox\SearchField
@@ -111,11 +110,6 @@ services:
         class: "%ezpublish.fieldType.indexable.ezdatetime.class%"
         tags:
             - {name: ezpublish.fieldType.indexable, alias: ezdatetime}
-
-    ezpublish.fieldType.indexable.ezrichtext:
-        class: "%ezpublish.fieldType.indexable.ezrichtext.class%"
-        tags:
-            - {name: ezpublish.fieldType.indexable, alias: ezrichtext}
 
     ezpublish.fieldType.indexable.ezisbn:
         class: "%ezpublish.fieldType.indexable.ezisbn.class%"

--- a/eZ/Publish/Core/settings/richtext.yml
+++ b/eZ/Publish/Core/settings/richtext.yml
@@ -1,0 +1,7 @@
+imports:
+    - {resource: richtext/fieldtype_external_storages.yml}
+    - {resource: richtext/fieldtype_services.yml}
+    - {resource: richtext/fieldtypes.yml}
+    - {resource: richtext/indexable_fieldtypes.yml}
+    - {resource: richtext/storage_engines/legacy/external_storage_gateways.yml}
+    - {resource: richtext/storage_engines/legacy/field_value_converters.yml}

--- a/eZ/Publish/Core/settings/richtext/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/richtext/fieldtype_external_storages.yml
@@ -1,0 +1,10 @@
+parameters:
+    ezpublish.fieldType.ezrichtext.externalStorage.class: eZ\Publish\Core\FieldType\RichText\RichTextStorage
+
+services:
+    ezpublish.fieldType.ezrichtext.externalStorage:
+        class: "%ezpublish.fieldType.ezrichtext.externalStorage.class%"
+        arguments: ["@ezpublish.fieldType.ezrichtext.storage_gateway"]
+        tags:
+            - {name: ezpublish.fieldType.externalStorageHandler, alias: ezrichtext}
+

--- a/eZ/Publish/Core/settings/richtext/fieldtype_services.yml
+++ b/eZ/Publish/Core/settings/richtext/fieldtype_services.yml
@@ -1,0 +1,42 @@
+parameters:
+    ezpublish.fieldType.ezrichtext.normalizer.aggregate.class: eZ\Publish\Core\FieldType\RichText\Normalizer\Aggregate
+    ezpublish.fieldType.ezrichtext.validator.dispatcher.class: eZ\Publish\Core\FieldType\RichText\ValidatorDispatcher
+    ezpublish.fieldType.ezrichtext.converter.dispatcher.class: eZ\Publish\Core\FieldType\RichText\ConverterDispatcher
+    ezpublish.fieldType.ezrichtext.validator.xml.class: eZ\Publish\Core\FieldType\RichText\Validator
+    ezpublish.fieldType.ezrichtext.resources: "%ezpublish.kernel.root_dir%/eZ/Publish/Core/FieldType/RichText/Resources"
+    ezpublish.fieldType.ezrichtext.validator.docbook.resources:
+        - "%ezpublish.fieldType.ezrichtext.resources%/schemas/docbook/ezpublish.rng"
+        - "%ezpublish.fieldType.ezrichtext.resources%/schemas/docbook/docbook.iso.sch.xsl"
+    ezpublish.fieldType.ezrichtext.validator.internal_link.class: eZ\Publish\Core\FieldType\RichText\InternalLinkValidator
+
+services:
+    # RichText
+    ezpublish.fieldType.ezrichtext.converter.input.dispatcher:
+        class: "%ezpublish.fieldType.ezrichtext.converter.dispatcher.class%"
+        arguments:
+            -
+                http://docbook.org/ns/docbook: null
+
+    ezpublish.fieldType.ezrichtext.validator.docbook:
+        class: "%ezpublish.fieldType.ezrichtext.validator.xml.class%"
+        arguments: ["%ezpublish.fieldType.ezrichtext.validator.docbook.resources%"]
+
+    ezpublish.fieldType.ezrichtext.validator.input.dispatcher:
+        class: "%ezpublish.fieldType.ezrichtext.validator.dispatcher.class%"
+        arguments:
+            -
+                http://docbook.org/ns/docbook: null
+
+    ezpublish.fieldType.ezrichtext.validator.internal_link:
+        class: '%ezpublish.fieldType.ezrichtext.validator.internal_link.class%'
+        arguments:
+            - '@ezpublish.spi.persistence.cache.contentHandler'
+            - '@ezpublish.spi.persistence.cache.locationHandler'
+
+    ezpublish.fieldType.ezrichtext.normalizer.input:
+        class: "%ezpublish.fieldType.ezrichtext.normalizer.aggregate.class%"
+
+    # Symfony 3.4+ service definitions:
+    eZ\Publish\Core\FieldType\RichText\CustomTagsValidator:
+        public: false
+        arguments: ['%ezplatform.ezrichtext.custom_tags%']

--- a/eZ/Publish/Core/settings/richtext/fieldtypes.yml
+++ b/eZ/Publish/Core/settings/richtext/fieldtypes.yml
@@ -1,0 +1,17 @@
+parameters:
+    ezpublish.fieldType.ezrichtext.class: eZ\Publish\Core\FieldType\RichText\Type
+
+services:
+    ezpublish.fieldType.ezrichtext:
+        class: "%ezpublish.fieldType.ezrichtext.class%"
+        parent: ezpublish.fieldType
+        arguments:
+            - "@ezpublish.fieldType.ezrichtext.validator.docbook"
+            - "@ezpublish.fieldType.ezrichtext.converter.input.dispatcher"
+            - "@ezpublish.fieldType.ezrichtext.normalizer.input"
+            - "@ezpublish.fieldType.ezrichtext.validator.input.dispatcher"
+            - '@ezpublish.fieldType.ezrichtext.validator.internal_link'
+            - '@eZ\Publish\Core\FieldType\RichText\CustomTagsValidator'
+        tags:
+            - {name: ezpublish.fieldType, alias: ezrichtext}
+

--- a/eZ/Publish/Core/settings/richtext/indexable_fieldtypes.yml
+++ b/eZ/Publish/Core/settings/richtext/indexable_fieldtypes.yml
@@ -1,0 +1,9 @@
+# deprecated: richtext in ezpublish-kernel is deprecated, and will be remove in the next major version
+parameters:
+    ezpublish.fieldType.indexable.ezrichtext.class: eZ\Publish\Core\FieldType\RichText\SearchField
+
+services:
+    ezpublish.fieldType.indexable.ezrichtext:
+        class: "%ezpublish.fieldType.indexable.ezrichtext.class%"
+        tags:
+            - {name: ezpublish.fieldType.indexable, alias: ezrichtext}

--- a/eZ/Publish/Core/settings/richtext/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/richtext/storage_engines/legacy/external_storage_gateways.yml
@@ -1,0 +1,10 @@
+parameters:
+    ezpublish.fieldType.ezrichtext.storage_gateway.class: eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\DoctrineStorage
+
+services:
+    ezpublish.fieldType.ezrichtext.storage_gateway:
+        class: "%ezpublish.fieldType.ezrichtext.storage_gateway.class%"
+        arguments:
+            - "@ezpublish.fieldType.ezurl.storage_gateway"
+            - "@ezpublish.api.storage_engine.legacy.connection"
+

--- a/eZ/Publish/Core/settings/richtext/storage_engines/legacy/field_value_converters.yml
+++ b/eZ/Publish/Core/settings/richtext/storage_engines/legacy/field_value_converters.yml
@@ -1,0 +1,9 @@
+parameters:
+    ezpublish.fieldType.ezrichtext.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichTextConverter
+
+services:
+    ezpublish.fieldType.ezrichtext.converter:
+        class: "%ezpublish.fieldType.ezrichtext.converter.class%"
+        tags:
+            - {name: ezpublish.storageEngine.legacy.converter, alias: ezrichtext}
+

--- a/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/external_storage_gateways.yml
@@ -6,7 +6,6 @@ parameters:
     ezpublish.fieldType.ezimage.storage_gateway.class: eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezkeyword.storage_gateway.class: eZ\Publish\Core\FieldType\Keyword\KeywordStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezmedia.storage_gateway.class: eZ\Publish\Core\FieldType\Media\MediaStorage\Gateway\DoctrineStorage
-    ezpublish.fieldType.ezrichtext.storage_gateway.class: eZ\Publish\Core\FieldType\RichText\RichTextStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezurl.storage_gateway.class: eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezuser.storage_gateway.class: eZ\Publish\Core\FieldType\User\UserStorage\Gateway\DoctrineStorage
     ezpublish.fieldType.ezpage.storage_gateway.class: eZ\Publish\Core\FieldType\Page\PageStorage\Gateway\DoctrineStorage
@@ -31,12 +30,6 @@ services:
     ezpublish.fieldType.ezmedia.storage_gateway:
         class: "%ezpublish.fieldType.ezmedia.storage_gateway.class%"
         arguments: ["@ezpublish.api.storage_engine.legacy.connection"]
-
-    ezpublish.fieldType.ezrichtext.storage_gateway:
-        class: "%ezpublish.fieldType.ezrichtext.storage_gateway.class%"
-        arguments:
-            - "@ezpublish.fieldType.ezurl.storage_gateway"
-            - "@ezpublish.api.storage_engine.legacy.connection"
 
     ezpublish.fieldType.ezurl.storage_gateway:
         class: "%ezpublish.fieldType.ezurl.storage_gateway.class%"

--- a/eZ/Publish/Core/settings/storage_engines/legacy/field_value_converters.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/field_value_converters.yml
@@ -21,7 +21,6 @@ parameters:
     ezpublish.fieldType.ezselection.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\SelectionConverter
     ezpublish.fieldType.ezstring.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLineConverter
     ezpublish.fieldType.eztext.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextBlockConverter
-    ezpublish.fieldType.ezrichtext.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RichTextConverter
     ezpublish.fieldType.ezsrrating.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\RatingConverter
     ezpublish.fieldType.ezurl.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\UrlConverter
     ezpublish.fieldType.ezuser.converter.class: eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\NullConverter
@@ -94,11 +93,6 @@ services:
         class: "%ezpublish.fieldType.eztext.converter.class%"
         tags:
             - {name: ezpublish.storageEngine.legacy.converter, alias: eztext}
-
-    ezpublish.fieldType.ezrichtext.converter:
-        class: "%ezpublish.fieldType.ezrichtext.converter.class%"
-        tags:
-            - {name: ezpublish.storageEngine.legacy.converter, alias: ezrichtext}
 
     ezpublish.fieldType.ezsrrating.converter:
         class: "%ezpublish.fieldType.ezsrrating.converter.class%"


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28009](https://jira.ez.no/browse/EZP-28009)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `master (7.2)`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Required to prevent conflicts with [ezsystems/ezplatform-richtext](http://github.com/ezsystems/ezplatform-richtext).

Two small changes to `EzPublishCoreBundle` and `EzPublishCoreExtension`. In both, disables some components of core richtext if the package is installed (default settings and config parser).

### TODO
- [x] Think of alternatives to `class_exists`, if not good enough. The limitation is that it will fail if the package is installed but the bundle is not enabled.
- [x] Should we target 7.1 with this ? It would allow users to install the package on top of it, and the changes are backward compatible.