### PR TITLE
EZP-25830: Selection Field Type should allow setting a default value

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/fielddefinition_settings.html.twig
@@ -149,6 +149,13 @@
 
 {% block ezselection_settings %}
 <ul class="ez-fielddefinition-settings ez-fielddefinition-{{ fielddefinition.fieldTypeIdentifier }}-settings">
+    {% set defaultValue = null %}
+    {% if settings.defaultValue %}
+        {% for value in settings.defaultValue %}
+            {% set defaultValue = defaultValue ~ settings.options[value] ~ ( not loop.last ? ', ' : '' ) %}
+        {% endfor %}
+    {% endif %}
+    {{ block( 'settings_defaultvalue' ) }}
     <li class="ez-fielddefinition-setting options">
         <div class="ez-fielddefinition-setting-name">{{ 'fielddefinition.options.label'|trans|desc("Defined options")}}</div>
         <div class="ez-fielddefinition-setting-value">

--- a/eZ/Publish/API/Repository/Tests/FieldType/SelectionIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SelectionIntegrationTest.php
@@ -45,6 +45,10 @@ class SelectionIntegrationTest extends SearchMultivaluedBaseIntegrationTest
                 'type' => 'hash',
                 'default' => array(),
             ),
+            'defaultValue' => array(
+                'type' => 'hash',
+                'default' => array(),
+            ),
         );
     }
 
@@ -64,6 +68,7 @@ class SelectionIntegrationTest extends SearchMultivaluedBaseIntegrationTest
                 3 => 'Turtles',
                 4 => 'Zombies',
             ),
+            'defaultValue' => array(),
         );
     }
 
@@ -78,6 +83,7 @@ class SelectionIntegrationTest extends SearchMultivaluedBaseIntegrationTest
             'somethingUnknown' => 0,
             'isMultiple' => array(),
             'options' => new \stdClass(),
+            'defaultValue' => 'bad',
         );
     }
 

--- a/eZ/Publish/Core/FieldType/Selection/Type.php
+++ b/eZ/Publish/Core/FieldType/Selection/Type.php
@@ -30,16 +30,20 @@ class Type extends FieldType
      *
      * @var mixed
      */
-    protected $settingsSchema = array(
-        'isMultiple' => array(
+    protected $settingsSchema = [
+        'isMultiple' => [
             'type' => 'bool',
             'default' => false,
-        ),
-        'options' => array(
+        ],
+        'options' => [
             'type' => 'hash',
-            'default' => array(),
-        ),
-    );
+            'default' => [],
+        ],
+        'defaultValue' => [
+            'type' => 'hash',
+            'default' => [],
+        ],
+    ];
 
     /**
      * Validates the fieldSettings of a FieldDefinitionCreateStruct or FieldDefinitionUpdateStruct.
@@ -50,7 +54,7 @@ class Type extends FieldType
      */
     public function validateFieldSettings($fieldSettings)
     {
-        $validationErrors = array();
+        $validationErrors = [];
 
         foreach ($fieldSettings as $settingKey => $settingValue) {
             switch ($settingKey) {
@@ -59,11 +63,11 @@ class Type extends FieldType
                         $validationErrors[] = new ValidationError(
                             "FieldType '%fieldType%' expects setting '%setting%' to be of type '%type%'",
                             null,
-                            array(
+                            [
                                 '%fieldType%' => $this->getFieldTypeIdentifier(),
                                 '%setting%' => $settingKey,
                                 '%type%' => 'bool',
-                            ),
+                            ],
                             "[$settingKey]"
                         );
                     }
@@ -73,22 +77,45 @@ class Type extends FieldType
                         $validationErrors[] = new ValidationError(
                             "FieldType '%fieldType%' expects setting '%setting%' to be of type '%type%'",
                             null,
-                            array(
+                            [
                                 '%fieldType%' => $this->getFieldTypeIdentifier(),
                                 '%setting%' => $settingKey,
                                 '%type%' => 'hash',
-                            ),
+                            ],
                             "[$settingKey]"
                         );
+                    }
+                    break;
+                case 'defaultValue':
+                    if (!is_array($settingValue)) {
+                        $validationErrors[] = new ValidationError(
+                            "FieldType '%fieldType%' expects setting '%setting%' to be of type '%type%'",
+                            null,
+                            [
+                                '%fieldType%' => $this->getFieldTypeIdentifier(),
+                                '%setting%' => $settingKey,
+                                '%type%' => 'hash',
+                            ],
+                            "[$settingKey]"
+                        );
+                    } else {
+                        if (!$fieldSettings['isMultiple'] && count($settingValue) > 1) {
+                            $validationErrors[] = new ValidationError(
+                                'Multiple choices option must be set to define more than one default value',
+                                null,
+                                [],
+                                "[$settingKey]"
+                            );
+                        }
                     }
                     break;
                 default:
                     $validationErrors[] = new ValidationError(
                         "Setting '%setting%' is unknown",
                         null,
-                        array(
+                        [
                             '%setting%' => $settingKey,
-                        ),
+                        ],
                         "[$settingKey]"
                     );
             }
