### PR TITLE
EZP-29113: UserHandler::assignRole should invalidate `location-path-` tags

### DIFF
--- a/eZ/Publish/API/Repository/Tests/RoleServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/RoleServiceTest.php
@@ -2329,6 +2329,36 @@ class RoleServiceTest extends BaseTest
     /**
      * Test for the assignRoleToUserGroup() method.
      *
+     * Related issue: EZP-29113
+     *
+     * @covers \eZ\Publish\API\Repository\RoleService::assignRoleToUserGroup()
+     */
+    public function testAssignRoleToUserGroupAffectsRoleAssignmentsForUser()
+    {
+        $roleService = $this->getRepository()->getRoleService();
+
+        /* BEGIN: Use Case */
+        $userGroup = $this->createUserGroupVersion1();
+        $user = $this->createUser('user', 'John', 'Doe', $userGroup);
+
+        $initRoleAssignments = $roleService->getRoleAssignmentsForUser($user, true);
+
+        // Load the existing "Administrator" role
+        $role = $roleService->loadRoleByIdentifier('Administrator');
+
+        // Assign the "Administrator" role to the newly created user group
+        $roleService->assignRoleToUserGroup($role, $userGroup);
+
+        $updatedRoleAssignments = $roleService->getRoleAssignmentsForUser($user, true);
+        /* END: Use Case */
+
+        $this->assertEmpty($initRoleAssignments);
+        $this->assertEquals(1, count($updatedRoleAssignments));
+    }
+
+    /**
+     * Test for the assignRoleToUserGroup() method.
+     *
      * @see \eZ\Publish\API\Repository\RoleService::assignRoleToUserGroup($role, $userGroup, $roleLimitation)
      * @depends eZ\Publish\API\Repository\Tests\RoleServiceTest::testAssignRoleToUserGroup
      */

--- a/eZ/Publish/Core/Persistence/Cache/Tests/AbstractCacheHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/AbstractCacheHandlerTest.php
@@ -27,7 +27,7 @@ abstract class AbstractCacheHandlerTest extends AbstractBaseHandlerTest
      * @param array|null $tags
      * @param string|null $key
      */
-    final public function testUnCachedMethods(string $method, array $arguments, array $tags = null, string $key = null, array $additionalCalls = [])
+    final public function testUnCachedMethods(string $method, array $arguments, array $tags = null, string $key = null)
     {
         $handlerMethodName = $this->getHandlerMethodName();
 
@@ -59,19 +59,6 @@ abstract class AbstractCacheHandlerTest extends AbstractBaseHandlerTest
             $this->cacheMock
                 ->expects($this->never())
                 ->method($this->anything());
-        }
-
-        foreach ($additionalCalls as $additionalCall) {
-            $innerHandlerMock = $this->createMock($additionalCall[1]);
-            $this->persistenceHandlerMock
-                ->expects($this->once())
-                ->method($additionalCall[0])
-                ->willReturn($innerHandlerMock);
-
-            $innerHandlerMock
-                ->expects($this->once())
-                ->method($additionalCall[2])
-                ->willReturn($additionalCall[3]);
         }
 
         $handler = $this->persistenceCacheHandler->$handlerMethodName();

--- a/eZ/Publish/Core/Persistence/Cache/Tests/AbstractCacheHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/AbstractCacheHandlerTest.php
@@ -27,7 +27,7 @@ abstract class AbstractCacheHandlerTest extends AbstractBaseHandlerTest
      * @param array|null $tags
      * @param string|null $key
      */
-    final public function testUnCachedMethods(string $method, array $arguments, array $tags = null, string $key = null)
+    final public function testUnCachedMethods(string $method, array $arguments, array $tags = null, string $key = null, array $additionalCalls = [])
     {
         $handlerMethodName = $this->getHandlerMethodName();
 
@@ -59,6 +59,19 @@ abstract class AbstractCacheHandlerTest extends AbstractBaseHandlerTest
             $this->cacheMock
                 ->expects($this->never())
                 ->method($this->anything());
+        }
+
+        foreach ($additionalCalls as $additionalCall) {
+            $innerHandlerMock = $this->createMock($additionalCall[1]);
+            $this->persistenceHandlerMock
+                ->expects($this->once())
+                ->method($additionalCall[0])
+                ->willReturn($innerHandlerMock);
+
+            $innerHandlerMock
+                ->expects($this->once())
+                ->method($additionalCall[2])
+                ->willReturn($additionalCall[3]);
         }
 
         $handler = $this->persistenceCacheHandler->$handlerMethodName();

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UserHandlerTest.php
@@ -37,6 +37,7 @@ class UserHandlerTest extends AbstractCacheHandlerTest
         $user = new User(['id' => 14]);
         $policy = new Policy(['id' => 13, 'roleId' => 9]);
         $userToken = new User\UserTokenUpdateStruct(['userId' => 14]);
