### PR TITLE
EZP-25487: Stored Image Variation in Image Variation Cache

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGenerator.php
@@ -16,6 +16,7 @@ use eZ\Publish\SPI\Variation\Values\ImageVariation;
 use eZ\Publish\SPI\Variation\VariationHandler;
 use eZ\Publish\Core\FieldType\Value;
 use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
+use Imagine\Exception\RuntimeException;
 use Liip\ImagineBundle\Binary\BinaryInterface;
 use Liip\ImagineBundle\Binary\Loader\LoaderInterface;
 use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
@@ -23,6 +24,7 @@ use Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotResolvableException;
 use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
 use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
 use Liip\ImagineBundle\Imagine\Filter\FilterManager;
+use Imagine\Image\ImagineInterface;
 use Psr\Log\LoggerInterface;
 use InvalidArgumentException;
 use SplFileInfo;
@@ -63,17 +65,24 @@ class AliasGenerator implements VariationHandler
      */
     private $ioResolver;
 
+    /**
+     * @var \Imagine\Image\ImagineInterface;
+     */
+    private $imagine;
+
     public function __construct(
         LoaderInterface $dataLoader,
         FilterManager $filterManager,
         ResolverInterface $ioResolver,
         FilterConfiguration $filterConfiguration,
+        ImagineInterface $imagine,
         LoggerInterface $logger = null
     ) {
         $this->dataLoader = $dataLoader;
         $this->filterManager = $filterManager;
         $this->ioResolver = $ioResolver;
         $this->filterConfiguration = $filterConfiguration;
+        $this->imagine = $imagine;
         $this->logger = $logger;
     }
 
@@ -118,11 +127,16 @@ class AliasGenerator implements VariationHandler
         }
 
         try {
+            $resolvedPath = $this->ioResolver->resolve($originalPath, $variationName);
+            $image = $this->imagine->open($resolvedPath);
+            $dimensions = $image->getSize();
             $aliasInfo = new SplFileInfo(
-                $this->ioResolver->resolve($originalPath, $variationName)
+                $resolvedPath
             );
         } catch (NotResolvableException $e) {
             // If for some reason image alias cannot be resolved, throw the appropriate exception.
+            throw new InvalidVariationException($variationName, 'image', 0, $e);
+        } catch (RuntimeException $e) {
             throw new InvalidVariationException($variationName, 'image', 0, $e);
         }
 
@@ -133,6 +147,8 @@ class AliasGenerator implements VariationHandler
                 'dirPath' => $aliasInfo->getPath(),
                 'uri' => $aliasInfo->getPathname(),
                 'imageId' => $imageValue->imageId,
+                'width' => $dimensions->getWidth(),
+                'height' => $dimensions->getHeight(),
             )
         );
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGenerator.php
@@ -14,7 +14,7 @@ use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\SPI\Variation\Values\ImageVariation;
 use eZ\Publish\SPI\Variation\VariationHandler;
-use eZ\Publish\Core\FieldType\Value;
+use eZ\Publish\SPI\FieldType\Value;
 use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
 use Imagine\Exception\RuntimeException;
 use Liip\ImagineBundle\Binary\BinaryInterface;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/AliasGeneratorDecorator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/AliasGeneratorDecorator.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Cache;
