### PR TITLE
EZEE-1976: Cannot display Home when Content / Read has everything selected in State

### DIFF
--- a/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
@@ -126,6 +126,11 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
             throw new InvalidArgumentException('$object', 'Must be of type: Content, VersionInfo or ContentInfo');
         }
 
+        // Skip evaluating for RootLocation
+        if (0 === $object->id) {
+            return true;
+        }
+
         if (empty($limitationValues)) {
             return false;
         }
@@ -286,6 +291,8 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
      *
      * @return mixed[]|int In case of array, a hash with key as valid limitations value and value as human readable name
      *                     of that option, in case of int on of VALUE_SCHEMA_ constants.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException
      */
     public function valueSchema()
     {

--- a/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
@@ -127,7 +127,7 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
         }
 
         // Skip evaluating for RootLocation
-        if (0 === $object->id) {
+        if (1 === $object->mainLocationId) {
             return true;
         }
 

--- a/eZ/Publish/Core/Limitation/Tests/ObjectStateLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/ObjectStateLimitationTypeTest.php
@@ -146,7 +146,7 @@ class ObjectStateLimitationTypeTest extends Base
             // RootLocation, no object states assigned
             [
                 'limitation' => new ObjectStateLimitation(['limitationValues' => [1, 3]]),
-                'object' => new ContentInfo(['id' => 0, 'published' => true]),
+                'object' => new ContentInfo(['id' => 0, 'mainLocationId' => 1, 'published' => true]),
                 'expected' => true,
             ],
         ];

--- a/eZ/Publish/Core/Limitation/Tests/ObjectStateLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/ObjectStateLimitationTypeTest.php
@@ -143,6 +143,12 @@ class ObjectStateLimitationTypeTest extends Base
                 'object' => new ContentInfo(['id' => 1, 'published' => false]),
                 'expected' => true,
             ],
+            // RootLocation, no object states assigned
+            [
+                'limitation' => new ObjectStateLimitation(['limitationValues' => [1, 3]]),
+                'object' => new ContentInfo(['id' => 0, 'published' => true]),
+                'expected' => true,
+            ],
         ];
     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZEE-1976](https://jira.ez.no/browse/EZEE-1976)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.1` 
| **BC breaks**      | no
| **Tests pass**     | 
| **Doc needed**     | no

As there are no existing object states assigned to contentInfo at location 0, we can skip whole evaluation process.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
