### PR TITLE
EZP-29137: As a developer, I want to replace missing images with placeholders

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/PlaceholderProviderPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/PlaceholderProviderPass.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
+
+use LogicException;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class PlaceholderProviderPass implements CompilerPassInterface
+{
+    const TAG_NAME = 'ezpublish.placeholder_provider';
+    const REGISTRY_DEFINITION_ID = 'ezpublish.image_alias.imagine.placeholder_provider.registry';
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition(self::REGISTRY_DEFINITION_ID)) {
+            return;
+        }
+
+        $definition = $container->getDefinition(self::REGISTRY_DEFINITION_ID);
+        foreach ($container->findTaggedServiceIds(self::TAG_NAME) as $id => $attributes) {
+            foreach ($attributes as $attribute) {
+                if (!isset($attribute['type'])) {
+                    throw new LogicException(self::TAG_NAME . ' service tag needs a "type" attribute to identify the placeholder provider type. None given.');
+                }
+
+                $definition->addMethodCall(
+                    'addProvider',
+                    [$attribute['type'], new Reference($id)]
+                );
+            }
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
@@ -63,6 +63,7 @@ class Configuration extends SiteAccessConfiguration
         $this->addRouterSection($rootNode);
         $this->addRichTextSection($rootNode);
         $this->addUrlAliasSection($rootNode);
+        $this->addImagePlaceholderSection($rootNode);
 
         // Delegate SiteAccess config to configuration parsers
         $this->mainConfigParser->addSemanticConfig($this->generateScopeBaseNode($rootNode));
@@ -568,6 +569,31 @@ EOT;
                 ->end()
             ->end()
         ;
+    }
+
+    /**
+     * Defines configuration the images placeholder generation.
+     *
+     * @param \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition $rootNode
+     */
+    private function addImagePlaceholderSection(ArrayNodeDefinition $rootNode)
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('image_placeholder')
+                    ->info('Configuration for strategy of replacing missing images')
+                    ->useAttributeAsKey('name')
+                    ->arrayPrototype()
+                        ->children()
+                            ->scalarNode('provider')
+                            ->end()
+                            ->variableNode('options')
+                                ->defaultValue([])
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -16,6 +16,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Suggestion\F
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider\PoliciesConfigBuilder;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider\PolicyProviderInterface;
 use eZ\Bundle\EzPublishCoreBundle\SiteAccess\SiteAccessConfigurationFilter;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -476,6 +477,19 @@ class EzPublishCoreExtension extends Extension
     private function handleImage(array $config, ContainerBuilder $container, FileLoader $loader)
     {
         $loader->load('image.yml');
+
+        $providers = [];
+        if (isset($config['image_placeholder'])) {
+            foreach ($config['image_placeholder'] as $name => $value) {
+                if (isset($providers[$name])) {
+                    throw new InvalidConfigurationException("A image_placeholder named $name already exists");
+                }
+
+                $providers[$name] = $value;
+            }
+        }
+
+        $container->setParameter('image_alias.placeholder_providers', $providers);
     }
 
     private function handleUrlChecker($config, ContainerBuilder $container, FileLoader $loader)

--- a/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
@@ -14,6 +14,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\ComplexSettingsPa
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\ConfigResolverParameterPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\FieldTypeParameterProviderRegistryPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\FragmentPass;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\PlaceholderProviderPass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\ImaginePass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\QueryTypePass;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\RegisterSearchEngineIndexerPass;
@@ -80,6 +81,7 @@ class EzPublishCoreBundle extends Bundle
         $container->addCompilerPass(new URLHandlerPass());
         $container->addCompilerPass(new BinaryContentDownloadPass());
         $container->addCompilerPass(new ViewProvidersPass());
