### PR TITLE
Deprecate ezxml

### DIFF
--- a/doc/specifications/rich_text/ezdocbook.md
+++ b/doc/specifications/rich_text/ezdocbook.md
@@ -199,9 +199,9 @@ eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/ezxml/docbook
 
 ### Legacy eZXML => Internal
 
-Conversion from XHTML5 from client side editor to the internal format is performed by `ToRichTextPreNormalize` and `Xslt` converters configures with main `Aggregate` converter to act as one:
+Conversion from Legacy eZXML to the internal format is performed by `ToRichTextPreNormalize` and `Xslt` converters configures with main `Aggregate` converter to act as one:
 
- 1. `eZ/Publish/Core/FieldType/RichText/Converter/Ezxml/ToRichTextPreNormalize` converter
+ 1. `eZ/Publish/Core/FieldType/XmlText/Converter/ToRichTextPreNormalize` converter
 
    With Legacy XmlText it is possible to store XML data differently in regard to the usage of temporary paragraphs that wrap block level elements. In Legacy Stack that is of no consequence as the difference is always normalized, but that also needs to be handled in the new stack. In XmlText field type implementation in the new stack that is handled by `Expanding` and `EmbedLinking` converters.
 

--- a/eZ/Publish/Core/FieldType/RichText/Converter/Ezxml/ToRichTextPreNormalize.php
+++ b/eZ/Publish/Core/FieldType/RichText/Converter/Ezxml/ToRichTextPreNormalize.php
@@ -17,6 +17,8 @@ use DOMDocument;
  * Expands paragraphs and links embeds of a XML document in legacy ezxml format.
  *
  * Relies on XmlText's Expanding and EmbedLinking converters implementation.
+ *
+ * @deprecated since version 7.2, to be removed in 8.0. Use eZ\Publish\Core\FieldType\XmlText\Converter\ToRichTextPreNormalize instead. *
  */
 class ToRichTextPreNormalize implements Converter
 {

--- a/eZ/Publish/Core/FieldType/RichText/Resources/schemas/ezxml/ezxml.xsd
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/schemas/ezxml/ezxml.xsd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Deprecated in version 7.2 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/" xmlns:image="http://ez.no/namespaces/ezpublish3/image/">
   <xs:import namespace="http://ez.no/namespaces/ezpublish3/xhtml/" schemaLocation="xhtml.xsd"/>
 

--- a/eZ/Publish/Core/FieldType/RichText/Resources/schemas/ezxml/xhtml.xsd
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/schemas/ezxml/xhtml.xsd
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Deprecated in version 7.2 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://ez.no/namespaces/ezpublish3/xhtml/" xmlns:xhtml="http://ez.no/namespaces/ezpublish3/xhtml/">
   <xs:attributeGroup name="id">
     <xs:attribute name="id" form="qualified" type="xs:string"/>

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/ezxml.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/docbook/ezxml.xsl
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Deprecated in version 7.2 -->
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:docbook="http://docbook.org/ns/docbook"

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/ezxml/docbook/core.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/ezxml/docbook/core.xsl
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Deprecated in version 7.2, use ezplatform-xmltext-fieldtype/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook_core.xsl instead -->
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"

--- a/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/ezxml/docbook/docbook.xsl
+++ b/eZ/Publish/Core/FieldType/RichText/Resources/stylesheets/ezxml/docbook/docbook.xsl
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Deprecated in version 7.2, use ezplatform-xmltext-fieldtype/lib/FieldType/XmlText/Input/Resources/stylesheets/eZXml2Docbook.xsl instead -->
 <xsl:stylesheet
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:custom="http://ez.no/namespaces/ezpublish3/custom/"

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/DocbookToEzxmlTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/DocbookToEzxmlTest.php
@@ -10,6 +10,8 @@ namespace eZ\Publish\Core\FieldType\Tests\RichText\Converter\Xslt;
 
 /**
  * Tests conversion from docbook to legacy ezxml format.
+ *
+ * @deprecated since version 7.2, to be removed in 8.0. *
  */
 class DocbookToEzxmlTest extends BaseTest
 {

--- a/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/EzxmlToDocbookTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RichText/Converter/Xslt/EzxmlToDocbookTest.php
@@ -16,6 +16,8 @@ use eZ\Publish\Core\FieldType\RichText\Converter\Xslt;
 
 /**
  * Tests conversion from legacy ezxml to docbook format.
+ *
+ * @deprecated since version 7.2, to be removed in 8.0. *
  */
 class EzxmlToDocbookTest extends BaseTest
 {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | Do I need one?
| **Bug/Improvement**| no
| **New feature**    | no
| **Target version** | `7.2`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This deprecates conversion from/to ezxmltext

Related to [ezxmltext PR](https://github.com/ezsystems/ezplatform-xmltext-fieldtype/pull/46)


**TODO**:
- [x] Implement feature / fix a bug.
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
