### PR TITLE
EZP-29211: Fixed logs for missing cache items in BookmarkHandler::loadByUserIdAndLocationId

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/BookmarkHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/BookmarkHandler.php
@@ -52,7 +52,7 @@ class BookmarkHandler extends AbstractHandler implements BookmarkHandlerInterfac
             $locationIds,
             'ez-bookmark-' . $userId . '-',
             function (array $missingIds) use ($userId) {
-                $this->logger->logCall(__METHOD__, [
+                $this->logger->logCall(__CLASS__ . '::loadByUserIdAndLocationId', [
                     'userId' => $userId,
                     'locationIds' => $missingIds,
                 ]);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29211](https://jira.ez.no/browse/EZP-29211)
| **Bug/Improvement**| yes
| **New feature**    | no
| **Target version** | `master`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Same as https://github.com/ezsystems/ezpublish-kernel/pull/2334 but for `\eZ\Publish\Core\Persistence\Cache\BookmarkHandler::loadByUserIdAndLocationId` 😉 

**TODO**:
- [X] Implement feature / fix a bug.
- [X] Implement tests.
- [X] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [X] Ask for Code Review.
