### PR TITLE
EZP-28224: Change the way cache is cleared in Behat tests

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/YamlConfigurationContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/YamlConfigurationContext.php
@@ -6,6 +6,9 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;
 
 use Behat\Behat\Context\Context;
+use Behat\Symfony2Extension\Context\KernelDictionary;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -16,6 +19,8 @@ use Symfony\Component\Yaml\Yaml;
  */
 class YamlConfigurationContext implements Context
 {
+    use KernelDictionary;
+
     private static $platformConfigurationFilePath = 'app/config/ezplatform_behat.yml';
 
     public function addConfiguration(array $configuration)
@@ -30,7 +35,14 @@ class YamlConfigurationContext implements Context
 
         $this->addImportToPlatformYaml($destinationFileName);
 
-        shell_exec('php bin/console --env=behat cache:clear');
+        $application = new Application($this->getKernel());
+        $application->setAutoExit(false);
+
+        $input = new ArrayInput([
+            'command' => 'cache:clear',
+        ]);
+
+        $application->run($input);
     }
 
     private function addImportToPlatformYaml($importedFileName)


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28224](https://jira.ez.no/browse/EZP-28224)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | 7.1
| **BC breaks**      | no
| **Tests pass**     | Yes
| **Doc needed**     | no

**Problem description:**
Currently repository-forms tests are not passing on Travis. There are some issues that will be fixed in a separate PR there (https://github.com/ezsystems/repository-forms/pull/235), but it also fails because the cache-clearing does not work.
Example:
```
    And the following user registration group configuration:                    # EzSystems\RepositoryForms\Features\Context\UserRegistrationContext::addUserRegistrationConfiguration()
      """
      ezpublish:
        system:
          default:
            user_registration:
              group_id: <userGroupContentId>
      """
PHP Warning:  Uncaught Behat\Testwork\Call\Exception\CallErrorException: Warning: require(/var/www/var/cache/behat/ContainerD5gwg2c/getEzpublish_FieldType_EzuserService.php): failed to open stream: No such file or directory in /var/www/var/cache/behat/ContainerD5gwg2c/appBehatProjectContainer.php line 4249 in /var/www/vendor/behat/behat/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php:90
Stack trace:
#0 /var/www/var/cache/behat/ContainerD5gwg2c/appBehatProjectContainer.php(4249): Behat\Testwork\Call\Handler\RuntimeCallHandler->handleError(2, 'require(/var/ww...', '/var/www/var/ca...', 4249, Array)
#1 /var/www/var/cache/behat/ContainerD5gwg2c/appBehatProjectContainer.php(4249): require()
#2 /var/www/vendor/symfony/symfony/src/Symfony/Component/DependencyInjection/Container.php(304): ContainerD5gwg2c\appBehatProjectContainer->load('getEzpublish_Fi...')
#3 /var/www/vendor/ezsystems/ezpublish-kernel/eZ/Publish/Core/Base/Container/ApiLoader/FieldTypeCollectionFactory.php(43): Symfony\Component\DependencyInjection\Containe in /var/www/vendor/behat/behat/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php on line 90
PHP Fatal error:  ContainerD5gwg2c\appBehatProjectContainer::load(): Failed opening required '/var/www/var/cache/behat/ContainerD5gwg2c/getEzpublish_FieldType_EzuserService.php' (include_path='.:/usr/local/lib/php') in /var/www/var/cache/behat/ContainerD5gwg2c/appBehatProjectContainer.php on line 4249
In appBehatProjectContainer.php line 4249:
                                                                                                                                                                                                                        
  Compile Error: ContainerD5gwg2c\appBehatProjectContainer::load(): Failed opening required '/var/www/var/cache/behat/ContainerD5gwg2c/getEzpublish_FieldType_EzuserService.php' (include_path='.:/usr/local/lib/php')  
```
(taken from https://travis-ci.org/ezsystems/repository-forms/jobs/365565662)

It is reproducible locally, so most probably it's not a permission issue (I've apache running as my local user, with local user being the owner of the whole application structure). I've found only one similar report: https://stackoverflow.com/questions/48166213/how-to-clear-cache-in-controller-in-symfony3-4 , but without a solution.

**Solution**
I've tried switching to another method of clearing cache (heavily influenced by https://stackoverflow.com/a/43568307 , I won't deny it), it works locally. 

In addition the `env` is taken now from the `behat.yml.dist` file, so that's one hardcoded thing less 😉 
But, truth to be told, I'm not sure why this issue happened in the first place and why invoking it this way works - any suggestions/opinions are more than welcome. You can see that this approach is working: I've added this PR as a dependency in https://github.com/ezsystems/repository-forms/pull/235 and the error is gone (see Travis logs for the second commit for details).

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.