### PR TITLE
EZP-27743: Criterion should implement CriterionInterface

### DIFF
--- a/doc/bc/changes-7.2.md
+++ b/doc/bc/changes-7.2.md
@@ -1,0 +1,20 @@
+# Backwards compatibility changes
+
+Changes affecting version compatibility with former or future versions.
+
+## Changes
+
+* The abstract class `eZ\Publish\API\Repository\Values\Content\Query\Criterion` now implements interface `eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface`.
+
+* The interface `eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface` no longer specifies `createFromQueryBuilder` and `getSpecifications` methods. The former was already specified by `eZ\Publish\API\Repository\Values\Content\Query\Criterion` abstract class and the latter was moved there.
+
+* Classes extending the abstract class `eZ\Publish\API\Repository\Values\Content\Query\Criterion` no longer directly implement interface `eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface`. This interface is still implemented in those classes via `eZ\Publish\API\Repository\Values\Content\Query\Criterion` abstract class.
+
+* The abstract class `eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOperator` now throws `eZ\Publish\API\Repository\Exceptions\NotImplementedException` for method `getSpecifications`. This method will be completely removed in 8.0 when `LogicalOperator` no longer extends `eZ\Publish\API\Repository\Values\Content\Query\Criterion`.
+
+## Deprecations
+
+* The method `createFromQueryBuilder` from the abstract class `eZ\Publish\API\Repository\Values\Content\Query\Criterion` is deprecated and will be removed in 8.0. All overrides of this method are also deprecated and will be removed in 8.0.
+Call constructors directly instead.
+
+## Removed features

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php
@@ -13,7 +13,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specificat
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
 use InvalidArgumentException;
 
