### PR TITLE
EZP-29267: Convertion of links with href from ezxmltext to richtext is not supported

### DIFF
--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/ezxml/docbook/core.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/ezxml/docbook/core.xsl
@@ -260,9 +260,14 @@
           <xsl:value-of select="concat( '#', @anchor_name )"/>
         </xsl:attribute>
       </xsl:when>
+      <xsl:when test="@href">
+        <xsl:attribute name="xlink:href">
+          <xsl:value-of select="concat( '', @href )"/>
+        </xsl:attribute>
+      </xsl:when>
       <xsl:otherwise>
         <xsl:message terminate="yes">
-          Unhandled link typeccc
+          Unhandled link type
         </xsl:message>
       </xsl:otherwise>
     </xsl:choose>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29267](https://jira.ez.no/browse/EZP-29267)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `6.13`/`7.x`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Handling of tags in format `<link href="http://foobar.com" ...>` is missing in xsl stylesheet

Related [PR](https://github.com/ezsystems/ezplatform-xmltext-fieldtype/pull/45) in ezplatform-xmltext-fieldtype


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
