### PR TITLE
EZP-29211: Fixed logs for missing cache items in the methods using AbstractHandler::getMultipleCacheItems

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -102,7 +102,7 @@ class ContentHandler extends AbstractHandler implements ContentHandlerInterface
             $contentIds,
             'ez-content-info-',
             function (array $cacheMissIds) {
-                $this->logger->logCall(__METHOD__, ['content' => $cacheMissIds]);
+                $this->logger->logCall(__CLASS__ . '::loadContentInfoList', ['content' => $cacheMissIds]);
 
                 return $this->persistenceHandler->contentHandler()->loadContentInfoList($cacheMissIds);
             },

--- a/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
@@ -90,7 +90,7 @@ class ContentTypeHandler extends AbstractHandler implements ContentTypeHandlerIn
             $groupIds,
             'ez-content-type-group-',
             function (array $cacheMissIds) {
-                $this->logger->logCall(__METHOD__, ['groups' => $cacheMissIds]);
+                $this->logger->logCall(__CLASS__ . '::loadGroups', ['groups' => $cacheMissIds]);
 
                 return $this->persistenceHandler->contentTypeHandler()->loadGroups($cacheMissIds);
             },


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29211](https://jira.ez.no/browse/EZP-29211)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `7.x` 
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Missing cache items in the methods using AbstractHandler::getMultipleCacheItems should be logged as `FQCN::method` instead of `FQCN\{closure}` e.g. `\eZ\Publish\Core\Persistence\Cache\ContentHandler::loadContentInfoList` instread of `\eZ\Publish\Core\Persistence\Cache\ContentHandler\{closure}`

Otherwise 
https://github.com/ezsystems/ezpublish-kernel/blob/e2d26faa54715675fc8f1eef3defbe192973bf5b/eZ/Bundle/EzPublishDebugBundle/Collector/PersistenceCacheCollector.php#L77
will cause `Notice: Undefined offset: 1` error when eZ Platform tab is opened in the Symfony Profiler

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
