### PR TITLE
Add a star to ezsystems/ezplatform when ezpublish-kernel is installed.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,10 @@
         "branch-alias": {
             "dev-master": "7.2.x-dev",
             "dev-tmp_ci_branch": "7.2.x-dev"
+        },
+        "thanks": {
+            "name": "ezsystems/ezplatform",
+            "url": "https://github.com/ezsystems/ezplatform"
         }
     }
 }


### PR DESCRIPTION
This PR solves this PR: https://github.com/symfony/thanks/pull/57 on the eZ side.

After a quick discussion with @nicolas-grekas and the fact eZ is not using any git subtree or anything.

`ezpublish-kernel` is always required and a forward "thanks" is a better option. I am closing the PR on symfony/thanks in favor of that one. 
