### PR TITLE
EZP-24968 : RichText: conversion and validation from Legacy ezxml involving temporary paragraphs

### DIFF
--- a/eZ/Publish/Core/FieldType/RichText/Converter/Ezxml/ToRichTextPreNormalize.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter/Ezxml/ToRichTextPreNormalize.php
@@ -8,38 +8,29 @@
  */
 namespace eZ\Publish\Core\FieldType\RichText\Converter\Ezxml;
 
-use eZ\Publish\Core\FieldType\XmlText\Converter\EmbedLinking;
-use eZ\Publish\Core\FieldType\XmlText\Converter\Expanding;
 use eZ\Publish\Core\FieldType\RichText\Converter;
 use DOMDocument;
 
 /**
  * Expands paragraphs and links embeds of a XML document in legacy ezxml format.
  *
- * Relies on XmlText's Expanding and EmbedLinking converters implementation.
+ * Relies on XmlText's ExpandingToRichText, ExpandingSectionParagraph and EmbedLinking converters implementation.
  */
 class ToRichTextPreNormalize implements Converter
 {
     /**
-     * @var \eZ\Publish\Core\FieldType\XmlText\Converter\Expanding
+     * @var \eZ\Publish\Core\FieldType\XmlText\Converter[]
      */
-    protected $expandingConverter;
-
-    /**
-     * @var \eZ\Publish\Core\FieldType\XmlText\Converter\EmbedLinking
-     */
-    protected $embedLinkingConverter;
+    protected $converters;
 
     /**
      * Construct from XmlText converters implementation.
      *
-     * @param \eZ\Publish\Core\FieldType\XmlText\Converter\Expanding $expandingConverter
-     * @param \eZ\Publish\Core\FieldType\XmlText\Converter\EmbedLinking $embedLinkingConverter
+     * @param \eZ\Publish\Core\FieldType\XmlText\Converter[] $converters
      */
-    public function __construct(Expanding $expandingConverter, EmbedLinking $embedLinkingConverter)
+    public function __construct(array $converters)
     {
-        $this->expandingConverter = $expandingConverter;
-        $this->embedLinkingConverter = $embedLinkingConverter;
+        $this->converters = $converters;
     }
 
     /**
@@ -51,10 +42,9 @@ class ToRichTextPreNormalize implements Converter
      */
     public function convert(DOMDocument $document)
     {
-        // First
-        $this->expandingConverter->convert($document);
-        // Second
-        $this->embedLinkingConverter->convert($document);
+        foreach ($this->converters as $converter) {
+            $converter->convert($document);
+        }
 
         return $document;
     }

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/ezxml/docbook/core.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/ezxml/docbook/core.xsl
@@ -102,6 +102,9 @@
     <xsl:apply-templates/>
   </xsl:template>
 
+  <xsl:template match="line">
+  </xsl:template>
+
   <xsl:template match="paragraph">
     <xsl:element name="para" namespace="http://docbook.org/ns/docbook">
       <xsl:if test="@class">
@@ -126,6 +129,8 @@
               </xsl:if>
             </xsl:for-each>
           </xsl:element>
+          <!-- paragraph may also contain a list so let's apply templates too -->
+          <xsl:apply-templates/>
         </xsl:when>
         <xsl:otherwise>
           <xsl:apply-templates/>

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/ezxml/docbook/core.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/ezxml/docbook/core.xsl
@@ -129,7 +129,7 @@
               </xsl:if>
             </xsl:for-each>
           </xsl:element>
-          <!-- paragraph may also contain a list so let's apply templates too -->
+          <!-- paragraph may also contain child elements which needs to be converted too -->
           <xsl:apply-templates/>
         </xsl:when>
         <xsl:otherwise>

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/ezxml/docbook/core.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/ezxml/docbook/core.xsl
@@ -351,9 +351,7 @@
           <xsl:value-of select="@class"/>
         </xsl:attribute>
       </xsl:if>
-      <xsl:element name="para" namespace="http://docbook.org/ns/docbook">
-        <xsl:apply-templates/>
-      </xsl:element>
+      <xsl:apply-templates/>
     </xsl:element>
   </xsl:template>
 

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/EzxmlToDocbookTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/EzxmlToDocbookTest.php
@@ -9,7 +9,8 @@
 namespace eZ\Publish\Core\FieldType\Tests\RichText\Converter\Xslt;
 
 use eZ\Publish\Core\FieldType\RichText\Converter\Aggregate;
-use eZ\Publish\Core\FieldType\XmlText\Converter\Expanding;
+use eZ\Publish\Core\FieldType\XmlText\Converter\ExpandingToRichText;
+use eZ\Publish\Core\FieldType\XmlText\Converter\ExpandingList;
 use eZ\Publish\Core\FieldType\RichText\Converter\Ezxml\ToRichTextPreNormalize;
 use eZ\Publish\Core\FieldType\XmlText\Converter\EmbedLinking;
 use eZ\Publish\Core\FieldType\RichText\Converter\Xslt;
@@ -23,20 +24,20 @@ class EzxmlToDocbookTest extends BaseTest
     {
         parent::setUp();
 
-        if (!class_exists(Expanding::class)) {
+        if (!class_exists(ExpandingToRichText::class)) {
             $this->markTestSkipped('This tests requires XmlText field type');
         }
     }
 
     /**
-     * @return \eZ\Publish\Core\FieldType\RichText\Converter\Xslt
+     * @return \eZ\Publish\Core\FieldType\RichText\Converter\Aggregate
      */
     protected function getConverter()
     {
         if ($this->converter === null) {
             $this->converter = new Aggregate(
                 array(
-                    new ToRichTextPreNormalize(new Expanding(), new EmbedLinking()),
+                    new ToRichTextPreNormalize([new ExpandingToRichText(), new ExpandingList(), new EmbedLinking()]),
                     new Xslt(
                         $this->getConversionTransformationStylesheet(),
                         $this->getCustomConversionTransformationStylesheets()


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-24968](https://jira.ez.no/browse/EZP-24968)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.13`
| **BC breaks**      | yes
| **Tests pass**     | N/A
| **Doc needed**     | no

This PR is dependent on [PR in ezplatform-xmltext-fieldtype](https://github.com/ezsystems/ezplatform-xmltext-fieldtype/pull/42) which will use the `<paragraph>` which exists in ezxmltext instead of creating a new `<para>` explicitly in the xslt

The BC break is about changes to `ToRichTextPreNormalize` which I believe is only used in tests which are never executed ( because they depend on ezplatform-xmltext-fieldtype)

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests ( tests are in [ezplatform-xmltext-fieldtype PR](https://github.com/ezsystems/ezplatform-xmltext-fieldtype/pull/42) )
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
