### PR TITLE
EZP-28890: Updated the way to set ach-UG locale for in-context transl…

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventSubscriber/CrowdinRequestLocaleSubscriber.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventSubscriber/CrowdinRequestLocaleSubscriber.php
@@ -19,7 +19,7 @@ class CrowdinRequestLocaleSubscriber implements EventSubscriberInterface
     {
         return [
             KernelEvents::REQUEST => [
-                ['setInContextAcceptLanguage', 100],
+                ['setInContextAcceptLanguage', -100],
             ],
         ];
     }
@@ -30,6 +30,6 @@ class CrowdinRequestLocaleSubscriber implements EventSubscriberInterface
             return;
         }
 
-        $e->getRequest()->headers->set('accept-language', 'ach-UG');
+        $e->getRequest()->setLocale('ach_UG');
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/EventSubscriber/CrowdinRequestLocaleSubscriber.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventSubscriber/CrowdinRequestLocaleSubscriber.php
@@ -19,7 +19,7 @@ class CrowdinRequestLocaleSubscriber implements EventSubscriberInterface
     {
         return [
             KernelEvents::REQUEST => [
-                ['setInContextAcceptLanguage', -100],
+                ['setInContextAcceptLanguage', 15],
             ],
         ];
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventSubscriber/CrowdinRequestLocaleSubscriberTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventSubscriber/CrowdinRequestLocaleSubscriberTest.php
@@ -29,7 +29,7 @@ class CrowdinRequestLocaleSubscriberTest extends TestCase
 
         $this->assertEquals(
             $shouldHaveCustomLocale,
-            'ach_UG' === $event->getRequest()->getPreferredLanguage(),
+            'ach_UG' === $event->getRequest()->getLocale(),
             'The custom ach_UG locale was expected to be set by the event subscriber'
         );
     }


### PR DESCRIPTION
…ation

| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-28890](https://jira.ez.no/browse/EZP-28890)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Updates the way the `ach-UG` locale is set:
- usage of `$request->setLocale()` to set the `ach_UG` locale
- increased the listener's priority

### Background
In-context translation by crowdin requires a pseudo-language translation to be loaded, Acholi (ach-UG). The event listener modified by this PR sets the Symfony locale when a `crowdin_in_context_translation` cookie is found.

This feature isn't really _required_, but it makes it much easier for translators to trigger in-context, as setting a custom request locale isn't very user friendly.

### TODO
- [ ] Consider using the cookie's value to set the crowdin project for in-context translation. Would allow usage of in-context for any source, including 3rd party (as long as they use crowdin).
- [ ] Figure out why the locale isn't ALWAYS changed (not on login, not on dashboard)
- [x] Implement feature / fix a bug.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
