### PR TITLE
Fixed EZEE-1864: Set ezpublish.cache_pool Service to be lazy

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/cache.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/cache.yml
@@ -17,6 +17,7 @@ services:
     # in Core configuration, see eZ/Publish/Core/settings/storage_engines/cache.yml for details
     ezpublish.cache_pool:
         class: "%ezpublish.cache_pool.class%"
+        lazy: true
         factory: ["@ezpublish.cache_pool.factory", getCachePool]
         arguments: ["@ezpublish.config.resolver"]
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZEE-1864](https://jira.ez.no/browse/EZEE-1864)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.13`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

When building Symfony DI Container, CachePool is created from factory
prior to setting SiteAccess-aware context. 
However the factory depends on SA-aware `ConfigResolver` which contains a setting for Persistence Cache Service (Filesystem, Redis, Memcached).

The issue occurs only in CLI mode, in HTTP Request context proper setting is already present when building Persistence handler.

Making `ezpublish.cache_pool` lazy solves problem of getting SA-specific `cache_pool_name` too early.

Please note that I wasn't able to reproduce this bug on `1.7/6.7 LTS` version. My wild guess is that `6.7` code somehow didn't depend that much on CachePool when building container.

**TODO**:
- [x] Fix a bug.
- ~Implement tests.~ - exposing the bug in tests would require some very specific Behat configuration due to a nature of the bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
