### PR TITLE
Allow installing Pagerfanta 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "sensio/distribution-bundle": "^5.0",
         "nelmio/cors-bundle": "^1.3.3",
         "hautelook/templated-uri-bundle": "^2.0",
-        "pagerfanta/pagerfanta": "~1.0",
+        "pagerfanta/pagerfanta": "^1.0|^2.0",
         "ocramius/proxy-manager": "^2.0",
         "doctrine/doctrine-bundle": "~1.3",
         "liip/imagine-bundle": "~1.0",


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | N/A
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

There's no breaking changes in v2.0 apart from bumping PHP requirements to PHP 7.

https://github.com/whiteoctober/Pagerfanta/compare/v1.1.0...v2.0.0

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
