### PR TITLE
Fixed EZP-29135 : Converting ezxmltext to richtext when embed tag contains neither node_id or object_id fails

### DIFF
--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/ezxml/docbook/core.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/ezxml/docbook/core.xsl
@@ -503,7 +503,7 @@
     </xsl:element>
   </xsl:template>
 
-  <xsl:template match="embed | embed-inline">
+  <xsl:template match="embed[@node_id|@object_id] | embed-inline[@node_id|@object_id]">
     <xsl:variable name="embedname">
       <xsl:choose>
         <xsl:when test="local-name() = 'embed-inline'">
@@ -526,11 +526,6 @@
             <xsl:value-of select="concat( 'ezcontent://', @object_id )"/>
           </xsl:attribute>
         </xsl:when>
-        <xsl:otherwise>
-          <xsl:message terminate="yes">
-            Unhandled link type
-          </xsl:message>
-        </xsl:otherwise>
       </xsl:choose>
       <xsl:if test="@xhtml:id">
         <xsl:choose>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29135](https://jira.ez.no/browse/EZP-29135)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.13`
| **BC breaks**      | no
| **Tests pass**     | yes/no
| **Doc needed**     | no

With this PR, the xlt will only deal with `<embed>` and `<embed-inline>` tags which has a `node_id` or `object_id` attribute.
And a fix in [ezplatform-xmltext-fieldtype](https://github.com/ezsystems/ezplatform-xmltext-fieldtype/pull/41) will instead output warning if neither `node_id` or `object_id` is set.


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests. ( tests are in [ezplatform-xmltext-fieldtype PR](https://github.com/ezsystems/ezplatform-xmltext-fieldtype/pull/41) )
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
