### PR TITLE
EZP-28950 Correct legacy instructions, site.ini is the best place for DB charset

### DIFF
--- a/doc/upgrade/7.2.md
+++ b/doc/upgrade/7.2.md
@@ -26,9 +26,8 @@ doctrine:
 ```
 Also make the corresponding change in `app/config/dfs/dfs.yml`.
 
-For legacy, in `ezpublish_legacy/settings/i18n.ini`, set the following:
+For legacy, in `ezpublish_legacy/settings/site.ini`, set the following:
 ```
-[CharacterSettings]
+[DatabaseSettings]
 Charset=utf8mb4
-HTTPCharset=utf-8
 ```


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28950](https://jira.ez.no/browse/EZP-28950)
| **Bug/Improvement**| bug
| **New feature**    | no
| **Target version** | 7.2
| **BC breaks**      | no
| **Tests pass**     | doc only
| **Doc needed**     | yes

[The original PR #2277](https://github.com/ezsystems/ezpublish-kernel/pull/2277) had this change in i18n.ini, for reasons unknown/forgotten. It should work fine according to docs, and no problem was found in testing. But @emodric [reported failures](https://github.com/ezsystems/ezpublish-kernel/pull/2277#discussion_r189580624) due to the mysql `utf8mb4` charset being expected in ini-files and templates. As he pointed out, site.ini is the right/best place for the DB charset, since you may want to have different charset in db and elsewhere.

Refs:
https://github.com/ezsystems/ezpublish-legacy/blob/master/settings/site.ini#L82
https://github.com/ezsystems/ezpublish-legacy/blob/master/settings/i18n.ini#L23
https://doc.ez.no/eZ-Publish/Technical-manual/4.x/Reference/Configuration-files/site.ini/DatabaseSettings/Charset
https://doc.ez.no/eZ-Publish/Technical-manual/4.x/Reference/Configuration-files/i18n.ini/CharacterSettings/Charset