### PR TITLE
[POC] EZP-25487: imageAlias missing width height parameters

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGenerator.php
@@ -65,7 +65,7 @@ class AliasGenerator implements VariationHandler
     private $ioResolver;
 
     /**
-     * @var IOServiceInterface
+     * @var \eZ\Publish\Core\IO\IOServiceInterface
      */
     private $ioService;
 
@@ -75,7 +75,7 @@ class AliasGenerator implements VariationHandler
         ResolverInterface $ioResolver,
         FilterConfiguration $filterConfiguration,
         LoggerInterface $logger = null,
-        IOServiceInterface $ioService
+        IOServiceInterface $ioService = null
     ) {
         $this->dataLoader = $dataLoader;
         $this->filterManager = $filterManager;
@@ -83,6 +83,13 @@ class AliasGenerator implements VariationHandler
         $this->filterConfiguration = $filterConfiguration;
         $this->logger = $logger;
         $this->ioService = $ioService;
+
+        if ($ioService === null) {
+            @trigger_error(
+                'IOService is missing, variation width and height parameters might not be set',
+                E_USER_WARNING
+            );
+        }
     }
 
     /**
@@ -127,7 +134,9 @@ class AliasGenerator implements VariationHandler
 
         try {
             $binaryFilePath = $this->ioResolver->getFilePath($originalPath, $variationName);
-            $binaryFile = $this->ioService->loadBinaryFile($binaryFilePath);
+            if ($this->ioService) {
+                $binaryFile = $this->ioService->loadBinaryFile($binaryFilePath);
+            }
             $aliasInfo = new SplFileInfo(
                 $this->ioResolver->resolve($originalPath, $variationName)
             );

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -89,6 +89,7 @@ services:
             - "@ezpublish.image_alias.imagine.cache_resolver"
             - "@liip_imagine.filter.configuration"
             - "@?logger"
+            - '@ezpublish.fieldType.ezimage.io_service'
 
     ezpublish.image_alias.imagine.alias_cleaner:
         class: "%ezpublish.image_alias.imagine.alias_cleaner.class%"

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -89,7 +89,7 @@ services:
             - "@ezpublish.image_alias.imagine.cache_resolver"
             - "@liip_imagine.filter.configuration"
             - "@?logger"
-            - '@ezpublish.fieldType.ezimage.io_service'
+            - '@?ezpublish.fieldType.ezimage.io_service'
 
     ezpublish.image_alias.imagine.alias_cleaner:
         class: "%ezpublish.image_alias.imagine.alias_cleaner.class%"

--- a/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
+++ b/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
@@ -136,12 +136,14 @@ services:
         class: "%ezpublish.core.io.metadata_handler.flysystem.class%"
         arguments:
             - ~
+            - ~
 
     # Default flysystem metadata handler
     ezpublish.core.io.metadata_handler.flysystem.default:
         class: "%ezpublish.core.io.metadata_handler.flysystem.class%"
         arguments:
             - "@ezpublish.core.io.flysystem.default_filesystem"
+            - '@ezpublish.fieldType.metadataHandler.imagesize'
 
     # Base service for flysystem binarydata handler
     ezpublish.core.io.binarydata_handler.flysystem:

--- a/eZ/Publish/Core/IO/IOMetadataHandler/Flysystem.php
+++ b/eZ/Publish/Core/IO/IOMetadataHandler/Flysystem.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\IO\IOMetadataHandler;
 use DateTime;
 use eZ\Publish\Core\IO\Exception\BinaryFileNotFoundException;
 use eZ\Publish\Core\IO\IOMetadataHandler;
+use eZ\Publish\Core\IO\MetadataHandler;
 use eZ\Publish\SPI\IO\BinaryFile as SPIBinaryFile;
 use eZ\Publish\SPI\IO\BinaryFileCreateStruct as SPIBinaryFileCreateStruct;
 use League\Flysystem\FileNotFoundException;
@@ -21,9 +22,15 @@ class Flysystem implements IOMetadataHandler
     /** @var FilesystemInterface */
     private $filesystem;
 
