### PR TITLE
EZP-29167: Logged a warning about using default URL alias transformation

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SlugConverterConfigurationPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SlugConverterConfigurationPass.php
@@ -62,16 +62,13 @@ class SlugConverterConfigurationPass implements CompilerPassInterface
                 implode(', ', array_keys($mergedConfiguration['transformationGroups']))
             ));
         } elseif (empty($mergedConfiguration['transformation'])) {
-            $container->log(
-                $this,
+            @trigger_error(
                 sprintf(
                     'Relying on default url_alias.slug_converter.transformation setting ("%s") is deprecated and might change in the next major. Set it explicitly to one of the following: %s',
                     SlugConverter::DEFAULT_CONFIGURATION['transformation'],
-                    implode(
-                        ', ',
-                        array_keys(SlugConverter::DEFAULT_CONFIGURATION['transformationGroups'])
-                    )
-                )
+                    implode(', ', array_keys($transformationGroups))
+                ),
+                E_USER_DEPRECATED
             );
         }
 

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SlugConverterConfigurationPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SlugConverterConfigurationPass.php
@@ -61,6 +61,18 @@ class SlugConverterConfigurationPass implements CompilerPassInterface
                 $mergedConfiguration['transformation'],
                 implode(', ', array_keys($mergedConfiguration['transformationGroups']))
             ));
+        } elseif (empty($mergedConfiguration['transformation'])) {
+            $container->log(
+                $this,
+                sprintf(
+                    'Relying on default url_alias.slug_converter.transformation setting ("%s") is deprecated and might change in the next major. Set it explicitly to one of the following: %s',
+                    SlugConverter::DEFAULT_CONFIGURATION['transformation'],
+                    implode(
+                        ', ',
+                        array_keys(SlugConverter::DEFAULT_CONFIGURATION['transformationGroups'])
+                    )
+                )
+            );
         }
 
         $slugConverterDefinition->setArgument(1, $mergedConfiguration);


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29167](https://jira.ez.no/browse/EZP-29167)
| **Related PR** | ezsystems/ezplatform#297 |
| **Bug/Improvement**| no
| **New feature**    | yes
| **Target version** | `master` (`7.2`)
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | maybe

This PR adds a warning to the Container log (`var/cache/*.log`) about relying on default URL alias Slug Converter transformation configuration instead of setting it explicitly via:
```yaml
ezpublish:
    url_alias:
        transformation: '<urlalias, urlalias_iri, urlalias_compat, urlalias_lowercase>'
```
Note that usual log destination `var/log/<SYMFONY_ENV>.log` is not available yet when building container, therefore Contailer Builder log is the only one that can be used.

In 8.0 this setting will probably become `urlalias_lowercase` by default.

**TODO**:
- [x] Log warning in a compiler pass
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