+
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use eZ\Publish\SPI\Variation\VariationHandler;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Persistence Cache layer for AliasGenerator.
+ */
+class AliasGeneratorDecorator implements VariationHandler
+{
+    /**
+     * @var \eZ\Publish\SPI\Variation\VariationHandler
+     */
+    private $aliasGenerator;
+
+    /**
+     * @var \Psr\Cache\CacheItemPoolInterface
+     */
+    private $cache;
+
+    /**
+     * @param \eZ\Publish\SPI\Variation\VariationHandler $aliasGenerator
+     * @param \Psr\Cache\CacheItemPoolInterface $cache
+     */
+    public function __construct(VariationHandler $aliasGenerator, CacheItemPoolInterface $cache)
+    {
+        $this->aliasGenerator = $aliasGenerator;
+        $this->cache = $cache;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Field $field
+     * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
+     * @param string $variationName
+     * @param array $parameters
+     *
+     * @return \eZ\Publish\SPI\Variation\Values\Variation
+     *
+     * @throws \Psr\Cache\InvalidArgumentException
+     */
+    public function getVariation(Field $field, VersionInfo $versionInfo, $variationName, array $parameters = [])
+    {
+        $item = $this->cache->getItem($this->getCacheKey($field, $versionInfo, $variationName));
+        $image = $item->get();
+        if (!$item->isHit()) {
+            $image = $this->aliasGenerator->getVariation($field, $versionInfo, $variationName, $parameters);
+            $item->set($image)->save();
+        }
+
+        return $image;
+    }
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Field $field
+     * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
+     * @param string $variationName
+     *
+     * @return string
+     */
+    private function getCacheKey(Field $field, VersionInfo $versionInfo, $variationName)
+    {
+        return sprintf(
+            'ez-image-variation-%d-%d-%s-%s',
+            $versionInfo->getContentInfo()->id,
+            $versionInfo->id,
+            $field->id,
+            $variationName
+        );
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Variation/ImagineAwareAliasGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Variation/ImagineAwareAliasGenerator.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Variation;
+
+use eZ\Bundle\EzPublishCoreBundle\Imagine\IORepositoryResolver;
+use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
+use eZ\Publish\Core\IO\IOServiceInterface;
+use eZ\Publish\SPI\Variation\Values\ImageVariation;
+use eZ\Publish\SPI\Variation\VariationHandler;
+use Imagine\Image\ImagineInterface;
+
+/**
+ * Alias Generator Decorator which ensures (using Imagine if needed) that ImageVariation has proper
+ * dimensions.
+ */
+class ImagineAwareAliasGenerator implements VariationHandler
+{
+    /**
+     * @var \eZ\Publish\SPI\Variation\VariationHandler
+     */
+    private $aliasGenerator;
+
+    /**
+     * @var \eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator
+     */
+    private $variationPathGenerator;
+
+    /**
+     * @var \eZ\Publish\Core\IO\IOServiceInterface
+     */
+    private $ioService;
+
+    /**
+     * @var \eZ\Publish\Core\MVC\ConfigResolverInterface
+     */
+    private $configResolver;
+
+    /**
+     * @var \Imagine\Image\ImagineInterface
+     */
+    private $imagine;
+
+    public function __construct(
+        VariationHandler $aliasGenerator,
+        VariationPathGenerator $variationPathGenerator,
+        IOServiceInterface $ioService,
+        ImagineInterface $imagine
+    ) {
+        $this->aliasGenerator = $aliasGenerator;
+        $this->variationPathGenerator = $variationPathGenerator;
+        $this->ioService = $ioService;
+        $this->imagine = $imagine;
+    }
+
+    /**
+     * Returns a Variation object, ensuring proper image dimensions.
+     *
+     * {@inheritdoc}
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function getVariation(
+        Field $field,
+        VersionInfo $versionInfo,
+        $variationName,
+        array $parameters = []
+    ) {
+        /** @var \eZ\Publish\SPI\Variation\Values\ImageVariation $variation */
+        $variation = $this->aliasGenerator->getVariation(
+            $field,
+            $versionInfo,
+            $variationName,
+            $parameters
+        );
+
+        if (null === $variation->width || null === $variation->height) {
+            $variationBinaryFile = $this->getVariationBinaryFile($field->value->id, $variationName);
+            $image = $this->imagine->load($this->ioService->getFileContents($variationBinaryFile));
+            $dimensions = $image->getSize();
+
+            return new ImageVariation(
+                [
+                    'name' => $variation->name,
+                    'fileName' => $variation->fileName,
+                    'dirPath' => $variation->dirPath,
+                    'uri' => $variation->uri,
+                    'imageId' => $variation->imageId,
+                    'width' => $dimensions->getWidth(),
+                    'height' => $dimensions->getHeight(),
+                    'fileSize' => $variationBinaryFile->size,
+                    'mimeType' => $this->ioService->getMimeType($variationBinaryFile->id),
+                    'lastModified' => $variationBinaryFile->mtime,
+                ]
+            );
+        }
+
+        return $variation;
+    }
+
+    /**
+     * Get image variation filesystem path.
+     *
+     * @param string $originalPath
+     * @param string $variationName
+     *
+     * @return \eZ\Publish\Core\IO\Values\BinaryFile
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    private function getVariationBinaryFile($originalPath, $variationName)
+    {
+        if ($variationName !== IORepositoryResolver::VARIATION_ORIGINAL) {
+            $variationPath = $this->variationPathGenerator->getVariationPath(
+                $originalPath,
+                $variationName
+            );
+        } else {
+            $variationPath = $originalPath;
+        }
+
+        return $this->ioService->loadBinaryFile($variationPath);
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -231,7 +231,7 @@ services:
 
     # Image alias generator
     ezpublish.fieldType.ezimage.variation_service:
-        alias: ezpublish.image_alias.imagine.alias_generator
+        alias: ezpublish.image_alias.imagine.cache.alias_generator_decorator
 
     ezpublish.fieldType.ezimage.io_service.published:
         parent: ezpublish.core.io.service

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -95,7 +95,6 @@ services:
             - "@liip_imagine.filter.manager"
             - "@ezpublish.image_alias.imagine.cache_resolver"
             - "@liip_imagine.filter.configuration"
-            - "@liip_imagine"
             - "@?logger"
 
     ezpublish.image_alias.imagine.alias_cleaner:

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -4,6 +4,7 @@ parameters:
     ezpublish.image_alias.imagine.binary_loader.class: eZ\Bundle\EzPublishCoreBundle\Imagine\BinaryLoader
     ezpublish.image_alias.imagine.cache_resolver.class: eZ\Bundle\EzPublishCoreBundle\Imagine\IORepositoryResolver
     ezpublish.image_alias.imagine.cache.alias_generator_decorator.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Cache\AliasGeneratorDecorator
+    ezpublish.image_alias.imagine.variation.imagine_alias_generator.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Variation\ImagineAwareAliasGenerator
     ezpublish.image_alias.imagine.alias_generator.class: eZ\Bundle\EzPublishCoreBundle\Imagine\AliasGenerator
     ezpublish.image_alias.imagine.alias_cleaner.class: eZ\Bundle\EzPublishCoreBundle\Imagine\AliasCleaner
 
@@ -85,8 +86,16 @@ services:
     ezpublish.image_alias.imagine.cache.alias_generator_decorator:
         class: '%ezpublish.image_alias.imagine.cache.alias_generator_decorator.class%'
         arguments:
-            - '@ezpublish.image_alias.imagine.alias_generator'
+            - '@ezpublish.image_alias.imagine.variation.imagine_alias_generator'
             - '@ezpublish.cache_pool'
+
+    ezpublish.image_alias.imagine.variation.imagine_alias_generator:
+        class: '%ezpublish.image_alias.imagine.variation.imagine_alias_generator.class%'
+        arguments:
+            - '@ezpublish.image_alias.imagine.alias_generator'
+            - '@ezpublish.image_alias.variation_path_generator'
+            - '@ezpublish.fieldType.ezimage.io_service'
+            - '@liip_imagine'
 
     ezpublish.image_alias.imagine.alias_generator:
         class: "%ezpublish.image_alias.imagine.alias_generator.class%"

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/image.yml
@@ -3,6 +3,7 @@ parameters:
 
     ezpublish.image_alias.imagine.binary_loader.class: eZ\Bundle\EzPublishCoreBundle\Imagine\BinaryLoader
     ezpublish.image_alias.imagine.cache_resolver.class: eZ\Bundle\EzPublishCoreBundle\Imagine\IORepositoryResolver
+    ezpublish.image_alias.imagine.cache.alias_generator_decorator.class: eZ\Bundle\EzPublishCoreBundle\Imagine\Cache\AliasGeneratorDecorator
     ezpublish.image_alias.imagine.alias_generator.class: eZ\Bundle\EzPublishCoreBundle\Imagine\AliasGenerator
     ezpublish.image_alias.imagine.alias_cleaner.class: eZ\Bundle\EzPublishCoreBundle\Imagine\AliasCleaner
 
@@ -81,6 +82,12 @@ services:
         tags:
             - { name: liip_imagine.cache.resolver, resolver: ezpublish }
 
+    ezpublish.image_alias.imagine.cache.alias_generator_decorator:
+        class: '%ezpublish.image_alias.imagine.cache.alias_generator_decorator.class%'
+        arguments:
+            - '@ezpublish.image_alias.imagine.alias_generator'
+            - '@ezpublish.cache_pool'
+
     ezpublish.image_alias.imagine.alias_generator:
         class: "%ezpublish.image_alias.imagine.alias_generator.class%"
         arguments:
@@ -88,6 +95,7 @@ services:
             - "@liip_imagine.filter.manager"
             - "@ezpublish.image_alias.imagine.cache_resolver"
             - "@liip_imagine.filter.configuration"
+            - "@liip_imagine"
             - "@?logger"
 
     ezpublish.image_alias.imagine.alias_cleaner:

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasGeneratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasGeneratorTest.php
@@ -47,9 +47,24 @@ class AliasGeneratorTest extends TestCase
     private $logger;
 
     /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $imagine;
+
+    /**
      * @var AliasGenerator
      */
     private $aliasGenerator;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $box;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $image;
 
     protected function setUp()
     {
@@ -61,12 +76,16 @@ class AliasGeneratorTest extends TestCase
             ->getMock();
         $this->ioResolver = $this->getMock('\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface');
         $this->filterConfiguration = new FilterConfiguration();
+        $this->imagine = $this->getMock('\Imagine\Image\ImagineInterface');
         $this->logger = $this->getMock('\Psr\Log\LoggerInterface');
+        $this->box = $this->getMock('\Imagine\Image\BoxInterface');
+        $this->image = $this->getMock('\Imagine\Image\ImageInterface');
         $this->aliasGenerator = new AliasGenerator(
             $this->dataLoader,
             $this->filterManager,
             $this->ioResolver,
             $this->filterConfiguration,
+            $this->imagine,
             $this->logger
         );
     }
@@ -104,6 +123,8 @@ class AliasGeneratorTest extends TestCase
         $variationName = 'my_variation';
         $this->filterConfiguration->set($variationName, array());
         $imageId = '123-45';
+        $imageWidth = 300;
+        $imageHeight = 300;
         $imageValue = new ImageValue(array('id' => $originalPath, 'imageId' => $imageId));
         $field = new Field(array('value' => $imageValue));
         $expectedUrl = "http://localhost/foo/bar/image_$variationName.jpg";
@@ -139,6 +160,25 @@ class AliasGeneratorTest extends TestCase
             ->with($originalPath, $variationName)
             ->will($this->returnValue($expectedUrl));
 
+        $this->imagine
+            ->expects($this->once())
+            ->method('open')
+            ->with($expectedUrl)
+            ->will($this->returnValue($this->image));
+        $this->image
+            ->expects($this->once())
+            ->method('getSize')
+            ->will($this->returnValue($this->box));
+
+        $this->box
+            ->expects($this->once())
+            ->method('getWidth')
+            ->will($this->returnValue($imageWidth));
+        $this->box
+            ->expects($this->once())
+            ->method('getHeight')
+            ->will($this->returnValue($imageHeight));
+
         $expected = new ImageVariation(
             array(
                 'name' => $variationName,
@@ -146,6 +186,8 @@ class AliasGeneratorTest extends TestCase
                 'dirPath' => 'http://localhost/foo/bar',
                 'uri' => $expectedUrl,
                 'imageId' => $imageId,
+                'height' => $imageHeight,
+                'width' => $imageWidth,
             )
         );
         $this->assertEquals($expected, $this->aliasGenerator->getVariation($field, new VersionInfo(), $variationName));
@@ -156,6 +198,8 @@ class AliasGeneratorTest extends TestCase
         $originalPath = 'foo/bar/image.jpg';
         $variationName = 'original';
         $imageId = '123-45';
+        $imageWidth = 300;
+        $imageHeight = 300;
         $imageValue = new ImageValue(array('id' => $originalPath, 'imageId' => $imageId));
         $field = new Field(array('value' => $imageValue));
         $expectedUrl = 'http://localhost/foo/bar/image.jpg';
@@ -176,6 +220,25 @@ class AliasGeneratorTest extends TestCase
             ->with($originalPath, $variationName)
             ->will($this->returnValue($expectedUrl));
 
+        $this->imagine
+            ->expects($this->once())
+            ->method('open')
+            ->with($expectedUrl)
+            ->will($this->returnValue($this->image));
+        $this->image
+            ->expects($this->once())
+            ->method('getSize')
+            ->will($this->returnValue($this->box));
+
+        $this->box
+            ->expects($this->once())
+            ->method('getWidth')
+            ->will($this->returnValue($imageWidth));
+        $this->box
+            ->expects($this->once())
+            ->method('getHeight')
+            ->will($this->returnValue($imageHeight));
+
         $expected = new ImageVariation(
             array(
                 'name' => $variationName,
@@ -183,6 +246,8 @@ class AliasGeneratorTest extends TestCase
                 'dirPath' => 'http://localhost/foo/bar',
                 'uri' => $expectedUrl,
                 'imageId' => $imageId,
+                'height' => $imageHeight,
+                'width' => $imageWidth,
             )
         );
         $this->assertEquals($expected, $this->aliasGenerator->getVariation($field, new VersionInfo(), $variationName));
@@ -201,6 +266,8 @@ class AliasGeneratorTest extends TestCase
         $this->filterConfiguration->set($reference1, $configReference1);
         $this->filterConfiguration->set($reference2, $configReference2);
         $imageId = '123-45';
+        $imageWidth = 300;
+        $imageHeight = 300;
         $imageValue = new ImageValue(array('id' => $originalPath, 'imageId' => $imageId));
         $field = new Field(array('value' => $imageValue));
         $expectedUrl = "http://localhost/foo/bar/image_$variationName.jpg";
@@ -249,6 +316,25 @@ class AliasGeneratorTest extends TestCase
             ->with($originalPath, $variationName)
             ->will($this->returnValue($expectedUrl));
 
+        $this->imagine
+            ->expects($this->once())
+            ->method('open')
+            ->with($expectedUrl)
+            ->will($this->returnValue($this->image));
+        $this->image
+            ->expects($this->once())
+            ->method('getSize')
+            ->will($this->returnValue($this->box));
+
+        $this->box
+            ->expects($this->once())
+            ->method('getWidth')
+            ->will($this->returnValue($imageWidth));
+        $this->box
+            ->expects($this->once())
+            ->method('getHeight')
+            ->will($this->returnValue($imageHeight));
+
         $expected = new ImageVariation(
             array(
                 'name' => $variationName,
@@ -256,6 +342,8 @@ class AliasGeneratorTest extends TestCase
                 'dirPath' => 'http://localhost/foo/bar',
                 'uri' => $expectedUrl,
                 'imageId' => $imageId,
+                'width' => $imageWidth,
+                'height' => $imageHeight,
             )
         );
         $this->assertEquals($expected, $this->aliasGenerator->getVariation($field, new VersionInfo(), $variationName));
@@ -266,6 +354,8 @@ class AliasGeneratorTest extends TestCase
         $originalPath = 'foo/bar/image.jpg';
         $variationName = 'my_variation';
         $imageId = '123-45';
+        $imageWidth = 300;
+        $imageHeight = 300;
         $imageValue = new ImageValue(array('id' => $originalPath, 'imageId' => $imageId));
         $field = new Field(array('value' => $imageValue));
         $expectedUrl = "http://localhost/foo/bar/image_$variationName.jpg";
@@ -296,6 +386,25 @@ class AliasGeneratorTest extends TestCase
             ->with($originalPath, $variationName)
             ->will($this->returnValue($expectedUrl));
 
+        $this->imagine
+            ->expects($this->once())
+            ->method('open')
+            ->with($expectedUrl)
+            ->will($this->returnValue($this->image));
+        $this->image
+            ->expects($this->once())
+            ->method('getSize')
+            ->will($this->returnValue($this->box));
+
+        $this->box
+            ->expects($this->once())
+            ->method('getWidth')
+            ->will($this->returnValue($imageWidth));
+        $this->box
+            ->expects($this->once())
+            ->method('getHeight')
+            ->will($this->returnValue($imageHeight));
+
         $expected = new ImageVariation(
             array(
                 'name' => $variationName,
@@ -303,6 +412,8 @@ class AliasGeneratorTest extends TestCase
                 'dirPath' => 'http://localhost/foo/bar',
                 'uri' => $expectedUrl,
                 'imageId' => $imageId,
+                'width' => $imageWidth,
+                'height' => $imageHeight,
             )
         );
         $this->assertEquals($expected, $this->aliasGenerator->getVariation($field, new VersionInfo(), $variationName));

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasGeneratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasGeneratorTest.php
@@ -9,30 +9,44 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine;
 
 use eZ\Bundle\EzPublishCoreBundle\Imagine\AliasGenerator;
+use eZ\Bundle\EzPublishCoreBundle\Imagine\Variation\ImagineAwareAliasGenerator;
+use eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator;
 use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\Base\Tests\PHPUnit5CompatTrait;
 use eZ\Publish\Core\FieldType\Image\Value as ImageValue;
 use eZ\Publish\Core\FieldType\TextLine\Value as TextLineValue;
+use eZ\Publish\SPI\FieldType\Value as FieldTypeValue;
+use eZ\Publish\Core\IO\IOServiceInterface;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use eZ\Publish\SPI\Variation\Values\ImageVariation;
+use Imagine\Image\BoxInterface;
+use Imagine\Image\ImageInterface;
+use Imagine\Image\ImagineInterface;
+use Liip\ImagineBundle\Binary\Loader\LoaderInterface;
 use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
 use Liip\ImagineBundle\Exception\Imagine\Cache\Resolver\NotResolvableException;
+use Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface;
 use Liip\ImagineBundle\Imagine\Filter\FilterConfiguration;
+use Liip\ImagineBundle\Imagine\Filter\FilterManager;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 class AliasGeneratorTest extends TestCase
 {
+    use PHPUnit5CompatTrait;
+
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Liip\ImagineBundle\Binary\Loader\LoaderInterface
      */
     private $dataLoader;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Liip\ImagineBundle\Imagine\Filter\FilterManager
      */
     private $filterManager;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface
      */
     private $ioResolver;
 
@@ -42,70 +56,103 @@ class AliasGeneratorTest extends TestCase
     private $filterConfiguration;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Psr\Log\LoggerInterface
      */
     private $logger;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Imagine\Image\ImagineInterface
      */
     private $imagine;
 
     /**
-     * @var AliasGenerator
+     * @var \eZ\Bundle\EzPublishCoreBundle\Imagine\AliasGenerator
      */
     private $aliasGenerator;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \eZ\Publish\SPI\Variation\VariationHandler
+     */
+    private $decoratedAliasGenerator;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Imagine\Image\BoxInterface
      */
     private $box;
 
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|\Imagine\Image\ImageInterface
      */
     private $image;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\Core\IO\IOServiceInterface
+     */
+    private $ioService;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|\eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator
+     */
+    private $variationPathGenerator;
 
     protected function setUp()
     {
         parent::setUp();
-        $this->dataLoader = $this->getMock('\Liip\ImagineBundle\Binary\Loader\LoaderInterface');
+        $this->dataLoader = $this->createMock(LoaderInterface::class);
         $this->filterManager = $this
-            ->getMockBuilder('\Liip\ImagineBundle\Imagine\Filter\FilterManager')
+            ->getMockBuilder(FilterManager::class)
             ->disableOriginalConstructor()
             ->getMock();
-        $this->ioResolver = $this->getMock('\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface');
+        $this->ioResolver = $this->createMock(ResolverInterface::class);
         $this->filterConfiguration = new FilterConfiguration();
-        $this->imagine = $this->getMock('\Imagine\Image\ImagineInterface');
-        $this->logger = $this->getMock('\Psr\Log\LoggerInterface');
-        $this->box = $this->getMock('\Imagine\Image\BoxInterface');
-        $this->image = $this->getMock('\Imagine\Image\ImageInterface');
+        $this->imagine = $this->createMock(ImagineInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->box = $this->createMock(BoxInterface::class);
+        $this->image = $this->createMock(ImageInterface::class);
+        $this->ioService = $this->createMock(IOServiceInterface::class);
+        $this->variationPathGenerator = $this->createMock(VariationPathGenerator::class);
         $this->aliasGenerator = new AliasGenerator(
             $this->dataLoader,
             $this->filterManager,
             $this->ioResolver,
             $this->filterConfiguration,
-            $this->imagine,
             $this->logger
+        );
+        $this->decoratedAliasGenerator = new ImagineAwareAliasGenerator(
+            $this->aliasGenerator,
+            $this->variationPathGenerator,
+            $this->ioService,
+            $this->imagine
         );
     }
 
     /**
      * @dataProvider supportsValueProvider
+     * @param \eZ\Publish\SPI\FieldType\Value $value
+     * @param bool $isSupported
      */
     public function testSupportsValue($value, $isSupported)
     {
         $this->assertSame($isSupported, $this->aliasGenerator->supportsValue($value));
     }
 
+    /**
+     * Data provider for testSupportsValue.
+     *
+     * @see testSupportsValue
+     *
+     * @return array
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
     public function supportsValueProvider()
     {
-        return array(
-            array($this->getMock('\eZ\Publish\Core\FieldType\Value'), false),
-            array(new TextLineValue(), false),
-            array(new ImageValue(), true),
-            array($this->getMock('\eZ\Publish\Core\FieldType\Image\Value'), true),
-        );
+        return [
+            [$this->createMock(FieldTypeValue::class), false],
+            [new TextLineValue(), false],
+            [new ImageValue(), true],
+            [$this->createMock(ImageValue::class), true],
+        ];
     }
 
     /**
@@ -117,6 +164,11 @@ class AliasGeneratorTest extends TestCase
         $this->aliasGenerator->getVariation($field, new VersionInfo(), 'foo');
     }
 
+    /**
+     * Test obtaining Image Variation that hasn't been stored yet.
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
+     */
     public function testGetVariationNotStored()
     {
         $originalPath = 'foo/bar/image.jpg';
@@ -125,8 +177,6 @@ class AliasGeneratorTest extends TestCase
         $imageId = '123-45';
         $imageWidth = 300;
         $imageHeight = 300;
-        $imageValue = new ImageValue(array('id' => $originalPath, 'imageId' => $imageId));
-        $field = new Field(array('value' => $imageValue));
         $expectedUrl = "http://localhost/foo/bar/image_$variationName.jpg";
 
         $this->ioResolver
@@ -154,43 +204,15 @@ class AliasGeneratorTest extends TestCase
             ->expects($this->once())
             ->method('store')
             ->with($binary, $originalPath, $variationName);
-        $this->ioResolver
-            ->expects($this->once())
-            ->method('resolve')
-            ->with($originalPath, $variationName)
-            ->will($this->returnValue($expectedUrl));
 
-        $this->imagine
-            ->expects($this->once())
-            ->method('open')
-            ->with($expectedUrl)
-            ->will($this->returnValue($this->image));
-        $this->image
-            ->expects($this->once())
-            ->method('getSize')
-            ->will($this->returnValue($this->box));
-
-        $this->box
-            ->expects($this->once())
-            ->method('getWidth')
-            ->will($this->returnValue($imageWidth));
-        $this->box
-            ->expects($this->once())
-            ->method('getHeight')
-            ->will($this->returnValue($imageHeight));
-
-        $expected = new ImageVariation(
-            array(
-                'name' => $variationName,
-                'fileName' => "image_$variationName.jpg",
-                'dirPath' => 'http://localhost/foo/bar',
-                'uri' => $expectedUrl,
-                'imageId' => $imageId,
-                'height' => $imageHeight,
-                'width' => $imageWidth,
-            )
+        $this->assertImageVariationIsCorrect(
+            $expectedUrl,
+            $variationName,
+            $imageId,
+            $originalPath,
+            $imageWidth,
+            $imageHeight
         );
-        $this->assertEquals($expected, $this->aliasGenerator->getVariation($field, new VersionInfo(), $variationName));
     }
 
     public function testGetVariationOriginal()
@@ -200,8 +222,16 @@ class AliasGeneratorTest extends TestCase
         $imageId = '123-45';
         $imageWidth = 300;
         $imageHeight = 300;
-        $imageValue = new ImageValue(array('id' => $originalPath, 'imageId' => $imageId));
-        $field = new Field(array('value' => $imageValue));
+        // original images already contain proper width and height
+        $imageValue = new ImageValue(
+            [
+                'id' => $originalPath,
+                'imageId' => $imageId,
+                'width' => $imageWidth,
+                'height' => $imageHeight,
+            ]
+        );
+        $field = new Field(['value' => $imageValue]);
         $expectedUrl = 'http://localhost/foo/bar/image.jpg';
 
         $this->ioResolver
@@ -220,25 +250,6 @@ class AliasGeneratorTest extends TestCase
             ->with($originalPath, $variationName)
             ->will($this->returnValue($expectedUrl));
 
-        $this->imagine
-            ->expects($this->once())
-            ->method('open')
-            ->with($expectedUrl)
-            ->will($this->returnValue($this->image));
-        $this->image
-            ->expects($this->once())
-            ->method('getSize')
-            ->will($this->returnValue($this->box));
-
-        $this->box
-            ->expects($this->once())
-            ->method('getWidth')
-            ->will($this->returnValue($imageWidth));
-        $this->box
-            ->expects($this->once())
-            ->method('getHeight')
-            ->will($this->returnValue($imageHeight));
-
         $expected = new ImageVariation(
             array(
                 'name' => $variationName,
@@ -250,9 +261,14 @@ class AliasGeneratorTest extends TestCase
                 'width' => $imageWidth,
             )
         );
-        $this->assertEquals($expected, $this->aliasGenerator->getVariation($field, new VersionInfo(), $variationName));
+        $this->assertEquals($expected, $this->decoratedAliasGenerator->getVariation($field, new VersionInfo(), $variationName));
     }
 
+    /**
+     * Test obtaining Image Variation that hasn't been stored yet and has multiple references.
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
+     */
     public function testGetVariationNotStoredHavingReferences()
     {
         $originalPath = 'foo/bar/image.jpg';
@@ -268,8 +284,6 @@ class AliasGeneratorTest extends TestCase
         $imageId = '123-45';
         $imageWidth = 300;
         $imageHeight = 300;
-        $imageValue = new ImageValue(array('id' => $originalPath, 'imageId' => $imageId));
-        $field = new Field(array('value' => $imageValue));
         $expectedUrl = "http://localhost/foo/bar/image_$variationName.jpg";
 
         $this->ioResolver
@@ -310,45 +324,22 @@ class AliasGeneratorTest extends TestCase
             ->expects($this->once())
             ->method('store')
             ->with($binary, $originalPath, $variationName);
-        $this->ioResolver
-            ->expects($this->once())
-            ->method('resolve')
-            ->with($originalPath, $variationName)
-            ->will($this->returnValue($expectedUrl));
 
-        $this->imagine
-            ->expects($this->once())
-            ->method('open')
-            ->with($expectedUrl)
-            ->will($this->returnValue($this->image));
-        $this->image
-            ->expects($this->once())
-            ->method('getSize')
-            ->will($this->returnValue($this->box));
-
-        $this->box
-            ->expects($this->once())
-            ->method('getWidth')
-            ->will($this->returnValue($imageWidth));
-        $this->box
-            ->expects($this->once())
-            ->method('getHeight')
-            ->will($this->returnValue($imageHeight));
-
-        $expected = new ImageVariation(
-            array(
-                'name' => $variationName,
-                'fileName' => "image_$variationName.jpg",
-                'dirPath' => 'http://localhost/foo/bar',
-                'uri' => $expectedUrl,
-                'imageId' => $imageId,
-                'width' => $imageWidth,
-                'height' => $imageHeight,
-            )
+        $this->assertImageVariationIsCorrect(
+            $expectedUrl,
+            $variationName,
+            $imageId,
+            $originalPath,
+            $imageWidth,
+            $imageHeight
         );
-        $this->assertEquals($expected, $this->aliasGenerator->getVariation($field, new VersionInfo(), $variationName));
     }
 
+    /**
+     * Test obtaining Image Variation that has been stored already.
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
+     */
     public function testGetVariationAlreadyStored()
     {
         $originalPath = 'foo/bar/image.jpg';
@@ -356,8 +347,6 @@ class AliasGeneratorTest extends TestCase
         $imageId = '123-45';
         $imageWidth = 300;
         $imageHeight = 300;
-        $imageValue = new ImageValue(array('id' => $originalPath, 'imageId' => $imageId));
-        $field = new Field(array('value' => $imageValue));
         $expectedUrl = "http://localhost/foo/bar/image_$variationName.jpg";
 
         $this->ioResolver
@@ -380,43 +369,14 @@ class AliasGeneratorTest extends TestCase
             ->expects($this->never())
             ->method('store');
 
-        $this->ioResolver
-            ->expects($this->once())
-            ->method('resolve')
-            ->with($originalPath, $variationName)
-            ->will($this->returnValue($expectedUrl));
-
-        $this->imagine
-            ->expects($this->once())
-            ->method('open')
-            ->with($expectedUrl)
-            ->will($this->returnValue($this->image));
-        $this->image
-            ->expects($this->once())
-            ->method('getSize')
-            ->will($this->returnValue($this->box));
-
-        $this->box
-            ->expects($this->once())
-            ->method('getWidth')
-            ->will($this->returnValue($imageWidth));
-        $this->box
-            ->expects($this->once())
-            ->method('getHeight')
-            ->will($this->returnValue($imageHeight));
-
-        $expected = new ImageVariation(
-            array(
-                'name' => $variationName,
-                'fileName' => "image_$variationName.jpg",
-                'dirPath' => 'http://localhost/foo/bar',
-                'uri' => $expectedUrl,
-                'imageId' => $imageId,
-                'width' => $imageWidth,
-                'height' => $imageHeight,
-            )
+        $this->assertImageVariationIsCorrect(
+            $expectedUrl,
+            $variationName,
+            $imageId,
+            $originalPath,
+            $imageWidth,
+            $imageHeight
         );
-        $this->assertEquals($expected, $this->aliasGenerator->getVariation($field, new VersionInfo(), $variationName));
     }
 
     /**
@@ -471,5 +431,94 @@ class AliasGeneratorTest extends TestCase
             ->will($this->throwException(new NotResolvableException()));
 
         $this->aliasGenerator->getVariation($field, new VersionInfo(), $variationName);
+    }
+
+    /**
+     * Prepare required Imagine-related mocks and assert that the Image Variation is as expected.
+     *
+     * @param string $expectedUrl
+     * @param string $variationName
+     * @param string $imageId
+     * @param string $originalPath
+     * @param int $imageWidth
+     * @param int $imageHeight
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentType
+     */
+    protected function assertImageVariationIsCorrect(
+        $expectedUrl,
+        $variationName,
+        $imageId,
+        $originalPath,
+        $imageWidth,
+        $imageHeight
+    ) {
+        $imageValue = new ImageValue(['id' => $originalPath, 'imageId' => $imageId]);
+        $field = new Field(['value' => $imageValue]);
+
+        $binaryFile = new \eZ\Publish\Core\IO\Values\BinaryFile(
+            [
+                'uri' => "_aliases/{$variationName}/foo/bar/image.jpg",
+            ]
+        );
+
+        $this->ioResolver
+            ->expects($this->once())
+            ->method('resolve')
+            ->with($originalPath, $variationName)
+            ->will($this->returnValue($expectedUrl));
+
+        $this->variationPathGenerator
+            ->expects($this->once())
+            ->method('getVariationPath')
+            ->with($originalPath, $variationName)
+            ->willReturn($binaryFile->uri);
+
+        $this->ioService
+            ->expects($this->once())
+            ->method('loadBinaryFile')
+            ->withAnyParameters()
+            ->willReturn($binaryFile);
+
+        $this->ioService
+            ->expects($this->once())
+            ->method('getFileContents')
+            ->with($binaryFile)
+            ->willReturn('file contents mock');
+
+        $this->imagine
+            ->expects($this->once())
+            ->method('load')
+            ->with('file contents mock')
+            ->will($this->returnValue($this->image));
+        $this->image
+            ->expects($this->once())
+            ->method('getSize')
+            ->will($this->returnValue($this->box));
+
+        $this->box
+            ->expects($this->once())
+            ->method('getWidth')
+            ->will($this->returnValue($imageWidth));
+        $this->box
+            ->expects($this->once())
+            ->method('getHeight')
+            ->will($this->returnValue($imageHeight));
+
+        $expected = new ImageVariation(
+            [
+                'name' => $variationName,
+                'fileName' => "image_$variationName.jpg",
+                'dirPath' => 'http://localhost/foo/bar',
+                'uri' => $expectedUrl,
+                'imageId' => $imageId,
+                'height' => $imageHeight,
+                'width' => $imageWidth,
+            ]
+        );
+        $this->assertEquals(
+            $expected,
+            $this->decoratedAliasGenerator->getVariation($field, new VersionInfo(), $variationName)
+        );
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-25487](https://jira.ez.no/browse/EZP-25487)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7`, `6.13`, `7.1`, `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes\*

## Summary
This is #2121 by @kmadejski including minor improvements.

This approach uses Persistence Cache to store Image variation. The only difference when compared to #2121 is type-hinting `Psr\Cache\` interface instead of the one from `Stash` to make merging up to 7.x easier. Moreover I've changed slashes in cache key to dashes as this is what we use in 7.x stack.

## Justification

Using persistence cache here might be seen as a workaround, but I rather see it as a clean solution.
Persistence layer goes beyond just a database. In fact it is any storage, which includes filesystem, AWS, NFS/DFS, etc, therefore some information about files can be cached in this layer.

## Concerns about cache invalidation

@kmadejski in his solution ensured that cache key relies on Version Id and Field Id, so when an image field is updated with new image, different cache key will be used. For 6.x stack it might lead to some obsolete entries. When merged up to 7.x we can try to use tags to invalidate obsolete cache. This is the same case as for every cache key where Version Id / No and/or Field Id is used.

It is true that in case of Redis, any change to a file bypassing our Repository (Liip configuration change, manual change of a file) will require clearing persistence cache, however it's worth to mention that a solution involving storing this data in a database would yield the same result.

\* We need to document that manual change of image variation properties (image itself or liip configuration) requires clearing persistence cache. It makes a difference in case of Redis or other external server // cc @DominikaK 

**TODO**:
- [x] Fix loading images via URIs (should be loaded via filesystem paths).
- [x] Fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