+        $calls = [['locationHandler', Location\Handler::class, 'loadLocationsByContent', [new Location(['id' => '43'])]]];
 
         // string $method, array $arguments, array? $tags, string? $key
         return [
@@ -59,7 +60,7 @@ class UserHandlerTest extends AbstractCacheHandlerTest
             ['updatePolicy', [$policy], ['policy-13', 'role-9']],
             ['deletePolicy', [13, 9], ['policy-13', 'role-9']],
             ['loadPoliciesByUserId', [14]],
-            ['assignRole', [14, 9], ['role-assignment-group-list-14', 'role-assignment-role-list-9']],
+            ['assignRole', [14, 9], ['role-assignment-group-list-14', 'role-assignment-role-list-9', 'location-path-43'], null, $calls],
             ['unassignRole', [14, 9], ['role-assignment-group-list-14', 'role-assignment-role-list-9']],
             ['removeRoleAssignment', [11], ['role-assignment-11']],
         ];

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UserHandlerTest.php
@@ -16,6 +16,7 @@ use eZ\Publish\SPI\Persistence\User\RoleUpdateStruct;
 use eZ\Publish\SPI\Persistence\User\RoleCreateStruct;
 use eZ\Publish\SPI\Persistence\User\Policy;
 use eZ\Publish\SPI\Persistence\User\Handler as SPIUserHandler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Handler as SPILocationHandler;
 
 /**
  * Test case for Persistence\Cache\UserHandler.
@@ -37,7 +38,6 @@ class UserHandlerTest extends AbstractCacheHandlerTest
         $user = new User(['id' => 14]);
         $policy = new Policy(['id' => 13, 'roleId' => 9]);
         $userToken = new User\UserTokenUpdateStruct(['userId' => 14]);
-        $calls = [['locationHandler', Location\Handler::class, 'loadLocationsByContent', [new Location(['id' => '43'])]]];
 
         // string $method, array $arguments, array? $tags, string? $key
         return [
@@ -60,7 +60,6 @@ class UserHandlerTest extends AbstractCacheHandlerTest
             ['updatePolicy', [$policy], ['policy-13', 'role-9']],
             ['deletePolicy', [13, 9], ['policy-13', 'role-9']],
             ['loadPoliciesByUserId', [14]],
-            ['assignRole', [14, 9], ['role-assignment-group-list-14', 'role-assignment-role-list-9', 'location-path-43'], null, $calls],
             ['unassignRole', [14, 9], ['role-assignment-group-list-14', 'role-assignment-role-list-9']],
             ['removeRoleAssignment', [11], ['role-assignment-11']],
         ];
@@ -141,5 +140,50 @@ class UserHandlerTest extends AbstractCacheHandlerTest
             ->method($this->anything());
         $handler = $this->persistenceCacheHandler->userHandler();
         $handler->publishRoleDraft($roleDraftId);
+    }
+
+    public function testAssignRole()
+    {
+        $innerUserHandlerMock = $this->createMock(SPIUserHandler::class);
+        $innerLocationHandlerMock = $this->createMock(SPILocationHandler::class);
+
+        $contentId = 14;
+        $roleId = 9;
+
+        $this->loggerMock->expects($this->once())->method('logCall');
+
+        $this->persistenceHandlerMock
+            ->expects($this->once())
+            ->method('userHandler')
+            ->willReturn($innerUserHandlerMock);
+
+        $innerUserHandlerMock
+            ->expects($this->once())
+            ->method('assignRole')
+            ->with($contentId, $roleId)
+            ->will($this->returnValue(null));
+
+        $this->persistenceHandlerMock
+            ->expects($this->once())
+            ->method('locationHandler')
+            ->willReturn($innerLocationHandlerMock);
+
+        $innerLocationHandlerMock
+            ->expects($this->once())
+            ->method('loadLocationsByContent')
+            ->with($contentId)
+            ->willReturn([new Location(['id' => '43'])]);
+
+        $this->cacheMock
+            ->expects($this->once())
+            ->method('invalidateTags')
+            ->with(['role-assignment-group-list-14', 'role-assignment-role-list-9', 'location-path-43']);
+
+        $this->cacheMock
+            ->expects($this->never())
+            ->method('deleteItem');
+
+        $handler = $this->persistenceCacheHandler->userHandler();
+        $handler->assignRole($contentId, $roleId);
     }
 }

--- a/eZ/Publish/Core/Persistence/Cache/UserHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UserHandler.php
@@ -458,7 +458,13 @@ class UserHandler extends AbstractHandler implements UserHandlerInterface
         $this->logger->logCall(__METHOD__, array('group' => $contentId, 'role' => $roleId, 'limitation' => $limitation));
         $return = $this->persistenceHandler->userHandler()->assignRole($contentId, $roleId, $limitation);
 
-        $this->cache->invalidateTags(['role-assignment-group-list-' . $contentId, 'role-assignment-role-list-' . $roleId]);
+        $tags = ['role-assignment-group-list-' . $contentId, 'role-assignment-role-list-' . $roleId];
+        $locations = $this->persistenceHandler->locationHandler()->loadLocationsByContent($contentId);
+        foreach ($locations as $location) {
+            $tags[] = 'location-path-' . $location->id;
+        }
+
+        $this->cache->invalidateTags($tags);
 
         return $return;
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29113](https://jira.ez.no/browse/EZP-29113)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.x` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     |no

<!-- Replace this comment with Pull Request description -->


**TODO**:
- [X] Integration tests (https://travis-ci.org/ezsystems/ezpublish-kernel/jobs/369053682).
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