@@ -181,7 +208,7 @@ class Type extends FieldType
      */
     public function validate(FieldDefinition $fieldDefinition, SPIValue $fieldValue)
     {
-        $validationErrors = array();
+        $validationErrors = [];
 
         if ($this->isEmptyValue($fieldValue)) {
             return $validationErrors;
@@ -194,7 +221,7 @@ class Type extends FieldType
             $validationErrors[] = new ValidationError(
                 'Field definition does not allow multiple options to be selected.',
                 null,
-                array(),
+                [],
                 'selection'
             );
         }
@@ -204,9 +231,9 @@ class Type extends FieldType
                 $validationErrors[] = new ValidationError(
                     'Option with index %index% does not exist in the field definition.',
                     null,
-                    array(
+                    [
                         '%index%' => $optionIndex,
-                    ),
+                    ],
                     'selection'
                 );
             }

--- a/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
@@ -46,7 +46,7 @@ class SelectionTest extends FieldTypeTest
      */
     protected function getValidatorConfigurationSchemaExpectation()
     {
-        return array();
+        return [];
     }
 
     /**
@@ -56,16 +56,20 @@ class SelectionTest extends FieldTypeTest
      */
     protected function getSettingsSchemaExpectation()
     {
-        return array(
-            'isMultiple' => array(
+        return [
+            'isMultiple' => [
                 'type' => 'bool',
                 'default' => false,
-            ),
-            'options' => array(
+            ],
+            'options' => [
                 'type' => 'hash',
-                'default' => array(),
-            ),
-        );
+                'default' => [],
+            ],
+            'defaultValue' => [
+                'type' => 'hash',
+                'default' => [],
+            ],
+        ];
     }
 
     /**
@@ -103,16 +107,16 @@ class SelectionTest extends FieldTypeTest
      */
     public function provideInvalidInputForAcceptValue()
     {
-        return array(
-            array(
+        return [
+            [
                 23,
                 InvalidArgumentException::class,
-            ),
-            array(
+            ],
+            [
                 'sindelfingen',
                 InvalidArgumentException::class,
-            ),
-        );
+            ],
+        ];
     }
 
     /**
@@ -146,24 +150,24 @@ class SelectionTest extends FieldTypeTest
      */
     public function provideValidInputForAcceptValue()
     {
-        return array(
-            array(
-                array(),
+        return [
+            [
+                [],
                 new SelectionValue(),
-            ),
-            array(
-                array(23),
-                new SelectionValue(array(23)),
-            ),
-            array(
-                array(23, 42),
-                new SelectionValue(array(23, 42)),
-            ),
-            array(
-                new SelectionValue(array(23, 42)),
-                new SelectionValue(array(23, 42)),
-            ),
-        );
+            ],
+            [
+                [23],
+                new SelectionValue([23]),
+            ],
+            [
+                [23, 42],
+                new SelectionValue([23, 42]),
+            ],
+            [
+                new SelectionValue([23, 42]),
+                new SelectionValue([23, 42]),
+            ],
+        ];
     }
 
     /**
@@ -203,16 +207,16 @@ class SelectionTest extends FieldTypeTest
      */
     public function provideInputForToHash()
     {
-        return array(
-            array(
+        return [
+            [
                 new SelectionValue(),
-                array(),
-            ),
-            array(
-                new SelectionValue(array(23, 42)),
-                array(23, 42),
-            ),
-        );
+                [],
+            ],
+            [
+                new SelectionValue([23, 42]),
+                [23, 42],
+            ],
+        ];
     }
 
     /**
@@ -252,16 +256,16 @@ class SelectionTest extends FieldTypeTest
      */
     public function provideInputForFromHash()
     {
-        return array(
-            array(
-                array(),
+        return [
+            [
+                [],
                 new SelectionValue(),
-            ),
-            array(
-                array(23, 42),
-                new SelectionValue(array(23, 42)),
-            ),
-        );
+            ],
+            [
+                [23, 42],
+                new SelectionValue([23, 42]),
+            ],
+        ];
     }
 
     /**
@@ -288,23 +292,25 @@ class SelectionTest extends FieldTypeTest
      */
     public function provideValidFieldSettings()
     {
-        return array(
-            array(
-                array(),
-            ),
-            array(
-                array(
+        return [
+            [
+                [],
+            ],
+            [
+                [
                     'isMultiple' => true,
-                    'options' => array('foo', 'bar'),
-                ),
-            ),
-            array(
-                array(
+                    'options' => ['foo', 'bar'],
+                    'defaultValue' => [0, 1],
+                ],
+            ],
+            [
+                [
                     'isMultiple' => false,
-                    'options' => array(23, 42),
-                ),
-            ),
-        );
+                    'options' => [23, 42],
+                    'defaultValue' => [1],
+                ],
+            ],
+        ];
     }
 
     /**
@@ -332,20 +338,26 @@ class SelectionTest extends FieldTypeTest
      */
     public function provideInValidFieldSettings()
     {
-        return array(
-            array(
-                array(
+        return [
+            [
+                [
                     // isMultiple must be bool
                     'isMultiple' => 23,
-                ),
-            ),
-            array(
-                array(
+                ],
+            ],
+            [
+                [
                     // options must be array
                     'options' => 23,
-                ),
-            ),
-        );
+                ],
+            ],
+            [
+                [
+                    // defaultValue must be array
+                    'defaultValue' => 23,
+                ],
+            ],
+        ];
     }
 
     protected function provideFieldTypeIdentifier()
