### PR TITLE
EZP-29093: Add state limitations to versionRead and VersionRemove

### DIFF
--- a/eZ/Publish/Core/settings/policies.yml
+++ b/eZ/Publish/Core/settings/policies.yml
@@ -12,8 +12,8 @@ parameters:
             reverserelatedlist: ~
             translate: { Class: true, Section: true, Owner: true, Node: true, Subtree: true, Language: true }
             remove: { Class: true, Section: true, Owner: true, Node: true, Subtree: true, State: true }
-            versionread: { Class: true, Section: true, Owner: true, Status: true, Node: true, Subtree: true }
-            versionremove: { Class: true, Section: true, Owner: true, Status: true, Node: true, Subtree: true }
+            versionread: { Class: true, Section: true, Owner: true, Status: true, Node: true, Subtree: true, State: true }
+            versionremove: { Class: true, Section: true, Owner: true, Status: true, Node: true, Subtree: true, State: true }
             translations: ~
             urltranslator: ~
             pendinglist: ~


### PR DESCRIPTION
Read and Remove both allow state limitations.  So should versionRead and VersionRemove.

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29093](https://jira.ez.no/browse/EZP-29093)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->