+        $container->addCompilerPass(new PlaceholderProviderPass());
 
         // Storage passes
         $container->addCompilerPass(new ExternalStorageRegistryPass());

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderAliasGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderAliasGenerator.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine;
+
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
+use eZ\Publish\Core\FieldType\Value;
+use eZ\Publish\Core\IO\IOServiceInterface;
+use eZ\Publish\SPI\Variation\VariationHandler;
+use InvalidArgumentException;
+use Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotResolvableException;
+use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
+
+class PlaceholderAliasGenerator implements VariationHandler
+{
+    /**
+     * @var \eZ\Publish\SPI\Variation\VariationHandler
+     */
+    private $aliasGenerator;
+
+    /**
+     * @var \Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface
+     */
+    private $ioResolver;
+
+    /**
+     * @var \eZ\Publish\Core\IO\IOServiceInterface
+     */
+    private $ioService;
+
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProvider|null
+     */
+    private $placeholderProvider;
+
+    /**
+     * @var array
+     */
+    private $placeholderOptions = [];
+
+    /**
+     * PlaceholderAliasGenerator constructor.
+     *
+     * @param \eZ\Publish\SPI\Variation\VariationHandler $aliasGenerator
+     * @param \Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface $ioResolver
+     * @param \eZ\Publish\Core\IO\IOServiceInterface $ioService
+     */
+    public function __construct(
+        VariationHandler $aliasGenerator,
+        ResolverInterface $ioResolver,
+        IOServiceInterface $ioService)
+    {
+        $this->aliasGenerator = $aliasGenerator;
+        $this->ioResolver = $ioResolver;
+        $this->ioService = $ioService;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getVariation(Field $field, VersionInfo $versionInfo, $variationName, array $parameters = [])
+    {
+        if ($this->placeholderProvider !== null) {
+            /** @var \eZ\Publish\Core\FieldType\Image\Value $imageValue */
+            $imageValue = $field->value;
+            if (!$this->supportsValue($imageValue)) {
+                throw new InvalidArgumentException("Value for field #{$field->id} ($field->fieldDefIdentifier) cannot be used for image placeholder generation.");
+            }
+
+            try {
+                $this->ioResolver->resolve($imageValue->id, IORepositoryResolver::VARIATION_ORIGINAL);
+            } catch (NotResolvableException $e) {
+                // Generate placeholder for original image
+                $binary = $this->ioService->newBinaryCreateStructFromLocalFile(
+                    $this->placeholderProvider->getPlaceholder($imageValue, $this->placeholderOptions)
+                );
+                $binary->id = $imageValue->id;
+
+                $this->ioService->createBinaryFile($binary);
+            }
+        }
+
+        return $this->aliasGenerator->getVariation($field, $versionInfo, $variationName, $parameters);
+    }
+
+    public function setPlaceholderProvider(PlaceholderProvider $provider, array $options = [])
+    {
+        $this->placeholderProvider = $provider;
+        $this->placeholderOptions = $options;
+    }
+
+    public function supportsValue(Value $value): bool
+    {
+        return $value instanceof ImageValue;
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderAliasGeneratorConfigurator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderAliasGeneratorConfigurator.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+
+class PlaceholderAliasGeneratorConfigurator
+{
+    /**
+     * @var \eZ\Publish\Core\MVC\ConfigResolverInterface
+     */
+    private $configResolver;
+
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProviderRegistry
+     */
+    private $providerRegistry;
+
+    /**
+     * @var array
+     */
+    private $providersConfig;
+
+    /**
+     * PlaceholderAliasGeneratorConfigurator constructor.
+     *
+     * @param \eZ\Publish\Core\MVC\ConfigResolverInterface $configResolver
+     * @param \eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProviderRegistry $providerRegistry
+     * @param array $providersConfig
+     */
+    public function __construct(ConfigResolverInterface $configResolver, PlaceholderProviderRegistry $providerRegistry, array $providersConfig)
+    {
+        $this->configResolver = $configResolver;
+        $this->providerRegistry = $providerRegistry;
+        $this->providersConfig = $providersConfig;
+    }
+
+    public function configure(PlaceholderAliasGenerator $generator)
+    {
+        $binaryHandlerName = $this->configResolver->getParameter('io.binarydata_handler');
+
+        if (isset($this->providersConfig[$binaryHandlerName])) {
+            $providersConfig = $this->providersConfig[$binaryHandlerName];
+
+            $provider = $this->providerRegistry->getProvider($providersConfig['provider']);
+            $generator->setPlaceholderProvider($provider, $providersConfig['options']);
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderProvider.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderProvider.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine;
+
+use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
+
+interface PlaceholderProvider
+{
+    /**
+     * Provides a placeholder image path for a given Image FieldType value.
+     *
+     * @param \eZ\Publish\Core\FieldType\Image\Value $value
+     * @param array $options
+     * @return string Path to placeholder
+     */
+    public function getPlaceholder(ImageValue $value, array $options = []): string;
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderProvider/GenericProvider.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderProvider/GenericProvider.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProvider;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProvider;
+use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
+use Imagine\Image as Image;
+use Imagine\Image\ImagineInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class GenericProvider implements PlaceholderProvider
+{
+    /**
+     * @var \Imagine\Image\ImagineInterface
+     */
+    private $imagine;
+
+    /**
+     * GenericProvider constructor.
+     *
+     * @param \Imagine\Image\ImagineInterface $imagine
+     */
+    public function __construct(ImagineInterface $imagine)
+    {
+        $this->imagine = $imagine;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPlaceholder(ImageValue $value, array $options = []): string
+    {
+        $options = $this->resolveOptions($options);
+
+        $palette = new Image\Palette\RGB();
+        $background = $palette->color($options['background']);
+        $foreground = $palette->color($options['foreground']);
+        $secondary = $palette->color($options['secondary']);
+
+        $size = new Image\Box($value->width, $value->height);
+        $font = $this->imagine->font($options['fontpath'], $options['fontsize'], $foreground);
+        $text = $this->getPlaceholderText($options['text'], $value);
+
+        $center = new Image\Point\Center($size);
+        $textbox = $font->box($text);
+        $textpos = new Image\Point(
+            max($center->getX() - ($textbox->getWidth() / 2), 0),
+            max($center->getY() - ($textbox->getHeight() / 2), 0)
+        );
+
+        $image = $this->imagine->create($size, $background);
+        $image->draw()->line(
+            new Image\Point(0, 0),
+            new Image\Point($value->width, $value->height),
+            $secondary
+        );
+
+        $image->draw()->line(
+            new Image\Point($value->width, 0),
+            new Image\Point(0, $value->height),
+            $secondary
+        );
+
+        $image->draw()->text($text, $font, $textpos, 0, $value->width);
+
+        $path = $this->getTemporaryPath();
+        $image->save($path, [
+            'format' => pathinfo($value->id, PATHINFO_EXTENSION),
+        ]);
+
+        return $path;
+    }
+
+    private function getPlaceholderText(string $pattern, ImageValue $value): string
+    {
+        return strtr($pattern, [
+            '%width%' => $value->width,
+            '%height%' => $value->height,
+            '%id%' => $value->id,
+        ]);
+    }
+
+    private function getTemporaryPath(): string
+    {
+        return stream_get_meta_data(tmpfile())['uri'];
+    }
+
+    private function resolveOptions(array $options): array
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            'background' => '#EEEEEE',
+            'foreground' => '#000000',
+            'secondary' => '#CCCCCC',
+            'fontsize' => 20,
+            'text' => "IMAGE PLACEHOLDER %width%x%height%\n(%id%)",
+        ]);
+        $resolver->setRequired('fontpath');
+
+        return $resolver->resolve($options);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderProvider/RemoteProvider.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderProvider/RemoteProvider.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProvider;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProvider;
+use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
+use RuntimeException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Remote placeholder provider e.g. http://placekitten.com.
+ */
+class RemoteProvider implements PlaceholderProvider
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getPlaceholder(ImageValue $value, array $options = []): string
+    {
+        $options = $this->resolveOptions($options);
+
+        $path = $this->getTemporaryPath();
+        $placeholderUrl = $this->getPlaceholderUrl($options['url_pattern'], $value);
+
+        try {
+            $handler = curl_init();
+
+            curl_setopt_array($handler, [
+                CURLOPT_URL => $placeholderUrl,
+                CURLOPT_FILE => fopen($path, 'wb'),
+                CURLOPT_TIMEOUT => $options['timeout'],
+                CURLOPT_FAILONERROR => true,
+            ]);
+
+            if (curl_exec($handler) === false) {
+                throw new RuntimeException("Unable to download placeholder for {$value->id} ($placeholderUrl): " . curl_error($handler));
+            }
+        } finally {
+            curl_close($handler);
+        }
+
+        return $path;
+    }
+
+    private function getPlaceholderUrl(string $urlPattern, ImageValue $value): string
+    {
+        return strtr($urlPattern, [
+            '%id%' => $value->id,
+            '%width%' => $value->width,
+            '%height%' => $value->height,
+        ]);
+    }
+
+    private function getTemporaryPath(): string
+    {
+        return stream_get_meta_data(tmpfile())['uri'];
+    }
+
+    private function resolveOptions(array $options): array
+    {
+        $resolver = new OptionsResolver();
+        $resolver->setDefaults([
+            'url_pattern' => '',
+            'timeout' => 5,
+        ]);
+        $resolver->setAllowedTypes('url_pattern', 'string');
+        $resolver->setAllowedTypes('timeout', 'int');
+
+        return $resolver->resolve($options);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderProviderRegistry.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderProviderRegistry.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine;
+
+use InvalidArgumentException;
+
+class PlaceholderProviderRegistry
+{
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProvider
+     */
+    private $providers;
+
+    /**
+     * PlaceholderProviderRegistry constructor.
+     *
+     * @param array $providers
+     */
+    public function __construct(array $providers = [])
+    {
+        $this->providers = $providers;
+    }
+
+    public function addProvider(string $type, PlaceholderProvider $provider)
+    {
+        $this->providers[$type] = $provider;
+    }
+
+    public function supports(string $type): bool
+    {
+        return isset($this->providers[$type]);
+    }
+
+    public function getProvider(string $type): PlaceholderProvider
+    {
+        if (!$this->supports($type)) {
+            throw new InvalidArgumentException("Unknown placeholder provider: $type");
+        }
+
+        return $this->providers[$type];
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -95,6 +95,38 @@ services:
         arguments: ["@ezpublish.image_alias.imagine.cache_resolver"]
         lazy: true
 
+    ezpublish.image_alias.imagine.placeholder_provider.configurator:
+        class: 'eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderAliasGeneratorConfigurator'
+        arguments:
+            - '@ezpublish.config.resolver'
+            - '@ezpublish.image_alias.imagine.placeholder_provider.registry'
+            - '%image_alias.placeholder_providers%'
+
+    ezpublish.image_alias.imagine.alias_generator.placeholder:
+        class: 'eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderAliasGenerator'
+        decorates: 'ezpublish.image_alias.imagine.alias_generator'
+        configurator: ['@ezpublish.image_alias.imagine.placeholder_provider.configurator', 'configure']
+        arguments:
+            - '@ezpublish.image_alias.imagine.alias_generator.placeholder.inner'
+            - '@ezpublish.image_alias.imagine.cache_resolver'
+            - '@ezpublish.fieldType.ezimage.io_service'
+        public: false
+
+    ezpublish.image_alias.imagine.placeholder_provider.registry:
+        class: 'eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProviderRegistry'
+
+    ezpublish.image_alias.placeholder_provider.generic:
+        class: 'eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProvider\GenericProvider'
+        arguments:
+            - '@liip_imagine'
+        tags:
+            - { name: 'ezpublish.placeholder_provider', type: 'generic' }
+
+    ezpublish.image_alias.imagine.placeholder_provider.remote:
+        class: 'eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProvider\RemoteProvider'
+        tags:
+            - { name: 'ezpublish.placeholder_provider', type: 'remote' }
+
     ezpublish.image_alias.imagine.filter.loader.scaledown.base:
         abstract: true
         public: false

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -188,7 +188,8 @@ services:
 
     ezpublish.twig.extension.image:
         class: "%ezpublish.twig.extension.image.class%"
-        arguments: ["@ezpublish.fieldType.ezimage.variation_service"]
+        arguments:
+            - '@ezpublish.image_alias.imagine.alias_generator'
         tags:
             - { name: twig.extension }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/PlaceholderProviderPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/PlaceholderProviderPassTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\PlaceholderProviderPass;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class PlaceholderProviderPassTest extends AbstractCompilerPassTestCase
+{
+    const PROVIDER_ID = 'provider.id';
+    const PROVIDER_TYPE = 'provider.test';
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->setDefinition(PlaceholderProviderPass::REGISTRY_DEFINITION_ID, new Definition());
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new PlaceholderProviderPass());
+    }
+
+    public function testAddProvider()
+    {
+        $definition = new Definition();
+        $definition->addTag(PlaceholderProviderPass::TAG_NAME, ['type' => self::PROVIDER_TYPE]);
+
+        $this->setDefinition(self::PROVIDER_ID, $definition);
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            PlaceholderProviderPass::REGISTRY_DEFINITION_ID,
+            'addProvider',
+            [self::PROVIDER_TYPE, new Reference(self::PROVIDER_ID)]
+        );
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testAddProviderWithoutType()
+    {
+        $definition = new Definition();
+        $definition->addTag(PlaceholderProviderPass::TAG_NAME);
+
+        $this->setDefinition(self::PROVIDER_ID, $definition);
+        $this->compile();
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
@@ -181,6 +181,38 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
         $this->assertSame($customFilters['wow'], $filters['wow']);
     }
 
+    public function testImagePlaceholderConfiguration()
+    {
+        $this->load([
+            'image_placeholder' => [
+                'default' => [
+                    'provider' => 'generic',
+                    'options' => [
+                        'foo' => 'Foo',
+                        'bar' => 'Bar',
+                    ],
+                ],
+                'fancy' => [
+                    'provider' => 'remote',
+                ],
+            ],
+        ]);
+
+        $this->assertEquals([
+            'default' => [
+                'provider' => 'generic',
+                'options' => [
+                    'foo' => 'Foo',
+                    'bar' => 'Bar',
+                ],
+            ],
+            'fancy' => [
+                'provider' => 'remote',
+                'options' => [],
+            ],
+        ], $this->container->getParameter('image_alias.placeholder_providers'));
+    }
+
     public function testEzPageConfiguration()
     {
         $customLayouts = array(

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderAliasGeneratorConfiguratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderAliasGeneratorConfiguratorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderAliasGenerator;
+use eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderAliasGeneratorConfigurator;
+use eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProvider;
+use eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProviderRegistry;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use PHPUnit\Framework\TestCase;
+
+class PlaceholderAliasGeneratorConfiguratorTest extends TestCase
+{
+    const BINARY_HANDLER_NAME = 'default';
+    const PROVIDER_TYPE = 'generic';
+    const PROVIDER_OPTIONS = [
+        'a' => 'A',
+        'b' => 'B',
+        'c' => 'C',
+    ];
+
+    public function testConfigure()
+    {
+        $configResolver = $this->createMock(ConfigResolverInterface::class);
+        $configResolver
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with('io.binarydata_handler')
+            ->willReturn(self::BINARY_HANDLER_NAME);
+
+        $provider = $this->createMock(PlaceholderProvider::class);
+
+        $providerRegistry = $this->createMock(PlaceholderProviderRegistry::class);
+        $providerRegistry
+            ->expects($this->once())
+            ->method('getProvider')
+            ->with(self::PROVIDER_TYPE)
+            ->willReturn($provider);
+
+        $providerConfig = [
+            self::BINARY_HANDLER_NAME => [
+                'provider' => self::PROVIDER_TYPE,
+                'options' => self::PROVIDER_OPTIONS,
+            ],
+        ];
+
+        $generator = $this->createMock(PlaceholderAliasGenerator::class);
+        $generator
+            ->expects($this->once())
+            ->method('setPlaceholderProvider')
+            ->with($provider, self::PROVIDER_OPTIONS);
+
+        $configurator = new PlaceholderAliasGeneratorConfigurator(
+            $configResolver,
+            $providerRegistry,
+            $providerConfig
+        );
+        $configurator->configure($generator);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderAliasGeneratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderAliasGeneratorTest.php
@@ -1,0 +1,233 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\IORepositoryResolver;
+use eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderAliasGenerator;
+use eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProvider;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
+use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
+use eZ\Publish\Core\FieldType\Null\Value as NullValue;
+use eZ\Publish\Core\FieldType\Value as FieldTypeValue;
+use eZ\Publish\Core\FieldType\Value;
+use eZ\Publish\Core\IO\IOServiceInterface;
+use eZ\Publish\Core\IO\Values\BinaryFileCreateStruct;
+use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use eZ\Publish\SPI\Variation\Values\ImageVariation;
+use eZ\Publish\SPI\Variation\VariationHandler;
+use Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotResolvableException;
+use PHPUnit\Framework\TestCase;
+
+class PlaceholderAliasGeneratorTest extends TestCase
+{
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderAliasGenerator
+     */
+    private $aliasGenerator;
+
+    /**
+     * @var \eZ\Publish\SPI\Variation\VariationHandler|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $innerAliasGenerator;
+
+    /**
+     * @var \eZ\Publish\Core\IO\IOServiceInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $ioService;
+
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\Imagine\IORepositoryResolver|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $ioResolver;
+
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProvider|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $placeholderProvider;
+
+    /**
+     * @var array
+     */
+    private $placeholderOptions;
+
+    protected function setUp()
+    {
+        $this->innerAliasGenerator = $this->createMock(VariationHandler::class);
+        $this->ioService = $this->createMock(IOServiceInterface::class);
+        $this->ioResolver = $this->createMock(IORepositoryResolver::class);
+        $this->placeholderProvider = $this->createMock(PlaceholderProvider::class);
+        $this->placeholderOptions = [
+            'foo' => 'foo',
+            'bar' => 'bar',
+        ];
+
+        $this->aliasGenerator = new PlaceholderAliasGenerator(
+            $this->innerAliasGenerator,
+            $this->ioResolver,
+            $this->ioService
+        );
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testGetVariationWrongValue()
+    {
+        $field = new Field([
+            'value' => $this->createMock(FieldTypeValue::class),
+        ]);
+
+        $this->aliasGenerator->setPlaceholderProvider(
+            $this->placeholderProvider,
+            $this->placeholderOptions
+        );
+        $this->aliasGenerator->getVariation($field, new VersionInfo(), 'foo');
+    }
+
+    /**
+     * @dataProvider getVariationProvider
+     */
+    public function testGetVariationSkipsPlaceholderGeneration(Field $field, APIVersionInfo $versionInfo, string $variationName, array $parameters)
+    {
+        $expectedVariation = $this->createMock(ImageVariation::class);
+
+        $this->ioResolver
+            ->expects($this->never())
+            ->method('resolve')
+            ->with($field->value->id, IORepositoryResolver::VARIATION_ORIGINAL);
+
+        $this->placeholderProvider
+            ->expects($this->never())
+            ->method('getPlaceholder')
+            ->with($field->value, $this->placeholderOptions);
+
+        $this->innerAliasGenerator
+            ->expects($this->once())
+            ->method('getVariation')
+            ->with($field, $versionInfo, $variationName, $parameters)
+            ->willReturn($expectedVariation);
+
+        $actualVariation = $this->aliasGenerator->getVariation(
+            $field, $versionInfo, $variationName, $parameters
+        );
+
+        $this->assertEquals($expectedVariation, $actualVariation);
+    }
+
+    /**
+     * @dataProvider getVariationProvider
+     */
+    public function testGetVariationOriginalFound(Field $field, APIVersionInfo $versionInfo, string $variationName, array $parameters)
+    {
+        $expectedVariation = $this->createMock(ImageVariation::class);
+
+        $this->ioResolver
+            ->expects($this->once())
+            ->method('resolve')
+            ->with($field->value->id, IORepositoryResolver::VARIATION_ORIGINAL);
+
+        $this->innerAliasGenerator
+            ->expects($this->once())
+            ->method('getVariation')
+            ->with($field, $versionInfo, $variationName, $parameters)
+            ->willReturn($expectedVariation);
+
+        $this->aliasGenerator->setPlaceholderProvider(
+            $this->placeholderProvider,
+            $this->placeholderOptions
+        );
+
+        $actualVariation = $this->aliasGenerator->getVariation(
+            $field, $versionInfo, $variationName, $parameters
+        );
+
+        $this->assertEquals($expectedVariation, $actualVariation);
+    }
+
+    /**
+     * @dataProvider getVariationProvider
+     */
+    public function testGetVariationOriginalNotFound(Field $field, APIVersionInfo $versionInfo, string $variationName, array $parameters)
+    {
+        $placeholderPath = '/tmp/placeholder.jpg';
+        $binaryCreateStruct = new BinaryFileCreateStruct();
+        $expectedVariation = $this->createMock(ImageVariation::class);
+
+        $this->ioResolver
+            ->expects($this->once())
+            ->method('resolve')
+            ->with($field->value->id, IORepositoryResolver::VARIATION_ORIGINAL)
+            ->willThrowException($this->createMock(NotResolvableException::class));
+
+        $this->placeholderProvider
+            ->expects($this->once())
+            ->method('getPlaceholder')
+            ->with($field->value, $this->placeholderOptions)
+            ->willReturn($placeholderPath);
+
+        $this->ioService
+            ->expects($this->once())
+            ->method('newBinaryCreateStructFromLocalFile')
+            ->with($placeholderPath)
+            ->willReturn($binaryCreateStruct);
+
+        $this->ioService
+            ->expects($this->once())
+            ->method('createBinaryFile')
+            ->with($binaryCreateStruct);
+
+        $this->aliasGenerator->setPlaceholderProvider(
+            $this->placeholderProvider,
+            $this->placeholderOptions
+        );
+
+        $this->innerAliasGenerator
+            ->expects($this->once())
+            ->method('getVariation')
+            ->with($field, $versionInfo, $variationName, $parameters)
+            ->willReturn($expectedVariation);
+
+        $actualVariation = $this->aliasGenerator->getVariation(
+            $field, $versionInfo, $variationName, $parameters
+        );
+
+        $this->assertEquals($field->value->id, $binaryCreateStruct->id);
+        $this->assertEquals($expectedVariation, $actualVariation);
+    }
+
+    /**
+     * @dataProvider supportsValueProvider
+     */
+    public function testSupportsValue(Value $value, bool $isSupported)
+    {
+        $this->assertSame($isSupported, $this->aliasGenerator->supportsValue($value));
+    }
+
+    public function supportsValueProvider(): array
+    {
+        return [
+            [new NullValue(), false],
+            [new ImageValue(), true],
+        ];
+    }
+
+    public function getVariationProvider(): array
+    {
+        $field = new Field([
+            'value' => new ImageValue([
+                'id' => 'images/6/8/4/0/486-10-eng-GB/photo.jpg',
+            ]),
+        ]);
+
+        return [
+            [$field, new VersionInfo(), 'thumbnail', []],
+        ];
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderProvider/GenericProviderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderProvider/GenericProviderTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\PlaceholderProvider;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProvider\GenericProvider;
+use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
+use Imagine\Draw\DrawerInterface;
+use Imagine\Image\AbstractFont;
+use Imagine\Image\BoxInterface;
+use Imagine\Image\ImageInterface;
+use Imagine\Image\ImagineInterface;
+use Imagine\Image\Palette\Color\ColorInterface;
+use PHPUnit\Framework\TestCase;
+
+class GenericProviderTest extends TestCase
+{
+    /**
+     * @dataProvider getPlaceholderDataProvider
+     */
+    public function testGetPlaceholder(ImageValue $value, array $options = [], $expectedText)
+    {
+        $font = $this->createMock(AbstractFont::class);
+
+        $imagine = $this->createMock(ImagineInterface::class);
+        $imagine
+            ->expects($this->atLeastOnce())
+            ->method('font')
+            ->willReturnCallback(function ($fontpath, $fontsize, ColorInterface $foreground) use ($options, $font) {
+                $this->assertEquals($options['fontpath'], $fontpath);
+                $this->assertEquals($options['fontsize'], $fontsize);
+                $this->assertColorEquals($options['foreground'], $foreground);
+
+                return $font;
+            });
+
+        $font
+            ->expects($this->any())
+            ->method('box')
+            ->willReturn($this->createMock(BoxInterface::class));
+
+        $image = $this->createMock(ImageInterface::class);
+
+        $imagine
+            ->expects($this->atLeastOnce())
+            ->method('create')
+            ->willReturnCallback(function (BoxInterface $size, ColorInterface $background) use ($value, $options, $image) {
+                $this->assertSizeEquals([$value->width, $value->height], $size);
+                $this->assertColorEquals($options['background'], $background);
+
+                return $image;
+            });
+
+        $drawer = $this->createMock(DrawerInterface::class);
+        $image
+            ->expects($this->any())
+            ->method('draw')
+            ->willReturn($drawer);
+
+        $drawer
+            ->expects($this->atLeastOnce())
+            ->method('text')
+            ->with($expectedText, $font);
+
+        $provider = new GenericProvider($imagine);
+        $provider->getPlaceholder($value, $options);
+    }
+
+    public function getPlaceholderDataProvider()
+    {
+        return [
+            [
+                new ImageValue([
+                    'id' => 'photo.jpg',
+                    'width' => 640,
+                    'height' => 480,
+                ]),
+                [
+                    'background' => '#00FF00',
+                    'foreground' => '#FF0000',
+                    'fontsize' => 72,
+                    'text' => "IMAGE PLACEHOLDER %width%x%height%\n(%id%)",
+                    'fontpath' => '/path/to/font.ttf',
+                ],
+                "IMAGE PLACEHOLDER 640x480\n(photo.jpg)",
+            ],
+        ];
+    }
+
+    private function assertSizeEquals(array $expected, BoxInterface $actual)
+    {
+        $this->assertEquals($expected[0], $actual->getWidth());
+        $this->assertEquals($expected[1], $actual->getHeight());
+    }
+
+    private function assertColorEquals($expected, ColorInterface $actual)
+    {
+        $this->assertEquals(strtolower($expected), strtolower((string)$actual));
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderProviderRegistryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderProviderRegistryTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This file is part of the eZ Publish Kernel package.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProvider;
+use eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProviderRegistry;
+use PHPUnit\Framework\TestCase;
+
+class PlaceholderProviderRegistryTest extends TestCase
+{
+    public function testConstructor()
+    {
+        $providers = [
+            'foo' => $this->getPlaceholderProviderMock(),
+            'bar' => $this->getPlaceholderProviderMock(),
+        ];
+
+        $registry = new PlaceholderProviderRegistry($providers);
+
+        $this->assertAttributeSame($providers, 'providers', $registry);
+    }
+
+    public function testAddProvider()
+    {
+        $provider = $this->getPlaceholderProviderMock();
+
+        $registry = new PlaceholderProviderRegistry();
+        $registry->addProvider('foo', $provider);
+
+        $this->assertAttributeSame(['foo' => $provider], 'providers', $registry);
+    }
+
+    public function testSupports()
+    {
+        $registry = new PlaceholderProviderRegistry([
+            'supported' => $this->getPlaceholderProviderMock(),
+        ]);
+
+        $this->assertTrue($registry->supports('supported'));
+        $this->assertFalse($registry->supports('unsupported'));
+    }
+
+    public function testGetProviderKnown()
+    {
+        $provider = $this->getPlaceholderProviderMock();
+
+        $registry = new PlaceholderProviderRegistry([
+            'foo' => $provider,
+        ]);
+
+        $this->assertEquals($provider, $registry->getProvider('foo'));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testGetProviderUnknown()
+    {
+        $registry = new PlaceholderProviderRegistry([
+            'foo' => $this->getPlaceholderProviderMock(),
+        ]);
+
+        $registry->getProvider('bar');
+    }
+
+    private function getPlaceholderProviderMock(): PlaceholderProvider
+    {
+        return $this->createMock(PlaceholderProvider::class);
+    }
+}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29137](https://jira.ez.no/browse/EZP-29137)
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

## Problem 

> Currently, when doing development on an eZ Platform site, you have to sync all of the images down to your local machine. This is not feasible for medium to large sites with > 1GB (arguably, over more than 300MB) of images. 

## Solution

In general the idea is to generate a image placeholders on the fly for missing images. 

From technical POV:  `PlaceholderAliasGenerator` decorates `AliasGenerator` as this is the only one place where we might get width and height of original image which are required to generate proper placeholder. 

`PlaceholderAliasGenerator::getVariation` method generates placeholder (by delegating it to the impl. of `PlaceholderProvider` interface) if original image cannot  be resolved and save it under the original path. 

This PR includes two implementations of `PlaceholderProvider` interface:

```php
namespace eZ\Bundle\EzPublishCoreBundle\Imagine;

use eZ\Publish\Core\FieldType\Image\Value as ImageValue;

interface PlaceholderProvider
{
    /**
     * Provides a placeholder image path for a given Image FieldType value.
     *
     * @param \eZ\Publish\Core\FieldType\Image\Value $value
     * @param array $options
     * @return string Path to placeholder
     */
    public function getPlaceholder(ImageValue $value, array $options = []): string;
}
```

####  GenericProvider

`\eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProvider\GenericProvider` generating placeholder with basic infromations about original image. Example:

![generic-placeholder](https://user-images.githubusercontent.com/211967/38982018-07b5ad6a-43c1-11e8-9974-f288ae10b736.jpg)

#### RemoteProvider

`\eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProvider\RemoteProvider` which  allows to download placeholders from remote source e.g. http://placekitten.com, https://dummyimage.com, https://placeholder.com (2) or live version of site (3).

### Semantic configuration

Placeholders generation can be configured for each `binary handler` under the `ezpublish.image_placeholder` key: 

```yml
ezpublish:
    # ...
    image_placeholder:
        <BINARY_HANDLER_NAME>:
            provider: <PROVIDER TYPE>
            options:  <OPTIONAL CONFIGURATION>
```

If there is no configuration assigned to` binary handler` name then the placeholder generation will be disabled.

Examples of configuration:

```yml
# Example (1)
ezpublish:
    # ...
    image_placeholder:
        default:
            provider: generic
            options:
                background: '#EEEEEE'
                foreground: '#FF0000'
                text: "MISSING IMAGE %%width%%x%%height%%"
```

```yml
# Example (2)
ezpublish:
    # ...
    image_placeholder:
        default:
            provider: remote
            options:
                url_pattern: 'https://placekitten.com/%%width%%/%%height%%'
```

```yml
# Example (3) 
ezpublish:
    # ...
    image_placeholder:
        default:
            provider: remote
            options:
                url_pattern: 'http://example.com/var/site/storage/%%id%%'
```

## Demo

GenericProvider             |  RemoteProvider (placekitten.com)
:-------------------------:|:-------------------------:
 ![screenshot-2018-4-19 home - 30 11 2015 13 10](https://user-images.githubusercontent.com/211967/38982265-b0141546-43c1-11e8-8c2d-2141e2d33cca.png) | ![screenshot-2018-4-17 home - 30 11 2015 13 10 1 1](https://user-images.githubusercontent.com/211967/38982239-9e2aeb52-43c1-11e8-897b-bcca1f49084e.jpg)

**TODO**:
- [X] Implement POC of the feature 
- [x] Ask for feedback
- [x] Implement feature
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