@@ -364,9 +376,9 @@ class SelectionTest extends FieldTypeTest
 
     public function provideDataForGetName()
     {
-        return array(
-            array($this->getEmptyValueExpectation(), ''),
-        );
+        return [
+            [$this->getEmptyValueExpectation(), ''],
+        ];
     }
 
     /**
@@ -416,35 +428,38 @@ class SelectionTest extends FieldTypeTest
      */
     public function provideValidDataForValidate()
     {
-        return array(
-            array(
-                array(
-                    'fieldSettings' => array(
+        return [
+            [
+                [
+                    'fieldSettings' => [
                         'isMultiple' => true,
-                        'options' => array(0 => 1, 1 => 2),
-                    ),
-                ),
-                new SelectionValue(array(0, 1)),
-            ),
-            array(
-                array(
-                    'fieldSettings' => array(
+                        'options' => [0 => 1, 1 => 2],
+                        'defaultValue' => [0, 1],
+                    ],
+                ],
+                new SelectionValue([0, 1]),
+            ],
+            [
+                [
+                    'fieldSettings' => [
                         'isMultiple' => false,
-                        'options' => array(0 => 1, 1 => 2),
-                    ),
-                ),
-                new SelectionValue(array(1)),
-            ),
-            array(
-                array(
-                    'fieldSettings' => array(
+                        'options' => [0 => 1, 1 => 2],
+                        'defaultValue' => [1],
+                    ],
+                ],
+                new SelectionValue([1]),
+            ],
+            [
+                [
+                    'fieldSettings' => [
                         'isMultiple' => false,
-                        'options' => array(0 => 1, 1 => 2),
-                    ),
-                ),
+                        'options' => [0 => 1, 1 => 2],
+                        'defaultValue' => [],
+                    ],
+                ],
                 new SelectionValue(),
-            ),
-        );
+            ],
+        ];
     }
 
     /**
@@ -513,43 +528,45 @@ class SelectionTest extends FieldTypeTest
      */
     public function provideInvalidDataForValidate()
     {
-        return array(
-            array(
-                array(
-                    'fieldSettings' => array(
+        return [
+            [
+                [
+                    'fieldSettings' => [
                         'isMultiple' => false,
-                        'options' => array(0 => 1, 1 => 2),
-                    ),
-                ),
-                new SelectionValue(array(0, 1)),
-                array(
+                        'options' => [0 => 1, 1 => 2],
+                        'defaultValue' => [1],
+                    ],
+                ],
+                new SelectionValue([0, 1]),
+                [
                     new ValidationError(
                         'Field definition does not allow multiple options to be selected.',
                         null,
-                        array(),
+                        [],
                         'selection'
                     ),
-                ),
-            ),
-            array(
-                array(
-                    'fieldSettings' => array(
+                ],
+            ],
+            [
+                [
+                    'fieldSettings' => [
                         'isMultiple' => false,
-                        'options' => array(0 => 1, 1 => 2),
-                    ),
-                ),
-                new SelectionValue(array(3)),
-                array(
+                        'options' => [0 => 1, 1 => 2],
+                        'defaultValue' => [1],
+                    ],
+                ],
+                new SelectionValue([3]),
+                [
                     new ValidationError(
                         'Option with index %index% does not exist in the field definition.',
                         null,
-                        array(
+                        [
                             '%index%' => 3,
-                        ),
+                        ],
                         'selection'
                     ),
-                ),
-            ),
-        );
+                ],
+            ],
+        ];
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
@@ -57,7 +57,7 @@ class SelectionConverter implements Converter
                 explode('-', $value->dataText)
             );
         } else {
-            $fieldValue->data = array();
+            $fieldValue->data = [];
         }
         $fieldValue->sortKey = $value->sortKeyString;
     }
