### PR TITLE
EZP-29296: UserService loadByEmail returns empty array from cache

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/UserHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UserHandler.php
@@ -93,16 +93,14 @@ class UserHandler extends AbstractHandler implements UserHandlerInterface
         $this->logger->logCall(__METHOD__, array('email' => $email));
         $users = $this->persistenceHandler->userHandler()->loadByEmail($email);
 
-        if (!empty($users)) {
-            $cacheItem->set($users);
-            $cacheTags = [];
-            foreach ($users as $user) {
-                $cacheTags[] = 'content-' . $user->id;
-                $cacheTags[] = 'user-' . $user->id;
-            }
-            $cacheItem->tag($cacheTags);
-            $this->cache->save($cacheItem);
+        $cacheItem->set($users);
+        $cacheTags = [];
+        foreach ($users as $user) {
+            $cacheTags[] = 'content-' . $user->id;
+            $cacheTags[] = 'user-' . $user->id;
         }
+        $cacheItem->tag($cacheTags);
+        $this->cache->save($cacheItem);
 
         return $users;
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZP-29296](https://jira.ez.no/browse/EZP-29296)
| **Bug**| yes
| **New feature**    | no
| **Target version** | `7.1` & `master`
| **BC breaks**      | no
| **Tests pass**     | yes/no
| **Doc needed**     | no

As described in JIRA issue, `UserService::loadByEmail` returns an empty array when following steps described in the ticket scenario. 


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