-abstract class Criterion
+abstract class Criterion implements CriterionInterface
 {
     /**
      * The operator used by the Criterion.
@@ -114,6 +114,38 @@ abstract class Criterion
     }
 
     /**
+     * Criterion description function.
+     *
+     * Returns the combination of the Criterion's supported operator/value,
+     * as an array of eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications objects
+     * - Operator is one supported Operator, as an Operator::* constant
+     * - ValueType is the type of input value this operator requires, either array or single
+     * - SupportedTypes is an array of types the operator will accept
+     * - ValueCountLimitation is an integer saying how many values are expected.
+     *
+     * <code>
+     * // IN and EQ are supported
+     * return [
+     *     // The EQ operator expects a single value, either as an integer or a string
+     *     new Specifications(
+     *         Operator::EQ,
+     *         Specifications::INPUT_TYPE_SINGLE,
+     *         [Specifications::INPUT_VALUE_INTEGER, Specifications::INPUT_VALUE_STRING],
+     *     ),
+     *     // The IN operator expects an array of values, of either integers or strings
+     *     new Specifications(
+     *         Operator::IN,
+     *         Specifications::INPUT_TYPE_ARRAY,
+     *         [Specifications::INPUT_VALUE_INTEGER, Specifications::INPUT_VALUE_STRING]
+     *     )
+     * ]
+     * </code>
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications[]
+     */
+    abstract public function getSpecifications();
+
+    /**
      * Returns a callback that checks the values types depending on the operator specifications.
      *
      * @param int $valueTypes The accepted values, as a bit field of Specifications::TYPE_* constants
@@ -146,8 +178,13 @@ abstract class Criterion
         return $callback;
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new static($target, $operator, $value);
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Ancestor.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Ancestor.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 use InvalidArgumentException;
 
 /**
@@ -18,7 +17,7 @@ use InvalidArgumentException;
  *
  * Content will be matched if it is part of at least one of the given subtree path strings.
  */
-class Ancestor extends Criterion implements CriterionInterface
+class Ancestor extends Criterion
 {
     /**
      * Creates a new Ancestor criterion.
@@ -57,8 +56,13 @@ class Ancestor extends Criterion implements CriterionInterface
         );
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self($value);
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentId.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 
 /**
  * A criterion that matches content based on its id.
@@ -19,7 +18,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
  * - IN: will match from a list of ContentId
  * - EQ: will match against one ContentId
  */
-class ContentId extends Criterion implements CriterionInterface
+class ContentId extends Criterion
 {
     /**
      * Creates a new ContentId criterion.
@@ -44,8 +43,13 @@ class ContentId extends Criterion implements CriterionInterface
         );
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self($value);
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeGroupId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeGroupId.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 
 /**
  * A criterion that will match content based on its ContentTypeGroup id.
@@ -20,7 +19,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
  * - IN: will match from a list of ContentTypeGroup id
  * - EQ: will match against one ContentTypeGroup id
  */
-class ContentTypeGroupId extends Criterion implements CriterionInterface
+class ContentTypeGroupId extends Criterion
 {
     /**
      * Creates a new ContentTypeGroup criterion.
@@ -54,8 +53,13 @@ class ContentTypeGroupId extends Criterion implements CriterionInterface
         );
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self($value);
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeId.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 
 /**
  * A criterion that matches content based on its ContentType id.
@@ -19,7 +18,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
  * - IN: will match from a list of ContentTypeId
  * - EQ: will match against one ContentTypeId
  */
-class ContentTypeId extends Criterion implements CriterionInterface
+class ContentTypeId extends Criterion
 {
     /**
      * Creates a new ContentType criterion.
@@ -46,8 +45,13 @@ class ContentTypeId extends Criterion implements CriterionInterface
         );
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self($value);
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeIdentifier.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeIdentifier.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 
 /**
  * A criterion that matches content based on its ContentType Identifier.
@@ -19,7 +18,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
  * - IN: will match from a list of ContentTypeIdentifier
  * - EQ: will match against one ContentTypeIdentifier
  */
-class ContentTypeIdentifier extends Criterion implements CriterionInterface
+class ContentTypeIdentifier extends Criterion
 {
     /**
      * Creates a new ContentType criterion.
@@ -51,8 +50,13 @@ class ContentTypeIdentifier extends Criterion implements CriterionInterface
         );
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self($value);
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/CustomField.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/CustomField.php
@@ -10,14 +10,13 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 
 /**
  * The Field Criterion class.
  *
  * Provides content filtering based on Fields contents & values.
  */
-class CustomField extends Criterion implements CriterionInterface
+class CustomField extends Criterion
 {
     public function getSpecifications()
     {

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/DateMetadata.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/DateMetadata.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 use InvalidArgumentException;
 
 /**
@@ -31,7 +30,7 @@ use InvalidArgumentException;
  * );
  * </code>
  */
-class DateMetadata extends Criterion implements CriterionInterface
+class DateMetadata extends Criterion
 {
     /**
      * DateMetadata target: modification date.

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Field.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Field.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 use eZ\Publish\API\Repository\Values\Content\Query\CustomFieldInterface;
 
 /**
@@ -18,7 +17,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\CustomFieldInterface;
  *
  * Provides content filtering based on Fields contents & values.
  */
-class Field extends Criterion implements CriterionInterface, CustomFieldInterface
+class Field extends Criterion implements CustomFieldInterface
 {
     /**
      * Custom field definitions to query instead of default field.

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/FieldRelation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/FieldRelation.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 
 /**
  * A criterion that matches Content based on the relations in relation field.
@@ -22,7 +21,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
  * - IN: will match if Content relates to one or more of the given ids through given relation field
  * - CONTAINS: will match if Content relates to all of the given ids through given relation field
  */
-class FieldRelation extends Criterion implements CriterionInterface
+class FieldRelation extends Criterion
 {
     public function getSpecifications()
     {
@@ -34,8 +33,13 @@ class FieldRelation extends Criterion implements CriterionInterface
         );
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self($target, $operator, $value);
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/FullText.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/FullText.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 use eZ\Publish\API\Repository\Values\Content\Query\CustomFieldInterface;
 
 /**
@@ -48,7 +47,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\CustomFieldInterface;
  * - Simple stop word removal might be applied to the words provided in the
  *   query.
  */
-class FullText extends Criterion implements CriterionInterface, CustomFieldInterface
+class FullText extends Criterion implements CustomFieldInterface
 {
     /**
      * Fuzziness of the fulltext search.
@@ -123,8 +122,13 @@ class FullText extends Criterion implements CriterionInterface, CustomFieldInter
         );
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self($value);
     }
 

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LanguageCode.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LanguageCode.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 
 /**
@@ -20,7 +19,7 @@ use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
  * - IN: matches against a list of language codes
  * - EQ: matches against one language code
  */
-class LanguageCode extends Criterion implements CriterionInterface
+class LanguageCode extends Criterion
 {
     /**
      * Switch for matching Content that is always-available.
@@ -66,10 +65,12 @@ class LanguageCode extends Criterion implements CriterionInterface
     }
 
     /**
-     * @todo needs to be updated for $matchAlwaysAvailable
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
      */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self($value);
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location.php
@@ -9,11 +9,10 @@
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 
 /**
  * This is the base class for Location criterions.
  */
-abstract class Location extends Criterion implements CriterionInterface
+abstract class Location extends Criterion
 {
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location/IsMainLocation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location/IsMainLocation.php
@@ -55,8 +55,13 @@ class IsMainLocation extends Location
         );
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self($value);
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location/Priority.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location/Priority.php
@@ -44,8 +44,13 @@ class Priority extends Location
         );
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self($operator, $value);
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LocationId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LocationId.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 
 /**
  * A criterion that matches content based on its own location id.
@@ -21,7 +20,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
  * - IN: matches against a list of location ids
  * - EQ: matches against a unique location id
  */
-class LocationId extends Criterion implements CriterionInterface
+class LocationId extends Criterion
 {
     /**
      * Creates a new LocationId criterion.
@@ -52,8 +51,13 @@ class LocationId extends Criterion implements CriterionInterface
         );
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self($value);
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LocationRemoteId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LocationRemoteId.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 
 /**
  * A criterion that matches content based on remote ID of its locations.
@@ -19,7 +18,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
  * - IN: will match from a list of location remote IDs
  * - EQ: will match against one location remote ID
  */
-class LocationRemoteId extends Criterion implements CriterionInterface
+class LocationRemoteId extends Criterion
 {
     /**
      * Creates a new locationRemoteId criterion.
@@ -50,8 +49,13 @@ class LocationRemoteId extends Criterion implements CriterionInterface
         );
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self($value);
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOperator.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOperator.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
+use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use InvalidArgumentException;
 
@@ -51,5 +52,16 @@ abstract class LogicalOperator extends Criterion
             }
             $this->criteria[] = $criterion;
         }
+    }
+
+    /**
+     * @deprecated in LogicalOperators since 7.2.
+     * It will be removed in 8.0 when Logical Operator no longer extends Criterion.
+     */
+    public function getSpecifications()
+    {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
+        throw new NotImplementedException('getSpecifications() not implemented for LogicalOperators');
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MapLocationDistance.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MapLocationDistance.php
@@ -11,7 +11,6 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Value\MapLocationValue;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 use eZ\Publish\API\Repository\Values\Content\Query\CustomFieldInterface;
 
 /**
@@ -19,7 +18,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\CustomFieldInterface;
  *
  * Provides content filtering based on distance from geographical location.
  */
-class MapLocationDistance extends Criterion implements CriterionInterface, CustomFieldInterface
+class MapLocationDistance extends Criterion implements CustomFieldInterface
 {
     /**
      * Custom field definitions to query instead of default field.

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchAll.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchAll.php
@@ -9,12 +9,11 @@
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 
 /**
  * A criterion that just matches everything.
  */
-class MatchAll extends Criterion implements CriterionInterface
+class MatchAll extends Criterion
 {
     /**
      * Creates a new MatchAll criterion.
@@ -29,8 +28,13 @@ class MatchAll extends Criterion implements CriterionInterface
         return array();
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self();
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchNone.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchNone.php
@@ -9,7 +9,6 @@
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 
 /**
  * A criterion that just matches nothing.
@@ -17,7 +16,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
  * Useful for BlockingLimitation type, where a limitation is typically missing and needs to
  * tell the system should block everything within the OR conditions it might be part of.
  */
-class MatchNone extends Criterion implements CriterionInterface
+class MatchNone extends Criterion
 {
     public function __construct()
     {
@@ -29,8 +28,13 @@ class MatchNone extends Criterion implements CriterionInterface
         return array();
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self();
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MoreLikeThis.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MoreLikeThis.php
@@ -10,13 +10,12 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 
 /**
  * A more like this criterion is matched by content which contains similar terms
  * found in the given content, text or url fetch.
  */
-class MoreLikeThis extends Criterion implements CriterionInterface
+class MoreLikeThis extends Criterion
 {
     const CONTENT = 1;
     const TEXT = 2;
@@ -51,8 +50,13 @@ class MoreLikeThis extends Criterion implements CriterionInterface
         );
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self($value);
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ObjectStateId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ObjectStateId.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 
 /**
  * A criterion that matches content based on its state.
@@ -19,7 +18,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
  * - IN: matches against a list of object state IDs
  * - EQ: matches against one object state ID
  */
-class ObjectStateId extends Criterion implements CriterionInterface
+class ObjectStateId extends Criterion
 {
     /**
      * Creates a new ObjectStateId criterion.
@@ -50,8 +49,13 @@ class ObjectStateId extends Criterion implements CriterionInterface
         );
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self($value);
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ParentLocationId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ParentLocationId.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 
 /**
  * A criterion that matches content based on its parent location id.
@@ -21,7 +20,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
  * - IN: matches against a list of location ids
  * - EQ: matches against a unique location id
  */
-class ParentLocationId extends Criterion implements CriterionInterface
+class ParentLocationId extends Criterion
 {
     /**
      * Creates a new ParentLocationId criterion.
@@ -52,8 +51,13 @@ class ParentLocationId extends Criterion implements CriterionInterface
         );
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self($value);
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/RemoteId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/RemoteId.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 
 /**
  * A criterion that matches content based on its RemoteId.
@@ -19,7 +18,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
  * - IN: will match from a list of RemoteId
  * - EQ: will match against one RemoteId
  */
-class RemoteId extends Criterion implements CriterionInterface
+class RemoteId extends Criterion
 {
     /**
      * Creates a new remoteId criterion.
@@ -50,8 +49,13 @@ class RemoteId extends Criterion implements CriterionInterface
         );
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self($value);
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/SectionId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/SectionId.php
@@ -10,14 +10,13 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 
 /**
  * SectionId Criterion.
  *
  * Will match content that belongs to one of the given sections
  */
-class SectionId extends Criterion implements CriterionInterface
+class SectionId extends Criterion
 {
     /**
      * Creates a new Section criterion.
@@ -50,8 +49,13 @@ class SectionId extends Criterion implements CriterionInterface
         );
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self($value);
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Subtree.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Subtree.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 use InvalidArgumentException;
 
 /**
@@ -18,7 +17,7 @@ use InvalidArgumentException;
  *
  * Content will be matched if it is part of at least one of the given subtree path strings
  */
-class Subtree extends Criterion implements CriterionInterface
+class Subtree extends Criterion
 {
     /**
      * Creates a new SubTree criterion.
@@ -55,8 +54,13 @@ class Subtree extends Criterion implements CriterionInterface
         );
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self($value);
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/UserMetadata.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/UserMetadata.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 use InvalidArgumentException;
 
 /**
@@ -29,7 +28,7 @@ use InvalidArgumentException;
  * );
  * </code>
  */
-class UserMetadata extends Criterion implements CriterionInterface
+class UserMetadata extends Criterion
 {
     /**
      * UserMetadata target: Owner user.

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Visibility.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Visibility.php
@@ -10,7 +10,6 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications;
-use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 use InvalidArgumentException;
 
 /**
@@ -20,7 +19,7 @@ use InvalidArgumentException;
  * content within the tree you are searching for if content has visible location elsewhere.
  * This is intentional and you should rather use LocationSearch if this is not the behaviour you want.
  */
-class Visibility extends Criterion implements CriterionInterface
+class Visibility extends Criterion
 {
     /**
      * Visibility constant: visible.
@@ -59,8 +58,13 @@ class Visibility extends Criterion implements CriterionInterface
         );
     }
 
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self($value);
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/CriterionInterface.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/CriterionInterface.php
@@ -13,46 +13,4 @@ namespace eZ\Publish\API\Repository\Values\Content\Query;
  */
 interface CriterionInterface
 {
-    /**
-     * Creates a new Criterion for $target with operator $operator on $value.
-     *
-     * @param string $target The target (field identifier for a field, metadata identifier, etc)
-     * @param string $operator The criterion operator, from Criterion\Operator
-     * @param mixed $value The Criterion value, either as an individual item or an array
-     *
-     *@return CriterionInterface
-     */
-    public static function createFromQueryBuilder($target, $operator, $value);
-
-    /**
-     * Criterion description function.
-     *
-     * Returns the combination of the Criterion's supported operator/value,
-     * as an array of eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications objects
-     * - Operator is one supported Operator, as an Operator::* constant
-     * - ValueType is the type of input value this operator requires, either array or single
-     * - SupportedTypes is an array of types the operator will accept
-     * - ValueCountLimitation is an integer saying how many values are expected.
-     *
-     * <code>
-     * // IN and EQ are supported
-     * return array(
-     *     // The EQ operator expects a single value, either as an integer or a string
-     *     new Specifications(
-     *         Operator::EQ,
-     *         Specifications::INPUT_TYPE_SINGLE,
-     *         array( Specifications::INPUT_VALUE_INTEGER, Specifications::INPUT_VALUE_STRING ),
-     *     ),
-     *     // The IN operator expects an array of values, of either integers or strings
-     *     new Specifications(
-     *         Operator::IN,
-     *         Specifications::INPUT_TYPE_ARRAY,
-     *         array( Specifications::INPUT_VALUE_INTEGER, Specifications::INPUT_VALUE_STRING )
-     *     )
-     * )*
-     * </code>
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator\Specifications[]
-     */
-    public function getSpecifications();
 }

--- a/eZ/Publish/Core/Repository/Values/Content/Query/Criterion/PermissionSubtree.php
+++ b/eZ/Publish/Core/Repository/Values/Content/Query/Criterion/PermissionSubtree.php
@@ -23,8 +23,13 @@ use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree as APISubtr
  */
 class PermissionSubtree extends APISubtreeCriterion
 {
+    /**
+     * @deprecated since 7.2, will be removed in 8.0. Use the constructor directly instead.
+     */
     public static function createFromQueryBuilder($target, $operator, $value)
     {
+        @trigger_error('The ' . __METHOD__ . ' method is deprecated since version 7.2 and will be removed in 8.0.', E_USER_DEPRECATED);
+
         return new self($value);
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-27743](https://jira.ez.no/browse/EZP-27743)
| **Bug/Improvement**| Improvement
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | yes
| **Tests pass**     | yes
| **Doc needed**     | yes

This PR is one of the series that aims at cleaning up the code related to Criterions.
Current issues:
* The abstract class `eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOperator` doesn't implement `eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface`, but extends `eZ\Publish\API\Repository\Values\Content\Query\Criterion` abstract class instead. This makes `CriterionInterface` not used almost at all, and it leads to `CriterionInterface|LogicalOperator` return type hint combo when it would make sense to have only CriterionInterface instead (see https://github.com/ezsystems/ezpublish-kernel/pull/2035).
* All classes extending abstract class `Criterion` implement `CriterionInterface`, even though `Criterion` does not. However, `Criterion` abstract class uses `getSpecifications` method that is present in `CriterionInterface`, and not in `Criterion`.
* The abstract class `LogicalOperator` extends `Criterion` abstract class, but doesn't use any code from there:
   * `LogicalOperator` doesn't use the constructor from the `Criterion` class, it overwrites it completely: https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOperator.php#L34 
   * As a result, `LogicalOperator` doesn't use the `getValueTypeCheckCallback` private function from `Criterion` class: https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php#L123
   * `LogicalOperator` inherits `createFromQueryBuilder` function from `Criterion` class, which looks plain wrong in `LogicalOperator`'s scope (it passes three arguments to the constructor when `LogicalOperator` has only one and it is different one): https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php#L149
   * `LogicalOperator` declares its own attribute and I don't think the attributes from `Criterion` class make much sense in `LogicalOperator`'s scope: https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOperator.php#L2

What this PR fixes:
* The abstract class `Criterion` now implements interface `CriterionInterface`.
* The `createFromQueryBuilder` and `getSpecifications` methods were moved from `CriterionInterface` to `Criterion` abstract class (the former was already there). This was done because neither of these methods is supposed to be implemented by `LogicalOperator`, which will implement this interface directly in the future.
* The method `createFromQueryBuilder` mentioned in the previous point was deprecated. This was done because I couldn't find any code that depends on it and under the hood it just calls the constructor. I think that one way to create an object is enough unless another way is specifically required.
* Since the abstract class `Criterion` now implements interface `CriterionInterface`, all classes that extend the `Criterion` no longer need to directly implement this interface, so `implements CriterionInterface` was removed from them.
* Abstract class `LogicalOperator` now has the new method `getSpecifications` which throws `eZ\Publish\API\Repository\Exceptions\NotImplementedException` and is immediately deprecated. This is a temporary measure until `LogicalOperator` will no longer extend `Criterion`.

This PR shouldn't break any code that depends on changed classes.

What is planned to be done:
* Remove `extends Criterion` from `LogicalOperator` and replace it with `implements CriterionInterface`. This will be done as part of 8.0 since it is a major BC break (types are changed).
* Check the codebase for all usages of `Criterion`, `CriterionInterface` and `LogicalOperator`. Change the usages where appropriate (`Criterion` should be used when singular Criterion should be expected, `LogicalOperator` when the operator should be expected and `CriterionInterface` when either can be expected). This should fix all `CriterionInterface|LogicalOperator` return type hint combos (among other things).

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests (skipped).
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
