### PR TITLE
Fixed EZP-29087: Sending to trash should rely on content/remove policy

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -515,6 +515,46 @@ abstract class BaseTest extends TestCase
     }
 
     /**
+     * Create user and assign new role with the given policies.
+     *
+     * @param string $login
+     * @param array $policiesData list of policies in the form of <code>[ [ 'module' => 'name', 'function' => 'name'] ]</code>
+     *
+     * @return \eZ\Publish\API\Repository\Values\User\User
+     *
+     * @throws \Exception
+     */
+    public function createUserWithPolicies($login, array $policiesData)
+    {
+        $repository = $this->getRepository(false);
+        $roleService = $repository->getRoleService();
+        $userService = $repository->getUserService();
+
+        $repository->beginTransaction();
+        try {
+            $userCreateStruct = $userService->newUserCreateStruct(
+                $login,
+                "{$login}@test.local",
+                $login,
+                'eng-GB'
+            );
+            $userCreateStruct->setField('first_name', $login);
+            $userCreateStruct->setField('last_name', $login);
+            $user = $userService->createUser($userCreateStruct, [$userService->loadUserGroup(4)]);
+
+            $role = $this->createRoleWithPolicies(uniqid('role_for_' . $login . '_'), $policiesData);
+            $roleService->assignRoleToUser($role, $user);
+
+            $repository->commit();
+
+            return $user;
+        } catch (\Exception $ex) {
+            $repository->rollback();
+            throw $ex;
+        }
+    }
+
+    /**
      * Traverse all errors for all fields in all Translations to find expected one.
      *
      * @param \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException $exception

--- a/eZ/Publish/Core/Repository/TrashService.php
+++ b/eZ/Publish/Core/Repository/TrashService.php
@@ -117,8 +117,8 @@ class TrashService implements TrashServiceInterface
             throw new InvalidArgumentValue('id', $location->id, 'Location');
         }
 
-        if ($this->repository->canUser('content', 'manage_locations', $location->getContentInfo(), $location) !== true) {
-            throw new UnauthorizedException('content', 'manage_locations');
+        if (!$this->repository->canUser('content', 'remove', $location->getContentInfo(), $location)) {
+            throw new UnauthorizedException('content', 'remove');
         }
 
         $this->repository->beginTransaction();


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29087](https://jira.ez.no/browse/EZP-29087)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`
| **BC breaks**      | no\*
| **Tests pass**     | yes
| **Doc needed**     | no

This PR fixes wrong policy name used when checking for permissions to perform `TrashService::trash(Location $location)`. 

We've checked for `content / manage_locations` policy, but what we should have checked is the 'content / remove' policy - the way it was in Legacy.

*\* while behavior changed, the previous behavior was kinda BC-breaking change, this PR fixes it.*

**TODO**:
- [x] Fix a bug (40f8f3f94e4439a68f4914b97b55cdaa0b2985e0).
- [x] Implement tests (1481dd5a7a77c90623e185de9fb32d1f9b560693).
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