@@ -93,6 +93,14 @@ class SelectionConverter implements Converter
             }
             $storageDef->dataText5 = $xml->saveXML();
         }
+
+        if ($fieldSettings['defaultValue'] == null) {
+            $fieldSettings['defaultValue'] = [];
+        }
+
+        $storageDef->dataText4 = empty($fieldSettings['defaultValue'])
+            ? ''
+            : implode(',', $fieldSettings['defaultValue']);
     }
 
     /**
@@ -103,7 +111,7 @@ class SelectionConverter implements Converter
      */
     public function toFieldDefinition(StorageFieldDefinition $storageDef, FieldDefinition $fieldDef)
     {
-        $options = array();
+        $options = [];
         $simpleXml = simplexml_load_string($storageDef->dataText5);
 
         if ($simpleXml !== false) {
@@ -112,17 +120,21 @@ class SelectionConverter implements Converter
             }
         }
 
+        $defaultValue = $storageDef->dataText4 == null
+            ? []
+            : explode(',', $storageDef->dataText4);
+
         $fieldDef->fieldTypeConstraints->fieldSettings = new FieldSettings(
-            array(
+            [
                 'isMultiple' => !empty($storageDef->dataInt1) ? (bool)$storageDef->dataInt1 : false,
                 'options' => $options,
-            )
+                'defaultValue' => $defaultValue,
+            ]
         );
 
-        // @todo: Can Selection store a default value in the DB?
         $fieldDef->defaultValue = new FieldValue();