-    public function __construct(FilesystemInterface $filesystem)
+    /**
+     * @var MetadataHandler
+     */
+    private $metadataHandler;
+
+    public function __construct(FilesystemInterface $filesystem, MetadataHandler $metadataHandler)
     {
         $this->filesystem = $filesystem;
+        $this->metadataHandler = $metadataHandler;
     }
 
     /**
@@ -60,6 +67,8 @@ class Flysystem implements IOMetadataHandler
         if (isset($info['timestamp'])) {
             $spiBinaryFile->mtime = new DateTime('@' . $info['timestamp']);
         }
+
+        $spiBinaryFile->extraData = $this->metadataHandler->extract($spiBinaryFileId);
 
         return $spiBinaryFile;
     }

--- a/eZ/Publish/Core/IO/IOService.php
+++ b/eZ/Publish/Core/IO/IOService.php
@@ -237,6 +237,7 @@ class IOService implements IOServiceInterface
         $spiBinaryCreateStruct->setInputStream($binaryFileCreateStruct->inputStream);
         $spiBinaryCreateStruct->mimeType = $binaryFileCreateStruct->mimeType;
         $spiBinaryCreateStruct->mtime = new \DateTime();
+        $spiBinaryCreateStruct->extraData = $binaryFileCreateStruct->extraData;
 
         return $spiBinaryCreateStruct;
     }
@@ -257,6 +258,7 @@ class IOService implements IOServiceInterface
                 'id' => $this->removeUriPrefix($spiBinaryFile->id),
                 'uri' => $spiBinaryFile->uri,
                 'mimeType' => $spiBinaryFile->mimeType ?: $this->metadataHandler->getMimeType($spiBinaryFile->id),
+                'extraData' => $spiBinaryFile->extraData,
             )
         );
     }

--- a/eZ/Publish/Core/IO/Values/BinaryFile.php
+++ b/eZ/Publish/Core/IO/Values/BinaryFile.php
@@ -19,6 +19,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read int $mtime File modification time
  * @property-read string $uri HTTP URI to the binary file
  * @property-read int $size File size
+ * @property-read array $extraData Extra metadata of the binary file
  */
 class BinaryFile extends ValueObject
 {
@@ -50,6 +51,13 @@ class BinaryFile extends ValueObject
      * @var string
      */
     protected $uri;
+
+    /**
+     * Extra metadata. For instance image width/height attributes.
+     *
+     * @var array
+     */
+    public $extraData;
 
     /**
      * The file's mime type.

--- a/eZ/Publish/Core/IO/Values/BinaryFileCreateStruct.php
+++ b/eZ/Publish/Core/IO/Values/BinaryFileCreateStruct.php
@@ -37,6 +37,13 @@ class BinaryFileCreateStruct extends ValueObject
     public $inputStream;
 
     /**
+     * Extra metadata. For instance image width/height attributes.
+     *
+     * @var array
+     */
+    public $extraData;
+
+    /**
      * The file's mime type
      * If not provided, will be auto-detected by the IOService
      * Example: text/xml.

--- a/eZ/Publish/Core/settings/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/fieldtype_external_storages.yml
@@ -71,3 +71,4 @@ services:
 
     ezpublish.fieldType.metadataHandler.imagesize:
         class: "%ezpublish.core.io.metadataHandler.imageSize.class%"
+        arguments: ['@ezpublish.core.io.flysystem.default_filesystem', '@liip_imagine']

--- a/eZ/Publish/Core/settings/io.yml
+++ b/eZ/Publish/Core/settings/io.yml
@@ -34,6 +34,7 @@ services:
         class: "%ezpublish.core.io.metadata_handler.flysystem.class%"
         arguments:
             - "@ezpublish.core.io.flysystem.default_filesystem"
+            - '@ezpublish.fieldType.metadataHandler.imagesize'
 
     # binarydata handlers
     ezpublish.core.io.binarydata_handler:

--- a/eZ/Publish/SPI/IO/BinaryFile.php
+++ b/eZ/Publish/SPI/IO/BinaryFile.php
@@ -46,6 +46,13 @@ class BinaryFile
     public $uri;
 
     /**
+     * Extra metadata. For instance image width/height attributes.
+     *
+     * @var array
+     */
+    public $extraData;
+
+    /**
      * The file's mime type.
      *
      * Example: text/xml

--- a/eZ/Publish/SPI/IO/BinaryFileCreateStruct.php
+++ b/eZ/Publish/SPI/IO/BinaryFileCreateStruct.php
@@ -46,6 +46,13 @@ class BinaryFileCreateStruct
     public $id;
 
     /**
+     * Extra metadata. For instance image width/height attributes.
+     *
+     * @var array
+     */
+    public $extraData;
+
+    /**
      * @var resource
      */
     private $inputStream;


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-25487](https://jira.ez.no/browse/EZP-25487)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`
| **BC breaks**      | no
| **Tests pass**     | no
| **Doc needed**     | no

POC for the image variation missing width/height parameters issue. This approach introduces new `extraData` property in `BinaryFile` and `BinaryFileCreateStruct ` (both `SPI` and `IO`), which is an array with `width` and `height` keys. That property is also reflected in DFS as a new JSON Data (or just `text`) column. I know that there is a bunch of tests to fix, but I'll wait for the feedback about the solution itself first. 

*Question*:
How to properly handle it on `AliasGenerator`? Currently, `IORepositoryResolver` returns only image variation path, but we need to get `eZ\Publish\API\Repository\Values\ValueObject\BinaryFile` object. 
As a simple solution, I did https://github.com/ezsystems/ezpublish-kernel/pull/2310/files#diff-b157d62547f250fa4ff446d8ec2ddcaaR129 but maybe there is a better way to do it. 

Previous approach with `ImageVariation` cache: https://github.com/ezsystems/ezpublish-kernel/pull/2121

**TODO**:
- [x] Implement feature / fix a bug.
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
