### PR TITLE
EZP-29206: MySQL deadlock errors happen when concurrently moving subtree

### DIFF
--- a/data/mysql/schema.sql
+++ b/data/mysql/schema.sql
@@ -625,7 +625,8 @@ CREATE TABLE `ezcontentobject` (
   KEY `ezcontentobject_lmask` (`language_mask`),
   KEY `ezcontentobject_owner` (`owner_id`),
   KEY `ezcontentobject_pub` (`published`),
-  KEY `ezcontentobject_status` (`status`)
+  KEY `ezcontentobject_status` (`status`),
+  KEY `ezcontentobject_section` (`section_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -764,7 +765,8 @@ CREATE TABLE `ezcontentobject_tree` (
   KEY `ezcontentobject_tree_p_node_id` (`parent_node_id`),
   KEY `ezcontentobject_tree_path` (`path_string`),
   KEY `ezcontentobject_tree_path_ident` (`path_identification_string`(50)),
-  KEY `modified_subnode` (`modified_subnode`)
+  KEY `modified_subnode` (`modified_subnode`),
+  KEY `ezcontentobject_tree_contentobject_id_path_string` (`path_string`, `contentobject_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/data/update/mysql/dbupdate-6.7.7-to-6.7.8.sql
+++ b/data/update/mysql/dbupdate-6.7.7-to-6.7.8.sql
@@ -1,0 +1,6 @@
+SET default_storage_engine=InnoDB;
+-- Set storage engine schema version number
+UPDATE ezsite_data SET value='6.7.8' WHERE name='ezpublish-version';
+
+CREATE INDEX `ezcontentobject_tree_contentobject_id_path_string` ON `ezcontentobject_tree` (`path_string`, `contentobject_id`);
+CREATE INDEX `ezcontentobject_section` ON `ezcontentobject` (`section_id`);

--- a/data/update/postgres/dbupdate-6.7.7-to-6.7.8.sql
+++ b/data/update/postgres/dbupdate-6.7.7-to-6.7.8.sql
@@ -1,0 +1,5 @@
+-- Set storage engine schema version number
+UPDATE ezsite_data SET value='6.7.8' WHERE name='ezpublish-version';
+
+CREATE INDEX ezcontentobject_tree_contentobject_id_path_string ON ezcontentobject_tree (path_string, contentobject_id);
+CREATE INDEX ezcontentobject_section ON ezcontentobject (section_id);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.mysql.sql
@@ -207,7 +207,8 @@ CREATE TABLE ezcontentobject (
   KEY ezcontentobject_owner (owner_id),
   KEY ezcontentobject_pub (published),
   UNIQUE KEY ezcontentobject_remote_id (remote_id),
-  KEY ezcontentobject_status (status)
+  KEY ezcontentobject_status (status),
+  KEY ezcontentobject_section (section_id)
 ) ENGINE=InnoDB;
 
 DROP TABLE IF EXISTS ezcontentobject_attribute;
@@ -311,7 +312,8 @@ CREATE TABLE ezcontentobject_tree (
   KEY ezcontentobject_tree_p_node_id (parent_node_id),
   KEY ezcontentobject_tree_path (path_string),
   KEY ezcontentobject_tree_path_ident (path_identification_string(50)),
-  KEY modified_subnode (modified_subnode)
+  KEY modified_subnode (modified_subnode),
+  KEY ezcontentobject_tree_contentobject_id_path_string (path_string, contentobject_id)
 ) ENGINE=InnoDB;
 
 DROP TABLE IF EXISTS ezcontentobject_version;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.pgsql.sql
@@ -609,6 +609,8 @@ CREATE UNIQUE INDEX ezcontentobject_remote_id ON ezcontentobject USING btree (re
 
 CREATE INDEX ezcontentobject_status ON ezcontentobject USING btree (status);
 
+CREATE INDEX ezcontentobject_section ON ezcontentobject USING btree (section_id);
+
 CREATE INDEX ezcontentobject_attribute_co_id_ver_lang_code ON ezcontentobject_attribute USING btree (contentobject_id, "version", language_code);
 
 CREATE INDEX ezcontentobject_attribute_language_code ON ezcontentobject_attribute USING btree (language_code);
@@ -652,6 +654,8 @@ CREATE INDEX ezcontentobject_tree_p_node_id ON ezcontentobject_tree USING btree 
 CREATE INDEX ezcontentobject_tree_path ON ezcontentobject_tree USING btree (path_string);
 
 CREATE INDEX ezcontentobject_tree_path_ident ON ezcontentobject_tree USING btree (path_identification_string);
+
+CREATE INDEX ezcontentobject_tree_contentobject_id_path_string ON ezcontentobject_tree USING btree (path_string, contentobject_id);
 
 CREATE INDEX modified_subnode ON ezcontentobject_tree USING btree (modified_subnode);
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/_fixtures/schema.sqlite.sql
@@ -189,6 +189,7 @@ CREATE INDEX ezcontentobject_lmask ON ezcontentobject (language_mask);
 CREATE INDEX ezcontentobject_owner ON ezcontentobject (owner_id);
 CREATE INDEX ezcontentobject_pub ON ezcontentobject (published);
 CREATE INDEX ezcontentobject_status ON ezcontentobject (status);
+CREATE INDEX ezcontentobject_section ON ezcontentobject (section_id);
 
 CREATE TABLE ezcontentobject_attribute (
   attribute_original_id integer DEFAULT 0,
@@ -286,6 +287,7 @@ CREATE INDEX ezcontentobject_tree_p_node_id ON ezcontentobject_tree (parent_node
 CREATE INDEX ezcontentobject_tree_path ON ezcontentobject_tree (path_string);
 CREATE INDEX ezcontentobject_tree_path_ident ON ezcontentobject_tree (path_identification_string);
 CREATE INDEX modified_subnode ON ezcontentobject_tree (modified_subnode);
+CREATE INDEX ezcontentobject_tree_contentobject_id_path_string ON ezcontentobject_tree (path_string, contentobject_id);
 
 CREATE TABLE ezcontentobject_version (
   contentobject_id integer,


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29206](https://jira.ez.no/browse/EZP-29206)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.7` and up.
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This PR presents one of the possible solutions for database deadlocks that occur when concurrently moving subtree. The solution was suggested by the Customer and improved by us.

The solution splits update-where-id-in-select query into two separate queries to avoid locks. While possible deadlocks are documented for InnoDB and solution is to set proper indices, there's no solution for the case when update and select operate on different tables.

Therefore obvious choice would be to split these operations. I was reluctant to do so because that introduces possible race condition between these select and update. However I haven't found so far real example where this would fail, so I'm presenting this as a possible solution.

**TODO**:
- [x] Split fetching content type Ids for update and update query into two separate queries
- [x] Introduce additional database indices.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
