### PR TITLE
EZP-25562: Missing check if imageAlias != null before access to width/height attributes

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -424,8 +424,8 @@
 <figure {{ block( 'field_attributes' ) }}>
     {% set imageAlias = ez_image_alias( field, versionInfo, parameters.alias|default( 'original' ) ) %}
     {% set src = imageAlias ? asset( imageAlias.uri ) : "//:0" %}
-    {% set width = parameters.width is defined ? parameters.width : imageAlias.width %}
-    {% set height = parameters.height is defined ? parameters.height : imageAlias.height %}
+    {% set width = parameters.width is defined ? parameters.width : (imageAlias ? imageAlias.width : '') %}
+    {% set height = parameters.height is defined ? parameters.height : (imageAlias ? imageAlias.height : '') %}
     <img src="{{ src }}"{% if width %} width="{{ width }}"{% endif %}{% if height %} height="{{ height }}"{% endif %} alt="{{ field.value.alternativeText }}"{% if parameters.class is defined and parameters.class is not empty %} class="{{ parameters.class }}"{% endif %} />
 </figure>
 {% endif %}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ImageExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ImageExtension.php
@@ -52,7 +52,7 @@ class ImageExtension extends Twig_Extension
      * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
      * @param string $variationName
      *
-     * @return \eZ\Publish\SPI\Variation\Values\Variation
+     * @return \eZ\Publish\SPI\Variation\Values\Variation|null
      */
     public function getImageVariation(Field $field, VersionInfo $versionInfo, $variationName)
     {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-25562](https://jira.ez.no/browse/EZP-25562)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Patch extracted from https://github.com/ezsystems/ezpublish-kernel/pull/2311#discussion_r183841309. In case of failure [`ImageExtension::getImageVariation`](https://github.com/ezsystems/ezpublish-kernel/blob/d422eca0da1f96e0928c5fa6a1527dfd849ac5c7/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ImageExtension.php#L57-L78) returns `null` which in consequense ends up  `Impossible to access an attribute ("width") on a null variable.` error when `ezimage_field` is trying to resolve width/height attribtues value of the `img` tag.

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