-        $fieldDef->defaultValue->data = array();
-        $fieldDef->defaultValue->sortKey = '';
+        $fieldDef->defaultValue->data = $defaultValue;
+        $fieldDef->defaultValue->sortKey = $storageDef->dataText4;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/SelectionTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/SelectionTest.php
@@ -41,7 +41,7 @@ class SelectionTest extends TestCase
     public function testToStorageValue()
     {
         $fieldValue = new FieldValue();
-        $fieldValue->data = array(1, 3);
+        $fieldValue->data = [1, 3];
         $fieldValue->sortKey = '1-3';
 
         $expectedStorageFieldValue = new StorageFieldValue();
@@ -66,7 +66,7 @@ class SelectionTest extends TestCase
     public function testToStorageValueEmpty()
     {
         $fieldValue = new FieldValue();
-        $fieldValue->data = array();
+        $fieldValue->data = [];
         $fieldValue->sortKey = '';
 
         $expectedStorageFieldValue = new StorageFieldValue();
@@ -95,7 +95,7 @@ class SelectionTest extends TestCase
         $storageFieldValue->sortKeyString = '1-3';
 
         $expectedFieldValue = new FieldValue();
-        $expectedFieldValue->data = array(1, 3);
+        $expectedFieldValue->data = [1, 3];
         $expectedFieldValue->sortKey = '1-3';
 
         $actualFieldValue = new FieldValue();
@@ -120,7 +120,7 @@ class SelectionTest extends TestCase
         $storageFieldValue->sortKeyString = '';
 
         $expectedFieldValue = new FieldValue();
-        $expectedFieldValue->data = array();
+        $expectedFieldValue->data = [];
         $expectedFieldValue->sortKey = '';
 
         $actualFieldValue = new FieldValue();
@@ -141,26 +141,31 @@ class SelectionTest extends TestCase
     public function testToStorageFieldDefinitionMultiple()
     {
         $fieldDefinition = new PersistenceFieldDefinition(
-            array(
+            [
                 'fieldTypeConstraints' => new FieldTypeConstraints(
-                    array(
+                    [
                         'fieldSettings' => new FieldSettings(
-                            array(
+                            [
                                 'isMultiple' => true,
-                                'options' => array(
+                                'options' => [
                                     0 => 'First',
                                     1 => 'Second',
                                     2 => 'Third',
-                                ),
-                            )
+                                ],
+                                'defaultValue' => [
+                                    0,
+                                    1,
+                                ],
+                            ]
                         ),
-                    )
+                    ]
                 ),
-            )
+            ]
         );
 
         $expectedStorageFieldDefinition = new StorageFieldDefinition();
         $expectedStorageFieldDefinition->dataInt1 = 1;
+        $expectedStorageFieldDefinition->dataText4 = '0,1';
         $expectedStorageFieldDefinition->dataText5 = <<<EOT
 <?xml version="1.0" encoding="utf-8"?>
 <ezselection><options><option id="0" name="First"/><option id="1" name="Second"/><option id="2" name="Third"/></options></ezselection>
@@ -182,24 +187,28 @@ EOT;
     public function testToStorageFieldDefinitionSingle()
     {
         $fieldDefinition = new PersistenceFieldDefinition(
-            array(
+            [
                 'fieldTypeConstraints' => new FieldTypeConstraints(
-                    array(
+                    [
                         'fieldSettings' => new FieldSettings(
-                            array(
+                            [
                                 'isMultiple' => false,
-                                'options' => array(
+                                'options' => [
                                     0 => 'First',
-                                ),
-                            )
+                                ],
+                                'defaultValue' => [
+                                    0,
+                                ],
+                            ]
                         ),
-                    )
+                    ]
                 ),
-            )
+            ]
         );
 
         $expectedStorageFieldDefinition = new StorageFieldDefinition();
         $expectedStorageFieldDefinition->dataInt1 = 0;
+        $expectedStorageFieldDefinition->dataText4 = '0';
         $expectedStorageFieldDefinition->dataText5 = <<<EOT
 <?xml version="1.0" encoding="utf-8"?>
 <ezselection><options><option id="0" name="First"/></options></ezselection>
@@ -222,6 +231,7 @@ EOT;
     {
         $storageFieldDefinition = new StorageFieldDefinition();
         $storageFieldDefinition->dataInt1 = 1;
+        $storageFieldDefinition->dataText4 = '0, 1';
         $storageFieldDefinition->dataText5 = <<<EOT
 <?xml version="1.0" encoding="utf-8"?>
 <ezselection>
@@ -234,28 +244,35 @@ EOT;
 EOT;
 
         $expectedFieldDefinition = new PersistenceFieldDefinition(
-            array(
+            [
                 'fieldTypeConstraints' => new FieldTypeConstraints(
-                    array(
+                    [
                         'fieldSettings' => new FieldSettings(
-                            array(
+                            [
                                 'isMultiple' => true,
-                                'options' => array(
+                                'options' => [
                                     0 => 'First',
                                     1 => 'Second',
                                     2 => 'Third',
-                                ),
-                            )
+                                ],
+                                'defaultValue' => [
+                                    0,
+                                    1,
+                                ],
+                            ]
                         ),
-                    )
+                    ]
                 ),
                 'defaultValue' => new FieldValue(
-                    array(
-                        'data' => array(),
-                        'sortKey' => '',
-                    )
+                    [
+                        'data' => [
+                            0 => '0',
+                            1 => ' 1',
+                        ],
+                        'sortKey' => '0, 1',
+                    ]
                 ),
-            )
+            ]
         );
 
         $actualFieldDefinition = new PersistenceFieldDefinition();
@@ -274,6 +291,7 @@ EOT;
     {
         $storageFieldDefinition = new StorageFieldDefinition();
         $storageFieldDefinition->dataInt1 = 0;
+        $storageFieldDefinition->dataInt4 = '';
         $storageFieldDefinition->dataText5 = <<<EOT
 <?xml version="1.0" encoding="utf-8"?>
 <ezselection>
@@ -283,19 +301,20 @@ EOT;
 EOT;
 
         $expectedFieldDefinition = new PersistenceFieldDefinition(
-            array(
+            [
                 'fieldTypeConstraints' => new FieldTypeConstraints(
-                    array(
+                    [
                         'fieldSettings' => new FieldSettings(
-                            array(
+                            [
                                 'isMultiple' => false,
-                                'options' => array(),
-                            )
+                                'options' => [],
+                                'defaultValue' => [],
+                            ]
                         ),
-                    )
+                    ]
                 ),
-                'defaultValue' => new FieldValue(array('data' => array())),
-            )
+                'defaultValue' => new FieldValue(['data' => []]),
+            ]
         );
 
         $actualFieldDefinition = new PersistenceFieldDefinition();

--- a/eZ/Publish/SPI/Tests/FieldType/SelectionIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/SelectionIntegrationTest.php
@@ -57,19 +57,23 @@ class SelectionIntegrationTest extends BaseIntegrationTest
     public function getTypeConstraints()
     {
         return new Content\FieldTypeConstraints(
-            array(
+            [
                 'validators' => null,
                 'fieldSettings' => new FieldSettings(
-                    array(
+                    [
                         'isMultiple' => true,
-                        'options' => array(
-                            1 => 'First',
-                            2 => 'Second',
-                            3 => 'Sindelfingen',
-                        ),
-                    )
+                        'options' => [
+                            0 => 'First',
+                            1 => 'Second',
+                            2 => 'Sindelfingen',
+                        ],
+                        'defaultValue' => [
+                            0,
+                            1,
+                        ],
+                    ]
                 ),
-            )
+            ]
         );
     }
 
@@ -82,27 +86,31 @@ class SelectionIntegrationTest extends BaseIntegrationTest
      */
     public function getFieldDefinitionData()
     {
-        return array(
-            array('fieldType', 'ezselection'),
-            array(
+        return [
+            ['fieldType', 'ezselection'],
+            [
                 'fieldTypeConstraints',
                 new Content\FieldTypeConstraints(
-                    array(
+                    [
                         'validators' => null,
                         'fieldSettings' => new FieldSettings(
-                            array(
+                            [
                                 'isMultiple' => true,
-                                'options' => array(
-                                    1 => 'First',
-                                    2 => 'Second',
-                                    3 => 'Sindelfingen',
-                                ),
-                            )
+                                'options' => [
+                                    0 => 'First',
+                                    1 => 'Second',
+                                    2 => 'Sindelfingen',
+                                ],
+                                'defaultValue' => [
+                                    0,
+                                    1,
+                                ],
+                            ]
                         ),
-                    )
+                    ]
                 ),
-            ),
-        );
+            ],
+        ];
     }
 
     /**
@@ -113,11 +121,11 @@ class SelectionIntegrationTest extends BaseIntegrationTest
     public function getInitialValue()
     {
         return new Content\FieldValue(
-            array(
-                'data' => array(1, 3),
+            [
+                'data' => [1, 3],
                 'externalData' => null,
                 'sortKey' => '1-3',
-            )
+            ]
         );
     }
 
@@ -131,11 +139,11 @@ class SelectionIntegrationTest extends BaseIntegrationTest
     public function getUpdatedValue()
     {
         return new Content\FieldValue(
-            array(
-                'data' => array(2),
+            [
+                'data' => [2],
                 'externalData' => null,
                 'sortKey' => '2',
-            )
+            ]
         );
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-25830](https://jira.ez.no/browse/EZP-25830)
| **Bug/Improvement**| yes
| **Target version** | 6.13
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Options can now be checked as default values.

Added new option "defaultValue" for Selection Type inside `$settingsSchema` that stores options indexes that should be treat as default value for selection. 

Submitted values for `defaultValue` field are stored in `dataText4` after converting to a string containing default options indexes, separated by `,`.

On retrieval, the string is converted back to array and assigned to `$fieldDef->defaultValue->data`.

**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
